### PR TITLE
docs: add worktree PR CI roadmap gate

### DIFF
--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -1,6 +1,6 @@
 # Screeps Project Roadmap
 
-Last updated: 2026-04-26T05:23:37+08:00
+Last updated: 2026-04-25T21:30:55Z
 
 This roadmap is the durable counterpart to the Discord `#roadmap` channel. It summarizes completed milestones, current blockers, next autonomous slices, and the required reporting behavior for main-agent/subagent work.
 
@@ -172,6 +172,37 @@ Current result:
 - Remaining work: automate the smoke harness and wire scheduled runtime-summary/runtime-alert monitoring after one more live-token monitor smoke, not unblock basic room initialization.
 
 ## Active blockers and decisions
+
+### P0: repository change-control migration to worktree + PR + CI
+
+Status: active owner requirement, now part of the roadmap.
+
+Requirement:
+
+- all future code and documentation edits must happen in a git worktree, never directly in the `main` worktree;
+- each meaningful change must be pushed on a topic branch and submitted as a GitHub pull request;
+- changes should pass GitHub CI before merge;
+- direct commits to `main` are forbidden for both code and docs.
+
+Current access findings:
+
+- SSH git access is already configured for `git@github.com:lanyusea/screeps.git`; branch push via git should work.
+- GitHub CLI (`gh`) is not installed in this environment, and no GitHub API token is currently available to Hermes.
+- Without a GitHub API token or `gh` authentication, Hermes can push branches over SSH but cannot create PRs, inspect private/protected branch settings, enable auto-merge, or administer GitHub Actions settings.
+- The public GitHub API currently reports no GitHub Actions workflows for this repo, and the public branch listing reports `main` as unprotected; protection details require authenticated API access.
+
+Roadmap tasks:
+
+1. establish the canonical worktree path convention, e.g. `/root/screeps-worktrees/<topic>`;
+2. add CI configuration under `.github/workflows/` for `prod` typecheck, Jest, and build;
+3. add or update runbooks documenting the worktree/PR/CI lifecycle;
+4. configure branch protection on `main` after CI exists: require PR review/owner merge policy as desired and require the CI check to pass;
+5. use the GitHub API/CLI to create PRs, monitor CI, and merge only after green checks.
+
+Human-owned secret/action needed:
+
+- Provide a GitHub token to Hermes through a safe out-of-band/local secret path, not in Discord, if you want Hermes to create PRs, inspect branch protection, configure CI settings, enable auto-merge, and merge PRs itself.
+- Minimum practical scope for a classic PAT: `repo` for branch/PR/admin-on-repo operations, plus `workflow` for creating/updating GitHub Actions workflow files. If using a fine-grained token, grant this repository: Contents read/write, Pull requests read/write, Actions read/write, Checks/Commit statuses read, Metadata read, and Administration read/write only if Hermes should manage branch protection.
 
 ### P0: agent operating-system health and owner visibility
 

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -181,7 +181,9 @@ Requirement:
 
 - all future code and documentation edits must happen in a git worktree, never directly in the `main` worktree;
 - each meaningful change must be pushed on a topic branch and submitted as a GitHub pull request;
-- changes should pass GitHub CI before merge;
+- at least 15 minutes must elapse between PR creation and merge so CodeRabbit can finish review;
+- all PR review comments/discussions must be resolved before merge; expect multiple follow-up commits when review finds issues;
+- changes should pass GitHub CI before merge once CI is configured; before the CI task is complete, PRs may still merge after the 15-minute CodeRabbit window and comment-resolution gate;
 - direct commits to `main` are forbidden for both code and docs.
 
 Current access findings:
@@ -197,7 +199,7 @@ Roadmap tasks:
 2. add CI configuration under `.github/workflows/` for `prod` typecheck, Jest, and build;
 3. add or update runbooks documenting the worktree/PR/CI lifecycle;
 4. configure branch protection on `main` after CI exists: require PR review/owner merge policy as desired and require the CI check to pass;
-5. use the GitHub API/CLI to create PRs, monitor CI, and merge only after green checks.
+5. use the GitHub API/CLI to create PRs, monitor CodeRabbit/review comments, wait at least 15 minutes after PR creation, monitor CI once available, and merge only after the configured gates are satisfied.
 
 Human-owned secret/action needed:
 

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -181,9 +181,9 @@ Requirement:
 
 - all future code and documentation edits must happen in a git worktree, never directly in the `main` worktree;
 - each meaningful change must be pushed on a topic branch and submitted as a GitHub pull request;
-- at least 15 minutes must elapse between PR creation and merge so CodeRabbit can finish review;
+- at least 15 minutes must elapse between PR creation and merge;
 - all PR review comments/discussions must be resolved before merge; expect multiple follow-up commits when review finds issues;
-- changes should pass GitHub CI before merge once CI is configured; before the CI task is complete, PRs may still merge after the 15-minute CodeRabbit window and comment-resolution gate;
+- changes should pass GitHub CI before merge once CI is configured; before the CI task is complete, PRs may still merge after the 15-minute wait and unresolved-comment gate;
 - direct commits to `main` are forbidden for both code and docs.
 
 Current access findings:
@@ -199,7 +199,7 @@ Roadmap tasks:
 2. add CI configuration under `.github/workflows/` for `prod` typecheck, Jest, and build;
 3. add or update runbooks documenting the worktree/PR/CI lifecycle;
 4. configure branch protection on `main` after CI exists: require PR review/owner merge policy as desired and require the CI check to pass;
-5. use the GitHub API/CLI to create PRs, monitor CodeRabbit/review comments, wait at least 15 minutes after PR creation, monitor CI once available, and merge only after the configured gates are satisfied.
+5. use the GitHub API/CLI to create PRs, inspect PR review comments/discussions, wait at least 15 minutes after PR creation, monitor CI once available, and merge only after the configured gates are satisfied.
 
 Human-owned secret/action needed:
 

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -183,7 +183,7 @@ Requirement:
 - each meaningful change must be pushed on a topic branch and submitted as a GitHub pull request;
 - at least 15 minutes must elapse between PR creation and merge;
 - all PR review comments/discussions must be resolved before merge; expect multiple follow-up commits when review finds issues;
-- changes should pass GitHub CI before merge once CI is configured; before the CI task is complete, PRs may still merge after the 15-minute wait and unresolved-comment gate;
+- changes should pass GitHub CI before merge once CI is configured; before the CI task is complete, PRs may still merge after the 15-minute wait and comment-resolution requirement;
 - direct commits to `main` are forbidden for both code and docs.
 
 Current access findings:


### PR DESCRIPTION
## Summary
- Records the new worktree + PR + CI change-control requirement in the roadmap
- Documents current GitHub access findings and required token/permission model
- Adds CI/branch-protection setup to the roadmap

## Test Plan
- Documentation-only change; verified git diff and pushed branch from a separate worktree

## Notes
- This PR intentionally does not modify main directly.
- CI workflow setup remains a follow-up roadmap task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated operational roadmap with stricter change-control rules: no direct main edits, use topic branches with PRs, require review discussions resolved and a minimum 15-minute delay before merging.
  * Added gating guidance to rely on CI for merges once available and listed follow-up tasks to enable branch protection and workflows.
  * Documented required GitHub token/permission scopes and current environment limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->