### PR TITLE
feat: add private server smoke harness

### DIFF
--- a/docs/ops/private-server-smoke-test.md
+++ b/docs/ops/private-server-smoke-test.md
@@ -30,6 +30,19 @@ Reasons:
 3. The launcher README explicitly supports Docker and Docker Compose.
 4. It can run the server with MongoDB/Redis-backed persistence when needed.
 
+## Automation helper
+
+Use the repository helper to prepare the pinned Dockerized harness without writing generated files into tracked source:
+
+```bash
+python3 scripts/screeps-private-smoke-harness.py self-test
+python3 scripts/screeps-private-smoke-harness.py prepare
+```
+
+By default, `prepare` writes only under ignored `runtime-artifacts/private-server-smoke/`: `config.yml`, `docker-compose.yml`, `maps/map-0b6758af.json`, and a local `STEAM_KEY` file if the configured Steam-key environment variable is present. The script prints paths, port selections, and next commands with secret values redacted. Use `prepare --help` for overrides such as `--workdir`, `--repo-root`, `--steam-key-env`, `--server-port`, `--username`, `--password`, `--map-url`, `--dry-run`, and `--no-download`.
+
+Generated harness files, cached maps, local secret files, Docker volumes, `node_modules`, and runtime logs must remain untracked. The helper does not start Docker unless the operator explicitly runs the printed `docker compose` commands from the generated work directory.
+
 ## Inputs and secrets required
 
 Do not commit any secrets to this repository.

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -1,6 +1,6 @@
 # Screeps Project Roadmap
 
-Last updated: 2026-04-25T21:30:55Z
+Last updated: 2026-04-25T21:41:14Z
 
 This roadmap is the durable counterpart to the Discord `#roadmap` channel. It summarizes completed milestones, current blockers, next autonomous slices, and the required reporting behavior for main-agent/subagent work.
 
@@ -14,7 +14,8 @@ This roadmap is the durable counterpart to the Discord `#roadmap` channel. It su
   - `cd prod && npm run build` — passing
 - Latest production/test milestone: parallel Codex hardening commits `7d2a04d test: harden body builder invariants` and `4706868 test: harden worker runner task execution`; verification now passes with 12 suites / 59 tests
 - Latest validation milestone: pinned Dockerized private-server smoke now initializes rooms via `utils.importMapFile`, places a local spawn, observes owned bot creeps, and has run past private `gametime: 5267` with one RCL 2 owned room
-- Latest documentation milestone: longer private-server observation note in `docs/process/2026-04-26-private-server-long-observation.md`
+- Latest automation milestone: reusable pinned private-server smoke harness added at `scripts/screeps-private-smoke-harness.py`; offline self-test passes and a fresh full harness rerun remains next
+- Latest documentation milestone: private smoke harness note in `docs/process/2026-04-26-private-smoke-harness.md`
 - Active state file: `docs/process/active-work-state.md`
 - Current top priority: continue high-throughput validation while keeping P0 agent communication/cron/Discord visibility healthy
 
@@ -169,7 +170,8 @@ Current result:
 - Room/map initialization is resolved for the pinned launcher path by pre-downloading `map-0b6758af.json`, setting `serverConfig.mapFile`, importing with `utils.importMapFile('/screeps/maps/map-0b6758af.json')`, restarting, and resuming simulation.
 - Follow-up observation reached `/stats` `gametime: 5267`, `totalRooms: 169`, `activeRooms: 1`, `ownedRooms: 1`, and one RCL 2 owned room.
 - Mongo room-object inspection showed owned `Spawn1` and three living bot-created `WORK/CARRY/MOVE` workers named `worker-E1S1-*`; post-restart log scanning found no current unhandled/type/reference/error hits.
-- Remaining work: automate the smoke harness and wire scheduled runtime-summary/runtime-alert monitoring after one more live-token monitor smoke, not unblock basic room initialization.
+- Reusable harness added: `scripts/screeps-private-smoke-harness.py prepare` writes the pinned config/Compose/map setup under ignored `runtime-artifacts/private-server-smoke/`, keeps secrets redacted, and `self-test` passes offline.
+- Remaining work: run the prepared harness end to end on a fresh private-server state and wire scheduled runtime-summary/runtime-alert monitoring after one more live-token monitor smoke, not unblock basic room initialization.
 
 ## Active blockers and decisions
 
@@ -227,20 +229,20 @@ Immediate operating change:
 - continuation/checkpoint workers remain subordinate to main-agent review and channel fanout;
 - if P0 health is abnormal, pause or defer new implementation work until corrected.
 
-### Validation follow-up: automate private-server smoke and runtime monitoring
+### Validation follow-up: run private-server harness and runtime monitoring
 
 Docker/Compose, package installation, HTTP startup, local auth, code upload, room/map initialization, spawn placement, and bot tick validation are no longer the primary blockers for the pinned launcher path. The active follow-up is making this repeatable and observable:
 
-1. package the pinned launcher config, map-file import, restart/resume, local user registration, code upload, spawn placement, stats polling, and redacted Mongo observation into an executable local smoke harness;
+1. run the new pinned launcher harness on a fresh private-server state, then extend it only where automation gaps remain;
 2. observe several additional windows or reruns to ensure the path is stable across fresh data resets;
 3. run one more live-token runtime-monitor smoke, then schedule `scripts/screeps-runtime-monitor.py` for hourly `#runtime-summary` images and `[SILENT]` no-alert `#runtime-alerts` checks;
 4. if the pinned runtime later exposes simulation incompatibilities, then revisit a Node.js 22.9+ private-server image/toolchain for current `screeps@4.3.0`.
 
-Recommendation: keep private-server-first validation as the release-quality gate before future official MMO deployment, but treat the next engineering step as smoke automation/runtime monitoring rather than resolving basic room initialization.
+Recommendation: keep private-server-first validation as the release-quality gate before future official MMO deployment, but treat the next engineering step as a fresh harness-backed smoke rerun/runtime monitoring rather than resolving basic room initialization.
 
 ### Decision: next code priority
 
-Recommended next slice: automate the pinned private-server smoke harness and/or schedule the verified runtime monitor after one more live-token smoke. If new runtime failures appear during observation, convert them into deterministic Jest hardening tasks for Codex.
+Recommended next slice: run the pinned private-server smoke harness end to end and/or schedule the verified runtime monitor after one more live-token smoke. If new runtime failures appear during observation, convert them into deterministic Jest hardening tasks for Codex.
 
 Reason:
 

--- a/docs/process/2026-04-26-private-smoke-harness.md
+++ b/docs/process/2026-04-26-private-smoke-harness.md
@@ -1,0 +1,41 @@
+# Private Smoke Harness Slice
+
+Date: 2026-04-26T05:41:14+08:00
+
+## What changed
+
+Added `scripts/screeps-private-smoke-harness.py`, a local/cron-friendly helper for preparing the pinned Dockerized private-server smoke environment outside production code.
+
+The helper supports:
+
+- `prepare`: writes `config.yml` and `docker-compose.yml` under ignored `runtime-artifacts/private-server-smoke/` by default, caches `maps/map-0b6758af.json`, and prints redacted next commands.
+- `self-test`: deterministic offline tests for config rendering, compose rendering, redaction, map naming, path safety, and no-download behavior.
+- local overrides for workdir, repo root, Steam-key env var name, server/CLI ports, local smoke username/password defaults, map URL, dry-run, no-download, and force-download.
+
+The generated config preserves the passing pinned launcher path:
+
+- `screeps@4.2.21`
+- launcher `nodeVersion: Erbium`
+- pinned transitive packages from the successful smoke run
+- `screepsmod-auth`, `screepsmod-admin-utils`, and `screepsmod-mongo`
+- `serverConfig.mapFile: /screeps/maps/map-0b6758af.json`
+
+## Safety boundaries
+
+- No `prod/` source or tests were changed.
+- `STEAM_KEY` is read only by name and never printed. If present during `prepare`, it is written only to the local untracked workdir as `STEAM_KEY` for `steamKeyFile` compatibility.
+- The default workdir is under ignored `runtime-artifacts/`.
+- The helper refuses an implicit tracked-source workdir outside `runtime-artifacts/`; explicit `--workdir` is required for non-default placement.
+
+## Verification
+
+```text
+python3 scripts/screeps-private-smoke-harness.py self-test
+cd prod && npm run typecheck
+cd prod && npm test -- --runInBand
+cd prod && npm run build
+```
+
+Result: harness self-test passed, 8 tests; production verification passed with 12 Jest suites / 59 tests and a rebuilt `prod/dist/main.js` artifact.
+
+A fresh Dockerized private-server rerun was not performed in this slice; the next validation step remains running the prepared harness end to end, importing the map, registering the local smoke user after import, uploading `prod/dist/main.js`, placing `Spawn1`, and collecting redacted observations.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T05:23:37+08:00
+Last updated: 2026-04-26T05:41:14+08:00
 
 ## Current active objective
 
@@ -149,14 +149,31 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   - `npm test -- --runInBand`: passed, 12 suites / 45 tests
   - `npm run build`: passed
 
+### private-smoke-harness
+
+- Status: implemented and self-tested; fresh full private-server rerun remains next
+- Process note: `docs/process/2026-04-26-private-smoke-harness.md`
+- Implemented:
+  - `scripts/screeps-private-smoke-harness.py`
+  - `prepare` command for ignored `runtime-artifacts/private-server-smoke/` config/Compose/map setup
+  - pinned launcher config for `screeps@4.2.21`, launcher `nodeVersion: Erbium`, documented transitive dependency pins, auth/admin-utils/mongo mods, and `/screeps/maps/map-0b6758af.json`
+  - local `STEAM_KEY` file support without printing the key value
+  - offline `self-test` coverage for rendering, redaction, path safety, map naming, and no-download behavior
+- Verification:
+  - `python3 scripts/screeps-private-smoke-harness.py self-test`: passed, 8 tests
+  - `cd prod && npm run typecheck`: passed
+  - `cd prod && npm test -- --runInBand`: passed, 12 suites / 59 tests
+  - `cd prod && npm run build`: passed
+
 ### next-runtime-validation
 
-- Status: pinned private-server smoke unblocked for room/map initialization and bot tick validation
+- Status: pinned private-server smoke unblocked for room/map initialization and bot tick validation; reusable harness now prepared and self-tested
 - Process note: `docs/process/2026-04-26-private-server-smoke-attempt.md`
 - Version-pin research note: `docs/process/2026-04-26-private-server-version-pin-research.md`
 - Pinned runtime retry note: `docs/process/2026-04-26-pinned-private-server-smoke-retry.md`
 - Parallel throughput/smoke note: `docs/process/2026-04-26-parallel-throughput-and-private-smoke.md`
 - Longer observation note: `docs/process/2026-04-26-private-server-long-observation.md`
+- Harness note: `docs/process/2026-04-26-private-smoke-harness.md`
 - Current recommendation: private-server-first validation remains the release-quality path. Dockerized `screepers/screeps-launcher` with explicit `version: 4.2.21`, launcher Node `12.22.12`, and transitive dependency resolutions (`body-parser: 1.20.3`, `path-to-regexp: 0.1.12`) can initialize rooms when the map import avoids the Node 12 global-`fetch` path by using a pre-downloaded map file plus `utils.importMapFile('/screeps/maps/map-0b6758af.json')`. A follow-up observation reached private `gametime: 5267`, `totalRooms: 169`, `ownedRooms: 1`, one RCL 2 room, and three live bot-created workers without post-restart log exceptions.
 - Local secret storage has public MMO token plus `STEAM_KEY`; safe selectors are `SCREEPS_BRANCH=main`, `SCREEPS_API_URL=https://screeps.com`, `SCREEPS_SHARD=shardX`, and `SCREEPS_ROOM=E48S28`. Private-server URL/username selectors are not yet defined locally.
 - Temporary owner-approved official MMO link validation completed on 2026-04-26: created official code branch `main`, uploaded current `prod/dist/main.js`, set `main` as `activeWorld`, placed `Spawn1` at `E48S28` `(25,23)` on `shardX`, and verified official world status `normal` with room owner `lanyusea`. This does not remove the private-server-first validation requirement for future release-quality deployments.
@@ -169,9 +186,10 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   - Dockerized launcher install preflight: `screeps-launcher apply` passed with explicit `version: 4.2.21`, `nodeVersion: Erbium`, and pinned package resolutions
   - Pinned Dockerized runtime smoke: pre-downloaded `map-0b6758af.json`, imported with `utils.importMapFile`, restarted/resumed simulation, registered local smoke user, uploaded `prod/dist/main.js`, placed `Spawn1` at `E1S1` `(20,20)`, and observed `/stats` with `totalRooms: 169`, `ownedRooms: 1`, `activeUsers: 1`, plus owned `worker-E1S1-*` creeps in Mongo
   - Longer pinned runtime observation: private `gametime: 5267`, one RCL 2 owned room, three live bot-created workers, average tick time about 200 ms, and no current post-restart `Unhandled`/`TypeError`/`ReferenceError`/`Error:` hits in launcher logs
+  - Private smoke harness self-test: `python3 scripts/screeps-private-smoke-harness.py self-test` passed, 8 tests
   - Runtime monitor self-test: `python3 scripts/screeps-runtime-monitor.py self-test` passed, 8 tests
 - Candidate next outputs:
-  1. automate the pinned private-server smoke harness and redacted observation capture
+  1. run the prepared pinned private-server smoke harness end to end and capture redacted observations
   2. run one more live-token runtime-monitor smoke, then schedule `#runtime-summary` / `[SILENT]` no-alert `#runtime-alerts` jobs
   3. continue deterministic Jest hardening for risks found during longer real-runtime observation
 - Verification target if code changes are made:

--- a/scripts/screeps-private-smoke-harness.py
+++ b/scripts/screeps-private-smoke-harness.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Prepare a pinned private-server smoke harness for the Screeps bot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+import tempfile
+import textwrap
+import unittest
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_WORKDIR_REL = Path("runtime-artifacts/private-server-smoke")
+DEFAULT_WORKDIR_ENV = "SCREEPS_PRIVATE_SMOKE_WORKDIR"
+DEFAULT_STEAM_KEY_ENV = "STEAM_KEY"
+DEFAULT_MAP_URL = "https://maps.screepspl.us/maps/map-0b6758af.json"
+DEFAULT_SERVER_PORT = 21025
+DEFAULT_CLI_PORT = 21026
+DEFAULT_USERNAME = "smoke"
+DEFAULT_PASSWORD = "smoke-local-only"
+STEAM_KEY_FILE = "STEAM_KEY"
+SCREEPS_VERSION = "4.2.21"
+NODE_VERSION = "Erbium"
+
+PINNED_PACKAGES = (
+    ("ssri", "8.0.1"),
+    ("cacache", "15.3.0"),
+    ("passport-steam", "1.0.17"),
+    ("minipass-fetch", "2.1.2"),
+    ("express-rate-limit", "6.7.0"),
+    ("body-parser", "1.20.3"),
+    ("path-to-regexp", "0.1.12"),
+    ("psl", "1.10.0"),
+)
+
+MODS = (
+    "screepsmod-auth",
+    "screepsmod-admin-utils",
+    "screepsmod-mongo",
+)
+
+
+@dataclass(frozen=True)
+class PreparePlan:
+    repo_root: Path
+    workdir: Path
+    explicit_workdir: bool
+    map_url: str
+    map_filename: str
+    server_port: int
+    cli_port: int
+    steam_key_env: str
+    username: str
+    password: str
+    dry_run: bool
+    no_download: bool
+    force_download: bool
+    no_steam_key_file: bool
+
+    @property
+    def config_path(self) -> Path:
+        return self.workdir / "config.yml"
+
+    @property
+    def compose_path(self) -> Path:
+        return self.workdir / "docker-compose.yml"
+
+    @property
+    def maps_dir(self) -> Path:
+        return self.workdir / "maps"
+
+    @property
+    def map_path(self) -> Path:
+        return self.maps_dir / self.map_filename
+
+    @property
+    def steam_key_path(self) -> Path:
+        return self.workdir / STEAM_KEY_FILE
+
+    @property
+    def container_map_path(self) -> str:
+        return f"/screeps/maps/{self.map_filename}"
+
+
+def is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_repo_root(value: str | None) -> Path:
+    if value:
+        return Path(value).expanduser().resolve()
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_workdir(repo_root: Path, value: str | None, env: dict[str, str]) -> tuple[Path, bool]:
+    if value:
+        candidate = Path(value).expanduser()
+        explicit = True
+    elif env.get(DEFAULT_WORKDIR_ENV):
+        candidate = Path(env[DEFAULT_WORKDIR_ENV]).expanduser()
+        explicit = True
+    else:
+        candidate = repo_root / DEFAULT_WORKDIR_REL
+        explicit = False
+
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    return candidate.resolve(strict=False), explicit
+
+
+def validate_workdir(repo_root: Path, workdir: Path, explicit_workdir: bool) -> None:
+    repo_root = repo_root.resolve()
+    workdir = workdir.resolve(strict=False)
+    runtime_root = (repo_root / "runtime-artifacts").resolve(strict=False)
+
+    if workdir == repo_root:
+        raise RuntimeError("refusing to use the repository root as the smoke workdir")
+
+    if is_relative_to(workdir, repo_root) and not is_relative_to(workdir, runtime_root) and not explicit_workdir:
+        raise RuntimeError(
+            "refusing to write an implicit smoke workdir inside tracked source; "
+            "use runtime-artifacts/ or pass --workdir explicitly"
+        )
+
+
+def map_filename_from_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    filename = Path(parsed.path).name
+    if not re.fullmatch(r"map-[A-Za-z0-9_-]+\.json", filename):
+        raise ValueError(
+            f"map URL must end in a map-*.json filename, got {filename!r}"
+        )
+    return filename
+
+
+def redact_text(text: str, secrets: Iterable[str | None]) -> str:
+    redacted = text
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, "<redacted>")
+    return redacted
+
+
+def render_config(container_map_path: str, cli_port: int) -> str:
+    lines = [
+        f"steamKeyFile: {STEAM_KEY_FILE}",
+        f"version: {SCREEPS_VERSION}",
+        f"nodeVersion: {NODE_VERSION}",
+        "pinnedPackages:",
+    ]
+    lines.extend(f"  {name}: {version}" for name, version in PINNED_PACKAGES)
+    lines.append("mods:")
+    lines.extend(f"  - {name}" for name in MODS)
+    lines.extend(
+        [
+            "env:",
+            "  backend:",
+            "    CLI_HOST: 0.0.0.0",
+            "serverConfig:",
+            '  welcomeText: "Local Screeps MVP pinned smoke server"',
+            "  tickRate: 200",
+            "  shardName: shardX",
+            f"  mapFile: {container_map_path}",
+            "cli:",
+            "  host: 127.0.0.1",
+            f"  port: {cli_port}",
+            '  username: ""',
+            '  password: ""',
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_compose(server_port: int, cli_port: int) -> str:
+    return (
+        textwrap.dedent(
+            f"""\
+            services:
+              screeps:
+                image: screepers/screeps-launcher:latest
+                volumes:
+                  - ./:/screeps
+                ports:
+                  - "127.0.0.1:{server_port}:21025/tcp"
+                  - "127.0.0.1:{cli_port}:21026/tcp"
+                environment:
+                  MONGO_HOST: mongo
+                  REDIS_HOST: redis
+                depends_on:
+                  mongo:
+                    condition: service_healthy
+                  redis:
+                    condition: service_healthy
+                restart: "no"
+                healthcheck:
+                  test: ["CMD-SHELL", "sh", "-c", "curl --fail --silent http://127.0.0.1:21025/ >/dev/null"]
+                  interval: 10s
+                  timeout: 5s
+                  start_period: 10s
+                  retries: 12
+
+              mongo:
+                image: mongo:8
+                volumes:
+                  - mongo-data:/data/db
+                restart: "no"
+                healthcheck:
+                  test: ["CMD-SHELL", "sh", "-c", "echo 'db.runCommand(\\"ping\\").ok' | mongosh localhost:27017/test --quiet"]
+                  interval: 10s
+                  timeout: 5s
+                  start_period: 10s
+                  retries: 12
+
+              redis:
+                image: redis:7
+                volumes:
+                  - redis-data:/data
+                restart: "no"
+                healthcheck:
+                  test: ["CMD", "redis-cli", "ping"]
+                  interval: 10s
+                  timeout: 5s
+                  start_period: 10s
+                  retries: 12
+
+            volumes:
+              redis-data:
+              mongo-data:
+            """
+        )
+        + "\n"
+    )
+
+
+def write_text(path: Path, content: str, dry_run: bool) -> str:
+    if dry_run:
+        return f"would write {path}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return f"wrote {path}"
+
+
+def write_steam_key_file(path: Path, steam_key: str, dry_run: bool) -> str:
+    if dry_run:
+        return f"would write local {path.name} secret file"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(steam_key)
+        if not steam_key.endswith("\n"):
+            handle.write("\n")
+    os.chmod(path, 0o600)
+    return f"wrote local {path.name} secret file"
+
+
+def download_map(plan: PreparePlan) -> str:
+    if plan.map_path.exists() and not plan.force_download:
+        return f"using cached map {plan.map_path}"
+    if plan.no_download:
+        return f"skipped map download; expected path is {plan.map_path}"
+    if plan.dry_run:
+        return f"would download {plan.map_url} to {plan.map_path}"
+
+    plan.maps_dir.mkdir(parents=True, exist_ok=True)
+    request = urllib.request.Request(
+        plan.map_url,
+        headers={"User-Agent": "screeps-private-smoke-harness/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = response.read()
+
+    try:
+        json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"downloaded map was not valid JSON: {plan.map_url}") from exc
+
+    plan.map_path.write_bytes(payload)
+    return f"downloaded map {plan.map_path}"
+
+
+def build_prepare_summary(plan: PreparePlan, actions: list[str], steam_key_present: bool) -> str:
+    steam_status = "present" if steam_key_present else "missing"
+    key_file_status = "not written"
+    if steam_key_present and not plan.no_steam_key_file:
+        key_file_status = f"{STEAM_KEY_FILE} written locally"
+    elif plan.no_steam_key_file:
+        key_file_status = "skipped by --no-steam-key-file"
+
+    lines = [
+        "Screeps private-server smoke harness prepared.",
+        f"workdir: {plan.workdir}",
+        f"config: {plan.config_path}",
+        f"compose: {plan.compose_path}",
+        f"map: {plan.map_path}",
+        f"server: http://127.0.0.1:{plan.server_port}",
+        f"launcher CLI: 127.0.0.1:{plan.cli_port}",
+        f"steam key env: {plan.steam_key_env} ({steam_status})",
+        f"steam key file: {key_file_status}",
+        f"local smoke username default: {plan.username}",
+        "local smoke password default: <redacted>",
+    ]
+    if plan.dry_run:
+        lines.append("dry run: no files were written")
+    lines.append("")
+    lines.append("Actions:")
+    lines.extend(f"- {action}" for action in actions)
+    lines.append("")
+    lines.append("Next commands:")
+    lines.append(f"cd {shlex.quote(str(plan.workdir))}")
+    lines.append("docker compose up -d")
+    lines.append("docker compose exec screeps screeps-launcher cli")
+    lines.append(f"utils.importMapFile('{plan.container_map_path}')")
+    lines.append("system.resumeSimulation()")
+    lines.append("")
+    lines.append(
+        "Then register the local smoke user after map import, upload prod/dist/main.js, "
+        "place Spawn1 in E1S1 at (20,20), and poll /stats plus room objects with secrets redacted."
+    )
+    return "\n".join(lines)
+
+
+def prepare(args: argparse.Namespace) -> int:
+    repo_root = resolve_repo_root(args.repo_root)
+    workdir, explicit_workdir = resolve_workdir(repo_root, args.workdir, os.environ)
+    validate_workdir(repo_root, workdir, explicit_workdir)
+    map_filename = map_filename_from_url(args.map_url)
+
+    plan = PreparePlan(
+        repo_root=repo_root,
+        workdir=workdir,
+        explicit_workdir=explicit_workdir,
+        map_url=args.map_url,
+        map_filename=map_filename,
+        server_port=args.server_port,
+        cli_port=args.cli_port,
+        steam_key_env=args.steam_key_env,
+        username=args.username,
+        password=args.password,
+        dry_run=args.dry_run,
+        no_download=args.no_download,
+        force_download=args.force_download,
+        no_steam_key_file=args.no_steam_key_file,
+    )
+
+    steam_key = os.environ.get(plan.steam_key_env)
+    actions: list[str] = []
+    actions.append(write_text(plan.config_path, render_config(plan.container_map_path, plan.cli_port), plan.dry_run))
+    actions.append(write_text(plan.compose_path, render_compose(plan.server_port, plan.cli_port), plan.dry_run))
+    if steam_key and not plan.no_steam_key_file:
+        actions.append(write_steam_key_file(plan.steam_key_path, steam_key, plan.dry_run))
+    elif not steam_key:
+        actions.append(f"{plan.steam_key_env} is not set; create {plan.steam_key_path} before starting the server")
+    actions.append(download_map(plan))
+
+    summary = build_prepare_summary(plan, actions, bool(steam_key))
+    print(redact_text(summary, [steam_key, plan.password]))
+    return 0
+
+
+class HarnessSelfTests(unittest.TestCase):
+    def test_config_renders_pinned_runtime_without_secret_value(self) -> None:
+        config = render_config("/screeps/maps/map-0b6758af.json", 21026)
+        self.assertTrue(config.startswith("steamKeyFile: STEAM_KEY\n"))
+        self.assertIn("version: 4.2.21", config)
+        self.assertIn("nodeVersion: Erbium", config)
+        self.assertIn("steamKeyFile: STEAM_KEY", config)
+        self.assertIn("\n  body-parser: 1.20.3", config)
+        self.assertIn("\n  path-to-regexp: 0.1.12", config)
+        self.assertIn("\n  - screepsmod-auth", config)
+        self.assertIn("mapFile: /screeps/maps/map-0b6758af.json", config)
+        self.assertNotIn("secret-value", config)
+
+    def test_compose_renders_local_ports_and_backing_services(self) -> None:
+        compose = render_compose(22025, 22026)
+        self.assertIn('"127.0.0.1:22025:21025/tcp"', compose)
+        self.assertIn('"127.0.0.1:22026:21026/tcp"', compose)
+        self.assertIn("MONGO_HOST: mongo", compose)
+        self.assertIn("REDIS_HOST: redis", compose)
+        self.assertIn("image: mongo:8", compose)
+        self.assertIn("image: redis:7", compose)
+
+    def test_redaction_removes_secrets(self) -> None:
+        text = redact_text("key=abc123 password=localpass", ["abc123", "localpass"])
+        self.assertEqual(text, "key=<redacted> password=<redacted>")
+
+    def test_map_filename_from_default_url(self) -> None:
+        self.assertEqual(map_filename_from_url(DEFAULT_MAP_URL), "map-0b6758af.json")
+
+    def test_map_filename_rejects_unexpected_names(self) -> None:
+        with self.assertRaises(ValueError):
+            map_filename_from_url("https://example.invalid/not-a-map.txt")
+
+    def test_default_workdir_is_under_runtime_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp).resolve()
+            workdir, explicit = resolve_workdir(repo, None, {})
+            self.assertFalse(explicit)
+            self.assertEqual(workdir, repo / DEFAULT_WORKDIR_REL)
+            validate_workdir(repo, workdir, explicit)
+
+    def test_implicit_tracked_source_workdir_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp).resolve()
+            bad_workdir = repo / "docs" / "private-smoke"
+            with self.assertRaises(RuntimeError):
+                validate_workdir(repo, bad_workdir, explicit_workdir=False)
+            validate_workdir(repo, bad_workdir, explicit_workdir=True)
+
+    def test_no_download_mode_is_offline_and_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp).resolve()
+            plan = PreparePlan(
+                repo_root=repo,
+                workdir=repo / DEFAULT_WORKDIR_REL,
+                explicit_workdir=False,
+                map_url=DEFAULT_MAP_URL,
+                map_filename="map-0b6758af.json",
+                server_port=DEFAULT_SERVER_PORT,
+                cli_port=DEFAULT_CLI_PORT,
+                steam_key_env=DEFAULT_STEAM_KEY_ENV,
+                username=DEFAULT_USERNAME,
+                password=DEFAULT_PASSWORD,
+                dry_run=False,
+                no_download=True,
+                force_download=False,
+                no_steam_key_file=False,
+            )
+            result = download_map(plan)
+            self.assertIn("skipped map download", result)
+            self.assertFalse(plan.map_path.exists())
+
+
+def self_test(_args: argparse.Namespace) -> int:
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(HarnessSelfTests)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if result.wasSuccessful():
+        print(f"self-test passed: {suite.countTestCases()} tests")
+        return 0
+    return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Prepare a pinned Dockerized Screeps private-server smoke harness outside production code.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare_parser = subparsers.add_parser(
+        "prepare",
+        help="write config.yml/docker-compose.yml and cache the pinned smoke map",
+    )
+    prepare_parser.add_argument("--repo-root", help="repository root; defaults to this script's parent repo")
+    prepare_parser.add_argument(
+        "--workdir",
+        help=(
+            "untracked smoke workdir; defaults to runtime-artifacts/private-server-smoke "
+            f"or ${DEFAULT_WORKDIR_ENV}"
+        ),
+    )
+    prepare_parser.add_argument("--steam-key-env", default=DEFAULT_STEAM_KEY_ENV, help="env var holding the Steam key")
+    prepare_parser.add_argument("--server-port", type=int, default=DEFAULT_SERVER_PORT, help="host HTTP/game port")
+    prepare_parser.add_argument("--cli-port", type=int, default=DEFAULT_CLI_PORT, help="host launcher CLI port")
+    prepare_parser.add_argument("--username", default=DEFAULT_USERNAME, help="local-only smoke username default")
+    prepare_parser.add_argument("--password", default=DEFAULT_PASSWORD, help="local-only smoke password default")
+    prepare_parser.add_argument("--map-url", default=DEFAULT_MAP_URL, help="map-*.json URL to cache under maps/")
+    prepare_parser.add_argument("--dry-run", action="store_true", help="print planned files and commands without writing")
+    prepare_parser.add_argument("--no-download", action="store_true", help="do not download the map JSON")
+    prepare_parser.add_argument("--force-download", action="store_true", help="refresh the cached map JSON if present")
+    prepare_parser.add_argument(
+        "--no-steam-key-file",
+        action="store_true",
+        help="do not copy the steam key env value into the local untracked STEAM_KEY file",
+    )
+    prepare_parser.set_defaults(func=prepare)
+
+    self_test_parser = subparsers.add_parser(
+        "self-test",
+        help="run deterministic offline tests; does not require Docker or network",
+    )
+    self_test_parser.set_defaults(func=self_test)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception as exc:  # noqa: BLE001 - top-level CLI should print clean errors
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a reusable pinned Dockerized private-server smoke harness under scripts/
- document prepare/self-test usage and keep generated config/map/secrets under ignored runtime-artifacts
- update active state and roadmap so the next slice is an end-to-end harness-backed rerun

## Verification
- python3 scripts/screeps-private-smoke-harness.py self-test
- cd prod && npm run typecheck
- cd prod && npm test -- --runInBand
- cd prod && npm run build

## Notes
- No prod source/test changes were made.
- No secrets are printed or committed; STEAM_KEY is only referenced by env/name and local untracked file path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool for operators to set up and execute private server smoke tests with Docker support, automated artifact generation, and offline validation modes.

* **Documentation**
  * Added operator runbooks for private server smoke validation workflows.
  * Documented smoke harness setup procedures and updated project roadmap with new validation process steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->