### PR TITLE
test: harden worker no-target fallbacks

### DIFF
--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -10,9 +10,9 @@ This roadmap is the durable counterpart to the Discord `#roadmap` channel. It su
 - Branch: `main`
 - Current verification baseline:
   - `cd prod && npm run typecheck` — passing
-  - `cd prod && npm test -- --runInBand` — passing, 12 suites / 59 tests
+  - `cd prod && npm test -- --runInBand` — passing, 12 suites / 66 tests
   - `cd prod && npm run build` — passing
-- Latest production/test milestone: parallel Codex hardening commits `7d2a04d test: harden body builder invariants` and `4706868 test: harden worker runner task execution`; verification now passes with 12 suites / 59 tests
+- Latest production/test milestone: Codex commit `12a2c4a test: harden worker no-target fallbacks` added deterministic no-source/no-controller/no-target worker fallback coverage
 - Latest validation milestone: pinned Dockerized private-server smoke now initializes rooms via `utils.importMapFile`, places a local spawn, observes owned bot creeps, and has run past private `gametime: 5267` with one RCL 2 owned room
 - Latest documentation milestone: longer private-server observation note in `docs/process/2026-04-26-private-server-long-observation.md`
 - Active state file: `docs/process/active-work-state.md`

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -1,6 +1,6 @@
 # Screeps Project Roadmap
 
-Last updated: 2026-04-25T21:30:55Z
+Last updated: 2026-04-25T23:20:20Z
 
 This roadmap is the durable counterpart to the Discord `#roadmap` channel. It summarizes completed milestones, current blockers, next autonomous slices, and the required reporting behavior for main-agent/subagent work.
 
@@ -10,9 +10,9 @@ This roadmap is the durable counterpart to the Discord `#roadmap` channel. It su
 - Branch: `main`
 - Current verification baseline:
   - `cd prod && npm run typecheck` — passing
-  - `cd prod && npm test -- --runInBand` — passing, 12 suites / 66 tests
+  - `cd prod && npm test -- --runInBand` — passing, 12 suites / 67 tests
   - `cd prod && npm run build` — passing
-- Latest production/test milestone: Codex commit `12a2c4a test: harden worker no-target fallbacks` added deterministic no-source/no-controller/no-target worker fallback coverage
+- Latest production/test milestone: Codex commit `12a2c4a test: harden worker no-target fallbacks` plus review follow-up `test: cover stale harvest worker tasks` added deterministic no-source/no-controller/no-target worker fallback coverage, including stale harvest targets
 - Latest validation milestone: pinned Dockerized private-server smoke now initializes rooms via `utils.importMapFile`, places a local spawn, observes owned bot creeps, and has run past private `gametime: 5267` with one RCL 2 owned room
 - Latest documentation milestone: longer private-server observation note in `docs/process/2026-04-26-private-server-long-observation.md`
 - Active state file: `docs/process/active-work-state.md`

--- a/docs/process/2026-04-26-pr7-conflict-refresh.md
+++ b/docs/process/2026-04-26-pr7-conflict-refresh.md
@@ -1,0 +1,37 @@
+# PR #7 conflict refresh
+
+Time: 2026-04-26T09:47:06+08:00
+
+## Context
+
+The scheduled continuation worker found PR #7 (`test/runtime-risk-hardening-20260426`) approved but merge-conflicted after `main` advanced with CI, P0 routing, and runtime-monitor live-smoke documentation.
+
+## Action
+
+Codex CLI updated the PR worktree by merging `origin/main` into `test/runtime-risk-hardening-20260426`, preserving:
+
+- the branch's deterministic worker no-target and stale-task Jest hardening;
+- current `main` CI workflow and runbook state;
+- current P0 routing checkpoint documentation;
+- current runtime-monitor live-token smoke documentation.
+
+The conflict resolution was committed as `6a54b8d` (`Merge origin/main into runtime risk hardening`) and pushed to the PR branch.
+
+## Verification
+
+Codex ran the required production verification from `prod/` before committing:
+
+- `npm run typecheck`: passed
+- `npm test -- --runInBand`: passed, 12 suites / 67 tests
+- `npm run build`: passed
+
+Controller follow-up confirmed:
+
+- main worktree remained clean;
+- PR #7 head is `6a54b8dd778c28e89aa4f84ac22952614b24883a`;
+- GitHub Actions `prod-ci` check passed on the updated head;
+- CodeRabbit status was still pending immediately after push, so merge state was `UNSTABLE` rather than fully clean at report time.
+
+## Next step
+
+Re-check PR #7 after CodeRabbit finishes. If it remains approved and CI/status contexts are green, it should be eligible for the normal PR-gated merge path.

--- a/docs/process/2026-04-26-worker-no-target-hardening.md
+++ b/docs/process/2026-04-26-worker-no-target-hardening.md
@@ -1,6 +1,6 @@
 # Worker no-target fallback hardening
 
-Date: 2026-04-26T07:11:23+08:00
+Date: 2026-04-26T07:20:20+08:00
 
 ## Objective
 
@@ -11,6 +11,7 @@ Add deterministic Jest coverage for real-runtime edge cases surfaced by private-
 Codex CLI implemented and committed the production/test slice in worktree `/root/screeps-worktrees/runtime-risk-hardening-20260426`.
 
 - Commit: `12a2c4a test: harden worker no-target fallbacks`
+- Review follow-up commit in this branch: `test: cover stale harvest worker tasks`
 - Changed files:
   - `prod/test/workerTasks.test.ts`
   - `prod/test/workerRunner.test.ts`
@@ -20,7 +21,7 @@ Codex CLI implemented and committed the production/test slice in worktree `/root
 - `selectWorkerTask` returns `null` without throwing when a zero-energy worker has no sources.
 - `selectWorkerTask` returns `null` without throwing when an energy-carrying worker has no energy sinks, construction sites, or owned controller.
 - `runWorker` leaves no task assigned and does not throw in both no-target task-selection cases.
-- `runWorker` clears stale `transfer`, `build`, and `upgrade` tasks in a controllerless/no-target room without calling `transfer`, `build`, `upgradeController`, or `moveTo`.
+- `runWorker` clears stale `harvest`, `transfer`, `build`, and `upgrade` tasks in a controllerless/no-target room without calling `harvest`, `transfer`, `build`, `upgradeController`, or `moveTo`.
 
 No production source change was required; the existing worker task selection and stale-target handling already matched the desired behavior. The slice makes that runtime safety contract explicit and regression-tested.
 
@@ -36,7 +37,7 @@ npm run build
 
 Result: passed.
 
-- Jest: 12 suites passed, 66 tests passed.
+- Jest: 12 suites passed, 67 tests passed.
 - Build: `prod/dist/main.js` built successfully and remained functionally unchanged because only tests changed.
 
 ## Follow-up

--- a/docs/process/2026-04-26-worker-no-target-hardening.md
+++ b/docs/process/2026-04-26-worker-no-target-hardening.md
@@ -1,0 +1,48 @@
+# Worker no-target fallback hardening
+
+Date: 2026-04-26T07:11:23+08:00
+
+## Objective
+
+Add deterministic Jest coverage for real-runtime edge cases surfaced by private-server validation planning: worker rooms may temporarily have no accessible source, no energy sink, no construction site, or no owned controller. The worker loop must not throw, retain invalid tasks, or attempt actions against stale targets in those states.
+
+## Codex-authored code/test change
+
+Codex CLI implemented and committed the production/test slice in worktree `/root/screeps-worktrees/runtime-risk-hardening-20260426`.
+
+- Commit: `12a2c4a test: harden worker no-target fallbacks`
+- Changed files:
+  - `prod/test/workerTasks.test.ts`
+  - `prod/test/workerRunner.test.ts`
+
+## Coverage added
+
+- `selectWorkerTask` returns `null` without throwing when a zero-energy worker has no sources.
+- `selectWorkerTask` returns `null` without throwing when an energy-carrying worker has no energy sinks, construction sites, or owned controller.
+- `runWorker` leaves no task assigned and does not throw in both no-target task-selection cases.
+- `runWorker` clears stale `transfer`, `build`, and `upgrade` tasks in a controllerless/no-target room without calling `transfer`, `build`, `upgradeController`, or `moveTo`.
+
+No production source change was required; the existing worker task selection and stale-target handling already matched the desired behavior. The slice makes that runtime safety contract explicit and regression-tested.
+
+## Verification
+
+Run from `prod/` after the Codex commit:
+
+```text
+npm run typecheck
+npm test -- --runInBand
+npm run build
+```
+
+Result: passed.
+
+- Jest: 12 suites passed, 66 tests passed.
+- Build: `prod/dist/main.js` built successfully and remained functionally unchanged because only tests changed.
+
+## Follow-up
+
+Continue the priority queue with one of:
+
+1. merge/reconcile the private-server smoke harness branch once review/CI gates allow it;
+2. run one more live-token runtime-monitor smoke and schedule `#runtime-summary` / `[SILENT]` no-alert `#runtime-alerts` jobs;
+3. add further deterministic hardening only when runtime observation exposes concrete risks.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T09:44:09+08:00
+Last updated: 2026-04-26T09:47:06+08:00
 
 ## Current active objective
 
@@ -175,6 +175,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   2. schedule the now live-smoked runtime monitor through dedicated `#runtime-summary` jobs and an alert scheduler/wrapper that converts `alert=false` JSON into a final `[SILENT]` response for `#runtime-alerts`, without creating cron jobs from the continuation worker
   3. continue deterministic Jest hardening for risks found during longer real-runtime observation
 - Latest deterministic hardening slice: Codex commit `12a2c4a` (`test: harden worker no-target fallbacks`) plus review follow-up `test: cover stale harvest worker tasks` added Jest coverage for no-source/no-controller/no-target worker fallback behavior, including stale harvest targets. Process note: `docs/process/2026-04-26-worker-no-target-hardening.md`.
+- PR #7 conflict refresh note: `docs/process/2026-04-26-pr7-conflict-refresh.md`; Codex merge commit `6a54b8d` brought `test/runtime-risk-hardening-20260426` up to `origin/main`, preserved latest CI/P0/runtime-monitor docs, passed prod verification with 12 suites / 67 tests, and pushed the branch. GitHub Actions `prod-ci` passed; CodeRabbit status was pending immediately after push.
 - Runtime monitor live-token smoke: `docs/process/2026-04-26-runtime-monitor-live-smoke.md`; `self-test` passed (8 tests), live summary rendered `runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png` in the first pass and `runtime-artifacts/screeps-monitor-live-smoke-20260426/summary-shardX-E48S28.png` in the 09:32 repeat pass; live alert returned `alert: false` with no warnings at official ticks `108687` and `109202` for `shardX/E48S28`; repeat prod verification passed typecheck, 12 suites / 59 tests, and build.
 - Verification target if code changes are made:
   - `cd prod && npm run typecheck`

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T07:11:23+08:00
+Last updated: 2026-04-26T07:20:20+08:00
 
 ## Current active objective
 
@@ -163,7 +163,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
 - Durable roadmap: `docs/ops/roadmap.md`
 - Latest verification:
   - `cd prod && npm run typecheck`: passed
-  - `cd prod && npm test -- --runInBand`: passed, 12 suites / 59 tests after two parallel Codex hardening commits
+  - `cd prod && npm test -- --runInBand`: passed, 12 suites / 67 tests after the stale-harvest worker task coverage follow-up
   - `cd prod && npm run build`: passed
   - Docker Compose startup with default `version: latest`: Mongo/Redis reached healthy; Screeps container restarted with default `screeps@4.3.0` engine mismatch (`>=22.9.0` required, `12.22.12` provided)
   - Dockerized launcher install preflight: `screeps-launcher apply` passed with explicit `version: 4.2.21`, `nodeVersion: Erbium`, and pinned package resolutions
@@ -174,7 +174,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   1. automate the pinned private-server smoke harness and redacted observation capture
   2. run one more live-token runtime-monitor smoke, then schedule `#runtime-summary` / `[SILENT]` no-alert `#runtime-alerts` jobs
   3. continue deterministic Jest hardening for risks found during longer real-runtime observation
-- Latest deterministic hardening slice: Codex commit `12a2c4a` (`test: harden worker no-target fallbacks`) added Jest coverage for no-source/no-controller/no-target worker fallback behavior. Process note: `docs/process/2026-04-26-worker-no-target-hardening.md`.
+- Latest deterministic hardening slice: Codex commit `12a2c4a` (`test: harden worker no-target fallbacks`) plus review follow-up `test: cover stale harvest worker tasks` added Jest coverage for no-source/no-controller/no-target worker fallback behavior, including stale harvest targets. Process note: `docs/process/2026-04-26-worker-no-target-hardening.md`.
 - Verification target if code changes are made:
   - `cd prod && npm run typecheck`
   - `cd prod && npm test -- --runInBand`

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T05:23:37+08:00
+Last updated: 2026-04-26T07:11:23+08:00
 
 ## Current active objective
 
@@ -174,6 +174,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   1. automate the pinned private-server smoke harness and redacted observation capture
   2. run one more live-token runtime-monitor smoke, then schedule `#runtime-summary` / `[SILENT]` no-alert `#runtime-alerts` jobs
   3. continue deterministic Jest hardening for risks found during longer real-runtime observation
+- Latest deterministic hardening slice: Codex commit `12a2c4a` (`test: harden worker no-target fallbacks`) added Jest coverage for no-source/no-controller/no-target worker fallback behavior. Process note: `docs/process/2026-04-26-worker-no-target-hardening.md`.
 - Verification target if code changes are made:
   - `cd prod && npm run typecheck`
   - `cd prod && npm test -- --runInBand`

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -24,6 +24,28 @@ describe('runWorker', () => {
     expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('leaves worker untasked when it has no energy and no sources', () => {
+    const creep = {
+      memory: {},
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room: { find: jest.fn().mockReturnValue([]) }
+    } as unknown as Creep;
+
+    expect(() => runWorker(creep)).not.toThrow();
+    expect(creep.memory.task).toBeUndefined();
+  });
+
+  it('leaves worker untasked when it has energy and no spending targets or controller', () => {
+    const creep = {
+      memory: {},
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: { find: jest.fn().mockReturnValue([]) }
+    } as unknown as Creep;
+
+    expect(() => runWorker(creep)).not.toThrow();
+    expect(creep.memory.task).toBeUndefined();
+  });
+
   it('moves toward harvest target when not in range', () => {
     const source = { id: 'source1' } as Source;
     const creep = {
@@ -176,6 +198,39 @@ describe('runWorker', () => {
 
     expect(creep.memory.task).toBeUndefined();
   });
+
+  it.each([
+    { type: 'transfer', targetId: 'missing-transfer' as Id<AnyStoreStructure> },
+    { type: 'build', targetId: 'missing-site' as Id<ConstructionSite> },
+    { type: 'upgrade', targetId: 'missing-controller' as Id<StructureController> }
+  ] satisfies CreepTaskMemory[])(
+    'clears stale $type task in a controllerless room without executing it',
+    (task) => {
+      const creep = {
+        memory: { task },
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(50),
+          getFreeCapacity: jest.fn().mockReturnValue(50)
+        },
+        room: { find: jest.fn().mockReturnValue([]) },
+        build: jest.fn(),
+        transfer: jest.fn(),
+        upgradeController: jest.fn(),
+        moveTo: jest.fn()
+      } as unknown as Creep;
+      (globalThis as unknown as { Game: Partial<Game> }).Game = {
+        getObjectById: jest.fn().mockReturnValue(null)
+      };
+
+      expect(() => runWorker(creep)).not.toThrow();
+
+      expect(creep.memory.task).toBeUndefined();
+      expect(creep.build).not.toHaveBeenCalled();
+      expect(creep.transfer).not.toHaveBeenCalled();
+      expect(creep.upgradeController).not.toHaveBeenCalled();
+      expect(creep.moveTo).not.toHaveBeenCalled();
+    }
+  );
 
   it('switches from harvest when creep is full', () => {
     const spawn = {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -200,6 +200,7 @@ describe('runWorker', () => {
   });
 
   it.each([
+    { type: 'harvest', targetId: 'missing-source' as Id<Source> },
     { type: 'transfer', targetId: 'missing-transfer' as Id<AnyStoreStructure> },
     { type: 'build', targetId: 'missing-site' as Id<ConstructionSite> },
     { type: 'upgrade', targetId: 'missing-controller' as Id<StructureController> }
@@ -209,22 +210,24 @@ describe('runWorker', () => {
       const creep = {
         memory: { task },
         store: {
-          getUsedCapacity: jest.fn().mockReturnValue(50),
+          getUsedCapacity: jest.fn().mockReturnValue(task.type === 'harvest' ? 0 : 50),
           getFreeCapacity: jest.fn().mockReturnValue(50)
         },
         room: { find: jest.fn().mockReturnValue([]) },
+        harvest: jest.fn(),
         build: jest.fn(),
         transfer: jest.fn(),
         upgradeController: jest.fn(),
         moveTo: jest.fn()
       } as unknown as Creep;
-      (globalThis as unknown as { Game: Partial<Game> }).Game = {
-        getObjectById: jest.fn().mockReturnValue(null)
-      };
+      const getObjectById = jest.fn().mockReturnValue(null);
+      (globalThis as unknown as { Game: Partial<Game> }).Game = { getObjectById };
 
       expect(() => runWorker(creep)).not.toThrow();
 
+      expect(getObjectById).toHaveBeenCalledWith(task.targetId);
       expect(creep.memory.task).toBeUndefined();
+      expect(creep.harvest).not.toHaveBeenCalled();
       expect(creep.build).not.toHaveBeenCalled();
       expect(creep.transfer).not.toHaveBeenCalled();
       expect(creep.upgradeController).not.toHaveBeenCalled();

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -20,6 +20,19 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('selects no task when worker has no energy and no sources', () => {
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room: { find: jest.fn().mockReturnValue([]) }
+    } as unknown as Creep;
+    let task: CreepTaskMemory | null | undefined;
+
+    expect(() => {
+      task = selectWorkerTask(creep);
+    }).not.toThrow();
+    expect(task).toBeNull();
+  });
+
   it('selects transfer when worker has energy and spawn needs energy', () => {
     const spawn = {
       id: 'spawn1',
@@ -52,5 +65,18 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('selects no task when worker has energy and the room has no spending targets or controller', () => {
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: { find: jest.fn().mockReturnValue([]) }
+    } as unknown as Creep;
+    let task: CreepTaskMemory | null | undefined;
+
+    expect(() => {
+      task = selectWorkerTask(creep);
+    }).not.toThrow();
+    expect(task).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add deterministic worker task tests for no-source/no-controller/no-target rooms
- add worker runner coverage proving stale spending tasks are cleared without actions or movement when no fallback target exists
- record active-state, roadmap, and process-note updates for this slice

## Verification
- cd prod && npm run typecheck
- cd prod && npm test -- --runInBand (12 suites / 66 tests)
- cd prod && npm run build

## Notes
- Codex-authored production/test commit: 12a2c4a test: harden worker no-target fallbacks
- Hermes-authored docs commit: a2a91ce docs: record worker no-target hardening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test suite to 67 tests (up from 59), with new coverage for worker edge cases including scenarios with limited resources and stale target handling.

* **Documentation**
  * Updated roadmap and process documentation reflecting completed worker hardening verification work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->