### PR TITLE
ci: add production verification workflow

### DIFF
--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -53,3 +53,6 @@ jobs:
 
       - name: Build bundled Screeps artifact
         run: npm run build
+
+      - name: Verify build artifact
+        run: test -f dist/main.js

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.9.0"
+          node-version: "20"
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -1,0 +1,54 @@
+name: prod-ci
+
+on:
+  pull_request:
+    paths:
+      - "prod/**"
+      - ".github/workflows/prod-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "prod/**"
+      - ".github/workflows/prod-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-prod:
+    name: Verify prod TypeScript, Jest, and bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    defaults:
+      run:
+        working-directory: prod
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: prod/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run Jest in-band
+        run: npm test -- --runInBand
+
+      - name: Build bundled Screeps artifact
+        run: npm run build

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -37,12 +37,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: prod/package-lock.json
+          node-version: "22.9.0"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-audit --no-fund
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -40,10 +40,10 @@ jobs:
           node-version: "20"
 
       - name: Install dependencies
-        run: npm install --include=dev --no-audit --no-fund
+        run: yarn install --non-interactive --no-progress
 
       - name: Verify dependency tree
-        run: npm ls --depth=0 typescript jest @types/jest @types/screeps esbuild
+        run: yarn list --pattern "typescript|jest|@types/jest|@types/screeps|esbuild"
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -40,7 +40,10 @@ jobs:
           node-version: "20"
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm install --include=dev --no-audit --no-fund
+
+      - name: Verify dependency tree
+        run: npm ls --depth=0 typescript jest @types/jest @types/screeps esbuild
 
       - name: Typecheck
         run: npm run typecheck

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ This directory is organized by purpose so research, decisions, operations, and b
 - `ops/discord-project-spec.md`
 - `ops/discord-server-setup-guide.md`
 - `ops/discord-server-configuration.md`
+- `ops/github-actions-prod-ci.md`
 - `ops/mvp-skeleton-implementation-plan.md`
 - `ops/private-server-smoke-test.md`
 - `ops/roadmap.md`
@@ -62,6 +63,7 @@ This directory is organized by purpose so research, decisions, operations, and b
 - `process/2026-04-26-telemetry-mvp.md`
 - `process/2026-04-26-agent-operations-restructure.md`
 - `process/2026-04-26-parallel-throughput-and-private-smoke.md`
+- `process/2026-04-26-prod-ci-workflow.md`
 - `process/active-work-state.md`
 
 ## Rules

--- a/docs/ops/github-actions-prod-ci.md
+++ b/docs/ops/github-actions-prod-ci.md
@@ -14,7 +14,7 @@ This repository uses a pull-request-oriented workflow. Production bot changes un
   - manual `workflow_dispatch`
 - Runner: `ubuntu-latest`
 - Node.js: `20`
-- Dependency install: `npm install --include=dev --no-audit --no-fund` in `prod/`; the workflow uses stable CI tooling for the TypeScript/Jest/bundle gate and verifies the expected dev dependency tree before typechecking. Private-server runtime validation remains a separate Node 22.9+ concern when testing current `screeps` server packages.
+- Dependency install: `yarn install --non-interactive --no-progress` in `prod/`; GitHub-hosted npm repeatedly hit an npm-internal `Exit handler never called` failure, so the workflow uses the runner-provided Yarn for dependency materialization while still running the package's npm scripts for typecheck/test/build. Private-server runtime validation remains a separate Node 22.9+ concern when testing current `screeps` server packages.
 
 ## Required checks
 

--- a/docs/ops/github-actions-prod-ci.md
+++ b/docs/ops/github-actions-prod-ci.md
@@ -13,8 +13,8 @@ This repository uses a pull-request-oriented workflow. Production bot changes un
   - pushes to `main` that touch `prod/**` or the workflow itself
   - manual `workflow_dispatch`
 - Runner: `ubuntu-latest`
-- Node.js: `22`
-- Dependency install: `npm ci` in `prod/`
+- Node.js: `22.9.0`
+- Dependency install: `npm ci --no-audit --no-fund` in `prod/`; the explicit patch version and no-audit/no-fund flags avoid npm/cache nondeterminism observed in the first CI run.
 
 ## Required checks
 

--- a/docs/ops/github-actions-prod-ci.md
+++ b/docs/ops/github-actions-prod-ci.md
@@ -14,7 +14,7 @@ This repository uses a pull-request-oriented workflow. Production bot changes un
   - manual `workflow_dispatch`
 - Runner: `ubuntu-latest`
 - Node.js: `20`
-- Dependency install: `npm ci --no-audit --no-fund` in `prod/`; the workflow uses stable CI tooling for the TypeScript/Jest/bundle gate. Private-server runtime validation remains a separate Node 22.9+ concern when testing current `screeps` server packages.
+- Dependency install: `npm install --include=dev --no-audit --no-fund` in `prod/`; the workflow uses stable CI tooling for the TypeScript/Jest/bundle gate and verifies the expected dev dependency tree before typechecking. Private-server runtime validation remains a separate Node 22.9+ concern when testing current `screeps` server packages.
 
 ## Required checks
 

--- a/docs/ops/github-actions-prod-ci.md
+++ b/docs/ops/github-actions-prod-ci.md
@@ -25,9 +25,10 @@ cd prod
 npm run typecheck
 npm test -- --runInBand
 npm run build
+test -f dist/main.js
 ```
 
-The in-band Jest command matches the local autonomous-worker gate and avoids worker-process nondeterminism in CI.
+The in-band Jest command matches the local autonomous-worker gate and avoids worker-process nondeterminism in CI. The artifact assertion makes the deployable Screeps bundle an explicit CI output condition.
 
 ## Branch protection follow-up
 

--- a/docs/ops/github-actions-prod-ci.md
+++ b/docs/ops/github-actions-prod-ci.md
@@ -13,8 +13,8 @@ This repository uses a pull-request-oriented workflow. Production bot changes un
   - pushes to `main` that touch `prod/**` or the workflow itself
   - manual `workflow_dispatch`
 - Runner: `ubuntu-latest`
-- Node.js: `22.9.0`
-- Dependency install: `npm ci --no-audit --no-fund` in `prod/`; the explicit patch version and no-audit/no-fund flags avoid npm/cache nondeterminism observed in the first CI run.
+- Node.js: `20`
+- Dependency install: `npm ci --no-audit --no-fund` in `prod/`; the workflow uses stable CI tooling for the TypeScript/Jest/bundle gate. Private-server runtime validation remains a separate Node 22.9+ concern when testing current `screeps` server packages.
 
 ## Required checks
 

--- a/docs/ops/github-actions-prod-ci.md
+++ b/docs/ops/github-actions-prod-ci.md
@@ -1,0 +1,40 @@
+# GitHub Actions production CI
+
+Last updated: 2026-04-26T07:44:52+08:00
+
+This repository uses a pull-request-oriented workflow. Production bot changes under `prod/` must be verified before merge with the same local gate used by continuation workers.
+
+## Workflow
+
+- File: `.github/workflows/prod-ci.yml`
+- Name: `prod-ci`
+- Triggers:
+  - pull requests that touch `prod/**` or the workflow itself
+  - pushes to `main` that touch `prod/**` or the workflow itself
+  - manual `workflow_dispatch`
+- Runner: `ubuntu-latest`
+- Node.js: `22`
+- Dependency install: `npm ci` in `prod/`
+
+## Required checks
+
+The CI job runs the release-quality production gate:
+
+```bash
+cd prod
+npm run typecheck
+npm test -- --runInBand
+npm run build
+```
+
+The in-band Jest command matches the local autonomous-worker gate and avoids worker-process nondeterminism in CI.
+
+## Branch protection follow-up
+
+After this workflow is merged to `main`, configure branch protection for `main` so PRs cannot merge unless the `Verify prod TypeScript, Jest, and bundle` job passes. GitHub API or `gh` authentication is still required for Hermes to configure this automatically.
+
+## Notes
+
+- The workflow intentionally does not upload `prod/dist/main.js`; deployment remains a separate human-authorized action.
+- The workflow does not read Screeps or Steam secrets.
+- If future runtime-monitor or private-smoke scripts become required merge gates, add separate jobs rather than overloading the production TypeScript/Jest/build check.

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -1,6 +1,6 @@
 # Screeps Project Roadmap
 
-Last updated: 2026-04-25T21:30:55Z
+Last updated: 2026-04-25T23:44:52Z
 
 This roadmap is the durable counterpart to the Discord `#roadmap` channel. It summarizes completed milestones, current blockers, next autonomous slices, and the required reporting behavior for main-agent/subagent work.
 
@@ -14,7 +14,7 @@ This roadmap is the durable counterpart to the Discord `#roadmap` channel. It su
   - `cd prod && npm run build` — passing
 - Latest production/test milestone: parallel Codex hardening commits `7d2a04d test: harden body builder invariants` and `4706868 test: harden worker runner task execution`; verification now passes with 12 suites / 59 tests
 - Latest validation milestone: pinned Dockerized private-server smoke now initializes rooms via `utils.importMapFile`, places a local spawn, observes owned bot creeps, and has run past private `gametime: 5267` with one RCL 2 owned room
-- Latest documentation milestone: longer private-server observation note in `docs/process/2026-04-26-private-server-long-observation.md`
+- Latest documentation milestone: production CI workflow/runbook added on branch `chore/add-prod-ci`
 - Active state file: `docs/process/active-work-state.md`
 - Current top priority: continue high-throughput validation while keeping P0 agent communication/cron/Discord visibility healthy
 
@@ -196,8 +196,8 @@ Current access findings:
 Roadmap tasks:
 
 1. establish the canonical worktree path convention, e.g. `/root/screeps-worktrees/<topic>`;
-2. add CI configuration under `.github/workflows/` for `prod` typecheck, Jest, and build;
-3. add or update runbooks documenting the worktree/PR/CI lifecycle;
+2. add CI configuration under `.github/workflows/` for `prod` typecheck, Jest, and build — branch `chore/add-prod-ci` adds `.github/workflows/prod-ci.yml`;
+3. add or update runbooks documenting the worktree/PR/CI lifecycle — branch `chore/add-prod-ci` adds `docs/ops/github-actions-prod-ci.md`;
 4. configure branch protection on `main` after CI exists: require PR review/owner merge policy as desired and require the CI check to pass;
 5. use the GitHub API/CLI to create PRs, inspect PR review comments/discussions, wait at least 15 minutes after PR creation, monitor CI once available, and merge only after the configured gates are satisfied.
 

--- a/docs/process/2026-04-26-prod-ci-workflow.md
+++ b/docs/process/2026-04-26-prod-ci-workflow.md
@@ -12,8 +12,8 @@ The roadmap now requires repository changes to move through worktrees and pull r
 Added `.github/workflows/prod-ci.yml` with a narrow production verification job:
 
 1. check out the repository;
-2. set up Node.js 22;
-3. install `prod/` dependencies with `npm ci`;
+2. set up Node.js 22.9.0;
+3. install `prod/` dependencies with `npm ci --no-audit --no-fund`;
 4. run `npm run typecheck`;
 5. run `npm test -- --runInBand`;
 6. run `npm run build`.
@@ -41,6 +41,7 @@ Results on this slice:
 - Typecheck: passed
 - Jest: passed, 12 suites / 59 tests
 - Build: passed
+- GitHub Actions first run: failed in `npm ci` with npm's `Exit handler never called`; workflow follow-up pinned Node to `22.9.0`, removed setup-node npm caching, and uses `npm ci --no-audit --no-fund` before rerunning CI.
 
 ## Follow-up
 

--- a/docs/process/2026-04-26-prod-ci-workflow.md
+++ b/docs/process/2026-04-26-prod-ci-workflow.md
@@ -13,10 +13,11 @@ Added `.github/workflows/prod-ci.yml` with a narrow production verification job:
 
 1. check out the repository;
 2. set up Node.js 20 for stable CI tooling;
-3. install `prod/` dependencies with `npm ci --no-audit --no-fund`;
-4. run `npm run typecheck`;
-5. run `npm test -- --runInBand`;
-6. run `npm run build`.
+3. install `prod/` dependencies with `npm install --include=dev --no-audit --no-fund`;
+4. verify the expected dev dependency tree;
+5. run `npm run typecheck`;
+6. run `npm test -- --runInBand`;
+7. run `npm run build`.
 
 Added `docs/ops/github-actions-prod-ci.md` to document the trigger conditions, local equivalent commands, branch-protection follow-up, and non-goals such as deployment or secret access.
 
@@ -41,7 +42,7 @@ Results on this slice:
 - Typecheck: passed
 - Jest: passed, 12 suites / 59 tests
 - Build: passed
-- GitHub Actions first two runs: failed in `npm ci` on the Node 22 runner path with npm's `Exit handler never called`; workflow follow-up moved the CI tooling lane to Node 20 while leaving Node 22.9+ private-server runtime validation as a separate gate.
+- GitHub Actions first three runs: exposed CI install instability. Node 22/`npm ci` and Node 20/`npm ci` both produced npm's `Exit handler never called`; one run continued with an incomplete dependency tree and typecheck failed. The workflow now uses `npm install --include=dev --no-audit --no-fund` plus an explicit `npm ls` dependency-tree check before typechecking.
 
 ## Follow-up
 

--- a/docs/process/2026-04-26-prod-ci-workflow.md
+++ b/docs/process/2026-04-26-prod-ci-workflow.md
@@ -17,7 +17,8 @@ Added `.github/workflows/prod-ci.yml` with a narrow production verification job:
 4. verify the expected dependency tree with `yarn list`;
 5. run `npm run typecheck`;
 6. run `npm test -- --runInBand`;
-7. run `npm run build`.
+7. run `npm run build`;
+8. assert `dist/main.js` exists.
 
 Added `docs/ops/github-actions-prod-ci.md` to document the trigger conditions, local equivalent commands, branch-protection follow-up, and non-goals such as deployment or secret access.
 

--- a/docs/process/2026-04-26-prod-ci-workflow.md
+++ b/docs/process/2026-04-26-prod-ci-workflow.md
@@ -13,8 +13,8 @@ Added `.github/workflows/prod-ci.yml` with a narrow production verification job:
 
 1. check out the repository;
 2. set up Node.js 20 for stable CI tooling;
-3. install `prod/` dependencies with `npm install --include=dev --no-audit --no-fund`;
-4. verify the expected dev dependency tree;
+3. install `prod/` dependencies with runner-provided Yarn;
+4. verify the expected dependency tree with `yarn list`;
 5. run `npm run typecheck`;
 6. run `npm test -- --runInBand`;
 7. run `npm run build`.
@@ -42,7 +42,7 @@ Results on this slice:
 - Typecheck: passed
 - Jest: passed, 12 suites / 59 tests
 - Build: passed
-- GitHub Actions first three runs: exposed CI install instability. Node 22/`npm ci` and Node 20/`npm ci` both produced npm's `Exit handler never called`; one run continued with an incomplete dependency tree and typecheck failed. The workflow now uses `npm install --include=dev --no-audit --no-fund` plus an explicit `npm ls` dependency-tree check before typechecking.
+- GitHub Actions first four runs: exposed CI install instability. Node 22/`npm ci`, Node 20/`npm ci`, and Node 20/`npm install` all produced npm's internal `Exit handler never called`; one run continued with an incomplete dependency tree and typecheck failed. The workflow now uses runner-provided Yarn for dependency materialization, then runs the existing npm scripts.
 
 ## Follow-up
 

--- a/docs/process/2026-04-26-prod-ci-workflow.md
+++ b/docs/process/2026-04-26-prod-ci-workflow.md
@@ -12,7 +12,7 @@ The roadmap now requires repository changes to move through worktrees and pull r
 Added `.github/workflows/prod-ci.yml` with a narrow production verification job:
 
 1. check out the repository;
-2. set up Node.js 22.9.0;
+2. set up Node.js 20 for stable CI tooling;
 3. install `prod/` dependencies with `npm ci --no-audit --no-fund`;
 4. run `npm run typecheck`;
 5. run `npm test -- --runInBand`;
@@ -41,7 +41,7 @@ Results on this slice:
 - Typecheck: passed
 - Jest: passed, 12 suites / 59 tests
 - Build: passed
-- GitHub Actions first run: failed in `npm ci` with npm's `Exit handler never called`; workflow follow-up pinned Node to `22.9.0`, removed setup-node npm caching, and uses `npm ci --no-audit --no-fund` before rerunning CI.
+- GitHub Actions first two runs: failed in `npm ci` on the Node 22 runner path with npm's `Exit handler never called`; workflow follow-up moved the CI tooling lane to Node 20 while leaving Node 22.9+ private-server runtime validation as a separate gate.
 
 ## Follow-up
 

--- a/docs/process/2026-04-26-prod-ci-workflow.md
+++ b/docs/process/2026-04-26-prod-ci-workflow.md
@@ -1,0 +1,49 @@
+# Production CI workflow slice
+
+Date: 2026-04-26
+Branch: `chore/add-prod-ci`
+
+## Context
+
+The roadmap now requires repository changes to move through worktrees and pull requests rather than direct commits to `main`. The next missing gate was CI for the production Screeps bot so PRs can be checked consistently before merge.
+
+## Work performed
+
+Added `.github/workflows/prod-ci.yml` with a narrow production verification job:
+
+1. check out the repository;
+2. set up Node.js 22;
+3. install `prod/` dependencies with `npm ci`;
+4. run `npm run typecheck`;
+5. run `npm test -- --runInBand`;
+6. run `npm run build`.
+
+Added `docs/ops/github-actions-prod-ci.md` to document the trigger conditions, local equivalent commands, branch-protection follow-up, and non-goals such as deployment or secret access.
+
+Updated:
+
+- `docs/README.md`
+- `docs/ops/roadmap.md`
+- `docs/process/active-work-state.md`
+
+## Verification
+
+Local verification used the existing production gate from `prod/`:
+
+```bash
+npm run typecheck
+npm test -- --runInBand
+npm run build
+```
+
+Results on this slice:
+
+- Typecheck: passed
+- Jest: passed, 12 suites / 59 tests
+- Build: passed
+
+## Follow-up
+
+- Push branch `chore/add-prod-ci`.
+- Create a PR once GitHub API/CLI auth is available, or manually open the compare URL.
+- After the workflow merges to `main`, configure branch protection so `main` requires the production CI job before merge.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T05:23:37+08:00
+Last updated: 2026-04-26T07:44:52+08:00
 
 ## Current active objective
 
@@ -178,6 +178,24 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   - `cd prod && npm run typecheck`
   - `cd prod && npm test -- --runInBand`
   - `cd prod && npm run build`
+
+### worktree-pr-ci-gate
+
+- Status: CI workflow/runbook branch prepared and pushed for PR creation
+- Process note: `docs/process/2026-04-26-prod-ci-workflow.md`
+- Branch: `chore/add-prod-ci`
+- Implemented:
+  - `.github/workflows/prod-ci.yml` for PR/push/manual verification of `prod` typecheck, in-band Jest, and build on Node.js 22
+  - `docs/ops/github-actions-prod-ci.md` runbook documenting triggers, required checks, and branch-protection follow-up
+  - docs index and roadmap references for the new CI gate
+- Verification:
+  - `cd prod && npm run typecheck`: passed
+  - `cd prod && npm test -- --runInBand`: passed, 12 suites / 59 tests
+  - `cd prod && npm run build`: passed
+- Follow-up:
+  - create PR for `chore/add-prod-ci` after GitHub token/CLI access is available, or use the compare URL from the continuation report
+  - once merged, configure `main` branch protection to require the CI job before merge
+
 - Reporting channels in non-cron/manual context: `#task-queue`, `#dev-log`, and `#roadmap` as appropriate; final owner decisions go to `#decisions`.
 - Subagent completion rule: after every subagent completes, main agent must review the result and report relevant task status, dev/test details, roadmap impact, research findings, or decision items to the corresponding Discord channel(s).
 - 4-hour summary due only if a new task is started and remains active after 4 hours.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -185,7 +185,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
 - Process note: `docs/process/2026-04-26-prod-ci-workflow.md`
 - Branch: `chore/add-prod-ci`
 - Implemented:
-  - `.github/workflows/prod-ci.yml` for PR/push/manual verification of `prod` typecheck, in-band Jest, and build on Node.js 20 CI tooling
+  - `.github/workflows/prod-ci.yml` for PR/push/manual verification of `prod` typecheck, in-band Jest, build, and `dist/main.js` artifact existence on Node.js 20 CI tooling
   - `docs/ops/github-actions-prod-ci.md` runbook documenting triggers, required checks, and branch-protection follow-up
   - docs index and roadmap references for the new CI gate
 - Verification:

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -185,7 +185,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
 - Process note: `docs/process/2026-04-26-prod-ci-workflow.md`
 - Branch: `chore/add-prod-ci`
 - Implemented:
-  - `.github/workflows/prod-ci.yml` for PR/push/manual verification of `prod` typecheck, in-band Jest, and build on Node.js 22.9.0
+  - `.github/workflows/prod-ci.yml` for PR/push/manual verification of `prod` typecheck, in-band Jest, and build on Node.js 20 CI tooling
   - `docs/ops/github-actions-prod-ci.md` runbook documenting triggers, required checks, and branch-protection follow-up
   - docs index and roadmap references for the new CI gate
 - Verification:

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -185,7 +185,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
 - Process note: `docs/process/2026-04-26-prod-ci-workflow.md`
 - Branch: `chore/add-prod-ci`
 - Implemented:
-  - `.github/workflows/prod-ci.yml` for PR/push/manual verification of `prod` typecheck, in-band Jest, and build on Node.js 22
+  - `.github/workflows/prod-ci.yml` for PR/push/manual verification of `prod` typecheck, in-band Jest, and build on Node.js 22.9.0
   - `docs/ops/github-actions-prod-ci.md` runbook documenting triggers, required checks, and branch-protection follow-up
   - docs index and roadmap references for the new CI gate
 - Verification:


### PR DESCRIPTION
## Summary
- adds GitHub Actions prod CI for Node 22 npm ci, typecheck, in-band Jest, and build
- documents the workflow and branch-protection follow-up
- updates roadmap, docs index, and active work state

## Verification
- cd prod && npm ci && npm run typecheck && npm test -- --runInBand && npm run build

## Notes
- workflow does not read Screeps/Steam secrets or deploy code
- branch protection follow-up should require the CI job after this merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a production CI verification workflow that runs typechecking, tests, and a production build.

* **Documentation**
  * Added comprehensive production CI runbook and process notes.
  * Updated docs index, roadmap, and active-work records with implementation status and next steps.

* **Chores**
  * Included instructions for updating main branch protection to require the production CI job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->