### PR TITLE
docs: record runtime monitor live smoke

### DIFF
--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -234,7 +234,7 @@ Docker/Compose, package installation, HTTP startup, local auth, code upload, roo
 
 1. package the pinned launcher config, map-file import, restart/resume, local user registration, code upload, spawn placement, stats polling, and redacted Mongo observation into an executable local smoke harness;
 2. observe several additional windows or reruns to ensure the path is stable across fresh data resets;
-3. configure or verify dedicated runtime-summary/runtime-alert scheduled jobs after the 2026-04-26 live-token monitor smoke succeeded (`summary` PNG rendered; `alert=false` with no warnings for `shardX/E48S28` at official tick `108687`);
+3. configure or verify dedicated runtime-summary/runtime-alert scheduled jobs after the 2026-04-26 live-token monitor smoke succeeded (`summary` PNG rendered; `alert=false` with no warnings for `shardX/E48S28` at official tick `108687`); for no-alert delivery, the scheduler/wrapper must convert the monitor JSON payload into a final `[SILENT]` response rather than expecting the current script to be silent by itself;
 4. if the pinned runtime later exposes simulation incompatibilities, then revisit a Node.js 22.9+ private-server image/toolchain for current `screeps@4.3.0`.
 
 Recommendation: keep private-server-first validation as the release-quality gate before future official MMO deployment, but treat the next engineering step as smoke automation/runtime monitoring rather than resolving basic room initialization.

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -14,6 +14,7 @@ This roadmap is the durable counterpart to the Discord `#roadmap` channel. It su
   - `cd prod && npm run build` — passing
 - Latest production/test milestone: parallel Codex hardening commits `7d2a04d test: harden body builder invariants` and `4706868 test: harden worker runner task execution`; verification now passes with 12 suites / 59 tests
 - Latest validation milestone: pinned Dockerized private-server smoke now initializes rooms via `utils.importMapFile`, places a local spawn, observes owned bot creeps, and has run past private `gametime: 5267` with one RCL 2 owned room
+- Latest runtime-monitor milestone: live-token monitor smoke succeeded for `shardX/E48S28` at official tick `108687`; summary rendered a PNG and alert returned `alert: false` with no warnings
 - Latest documentation milestone: production CI workflow/runbook added on branch `chore/add-prod-ci`
 - Active state file: `docs/process/active-work-state.md`
 - Current top priority: continue high-throughput validation while keeping P0 agent communication/cron/Discord visibility healthy
@@ -233,7 +234,7 @@ Docker/Compose, package installation, HTTP startup, local auth, code upload, roo
 
 1. package the pinned launcher config, map-file import, restart/resume, local user registration, code upload, spawn placement, stats polling, and redacted Mongo observation into an executable local smoke harness;
 2. observe several additional windows or reruns to ensure the path is stable across fresh data resets;
-3. run one more live-token runtime-monitor smoke, then schedule `scripts/screeps-runtime-monitor.py` for hourly `#runtime-summary` images and `[SILENT]` no-alert `#runtime-alerts` checks;
+3. configure or verify dedicated runtime-summary/runtime-alert scheduled jobs after the 2026-04-26 live-token monitor smoke succeeded (`summary` PNG rendered; `alert=false` with no warnings for `shardX/E48S28` at official tick `108687`);
 4. if the pinned runtime later exposes simulation incompatibilities, then revisit a Node.js 22.9+ private-server image/toolchain for current `screeps@4.3.0`.
 
 Recommendation: keep private-server-first validation as the release-quality gate before future official MMO deployment, but treat the next engineering step as smoke automation/runtime monitoring rather than resolving basic room initialization.

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -190,9 +190,10 @@ Requirement:
 Current access findings:
 
 - SSH git access is already configured for `git@github.com:lanyusea/screeps.git`; branch push via git should work.
-- GitHub CLI (`gh`) is not installed in this environment, and no GitHub API token is currently available to Hermes.
-- Without a GitHub API token or `gh` authentication, Hermes can push branches over SSH but cannot create PRs, inspect private/protected branch settings, enable auto-merge, or administer GitHub Actions settings.
-- The public GitHub API currently reports no GitHub Actions workflows for this repo, and the public branch listing reports `main` as unprotected; protection details require authenticated API access.
+- GitHub CLI (`gh`) is installed and authenticated as `lanyusea`; PR creation and review/check inspection worked for PR #10.
+- Git operations use SSH, and the authenticated `gh` token currently reports scopes `admin:public_key`, `gist`, `read:org`, and `repo`.
+- Branch push via git works; branch `docs/runtime-monitor-live-smoke-20260426` was pushed and PR #10 was created from this environment.
+- The public branch listing previously reported `main` as unprotected; protection administration should still be verified before relying on automation to merge or manage branch protection.
 
 Roadmap tasks:
 

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -1,6 +1,6 @@
 # Screeps Project Roadmap
 
-Last updated: 2026-04-25T23:44:52Z
+Last updated: 2026-04-26T01:32:58Z
 
 This roadmap is the durable counterpart to the Discord `#roadmap` channel. It summarizes completed milestones, current blockers, next autonomous slices, and the required reporting behavior for main-agent/subagent work.
 
@@ -14,7 +14,7 @@ This roadmap is the durable counterpart to the Discord `#roadmap` channel. It su
   - `cd prod && npm run build` — passing
 - Latest production/test milestone: parallel Codex hardening commits `7d2a04d test: harden body builder invariants` and `4706868 test: harden worker runner task execution`; verification now passes with 12 suites / 59 tests
 - Latest validation milestone: pinned Dockerized private-server smoke now initializes rooms via `utils.importMapFile`, places a local spawn, observes owned bot creeps, and has run past private `gametime: 5267` with one RCL 2 owned room
-- Latest runtime-monitor milestone: live-token monitor smoke succeeded for `shardX/E48S28` at official tick `108687`; summary rendered a PNG and alert returned `alert: false` with no warnings
+- Latest runtime-monitor milestone: live-token monitor smoke succeeded twice for `shardX/E48S28` at official ticks `108687` and `109202`; summary rendered PNGs and alert returned `alert: false` with no warnings
 - Latest documentation milestone: production CI workflow/runbook added on branch `chore/add-prod-ci`
 - Active state file: `docs/process/active-work-state.md`
 - Current top priority: continue high-throughput validation while keeping P0 agent communication/cron/Discord visibility healthy
@@ -170,7 +170,7 @@ Current result:
 - Room/map initialization is resolved for the pinned launcher path by pre-downloading `map-0b6758af.json`, setting `serverConfig.mapFile`, importing with `utils.importMapFile('/screeps/maps/map-0b6758af.json')`, restarting, and resuming simulation.
 - Follow-up observation reached `/stats` `gametime: 5267`, `totalRooms: 169`, `activeRooms: 1`, `ownedRooms: 1`, and one RCL 2 owned room.
 - Mongo room-object inspection showed owned `Spawn1` and three living bot-created `WORK/CARRY/MOVE` workers named `worker-E1S1-*`; post-restart log scanning found no current unhandled/type/reference/error hits.
-- Remaining work: automate the smoke harness and wire scheduled runtime-summary/runtime-alert monitoring after one more live-token monitor smoke, not unblock basic room initialization.
+- Remaining work: automate the smoke harness and wire scheduled runtime-summary/runtime-alert monitoring using the now-repeat-smoked live-token monitor path, not unblock basic room initialization.
 
 ## Active blockers and decisions
 
@@ -235,14 +235,14 @@ Docker/Compose, package installation, HTTP startup, local auth, code upload, roo
 
 1. package the pinned launcher config, map-file import, restart/resume, local user registration, code upload, spawn placement, stats polling, and redacted Mongo observation into an executable local smoke harness;
 2. observe several additional windows or reruns to ensure the path is stable across fresh data resets;
-3. configure or verify dedicated runtime-summary/runtime-alert scheduled jobs after the 2026-04-26 live-token monitor smoke succeeded (`summary` PNG rendered; `alert=false` with no warnings for `shardX/E48S28` at official tick `108687`); for no-alert delivery, the scheduler/wrapper must convert the monitor JSON payload into a final `[SILENT]` response rather than expecting the current script to be silent by itself;
+3. configure or verify dedicated runtime-summary/runtime-alert scheduled jobs after the 2026-04-26 live-token monitor smoke succeeded twice (`summary` PNGs rendered; `alert=false` with no warnings for `shardX/E48S28` at official ticks `108687` and `109202`); for no-alert delivery, the scheduler/wrapper must convert the monitor JSON payload into a final `[SILENT]` response rather than expecting the current script to be silent by itself;
 4. if the pinned runtime later exposes simulation incompatibilities, then revisit a Node.js 22.9+ private-server image/toolchain for current `screeps@4.3.0`.
 
 Recommendation: keep private-server-first validation as the release-quality gate before future official MMO deployment, but treat the next engineering step as smoke automation/runtime monitoring rather than resolving basic room initialization.
 
 ### Decision: next code priority
 
-Recommended next slice: automate the pinned private-server smoke harness and/or schedule the verified runtime monitor after one more live-token smoke. If new runtime failures appear during observation, convert them into deterministic Jest hardening tasks for Codex.
+Recommended next slice: finish review/PR routing for the pinned private-server smoke harness and configure or verify the already live-smoked runtime monitor through dedicated scheduler jobs. If new runtime failures appear during observation, convert them into deterministic Jest hardening tasks for Codex.
 
 Reason:
 

--- a/docs/process/2026-04-26-runtime-monitor-live-smoke.md
+++ b/docs/process/2026-04-26-runtime-monitor-live-smoke.md
@@ -29,13 +29,43 @@ python3 scripts/screeps-runtime-monitor.py alert --format json
 ## Results
 
 - Offline monitor self-test passed: 8 tests.
-- Live `summary` command succeeded and rendered `/root/screeps/runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png`.
-- Live summary payload reported:
+- Live `summary` command succeeded and rendered `/root/screeps/runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png` in the first pass.
+- First live summary payload reported:
   - room: `shardX/E48S28`
   - tick: `108687`
   - creeps: `3`
   - hostiles: `0`
   - objects: `8`
+  - structures: `2`
+  - warnings: none
+- First live `alert` command succeeded with no alert:
+  - `alert: false`
+  - reasons: none
+  - suppressed: false
+  - warnings: none
+  - state file: `/root/.hermes/screeps-runtime-monitor/state.json`
+
+## Repeat smoke on 2026-04-26T09:32:58+08:00
+
+Commands run from `/root/screeps` with local ignored secret/config sourced and no secret values printed:
+
+```bash
+python3 scripts/screeps-runtime-monitor.py self-test
+python3 scripts/screeps-runtime-monitor.py summary --room shardX/E48S28 --out-dir /root/screeps/runtime-artifacts/screeps-monitor-live-smoke-20260426
+python3 scripts/screeps-runtime-monitor.py alert --room shardX/E48S28 --out-dir /root/screeps/runtime-artifacts/screeps-monitor-live-smoke-20260426
+cd prod && npm run typecheck && npm test -- --runInBand && npm run build
+```
+
+Results:
+
+- Offline monitor self-test passed: 8 tests.
+- Live `summary` command succeeded and rendered `/root/screeps/runtime-artifacts/screeps-monitor-live-smoke-20260426/summary-shardX-E48S28.png`.
+- Live summary payload reported:
+  - room: `shardX/E48S28`
+  - tick: `109202`
+  - creeps: `4`
+  - hostiles: `0`
+  - objects: `9`
   - structures: `2`
   - warnings: none
 - Live `alert` command succeeded with no alert:
@@ -44,6 +74,10 @@ python3 scripts/screeps-runtime-monitor.py alert --format json
   - suppressed: false
   - warnings: none
   - state file: `/root/.hermes/screeps-runtime-monitor/state.json`
+- Production baseline verification still passes:
+  - `npm run typecheck`: passed
+  - `npm test -- --runInBand`: passed, 12 suites / 59 tests
+  - `npm run build`: passed
 
 ## Interpretation
 

--- a/docs/process/2026-04-26-runtime-monitor-live-smoke.md
+++ b/docs/process/2026-04-26-runtime-monitor-live-smoke.md
@@ -1,0 +1,58 @@
+# Runtime monitor live-token smoke
+
+Date: 2026-04-26
+Branch: `docs/runtime-monitor-live-smoke-20260426`
+
+## Goal
+
+Run one bounded live-token smoke of the existing external runtime monitor after the private-server validation path was unblocked, without printing secrets and without creating recursive cron jobs from the continuation worker.
+
+## Preconditions checked
+
+- Main worktree was clean before the slice.
+- Local secret/config was sourced from the existing ignored environment path without printing token values.
+- Safe selectors observed by the monitor path:
+  - `SCREEPS_API_URL=https://screeps.com`
+  - `SCREEPS_SHARD=shardX`
+  - `SCREEPS_ROOM=E48S28`
+
+## Commands run
+
+From `/root/screeps`:
+
+```bash
+python3 scripts/screeps-runtime-monitor.py self-test
+python3 scripts/screeps-runtime-monitor.py summary --format json
+python3 scripts/screeps-runtime-monitor.py alert --format json
+```
+
+## Results
+
+- Offline monitor self-test passed: 8 tests.
+- Live `summary` command succeeded and rendered `/root/screeps/runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png`.
+- Live summary payload reported:
+  - room: `shardX/E48S28`
+  - tick: `108687`
+  - creeps: `3`
+  - hostiles: `0`
+  - objects: `8`
+  - structures: `2`
+  - warnings: none
+- Live `alert` command succeeded with no alert:
+  - `alert: false`
+  - reasons: none
+  - suppressed: false
+  - warnings: none
+  - state file: `/root/.hermes/screeps-runtime-monitor/state.json`
+
+## Interpretation
+
+The runtime monitor is ready for scheduled delivery from a dedicated runtime-summary/runtime-alerts job: summary should deliver the rendered PNG to `discord:#runtime-summary`; alert should return exactly `[SILENT]` when `alert=false` and only deliver images/text to `discord:#runtime-alerts` for real anomalies.
+
+This continuation worker intentionally did **not** create or modify cron jobs, because the scheduled-worker prompt forbids recursive cron creation.
+
+## Follow-up
+
+1. In a separate scheduler-management slice, configure or verify the existing runtime-summary/runtime-alert jobs rather than doing it from this continuation worker.
+2. Keep generated monitor artifacts under ignored `runtime-artifacts/` and monitor state under `/root/.hermes/screeps-runtime-monitor/`.
+3. Continue using private-server-first validation before future release-quality MMO deployments.

--- a/docs/process/2026-04-26-runtime-monitor-live-smoke.md
+++ b/docs/process/2026-04-26-runtime-monitor-live-smoke.md
@@ -47,7 +47,7 @@ python3 scripts/screeps-runtime-monitor.py alert --format json
 
 ## Interpretation
 
-The runtime monitor is ready for scheduled delivery from a dedicated runtime-summary/runtime-alerts job: summary should deliver the rendered PNG to `discord:#runtime-summary`; alert should return exactly `[SILENT]` when `alert=false` and only deliver images/text to `discord:#runtime-alerts` for real anomalies.
+The runtime monitor is ready for scheduled delivery from a dedicated runtime-summary/runtime-alerts job: summary should deliver the rendered PNG to `discord:#runtime-summary`; the alert scheduler/wrapper should inspect the JSON payload and make the scheduled job's final response exactly `[SILENT]` when `alert=false`, while delivering images/text to `discord:#runtime-alerts` only for real anomalies. The monitor script itself currently emits JSON for `--format json`; quiet no-alert delivery is a scheduler/wrapper responsibility unless a future script flag adds that behavior directly.
 
 This continuation worker intentionally did **not** create or modify cron jobs, because the scheduled-worker prompt forbids recursive cron creation.
 

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T09:17:48+08:00
+Last updated: 2026-04-26T09:32:58+08:00
 
 ## Current active objective
 
@@ -174,7 +174,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   1. automate the pinned private-server smoke harness and redacted observation capture
   2. schedule the now live-smoked runtime monitor through dedicated `#runtime-summary` jobs and an alert scheduler/wrapper that converts `alert=false` JSON into a final `[SILENT]` response for `#runtime-alerts`, without creating cron jobs from the continuation worker
   3. continue deterministic Jest hardening for risks found during longer real-runtime observation
-- Runtime monitor live-token smoke: `docs/process/2026-04-26-runtime-monitor-live-smoke.md`; `self-test` passed (8 tests), live summary rendered `runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png`, and live alert returned `alert: false` with no warnings at official tick `108687` for `shardX/E48S28`.
+- Runtime monitor live-token smoke: `docs/process/2026-04-26-runtime-monitor-live-smoke.md`; `self-test` passed (8 tests), live summary rendered `runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png` in the first pass and `runtime-artifacts/screeps-monitor-live-smoke-20260426/summary-shardX-E48S28.png` in the 09:32 repeat pass; live alert returned `alert: false` with no warnings at official ticks `108687` and `109202` for `shardX/E48S28`; repeat prod verification passed typecheck, 12 suites / 59 tests, and build.
 - Verification target if code changes are made:
   - `cd prod && npm run typecheck`
   - `cd prod && npm test -- --runInBand`

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T09:12:32+08:00
+Last updated: 2026-04-26T09:17:48+08:00
 
 ## Current active objective
 
@@ -172,8 +172,9 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   - Runtime monitor self-test: `python3 scripts/screeps-runtime-monitor.py self-test` passed, 8 tests
 - Candidate next outputs:
   1. automate the pinned private-server smoke harness and redacted observation capture
-  2. run one more live-token runtime-monitor smoke, then schedule `#runtime-summary` / `[SILENT]` no-alert `#runtime-alerts` jobs
+  2. schedule the now live-smoked runtime monitor through dedicated `#runtime-summary` / `[SILENT]` no-alert `#runtime-alerts` jobs without creating cron jobs from the continuation worker
   3. continue deterministic Jest hardening for risks found during longer real-runtime observation
+- Runtime monitor live-token smoke: `docs/process/2026-04-26-runtime-monitor-live-smoke.md`; `self-test` passed (8 tests), live summary rendered `runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png`, and live alert returned `alert: false` with no warnings at official tick `108687` for `shardX/E48S28`.
 - Verification target if code changes are made:
   - `cd prod && npm run typecheck`
   - `cd prod && npm test -- --runInBand`

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -172,7 +172,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   - Runtime monitor self-test: `python3 scripts/screeps-runtime-monitor.py self-test` passed, 8 tests
 - Candidate next outputs:
   1. automate the pinned private-server smoke harness and redacted observation capture
-  2. schedule the now live-smoked runtime monitor through dedicated `#runtime-summary` / `[SILENT]` no-alert `#runtime-alerts` jobs without creating cron jobs from the continuation worker
+  2. schedule the now live-smoked runtime monitor through dedicated `#runtime-summary` jobs and an alert scheduler/wrapper that converts `alert=false` JSON into a final `[SILENT]` response for `#runtime-alerts`, without creating cron jobs from the continuation worker
   3. continue deterministic Jest hardening for risks found during longer real-runtime observation
 - Runtime monitor live-token smoke: `docs/process/2026-04-26-runtime-monitor-live-smoke.md`; `self-test` passed (8 tests), live summary rendered `runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png`, and live alert returned `alert: false` with no warnings at official tick `108687` for `shardX/E48S28`.
 - Verification target if code changes are made:


### PR DESCRIPTION
## Summary
- ran the existing runtime monitor self-test and live-token summary/alert smoke for shardX/E48S28
- recorded the no-secret results in a dated process note
- updated active work state and roadmap to move runtime-monitor follow-up from live smoke to scheduler verification/configuration

## Verification
- python3 scripts/screeps-runtime-monitor.py self-test
- python3 scripts/screeps-runtime-monitor.py summary --format json
- python3 scripts/screeps-runtime-monitor.py alert --format json

No prod code changed; full prod typecheck/Jest/build was not rerun for this docs-only branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project roadmap and process documentation to reflect completion of runtime monitoring validation testing.
  * Added documentation for runtime monitor verification procedures.
  * Updated status tracking with successful runtime monitoring test outcomes and scheduled integration plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->