### PR TITLE
docs: record PR #9 merge follow-up

### DIFF
--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -15,7 +15,7 @@ This roadmap is the durable counterpart to the Discord `#roadmap` channel. It su
 - Latest production/test milestones: Codex commit `12a2c4a test: harden worker no-target fallbacks` plus review follow-up `test: cover stale harvest worker tasks` added deterministic no-source/no-controller/no-target worker fallback coverage, including stale harvest targets; refreshed PR #9 commits `a95afdc test: handle full transfer result race` and `83eb0d5 fix: use screeps err full constant` clear stale transfer tasks when `creep.transfer` returns the Screeps global `ERR_FULL`
 - Latest validation milestone: pinned Dockerized private-server smoke now initializes rooms via `utils.importMapFile`, places a local spawn, observes owned bot creeps, and has run past private `gametime: 5267` with one RCL 2 owned room
 - Latest runtime-monitor milestone: live-token monitor smoke succeeded twice for `shardX/E48S28` at official ticks `108687` and `109202`; summary rendered PNGs and alert returned `alert: false` with no warnings
-- Latest documentation milestone: production CI workflow/runbook added on branch `chore/add-prod-ci`
+- Latest documentation milestone: PR #9 merge follow-up recorded on branch `docs/pr9-merge-record-20260426`; production CI workflow/runbook added earlier on branch `chore/add-prod-ci`
 - Active state file: `docs/process/active-work-state.md`
 - Current top priority: continue high-throughput validation while keeping P0 agent communication/cron/Discord visibility healthy
 

--- a/docs/process/2026-04-26-pr9-merge-follow-up.md
+++ b/docs/process/2026-04-26-pr9-merge-follow-up.md
@@ -1,0 +1,43 @@
+# PR #9 Merge Follow-up
+
+Timestamp: 2026-04-26T10:44:46+08:00
+
+## Summary
+
+The scheduled continuation worker finalized the deterministic transfer-result race hardening branch by merging PR #9 into `main`.
+
+## PR state before merge
+
+- PR: https://github.com/lanyusea/screeps/pull/9
+- Head branch: `test/transfer-result-hardening-20260426`
+- Required wait window: satisfied; PR was created at 2026-04-26T00:58:34Z and merged at 2026-04-26T02:43:07Z.
+- Merge state: `CLEAN`
+- GitHub Actions `prod-ci`: success
+- CodeRabbit status context: success
+- Gemini review feedback: addressed by Codex-authored review-fix commit `83eb0d5` using the Screeps global `ERR_FULL` constant.
+
+## Merge result
+
+- Merge commit: `b7e5c94` (`Merge pull request #9 from lanyusea/test/transfer-result-hardening-20260426`)
+- Local `main` was fast-forwarded to the merged commit.
+- The linked local worktree `/root/screeps-worktrees/transfer-result-hardening-20260426` blocked automatic local branch deletion after `gh pr merge`; this was treated as the expected partial-success case.
+- Cleanup completed:
+  - removed `/root/screeps-worktrees/transfer-result-hardening-20260426`
+  - deleted local branch `test/transfer-result-hardening-20260426`
+  - remote PR branch was deleted by GitHub merge flow
+
+## Verification after merge
+
+From `/root/screeps/prod` after `main` was fast-forwarded to `b7e5c94`:
+
+- `npm run typecheck`: passed
+- `npm test -- --runInBand`: passed, 12 suites / 68 tests
+- `npm run build`: passed
+
+## Outcome
+
+Transfer-result race hardening is now on `main`. The bot clears stale transfer tasks when `creep.transfer` returns `ERR_FULL`, reselects through existing worker-task priority in the same tick, and avoids moving toward the full sink.
+
+## Next suggested slice
+
+Continue the roadmap's validation follow-up: automate or reconcile the pinned private-server smoke harness and runtime-monitor scheduling path, or add deterministic Jest hardening only if new real-runtime observations expose a concrete bot logic risk.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T09:58:48+08:00
+Last updated: 2026-04-26T10:44:46+08:00
 
 ## Current active objective
 
@@ -151,9 +151,10 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
 
 ### transfer-result-race-hardening
 
-- Status: implemented and verified
+- Status: implemented, verified, PR-reviewed, and merged to `main`
 - Process note: `docs/process/2026-04-26-transfer-result-hardening.md`
-- Pull request: https://github.com/lanyusea/screeps/pull/9
+- Merge follow-up note: `docs/process/2026-04-26-pr9-merge-follow-up.md`
+- Pull request: https://github.com/lanyusea/screeps/pull/9 (merged 2026-04-26T02:43:07Z as `b7e5c94`)
 - Codex-authored commit: `a95afdc` (`test: handle full transfer result race`)
 - Codex-authored review-fix commit: `83eb0d5` (`fix: use screeps err full constant`)
 - Implemented:
@@ -163,7 +164,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   - rebuilt `prod/dist/main.js`
 - Verification:
   - `npm run typecheck`: passed
-  - `npm test -- --runInBand`: passed, 12 suites / 60 tests
+  - `npm test -- --runInBand`: passed, 12 suites / 68 tests after merge to `main`
   - `npm run build`: passed
 
 ### worker-no-target-hardening
@@ -206,8 +207,7 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   1. automate the pinned private-server smoke harness and redacted observation capture
   2. schedule the now live-smoked runtime monitor through dedicated `#runtime-summary` jobs and an alert scheduler/wrapper that converts `alert=false` JSON into a final `[SILENT]` response for `#runtime-alerts`, without creating cron jobs from the continuation worker
   3. continue deterministic Jest hardening for risks found during longer real-runtime observation
-- Latest deterministic hardening slice from `origin/main`: Codex commit `12a2c4a` (`test: harden worker no-target fallbacks`) plus review follow-up `test: cover stale harvest worker tasks` added Jest coverage for no-source/no-controller/no-target worker fallback behavior, including stale harvest targets. Process note: `docs/process/2026-04-26-worker-no-target-hardening.md`.
-- Current PR #9 refresh slice: transfer-result race hardening remains in this branch, including use of the Screeps global `ERR_FULL` constant and deterministic coverage proving the stale transfer task is cleared/reselected without moving toward the full target. PR #9 refresh reporting must not print secrets; use only safe selectors and redacted runtime observations. Process note: `docs/process/2026-04-26-pr9-conflict-refresh.md`; merge commit `1157baf` brought the branch up to `origin/main`, local verification passed with 12 suites / 68 tests, GitHub Actions `prod-ci` passed, CodeRabbit status was `SUCCESS`, and PR #9 merge state became `CLEAN`.
+- Latest deterministic hardening slice on `main`: PR #9 transfer-result race hardening merged as `b7e5c94` on 2026-04-26T02:43:07Z after CI/CodeRabbit were green and review feedback was addressed; it includes Codex commit `a95afdc` plus review-fix commit `83eb0d5`, uses the Screeps global `ERR_FULL` constant, and verifies stale transfer tasks are cleared/reselected without moving toward a full target. Post-merge local verification passed typecheck, 12 suites / 68 tests, and build. Process notes: `docs/process/2026-04-26-transfer-result-hardening.md`, `docs/process/2026-04-26-pr9-conflict-refresh.md`, and `docs/process/2026-04-26-pr9-merge-follow-up.md`.
 - PR #7 conflict refresh note from `origin/main`: `docs/process/2026-04-26-pr7-conflict-refresh.md`; Codex merge commit `6a54b8d` brought `test/runtime-risk-hardening-20260426` up to `origin/main`, preserved latest CI/P0/runtime-monitor docs, passed prod verification with 12 suites / 67 tests, and pushed the branch. GitHub Actions `prod-ci` passed; CodeRabbit status was pending immediately after push.
 - Runtime monitor live-token smoke: `docs/process/2026-04-26-runtime-monitor-live-smoke.md`; `self-test` passed (8 tests), live summary rendered `runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png` in the first pass and `runtime-artifacts/screeps-monitor-live-smoke-20260426/summary-shardX-E48S28.png` in the 09:32 repeat pass; live alert returned `alert: false` with no warnings at official ticks `108687` and `109202` for `shardX/E48S28`; repeat prod verification passed typecheck, 12 suites / 59 tests, and build.
 - Verification target if code changes are made:


### PR DESCRIPTION
## Summary
- records PR #9 merge/follow-up state after transfer-result race hardening landed on main
- updates active work state and roadmap snapshot with post-merge verification
- documents cleanup of the linked worktree branch-deletion partial-success case

## Verification
- cd prod && npm run typecheck
- cd prod && npm test -- --runInBand (12 suites / 68 tests)
- cd prod && npm run build

Docs-only branch; no production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a merge follow-up page capturing post-merge actions, verification steps, and cleanup notes.
  * Updated roadmap to reference the merge-follow-up and milestone progression.
  * Revised active-work-state notes to mark the transfer-result race hardening as merged to main, record updated test/verification results, and consolidate post-merge process details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->