### PR TITLE
docs: route P0 monitor to dedicated channel

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ This directory is organized by purpose so research, decisions, operations, and b
 - `process/2026-04-26-agent-operations-restructure.md`
 - `process/2026-04-26-parallel-throughput-and-private-smoke.md`
 - `process/2026-04-26-prod-ci-workflow.md`
+- `process/2026-04-26-p0-monitor-dedicated-channel.md`
 - `process/active-work-state.md`
 
 ## Rules

--- a/docs/ops/agent-operating-system.md
+++ b/docs/ops/agent-operating-system.md
@@ -78,7 +78,7 @@ The main agent must maintain an internal operations monitor that checks:
 - git working tree is not unsafe for autonomous workers;
 - obvious routing contradictions have not reappeared.
 
-If this monitoring detects an abnormal state, it must report to the home channel and preserve a durable process note if the issue is non-trivial.
+If this monitoring detects an abnormal state, it must report to the dedicated P0 operations channel `discord:1497820688843800776` and preserve a durable process note if the issue is non-trivial.
 
 ## Priority model
 
@@ -126,23 +126,31 @@ Delivery: `discord:#task-queue`.
 
 Purpose: monitor the health of the agent operating system itself.
 
-Delivery: Discord home channel (`discord`).
+Delivery: dedicated P0 operations channel `discord:1497820688843800776`.
 
 Behavior:
 
 - run frequently enough to catch broken automation quickly;
-- report abnormal states to home;
+- report abnormal states to the dedicated P0 operations channel;
 - remain concise when healthy;
 - never perform implementation work;
 - never modify production code;
 - if it changes docs, commit/push docs-only成果 as Hermes.
+
+### P0 dedicated monitor channel
+
+- Status: live route updated on 2026-04-26.
+- Channel ID: `1497820688843800776`.
+- Cron job: `Screeps P0 agent operations monitor` (`75cedbb77150`).
+- Delivery target: `discord:1497820688843800776`.
+- Purpose: keep P0 health output separate from owner-task/home-channel conversation while still escalating to home if owner action is urgently required.
 
 ## Discord routing matrix
 
 | Event | Primary target | Secondary/detail target | Owner interrupt? |
 | --- | --- | --- | --- |
 | New owner task | home channel | `#task-queue` when accepted | yes, if clarification/blocker needed |
-| P0 health anomaly | home channel | `#task-queue` / `#dev-log` as applicable | yes |
+| P0 health anomaly | dedicated P0 operations channel `discord:1497820688843800776` | home only if owner action is urgently required | yes |
 | Subagent research result | main agent review first | `#research-notes` | no, unless decision needed |
 | Subagent development result | main agent review first | `#dev-log` | no, unless blocker/decision needed |
 | Decision needed/finalized | `#decisions` | home if owner action needed | yes |

--- a/docs/ops/agent-operating-system.md
+++ b/docs/ops/agent-operating-system.md
@@ -103,7 +103,7 @@ For every meaningful task:
 6. Review and verify before accepting.
 7. Update durable docs if the result changes state.
 8. Fan out summaries to the corresponding Discord channels.
-9. Commit/push meaningful docs-only成果 as Hermes; Codex commits production/test/build work.
+9. Commit/push meaningful docs-only changes as Hermes; Codex commits production/test/build work.
 10. Resume/trigger scheduled continuation only after state is durable and safe.
 
 ## Scheduled worker roles
@@ -150,7 +150,7 @@ Behavior:
 | Event | Primary target | Secondary/detail target | Owner interrupt? |
 | --- | --- | --- | --- |
 | New owner task | home channel | `#task-queue` when accepted | yes, if clarification/blocker needed |
-| P0 health anomaly | dedicated P0 operations channel `discord:1497820688843800776` | home only if owner action is urgently required | yes |
+| P0 health anomaly | `discord:1497820688843800776` | home only if owner action is urgently required | yes |
 | Subagent research result | main agent review first | `#research-notes` | no, unless decision needed |
 | Subagent development result | main agent review first | `#dev-log` | no, unless blocker/decision needed |
 | Decision needed/finalized | `#decisions` | home if owner action needed | yes |

--- a/docs/ops/agent-operating-system.md
+++ b/docs/ops/agent-operating-system.md
@@ -135,7 +135,7 @@ Behavior:
 - remain concise when healthy;
 - never perform implementation work;
 - never modify production code;
-- if it changes docs, commit/push docs-only成果 as Hermes.
+- if it changes docs, commit/push docs-only changes as Hermes.
 
 ### P0 dedicated monitor channel
 

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -238,6 +238,7 @@ Requirement:
 Immediate operating change:
 
 - dedicated P0 agent operations monitor checks cron/job/routing/git/active-state health;
+- P0 monitor output now goes to dedicated channel `1497820688843800776` (`discord:1497820688843800776`) instead of the general home conversation; escalate to home only for urgent owner action;
 - live monitoring cadence: continuation every 5 minutes during P0/active-development periods, operations monitor every 15 minutes, 4-hour checkpoint every 240 minutes;
 - continuation/checkpoint workers remain subordinate to main-agent review and channel fanout;
 - if P0 health is abnormal, pause or defer new implementation work until corrected.

--- a/docs/process/2026-04-26-p0-monitor-dedicated-channel.md
+++ b/docs/process/2026-04-26-p0-monitor-dedicated-channel.md
@@ -1,0 +1,38 @@
+# P0 Monitor Dedicated Channel Routing
+
+Date: 2026-04-26T12:55:00+08:00
+
+## Trigger
+
+The owner created a new Discord channel `<#1497820688843800776>` and requested that scheduled output from the `Screeps P0 agent operations monitor` be delivered there.
+
+## Live change applied
+
+Updated cron job:
+
+- Job name: `Screeps P0 agent operations monitor`
+- Job ID: `75cedbb77150`
+- Previous delivery: general configured Discord home target (`discord`)
+- New delivery: `discord:1497820688843800776`
+- Schedule remains: every 15 minutes
+- Workdir remains: `/root/screeps`
+
+A one-time manual verification message was sent successfully to `discord:1497820688843800776`.
+
+## Routing rationale
+
+The home channel remains the owner command/proactive-report surface for main-agent interaction. P0 monitor output can be noisy or repetitive, so it now has a dedicated operations channel. The main agent should still escalate to home if a P0 anomaly requires urgent owner action.
+
+## Durable docs updated
+
+- `docs/ops/agent-operating-system.md`
+- `docs/process/active-work-state.md`
+- `docs/ops/roadmap.md`
+
+## Anti-regression rule
+
+Do not move `Screeps P0 agent operations monitor` back to generic `discord`/home delivery unless the owner explicitly requests it. Expected delivery target is now:
+
+```text
+discord:1497820688843800776
+```

--- a/docs/process/2026-04-26-p0-monitor-dedicated-channel.md
+++ b/docs/process/2026-04-26-p0-monitor-dedicated-channel.md
@@ -28,6 +28,7 @@ The home channel remains the owner command/proactive-report surface for main-age
 - `docs/ops/agent-operating-system.md`
 - `docs/process/active-work-state.md`
 - `docs/ops/roadmap.md`
+- `docs/README.md`
 
 ## Anti-regression rule
 

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -4,7 +4,7 @@ Last updated: 2026-04-26T12:40:22+08:00
 
 ## Current active objective
 
-P0: stabilize and monitor the Screeps agent operating system before continuing normal development. The main agent must preserve owner visibility through the home channel, delegate minimal tasks to subagents/Codex, review subagent conclusions, route summaries to typed Discord channels, and keep scheduled-worker health monitored. Canonical operating contract: `docs/ops/agent-operating-system.md`.
+P0: stabilize and monitor the Screeps agent operating system before continuing normal development. The main agent must preserve owner visibility through the home channel, delegate minimal tasks to subagents/Codex, review subagent conclusions, route summaries to typed Discord channels, and keep scheduled-worker health monitored. Canonical operating contract: `docs/ops/agent-operating-system.md`. Dedicated P0 monitor output is routed to channel `1497820688843800776` via cron delivery target `discord:1497820688843800776`.
 
 ## Completed tasks
 


### PR DESCRIPTION
## Summary\n- Document dedicated Discord channel 1497820688843800776 for P0 monitor output\n- Update agent operating-system routing matrix, roadmap, active state, and docs index\n- Record the live cron delivery change for job 75cedbb77150\n\n## Verification\n- Docs-only change\n- Live cron delivery verified as discord:1497820688843800776\n- One-time test message sent successfully to the new channel\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated P0 operations monitoring to route to a dedicated Discord channel for better organization
  * Added process documentation entry for P0 monitor channel configuration and routing guidelines
  * Clarified escalation behavior for urgent owner actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->