### PR TITLE
docs: require PR closure for agent tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ This repository builds and operates a Screeps: World bot. Use this file as the c
 
 - Do not edit or commit directly on `main`. Use a topic branch in a git worktree, normally under `~/screeps-worktrees/<topic>`.
 - Production/test/build code changes under `prod/` must be implemented through the Codex CLI coding agent when this project is being operated by Hermes. Hermes may edit docs/config directly, but Codex owns production code implementation commits.
-- A Codex coding task is not complete until the change is verified and committed.
+- A Codex coding task is not complete until the change is verified, committed, pushed, reviewed, and merged to `main` when it creates a PR. If a PR is superseded, close it with a PR comment explaining the replacement.
 - Preferred commit identity for Codex-authored coding commits: `lanyusea's bot <lanyusea@gmail.com>`.
 - Documentation-only and review-configuration changes may be authored directly by the orchestrating agent.
 - Never print or commit secrets. Screeps auth tokens, Steam keys, private-server credentials, and local selectors belong only in ignored/local env files.

--- a/docs/ops/codex-skills.md
+++ b/docs/ops/codex-skills.md
@@ -117,7 +117,8 @@ Use for any repository change.
 3. Verify syntax/tests appropriate to the change.
 4. Commit with a Conventional Commit message.
 5. Push the branch and open a PR.
-6. Do not merge until project gates are satisfied: at least 15 minutes after PR creation, all review comments/discussions resolved, and CI green once configured.
+6. If the change creates or updates a PR, the task remains open until the PR is merged to `main` or explicitly closed as superseded with a PR comment. Continue resolving review comments/discussions on the same PR branch until this is true.
+7. Do not merge until project gates are satisfied: at least 15 minutes after PR creation, all review comments/discussions resolved, and CI green once configured.
 
 ## Recommended skill-to-task mapping
 


### PR DESCRIPTION
## Summary
- clarify that PR-producing agent tasks remain open until merged or explicitly closed as superseded
- add the same closure rule to the worktree/PR hygiene playbook

## Verification
- python3 YAML parse check for .coderabbit.yaml and .gemini/config.yaml

## Gate note
Created after existing PR drain; will wait at least 15 minutes before merge and require all review discussions resolved.