### PR TITLE
fix: make smoke steam key container-readable

### DIFF
--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -247,7 +247,7 @@ Immediate operating change:
 
 Docker/Compose, package installation, HTTP startup, local auth, code upload, room/map initialization, spawn placement, and bot tick validation are no longer the primary blockers for the pinned launcher path. The active follow-up is making this repeatable and observable:
 
-1. finish PR #16 review/check/merge gates for the harness live-rerun fixes; the latest live rerun from `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0616Z` passed with one owned room and one bot-created worker;
+1. finish PR #16 review/check/merge gates for the harness live-rerun fixes; the latest secure live rerun from `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0633Z` passed with one owned room and one bot-created worker;
 2. observe several additional windows or reruns to ensure the harness path is stable across fresh data resets;
 3. configure or verify dedicated runtime-summary/runtime-alert scheduled jobs after the 2026-04-26 live-token monitor smoke succeeded twice (`summary` PNGs rendered; `alert=false` with no warnings for `shardX/E48S28` at official ticks `108687` and `109202`); for no-alert delivery, the scheduler/wrapper must convert the monitor JSON payload into a final `[SILENT]` response rather than expecting the current script to be silent by itself;
 4. if the pinned runtime later exposes simulation incompatibilities, then revisit a Node.js 22.9+ private-server image/toolchain for current `screeps@4.3.0`.

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -156,7 +156,7 @@ Recent additions:
 
 ### 7. Private-server smoke attempt and harness
 
-Status: pinned Dockerized path passed room/map initialization and bot tick validation; committed harness exists, and the next validation step is a fresh live harness run before treating it as a reusable release gate.
+Status: pinned Dockerized path passed room/map initialization and bot tick validation; PR #16 live-rerun fixes made the committed harness pass a fresh live run from an ignored workdir, and the PR remains open until merge gates complete.
 
 Artifacts:
 
@@ -183,7 +183,7 @@ Current result:
 - Follow-up observation reached `/stats` `gametime: 5267`, `totalRooms: 169`, `activeRooms: 1`, `ownedRooms: 1`, and one RCL 2 owned room.
 - Mongo room-object inspection showed owned `Spawn1` and three living bot-created `WORK/CARRY/MOVE` workers named `worker-E1S1-*`; post-restart log scanning found no current unhandled/type/reference/error hits.
 - Harness status: PR #12 `scripts/screeps-private-smoke.py` now supports offline `self-test`, `dry-run`, and live `run`. It writes a secret-free launcher config, keeps the actual Steam key and local auth password out of committed files and reports, rejects unsafe repo-local workdirs before writing secrets, retries transient `/stats` failures, requires room-specific Mongo spawn evidence for the `already playing` placement path, pins Docker image tags (`screepers/screeps-launcher:v1.16.2`, `mongo:8.2.7`, `redis:7.4.8`), signs in with the configured smoke email, uploads `prod/dist/main.js` without printing code contents, and writes a redacted JSON observation report.
-- Remaining work: run the harness live from a clean ignored work directory, then wire scheduled runtime-summary/runtime-alert monitoring using the now-repeat-smoked live-token monitor path. Basic room initialization is no longer the blocker.
+- Remaining work: merge PR #16 after checks/review gates; then wire scheduled runtime-summary/runtime-alert monitoring using the now-repeat-smoked live-token monitor path. Basic room initialization and harness live execution are no longer blockers.
 
 ## Active blockers and decisions
 
@@ -247,7 +247,7 @@ Immediate operating change:
 
 Docker/Compose, package installation, HTTP startup, local auth, code upload, room/map initialization, spawn placement, and bot tick validation are no longer the primary blockers for the pinned launcher path. The active follow-up is making this repeatable and observable:
 
-1. wait for PR #12 review state to refresh after latest harness hardening commit `d8c9197`, then merge through the PR gate and run the new pinned launcher harness live from a clean ignored work directory, archiving the redacted report in a process note;
+1. finish PR #16 review/check/merge gates for the harness live-rerun fixes; the latest live rerun from `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0616Z` passed with one owned room and one bot-created worker;
 2. observe several additional windows or reruns to ensure the harness path is stable across fresh data resets;
 3. configure or verify dedicated runtime-summary/runtime-alert scheduled jobs after the 2026-04-26 live-token monitor smoke succeeded twice (`summary` PNGs rendered; `alert=false` with no warnings for `shardX/E48S28` at official ticks `108687` and `109202`); for no-alert delivery, the scheduler/wrapper must convert the monitor JSON payload into a final `[SILENT]` response rather than expecting the current script to be silent by itself;
 4. if the pinned runtime later exposes simulation incompatibilities, then revisit a Node.js 22.9+ private-server image/toolchain for current `screeps@4.3.0`.

--- a/docs/process/2026-04-26-private-smoke-harness-live-rerun.md
+++ b/docs/process/2026-04-26-private-smoke-harness-live-rerun.md
@@ -26,6 +26,11 @@ The harness then exposed three automation issues:
    - Codex commit: `a27532f fix: run smoke cli through http endpoint`.
    - Fix: the harness now uses the generated local HTTP CLI endpoint at `http://<host>:<cli_port>/cli` for `system.resetAllData()`, `utils.importMapFile(...)`, and `system.resumeSimulation()`.
 
+4. Review bots correctly flagged the initial permission fix as too broad: `STEAM_KEY` mode `0644` and `01777` generated directories exposed local multi-user risks.
+   - Codex commit: `28677d6 fix: harden smoke harness file permissions`.
+   - Fix: the Screeps container is configured to run as the host writer UID/GID, generated files use owner-only mode `0600`, generated directories use owner-only mode `0700`, and generated writes reject preexisting symlinks for sensitive/runtime paths.
+   - Secure live rerun passed after this fix; see below.
+
 ## Verification
 
 Controller verification after each Codex fix passed:
@@ -37,9 +42,9 @@ SCREEPS_PRIVATE_SMOKE_WORKDIR=/tmp/screeps-private-smoke-dry-run-verify-controll
 cd prod && npm run typecheck && npm test -- --runInBand && npm run build
 ```
 
-Latest offline result after the HTTP CLI fix:
+Latest offline result after the permission review fix:
 
-- Private smoke self-test: 27 tests passed.
+- Private smoke self-test: 30 tests passed.
 - Prod Jest: 12 suites / 68 tests passed.
 - Prod build succeeded and regenerated `prod/dist/main.js` from the existing source.
 

--- a/docs/process/2026-04-26-private-smoke-harness-live-rerun.md
+++ b/docs/process/2026-04-26-private-smoke-harness-live-rerun.md
@@ -1,0 +1,81 @@
+# Private smoke harness live rerun
+
+Date: 2026-04-26
+Branch: `fix/private-smoke-steam-key-perms-20260426`
+Pull request: <https://github.com/lanyusea/screeps/pull/16>
+
+## Objective
+
+Run the merged private-server smoke harness live from a fresh ignored workdir and fix any harness automation issues that prevented the pinned Dockerized path from being reusable.
+
+## Findings and fixes
+
+The first live rerun attempt used the default local ports and failed because an older pinned smoke stack was still bound to `127.0.0.1:21025-21026`. Follow-up live reruns used alternate local ports `21125/21126` to avoid disturbing the older observation stack.
+
+The harness then exposed three automation issues:
+
+1. `screeps-launcher` could not read the generated `STEAM_KEY` file through the bind mount when it was written with mode `0600`.
+   - Codex commit: `b7e05fd fix: make smoke steam key container-readable`.
+   - Fix: generated ignored `STEAM_KEY` is mode `0644`; reports and logs still redact secret values.
+
+2. `screeps-launcher` could not install Node into the bind-mounted workdir because the container user did not have write permission.
+   - Codex commit: `342d766 fix: make smoke workdir container-writable`.
+   - Fix: live preparation makes only the harness-generated, already-safe ignored workdir/subdirectories container-writable with sticky directory permissions.
+
+3. `docker compose exec -T screeps screeps-launcher cli` panicked in go-prompt because the launcher CLI expects a TTY.
+   - Codex commit: `a27532f fix: run smoke cli through http endpoint`.
+   - Fix: the harness now uses the generated local HTTP CLI endpoint at `http://<host>:<cli_port>/cli` for `system.resetAllData()`, `utils.importMapFile(...)`, and `system.resumeSimulation()`.
+
+## Verification
+
+Controller verification after each Codex fix passed:
+
+```bash
+python3 -m py_compile scripts/screeps-private-smoke.py
+python3 scripts/screeps-private-smoke.py self-test
+SCREEPS_PRIVATE_SMOKE_WORKDIR=/tmp/screeps-private-smoke-dry-run-verify-controller-cli python3 scripts/screeps-private-smoke.py dry-run
+cd prod && npm run typecheck && npm test -- --runInBand && npm run build
+```
+
+Latest offline result after the HTTP CLI fix:
+
+- Private smoke self-test: 27 tests passed.
+- Prod Jest: 12 suites / 68 tests passed.
+- Prod build succeeded and regenerated `prod/dist/main.js` from the existing source.
+
+## Live smoke result
+
+Command shape, with secret values sourced locally but not printed:
+
+```bash
+SCREEPS_PRIVATE_SMOKE_HTTP_PORT=21125 \
+SCREEPS_PRIVATE_SMOKE_CLI_PORT=21126 \
+python3 scripts/screeps-private-smoke.py run \
+  --work-dir /root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0616Z \
+  --stats-timeout 420 \
+  --poll-interval 5 \
+  --min-creeps 1
+```
+
+Result: `ok: true`.
+
+Redacted report path:
+
+- `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0616Z/private-smoke-report-20260426T061745Z.json`
+
+Key observations:
+
+- Dockerized pinned launcher started with `screepers/screeps-launcher:v1.16.2`, `screeps@4.2.21`, launcher Node `Erbium`, Mongo `8.2.7`, and Redis `7.4.8`.
+- HTTP readiness succeeded on alternate local server URL `http://127.0.0.1:21125`.
+- HTTP CLI reset/import/resume succeeded:
+  - `system.resetAllData()` returned `undefined`.
+  - `utils.importMapFile('/screeps/maps/map-0b6758af.json')` returned `Map imported! Restart the server and use system.resumeSimulation() to unpause ticks`.
+  - `system.resumeSimulation()` returned `OK`.
+- The harness registered the local `smoke` user, signed in, uploaded the current `prod/dist/main.js`, and verified the code round-trip hash matched the local artifact.
+- Spawn placement succeeded for `Spawn1` in `E1S1` at `(20,20)`.
+- `/stats` reached `gametime: 30`, `totalRooms: 169`, `ownedRooms: 1`, `activeUsers: 1`, and one smoke-user creep.
+- Mongo summary found one owned spawn and one bot-created `WORK/CARRY/MOVE` worker, `worker-E1S1-5`, in `E1S1`.
+
+## Current status
+
+PR #16 remains open and must be merged or explicitly closed as obsolete before this task is complete. The 15-minute merge wait from PR creation has elapsed; remaining gates are PR checks/review-thread state and mergeability.

--- a/docs/process/2026-04-26-private-smoke-harness-live-rerun.md
+++ b/docs/process/2026-04-26-private-smoke-harness-live-rerun.md
@@ -64,9 +64,10 @@ python3 scripts/screeps-private-smoke.py run \
 
 Result: `ok: true`.
 
-Redacted report path:
+Redacted report paths:
 
-- `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0616Z/private-smoke-report-20260426T061745Z.json`
+- Initial passing rerun before permission hardening: `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0616Z/private-smoke-report-20260426T061745Z.json`
+- Secure rerun after permission hardening: `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0633Z/private-smoke-report-20260426T063440Z.json`
 
 Key observations:
 
@@ -78,8 +79,8 @@ Key observations:
   - `system.resumeSimulation()` returned `OK`.
 - The harness registered the local `smoke` user, signed in, uploaded the current `prod/dist/main.js`, and verified the code round-trip hash matched the local artifact.
 - Spawn placement succeeded for `Spawn1` in `E1S1` at `(20,20)`.
-- `/stats` reached `gametime: 30`, `totalRooms: 169`, `ownedRooms: 1`, `activeUsers: 1`, and one smoke-user creep.
-- Mongo summary found one owned spawn and one bot-created `WORK/CARRY/MOVE` worker, `worker-E1S1-5`, in `E1S1`.
+- `/stats` reached `gametime: 31`, `totalRooms: 169`, `ownedRooms: 1`, `activeUsers: 1`, and one smoke-user creep on the secure rerun.
+- Mongo summary found one owned spawn and one bot-created `WORK/CARRY/MOVE` worker, `worker-E1S1-6`, in `E1S1` on the secure rerun.
 
 ## Current status
 

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -185,13 +185,14 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
 
 ### next-runtime-validation
 
-- Status: pinned private-server smoke unblocked for room/map initialization and bot tick validation; committed local harness now exists and awaits a fresh live run
+- Status: pinned private-server smoke harness live rerun passed on PR #16; PR #16 remains open until merge/closure gates complete
 - Process note: `docs/process/2026-04-26-private-server-smoke-attempt.md`
 - Version-pin research note: `docs/process/2026-04-26-private-server-version-pin-research.md`
 - Pinned runtime retry note: `docs/process/2026-04-26-pinned-private-server-smoke-retry.md`
 - Parallel throughput/smoke note: `docs/process/2026-04-26-parallel-throughput-and-private-smoke.md`
 - Longer observation note: `docs/process/2026-04-26-private-server-long-observation.md`
 - Harness note: `docs/process/2026-04-26-private-server-smoke-harness.md`
+- Harness live rerun note: `docs/process/2026-04-26-private-smoke-harness-live-rerun.md`
 - Current recommendation: private-server-first validation remains the release-quality path. Dockerized `screepers/screeps-launcher` with explicit `version: 4.2.21`, launcher Node `12.22.12`, and transitive dependency resolutions (`body-parser: 1.20.3`, `path-to-regexp: 0.1.12`) can initialize rooms when the map import avoids the Node 12 global-`fetch` path by using a pre-downloaded map file plus `utils.importMapFile('/screeps/maps/map-0b6758af.json')`. A follow-up observation reached private `gametime: 5267`, `totalRooms: 169`, `ownedRooms: 1`, one RCL 2 room, and three live bot-created workers without post-restart log exceptions.
 - Harness status: PR #12 `scripts/screeps-private-smoke.py` is ready for a fresh live run; see `docs/process/2026-04-26-private-server-smoke-harness.md` for full details.
   - Modes: offline `self-test`, secret-free `dry-run`, and live `run`.
@@ -210,13 +211,15 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   - Pinned Dockerized runtime smoke: pre-downloaded `map-0b6758af.json`, imported with `utils.importMapFile`, restarted/resumed simulation, registered local smoke user, uploaded `prod/dist/main.js`, placed `Spawn1` at `E1S1` `(20,20)`, and observed `/stats` with `totalRooms: 169`, `ownedRooms: 1`, `activeUsers: 1`, plus owned `worker-E1S1-*` creeps in Mongo
   - Longer pinned runtime observation: private `gametime: 5267`, one RCL 2 owned room, three live bot-created workers, average tick time about 200 ms, and no current post-restart `Unhandled`/`TypeError`/`ReferenceError`/`Error:` hits in launcher logs
   - Runtime monitor self-test: `python3 scripts/screeps-runtime-monitor.py self-test` passed, 8 tests
-  - Private smoke harness self-test: `python3 scripts/screeps-private-smoke.py self-test` passed, 22 tests after PR #12 review fix `d8c9197`
+  - Private smoke harness self-test: `python3 scripts/screeps-private-smoke.py self-test` passed, 27 tests after PR #16 harness live-rerun fixes
   - Private smoke harness dry-run: `python3 scripts/screeps-private-smoke.py dry-run` passed and wrote a redacted report without Docker, network, secrets, or a live server
-  - Current prod verification after harness addition: `npm run typecheck`, `npm test -- --runInBand` (12 suites / 68 tests), and `npm run build` all passed in `prod/`
+  - Private smoke harness live rerun on alternate local ports `21125/21126`: passed with redacted report `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0616Z/private-smoke-report-20260426T061745Z.json`; reached `gametime: 30`, `totalRooms: 169`, one owned room, one bot-created worker, code upload/roundtrip success, and Mongo spawn/creep evidence
+  - Current prod verification after harness live-rerun fixes: `npm run typecheck`, `npm test -- --runInBand` (12 suites / 68 tests), and `npm run build` all passed in `prod/`
 - Candidate next outputs:
-  1. wait for PR #12 review state to refresh after `d8c9197`, then run the pinned private-server smoke harness live from a clean ignored work directory and capture the redacted report once the harness PR is accepted/merged
-  2. wire the now live-smoked runtime monitor through dedicated `#runtime-summary` jobs and an alert scheduler/wrapper that converts `alert=false` JSON into a final `[SILENT]` response for `#runtime-alerts`, without creating cron jobs from the continuation worker
-  3. continue deterministic Jest hardening for risks found during longer real-runtime observation
+  1. finish PR #16 review/check/merge gates for the harness live-rerun fixes, then fast-forward `main`
+  2. after PR #16 merges, stop/clean any no-longer-needed smoke stacks or keep exactly one intentional observation stack documented
+  3. wire the now live-smoked runtime monitor through dedicated `#runtime-summary` jobs and an alert scheduler/wrapper that converts `alert=false` JSON into a final `[SILENT]` response for `#runtime-alerts`, without creating cron jobs from the continuation worker
+  4. continue deterministic Jest hardening for risks found during longer real-runtime observation
 - Latest deterministic hardening slice on `main`: PR #9 transfer-result race hardening merged as `b7e5c94` on 2026-04-26T02:43:07Z after CI/CodeRabbit were green and review feedback was addressed.
   - It includes Codex commit `a95afdc` plus review-fix commit `83eb0d5`, uses the Screeps global `ERR_FULL` constant, and verifies stale transfer tasks are cleared/reselected without moving toward a full target.
   - Post-merge local verification passed typecheck, 12 suites / 68 tests, and build.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -211,9 +211,9 @@ P0: stabilize and monitor the Screeps agent operating system before continuing n
   - Pinned Dockerized runtime smoke: pre-downloaded `map-0b6758af.json`, imported with `utils.importMapFile`, restarted/resumed simulation, registered local smoke user, uploaded `prod/dist/main.js`, placed `Spawn1` at `E1S1` `(20,20)`, and observed `/stats` with `totalRooms: 169`, `ownedRooms: 1`, `activeUsers: 1`, plus owned `worker-E1S1-*` creeps in Mongo
   - Longer pinned runtime observation: private `gametime: 5267`, one RCL 2 owned room, three live bot-created workers, average tick time about 200 ms, and no current post-restart `Unhandled`/`TypeError`/`ReferenceError`/`Error:` hits in launcher logs
   - Runtime monitor self-test: `python3 scripts/screeps-runtime-monitor.py self-test` passed, 8 tests
-  - Private smoke harness self-test: `python3 scripts/screeps-private-smoke.py self-test` passed, 27 tests after PR #16 harness live-rerun fixes
+  - Private smoke harness self-test: `python3 scripts/screeps-private-smoke.py self-test` passed, 30 tests after PR #16 permission-review fix
   - Private smoke harness dry-run: `python3 scripts/screeps-private-smoke.py dry-run` passed and wrote a redacted report without Docker, network, secrets, or a live server
-  - Private smoke harness live rerun on alternate local ports `21125/21126`: passed with redacted report `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0616Z/private-smoke-report-20260426T061745Z.json`; reached `gametime: 30`, `totalRooms: 169`, one owned room, one bot-created worker, code upload/roundtrip success, and Mongo spawn/creep evidence
+  - Private smoke harness secure live rerun on alternate local ports `21125/21126`: passed with redacted report `/root/screeps/runtime-artifacts/screeps-private-smoke-live-20260426T0633Z/private-smoke-report-20260426T063440Z.json`; reached `gametime: 31`, `totalRooms: 169`, one owned room, one bot-created worker, code upload/roundtrip success, and Mongo spawn/creep evidence
   - Current prod verification after harness live-rerun fixes: `npm run typecheck`, `npm test -- --runInBand` (12 suites / 68 tests), and `npm run build` all passed in `prod/`
 - Candidate next outputs:
   1. finish PR #16 review/check/merge gates for the harness live-rerun fixes, then fast-forward `main`

--- a/scripts/screeps-private-smoke.py
+++ b/scripts/screeps-private-smoke.py
@@ -46,6 +46,7 @@ DEFAULT_USERNAME = "smoke"
 DEFAULT_SPAWN_NAME = "Spawn1"
 DEFAULT_SPAWN_X = 20
 DEFAULT_SPAWN_Y = 20
+STEAM_KEY_FILE_MODE = 0o644
 SECRET_KEYS = {
     "authorization",
     "password",
@@ -539,7 +540,9 @@ def prepare_work_dir(cfg: SmokeConfig) -> dict[str, Any]:
     if not cfg.dry_run:
         steam_key = os.environ["STEAM_KEY"]
         cfg.steam_key_path.write_text(steam_key, encoding="utf-8")
-        cfg.steam_key_path.chmod(0o600)
+        # Docker may run screeps-launcher as a different UID/GID than the host writer;
+        # this generated gitignored file must be readable through the bind mount.
+        cfg.steam_key_path.chmod(STEAM_KEY_FILE_MODE)
         shutil.copyfile(cfg.code_path, cfg.bot_main_path)
     return {
         "work_dir": str(cfg.work_dir),
@@ -1223,6 +1226,59 @@ class SmokeSelfTest(unittest.TestCase):
 
         self.assertEqual(persisted["report_path"], str(report_path))
         self.assertEqual(report["report_path"], str(report_path))
+
+    def test_live_prepare_sets_container_readable_steam_key_mode(self) -> None:
+        """Live preparation should make the generated Steam key readable in Docker."""
+        steam_key_was_set = "STEAM_KEY" in os.environ
+        old_steam_key = os.environ.get("STEAM_KEY")
+        try:
+            os.environ["STEAM_KEY"] = "self-test-steam-key"
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_path = Path(temp_dir)
+                code_path = temp_path / "main.js"
+                code_path.write_text("module.exports.loop = function loop() {};", encoding="utf-8")
+                cfg = SmokeConfig(
+                    **{
+                        **self.make_cfg().__dict__,
+                        "work_dir": temp_path / "work",
+                        "code_path": code_path,
+                        "dry_run": False,
+                    }
+                )
+                details = prepare_work_dir(cfg)
+                steam_key_mode = cfg.steam_key_path.stat().st_mode & 0o777
+
+        finally:
+            if steam_key_was_set:
+                os.environ["STEAM_KEY"] = old_steam_key or ""
+            else:
+                os.environ.pop("STEAM_KEY", None)
+
+        self.assertEqual(steam_key_mode, STEAM_KEY_FILE_MODE)
+        self.assertEqual(steam_key_mode & 0o444, 0o444)
+        self.assertEqual(steam_key_mode & 0o111, 0)
+        self.assertNotIn("self-test-steam-key", json.dumps(details))
+
+    def test_dry_run_does_not_create_or_report_steam_key(self) -> None:
+        """Dry-run should remain secret-free even if STEAM_KEY is present."""
+        steam_key_was_set = "STEAM_KEY" in os.environ
+        old_steam_key = os.environ.get("STEAM_KEY")
+        try:
+            os.environ["STEAM_KEY"] = "dry-run-env-steam-key"
+            with tempfile.TemporaryDirectory() as temp_dir:
+                cfg = SmokeConfig(**{**self.make_cfg().__dict__, "work_dir": Path(temp_dir)})
+                report = run_dry(cfg)
+                persisted = json.loads(Path(report["report_path"]).read_text(encoding="utf-8"))
+                encoded = json.dumps({"report": report, "persisted": persisted}, sort_keys=True)
+                steam_key_exists = cfg.steam_key_path.exists()
+        finally:
+            if steam_key_was_set:
+                os.environ["STEAM_KEY"] = old_steam_key or ""
+            else:
+                os.environ.pop("STEAM_KEY", None)
+
+        self.assertFalse(steam_key_exists)
+        self.assertNotIn("dry-run-env-steam-key", encoded)
 
     def test_upload_code_accepts_common_success_payloads(self) -> None:
         """/api/user/code should accept timestamp and ok-style success bodies."""

--- a/scripts/screeps-private-smoke.py
+++ b/scripts/screeps-private-smoke.py
@@ -47,6 +47,14 @@ DEFAULT_SPAWN_NAME = "Spawn1"
 DEFAULT_SPAWN_X = 20
 DEFAULT_SPAWN_Y = 20
 STEAM_KEY_FILE_MODE = 0o644
+CONTAINER_WRITABLE_DIR_MODE = 0o1777
+CONTAINER_WRITABLE_SUBDIRS = (
+    "maps",
+    "bots",
+    "bots/mvpbot",
+    "mods",
+    "deps",
+)
 SECRET_KEYS = {
     "authorization",
     "password",
@@ -196,6 +204,39 @@ def assert_safe_work_dir(work_dir: Path) -> None:
     )
     if check.returncode != 0:
         raise SmokeError(f"work dir must be outside the repo or gitignored before writing secrets: {resolved}")
+
+
+def assert_path_inside_work_dir(work_dir: Path, path: Path) -> None:
+    """Raise unless a generated path resolves under the configured workdir."""
+    resolved_work_dir = work_dir.resolve()
+    resolved_path = path.resolve()
+    try:
+        resolved_path.relative_to(resolved_work_dir)
+    except ValueError as exc:
+        raise SmokeError(f"generated path escapes smoke work dir: {resolved_path}") from exc
+
+
+def ensure_generated_dir(work_dir: Path, path: Path) -> None:
+    """Create and chmod one generated directory without following symlink escapes."""
+    assert_path_inside_work_dir(work_dir, path)
+    if path.exists() and path.is_symlink():
+        raise SmokeError(f"refusing to chmod symlinked smoke work dir path: {path}")
+    path.mkdir(parents=True, exist_ok=True)
+    if not path.is_dir():
+        raise SmokeError(f"generated smoke work dir path is not a directory: {path}")
+    path.chmod(CONTAINER_WRITABLE_DIR_MODE)
+
+
+def prepare_container_writable_work_dir(cfg: SmokeConfig) -> list[str]:
+    """Make only the generated smoke workdir tree writable by arbitrary container UIDs."""
+    assert_safe_work_dir(cfg.work_dir)
+    ensure_generated_dir(cfg.work_dir, cfg.work_dir)
+    prepared = ["."]
+    for relative in CONTAINER_WRITABLE_SUBDIRS:
+        path = cfg.work_dir / relative
+        ensure_generated_dir(cfg.work_dir, path)
+        prepared.append(relative)
+    return prepared
 
 
 def config_from_env(args: argparse.Namespace) -> SmokeConfig:
@@ -532,22 +573,30 @@ def request_shape(method: str, path: str, body: dict[str, Any] | None = None) ->
 def prepare_work_dir(cfg: SmokeConfig) -> dict[str, Any]:
     """Create launcher files and copy live-only secret/runtime inputs."""
     assert_safe_work_dir(cfg.work_dir)
-    cfg.work_dir.mkdir(parents=True, exist_ok=True)
-    (cfg.work_dir / "maps").mkdir(parents=True, exist_ok=True)
-    cfg.bot_main_path.parent.mkdir(parents=True, exist_ok=True)
+    if cfg.dry_run:
+        cfg.work_dir.mkdir(parents=True, exist_ok=True)
+        (cfg.work_dir / "maps").mkdir(parents=True, exist_ok=True)
+        cfg.bot_main_path.parent.mkdir(parents=True, exist_ok=True)
+        container_writable_dirs: list[str] | str = "not-applied-dry-run"
+    else:
+        container_writable_dirs = prepare_container_writable_work_dir(cfg)
     cfg.config_path.write_text(build_launcher_config(cfg), encoding="utf-8")
     cfg.compose_path.write_text(build_compose_file(cfg), encoding="utf-8")
     if not cfg.dry_run:
+        cfg.config_path.chmod(STEAM_KEY_FILE_MODE)
+        cfg.compose_path.chmod(STEAM_KEY_FILE_MODE)
         steam_key = os.environ["STEAM_KEY"]
         cfg.steam_key_path.write_text(steam_key, encoding="utf-8")
         # Docker may run screeps-launcher as a different UID/GID than the host writer;
         # this generated gitignored file must be readable through the bind mount.
         cfg.steam_key_path.chmod(STEAM_KEY_FILE_MODE)
         shutil.copyfile(cfg.code_path, cfg.bot_main_path)
+        cfg.bot_main_path.chmod(STEAM_KEY_FILE_MODE)
     return {
         "work_dir": str(cfg.work_dir),
         "config": str(cfg.config_path),
         "compose": str(cfg.compose_path),
+        "container_writable_dirs": container_writable_dirs,
         "steam_key_file": "created" if not cfg.dry_run else "not-created-dry-run",
         "bot_package_main": str(cfg.bot_main_path) if not cfg.dry_run else "not-copied-dry-run",
     }
@@ -1227,8 +1276,8 @@ class SmokeSelfTest(unittest.TestCase):
         self.assertEqual(persisted["report_path"], str(report_path))
         self.assertEqual(report["report_path"], str(report_path))
 
-    def test_live_prepare_sets_container_readable_steam_key_mode(self) -> None:
-        """Live preparation should make the generated Steam key readable in Docker."""
+    def test_live_prepare_sets_container_writable_workdir_and_steam_key_mode(self) -> None:
+        """Live preparation should make generated dirs writable and Steam key readable."""
         steam_key_was_set = "STEAM_KEY" in os.environ
         old_steam_key = os.environ.get("STEAM_KEY")
         try:
@@ -1247,6 +1296,10 @@ class SmokeSelfTest(unittest.TestCase):
                 )
                 details = prepare_work_dir(cfg)
                 steam_key_mode = cfg.steam_key_path.stat().st_mode & 0o777
+                directory_modes = {
+                    relative: (cfg.work_dir / relative).stat().st_mode & 0o7777
+                    for relative in (".", *CONTAINER_WRITABLE_SUBDIRS)
+                }
 
         finally:
             if steam_key_was_set:
@@ -1254,6 +1307,10 @@ class SmokeSelfTest(unittest.TestCase):
             else:
                 os.environ.pop("STEAM_KEY", None)
 
+        for relative, mode in directory_modes.items():
+            with self.subTest(relative=relative):
+                self.assertEqual(mode, CONTAINER_WRITABLE_DIR_MODE)
+        self.assertIn("deps", details["container_writable_dirs"])
         self.assertEqual(steam_key_mode, STEAM_KEY_FILE_MODE)
         self.assertEqual(steam_key_mode & 0o444, 0o444)
         self.assertEqual(steam_key_mode & 0o111, 0)
@@ -1278,6 +1335,7 @@ class SmokeSelfTest(unittest.TestCase):
                 os.environ.pop("STEAM_KEY", None)
 
         self.assertFalse(steam_key_exists)
+        self.assertEqual(report["prepare"]["container_writable_dirs"], "not-applied-dry-run")
         self.assertNotIn("dry-run-env-steam-key", encoded)
 
     def test_upload_code_accepts_common_success_payloads(self) -> None:

--- a/scripts/screeps-private-smoke.py
+++ b/scripts/screeps-private-smoke.py
@@ -40,6 +40,7 @@ REDIS_IMAGE = "redis:7.4.8"
 DEFAULT_CODE_PATH = REPO_ROOT / "prod" / "dist" / "main.js"
 DEFAULT_HTTP_PORT = 21025
 DEFAULT_CLI_PORT = 21026
+LAUNCHER_CLI_RESPONSE_LIMIT = 1400
 DEFAULT_ROOM = "E1S1"
 DEFAULT_SHARD = "shardX"
 DEFAULT_USERNAME = "smoke"
@@ -746,6 +747,36 @@ def http_json(
         return HttpResult(exc.code, parsed, dict(exc.headers.items()))
 
 
+def http_text(
+    method: str,
+    base_url: str,
+    path: str,
+    body: str | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: int = 25,
+    max_len: int = LAUNCHER_CLI_RESPONSE_LIMIT,
+) -> HttpResult:
+    """Send an HTTP request with a text body and return bounded text."""
+    url = base_url.rstrip("/") + path
+    data = body.encode("utf-8") if body is not None else None
+    request_headers = {"User-Agent": "screeps-private-smoke/1.0"}
+    if body is not None:
+        request_headers["Content-Type"] = "text/plain; charset=utf-8"
+    if headers:
+        request_headers.update(headers)
+    request = urllib.request.Request(url, data=data, headers=request_headers, method=method)
+
+    def read_bounded(response: Any) -> str:
+        raw = response.read(max_len + 1)
+        return short_text(raw.decode("utf-8", errors="replace"), max_len)
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return HttpResult(response.status, read_bounded(response), dict(response.headers.items()))
+    except urllib.error.HTTPError as exc:
+        return HttpResult(exc.code, read_bounded(exc), dict(exc.headers.items()))
+
+
 def token_headers(token: str) -> dict[str, str]:
     """Return the Screeps token headers expected by the private server."""
     return {
@@ -785,9 +816,38 @@ def wait_for_http(cfg: SmokeConfig, timeout: int = 300) -> dict[str, Any]:
 
 
 def run_launcher_cli(compose: list[str], cfg: SmokeConfig, expression: str) -> dict[str, Any]:
-    """Execute a screeps-launcher CLI expression inside the stack."""
-    command = [*compose, "exec", "-T", "screeps", "screeps-launcher", "cli"]
-    return require_success(run_command(command, cfg, input_text=expression + "\n", timeout=240))
+    """Execute a screeps-launcher CLI expression through the local HTTP CLI."""
+    _ = compose
+    started = time.time()
+    secrets_to_hide = [os.environ.get("STEAM_KEY", ""), cfg.password or ""]
+    cli_base_url = f"http://{cfg.server_host}:{cfg.cli_port}"
+    endpoint = cli_base_url.rstrip("/") + "/cli"
+    try:
+        result = http_text(
+            "POST",
+            cli_base_url,
+            "/cli",
+            expression,
+            timeout=240,
+            max_len=LAUNCHER_CLI_RESPONSE_LIMIT,
+        )
+    except Exception as exc:  # noqa: BLE001 - sanitized below for report
+        message = redact(short_text(exc, 200), secrets_to_hide)
+        raise SmokeError(f"launcher CLI HTTP request failed: {message}") from exc
+
+    elapsed = round(time.time() - started, 3)
+    response_excerpt = redact(short_text(result.payload, LAUNCHER_CLI_RESPONSE_LIMIT), secrets_to_hide)
+    details = {
+        "endpoint": endpoint,
+        "status": result.status,
+        "elapsed_seconds": elapsed,
+        "response_excerpt": response_excerpt,
+    }
+    if result.status < 200 or result.status >= 300:
+        raise SmokeError(f"launcher CLI HTTP request failed: {endpoint} returned {result.status}: {response_excerpt}")
+    if isinstance(result.payload, str) and result.payload.startswith("Error:"):
+        raise SmokeError(f"launcher CLI returned error: {response_excerpt}")
+    return details
 
 
 def safe_user_stats(stats: dict[str, Any], username: str) -> dict[str, Any]:
@@ -1370,6 +1430,109 @@ class SmokeSelfTest(unittest.TestCase):
                     record_required_api_probe(phases, "user-overview", "/api/user/overview", result, [hidden])
                 self.assertFalse(phases[-1]["ok"])
                 self.assertNotIn(hidden, str(caught.exception))
+
+    def test_run_launcher_cli_posts_expression_to_http_endpoint(self) -> None:
+        """Launcher CLI execution should post raw expressions to the HTTP CLI."""
+        cfg = self.make_cfg()
+        original_http_text = globals()["http_text"]
+        captured: dict[str, Any] = {}
+
+        def fake_http_text(
+            method: str,
+            base_url: str,
+            path: str,
+            body: str | None = None,
+            **kwargs: Any,
+        ) -> HttpResult:
+            """Capture the request shape without touching the network."""
+            captured.update({
+                "method": method,
+                "base_url": base_url,
+                "path": path,
+                "body": body,
+                "timeout": kwargs.get("timeout"),
+                "max_len": kwargs.get("max_len"),
+            })
+            return HttpResult(200, "2\n", {})
+
+        try:
+            globals()["http_text"] = fake_http_text
+            details = run_launcher_cli(["docker", "compose"], cfg, "1+1")
+        finally:
+            globals()["http_text"] = original_http_text
+
+        self.assertEqual(
+            captured,
+            {
+                "method": "POST",
+                "base_url": "http://127.0.0.1:21026",
+                "path": "/cli",
+                "body": "1+1",
+                "timeout": 240,
+                "max_len": LAUNCHER_CLI_RESPONSE_LIMIT,
+            },
+        )
+        self.assertEqual(details["endpoint"], "http://127.0.0.1:21026/cli")
+        self.assertEqual(details["status"], 200)
+        self.assertEqual(details["response_excerpt"], "2\n")
+
+    def test_run_launcher_cli_rejects_http_and_cli_error_payloads(self) -> None:
+        """Launcher CLI execution should fail on HTTP errors and Error: payloads."""
+        cfg = self.make_cfg()
+        original_http_text = globals()["http_text"]
+
+        cases = (
+            ("http-status", HttpResult(503, "temporary unavailable", {}), "returned 503"),
+            ("cli-error", HttpResult(200, "Error: bad expression", {}), "launcher CLI returned error"),
+            ("timeout", TimeoutError("temporary timeout"), "temporary timeout"),
+        )
+        for name, outcome, expected in cases:
+            with self.subTest(name=name):
+
+                def fake_http_text(*args: Any, **kwargs: Any) -> HttpResult:
+                    """Return a deterministic launcher CLI failure."""
+                    if isinstance(outcome, BaseException):
+                        raise outcome
+                    return outcome
+
+                try:
+                    globals()["http_text"] = fake_http_text
+                    with self.assertRaises(SmokeError) as caught:
+                        run_launcher_cli([], cfg, "bad()")
+                finally:
+                    globals()["http_text"] = original_http_text
+                self.assertIn(expected, str(caught.exception))
+
+    def test_run_launcher_cli_redacts_and_bounds_response_output(self) -> None:
+        """Launcher CLI reports should redact secrets and bound response text."""
+        cfg = self.make_cfg()
+        original_http_text = globals()["http_text"]
+        steam_key_was_set = "STEAM_KEY" in os.environ
+        old_steam_key = os.environ.get("STEAM_KEY")
+        hidden_steam_key = "self-test-steam-key"
+        long_response = f"ok {hidden_steam_key} {cfg.password} " + ("x" * 2000)
+
+        def fake_http_text(*args: Any, **kwargs: Any) -> HttpResult:
+            """Return a successful response that still needs report sanitation."""
+            return HttpResult(200, long_response, {})
+
+        try:
+            os.environ["STEAM_KEY"] = hidden_steam_key
+            globals()["http_text"] = fake_http_text
+            details = run_launcher_cli([], cfg, "secretProbe()")
+        finally:
+            globals()["http_text"] = original_http_text
+            if steam_key_was_set:
+                os.environ["STEAM_KEY"] = old_steam_key or ""
+            else:
+                os.environ.pop("STEAM_KEY", None)
+
+        excerpt = details["response_excerpt"]
+        self.assertLessEqual(len(excerpt), LAUNCHER_CLI_RESPONSE_LIMIT)
+        self.assertTrue(excerpt.endswith("..."))
+        self.assertIn("[REDACTED]", excerpt)
+        self.assertNotIn(hidden_steam_key, excerpt)
+        self.assertNotIn(cfg.password or "", excerpt)
 
     def test_signin_payload_uses_configured_email(self) -> None:
         """Sign-in should use the registered email even when username differs."""

--- a/scripts/screeps-private-smoke.py
+++ b/scripts/screeps-private-smoke.py
@@ -47,8 +47,9 @@ DEFAULT_USERNAME = "smoke"
 DEFAULT_SPAWN_NAME = "Spawn1"
 DEFAULT_SPAWN_X = 20
 DEFAULT_SPAWN_Y = 20
-STEAM_KEY_FILE_MODE = 0o644
-CONTAINER_WRITABLE_DIR_MODE = 0o1777
+GENERATED_FILE_MODE = 0o600
+GENERATED_DIR_MODE = 0o700
+STEAM_KEY_FILE_MODE = GENERATED_FILE_MODE
 CONTAINER_WRITABLE_SUBDIRS = (
     "maps",
     "bots",
@@ -217,19 +218,61 @@ def assert_path_inside_work_dir(work_dir: Path, path: Path) -> None:
         raise SmokeError(f"generated path escapes smoke work dir: {resolved_path}") from exc
 
 
-def ensure_generated_dir(work_dir: Path, path: Path) -> None:
-    """Create and chmod one generated directory without following symlink escapes."""
+def reject_existing_symlink(path: Path) -> None:
+    """Reject an existing generated path component when it is a symlink."""
+    if path.is_symlink():
+        raise SmokeError(f"refusing to use symlinked smoke work dir path: {path}")
+
+
+def assert_generated_path_has_no_symlink(work_dir: Path, path: Path) -> None:
+    """Reject existing symlinks from the workdir root through a generated path."""
     assert_path_inside_work_dir(work_dir, path)
-    if path.exists() and path.is_symlink():
-        raise SmokeError(f"refusing to chmod symlinked smoke work dir path: {path}")
-    path.mkdir(parents=True, exist_ok=True)
+    reject_existing_symlink(work_dir)
+    try:
+        relative = path.relative_to(work_dir)
+    except ValueError:
+        relative = path.resolve().relative_to(work_dir.resolve())
+    current = work_dir
+    for part in relative.parts:
+        current = current / part
+        reject_existing_symlink(current)
+
+
+def ensure_generated_dir(work_dir: Path, path: Path) -> None:
+    """Create and chmod one generated directory without following symlink paths."""
+    assert_generated_path_has_no_symlink(work_dir, path)
+    path.mkdir(mode=GENERATED_DIR_MODE, parents=True, exist_ok=True)
+    assert_generated_path_has_no_symlink(work_dir, path)
     if not path.is_dir():
         raise SmokeError(f"generated smoke work dir path is not a directory: {path}")
-    path.chmod(CONTAINER_WRITABLE_DIR_MODE)
+    path.chmod(GENERATED_DIR_MODE)
+
+
+def write_generated_bytes(work_dir: Path, path: Path, data: bytes, mode: int = GENERATED_FILE_MODE) -> None:
+    """Atomically write a generated file without following a preexisting symlink."""
+    ensure_generated_dir(work_dir, path.parent)
+    assert_generated_path_has_no_symlink(work_dir, path)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "wb") as temp_file:
+            temp_file.write(data)
+        temp_path.chmod(mode)
+        assert_generated_path_has_no_symlink(work_dir, path)
+        os.replace(temp_path, path)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+    assert_generated_path_has_no_symlink(work_dir, path)
+
+
+def write_generated_text(work_dir: Path, path: Path, text: str, mode: int = GENERATED_FILE_MODE) -> None:
+    """Atomically write generated UTF-8 text without following symlink paths."""
+    write_generated_bytes(work_dir, path, text.encode("utf-8"), mode)
 
 
 def prepare_container_writable_work_dir(cfg: SmokeConfig) -> list[str]:
-    """Make only the generated smoke workdir tree writable by arbitrary container UIDs."""
+    """Prepare only generated smoke workdir paths for the mapped container UID."""
     assert_safe_work_dir(cfg.work_dir)
     ensure_generated_dir(cfg.work_dir, cfg.work_dir)
     prepared = ["."]
@@ -357,6 +400,7 @@ def build_compose_file(cfg: SmokeConfig) -> str:
     return f"""services:
   screeps:
     image: {SCREEPS_LAUNCHER_IMAGE}
+    user: "{os.getuid()}:{os.getgid()}"
     volumes:
       - ./:/screeps
     ports:
@@ -575,24 +619,18 @@ def prepare_work_dir(cfg: SmokeConfig) -> dict[str, Any]:
     """Create launcher files and copy live-only secret/runtime inputs."""
     assert_safe_work_dir(cfg.work_dir)
     if cfg.dry_run:
-        cfg.work_dir.mkdir(parents=True, exist_ok=True)
-        (cfg.work_dir / "maps").mkdir(parents=True, exist_ok=True)
-        cfg.bot_main_path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_generated_dir(cfg.work_dir, cfg.work_dir)
+        for relative in ("maps", "bots", "bots/mvpbot"):
+            ensure_generated_dir(cfg.work_dir, cfg.work_dir / relative)
         container_writable_dirs: list[str] | str = "not-applied-dry-run"
     else:
         container_writable_dirs = prepare_container_writable_work_dir(cfg)
-    cfg.config_path.write_text(build_launcher_config(cfg), encoding="utf-8")
-    cfg.compose_path.write_text(build_compose_file(cfg), encoding="utf-8")
+    write_generated_text(cfg.work_dir, cfg.config_path, build_launcher_config(cfg))
+    write_generated_text(cfg.work_dir, cfg.compose_path, build_compose_file(cfg))
     if not cfg.dry_run:
-        cfg.config_path.chmod(STEAM_KEY_FILE_MODE)
-        cfg.compose_path.chmod(STEAM_KEY_FILE_MODE)
         steam_key = os.environ["STEAM_KEY"]
-        cfg.steam_key_path.write_text(steam_key, encoding="utf-8")
-        # Docker may run screeps-launcher as a different UID/GID than the host writer;
-        # this generated gitignored file must be readable through the bind mount.
-        cfg.steam_key_path.chmod(STEAM_KEY_FILE_MODE)
-        shutil.copyfile(cfg.code_path, cfg.bot_main_path)
-        cfg.bot_main_path.chmod(STEAM_KEY_FILE_MODE)
+        write_generated_text(cfg.work_dir, cfg.steam_key_path, steam_key, STEAM_KEY_FILE_MODE)
+        write_generated_bytes(cfg.work_dir, cfg.bot_main_path, cfg.code_path.read_bytes())
     return {
         "work_dir": str(cfg.work_dir),
         "config": str(cfg.config_path),
@@ -615,9 +653,10 @@ def prepare_map(cfg: SmokeConfig) -> dict[str, Any]:
     if cfg.map_source_file:
         if not cfg.map_source_file.exists():
             raise SmokeError(f"map source file does not exist: {cfg.map_source_file}")
-        shutil.copyfile(cfg.map_source_file, cfg.map_path)
+        write_generated_bytes(cfg.work_dir, cfg.map_path, cfg.map_source_file.read_bytes())
         source = str(cfg.map_source_file)
     elif cfg.map_path.exists():
+        assert_generated_path_has_no_symlink(cfg.work_dir, cfg.map_path)
         source = "existing-workdir-file"
     else:
         parsed = urllib.parse.urlparse(cfg.map_url)
@@ -628,7 +667,7 @@ def prepare_map(cfg: SmokeConfig) -> dict[str, Any]:
             )
         request = urllib.request.Request(cfg.map_url, headers={"User-Agent": "screeps-private-smoke/1.0"})
         with urllib.request.urlopen(request, timeout=60) as response:
-            cfg.map_path.write_bytes(response.read())
+            write_generated_bytes(cfg.work_dir, cfg.map_path, response.read())
         source = cfg.map_url
     return {
         "path": str(cfg.map_path),
@@ -1184,8 +1223,7 @@ def run_live(cfg: SmokeConfig) -> dict[str, Any]:
         report["report_path"] = str(report_path)
         assert_no_secret_leak(report, secrets_to_hide)
         assert_safe_work_dir(cfg.work_dir)
-        cfg.work_dir.mkdir(parents=True, exist_ok=True)
-        report_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+        write_generated_text(cfg.work_dir, report_path, json.dumps(report, indent=2, sort_keys=True))
     return report
 
 
@@ -1221,7 +1259,7 @@ def run_dry(cfg: SmokeConfig) -> dict[str, Any]:
     report_path = dry_cfg.report_path
     report["report_path"] = str(report_path)
     assert_no_secret_leak(report, [fake_password, sample_code])
-    report_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    write_generated_text(dry_cfg.work_dir, report_path, json.dumps(report, indent=2, sort_keys=True))
     return report
 
 
@@ -1284,11 +1322,12 @@ class SmokeSelfTest(unittest.TestCase):
         self.assertNotIn("super-secret-password", config_text)
 
     def test_compose_file_binds_local_ports(self) -> None:
-        """Compose output should bind the configured loopback ports."""
+        """Compose output should bind local ports and map the launcher UID/GID."""
         cfg = self.make_cfg()
         compose = build_compose_file(cfg)
         self.assertIn('"127.0.0.1:21025:21025/tcp"', compose)
         self.assertIn('"127.0.0.1:21026:21026/tcp"', compose)
+        self.assertIn(f'user: "{os.getuid()}:{os.getgid()}"', compose)
         self.assertIn(f"image: {SCREEPS_LAUNCHER_IMAGE}", compose)
         self.assertIn(f"image: {MONGO_IMAGE}", compose)
         self.assertIn(f"image: {REDIS_IMAGE}", compose)
@@ -1336,8 +1375,8 @@ class SmokeSelfTest(unittest.TestCase):
         self.assertEqual(persisted["report_path"], str(report_path))
         self.assertEqual(report["report_path"], str(report_path))
 
-    def test_live_prepare_sets_container_writable_workdir_and_steam_key_mode(self) -> None:
-        """Live preparation should make generated dirs writable and Steam key readable."""
+    def test_live_prepare_sets_owner_only_generated_modes(self) -> None:
+        """Live preparation should keep generated dirs and files owner-only."""
         steam_key_was_set = "STEAM_KEY" in os.environ
         old_steam_key = os.environ.get("STEAM_KEY")
         try:
@@ -1360,6 +1399,12 @@ class SmokeSelfTest(unittest.TestCase):
                     relative: (cfg.work_dir / relative).stat().st_mode & 0o7777
                     for relative in (".", *CONTAINER_WRITABLE_SUBDIRS)
                 }
+                file_modes = {
+                    "config": cfg.config_path.stat().st_mode & 0o777,
+                    "compose": cfg.compose_path.stat().st_mode & 0o777,
+                    "steam_key": steam_key_mode,
+                    "bot_main": cfg.bot_main_path.stat().st_mode & 0o777,
+                }
 
         finally:
             if steam_key_was_set:
@@ -1369,12 +1414,81 @@ class SmokeSelfTest(unittest.TestCase):
 
         for relative, mode in directory_modes.items():
             with self.subTest(relative=relative):
-                self.assertEqual(mode, CONTAINER_WRITABLE_DIR_MODE)
+                self.assertEqual(mode, GENERATED_DIR_MODE)
+                self.assertEqual(mode & 0o077, 0)
+        for name, mode in file_modes.items():
+            with self.subTest(name=name):
+                self.assertEqual(mode, GENERATED_FILE_MODE)
+                self.assertEqual(mode & 0o077, 0)
         self.assertIn("deps", details["container_writable_dirs"])
         self.assertEqual(steam_key_mode, STEAM_KEY_FILE_MODE)
-        self.assertEqual(steam_key_mode & 0o444, 0o444)
+        self.assertEqual(steam_key_mode & 0o700, 0o600)
         self.assertEqual(steam_key_mode & 0o111, 0)
         self.assertNotIn("self-test-steam-key", json.dumps(details))
+
+    def test_live_prepare_rejects_preexisting_steam_key_symlink(self) -> None:
+        """Live preparation should not follow a preexisting STEAM_KEY symlink."""
+        if not hasattr(os, "symlink"):
+            self.skipTest("os.symlink is unavailable")
+        steam_key_was_set = "STEAM_KEY" in os.environ
+        old_steam_key = os.environ.get("STEAM_KEY")
+        try:
+            os.environ["STEAM_KEY"] = "self-test-steam-key"
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_path = Path(temp_dir)
+                code_path = temp_path / "main.js"
+                code_path.write_text("module.exports.loop = function loop() {};", encoding="utf-8")
+                cfg = SmokeConfig(
+                    **{
+                        **self.make_cfg().__dict__,
+                        "work_dir": temp_path / "work",
+                        "code_path": code_path,
+                        "dry_run": False,
+                    }
+                )
+                cfg.work_dir.mkdir(mode=GENERATED_DIR_MODE)
+                target = cfg.work_dir / "target-steam-key"
+                os.symlink(target, cfg.steam_key_path)
+                with self.assertRaises(SmokeError):
+                    prepare_work_dir(cfg)
+                self.assertFalse(target.exists())
+        finally:
+            if steam_key_was_set:
+                os.environ["STEAM_KEY"] = old_steam_key or ""
+            else:
+                os.environ.pop("STEAM_KEY", None)
+
+    def test_live_prepare_rejects_preexisting_bot_main_symlink(self) -> None:
+        """Live preparation should not follow a preexisting bot main symlink."""
+        if not hasattr(os, "symlink"):
+            self.skipTest("os.symlink is unavailable")
+        steam_key_was_set = "STEAM_KEY" in os.environ
+        old_steam_key = os.environ.get("STEAM_KEY")
+        try:
+            os.environ["STEAM_KEY"] = "self-test-steam-key"
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_path = Path(temp_dir)
+                code_path = temp_path / "main.js"
+                code_path.write_text("module.exports.loop = function loop() {};", encoding="utf-8")
+                cfg = SmokeConfig(
+                    **{
+                        **self.make_cfg().__dict__,
+                        "work_dir": temp_path / "work",
+                        "code_path": code_path,
+                        "dry_run": False,
+                    }
+                )
+                cfg.bot_main_path.parent.mkdir(mode=GENERATED_DIR_MODE, parents=True)
+                target = cfg.work_dir / "target-main.js"
+                os.symlink(target, cfg.bot_main_path)
+                with self.assertRaises(SmokeError):
+                    prepare_work_dir(cfg)
+                self.assertFalse(target.exists())
+        finally:
+            if steam_key_was_set:
+                os.environ["STEAM_KEY"] = old_steam_key or ""
+            else:
+                os.environ.pop("STEAM_KEY", None)
 
     def test_dry_run_does_not_create_or_report_steam_key(self) -> None:
         """Dry-run should remain secret-free even if STEAM_KEY is present."""
@@ -1388,6 +1502,10 @@ class SmokeSelfTest(unittest.TestCase):
                 persisted = json.loads(Path(report["report_path"]).read_text(encoding="utf-8"))
                 encoded = json.dumps({"report": report, "persisted": persisted}, sort_keys=True)
                 steam_key_exists = cfg.steam_key_path.exists()
+                dry_run_directory_modes = {
+                    relative: (cfg.work_dir / relative).stat().st_mode & 0o7777
+                    for relative in (".", "maps", "bots", "bots/mvpbot")
+                }
         finally:
             if steam_key_was_set:
                 os.environ["STEAM_KEY"] = old_steam_key or ""
@@ -1395,6 +1513,10 @@ class SmokeSelfTest(unittest.TestCase):
                 os.environ.pop("STEAM_KEY", None)
 
         self.assertFalse(steam_key_exists)
+        for relative, mode in dry_run_directory_modes.items():
+            with self.subTest(relative=relative):
+                self.assertEqual(mode, GENERATED_DIR_MODE)
+                self.assertEqual(mode & 0o077, 0)
         self.assertEqual(report["prepare"]["container_writable_dirs"], "not-applied-dry-run")
         self.assertNotIn("dry-run-env-steam-key", encoded)
 
@@ -1489,7 +1611,11 @@ class SmokeSelfTest(unittest.TestCase):
         for name, outcome, expected in cases:
             with self.subTest(name=name):
 
-                def fake_http_text(*args: Any, **kwargs: Any) -> HttpResult:
+                def fake_http_text(
+                    *args: Any,
+                    outcome: HttpResult | BaseException = outcome,
+                    **kwargs: Any,
+                ) -> HttpResult:
                     """Return a deterministic launcher CLI failure."""
                     if isinstance(outcome, BaseException):
                         raise outcome
@@ -1626,6 +1752,29 @@ class SmokeSelfTest(unittest.TestCase):
             )
             with self.assertRaisesRegex(SmokeError, "SCREEPS_PRIVATE_SMOKE_MAP_URL"):
                 prepare_map(cfg)
+
+    def test_prepare_map_rejects_preexisting_map_symlink(self) -> None:
+        """Map preparation should not follow a preexisting map-file symlink."""
+        if not hasattr(os, "symlink"):
+            self.skipTest("os.symlink is unavailable")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            source = temp_path / "source-map.json"
+            source.write_text("{}", encoding="utf-8")
+            cfg = SmokeConfig(
+                **{
+                    **self.make_cfg().__dict__,
+                    "work_dir": temp_path / "work",
+                    "map_source_file": source,
+                    "dry_run": False,
+                }
+            )
+            cfg.map_path.parent.mkdir(mode=GENERATED_DIR_MODE, parents=True)
+            target = cfg.work_dir / "target-map.json"
+            os.symlink(target, cfg.map_path)
+            with self.assertRaises(SmokeError):
+                prepare_map(cfg)
+            self.assertFalse(target.exists())
 
     def test_safe_work_dir_rejects_unignored_repo_paths(self) -> None:
         """Secret-bearing workdirs must be outside the repo or ignored."""


### PR DESCRIPTION
## Summary
- fixes the live private-server smoke harness STEAM_KEY file mode so Dockerized screeps-launcher can read the generated ignored secret file through its bind mount
- keeps reports/logs redacted and dry-run secret-free
- adds offline self-test coverage for the live file mode and dry-run behavior

## Verification
- `python3 -m py_compile scripts/screeps-private-smoke.py`
- `python3 scripts/screeps-private-smoke.py self-test` (24 tests)
- `SCREEPS_PRIVATE_SMOKE_WORKDIR=/tmp/screeps-private-smoke-dry-run-verify-controller python3 scripts/screeps-private-smoke.py dry-run`
- `cd prod && npm run typecheck && npm test -- --runInBand && npm run build` (12 suites / 68 tests)

## Notes
- Follow-up live smoke should use non-conflicting ports or stop the older pinned smoke stack first; the first fresh run found the permission bug after a default-port conflict with the old pinned stack.

Fixes #23
