### PR TITLE
docs: add goal-oriented PM reporting contract

### DIFF
--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -13,11 +13,24 @@ This roadmap is the durable counterpart to the Discord `#roadmap` channel. It su
   - `cd prod && npm test -- --runInBand` — passing, 12 suites / 68 tests
   - `cd prod && npm run build` — passing
 - Latest production/test milestones: Codex commit `12a2c4a test: harden worker no-target fallbacks` plus review follow-up `test: cover stale harvest worker tasks` added deterministic no-source/no-controller/no-target worker fallback coverage, including stale harvest targets; refreshed PR #9 commits `a95afdc test: handle full transfer result race` and `83eb0d5 fix: use screeps err full constant` clear stale transfer tasks when `creep.transfer` returns the Screeps global `ERR_FULL`
-- Latest validation milestone: pinned Dockerized private-server smoke now initializes rooms via `utils.importMapFile`, places a local spawn, observes owned bot creeps, and has run past private `gametime: 5267` with one RCL 2 owned room; a committed, review-hardened harness now automates that pinned path for fresh local reruns and passes 19 offline self-tests
+- Latest validation milestone: pinned Dockerized private-server smoke now initializes rooms via `utils.importMapFile`, places a local spawn, observes owned bot creeps, and has run past private `gametime: 5267` with one RCL 2 owned room; a committed, review-hardened harness now automates that pinned path for fresh local reruns and passes 22 offline self-tests
 - Latest runtime-monitor milestone: live-token monitor smoke succeeded twice for `shardX/E48S28` at official ticks `108687` and `109202`; summary rendered PNGs and alert returned `alert: false` with no warnings
-- Latest documentation milestone: PR #9 merge follow-up recorded on branch `docs/pr9-merge-record-20260426`; production CI workflow/runbook added earlier on branch `chore/add-prod-ci`
+- Latest project-management milestone: roadmap snapshots now include next-point completion percentages, and a six-hour development report is scheduled for `discord:1497587260835758222:1497833662241181746`
 - Active state file: `docs/process/active-work-state.md`
-- Current top priority: continue high-throughput validation while keeping P0 agent communication/cron/Discord visibility healthy
+- Current top priority: goal-oriented concurrent progress across all six roadmap domains, with P0 agent communication/cron/Discord visibility treated as the first reliability gate
+
+## Six-domain next-point progress
+
+These percentages are explicit next-point estimates for the current roadmap snapshot; they should move only when there is verified evidence such as merged PRs, passing checks, redacted live reports, rendered artifacts, or scheduler-health proof.
+
+| Domain | Next-point completion | Current next point |
+| --- | ---: | --- |
+| Agent OS / visibility | 88% | scheduler reliability audit and no-stall visibility proof |
+| Engineering governance | 75% | enforceable `main` branch protection / required checks |
+| Private-server validation | 85% | fresh live harness run and redacted report |
+| Runtime Monitor | 85% | reliable scheduled summary images plus no-alert silence |
+| Bot Capability | 80% | runtime-driven deterministic hardening after fresh smoke evidence |
+| Official MMO | 50% | release-quality deploy gate evidence after private-server validation |
 
 ## Completed milestones
 

--- a/docs/process/2026-04-26-goal-oriented-pm-and-reporting.md
+++ b/docs/process/2026-04-26-goal-oriented-pm-and-reporting.md
@@ -1,0 +1,48 @@
+# Goal-oriented PM, percentage roadmap, and 6h reporting
+
+Date: 2026-04-26
+
+## Owner correction
+
+The owner clarified that the Screeps operating model must be goal-oriented project management, not only process scheduling:
+
+1. Every roadmap domain should advance concurrently, with subagents working under main-agent management.
+2. Roadmap snapshots must show each domain's next-point completion percentage so progress is visible at a glance.
+3. Every 6 hours, a development report must be sent to Discord target `discord:1497587260835758222:1497833662241181746` with:
+   - past 6 hours completed;
+   - overall roadmap progress explanation;
+   - next 6 hours plan.
+4. When a roadmap goal is achieved, or the next roadmap goal needs clarification, the main agent should proactively ask the owner rather than silently continuing process work.
+
+## Mechanism changes made
+
+- Created scheduled job `Screeps 6h development report` (`dfcaf65d7ea7`) with schedule `every 360m`, delivery target `discord:1497587260835758222:1497833662241181746`, and a prompt requiring the three owner-requested sections.
+- Updated the live roadmap visual reporter prompt (`92ca290f7996`) to require next-point completion percentages on every domain card and to use format version `roadmap-visual-percent-v4`.
+- Updated `/root/.hermes/scripts/render-screeps-roadmap.js` so the roadmap image includes percentage bars on all six domain cards.
+- Render verification passed: `/tmp/screeps-roadmap-snapshot.png` is a non-empty 1800x1450 PNG.
+- Ran six parallel domain-audit subagents in two batches to establish current domain progress and next delegated tasks.
+
+## Six-domain audit baseline
+
+| Domain | Current estimate | Next milestone | Next delegated task |
+| --- | ---: | --- | --- |
+| Agent OS / visibility | 88% | Scheduler reliability and no-stall visibility | Audit why due cron jobs can show past `next_run_at` while enabled; determine if long workdir-serialized jobs block scheduled reporting. |
+| Engineering governance | 75% | Enforceable main branch protection / required checks | Inspect/apply branch protection or rulesets compatible with current CI; document enforced gate. |
+| Private-server validation | 85% | Fresh live harness run and redacted report | Run `scripts/screeps-private-smoke.py run` from clean ignored workdir with local secrets, archive redacted report. |
+| Runtime Monitor | 85% | Reliable scheduled summary images + no-alert silence | Verify scheduler cadence for runtime summary/alert jobs and fix/report lag source. |
+| Bot Capability | 80% | Runtime-driven deterministic hardening | After private smoke report, convert observed runtime failures into Codex-owned tests/fixes. |
+| Official MMO | 50% | Release-quality deploy gate evidence | Do not treat temporary MMO link validation as release-quality until private-server gate and monitor evidence are complete. |
+
+## PM operating contract going forward
+
+The main agent owns the roadmap, not only cron/process health. In every active cycle it should:
+
+1. Keep all six roadmap domains represented by an active or queued delegated task.
+2. Review subagent outputs and decide whether each domain's percentage changes.
+3. Convert results into roadmap updates, 6h reports, and next delegated tasks.
+4. Prefer outcome evidence: merged PRs, passing verification, redacted live reports, rendered artifacts, and scheduler-health proof.
+5. Escalate to the owner when a domain target is complete and the next target is ambiguous, or when a human-owned decision blocks progress.
+
+## Immediate caveat
+
+The first domain audits found scheduler-health concerns: several jobs appeared enabled with old/past `next_run_at` values. That is now a P0 PM item because it directly affects visibility and concurrent domain progress.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T12:40:22+08:00
+Last updated: 2026-04-26T14:00:00+08:00
 
 ## Current active objective
 
@@ -277,3 +277,19 @@ If any task remains open for more than 4 hours without a final conclusion, publi
 - Telemetry MVP implemented and verified: stable `#runtime-summary ` JSON console summaries now emit on spawn events or every 20 ticks, including room energy, worker count, spawn status, task counts, and CPU used/bucket.
 - Spawn busy retry hardening implemented by Codex and verified: if a planned spawn returns `ERR_BUSY`, the economy loop retries other idle colony spawns in the same tick and telemetry records each attempt; deterministic test count is now 45.
 - Private-server version-pin research completed: launcher source/config inspection confirmed `version: latest` becomes `screeps: *`; npm metadata identified `screeps@4.2.21` as Node 12-compatible; Dockerized `screeps-launcher apply` passed with `version: 4.2.21`; the follow-up pinned runtime retry started the server and uploaded code after adding `body-parser: 1.20.3` / `path-to-regexp: 0.1.12` resolutions, but room/map initialization remained unresolved (`totalRooms: 0`).
+
+
+## Goal-oriented six-domain PM contract
+
+Owner correction on 2026-04-26: the main agent is responsible for project management outcomes, not only process scheduling. Every active planning/reporting cycle must keep all six roadmap domains advancing concurrently through delegated subagent/Codex tasks:
+
+1. Agent OS / visibility — current estimate 88%; next delegated task: scheduler reliability/no-stall audit.
+2. Engineering governance — current estimate 75%; next delegated task: branch protection / required-check gate.
+3. Private-server validation — current estimate 85%; next delegated task: fresh live `scripts/screeps-private-smoke.py run` from a clean ignored workdir and redacted report.
+4. Runtime Monitor — current estimate 85%; next delegated task: verify scheduled summary/alert cadence and no-alert silence.
+5. Bot Capability — current estimate 80%; next delegated task: convert real private-smoke/runtime observations into deterministic Codex-owned hardening.
+6. Official MMO — current estimate 50%; next delegated task: keep the temporary official link validation subordinate to the private-server release gate and monitoring evidence.
+
+Roadmap snapshots must include each domain's next-point completion percentage. A six-hour development report job (`dfcaf65d7ea7`) sends to `discord:1497587260835758222:1497833662241181746` with exactly: past six hours completed, overall roadmap progress, and next six hours plan.
+
+If a roadmap target is achieved or the next target requires clarification, the main agent should proactively ask the owner rather than silently continuing process-only work.


### PR DESCRIPTION
## Summary
- record owner correction that the main agent owns goal-oriented six-domain project management, not only process scheduling
- add next-point completion percentages and current next tasks to the roadmap
- document the six-hour development report job and proactive owner-clarification rule

## Verification
- git diff --check
- roadmap renderer verified separately: /tmp/screeps-roadmap-snapshot.png is a non-empty PNG

No production code changed.