### PR TITLE
docs: refresh project vision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This repository builds and operates a Screeps: World bot. Use this file as the c
 
 - Target game: Screeps: World official MMO.
 - Current official target: branch `main`, shard `shardX`, room `E48S28`.
+- Project vision: on competition maps, build toward sufficiently large territory first, sufficiently many resources second, and sufficiently many enemy kills third. All roadmap decomposition and priority evaluation must serve that ordered end goal; see `docs/ops/project-vision.md`.
 - Runtime code lives in `prod/`; durable project docs live in `docs/`.
 - Discord is the coordination contract: research, decisions, roadmap, task queue, dev log, runtime summaries, and runtime alerts are mirrored in docs where practical.
 - The user prefers meaningful shipped成果 over noisy churn. Keep changes focused, verified, committed, and PR-ready.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ This directory is organized by purpose so research, decisions, operations, and b
 
 ### Operations
 - `ops/agent-operating-system.md`
+- `ops/project-vision.md`
 - `ops/discord-project-spec.md`
 - `ops/discord-server-setup-guide.md`
 - `ops/discord-server-configuration.md`
@@ -66,6 +67,7 @@ This directory is organized by purpose so research, decisions, operations, and b
 - `process/2026-04-26-typed-channel-fanout-reporters.md`
 - `process/2026-04-26-prod-ci-workflow.md`
 - `process/2026-04-26-p0-monitor-dedicated-channel.md`
+- `process/2026-04-26-project-vision-refresh.md`
 - `process/active-work-state.md`
 
 ## Rules

--- a/docs/ops/discord-project-spec.md
+++ b/docs/ops/discord-project-spec.md
@@ -52,10 +52,12 @@ Create the following channels in this order:
 ### Channel responsibilities
 
 #### `#project-vision`
+- Final gameplay objective: on Screeps competition maps, maximize sufficiently large territory first, sufficiently many resources second, and sufficiently many enemy kills third
 - Project mission
 - Scope boundaries
 - Principles
 - Success criteria
+- Priority contract for all roadmap decomposition and trade-off decisions
 
 #### `#decisions`
 - Final decisions only

--- a/docs/ops/project-vision.md
+++ b/docs/ops/project-vision.md
@@ -1,0 +1,43 @@
+# Screeps Project Vision
+
+Last updated: 2026-04-26T06:03:38Z
+
+This document is the durable counterpart to the Discord `#project-vision` channel. It is the north star for roadmap decomposition, priority evaluation, and trade-off decisions.
+
+## Final objective
+
+In Screeps competition-map play, build a bot that achieves, in strict priority order:
+
+1. **Enough large territory** — claim, hold, defend, and operate a large footprint of rooms.
+2. **Enough resources across categories** — convert territory into durable energy, minerals, commodities, infrastructure, and logistical throughput.
+3. **Enough enemy kills** — develop combat capability that removes threats and wins fights, but only after the bot can expand and sustain itself.
+
+The priority order is intentional: territory comes before resource volume, and resource volume comes before kill count. Combat matters, but it should serve expansion, defense, and economic control rather than become an isolated optimization target.
+
+## Roadmap evaluation contract
+
+Every roadmap item must answer how it advances at least one layer of the vision:
+
+- **Territory:** Does this help us safely claim, reserve, scout, path through, defend, or coordinate more rooms?
+- **Resources:** Does this improve energy/mineral extraction, logistics, storage, market readiness, build/repair throughput, or CPU efficiency that scales with room count?
+- **Kills:** Does this improve threat detection, tower/rampart defense, squad control, target selection, or post-economy offensive capability?
+
+When two tasks compete for priority, prefer the task that unlocks the earliest bottleneck in this chain:
+
+```text
+survive reliably → expand territory → scale resources → defend/attack effectively → optimize kills
+```
+
+## Practical implications for current planning
+
+- Early bot work should still focus on survivability, validation, runtime visibility, and recovery because those are prerequisites for holding territory.
+- The next strategic jump after stable single-room operation is not “more features” generically; it is the minimum system that can evaluate expansion candidates, claim/reserve rooms, and maintain remote logistics safely.
+- Resource systems should be designed as territory multipliers: hauling, storage, roads, repairs, remote mining, minerals, and market behavior should be ranked by how much they increase sustainable controlled footprint.
+- Military work should start with defense and threat telemetry, then progress to coordinated combat only when the economy can replace losses and support sustained operations.
+- Roadmap snapshots should show each domain's contribution to territory/resources/kills, plus next-point completion percentage, so progress remains tied to the final objective rather than local implementation churn.
+
+## Non-goals
+
+- Do not optimize for elegant architecture unless it accelerates the territory/resources/kills chain.
+- Do not chase kill count before expansion and resource foundations can sustain combat losses.
+- Do not treat private-server or CI infrastructure as the final goal; they are release gates that protect progress toward the gameplay vision.

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -1,8 +1,18 @@
 # Screeps Project Roadmap
 
-Last updated: 2026-04-26T03:01:39Z
+Last updated: 2026-04-26T06:03:38Z
 
 This roadmap is the durable counterpart to the Discord `#roadmap` channel. It summarizes completed milestones, current blockers, next autonomous slices, and the required reporting behavior for main-agent/subagent work.
+
+## Project vision and priority contract
+
+Canonical vision: on Screeps competition maps, achieve the following in strict priority order:
+
+1. **Enough large territory** — claim, hold, defend, and coordinate a large footprint of rooms.
+2. **Enough resources across categories** — convert territory into durable energy, minerals, infrastructure, logistics, and market-ready value.
+3. **Enough enemy kills** — build defensive/offensive combat capability that serves territorial and economic control.
+
+All roadmap decomposition and priority evaluation must tie back to this ordered end goal. When tasks compete, prefer the one that clears the earliest bottleneck in the chain `survive reliably → expand territory → scale resources → defend/attack effectively → optimize kills`. The durable project-vision document is `docs/ops/project-vision.md`.
 
 ## Current status snapshot
 

--- a/docs/process/2026-04-26-project-vision-refresh.md
+++ b/docs/process/2026-04-26-project-vision-refresh.md
@@ -1,0 +1,32 @@
+# Project Vision Refresh
+
+Date: 2026-04-26T06:03:38Z
+
+## Trigger
+
+Owner refreshed the project vision in Discord: in Screeps competition-map play, the bot should obtain enough large territory, enough resources across categories, and enough enemy kills, in that priority order. All roadmap decomposition and priority evaluation should serve the final vision.
+
+## Durable decision
+
+The project vision is now documented as:
+
+1. Territory first: claim, hold, defend, and coordinate a large room footprint.
+2. Resources second: turn territory into energy, minerals, infrastructure, logistics, storage, and market-ready value.
+3. Kills third: build defense/offense and kill capability only as it supports territorial and economic control.
+
+## Files updated
+
+- `AGENTS.md` now names the project vision in the mission/operating model.
+- `docs/ops/project-vision.md` is the canonical project-vision counterpart to Discord `#project-vision`.
+- `docs/ops/roadmap.md` now includes a priority contract and task-ranking chain.
+- `docs/ops/discord-project-spec.md` now treats `#project-vision` as the place for the final gameplay objective and priority contract.
+- `docs/process/active-work-state.md` now references the vision while preserving current P0 agent-operations work.
+- `docs/README.md` indexes the new vision document.
+
+## Planning implications
+
+Near-term P0 communication/validation work remains valid because it protects reliable progress toward the gameplay target. The next product-strategy roadmapping pass should classify each domain by its direct contribution to territory, resource scaling, or combat/kill capability, and should prefer tasks that unblock the earliest missing step in:
+
+```text
+survive reliably → expand territory → scale resources → defend/attack effectively → optimize kills
+```

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -4,7 +4,7 @@ Last updated: 2026-04-26T12:40:22+08:00
 
 ## Current active objective
 
-P0: stabilize and monitor the Screeps agent operating system before continuing normal development. The main agent must preserve owner visibility through the home channel, delegate minimal tasks to subagents/Codex, review subagent conclusions, route summaries to typed Discord channels, and keep scheduled-worker health monitored. Canonical operating contract: `docs/ops/agent-operating-system.md`. Dedicated P0 monitor output is routed to channel `1497820688843800776` via cron delivery target `discord:1497820688843800776`.
+P0: stabilize and monitor the Screeps agent operating system before continuing normal development, while preserving the updated project-vision priority contract: competition-map success means sufficiently large territory first, sufficiently many resources second, and sufficiently many enemy kills third. The main agent must preserve owner visibility through the home channel, delegate minimal tasks to subagents/Codex, review subagent conclusions, route summaries to typed Discord channels, and keep scheduled-worker health monitored. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Dedicated P0 monitor output is routed to channel `1497820688843800776` via cron delivery target `discord:1497820688843800776`.
 
 ## Completed tasks
 


### PR DESCRIPTION
## Summary
- add canonical docs/ops/project-vision.md for the competition-map objective
- update roadmap/agent/Discord docs so roadmap priorities follow territory -> resources -> kills
- add a process note recording the owner vision refresh

## Test Plan
- git diff --check
- verified new docs files exist

Docs-only change; no prod code touched.