### PR TITLE
chore: remove obsolete AGENT.md pointer

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,5 +1,0 @@
-# Agent Guide Pointer
-
-Codex and other AI tools should use `AGENTS.md` at the repository root as the canonical project guide.
-
-This short `AGENT.md` exists because some tools or prompts refer to the singular filename. Do not duplicate instructions here; update `AGENTS.md` instead.


### PR DESCRIPTION
## Summary
- Remove the unused singular root AGENT.md pointer file
- Keep AGENTS.md as the canonical project guide

## Verification
- Confirmed AGENT.md is absent and AGENTS.md remains present

Fixes #24
