### PR TITLE
chore: add issue and PR management templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Roadmap source of truth
+    url: https://github.com/lanyusea/screeps/blob/main/docs/ops/roadmap.md
+    about: Use roadmap entries as issue categories and labels.

--- a/.github/ISSUE_TEMPLATE/known_problem.yml
+++ b/.github/ISSUE_TEMPLATE/known_problem.yml
@@ -1,5 +1,5 @@
 name: Known problem
-关于: Track every known problem against a roadmap item
+description: Track every known problem against a roadmap item
 labels: [kind:bug]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/known_problem.yml
+++ b/.github/ISSUE_TEMPLATE/known_problem.yml
@@ -1,0 +1,73 @@
+name: Known problem
+关于: Track every known problem against a roadmap item
+labels: [kind:bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        所有已知问题都必须建 issue。标题格式必须为：`<优先级>:<roadmap>:<具体问题>`，例如 `P0:Phase D:私服 smoke harness clean rerun 未完成`。
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 优先级
+      description: 选择 P0/P1/P2，并保持标题前缀一致。
+      options:
+        - P0
+        - P1
+        - P2
+    validations:
+      required: true
+  - type: dropdown
+    id: roadmap
+    attributes:
+      label: Roadmap 分类
+      description: 分类必须对应 docs/ops/roadmap.md 的 roadmap 条目。
+      options:
+        - P0 change-control
+        - P0 agent-ops
+        - Phase A docs-sync
+        - Phase B spawn-lifecycle
+        - Phase C telemetry
+        - Phase D private-smoke
+        - Phase E MMO-deploy
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: 问题描述
+      description: 说明现象、影响范围、为什么阻塞 roadmap。
+      placeholder: 当前发生了什么？对 territory/resources/kills 或交付链路有什么影响？
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: 问题日志
+      description: 粘贴 redacted 日志、命令输出、PR/commit/doc 链接；不得包含 secret。
+      placeholder: |
+        - Redacted log/output:
+        - Related docs/PRs/commits:
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 问题复现方式说明
+      description: 写清楚从 clean checkout / runtime / scheduler 如何复现；如果暂不可复现，写明观测入口。
+      placeholder: |
+        1. ...
+        2. ...
+        Actual: ...
+        Expected: ...
+    validations:
+      required: true
+  - type: textarea
+    id: fix_pr
+    attributes:
+      label: 修复 PR 关联要求
+      description: 修复 PR 必须在 PR body 写 `Fixes #<issue>` / `Closes #<issue>` / `Resolves #<issue>`。
+      value: |
+        Fix PR must link this issue with a closing keyword before merge.
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Linked issue
+
+- Fixes #<!-- required: every problem-fix PR must link exactly one or more GitHub issues with a closing keyword -->
+
+## Roadmap category
+
+- <!-- Choose one: P0 change-control / P0 agent-ops / Phase A docs-sync / Phase B spawn-lifecycle / Phase C telemetry / Phase D private-smoke / Phase E MMO-deploy -->
+
+## Summary
+
+- 
+
+## Verification
+
+- [ ] <!-- command or check -->
+
+## Notes
+
+- No secrets are included in this PR.
+- Review/merge gates: wait at least 15 minutes after PR creation, resolve all discussions, and require green CI once configured.

--- a/docs/ops/github-issue-management.md
+++ b/docs/ops/github-issue-management.md
@@ -1,0 +1,52 @@
+# GitHub Issue and PR Management Contract
+
+All known project problems must be tracked in GitHub Issues instead of local-only notes so they remain visible, searchable, and linkable from fixes.
+
+## Issue requirements
+
+Every problem issue must use this title format:
+
+```text
+<优先级>:<roadmap>:<具体问题>
+```
+
+Examples:
+
+```text
+P0:Phase D:私服 smoke harness clean rerun 未完成
+P1:Phase C:runtime-summary 定时投递尚未验证
+```
+
+Every issue body must include:
+
+1. **问题描述** — what is wrong, impact, and why it matters to the roadmap/vision.
+2. **问题日志** — redacted logs, command output, linked docs, PRs, commits, screenshots, or monitor payloads. Never include secrets.
+3. **问题复现方式说明** — exact reproduction steps or, if not yet deterministically reproducible, the observation entry point and expected vs actual behavior.
+
+## Roadmap category labels
+
+Use exactly one roadmap label whenever practical:
+
+- `roadmap:p0-change-control`
+- `roadmap:p0-agent-ops`
+- `roadmap:phase-a-docs-sync`
+- `roadmap:phase-b-spawn-lifecycle`
+- `roadmap:phase-c-telemetry`
+- `roadmap:phase-d-private-smoke`
+- `roadmap:phase-e-mmo-deploy`
+
+Also apply a priority label (`priority:p0`, `priority:p1`, `priority:p2`) and kind label (`kind:bug`, `kind:ops`, `kind:docs`, `kind:test`) where applicable.
+
+## PR requirements
+
+Every PR that fixes a known problem must link its issue in the PR body with a GitHub closing keyword before merge:
+
+```text
+Fixes #123
+Closes #123
+Resolves #123
+```
+
+If a PR touches multiple tracked problems, list every linked issue. A PR that only documents or enables issue-management policy should still link the policy issue.
+
+The normal project PR gates still apply: worktree branch, no direct `main` edits, at least 15 minutes after PR creation before merge, all discussions resolved, and green CI once configured.


### PR DESCRIPTION
## Linked issue

- Fixes #22

## Roadmap category

- P0 change-control

## Summary

- Add a required known-problem GitHub issue form with roadmap category, priority, problem description, logs, and reproduction fields.
- Add a pull request template requiring closing-keyword issue links before fixes merge.
- Document the GitHub issue/PR management contract in docs/ops.

## Verification

- [x] git diff --check
- [x] YAML issue-template parse check

## Notes

- No secrets are included in this PR.
- Review/merge gates: wait at least 15 minutes after PR creation, resolve all discussions, and require green CI once configured.