### PR TITLE
docs: add QA acceptance gate

### DIFF
--- a/docs/ops/agent-operating-system.md
+++ b/docs/ops/agent-operating-system.md
@@ -1,6 +1,6 @@
 # Screeps Agent Operating System
 
-Last updated: 2026-04-26T04:56:00+08:00
+Last updated: 2026-04-26T16:08:57+08:00
 
 ## Purpose
 
@@ -39,6 +39,36 @@ A subagent result is not accepted until the main agent reviews it. The main agen
 - dev/test/build state;
 - runtime status;
 - blockers.
+
+### R2a — Dedicated QA acceptance gate for deliverables
+
+For any meaningful deliverable, the main agent must provide a QA/acceptance-check agent with explicit deliverables, common acceptance criteria, and task-specific acceptance criteria before treating the work as complete.
+
+Use the QA gate for:
+
+- production, test, build, deployment, runtime-monitor, cron, or configuration changes;
+- PR merge readiness and post-merge completion checks;
+- GitHub Issue, Milestone, or Project state changes;
+- roadmap next-point percentage changes;
+- long-running task completion claims;
+- cross-file documentation/process updates that change the operating contract.
+
+The QA agent verifies evidence. It does not own roadmap priority, cross-channel routing, or final project-management decisions. The main agent remains accountable for accepting or rejecting the QA result and for deciding the next roadmap move.
+
+QA checks must cover, when relevant:
+
+- code/documentation changes match the requested deliverables;
+- verification commands, CI, smoke tests, generated artifacts, or redacted runtime reports support the completion claim;
+- PRs are pushed, reviewed, merged, or explicitly closed as superseded according to project gates;
+- GitHub Issues, Milestones, and Project `screeps` fields reflect the final state;
+- process/roadmap docs match GitHub source-of-truth state;
+- no secrets or unsafe local paths were exposed;
+- Discord/channel reporting requirements were satisfied or explicitly marked not applicable.
+
+QA output must be evidence-based and use this verdict model:
+
+- `PASS` — all common and task-specific acceptance criteria are satisfied, with evidence listed.
+- `REQUEST_CHANGES` — at least one required criterion is not satisfied, with concrete required fixes.
 
 ### R3 — Main agent owns channel-appropriate summary fanout
 
@@ -98,13 +128,15 @@ For every meaningful task:
 1. Read current active state and git status.
 2. If P0 health is unknown, run an operations health check first.
 3. Decompose into minimal subagent/Codex tasks if useful.
-4. Give each subagent a single clear task and requested output format.
-5. Collect subagent final result and logs/artifacts.
-6. Review and verify before accepting.
-7. Update durable docs if the result changes state.
-8. Fan out summaries to the corresponding Discord channels.
-9. Commit/push meaningful docs-only changes as Hermes; Codex commits production/test/build work.
-10. Resume/trigger scheduled continuation only after state is durable and safe.
+4. Define the deliverables, common acceptance criteria, and task-specific acceptance criteria before implementation/review starts.
+5. Give each subagent a single clear task and requested output format.
+6. Collect subagent final result and logs/artifacts.
+7. Run a QA/acceptance-check pass for meaningful deliverables before accepting completion.
+8. Review QA evidence and either request changes or accept the result.
+9. Update durable docs if the result changes state.
+10. Fan out summaries to the corresponding Discord channels.
+11. Commit/push meaningful docs-only changes as Hermes; Codex commits production/test/build work.
+12. Resume/trigger scheduled continuation only after state is durable and safe.
 
 ## Scheduled worker roles
 
@@ -173,7 +205,8 @@ These reporters are not authoritative decision-makers. They are narrow visibilit
 | New owner task | home channel | `#task-queue` when accepted | yes, if clarification/blocker needed |
 | P0 health anomaly | `discord:1497820688843800776` | home only if owner action is urgently required | yes |
 | Subagent research result | main agent review first | `#research-notes` | no, unless decision needed |
-| Subagent development result | main agent review first | `#dev-log` | no, unless blocker/decision needed |
+| Subagent development result | main agent review first, then QA gate when deliverable-significant | `#dev-log` | no, unless blocker/decision needed |
+| QA acceptance result | main agent review first | `#task-queue` for PASS/REQUEST_CHANGES; `#dev-log` for verification evidence | no, unless blocker/decision needed |
 | Decision needed/finalized | `#decisions` | home if owner action needed | yes |
 | Roadmap/priorities changed | `#roadmap` | home only if major | maybe |
 | Active task/blocker | `#task-queue` | home if owner action needed | maybe |
@@ -188,3 +221,4 @@ These reporters are not authoritative decision-makers. They are narrow visibilit
 - Do not treat subagent output as accepted until the main agent reviews it.
 - Do not let subagents own cross-channel summary/decision routing.
 - Do not resume normal implementation work while P0 routing/monitoring is known broken.
+- Do not mark meaningful deliverables complete without a QA/acceptance-check verdict that cites evidence against both common and task-specific criteria.

--- a/docs/ops/discord-project-spec.md
+++ b/docs/ops/discord-project-spec.md
@@ -203,7 +203,8 @@ Main-agent responsibilities:
 4. pull subagent conclusions back into the main context;
 5. verify/review before accepting;
 6. route summaries to the typed Discord channels;
-7. maintain P0 monitoring of scheduled jobs, delivery targets, active-state freshness, and subagent communication.
+7. maintain P0 monitoring of scheduled jobs, delivery targets, active-state freshness, and subagent communication;
+8. run a QA/acceptance-check pass before marking meaningful deliverables complete.
 
 Subagent responsibilities:
 
@@ -212,7 +213,14 @@ Subagent responsibilities:
 - write or expose process detail if the task is long/complex;
 - avoid owning cross-channel decisions, roadmap, or task-queue state.
 
-If a spawned long-running agent has messaging access and a single obvious detail channel, it may post low-level progress to that one channel only, e.g. research → `#research-notes`, development → `#dev-log`. The main agent remains accountable for summary fanout and owner-facing status.
+QA/acceptance-check agent responsibilities:
+
+- verify one explicit delivery package against the main agent's common and task-specific acceptance criteria;
+- check code/docs diffs, verification evidence, PR state, merge state, GitHub Issue/Milestone/Project updates, and delivery-standard compliance when applicable;
+- return `PASS` or `REQUEST_CHANGES` with evidence and required fixes;
+- avoid changing roadmap priority, cross-channel authority, or final completion state independently.
+
+If a spawned long-running agent has messaging access and a single obvious detail channel, it may post low-level progress only to that channel, e.g. research → `#research-notes`, development → `#dev-log`. The main agent remains accountable for summary fanout and owner-facing status.
 
 ---
 
@@ -243,6 +251,29 @@ If a spawned long-running agent has messaging access and a single obvious detail
 [Owner] Owner / Bot
 [Done when] explicit acceptance criterion
 [Blockers] if any
+[QA gate] required / not required; if required, name common + task-specific acceptance criteria
+```
+
+### QA acceptance check
+```text
+[Delivery package] issue / PR / branch / commit / artifact links
+[Common criteria checked]
+- [ ] worktree/PR discipline
+- [ ] verification commands or CI
+- [ ] merge/closure state
+- [ ] GitHub Issue/Milestone/Project state
+- [ ] docs/process/roadmap consistency
+- [ ] no secrets exposed
+- [ ] Discord routing/reporting as applicable
+[Task-specific criteria checked]
+- [ ] ...
+[Evidence]
+commands, PR/Issue URLs, commit SHAs, artifact/report paths
+[Failed items]
+none, or concrete missing criteria
+[Required fixes]
+none, or exact follow-up actions
+[Verdict] PASS / REQUEST_CHANGES
 ```
 
 ### Owner-created task follow-up thread

--- a/docs/process/2026-04-26-qa-acceptance-agent-contract.md
+++ b/docs/process/2026-04-26-qa-acceptance-agent-contract.md
@@ -1,0 +1,45 @@
+# QA Acceptance Agent Contract
+
+Date: 2026-04-26
+
+## Context
+
+The owner approved adding a dedicated QA / acceptance-check agent role because the main agent's checklist burden had grown across roadmap management, implementation coordination, PR/CI/merge verification, GitHub Issue/Project updates, durable docs, and Discord reporting.
+
+A parallel task was already updating the GitHub-state-before-completion requirement in PR #40. To avoid conflict, this change deliberately avoids touching:
+
+- `AGENTS.md`
+- `docs/ops/github-issue-management.md`
+- `docs/ops/github-roadmap-management.md`
+
+This change is scoped to the agent operating-system and Discord coordination contracts.
+
+## Decision
+
+For meaningful deliverables, the main agent remains the project manager and final delivery owner, but must define explicit deliverables plus common and task-specific acceptance criteria for a QA / acceptance-check agent.
+
+The QA agent independently verifies evidence and returns either:
+
+- `PASS` — criteria are satisfied with cited evidence.
+- `REQUEST_CHANGES` — one or more required criteria are missing, with concrete required fixes.
+
+The QA agent does not own roadmap priority, final completion state, or cross-channel routing decisions.
+
+## Implemented documentation changes
+
+- `docs/ops/agent-operating-system.md`
+  - Added the dedicated QA acceptance gate.
+  - Added QA to the main-agent workflow.
+  - Added QA acceptance output routing.
+  - Added an anti-regression rule prohibiting completion without evidence-based QA for meaningful deliverables.
+- `docs/ops/discord-project-spec.md`
+  - Added QA acceptance-check responsibilities.
+  - Added task-template QA gate field.
+  - Added a QA acceptance-check message template.
+
+## Verification plan
+
+- `git diff --check`
+- Confirm this branch does not modify the files owned by concurrent PR #40.
+- Create a docs-only PR linked to issue #41.
+- Use the new QA gate on this very change before final completion.


### PR DESCRIPTION
## Summary
- codify a dedicated QA / acceptance-check agent gate for meaningful Screeps deliverables
- require main agent to define explicit deliverables, common criteria, and task-specific acceptance criteria before accepting completion
- add QA output/routing responsibilities and message templates
- intentionally avoid PR #40 files (`AGENTS.md`, `docs/ops/github-issue-management.md`, `docs/ops/github-roadmap-management.md`) to prevent conflicts with the concurrent GitHub-state task

## Linked issue
Fixes #41

## Roadmap category
P0 Agent OS / Discord visibility gate (`roadmap:p0-agent-ops`)

## Verification
- `git diff --check`
- changed files limited to `docs/ops/agent-operating-system.md`, `docs/ops/discord-project-spec.md`, and `docs/process/2026-04-26-qa-acceptance-agent-contract.md`
