### PR TITLE
docs: record scheduler cadence follow-up

### DIFF
--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -37,7 +37,7 @@ These percentages are explicit next-point estimates for the current roadmap snap
 
 | Domain | Next-point completion | Current next point |
 | --- | ---: | --- |
-| Agent OS / visibility | 88% | follow up runtime-alert/P0-monitor scheduler-cadence gap and prove `next_run_at` advances normally |
+| Agent OS / visibility | 88% | repair or operator-inspect the scheduler runner/cadence defect; prove runtime-alert job `1c093252ab70` advances across two no-alert `[SILENT]` intervals |
 | Engineering governance | 75% | enforceable `main` branch protection / required checks |
 | Private-server validation | 85% | fresh live harness run and redacted report |
 | Runtime Monitor | 85% | reliable scheduled summary images plus no-alert silence |
@@ -267,6 +267,11 @@ Immediate operating change:
 - live monitoring cadence: continuation every 5 minutes during P0/active-development periods, operations monitor every 15 minutes, 4-hour checkpoint every 240 minutes;
 - continuation/checkpoint workers remain subordinate to main-agent review and channel fanout;
 - if P0 health is abnormal, pause or defer new implementation work until corrected.
+
+Current evidence update:
+
+- `docs/process/2026-04-26-scheduler-alert-gap-audit.md` found the runtime-alert job stale despite correct delivery configuration.
+- `docs/process/2026-04-26-scheduler-cadence-followup.md` reproduced the defect: alert job `1c093252ab70` still did not launch after its overdue `next_run_at`, and no new alert session appeared after `2026-04-26T16:04+08:00`. The latest successful alert session did return `alert: false`, `ok: true`, and final `[SILENT]`, so no-alert output behavior is proven when the job runs; the remaining blocker is scheduler cadence/rescheduling.
 
 ### Validation follow-up: automate private-server smoke and runtime monitoring
 

--- a/docs/process/2026-04-26-scheduler-cadence-followup.md
+++ b/docs/process/2026-04-26-scheduler-cadence-followup.md
@@ -1,0 +1,47 @@
+# Scheduler cadence follow-up
+
+Date: 2026-04-26
+
+## Bounded slice
+
+This continuation worker started at `2026-04-26T17:00:07+08:00` with a target runtime of 25 minutes and absolute maximum of 45 minutes. The slice was limited to verifying the P0 scheduler/reporting gap identified in `docs/process/2026-04-26-scheduler-alert-gap-audit.md`; no cron jobs were created or modified.
+
+## Repository and PR state
+
+- `/root/screeps` was clean on `main` at slice start.
+- `gh pr list --state open` returned an empty list, so there was no active PR loop to close before investigating the visibility issue.
+- Investigation and documentation were performed from worktree `/root/screeps-worktrees/scheduler-cadence-followup-20260426` on branch `docs/scheduler-cadence-followup-20260426`.
+
+## Evidence collected
+
+Safe metadata from `/root/.hermes/cron/jobs.json` and `/root/.hermes/sessions` was inspected without printing job prompts, command bodies, env values, or secrets.
+
+At `2026-04-26T17:00:54+08:00`:
+
+- `Screeps runtime room alert image check` (`1c093252ab70`) was still enabled with `last_status: ok` and no delivery error, but its `last_run_at` remained `2026-04-26T16:04:43.914467+08:00`.
+- The same alert job's `next_run_at` was `2026-04-26T17:00:29.431092+08:00`, already overdue by inspection time.
+- The newest alert job session files remained:
+  - `session_cron_1c093252ab70_20260426_145657.json`
+  - `session_cron_1c093252ab70_20260426_155756.json`
+  - `session_cron_1c093252ab70_20260426_160432.json`
+- The latest alert session returned valid monitor JSON with `alert: false`, `ok: true`, no warnings, and final response `[SILENT]`, so the monitor command and no-alert silence behavior worked when the scheduler actually ran it.
+- `Screeps runtime room summary images` (`befcbb7b2d60`) had run recently at `2026-04-26T16:55:50.158902+08:00`, rendered `summary-shardX-E48S28.png`, and delivered a normal runtime summary.
+
+After an additional 90-second wait, at `2026-04-26T17:03:00+08:00`:
+
+- The alert job still had not advanced: `last_run_at` remained `2026-04-26T16:04:43.914467+08:00` and `next_run_at` remained the overdue `2026-04-26T17:00:29.431092+08:00`.
+- No new `session_cron_1c093252ab70_*` files appeared after `2026-04-26T16:04:32`.
+- The P0 operations monitor (`75cedbb77150`) was also stale relative to its 15-minute interval: `last_run_at` remained `2026-04-26T15:56:56.619704+08:00`, although its `next_run_at` was still in the future at `2026-04-26T17:10:29.431092+08:00`.
+
+## Conclusion
+
+The earlier suspected scheduler cadence gap is still reproducible. Runtime alert delivery configuration is correct and the alert monitor itself returns proper `[SILENT]` output when no alert exists, but the scheduler did not launch the every-5-minute runtime-alert job for nearly an hour and did not consume an overdue `next_run_at` during this bounded slice.
+
+This is now a P0 visibility blocker for runtime-alert reliability, not a Screeps monitor script bug. The continuation worker should not proceed to private-server smoke or unrelated bot hardening until the scheduler runner/cadence issue is repaired or explicitly accepted.
+
+## Recommended next action
+
+1. Inspect the Hermes scheduler runner/gateway logs and scheduler state transitions for job `1c093252ab70` around `2026-04-26T16:04` through `17:03`.
+2. Verify whether jobs that return final `[SILENT]` are being rescheduled correctly, because the runtime-summary job continued to run while the alert job stopped advancing.
+3. Repair or restart the scheduler runner from an operator-controlled context if needed; this continuation worker intentionally did not create, delete, or mutate cron jobs.
+4. After repair, require fresh proof that `1c093252ab70` advances `last_run_at` and `next_run_at` across at least two consecutive intervals while returning `[SILENT]` for no-alert output.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,6 +1,6 @@
 # Active Work State
 
-Last updated: 2026-04-26T16:36:00+08:00
+Last updated: 2026-04-26T17:03:00+08:00
 
 ## Current active objective
 
@@ -276,6 +276,7 @@ If any task remains open for more than 4 hours without a final conclusion, publi
 - Discord visibility root-cause postmortem recorded in `docs/process/2026-04-26-discord-visibility-root-cause-postmortem.md`: scheduled Screeps continuation/checkpoint jobs should deliver to the named project channel `discord:#task-queue`; global/home notifications may use home channel `1497537021378564200`; avoid sending global notices to thread `1497579848594493560`.
 - Background terminal process completion notifications can bypass normal `send_message`/cron delivery routing and return to the invoking thread; future global/public long-running shell tasks should avoid `notify_on_complete=true` and instead poll/wait then report through the intended channel/cron delivery path.
 - P0 checkpoint on 2026-04-26T09:12:32+08:00 recorded `docs/process/2026-04-26-p0-routing-checkpoint-0912.md` and marked the older background-process routing note as superseded for scheduled-worker delivery. Current scheduled Screeps continuation/checkpoint target remains `discord:#task-queue`; home channel `1497537021378564200` is for global/home notifications, not routine scheduled project-progress delivery.
+- P0 scheduler cadence follow-up on 2026-04-26T17:03:00+08:00 recorded `docs/process/2026-04-26-scheduler-cadence-followup.md`: runtime-alert job `1c093252ab70` still did not advance after its overdue `next_run_at`, no new alert session appeared after `16:04`, and the latest successful alert run did prove no-alert `[SILENT]` behavior. Treat this as a scheduler runner/cadence blocker before private-server smoke or unrelated bot hardening.
 - Coding boundary clarified: future production/test/build code changes under `prod/` must be implemented via OpenAI Codex CLI, while Hermes orchestrates, verifies, documents, reports, and pushes.
 - Commit behavior clarified: Codex must commit after each completed coding task; documentation-only changes may be committed by Hermes directly.
 - Git identity configured globally and local history rewritten to `lanyusea's bot <lanyusea@gmail.com>`; local rewrite succeeded, remote force push was blocked by platform smart approval and still needs an approved force-push path if remote history rewrite is still desired.
@@ -295,7 +296,7 @@ If any task remains open for more than 4 hours without a final conclusion, publi
 
 Owner correction on 2026-04-26: the main agent is responsible for project management outcomes, not only process scheduling. Every active planning/reporting cycle must keep all six roadmap domains advancing concurrently through delegated subagent/Codex tasks:
 
-1. Agent OS / visibility — current estimate 88%; next delegated task: follow up the runtime-alert/P0-monitor scheduler-cadence gap recorded in `docs/process/2026-04-26-scheduler-alert-gap-audit.md` and prove whether `next_run_at` advances normally after this slice.
+1. Agent OS / visibility — current estimate 88%; next delegated task: repair or operator-inspect the scheduler runner/cadence defect recorded in `docs/process/2026-04-26-scheduler-cadence-followup.md`, then prove runtime-alert job `1c093252ab70` advances across at least two no-alert `[SILENT]` intervals.
 2. Engineering governance — current estimate 75%; next delegated task: branch protection / required-check gate.
 3. Private-server validation — current estimate 85%; next delegated task: fresh live `scripts/screeps-private-smoke.py run` from a clean ignored workdir and redacted report.
 4. Runtime Monitor — current estimate 85%; next delegated task: verify scheduled summary/alert cadence and no-alert silence.


### PR DESCRIPTION
## Summary
- records follow-up scheduler cadence evidence for the runtime-alert job
- updates active work state and roadmap next point to treat the stale alert cadence as the current P0 visibility blocker
- documents that no-alert `[SILENT]` behavior works when the alert job actually runs, narrowing the blocker to scheduler cadence/rescheduling

## Roadmap category
- P0 agent-ops / visibility gate

## Linked issue
- Related to #27

## Verification
- `git diff --check`
- `gh pr view 44 --json comments,reviews,statusCheckRollup`
- GraphQL review-thread inspection returned no unresolved review threads
- Docs-only change; no prod verification required

## Operational note
No cron jobs were created, deleted, or modified in this slice.
