### PR TITLE
ci: make prod verification required-check friendly

### DIFF
--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -2,15 +2,9 @@ name: prod-ci
 
 on:
   pull_request:
-    paths:
-      - "prod/**"
-      - ".github/workflows/prod-ci.yml"
   push:
     branches:
       - main
-    paths:
-      - "prod/**"
-      - ".github/workflows/prod-ci.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- runs `prod-ci` on every pull request so the check context is always present
- keeps push coverage on `main` without path filters
- prepares the repo for enforcing `Verify prod TypeScript, Jest, and bundle` as a required check on `main`

## Verification
- [x] `git diff --check`
- [x] `.github/workflows/prod-ci.yml` parsed with PyYAML

Fixes #26
