### PR TITLE
feat: add runtime KPI telemetry

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -263,13 +263,17 @@ function shouldEmitRuntimeSummary(tick, events) {
 }
 function summarizeRoom(colony, creeps) {
   const colonyWorkers = creeps.filter((creep) => creep.memory.role === "worker" && creep.memory.colony === colony.room.name);
+  const eventMetrics = summarizeRoomEventMetrics(colony.room);
   return {
     roomName: colony.room.name,
     energyAvailable: colony.energyAvailable,
     energyCapacity: colony.energyCapacityAvailable,
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
-    taskCounts: countWorkerTasks(colonyWorkers)
+    taskCounts: countWorkerTasks(colonyWorkers),
+    ...buildControllerSummary(colony.room),
+    resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
+    combat: summarizeCombat(colony.room, eventMetrics.combat)
   };
 }
 function summarizeSpawn(spawn) {
@@ -307,6 +311,167 @@ function countWorkerTasks(workers) {
 }
 function isWorkerTaskType(taskType) {
   return WORKER_TASK_TYPES.includes(taskType);
+}
+function buildControllerSummary(room) {
+  const controller = room.controller;
+  if (!(controller == null ? void 0 : controller.my)) {
+    return {};
+  }
+  const summary = {
+    level: controller.level
+  };
+  if (typeof controller.progress === "number") {
+    summary.progress = controller.progress;
+  }
+  if (typeof controller.progressTotal === "number") {
+    summary.progressTotal = controller.progressTotal;
+  }
+  if (typeof controller.ticksToDowngrade === "number") {
+    summary.ticksToDowngrade = controller.ticksToDowngrade;
+  }
+  return { controller: summary };
+}
+function summarizeResources(colony, colonyWorkers, events) {
+  var _a, _b, _c;
+  const roomStructures = (_a = findRoomObjects(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const droppedResources = (_b = findRoomObjects(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _b : [];
+  const sources = (_c = findRoomObjects(colony.room, "FIND_SOURCES")) != null ? _c : [];
+  return {
+    storedEnergy: sumEnergyInStores(roomStructures),
+    workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
+    droppedEnergy: sumDroppedEnergy(droppedResources),
+    sourceCount: sources.length,
+    ...events ? { events } : {}
+  };
+}
+function summarizeCombat(room, events) {
+  var _a, _b;
+  const hostileCreeps = (_a = findRoomObjects(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
+  const hostileStructures = (_b = findRoomObjects(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
+  return {
+    hostileCreepCount: hostileCreeps.length,
+    hostileStructureCount: hostileStructures.length,
+    ...events ? { events } : {}
+  };
+}
+function summarizeRoomEventMetrics(room) {
+  const eventLog = getRoomEventLog(room);
+  if (!eventLog) {
+    return {};
+  }
+  const harvestEvent = getGlobalNumber("EVENT_HARVEST");
+  const transferEvent = getGlobalNumber("EVENT_TRANSFER");
+  const attackEvent = getGlobalNumber("EVENT_ATTACK");
+  const objectDestroyedEvent = getGlobalNumber("EVENT_OBJECT_DESTROYED");
+  const resourceEvents = {
+    harvestedEnergy: 0,
+    transferredEnergy: 0
+  };
+  const combatEvents = {
+    attackCount: 0,
+    attackDamage: 0,
+    objectDestroyedCount: 0,
+    creepDestroyedCount: 0
+  };
+  let hasResourceEvents = false;
+  let hasCombatEvents = false;
+  for (const entry of eventLog) {
+    if (!isRecord(entry) || typeof entry.event !== "number") {
+      continue;
+    }
+    const data = isRecord(entry.data) ? entry.data : {};
+    if (entry.event === harvestEvent && isEnergyEventData(data)) {
+      resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
+      hasResourceEvents = true;
+    }
+    if (entry.event === transferEvent && isEnergyEventData(data)) {
+      resourceEvents.transferredEnergy += getNumericEventData(data, "amount");
+      hasResourceEvents = true;
+    }
+    if (entry.event === attackEvent) {
+      combatEvents.attackCount += 1;
+      combatEvents.attackDamage += getNumericEventData(data, "damage");
+      hasCombatEvents = true;
+    }
+    if (entry.event === objectDestroyedEvent) {
+      combatEvents.objectDestroyedCount += 1;
+      if (data.type === "creep") {
+        combatEvents.creepDestroyedCount += 1;
+      }
+      hasCombatEvents = true;
+    }
+  }
+  return {
+    ...hasResourceEvents ? { resources: resourceEvents } : {},
+    ...hasCombatEvents ? { combat: combatEvents } : {}
+  };
+}
+function findRoomObjects(room, constantName) {
+  const findConstant = getGlobalNumber(constantName);
+  const find = room.find;
+  if (typeof findConstant !== "number" || typeof find !== "function") {
+    return void 0;
+  }
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return void 0;
+  }
+}
+function getRoomEventLog(room) {
+  const getEventLog = room.getEventLog;
+  if (typeof getEventLog !== "function") {
+    return void 0;
+  }
+  try {
+    const eventLog = getEventLog.call(room);
+    return Array.isArray(eventLog) ? eventLog : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function sumEnergyInStores(objects) {
+  return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
+}
+function getEnergyInStore(object) {
+  if (!isRecord(object) || !isRecord(object.store)) {
+    return 0;
+  }
+  const getUsedCapacity = object.store.getUsedCapacity;
+  if (typeof getUsedCapacity === "function") {
+    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource());
+    return typeof usedCapacity === "number" ? usedCapacity : 0;
+  }
+  const storedEnergy = object.store[getEnergyResource()];
+  return typeof storedEnergy === "number" ? storedEnergy : 0;
+}
+function sumDroppedEnergy(droppedResources) {
+  const energyResource = getEnergyResource();
+  return droppedResources.reduce((total, droppedResource) => {
+    if (!isRecord(droppedResource) || droppedResource.resourceType !== energyResource) {
+      return total;
+    }
+    return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
+  }, 0);
+}
+function isEnergyEventData(data) {
+  return data.resourceType === void 0 || data.resourceType === getEnergyResource();
+}
+function getNumericEventData(data, key) {
+  const value = data[key];
+  return typeof value === "number" ? value : 0;
+}
+function getGlobalNumber(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function getEnergyResource() {
+  const value = globalThis.RESOURCE_ENERGY;
+  return typeof value === "string" ? value : "energy";
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
   const gameWithOptionalCpu = Game;

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -35,6 +35,47 @@ interface RuntimeRoomSummary {
   workerCount: number;
   spawnStatus: RuntimeSpawnStatus[];
   taskCounts: WorkerTaskCounts;
+  controller?: RuntimeControllerSummary;
+  resources: RuntimeResourceSummary;
+  combat: RuntimeCombatSummary;
+}
+
+interface RuntimeControllerSummary {
+  level: number;
+  progress?: number;
+  progressTotal?: number;
+  ticksToDowngrade?: number;
+}
+
+interface RuntimeResourceEventSummary {
+  harvestedEnergy: number;
+  transferredEnergy: number;
+}
+
+interface RuntimeResourceSummary {
+  storedEnergy: number;
+  workerCarriedEnergy: number;
+  droppedEnergy: number;
+  sourceCount: number;
+  events?: RuntimeResourceEventSummary;
+}
+
+interface RuntimeCombatEventSummary {
+  attackCount: number;
+  attackDamage: number;
+  objectDestroyedCount: number;
+  creepDestroyedCount: number;
+}
+
+interface RuntimeCombatSummary {
+  hostileCreepCount: number;
+  hostileStructureCount: number;
+  events?: RuntimeCombatEventSummary;
+}
+
+interface RuntimeRoomEventMetrics {
+  resources?: RuntimeResourceEventSummary;
+  combat?: RuntimeCombatEventSummary;
 }
 
 interface RuntimeCpuSummary {
@@ -80,6 +121,7 @@ export function shouldEmitRuntimeSummary(tick: number, events: RuntimeTelemetryE
 
 function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSummary {
   const colonyWorkers = creeps.filter((creep) => creep.memory.role === 'worker' && creep.memory.colony === colony.room.name);
+  const eventMetrics = summarizeRoomEventMetrics(colony.room);
 
   return {
     roomName: colony.room.name,
@@ -87,7 +129,10 @@ function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSumm
     energyCapacity: colony.energyCapacityAvailable,
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
-    taskCounts: countWorkerTasks(colonyWorkers)
+    taskCounts: countWorkerTasks(colonyWorkers),
+    ...buildControllerSummary(colony.room),
+    resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
+    combat: summarizeCombat(colony.room, eventMetrics.combat)
   };
 }
 
@@ -130,6 +175,203 @@ function countWorkerTasks(workers: Creep[]): WorkerTaskCounts {
 
 function isWorkerTaskType(taskType: string | undefined): taskType is WorkerTaskType {
   return WORKER_TASK_TYPES.includes(taskType as WorkerTaskType);
+}
+
+function buildControllerSummary(room: Room): { controller?: RuntimeControllerSummary } {
+  const controller = room.controller;
+  if (!controller?.my) {
+    return {};
+  }
+
+  const summary: RuntimeControllerSummary = {
+    level: controller.level
+  };
+
+  if (typeof controller.progress === 'number') {
+    summary.progress = controller.progress;
+  }
+
+  if (typeof controller.progressTotal === 'number') {
+    summary.progressTotal = controller.progressTotal;
+  }
+
+  if (typeof controller.ticksToDowngrade === 'number') {
+    summary.ticksToDowngrade = controller.ticksToDowngrade;
+  }
+
+  return { controller: summary };
+}
+
+function summarizeResources(
+  colony: ColonySnapshot,
+  colonyWorkers: Creep[],
+  events: RuntimeResourceEventSummary | undefined
+): RuntimeResourceSummary {
+  const roomStructures = findRoomObjects(colony.room, 'FIND_STRUCTURES') ?? colony.spawns;
+  const droppedResources = findRoomObjects(colony.room, 'FIND_DROPPED_RESOURCES') ?? [];
+  const sources = findRoomObjects(colony.room, 'FIND_SOURCES') ?? [];
+
+  return {
+    storedEnergy: sumEnergyInStores(roomStructures),
+    workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
+    droppedEnergy: sumDroppedEnergy(droppedResources),
+    sourceCount: sources.length,
+    ...(events ? { events } : {})
+  };
+}
+
+function summarizeCombat(room: Room, events: RuntimeCombatEventSummary | undefined): RuntimeCombatSummary {
+  const hostileCreeps = findRoomObjects(room, 'FIND_HOSTILE_CREEPS') ?? [];
+  const hostileStructures = findRoomObjects(room, 'FIND_HOSTILE_STRUCTURES') ?? [];
+
+  return {
+    hostileCreepCount: hostileCreeps.length,
+    hostileStructureCount: hostileStructures.length,
+    ...(events ? { events } : {})
+  };
+}
+
+function summarizeRoomEventMetrics(room: Room): RuntimeRoomEventMetrics {
+  const eventLog = getRoomEventLog(room);
+  if (!eventLog) {
+    return {};
+  }
+
+  const harvestEvent = getGlobalNumber('EVENT_HARVEST');
+  const transferEvent = getGlobalNumber('EVENT_TRANSFER');
+  const attackEvent = getGlobalNumber('EVENT_ATTACK');
+  const objectDestroyedEvent = getGlobalNumber('EVENT_OBJECT_DESTROYED');
+  const resourceEvents: RuntimeResourceEventSummary = {
+    harvestedEnergy: 0,
+    transferredEnergy: 0
+  };
+  const combatEvents: RuntimeCombatEventSummary = {
+    attackCount: 0,
+    attackDamage: 0,
+    objectDestroyedCount: 0,
+    creepDestroyedCount: 0
+  };
+  let hasResourceEvents = false;
+  let hasCombatEvents = false;
+
+  for (const entry of eventLog) {
+    if (!isRecord(entry) || typeof entry.event !== 'number') {
+      continue;
+    }
+
+    const data = isRecord(entry.data) ? entry.data : {};
+    if (entry.event === harvestEvent && isEnergyEventData(data)) {
+      resourceEvents.harvestedEnergy += getNumericEventData(data, 'amount');
+      hasResourceEvents = true;
+    }
+
+    if (entry.event === transferEvent && isEnergyEventData(data)) {
+      resourceEvents.transferredEnergy += getNumericEventData(data, 'amount');
+      hasResourceEvents = true;
+    }
+
+    if (entry.event === attackEvent) {
+      combatEvents.attackCount += 1;
+      combatEvents.attackDamage += getNumericEventData(data, 'damage');
+      hasCombatEvents = true;
+    }
+
+    if (entry.event === objectDestroyedEvent) {
+      combatEvents.objectDestroyedCount += 1;
+      if (data.type === 'creep') {
+        combatEvents.creepDestroyedCount += 1;
+      }
+      hasCombatEvents = true;
+    }
+  }
+
+  return {
+    ...(hasResourceEvents ? { resources: resourceEvents } : {}),
+    ...(hasCombatEvents ? { combat: combatEvents } : {})
+  };
+}
+
+function findRoomObjects(room: Room, constantName: string): unknown[] | undefined {
+  const findConstant = getGlobalNumber(constantName);
+  const find = (room as unknown as { find?: unknown }).find;
+  if (typeof findConstant !== 'number' || typeof find !== 'function') {
+    return undefined;
+  }
+
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return undefined;
+  }
+}
+
+function getRoomEventLog(room: Room): unknown[] | undefined {
+  const getEventLog = (room as unknown as { getEventLog?: unknown }).getEventLog;
+  if (typeof getEventLog !== 'function') {
+    return undefined;
+  }
+
+  try {
+    const eventLog = getEventLog.call(room);
+    return Array.isArray(eventLog) ? eventLog : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function sumEnergyInStores(objects: unknown[]): number {
+  return objects.reduce<number>((total, object) => total + getEnergyInStore(object), 0);
+}
+
+function getEnergyInStore(object: unknown): number {
+  if (!isRecord(object) || !isRecord(object.store)) {
+    return 0;
+  }
+
+  const getUsedCapacity = object.store.getUsedCapacity;
+  if (typeof getUsedCapacity === 'function') {
+    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource());
+    return typeof usedCapacity === 'number' ? usedCapacity : 0;
+  }
+
+  const storedEnergy = object.store[getEnergyResource()];
+  return typeof storedEnergy === 'number' ? storedEnergy : 0;
+}
+
+function sumDroppedEnergy(droppedResources: unknown[]): number {
+  const energyResource = getEnergyResource();
+
+  return droppedResources.reduce<number>((total, droppedResource) => {
+    if (!isRecord(droppedResource) || droppedResource.resourceType !== energyResource) {
+      return total;
+    }
+
+    return total + (typeof droppedResource.amount === 'number' ? droppedResource.amount : 0);
+  }, 0);
+}
+
+function isEnergyEventData(data: Record<string, unknown>): boolean {
+  return data.resourceType === undefined || data.resourceType === getEnergyResource();
+}
+
+function getNumericEventData(data: Record<string, unknown>, key: string): number {
+  const value = data[key];
+  return typeof value === 'number' ? value : 0;
+}
+
+function getGlobalNumber(name: string): number | undefined {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function getEnergyResource(): ResourceConstant {
+  const value = (globalThis as Record<string, unknown>).RESOURCE_ENERGY;
+  return (typeof value === 'string' ? value : 'energy') as ResourceConstant;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function buildCpuSummary(): { cpu?: RuntimeCpuSummary } {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -7,18 +7,35 @@ import {
   type RuntimeTelemetryEvent
 } from '../src/telemetry/runtimeSummary';
 
+const TEST_GLOBALS = {
+  FIND_STRUCTURES: 101,
+  FIND_DROPPED_RESOURCES: 102,
+  FIND_SOURCES: 103,
+  FIND_HOSTILE_CREEPS: 104,
+  FIND_HOSTILE_STRUCTURES: 105,
+  EVENT_HARVEST: 201,
+  EVENT_TRANSFER: 202,
+  EVENT_ATTACK: 203,
+  EVENT_OBJECT_DESTROYED: 204,
+  RESOURCE_ENERGY: 'energy'
+} as const;
+
+const RUNTIME_GLOBAL_KEYS = Object.keys(TEST_GLOBALS);
+
 describe('runtime telemetry summaries', () => {
   let logSpy: jest.SpyInstance<void, [message?: unknown, ...optionalParams: unknown[]]>;
 
   beforeEach(() => {
+    clearRuntimeTelemetryGlobals();
     logSpy = jest.spyOn(console, 'log').mockImplementation();
   });
 
   afterEach(() => {
     logSpy.mockRestore();
+    clearRuntimeTelemetryGlobals();
   });
 
-  it('emits cadence-limited runtime summaries with room, spawn, task, and CPU fields', () => {
+  it('emits cadence-limited runtime summaries with room, spawn, task, CPU, and KPI fields', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,
       spawn: {
@@ -27,9 +44,9 @@ describe('runtime telemetry summaries', () => {
       }
     });
     const creeps = [
-      makeWorker({ role: 'worker', colony: 'W1N1', task: { type: 'harvest', targetId: 'source1' as Id<Source> } }),
-      makeWorker({ role: 'worker', colony: 'W1N1' }),
-      makeWorker({ role: 'worker', colony: 'W2N2', task: { type: 'transfer', targetId: 'spawn2' as Id<AnyStoreStructure> } })
+      makeWorker({ role: 'worker', colony: 'W1N1', task: { type: 'harvest', targetId: 'source1' as Id<Source> } }, 40),
+      makeWorker({ role: 'worker', colony: 'W1N1' }, 20),
+      makeWorker({ role: 'worker', colony: 'W2N2', task: { type: 'transfer', targetId: 'spawn2' as Id<AnyStoreStructure> } }, 80)
     ];
 
     emitRuntimeSummary([colony], creeps);
@@ -58,6 +75,32 @@ describe('runtime telemetry summaries', () => {
             transfer: 0,
             build: 0,
             upgrade: 0
+          },
+          controller: {
+            level: 2,
+            progress: 1234,
+            progressTotal: 45000,
+            ticksToDowngrade: 15000
+          },
+          resources: {
+            storedEnergy: 175,
+            workerCarriedEnergy: 60,
+            droppedEnergy: 25,
+            sourceCount: 2,
+            events: {
+              harvestedEnergy: 10,
+              transferredEnergy: 5
+            }
+          },
+          combat: {
+            hostileCreepCount: 1,
+            hostileStructureCount: 1,
+            events: {
+              attackCount: 1,
+              attackDamage: 30,
+              objectDestroyedCount: 1,
+              creepDestroyedCount: 1
+            }
           }
         }
       ],
@@ -103,6 +146,41 @@ describe('runtime telemetry summaries', () => {
     expect(payload.omittedEventCount).toBe(2);
   });
 
+  it('keeps KPI summaries safe when optional Screeps APIs and constants are absent', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      installGlobals: false,
+      includeRoomFind: false,
+      includeEventLog: false
+    });
+    const creeps = [makeWorker({ role: 'worker', colony: 'W1N1' }, 7)];
+
+    expect(() => emitRuntimeSummary([colony], creeps)).not.toThrow();
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room).toMatchObject({
+      controller: {
+        level: 2,
+        progress: 1234,
+        progressTotal: 45000,
+        ticksToDowngrade: 15000
+      },
+      resources: {
+        storedEnergy: 50,
+        workerCarriedEnergy: 7,
+        droppedEnergy: 0,
+        sourceCount: 0
+      },
+      combat: {
+        hostileCreepCount: 0,
+        hostileStructureCount: 0
+      }
+    });
+    expect((room.resources as Record<string, unknown>).events).toBeUndefined();
+    expect((room.combat as Record<string, unknown>).events).toBeUndefined();
+  });
+
   it('keeps emission gating deterministic', () => {
     expect(shouldEmitRuntimeSummary(1, [])).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [])).toBe(true);
@@ -130,28 +208,90 @@ describe('runtime telemetry summaries', () => {
   }
 });
 
+function installRuntimeTelemetryGlobals(): void {
+  const globals = globalThis as Record<string, unknown>;
+  for (const [key, value] of Object.entries(TEST_GLOBALS)) {
+    globals[key] = value;
+  }
+}
+
+function clearRuntimeTelemetryGlobals(): void {
+  const globals = globalThis as Record<string, unknown>;
+  for (const key of RUNTIME_GLOBAL_KEYS) {
+    delete globals[key];
+  }
+}
+
 function makeColony(options: {
   time: number;
   spawn?: {
     name: string;
     spawning: { name: string; remainingTime: number } | null;
   };
+  installGlobals?: boolean;
+  includeRoomFind?: boolean;
+  includeEventLog?: boolean;
 }): ColonySnapshot {
+  if (options.installGlobals !== false) {
+    installRuntimeTelemetryGlobals();
+  }
+
   const room = {
     name: 'W1N1',
     energyAvailable: 250,
-    energyCapacityAvailable: 300
-  } as Room;
+    energyCapacityAvailable: 300,
+    controller: {
+      my: true,
+      level: 2,
+      progress: 1234,
+      progressTotal: 45000,
+      ticksToDowngrade: 15000
+    }
+  } as unknown as Room;
   const spawn = {
     name: options.spawn?.name ?? 'Spawn1',
     room,
-    spawning: options.spawn?.spawning ?? null
+    spawning: options.spawn?.spawning ?? null,
+    store: makeEnergyStore(50)
   } as unknown as StructureSpawn;
+  const structures = [spawn, { store: makeEnergyStore(125) }];
+
+  if (options.includeRoomFind !== false) {
+    (room as unknown as { find?: jest.Mock }).find = jest.fn((findType: number): unknown[] => {
+      switch (findType) {
+        case TEST_GLOBALS.FIND_STRUCTURES:
+          return structures;
+        case TEST_GLOBALS.FIND_DROPPED_RESOURCES:
+          return [
+            { resourceType: TEST_GLOBALS.RESOURCE_ENERGY, amount: 25 },
+            { resourceType: 'power', amount: 100 }
+          ];
+        case TEST_GLOBALS.FIND_SOURCES:
+          return [{ id: 'source1' }, { id: 'source2' }];
+        case TEST_GLOBALS.FIND_HOSTILE_CREEPS:
+          return [{ id: 'hostile1' }];
+        case TEST_GLOBALS.FIND_HOSTILE_STRUCTURES:
+          return [{ id: 'hostile-structure1' }];
+        default:
+          return [];
+      }
+    });
+  }
+
+  if (options.includeEventLog !== false) {
+    (room as unknown as { getEventLog?: jest.Mock }).getEventLog = jest.fn(() => [
+      { event: TEST_GLOBALS.EVENT_HARVEST, data: { amount: 10, resourceType: TEST_GLOBALS.RESOURCE_ENERGY } },
+      { event: TEST_GLOBALS.EVENT_TRANSFER, data: { amount: 5, resourceType: TEST_GLOBALS.RESOURCE_ENERGY } },
+      { event: TEST_GLOBALS.EVENT_TRANSFER, data: { amount: 99, resourceType: 'power' } },
+      { event: TEST_GLOBALS.EVENT_ATTACK, data: { damage: 30 } },
+      { event: TEST_GLOBALS.EVENT_OBJECT_DESTROYED, data: { type: 'creep' } }
+    ]);
+  }
 
   (globalThis as unknown as { Game: Partial<Game> }).Game = {
     time: options.time,
     rooms: { W1N1: room },
-    spawns: { Spawn1: spawn },
+    spawns: { [spawn.name]: spawn },
     creeps: {},
     cpu: {
       getUsed: jest.fn().mockReturnValue(4.2),
@@ -167,8 +307,15 @@ function makeColony(options: {
   };
 }
 
-function makeWorker(memory: CreepMemory): Creep {
+function makeWorker(memory: CreepMemory, energy = 0): Creep {
   return {
-    memory
-  } as Creep;
+    memory,
+    store: makeEnergyStore(energy)
+  } as unknown as Creep;
+}
+
+function makeEnergyStore(energy: number): { getUsedCapacity: (resource?: ResourceConstant) => number } {
+  return {
+    getUsedCapacity: (resource?: ResourceConstant) => (resource === TEST_GLOBALS.RESOURCE_ENERGY ? energy : 0)
+  };
 }


### PR DESCRIPTION
## Summary
- Adds additive per-room `controller`, `resources`, and `combat` KPI sections to in-game `#runtime-summary` telemetry.
- Captures territory/control state, stored/carried/dropped energy, source count, hostile counts, and guarded per-tick resource/combat event metrics where Screeps APIs are available.
- Keeps optional Screeps APIs/constants guarded so mock/private contexts without `room.find`, `room.getEventLog`, or `FIND_*`/`EVENT_*` globals do not crash.
- Updates Jest coverage and rebuilds `prod/dist/main.js`.

## Linked issue
Refs #29
Refs #61

## Roadmap category
Runtime KPI/monitor — first telemetry bridge for Gameplay Evolution review.

## Served vision layer
Territory visibility first, resource/economy scale second, and enemy-kill/combat visibility third. This beats non-blocking foundation work because P0 automation is currently healthy and the missing KPI payload is the immediate blocker for gameplay-result review.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (12 suites / 69 tests)
- [x] `cd prod && npm run build`

## Notes
- No secrets included.
- This is a bounded first bridge; roadmap renderer/reducer and full 12h finding-to-Codex automation remain follow-up work under #29/#61.
