### PR TITLE
docs: define gameplay finding Codex bridge

### DIFF
--- a/docs/ops/gameplay-evolution-roadmap.md
+++ b/docs/ops/gameplay-evolution-roadmap.md
@@ -223,6 +223,8 @@ Acceptance:
 
 Goal: make review conclusions automatically become schedulable work without falling through cracks.
 
+Runbook: `docs/ops/gameplay-finding-to-codex-bridge.md`.
+
 Initial tasks:
 
 1. Define issue templates/body structure for gameplay findings.
@@ -234,6 +236,7 @@ Acceptance:
 
 - Every accepted gameplay finding has a GitHub issue or a comment updating an existing issue.
 - Every active issue has milestone, Project status, priority, domain, kind, evidence, and next action.
+- Every Codex prompt generated from a finding states the evidence window, expected KPI movement, acceptance evidence, and rollback/stop condition.
 
 ### Track 4 — Tactical emergency response
 

--- a/docs/ops/gameplay-finding-to-codex-bridge.md
+++ b/docs/ops/gameplay-finding-to-codex-bridge.md
@@ -1,0 +1,140 @@
+# Gameplay finding to Codex task bridge
+
+This runbook converts accepted Gameplay Evolution Review findings into GitHub-tracked work that Codex can implement safely. It exists for issue #61 and is part of the Gameplay Evolution loop.
+
+## Priority contract
+
+When P0 automation health is clear, choose findings in this order:
+
+1. **Territory/control** — owned rooms, reserved/remote rooms, room gain/loss, controller progress, downgrade risk.
+2. **Resource/economy scale** — stored resources, harvest/collection deltas, spawn utilization, remote uptime, GCL/RCL deltas.
+3. **Enemy kills/combat value** — hostile creeps/structures destroyed, own losses, net combat outcome.
+4. **Foundation/ops** — only outranks the gameplay ordering when it blocks evidence, implementation, release, or rollback for one of the gameplay layers.
+
+## Intake rule
+
+A Gameplay Evolution finding is actionable only when it contains all of these fields. If any field is missing, update the existing issue or add a review comment asking the next worker to fill the gap before dispatching Codex.
+
+```markdown
+## Gameplay finding intake
+- Evidence window:
+- Shard / room:
+- Code version / deployed commit:
+- Served vision layer: territory | resources | enemy kills | foundation blocker
+- KPI delta observed:
+- Reliability guardrails observed:
+- Hypothesis:
+- Target area: prod | scripts | docs/ops | GitHub/Project | cron/runtime monitor
+- Expected KPI movement:
+- Acceptance evidence:
+- Rollback / stop condition:
+- No-secret considerations:
+```
+
+## Main-agent decision states
+
+The main Hermes agent must classify each finding before work starts:
+
+- **Accept** — create or update a GitHub issue and Project item, then dispatch the next bounded worker/Codex task.
+- **Defer** — update Evidence and Next action with the missing prerequisite or later review window.
+- **Reject** — add a concise issue/comment explanation when the finding is unsupported, lower priority, duplicated, or unsafe.
+- **Escalate** — use the tactical emergency response path when the finding indicates room loss, attack, spawn collapse, controller downgrade risk, deploy breakage, or telemetry silence.
+
+## GitHub source-of-truth update checklist
+
+Before implementation begins:
+
+1. Create a new issue or update the most specific existing issue.
+2. Ensure the issue has a roadmap label, priority label, kind label, milestone, and Project `screeps` item.
+3. Set Project fields:
+   - `Status`: `In progress` when the current worker owns the next implementation slice; otherwise `Ready`.
+   - `Priority`: `P0`, `P1`, or `P2`.
+   - `Domain`: the owner of the result, not merely the file path.
+   - `Kind`: `code`, `test`, `ops`, `docs`, `bug`, or `review`.
+   - `Evidence`: the accepted finding, reviewed artifacts, and current repo/cron/PR state.
+   - `Next action`: one bounded worker action.
+   - `Blocked by`: only when the next action cannot be executed safely.
+   - `Next-point %`: move only with verified evidence.
+4. If implementation will create a PR, add the PR to Project `screeps` immediately after creation and keep it `In review` until merged or closed.
+
+## Issue body template for accepted findings
+
+```markdown
+## Accepted Gameplay Evolution finding
+- Evidence window:
+- Served vision layer:
+- KPI delta observed:
+- Hypothesis:
+- Expected KPI movement:
+- Rollback / stop condition:
+
+## Implementation target
+- Scope:
+- Files / subsystems expected:
+- Codex required for `prod/`: yes/no
+- Verification:
+
+## Acceptance criteria
+- [ ] GitHub issue and Project fields are current.
+- [ ] Implementation preserves no-secret policy.
+- [ ] If `prod/` changes, Codex authors the code commit and `npm run typecheck`, `npm test -- --runInBand`, and `npm run build` pass from `prod/`.
+- [ ] PR is in Project `screeps` and passes the automated review gate.
+- [ ] Runtime/private/monitor evidence is attached when release or gameplay KPI movement is claimed.
+```
+
+## Codex prompt template
+
+Use this only after the issue is accepted and Project state is current. Keep it self-contained and bounded.
+
+```text
+Repository: /root/screeps-worktrees/<topic>
+Branch: <branch>
+Issue: #<number> <title>
+Author commits as: lanyusea's bot <lanyusea@gmail.com>
+
+Implement exactly this accepted Gameplay Evolution finding.
+
+Served vision layer: <territory/resources/enemy kills/foundation blocker>
+Evidence window: <time range and artifacts>
+Current KPI delta: <observed delta or not instrumented>
+Hypothesis: <why this change should improve the KPI>
+Expected KPI movement: <specific observable movement>
+Rollback / stop condition: <condition>
+
+Scope:
+- <files/subsystems>
+
+Requirements:
+- Production/test/build code under prod/ must be implemented by Codex in this worktree.
+- Keep the change small and additive; do not remove existing telemetry or behavior unless the issue explicitly says so.
+- Guard optional Screeps APIs/constants so Jest, private-server, and official contexts do not crash.
+- Do not print, commit, or expose secrets.
+- Update generated build artifacts only by running the proper build command.
+
+Verification to run before committing:
+- git diff --check
+- cd prod && npm run typecheck
+- cd prod && npm test -- --runInBand
+- cd prod && npm run build
+
+Commit the verified change before returning. Stage exactly the intended files and exclude transient `.codex`, runtime artifacts, logs, and local secret/config files.
+```
+
+## QA acceptance checklist
+
+A finding-to-Codex task is not accepted until the main agent verifies:
+
+- the issue and PR Project items have current `Status`, `Evidence`, and `Next action`;
+- the implementation matches the accepted finding and does not expand into unrelated work;
+- verification commands passed or failures are documented as blockers;
+- no secret material appears in diffs, logs, PR bodies, issue comments, or final reports;
+- PR gate state is checked: elapsed window, CI, CodeRabbit/Gemini comments, review threads, and mergeability;
+- after merge, the linked issue/Project item is updated with merge evidence and the next review/monitor observation step.
+
+## First application after PR #65
+
+PR #65 landed the first additive in-game KPI telemetry bridge for #29/#61. The next accepted finding should be transformed with this runbook into one of these bounded tasks:
+
+1. **#29 reducer/renderer follow-up** — consume the new `controller`, `resources`, and `combat` runtime-summary fields so review reports and roadmap snapshots can show territory/resource/combat deltas instead of `not instrumented`.
+2. **#61 bridge hardening** — convert the next 12-hour Gameplay Evolution recommendation into a concrete issue with expected KPI movement, acceptance evidence, and rollback/stop condition.
+3. **#30/#31 bot-capability tests** — if the next worker slot is free before reducer work is ready, dispatch Codex to harden spawn lifecycle or emergency recovery coverage.

--- a/docs/ops/roadmap.md
+++ b/docs/ops/roadmap.md
@@ -316,10 +316,10 @@ Decision:
 
 Immediate next slices:
 
-1. Keep #29 in progress as the immediate runtime KPI telemetry bridge for territory/resource/combat visibility.
-2. Convert the first accepted gameplay-review finding into #61 / a Codex-ready task with expected KPI movement.
+1. Keep #29 in progress as the immediate runtime KPI telemetry/reducer bridge for territory/resource/combat visibility; PR #65 landed the first in-game payload, so the next #29 worker should consume it in reports/renderers.
+2. Use `docs/ops/gameplay-finding-to-codex-bridge.md` to convert the next accepted gameplay-review finding into #61 / a Codex-ready task with expected KPI movement, acceptance evidence, and rollback/stop condition.
 3. Keep foundation lines active in parallel: #28 for private-smoke release evidence, #62 for tactical response wiring, #63 for release/hotfix gate enforcement, and routine P0 monitor watch for #27.
-4. Run one manual Gameplay Evolution Review dry run before enabling recurring cadence.
+4. Keep #30/#31 Ready for the next free Codex/test worker slot so bot-capability coverage does not go idle.
 
 ### Decision: next code priority
 

--- a/docs/process/2026-04-27-finding-codex-bridge.md
+++ b/docs/process/2026-04-27-finding-codex-bridge.md
@@ -1,0 +1,34 @@
+# Finding-to-Codex bridge checkpoint
+
+Date: 2026-04-27T11:08+08:00
+
+## Context
+
+P0 automation health was checked first. `/root/.hermes/cron/jobs.json` showed the Screeps continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, six-hour report, and Gameplay Evolution Review enabled, using `workdir: null`, and scheduled with current `last_run_at` / `next_run_at` values. No open PRs were present, so the bounded slice selected #61 in support of #29.
+
+## Change
+
+Added `docs/ops/gameplay-finding-to-codex-bridge.md` as the durable bridge from accepted Gameplay Evolution findings to GitHub issue / Project state / Codex prompts.
+
+The runbook defines:
+
+- required finding intake fields;
+- main-agent accept/defer/reject/escalate states;
+- Project `screeps` source-of-truth update checklist;
+- accepted-finding issue body template;
+- bounded Codex prompt template for `prod/` work;
+- QA acceptance checklist;
+- first application after PR #65.
+
+Updated `docs/ops/gameplay-evolution-roadmap.md`, `docs/ops/roadmap.md`, and `docs/process/active-work-state.md` so the next worker can use this bridge instead of reconstructing the #61 workflow from chat history.
+
+## Verification
+
+- `git diff --check`
+- Markdown link/path existence check for the new runbook and updated references
+- GitHub open PR/issue/Project inspection before editing
+- Cron metadata inspection before editing
+
+## Follow-up
+
+Next #29 worker should consume the newly merged runtime-summary `controller`, `resources`, and `combat` fields in the runtime reducer/roadmap/reporting layer so territory/resource/combat deltas appear in review outputs instead of `not instrumented`.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,10 +1,10 @@
 # Active Work State
 
-Last updated: 2026-04-26T21:03:00+08:00
+Last updated: 2026-04-27T11:08:00+08:00
 
 ## Current active objective
 
-P0: stabilize and monitor the Screeps agent operating system before continuing normal development, while preserving the updated project-vision priority contract: competition-map success means sufficiently large territory first, sufficiently many resources second, and sufficiently many enemy kills third. The main agent must preserve owner visibility through the home channel, delegate minimal tasks to subagents/Codex, review subagent conclusions, route summaries to typed Discord channels, and keep scheduled-worker health monitored. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Dedicated P0 monitor output is routed to channel `1497820688843800776` via cron delivery target `discord:1497820688843800776`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
+P0 agent operating-system health is repaired/watch-only in the current cron window: `/root/.hermes/cron/jobs.json` shows the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null`, current `last_run_at`, and non-overdue `next_run_at` values at slice start. Normal development may proceed while routine P0 monitor watch continues. The active gameplay priority is #29/#61: consume the newly merged KPI telemetry bridge and convert accepted Gameplay Evolution findings into GitHub/Project/Codex-ready tasks. The competition-map vision ordering remains territory first, resource scale second, enemy kills third; foundation work outranks that order only when it blocks evidence, implementation, release, or rollback. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
 
 ## Completed tasks
 


### PR DESCRIPTION
## Summary
- Adds `docs/ops/gameplay-finding-to-codex-bridge.md` to convert accepted Gameplay Evolution findings into issue/Project/Codex-ready tasks.
- Links the new bridge from the Gameplay Evolution roadmap and current roadmap next slices.
- Refreshes active work state after P0 cron health inspection so #29/#61 remain the active gameplay priority.
- Records a process checkpoint for this bounded continuation slice.

## Linked issue
Refs #61
Refs #29

## Roadmap category
Gameplay Evolution / finding-to-Codex task bridge

## Served vision layer
Territory/control visibility first, resource/economy scale second, enemy-kill/combat visibility third. This is a foundation bridge, but it directly unblocks game-KPI delivery by ensuring review findings become Codex-ready tasks with expected KPI movement, acceptance evidence, and rollback conditions.

## Verification
- [x] `git diff --check`
- [x] Markdown link/path existence check for new runbook and updated references
- [x] GitHub PR/issue/Project inspection before editing
- [x] Cron metadata inspection before editing

## Notes
- Docs/process only; no `prod/` code changed.
- No secrets included.
- Next #29 worker should consume PR #65's runtime-summary KPI fields in the reducer/renderer/reporting path.
