### PR TITLE
feat: add runtime KPI reducer

### DIFF
--- a/docs/ops/gameplay-evolution-roadmap.md
+++ b/docs/ops/gameplay-evolution-roadmap.md
@@ -66,6 +66,14 @@ Inputs:
 - recent merged PRs/deploys;
 - open GitHub roadmap issues and Project fields.
 
+Saved `#runtime-summary` console logs can be reduced into KPI evidence without live API access:
+
+```bash
+python3 scripts/screeps_runtime_kpi_reducer.py saved-runtime-summary.log > runtime-kpi-report.json
+```
+
+Use `-` for stdin, and add `--format human` for a compact reviewer-facing readout. The JSON output is deterministic and marks missing KPI sections as `not instrumented`.
+
 Required output:
 
 ```markdown
@@ -195,7 +203,7 @@ Initial tasks:
 
 1. Extend runtime telemetry schema with territory/economy/combat KPI fields.
 2. Add deterministic tests for KPI aggregation where feasible.
-3. Add an external reducer that compares the current window to the prior 12-hour baseline.
+3. Add an external reducer that consumes saved `#runtime-summary` logs and emits territory/resource/combat KPI evidence.
 4. Render or publish a concise KPI board for routine review.
 
 Acceptance:

--- a/docs/ops/gameplay-finding-to-codex-bridge.md
+++ b/docs/ops/gameplay-finding-to-codex-bridge.md
@@ -135,6 +135,11 @@ A finding-to-Codex task is not accepted until the main agent verifies:
 
 PR #65 landed the first additive in-game KPI telemetry bridge for #29/#61. The next accepted finding should be transformed with this runbook into one of these bounded tasks:
 
-1. **#29 reducer/renderer follow-up** — consume the new `controller`, `resources`, and `combat` runtime-summary fields so review reports and roadmap snapshots can show territory/resource/combat deltas instead of `not instrumented`.
+1. **#29 reducer/renderer follow-up** — consume the new `controller`, `resources`, and `combat` runtime-summary fields so review reports and roadmap snapshots can show territory/resource/combat deltas instead of `not instrumented`. The reducer command for saved logs is:
+
+   ```bash
+   python3 scripts/screeps_runtime_kpi_reducer.py saved-runtime-summary.log > runtime-kpi-report.json
+   ```
+
 2. **#61 bridge hardening** — convert the next 12-hour Gameplay Evolution recommendation into a concrete issue with expected KPI movement, acceptance evidence, and rollback/stop condition.
 3. **#30/#31 bot-capability tests** — if the next worker slot is free before reducer work is ready, dispatch Codex to harden spawn lifecycle or emergency recovery coverage.

--- a/docs/process/2026-04-27-runtime-kpi-reducer.md
+++ b/docs/process/2026-04-27-runtime-kpi-reducer.md
@@ -1,0 +1,38 @@
+# Runtime KPI reducer checkpoint
+
+Date: 2026-04-27
+
+## Context
+
+PR #65 added additive `#runtime-summary` fields for room controller, resource, and combat state. Issue #29 needed the next bridge slice to consume those fields from saved logs so Gameplay Evolution reviews can show territory/resource/combat evidence instead of `not instrumented`.
+
+## Change
+
+Added `scripts/screeps_runtime_kpi_reducer.py` and deterministic local tests. The reducer reads one or more saved log files and/or stdin, ignores non-summary lines and malformed prefixed JSON safely, and emits deterministic JSON by default.
+
+It aggregates:
+
+- owned-room latest count plus gained/lost room delta;
+- per-room controller RCL, progress, progress total, and ticks-to-downgrade latest values plus numeric deltas;
+- resource latest stored energy, worker-carried energy, dropped energy, source count, and harvest/transfer event deltas;
+- combat latest hostile creep/structure counts and attack/destroyed event deltas.
+
+Missing KPI sections are explicitly marked `not instrumented`; absent event samples are marked `not observed`.
+
+## Reviewer command
+
+```bash
+python3 scripts/screeps_runtime_kpi_reducer.py saved-runtime-summary.log > runtime-kpi-report.json
+```
+
+Use `-` for stdin and `--format human` for a compact text view. This command uses only saved logs; it does not call Screeps, Discord, or GitHub APIs.
+
+## Verification
+
+- `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_reducer.py`
+- `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py`
+- `git diff --check`
+
+## Follow-up
+
+The next renderer/reporting worker can feed `runtime-kpi-report.json` into Gameplay Evolution review output or a KPI board without re-parsing raw console logs.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,10 +1,10 @@
 # Active Work State
 
-Last updated: 2026-04-27T11:08:00+08:00
+Last updated: 2026-04-27T12:02:00+08:00
 
 ## Current active objective
 
-P0 agent operating-system health is repaired/watch-only in the current cron window: `/root/.hermes/cron/jobs.json` shows the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null`, current `last_run_at`, and non-overdue `next_run_at` values at slice start. Normal development may proceed while routine P0 monitor watch continues. The active gameplay priority is #29/#61: consume the newly merged KPI telemetry bridge and convert accepted Gameplay Evolution findings into GitHub/Project/Codex-ready tasks. The competition-map vision ordering remains territory first, resource scale second, enemy kills third; foundation work outranks that order only when it blocks evidence, implementation, release, or rollback. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
+P0 agent operating-system health is repaired/watch-only in the current cron window: `/root/.hermes/cron/jobs.json` shows the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null`, current `last_run_at`, and non-overdue `next_run_at` values at slice start. Normal development may proceed while routine P0 monitor watch continues. The active gameplay priority is #29: finish PR #67's runtime KPI reducer review/merge gate, then feed persisted `#runtime-summary` logs into the reducer and wire its territory/resource/combat evidence into 12h Gameplay Evolution and roadmap reporting. #61's durable finding-to-Codex bridge is done/watch. The competition-map vision ordering remains territory first, resource scale second, enemy kills third; foundation work outranks that order only when it blocks evidence, implementation, release, or rollback. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
 
 ## Completed tasks
 
@@ -235,6 +235,27 @@ P0 agent operating-system health is repaired/watch-only in the current cron wind
   - Process notes: `docs/process/2026-04-26-transfer-result-hardening.md`, `docs/process/2026-04-26-pr9-conflict-refresh.md`, and `docs/process/2026-04-26-pr9-merge-follow-up.md`.
 - PR #7 conflict refresh note from `origin/main`: `docs/process/2026-04-26-pr7-conflict-refresh.md`; Codex merge commit `6a54b8d` brought `test/runtime-risk-hardening-20260426` up to `origin/main`, preserved latest CI/P0/runtime-monitor docs, passed prod verification with 12 suites / 67 tests, and pushed the branch. GitHub Actions `prod-ci` passed; CodeRabbit status was pending immediately after push.
 - Runtime monitor live-token smoke: `docs/process/2026-04-26-runtime-monitor-live-smoke.md`; `self-test` passed (8 tests), live summary rendered `runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png` in the first pass and `runtime-artifacts/screeps-monitor-live-smoke-20260426/summary-shardX-E48S28.png` in the 09:32 repeat pass; live alert returned `alert: false` with no warnings at official ticks `108687` and `109202` for `shardX/E48S28`; repeat prod verification passed typecheck, 12 suites / 59 tests, and build.
+### runtime-kpi-reducer
+
+- Status: PR opened and in review gate
+- Process note: `docs/process/2026-04-27-runtime-kpi-reducer.md`
+- Pull request: https://github.com/lanyusea/screeps/pull/67
+- Codex-authored commit: `80a571f` (`feat: add runtime KPI reducer`)
+- Implemented:
+  - `scripts/screeps_runtime_kpi_reducer.py` parses saved `#runtime-summary` JSON lines from files or stdin.
+  - Deterministic JSON report aggregates territory/owned rooms, controller state, resource latest/deltas/events, and combat latest/deltas/events, with explicit `not instrumented` / `not observed` markers.
+  - `--format human` emits a compact review-readable summary.
+  - `scripts/test_screeps_runtime_kpi_reducer.py` adds deterministic local coverage for observed, missing, malformed, file/stdin, and human-rendering cases.
+  - Gameplay Evolution roadmap and finding-to-Codex bridge now document the saved-log reducer command.
+- Verification:
+  - `git diff --check`: passed
+  - `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_reducer.py`: passed
+  - `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py`: passed, 5 tests
+  - No `prod/` files changed; prod typecheck/test/build not required for this slice.
+- Remaining gate:
+  - PR #67 prod-ci passed; CodeRabbit review is pending and the >=15-minute review-age gate matures at 2026-04-27T12:15:04+08:00.
+  - After merge, update #29 with merge evidence and wire persisted runtime-summary logs/reducer output into 12h Gameplay Evolution / roadmap reporting.
+
 - Verification target if code changes are made:
   - `cd prod && npm run typecheck`
   - `cd prod && npm test -- --runInBand`

--- a/scripts/screeps_runtime_kpi_reducer.py
+++ b/scripts/screeps_runtime_kpi_reducer.py
@@ -207,6 +207,7 @@ def build_report(state: ReductionState) -> JsonObject:
         "territory": build_territory_report(state, first_rooms, latest_rooms),
         "resources": build_numeric_section_report(
             state.rooms,
+            first_rooms,
             latest_rooms,
             RESOURCE_FIELDS,
             "resources",
@@ -216,6 +217,7 @@ def build_report(state: ReductionState) -> JsonObject:
         ),
         "combat": build_numeric_section_report(
             state.rooms,
+            first_rooms,
             latest_rooms,
             COMBAT_FIELDS,
             "combat",
@@ -247,6 +249,7 @@ def build_territory_report(state: ReductionState, first_rooms: set[str], latest_
         "ownedRooms": owned_rooms,
         "controllers": build_numeric_section_report(
             state.rooms,
+            first_rooms,
             latest_rooms,
             CONTROLLER_FIELDS,
             "controller",
@@ -259,6 +262,7 @@ def build_territory_report(state: ReductionState, first_rooms: set[str], latest_
 
 def build_numeric_section_report(
     rooms: dict[str, RoomState],
+    first_rooms: set[str],
     latest_rooms: set[str],
     fields: tuple[str, ...],
     state_attr: str,
@@ -297,7 +301,7 @@ def build_numeric_section_report(
 
         room_reports[room_name] = report
 
-    status = OBSERVED if observed_room_count > 0 else NOT_INSTRUMENTED
+    status = OBSERVED if observed_room_count > 0 or has_section_values(rooms, first_rooms, state_attr) else NOT_INSTRUMENTED
     report = {
         "status": status,
         "observedRoomCount": observed_room_count,
@@ -311,7 +315,7 @@ def build_numeric_section_report(
 
     report["totals"] = {
         "latest": sum_latest_values(rooms, latest_rooms, fields, state_attr),
-        "delta": sum_latest_delta(rooms, latest_rooms, fields, state_attr),
+        "delta": sum_window_delta(rooms, first_rooms, latest_rooms, fields, state_attr),
     }
 
     if event_fields:
@@ -357,8 +361,18 @@ def sum_latest_values(
     return totals
 
 
-def sum_latest_delta(
+def has_section_values(rooms: dict[str, RoomState], room_names: set[str], state_attr: str) -> bool:
+    for room_name in room_names:
+        room_state = rooms.get(room_name)
+        section_state = getattr(room_state, state_attr) if room_state is not None else None
+        if section_state is not None and section_state.first is not None:
+            return True
+    return False
+
+
+def sum_window_delta(
     rooms: dict[str, RoomState],
+    first_rooms: set[str],
     latest_rooms: set[str],
     fields: tuple[str, ...],
     state_attr: str,
@@ -367,12 +381,24 @@ def sum_latest_delta(
     for room_name in latest_rooms:
         room_state = rooms.get(room_name)
         section_state = getattr(room_state, state_attr) if room_state is not None else None
-        if section_state is None or section_state.latest is None:
+        latest = section_state.latest if section_state is not None else None
+        if latest is None:
             continue
-        delta = numeric_delta(section_state.first, section_state.latest, fields)
-        for field_name, value in delta.items():
+        for field_name in fields:
+            value = latest.get(field_name)
             if is_number(value):
                 totals[field_name] += value
+
+    for room_name in first_rooms:
+        room_state = rooms.get(room_name)
+        section_state = getattr(room_state, state_attr) if room_state is not None else None
+        first = section_state.first if section_state is not None else None
+        if first is None:
+            continue
+        for field_name in fields:
+            value = first.get(field_name)
+            if is_number(value):
+                totals[field_name] -= value
     return totals
 
 

--- a/scripts/screeps_runtime_kpi_reducer.py
+++ b/scripts/screeps_runtime_kpi_reducer.py
@@ -116,7 +116,7 @@ def parse_runtime_summary_line(line: str) -> tuple[JsonObject | None, bool]:
         return None, saw_prefix
 
     try:
-        payload, _ = json.JSONDecoder().raw_decode(payload_text)
+        payload = json.loads(payload_text)
     except json.JSONDecodeError:
         return None, saw_prefix
 

--- a/scripts/screeps_runtime_kpi_reducer.py
+++ b/scripts/screeps_runtime_kpi_reducer.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Reduce Screeps #runtime-summary lines into Gameplay Evolution KPIs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, TextIO
+
+
+RUNTIME_SUMMARY_PREFIX = "#runtime-summary "
+REPORT_TYPE = "runtime-kpi-report"
+SCHEMA_VERSION = 1
+
+OBSERVED = "observed"
+NOT_INSTRUMENTED = "not instrumented"
+NOT_OBSERVED = "not observed"
+
+CONTROLLER_FIELDS = ("level", "progress", "progressTotal", "ticksToDowngrade")
+RESOURCE_FIELDS = ("storedEnergy", "workerCarriedEnergy", "droppedEnergy", "sourceCount")
+RESOURCE_EVENT_FIELDS = ("harvestedEnergy", "transferredEnergy")
+COMBAT_FIELDS = ("hostileCreepCount", "hostileStructureCount")
+COMBAT_EVENT_FIELDS = ("attackCount", "attackDamage", "objectDestroyedCount", "creepDestroyedCount")
+
+
+JsonObject = dict[str, Any]
+
+
+@dataclass
+class SectionState:
+    first: dict[str, int | float | None] | None = None
+    latest: dict[str, int | float | None] | None = None
+
+
+@dataclass
+class RoomState:
+    controller: SectionState = field(default_factory=SectionState)
+    resources: SectionState = field(default_factory=SectionState)
+    combat: SectionState = field(default_factory=SectionState)
+    resource_events: dict[str, int | float] = field(default_factory=lambda: zero_totals(RESOURCE_EVENT_FIELDS))
+    combat_events: dict[str, int | float] = field(default_factory=lambda: zero_totals(COMBAT_EVENT_FIELDS))
+    resource_event_seen: bool = False
+    combat_event_seen: bool = False
+
+
+@dataclass
+class ReductionState:
+    line_count: int = 0
+    runtime_summary_count: int = 0
+    malformed_runtime_summary_count: int = 0
+    ignored_line_count: int = 0
+    first_tick: int | float | None = None
+    latest_tick: int | float | None = None
+    first_rooms: set[str] | None = None
+    latest_rooms: set[str] | None = None
+    rooms_seen: bool = False
+    rooms: dict[str, RoomState] = field(default_factory=dict)
+
+
+def zero_totals(fields: Iterable[str]) -> dict[str, int | float]:
+    return {field_name: 0 for field_name in fields}
+
+
+def is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def clean_numeric_section(section: Any, fields: tuple[str, ...]) -> dict[str, int | float | None] | None:
+    if not isinstance(section, dict):
+        return None
+
+    values = {field_name: section.get(field_name) if is_number(section.get(field_name)) else None for field_name in fields}
+    if all(value is None for value in values.values()):
+        return None
+
+    return values
+
+
+def add_events(target: dict[str, int | float], events: Any, fields: tuple[str, ...]) -> bool:
+    if not isinstance(events, dict):
+        return False
+
+    seen = False
+    for field_name in fields:
+        value = events.get(field_name)
+        if is_number(value):
+            target[field_name] += value
+            seen = True
+
+    return seen
+
+
+def update_section(state: SectionState, values: dict[str, int | float | None] | None) -> None:
+    if values is None:
+        state.latest = None
+        return
+
+    if state.first is None:
+        state.first = dict(values)
+    state.latest = dict(values)
+
+
+def parse_runtime_summary_line(line: str) -> tuple[JsonObject | None, bool]:
+    """Return (payload, malformed_prefixed_line)."""
+    if RUNTIME_SUMMARY_PREFIX in line:
+        payload_text = line.split(RUNTIME_SUMMARY_PREFIX, 1)[1].strip()
+        saw_prefix = True
+    else:
+        payload_text = line.strip()
+        saw_prefix = False
+
+    if not payload_text:
+        return None, saw_prefix
+
+    try:
+        payload, _ = json.JSONDecoder().raw_decode(payload_text)
+    except json.JSONDecodeError:
+        return None, saw_prefix
+
+    if isinstance(payload, dict) and payload.get("type") == "runtime-summary":
+        return payload, False
+
+    return None, False
+
+
+def reduce_runtime_kpis(lines: Iterable[str]) -> JsonObject:
+    state = ReductionState()
+
+    for line in lines:
+        state.line_count += 1
+        payload, malformed = parse_runtime_summary_line(line)
+        if malformed:
+            state.malformed_runtime_summary_count += 1
+            state.ignored_line_count += 1
+            continue
+        if payload is None:
+            state.ignored_line_count += 1
+            continue
+
+        state.runtime_summary_count += 1
+        tick = payload.get("tick")
+        if is_number(tick):
+            if state.first_tick is None:
+                state.first_tick = tick
+            state.latest_tick = tick
+
+        rooms = payload.get("rooms")
+        if isinstance(rooms, list):
+            state.rooms_seen = True
+            summary_rooms: set[str] = set()
+            for room in rooms:
+                if not isinstance(room, dict):
+                    continue
+                room_name = room.get("roomName")
+                if not isinstance(room_name, str) or not room_name:
+                    continue
+
+                summary_rooms.add(room_name)
+                room_state = state.rooms.setdefault(room_name, RoomState())
+
+                controller = clean_numeric_section(room.get("controller"), CONTROLLER_FIELDS)
+                update_section(room_state.controller, controller)
+
+                resources = clean_numeric_section(room.get("resources"), RESOURCE_FIELDS)
+                update_section(room_state.resources, resources)
+                if isinstance(room.get("resources"), dict):
+                    room_state.resource_event_seen = (
+                        add_events(room_state.resource_events, room["resources"].get("events"), RESOURCE_EVENT_FIELDS)
+                        or room_state.resource_event_seen
+                    )
+
+                combat = clean_numeric_section(room.get("combat"), COMBAT_FIELDS)
+                update_section(room_state.combat, combat)
+                if isinstance(room.get("combat"), dict):
+                    room_state.combat_event_seen = (
+                        add_events(room_state.combat_events, room["combat"].get("events"), COMBAT_EVENT_FIELDS)
+                        or room_state.combat_event_seen
+                    )
+
+            if state.first_rooms is None:
+                state.first_rooms = set(summary_rooms)
+            state.latest_rooms = set(summary_rooms)
+
+    return build_report(state)
+
+
+def build_report(state: ReductionState) -> JsonObject:
+    latest_rooms = set(state.latest_rooms or set())
+    first_rooms = set(state.first_rooms or set())
+
+    return {
+        "type": REPORT_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "input": {
+            "lineCount": state.line_count,
+            "runtimeSummaryCount": state.runtime_summary_count,
+            "ignoredLineCount": state.ignored_line_count,
+            "malformedRuntimeSummaryCount": state.malformed_runtime_summary_count,
+        },
+        "window": {
+            "firstTick": state.first_tick,
+            "latestTick": state.latest_tick,
+        },
+        "territory": build_territory_report(state, first_rooms, latest_rooms),
+        "resources": build_numeric_section_report(
+            state.rooms,
+            latest_rooms,
+            RESOURCE_FIELDS,
+            "resources",
+            RESOURCE_EVENT_FIELDS,
+            "resource_events",
+            "resource_event_seen",
+        ),
+        "combat": build_numeric_section_report(
+            state.rooms,
+            latest_rooms,
+            COMBAT_FIELDS,
+            "combat",
+            COMBAT_EVENT_FIELDS,
+            "combat_events",
+            "combat_event_seen",
+        ),
+    }
+
+
+def build_territory_report(state: ReductionState, first_rooms: set[str], latest_rooms: set[str]) -> JsonObject:
+    if not state.rooms_seen:
+        owned_rooms: JsonObject = {
+            "status": NOT_INSTRUMENTED,
+            "message": NOT_INSTRUMENTED,
+        }
+    else:
+        owned_rooms = {
+            "status": OBSERVED,
+            "latest": sorted(latest_rooms),
+            "latestCount": len(latest_rooms),
+            "deltaCount": len(latest_rooms) - len(first_rooms),
+            "gained": sorted(latest_rooms - first_rooms),
+            "lost": sorted(first_rooms - latest_rooms),
+        }
+
+    return {
+        "status": OBSERVED if state.rooms_seen else NOT_INSTRUMENTED,
+        "ownedRooms": owned_rooms,
+        "controllers": build_numeric_section_report(
+            state.rooms,
+            latest_rooms,
+            CONTROLLER_FIELDS,
+            "controller",
+            (),
+            "",
+            "",
+        ),
+    }
+
+
+def build_numeric_section_report(
+    rooms: dict[str, RoomState],
+    latest_rooms: set[str],
+    fields: tuple[str, ...],
+    state_attr: str,
+    event_fields: tuple[str, ...],
+    event_attr: str,
+    event_seen_attr: str,
+) -> JsonObject:
+    room_reports: dict[str, JsonObject] = {}
+    missing_rooms: list[str] = []
+    observed_room_count = 0
+
+    for room_name in sorted(latest_rooms):
+        room_state = rooms.get(room_name)
+        section_state = getattr(room_state, state_attr) if room_state is not None else SectionState()
+        if section_state.latest is None:
+            room_reports[room_name] = {
+                "status": NOT_INSTRUMENTED,
+                "message": NOT_INSTRUMENTED,
+            }
+            missing_rooms.append(room_name)
+            continue
+
+        observed_room_count += 1
+        report: JsonObject = {
+            "status": OBSERVED,
+            "latest": section_state.latest,
+            "delta": numeric_delta(section_state.first, section_state.latest, fields),
+        }
+
+        if event_fields and room_state is not None:
+            event_seen = bool(getattr(room_state, event_seen_attr))
+            report["eventDeltas"] = {
+                "status": OBSERVED if event_seen else NOT_OBSERVED,
+                **getattr(room_state, event_attr),
+            }
+
+        room_reports[room_name] = report
+
+    status = OBSERVED if observed_room_count > 0 else NOT_INSTRUMENTED
+    report = {
+        "status": status,
+        "observedRoomCount": observed_room_count,
+        "missingRooms": missing_rooms,
+        "rooms": room_reports,
+    }
+
+    if status == NOT_INSTRUMENTED:
+        report["message"] = NOT_INSTRUMENTED
+        return report
+
+    report["totals"] = {
+        "latest": sum_latest_values(rooms, latest_rooms, fields, state_attr),
+        "delta": sum_latest_delta(rooms, latest_rooms, fields, state_attr),
+    }
+
+    if event_fields:
+        events, event_seen = sum_events(rooms, set(rooms), event_fields, event_attr, event_seen_attr)
+        report["eventDeltas"] = {
+            "status": OBSERVED if event_seen else NOT_OBSERVED,
+            **events,
+        }
+
+    return report
+
+
+def numeric_delta(
+    first: dict[str, int | float | None] | None,
+    latest: dict[str, int | float | None],
+    fields: tuple[str, ...],
+) -> dict[str, int | float | None]:
+    deltas: dict[str, int | float | None] = {}
+    for field_name in fields:
+        first_value = first.get(field_name) if first is not None else None
+        latest_value = latest.get(field_name)
+        deltas[field_name] = latest_value - first_value if is_number(first_value) and is_number(latest_value) else None
+    return deltas
+
+
+def sum_latest_values(
+    rooms: dict[str, RoomState],
+    latest_rooms: set[str],
+    fields: tuple[str, ...],
+    state_attr: str,
+) -> dict[str, int | float]:
+    totals = zero_totals(fields)
+    for room_name in latest_rooms:
+        room_state = rooms.get(room_name)
+        section_state = getattr(room_state, state_attr) if room_state is not None else None
+        latest = section_state.latest if section_state is not None else None
+        if latest is None:
+            continue
+        for field_name in fields:
+            value = latest.get(field_name)
+            if is_number(value):
+                totals[field_name] += value
+    return totals
+
+
+def sum_latest_delta(
+    rooms: dict[str, RoomState],
+    latest_rooms: set[str],
+    fields: tuple[str, ...],
+    state_attr: str,
+) -> dict[str, int | float]:
+    totals = zero_totals(fields)
+    for room_name in latest_rooms:
+        room_state = rooms.get(room_name)
+        section_state = getattr(room_state, state_attr) if room_state is not None else None
+        if section_state is None or section_state.latest is None:
+            continue
+        delta = numeric_delta(section_state.first, section_state.latest, fields)
+        for field_name, value in delta.items():
+            if is_number(value):
+                totals[field_name] += value
+    return totals
+
+
+def sum_events(
+    rooms: dict[str, RoomState],
+    latest_rooms: set[str],
+    fields: tuple[str, ...],
+    event_attr: str,
+    event_seen_attr: str,
+) -> tuple[dict[str, int | float], bool]:
+    totals = zero_totals(fields)
+    seen = False
+    for room_name in latest_rooms:
+        room_state = rooms.get(room_name)
+        if room_state is None:
+            continue
+        room_events = getattr(room_state, event_attr)
+        seen = bool(getattr(room_state, event_seen_attr)) or seen
+        for field_name in fields:
+            value = room_events.get(field_name)
+            if is_number(value):
+                totals[field_name] += value
+    return totals, seen
+
+
+def iter_input_lines(paths: list[str], stdin: TextIO = sys.stdin) -> Iterable[str]:
+    input_paths = paths or ["-"]
+    for path_text in input_paths:
+        if path_text == "-":
+            yield from stdin
+            continue
+
+        with Path(path_text).open("r", encoding="utf-8") as input_file:
+            yield from input_file
+
+
+def render_json(report: JsonObject) -> str:
+    return json.dumps(report, indent=2, sort_keys=True)
+
+
+def render_human(report: JsonObject) -> str:
+    lines = [
+        f"runtime summaries: {report['input']['runtimeSummaryCount']} "
+        f"(ignored {report['input']['ignoredLineCount']}, malformed {report['input']['malformedRuntimeSummaryCount']})",
+        f"ticks: {format_value(report['window']['firstTick'])}..{format_value(report['window']['latestTick'])}",
+    ]
+
+    territory = report["territory"]
+    owned_rooms = territory["ownedRooms"]
+    if owned_rooms["status"] == OBSERVED:
+        lines.append(
+            f"territory: {owned_rooms['latestCount']} owned room(s): {', '.join(owned_rooms['latest']) or 'none'} "
+            f"(delta {format_delta(owned_rooms['deltaCount'])})"
+        )
+    else:
+        lines.append(f"territory: {NOT_INSTRUMENTED}")
+
+    controller_lines = render_controller_human(territory["controllers"])
+    if controller_lines:
+        lines.extend(controller_lines)
+
+    lines.append(render_section_human("resources", report["resources"], RESOURCE_FIELDS, RESOURCE_EVENT_FIELDS))
+    lines.append(render_section_human("combat", report["combat"], COMBAT_FIELDS, COMBAT_EVENT_FIELDS))
+
+    return "\n".join(lines)
+
+
+def render_controller_human(controller_report: JsonObject) -> list[str]:
+    if controller_report["status"] != OBSERVED:
+        return [f"controllers: {NOT_INSTRUMENTED}"]
+
+    lines: list[str] = []
+    for room_name, room_report in controller_report["rooms"].items():
+        if room_report["status"] != OBSERVED:
+            lines.append(f"controller {room_name}: {NOT_INSTRUMENTED}")
+            continue
+
+        latest = room_report["latest"]
+        delta = room_report["delta"]
+        progress = format_progress(latest.get("progress"), latest.get("progressTotal"))
+        lines.append(
+            f"controller {room_name}: RCL {format_value(latest.get('level'))} "
+            f"progress {progress} ({format_delta(delta.get('progress'))}) "
+            f"downgrade {format_value(latest.get('ticksToDowngrade'))}"
+        )
+
+    return lines
+
+
+def render_section_human(
+    label: str,
+    section_report: JsonObject,
+    fields: tuple[str, ...],
+    event_fields: tuple[str, ...],
+) -> str:
+    if section_report["status"] != OBSERVED:
+        return f"{label}: {NOT_INSTRUMENTED}"
+
+    latest = section_report["totals"]["latest"]
+    delta = section_report["totals"]["delta"]
+    values = ", ".join(f"{field_name} {format_value(latest[field_name])} ({format_delta(delta[field_name])})" for field_name in fields)
+    events = section_report.get("eventDeltas")
+    if not isinstance(events, dict) or events["status"] != OBSERVED:
+        return f"{label}: {values}; events {NOT_OBSERVED}"
+
+    event_values = ", ".join(f"{field_name} {format_delta(events[field_name])}" for field_name in event_fields)
+    return f"{label}: {values}; events {event_values}"
+
+
+def format_progress(progress: Any, progress_total: Any) -> str:
+    if progress is None and progress_total is None:
+        return "unknown"
+    return f"{format_value(progress)}/{format_value(progress_total)}"
+
+
+def format_value(value: Any) -> str:
+    return "unknown" if value is None else str(value)
+
+
+def format_delta(value: Any) -> str:
+    if not is_number(value):
+        return "unknown"
+    if value > 0:
+        return f"+{value}"
+    return str(value)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reduce Screeps #runtime-summary JSON lines into compact Gameplay Evolution KPI evidence.",
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="*",
+        help="Input log files. Use '-' for stdin. Reads stdin when no inputs are provided.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "human"),
+        default="json",
+        help="Output format. JSON is deterministic and is the default.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None, stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
+    args = build_parser().parse_args(argv)
+    report = reduce_runtime_kpis(iter_input_lines(args.inputs, stdin))
+    output = render_human(report) if args.format == "human" else render_json(report)
+    stdout.write(output)
+    stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_screeps_runtime_kpi_reducer.py
+++ b/scripts/test_screeps_runtime_kpi_reducer.py
@@ -127,6 +127,16 @@ class RuntimeKpiReducerTest(unittest.TestCase):
             "creepDestroyedCount": 1,
         })
 
+    def test_rejects_runtime_summary_lines_with_trailing_garbage(self) -> None:
+        report = reducer.reduce_runtime_kpis(['#runtime-summary {"type":"runtime-summary"} garbage\n'])
+
+        self.assertEqual(report["input"], {
+            "lineCount": 1,
+            "runtimeSummaryCount": 0,
+            "ignoredLineCount": 1,
+            "malformedRuntimeSummaryCount": 1,
+        })
+
     def test_marks_missing_kpi_sections_as_not_instrumented(self) -> None:
         report = reducer.reduce_runtime_kpis(
             [

--- a/scripts/test_screeps_runtime_kpi_reducer.py
+++ b/scripts/test_screeps_runtime_kpi_reducer.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_runtime_kpi_reducer as reducer
+
+
+def runtime_line(payload: dict[str, object]) -> str:
+    return f"#runtime-summary {json.dumps(payload, sort_keys=True)}\n"
+
+
+class RuntimeKpiReducerTest(unittest.TestCase):
+    def test_aggregates_runtime_summary_kpis_and_ignores_bad_lines(self) -> None:
+        first = {
+            "type": "runtime-summary",
+            "tick": 100,
+            "rooms": [
+                {
+                    "roomName": "W1N1",
+                    "controller": {"level": 2, "progress": 1000, "progressTotal": 45000, "ticksToDowngrade": 15000},
+                    "resources": {
+                        "storedEnergy": 175,
+                        "workerCarriedEnergy": 60,
+                        "droppedEnergy": 25,
+                        "sourceCount": 2,
+                        "events": {"harvestedEnergy": 10, "transferredEnergy": 5},
+                    },
+                    "combat": {
+                        "hostileCreepCount": 1,
+                        "hostileStructureCount": 1,
+                        "events": {
+                            "attackCount": 1,
+                            "attackDamage": 30,
+                            "objectDestroyedCount": 1,
+                            "creepDestroyedCount": 1,
+                        },
+                    },
+                }
+            ],
+        }
+        latest = {
+            "type": "runtime-summary",
+            "tick": 120,
+            "rooms": [
+                {
+                    "roomName": "W1N1",
+                    "controller": {"level": 2, "progress": 1300, "progressTotal": 45000, "ticksToDowngrade": 14950},
+                    "resources": {
+                        "storedEnergy": 210,
+                        "workerCarriedEnergy": 20,
+                        "droppedEnergy": 5,
+                        "sourceCount": 2,
+                        "events": {"harvestedEnergy": 7, "transferredEnergy": 3},
+                    },
+                    "combat": {"hostileCreepCount": 0, "hostileStructureCount": 1},
+                }
+            ],
+        }
+
+        report = reducer.reduce_runtime_kpis(
+            [
+                "noise before\n",
+                runtime_line(first),
+                "#runtime-summary {not json}\n",
+                runtime_line(latest),
+                '{"type":"not-runtime-summary"}\n',
+            ]
+        )
+
+        self.assertEqual(report["input"], {
+            "lineCount": 5,
+            "runtimeSummaryCount": 2,
+            "ignoredLineCount": 3,
+            "malformedRuntimeSummaryCount": 1,
+        })
+        self.assertEqual(report["window"], {"firstTick": 100, "latestTick": 120})
+        self.assertEqual(report["territory"]["ownedRooms"], {
+            "status": "observed",
+            "latest": ["W1N1"],
+            "latestCount": 1,
+            "deltaCount": 0,
+            "gained": [],
+            "lost": [],
+        })
+        self.assertEqual(
+            report["territory"]["controllers"]["rooms"]["W1N1"],
+            {
+                "status": "observed",
+                "latest": {"level": 2, "progress": 1300, "progressTotal": 45000, "ticksToDowngrade": 14950},
+                "delta": {"level": 0, "progress": 300, "progressTotal": 0, "ticksToDowngrade": -50},
+            },
+        )
+        self.assertEqual(report["resources"]["totals"]["latest"], {
+            "storedEnergy": 210,
+            "workerCarriedEnergy": 20,
+            "droppedEnergy": 5,
+            "sourceCount": 2,
+        })
+        self.assertEqual(report["resources"]["totals"]["delta"], {
+            "storedEnergy": 35,
+            "workerCarriedEnergy": -40,
+            "droppedEnergy": -20,
+            "sourceCount": 0,
+        })
+        self.assertEqual(report["resources"]["eventDeltas"], {
+            "status": "observed",
+            "harvestedEnergy": 17,
+            "transferredEnergy": 8,
+        })
+        self.assertEqual(report["combat"]["totals"]["latest"], {
+            "hostileCreepCount": 0,
+            "hostileStructureCount": 1,
+        })
+        self.assertEqual(report["combat"]["eventDeltas"], {
+            "status": "observed",
+            "attackCount": 1,
+            "attackDamage": 30,
+            "objectDestroyedCount": 1,
+            "creepDestroyedCount": 1,
+        })
+
+    def test_marks_missing_kpi_sections_as_not_instrumented(self) -> None:
+        report = reducer.reduce_runtime_kpis(
+            [
+                runtime_line(
+                    {
+                        "type": "runtime-summary",
+                        "tick": 80,
+                        "rooms": [{"roomName": "W1N1", "energyAvailable": 250}],
+                    }
+                )
+            ]
+        )
+
+        self.assertEqual(report["territory"]["ownedRooms"]["latest"], ["W1N1"])
+        self.assertEqual(report["territory"]["controllers"]["status"], "not instrumented")
+        self.assertEqual(report["territory"]["controllers"]["rooms"]["W1N1"]["message"], "not instrumented")
+        self.assertEqual(report["resources"]["status"], "not instrumented")
+        self.assertEqual(report["combat"]["status"], "not instrumented")
+
+    def test_event_deltas_include_rooms_seen_across_the_window(self) -> None:
+        first = {
+            "type": "runtime-summary",
+            "tick": 10,
+            "rooms": [
+                {
+                    "roomName": "W1N1",
+                    "resources": {"storedEnergy": 1, "workerCarriedEnergy": 0, "droppedEnergy": 0, "sourceCount": 1},
+                    "combat": {"hostileCreepCount": 0, "hostileStructureCount": 0},
+                },
+                {
+                    "roomName": "W2N2",
+                    "resources": {
+                        "storedEnergy": 2,
+                        "workerCarriedEnergy": 0,
+                        "droppedEnergy": 0,
+                        "sourceCount": 1,
+                        "events": {"harvestedEnergy": 4, "transferredEnergy": 3},
+                    },
+                    "combat": {
+                        "hostileCreepCount": 1,
+                        "hostileStructureCount": 0,
+                        "events": {"attackCount": 2, "attackDamage": 9, "objectDestroyedCount": 1, "creepDestroyedCount": 0},
+                    },
+                },
+            ],
+        }
+        latest = {
+            "type": "runtime-summary",
+            "tick": 20,
+            "rooms": [
+                {
+                    "roomName": "W1N1",
+                    "resources": {"storedEnergy": 5, "workerCarriedEnergy": 0, "droppedEnergy": 0, "sourceCount": 1},
+                    "combat": {"hostileCreepCount": 0, "hostileStructureCount": 0},
+                }
+            ],
+        }
+
+        report = reducer.reduce_runtime_kpis([runtime_line(first), runtime_line(latest)])
+
+        self.assertEqual(report["territory"]["ownedRooms"]["lost"], ["W2N2"])
+        self.assertEqual(report["resources"]["eventDeltas"], {
+            "status": "observed",
+            "harvestedEnergy": 4,
+            "transferredEnergy": 3,
+        })
+        self.assertEqual(report["combat"]["eventDeltas"], {
+            "status": "observed",
+            "attackCount": 2,
+            "attackDamage": 9,
+            "objectDestroyedCount": 1,
+            "creepDestroyedCount": 0,
+        })
+
+    def test_reads_files_and_stdin_marker_and_renders_deterministic_json(self) -> None:
+        file_payload = {
+            "type": "runtime-summary",
+            "tick": 10,
+            "rooms": [{"roomName": "W1N1", "resources": {"storedEnergy": 1, "workerCarriedEnergy": 2, "droppedEnergy": 3, "sourceCount": 1}}],
+        }
+        stdin_payload = {
+            "type": "runtime-summary",
+            "tick": 20,
+            "rooms": [{"roomName": "W1N1", "resources": {"storedEnergy": 5, "workerCarriedEnergy": 7, "droppedEnergy": 0, "sourceCount": 1}}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "runtime.log"
+            path.write_text(runtime_line(file_payload), encoding="utf-8")
+            report = reducer.reduce_runtime_kpis(
+                reducer.iter_input_lines([str(path), "-"], stdin=io.StringIO(runtime_line(stdin_payload)))
+            )
+
+        rendered = reducer.render_json(report)
+        self.assertEqual(json.loads(rendered), report)
+        self.assertEqual(report["window"], {"firstTick": 10, "latestTick": 20})
+        self.assertEqual(report["resources"]["totals"]["latest"]["storedEnergy"], 5)
+        self.assertEqual(report["resources"]["totals"]["delta"]["storedEnergy"], 4)
+
+    def test_human_mode_is_short_and_marks_unobserved_events(self) -> None:
+        report = reducer.reduce_runtime_kpis(
+            [
+                runtime_line(
+                    {
+                        "type": "runtime-summary",
+                        "tick": 20,
+                        "rooms": [
+                            {
+                                "roomName": "W1N1",
+                                "controller": {"level": 2, "progress": 10, "progressTotal": 45000, "ticksToDowngrade": 1000},
+                                "resources": {"storedEnergy": 20, "workerCarriedEnergy": 1, "droppedEnergy": 0, "sourceCount": 2},
+                                "combat": {"hostileCreepCount": 0, "hostileStructureCount": 0},
+                            }
+                        ],
+                    }
+                )
+            ]
+        )
+
+        human = reducer.render_human(report)
+
+        self.assertIn("territory: 1 owned room(s): W1N1", human)
+        self.assertIn("controller W1N1: RCL 2 progress 10/45000", human)
+        self.assertIn("resources:", human)
+        self.assertIn("events not observed", human)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_runtime_kpi_reducer.py
+++ b/scripts/test_screeps_runtime_kpi_reducer.py
@@ -211,6 +211,40 @@ class RuntimeKpiReducerTest(unittest.TestCase):
             "creepDestroyedCount": 0,
         })
 
+    def test_resource_total_delta_includes_lost_room_values(self) -> None:
+        first = {
+            "type": "runtime-summary",
+            "tick": 10,
+            "rooms": [
+                {
+                    "roomName": "W2N2",
+                    "resources": {"storedEnergy": 100, "workerCarriedEnergy": 7, "droppedEnergy": 3, "sourceCount": 2},
+                },
+            ],
+        }
+        latest = {
+            "type": "runtime-summary",
+            "tick": 20,
+            "rooms": [],
+        }
+
+        report = reducer.reduce_runtime_kpis([runtime_line(first), runtime_line(latest)])
+
+        self.assertEqual(report["territory"]["ownedRooms"]["lost"], ["W2N2"])
+        self.assertEqual(report["resources"]["status"], "observed")
+        self.assertEqual(report["resources"]["totals"]["latest"], {
+            "storedEnergy": 0,
+            "workerCarriedEnergy": 0,
+            "droppedEnergy": 0,
+            "sourceCount": 0,
+        })
+        self.assertEqual(report["resources"]["totals"]["delta"], {
+            "storedEnergy": -100,
+            "workerCarriedEnergy": -7,
+            "droppedEnergy": -3,
+            "sourceCount": -2,
+        })
+
     def test_reads_files_and_stdin_marker_and_renders_deterministic_json(self) -> None:
         file_payload = {
             "type": "runtime-summary",


### PR DESCRIPTION
## Summary
- Adds `scripts/screeps_runtime_kpi_reducer.py`, a deterministic reducer for saved `#runtime-summary` JSON lines from PR #65.
- Aggregates territory/controller, resource, and combat KPI latest values plus deltas/event totals for Gameplay Evolution review evidence.
- Adds local reducer tests, documents the saved-log command, and records a process checkpoint.

## Linked issue
Refs #29
Refs #61

## Roadmap category
Runtime KPI/monitor — reducer/reporting consumption for Gameplay Evolution.

## Served vision layer
Territory/control visibility first, resource/economy scale second, and combat/enemy-kill visibility third. This beats non-blocking foundation work because P0 automation is healthy and #29 remains the immediate blocker for turning runtime telemetry into review/report evidence.

## Verification
- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_reducer.py`
- [x] `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py` (5 tests)

## Notes
- No secrets included.
- No `prod/` files changed, so prod typecheck/test/build was not required.
- This is a bounded bridge; the next worker can wire the reducer output into the 12h review/roadmap snapshot jobs or feed it with persisted official/private runtime-summary logs.
