### PR TITLE
feat: add runtime KPI artifact bridge

### DIFF
--- a/docs/ops/gameplay-evolution-roadmap.md
+++ b/docs/ops/gameplay-evolution-roadmap.md
@@ -66,13 +66,25 @@ Inputs:
 - recent merged PRs/deploys;
 - open GitHub roadmap issues and Project fields.
 
-Saved `#runtime-summary` console logs can be reduced into KPI evidence without live API access:
+Preferred persisted-artifact feeder for KPI evidence:
+
+```bash
+python3 scripts/screeps_runtime_kpi_artifact_bridge.py > runtime-kpi-report.json
+```
+
+With no paths, the bridge scans safe local artifact roots such as `/root/screeps/runtime-artifacts` and `/root/.hermes/cron/output`, tolerates missing directories, skips binary/oversized files, and attaches source counts without file contents. Pass explicit files or directories to bound a review window:
+
+```bash
+python3 scripts/screeps_runtime_kpi_artifact_bridge.py /path/to/runtime-artifacts > runtime-kpi-report.json
+```
+
+Use `--format human` for a compact reviewer-facing readout. If a worker has only one raw saved console log and does not need artifact discovery, use the reducer fallback:
 
 ```bash
 python3 scripts/screeps_runtime_kpi_reducer.py saved-runtime-summary.log > runtime-kpi-report.json
 ```
 
-Use `-` for stdin, and add `--format human` for a compact reviewer-facing readout. The JSON output is deterministic and marks missing KPI sections as `not instrumented`.
+The reducer also accepts `-` for stdin. Both JSON outputs are deterministic and mark missing KPI sections as `not instrumented`.
 
 Required output:
 

--- a/docs/ops/gameplay-finding-to-codex-bridge.md
+++ b/docs/ops/gameplay-finding-to-codex-bridge.md
@@ -40,6 +40,28 @@ The main Hermes agent must classify each finding before work starts:
 - **Reject** — add a concise issue/comment explanation when the finding is unsupported, lower priority, duplicated, or unsafe.
 - **Escalate** — use the tactical emergency response path when the finding indicates room loss, attack, spawn collapse, controller downgrade risk, deploy breakage, or telemetry silence.
 
+## Runtime KPI evidence feeder
+
+Use the persisted-artifact bridge first when a Gameplay Evolution Review, roadmap snapshot, or accepted finding needs territory/resource/combat KPI evidence:
+
+```bash
+python3 scripts/screeps_runtime_kpi_artifact_bridge.py > runtime-kpi-report.json
+```
+
+With explicit review-window roots:
+
+```bash
+python3 scripts/screeps_runtime_kpi_artifact_bridge.py /path/to/runtime-artifacts /path/to/cron-output > runtime-kpi-report.json
+```
+
+The bridge scans files/directories for `#runtime-summary ` lines, skips binary and oversized files, tolerates missing default roots, and includes source metadata without artifact contents. Use `--format human` for quick review text.
+
+If artifact discovery is unnecessary and a worker has a single raw saved console log, use the reducer fallback:
+
+```bash
+python3 scripts/screeps_runtime_kpi_reducer.py saved-runtime-summary.log > runtime-kpi-report.json
+```
+
 ## GitHub source-of-truth update checklist
 
 Before implementation begins:
@@ -135,10 +157,10 @@ A finding-to-Codex task is not accepted until the main agent verifies:
 
 PR #65 landed the first additive in-game KPI telemetry bridge for #29/#61. The next accepted finding should be transformed with this runbook into one of these bounded tasks:
 
-1. **#29 reducer/renderer follow-up** — consume the new `controller`, `resources`, and `combat` runtime-summary fields so review reports and roadmap snapshots can show territory/resource/combat deltas instead of `not instrumented`. The reducer command for saved logs is:
+1. **#29 reducer/artifact feeder follow-up** — consume the new `controller`, `resources`, and `combat` runtime-summary fields so review reports and roadmap snapshots can show territory/resource/combat deltas instead of `not instrumented`. The preferred persisted-artifact feeder is:
 
    ```bash
-   python3 scripts/screeps_runtime_kpi_reducer.py saved-runtime-summary.log > runtime-kpi-report.json
+   python3 scripts/screeps_runtime_kpi_artifact_bridge.py > runtime-kpi-report.json
    ```
 
 2. **#61 bridge hardening** — convert the next 12-hour Gameplay Evolution recommendation into a concrete issue with expected KPI movement, acceptance evidence, and rollback/stop condition.

--- a/docs/process/2026-04-27-runtime-kpi-artifact-bridge.md
+++ b/docs/process/2026-04-27-runtime-kpi-artifact-bridge.md
@@ -1,0 +1,31 @@
+# Runtime KPI artifact bridge checkpoint
+
+Date: 2026-04-27
+
+## Slice
+
+Added a bounded persisted-artifact feeder for issue #29:
+
+```bash
+python3 scripts/screeps_runtime_kpi_artifact_bridge.py > runtime-kpi-report.json
+```
+
+The bridge scans local artifact roots for `#runtime-summary ` lines, defaults to `/root/screeps/runtime-artifacts` and `/root/.hermes/cron/output`, tolerates missing directories, skips binary and oversized files, and feeds only discovered summary lines into `scripts/screeps_runtime_kpi_reducer.py`.
+
+It emits deterministic JSON by default with reducer KPI output plus source metadata: input paths, scanned file count, matched file count, runtime-summary line count, and skipped file paths/reasons. `--format human` emits a short reviewer-facing summary. No live APIs, secrets, cron changes, or `prod/` files are involved.
+
+## Served vision layer
+
+Foundation blocker for the Gameplay Evolution loop. This makes territory, resource, and combat KPI evidence available from persisted runtime artifacts before the 12-hour review and roadmap/reporting jobs are wired to consume it.
+
+## Verification
+
+```bash
+git diff --check
+python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py
+python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py
+```
+
+## Remaining next step
+
+Wire this command into the 12h Gameplay Evolution Review prompt and roadmap KPI snapshot job prompts in a later scheduler-management slice. Do not create or schedule cron jobs in this bridge slice.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,10 +1,10 @@
 # Active Work State
 
-Last updated: 2026-04-27T12:02:00+08:00
+Last updated: 2026-04-27T12:34:28+08:00
 
 ## Current active objective
 
-P0 agent operating-system health is repaired/watch-only in the current cron window: `/root/.hermes/cron/jobs.json` shows the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null`, current `last_run_at`, and non-overdue `next_run_at` values at slice start. Normal development may proceed while routine P0 monitor watch continues. The active gameplay priority is #29: finish PR #67's runtime KPI reducer review/merge gate, then feed persisted `#runtime-summary` logs into the reducer and wire its territory/resource/combat evidence into 12h Gameplay Evolution and roadmap reporting. #61's durable finding-to-Codex bridge is done/watch. The competition-map vision ordering remains territory first, resource scale second, enemy kills third; foundation work outranks that order only when it blocks evidence, implementation, release, or rollback. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
+P0 agent operating-system health is repaired/watch-only in the current cron window: `/root/.hermes/cron/jobs.json` shows the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null`, current `last_run_at`, and non-overdue `next_run_at` values at slice start. Normal development may proceed while routine P0 monitor watch continues. The active gameplay priority remains #29: PR #67's runtime KPI reducer is merged, and the current artifact-bridge slice is PR-ready/in review to feed persisted `#runtime-summary` logs into the reducer; the next #29 step is wiring its territory/resource/combat evidence into 12h Gameplay Evolution and roadmap reporting prompts. #61's durable finding-to-Codex bridge is done/watch. The competition-map vision ordering remains territory first, resource scale second, enemy kills third; foundation work outranks that order only when it blocks evidence, implementation, release, or rollback. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
 
 ## Completed tasks
 
@@ -237,7 +237,7 @@ P0 agent operating-system health is repaired/watch-only in the current cron wind
 - Runtime monitor live-token smoke: `docs/process/2026-04-26-runtime-monitor-live-smoke.md`; `self-test` passed (8 tests), live summary rendered `runtime-artifacts/screeps-monitor/summary-shardX-E48S28.png` in the first pass and `runtime-artifacts/screeps-monitor-live-smoke-20260426/summary-shardX-E48S28.png` in the 09:32 repeat pass; live alert returned `alert: false` with no warnings at official ticks `108687` and `109202` for `shardX/E48S28`; repeat prod verification passed typecheck, 12 suites / 59 tests, and build.
 ### runtime-kpi-reducer
 
-- Status: PR opened and in review gate
+- Status: merged to `main`
 - Process note: `docs/process/2026-04-27-runtime-kpi-reducer.md`
 - Pull request: https://github.com/lanyusea/screeps/pull/67
 - Codex-authored commit: `80a571f` (`feat: add runtime KPI reducer`)
@@ -252,11 +252,31 @@ P0 agent operating-system health is repaired/watch-only in the current cron wind
   - `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_reducer.py`: passed
   - `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py`: passed, 5 tests
   - No `prod/` files changed; prod typecheck/test/build not required for this slice.
-- Remaining gate:
-  - PR #67 prod-ci passed; CodeRabbit review is pending and the >=15-minute review-age gate matures at 2026-04-27T12:15:04+08:00.
-  - After merge, update #29 with merge evidence and wire persisted runtime-summary logs/reducer output into 12h Gameplay Evolution / roadmap reporting.
+- Merge evidence:
+  - Merge commit on current branch: `f32cdc3` (`feat: add runtime KPI reducer (#67)`).
+  - Follow-up remains active under #29: wire persisted runtime-summary logs/reducer output into 12h Gameplay Evolution / roadmap reporting.
 
-- Verification target if code changes are made:
+### runtime-kpi-artifact-bridge
+
+- Status: PR-ready / in review for #29
+- Process note: `docs/process/2026-04-27-runtime-kpi-artifact-bridge.md`
+- Branch: `feat/kpi-artifact-bridge-29`
+- Implemented:
+  - `scripts/screeps_runtime_kpi_artifact_bridge.py` scans files/directories for persisted `#runtime-summary ` lines, defaults to `/root/screeps/runtime-artifacts` and `/root/.hermes/cron/output`, tolerates missing dirs, and skips binary/oversized files.
+  - JSON output remains deterministic and adds source metadata without artifact contents: input paths, scanned files, matched files, runtime-summary line count, and skipped file paths/reasons.
+  - `--format human` emits a concise source/reducer summary.
+  - `scripts/test_screeps_runtime_kpi_artifact_bridge.py` covers file scanning, recursive directory scans, binary/oversized skips, default no-match/no-input behavior, reducer integration, and human output.
+  - Gameplay Evolution roadmap and finding-to-Codex bridge now prefer the artifact feeder before raw saved-log reducer fallback.
+- Verification target:
+  - `git diff --check`
+  - `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py`
+  - `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py`
+- Remaining next step:
+  - In a later scheduler-management slice, wire `python3 scripts/screeps_runtime_kpi_artifact_bridge.py` into the 12h Gameplay Evolution Review and roadmap KPI snapshot job prompts. Keep #29 active until that wiring is merged and observed.
+
+## General production verification reminder
+
+- Verification target if future `prod/` code changes are made:
   - `cd prod && npm run typecheck`
   - `cd prod && npm test -- --runInBand`
   - `cd prod && npm run build`

--- a/scripts/screeps_runtime_kpi_artifact_bridge.py
+++ b/scripts/screeps_runtime_kpi_artifact_bridge.py
@@ -135,7 +135,7 @@ def scan_file(path: Path, result: ScanResult, max_file_bytes: int) -> None:
     matching_lines = [
         line if line.endswith("\n") else f"{line}\n"
         for line in text.splitlines()
-        if reducer.RUNTIME_SUMMARY_PREFIX in line
+        if line.startswith(reducer.RUNTIME_SUMMARY_PREFIX)
     ]
     if not matching_lines:
         return

--- a/scripts/screeps_runtime_kpi_artifact_bridge.py
+++ b/scripts/screeps_runtime_kpi_artifact_bridge.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Feed persisted Screeps runtime-summary artifacts into the KPI reducer."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Sequence, TextIO
+
+import screeps_runtime_kpi_reducer as reducer
+
+
+DEFAULT_INPUT_PATHS = (
+    "/root/screeps/runtime-artifacts",
+    "/root/.hermes/cron/output",
+)
+DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024
+
+JsonObject = dict[str, Any]
+
+
+@dataclass
+class ScanResult:
+    input_paths: list[str]
+    lines: list[str] = field(default_factory=list)
+    scanned_files: int = 0
+    matched_files: int = 0
+    skipped_files: list[JsonObject] = field(default_factory=list)
+
+    def skip(self, path: Path | str, reason: str, **details: Any) -> None:
+        entry: JsonObject = {"path": str(path), "reason": reason}
+        entry.update(details)
+        self.skipped_files.append(entry)
+
+    def metadata(self) -> JsonObject:
+        return {
+            "inputPaths": self.input_paths,
+            "matchedFiles": self.matched_files,
+            "runtimeSummaryLines": len(self.lines),
+            "scannedFiles": self.scanned_files,
+            "skippedFileCount": len(self.skipped_files),
+            "skippedFiles": self.skipped_files,
+        }
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def collect_runtime_summary_lines(paths: Sequence[str], max_file_bytes: int = DEFAULT_MAX_FILE_BYTES) -> ScanResult:
+    input_paths = list(paths) if paths else list(DEFAULT_INPUT_PATHS)
+    result = ScanResult(input_paths=input_paths)
+
+    for path_text in input_paths:
+        path = Path(path_text).expanduser()
+        if not path.exists():
+            result.skip(path, "missing")
+            continue
+
+        if path.is_file():
+            scan_file(path, result, max_file_bytes)
+            continue
+
+        if path.is_dir():
+            for file_path in iter_directory_files(path, result):
+                scan_file(file_path, result, max_file_bytes)
+            continue
+
+        result.skip(path, "not_file_or_directory")
+
+    return result
+
+
+def iter_directory_files(root: Path, result: ScanResult) -> list[Path]:
+    files: list[Path] = []
+
+    def record_error(error: OSError) -> None:
+        result.skip(error.filename or root, "read_error")
+
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True, onerror=record_error, followlinks=False):
+        dirnames[:] = sorted(dirnames)
+        directory = Path(dirpath)
+        for filename in sorted(filenames):
+            files.append(directory / filename)
+
+    return sorted(files, key=lambda path: str(path))
+
+
+def scan_file(path: Path, result: ScanResult, max_file_bytes: int) -> None:
+    if path.is_symlink():
+        result.skip(path, "symlink")
+        return
+
+    try:
+        stat_result = path.stat()
+    except OSError:
+        result.skip(path, "read_error")
+        return
+
+    if not path.is_file():
+        result.skip(path, "not_regular_file")
+        return
+
+    result.scanned_files += 1
+    if stat_result.st_size > max_file_bytes:
+        result.skip(path, "oversized", sizeBytes=stat_result.st_size, maxFileBytes=max_file_bytes)
+        return
+
+    try:
+        data = path.read_bytes()
+    except OSError:
+        result.skip(path, "read_error")
+        return
+
+    if b"\0" in data:
+        result.skip(path, "binary")
+        return
+
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        result.skip(path, "binary")
+        return
+
+    matching_lines = [
+        line if line.endswith("\n") else f"{line}\n"
+        for line in text.splitlines()
+        if reducer.RUNTIME_SUMMARY_PREFIX in line
+    ]
+    if not matching_lines:
+        return
+
+    result.matched_files += 1
+    result.lines.extend(matching_lines)
+
+
+def build_bridge_report(paths: Sequence[str], max_file_bytes: int = DEFAULT_MAX_FILE_BYTES) -> JsonObject:
+    scan_result = collect_runtime_summary_lines(paths, max_file_bytes)
+    report = reducer.reduce_runtime_kpis(scan_result.lines)
+    report["source"] = scan_result.metadata()
+    return report
+
+
+def render_human(report: JsonObject) -> str:
+    source = report["source"]
+    source_line = (
+        f"source: scanned {source['scannedFiles']} file(s), matched {source['matchedFiles']}, "
+        f"runtime-summary lines {source['runtimeSummaryLines']}, skipped {source['skippedFileCount']}"
+    )
+    return "\n".join([source_line, reducer.render_human(report)])
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Scan persisted local artifacts for #runtime-summary lines and reduce them into KPI evidence.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=(
+            "Files or directories to scan. Defaults to /root/screeps/runtime-artifacts "
+            "and /root/.hermes/cron/output when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "human"),
+        default="json",
+        help="Output format. JSON is deterministic and is the default.",
+    )
+    parser.add_argument(
+        "--max-file-bytes",
+        type=positive_int,
+        default=DEFAULT_MAX_FILE_BYTES,
+        help=f"Skip files larger than this many bytes. Default: {DEFAULT_MAX_FILE_BYTES}.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout) -> int:
+    args = build_parser().parse_args(argv)
+    report = build_bridge_report(args.paths, max_file_bytes=args.max_file_bytes)
+    output = render_human(report) if args.format == "human" else reducer.render_json(report)
+    stdout.write(output)
+    stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_screeps_runtime_kpi_artifact_bridge.py
+++ b/scripts/test_screeps_runtime_kpi_artifact_bridge.py
@@ -40,6 +40,30 @@ class RuntimeKpiArtifactBridgeTest(unittest.TestCase):
         self.assertEqual(report["input"]["runtimeSummaryCount"], 1)
         self.assertEqual(report["territory"]["ownedRooms"]["latest"], ["W1N1"])
 
+    def test_ignores_embedded_runtime_summary_markers(self) -> None:
+        embedded = {"type": "runtime-summary", "tick": 5, "rooms": [{"roomName": "W9N9"}]}
+        accepted = {"type": "runtime-summary", "tick": 10, "rooms": [{"roomName": "W1N1"}]}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "console.log"
+            embedded_json = json.dumps(embedded, sort_keys=True)
+            path.write_text(
+                f"noise #runtime-summary {embedded_json}\n"
+                f'"noise #runtime-summary {embedded_json}"\n'
+                f"{runtime_line(accepted)}",
+                encoding="utf-8",
+            )
+
+            report = bridge.build_bridge_report([str(path)])
+
+        self.assertEqual(report["source"]["matchedFiles"], 1)
+        self.assertEqual(report["source"]["runtimeSummaryLines"], 1)
+        self.assertEqual(report["input"]["lineCount"], 1)
+        self.assertEqual(report["input"]["runtimeSummaryCount"], 1)
+        self.assertEqual(report["input"]["malformedRuntimeSummaryCount"], 0)
+        self.assertEqual(report["window"], {"firstTick": 10, "latestTick": 10})
+        self.assertEqual(report["territory"]["ownedRooms"]["latest"], ["W1N1"])
+
     def test_recurses_directories_in_deterministic_order(self) -> None:
         first = {"type": "runtime-summary", "tick": 10, "rooms": [{"roomName": "W1N1"}]}
         latest = {"type": "runtime-summary", "tick": 20, "rooms": [{"roomName": "W1N1"}, {"roomName": "W2N2"}]}

--- a/scripts/test_screeps_runtime_kpi_artifact_bridge.py
+++ b/scripts/test_screeps_runtime_kpi_artifact_bridge.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_runtime_kpi_artifact_bridge as bridge
+
+
+def runtime_line(payload: dict[str, object]) -> str:
+    return f"#runtime-summary {json.dumps(payload, sort_keys=True)}\n"
+
+
+class RuntimeKpiArtifactBridgeTest(unittest.TestCase):
+    def test_scans_file_and_reports_source_metadata(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 100,
+            "rooms": [{"roomName": "W1N1"}],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "console.log"
+            path.write_text(f"noise\n{runtime_line(payload)}", encoding="utf-8")
+
+            report = bridge.build_bridge_report([str(path)])
+
+        self.assertEqual(report["source"]["inputPaths"], [str(path)])
+        self.assertEqual(report["source"]["scannedFiles"], 1)
+        self.assertEqual(report["source"]["matchedFiles"], 1)
+        self.assertEqual(report["source"]["runtimeSummaryLines"], 1)
+        self.assertEqual(report["source"]["skippedFiles"], [])
+        self.assertEqual(report["input"]["runtimeSummaryCount"], 1)
+        self.assertEqual(report["territory"]["ownedRooms"]["latest"], ["W1N1"])
+
+    def test_recurses_directories_in_deterministic_order(self) -> None:
+        first = {"type": "runtime-summary", "tick": 10, "rooms": [{"roomName": "W1N1"}]}
+        latest = {"type": "runtime-summary", "tick": 20, "rooms": [{"roomName": "W1N1"}, {"roomName": "W2N2"}]}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            nested = root / "nested"
+            nested.mkdir()
+            (root / "a.log").write_text(runtime_line(first), encoding="utf-8")
+            (nested / "z.log").write_text(runtime_line(latest), encoding="utf-8")
+
+            report = bridge.build_bridge_report([str(root)])
+
+        self.assertEqual(report["source"]["scannedFiles"], 2)
+        self.assertEqual(report["source"]["matchedFiles"], 2)
+        self.assertEqual(report["window"], {"firstTick": 10, "latestTick": 20})
+        self.assertEqual(report["territory"]["ownedRooms"]["latest"], ["W1N1", "W2N2"])
+
+    def test_skips_binary_and_oversized_files_without_matching_contents(self) -> None:
+        payload = {"type": "runtime-summary", "tick": 50, "rooms": [{"roomName": "W1N1"}]}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "binary.log").write_bytes(b"\0not text")
+            (root / "large.log").write_text("x" * 128 + runtime_line(payload), encoding="utf-8")
+
+            report = bridge.build_bridge_report([str(root)], max_file_bytes=64)
+
+        self.assertEqual(report["source"]["scannedFiles"], 2)
+        self.assertEqual(report["source"]["matchedFiles"], 0)
+        self.assertEqual(report["source"]["runtimeSummaryLines"], 0)
+        self.assertEqual({entry["reason"] for entry in report["source"]["skippedFiles"]}, {"binary", "oversized"})
+        self.assertEqual(report["input"]["runtimeSummaryCount"], 0)
+
+    def test_no_supplied_paths_uses_defaults_and_exits_zero_without_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            empty_root = Path(temp_dir) / "empty"
+            empty_root.mkdir()
+            missing_root = Path(temp_dir) / "missing"
+            output = io.StringIO()
+
+            with mock.patch.object(bridge, "DEFAULT_INPUT_PATHS", (str(empty_root), str(missing_root))):
+                exit_code = bridge.main([], stdout=output)
+
+        report = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(report["source"]["inputPaths"], [str(empty_root), str(missing_root)])
+        self.assertEqual(report["source"]["scannedFiles"], 0)
+        self.assertEqual(report["source"]["matchedFiles"], 0)
+        self.assertEqual(report["source"]["runtimeSummaryLines"], 0)
+        self.assertEqual(report["source"]["skippedFiles"], [{"path": str(missing_root), "reason": "missing"}])
+        self.assertEqual(report["input"]["lineCount"], 0)
+        self.assertEqual(report["input"]["runtimeSummaryCount"], 0)
+        self.assertEqual(report["territory"]["ownedRooms"]["status"], "not instrumented")
+        self.assertEqual(report["resources"]["status"], "not instrumented")
+        self.assertEqual(report["combat"]["status"], "not instrumented")
+
+    def test_reducer_integration_aggregates_discovered_summary_lines(self) -> None:
+        first = {
+            "type": "runtime-summary",
+            "tick": 10,
+            "rooms": [
+                {
+                    "roomName": "W1N1",
+                    "resources": {"storedEnergy": 1, "workerCarriedEnergy": 2, "droppedEnergy": 3, "sourceCount": 1},
+                }
+            ],
+        }
+        latest = {
+            "type": "runtime-summary",
+            "tick": 20,
+            "rooms": [
+                {
+                    "roomName": "W1N1",
+                    "resources": {
+                        "storedEnergy": 5,
+                        "workerCarriedEnergy": 1,
+                        "droppedEnergy": 0,
+                        "sourceCount": 1,
+                        "events": {"harvestedEnergy": 8, "transferredEnergy": 4},
+                    },
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "runtime.log"
+            path.write_text(f"ignored\n{runtime_line(first)}#runtime-summary {{bad json}}\n{runtime_line(latest)}", encoding="utf-8")
+
+            report = bridge.build_bridge_report([str(path)])
+
+        self.assertEqual(report["source"]["runtimeSummaryLines"], 3)
+        self.assertEqual(report["input"]["lineCount"], 3)
+        self.assertEqual(report["input"]["runtimeSummaryCount"], 2)
+        self.assertEqual(report["input"]["malformedRuntimeSummaryCount"], 1)
+        self.assertEqual(report["resources"]["totals"]["latest"]["storedEnergy"], 5)
+        self.assertEqual(report["resources"]["totals"]["delta"]["storedEnergy"], 4)
+        self.assertEqual(report["resources"]["eventDeltas"], {
+            "status": "observed",
+            "harvestedEnergy": 8,
+            "transferredEnergy": 4,
+        })
+
+    def test_human_format_includes_source_and_reducer_summary(self) -> None:
+        payload = {"type": "runtime-summary", "tick": 100, "rooms": [{"roomName": "W1N1"}]}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "console.log"
+            path.write_text(runtime_line(payload), encoding="utf-8")
+            output = io.StringIO()
+
+            exit_code = bridge.main([str(path), "--format", "human"], stdout=output)
+
+        self.assertEqual(exit_code, 0)
+        rendered = output.getvalue()
+        self.assertIn("source: scanned 1 file(s), matched 1, runtime-summary lines 1, skipped 0", rendered)
+        self.assertIn("runtime summaries: 1", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `scripts/screeps_runtime_kpi_artifact_bridge.py` to scan persisted local artifacts for `#runtime-summary ` lines and feed them into the existing KPI reducer.
- Adds deterministic unittest coverage for scanning files/directories, binary/oversized skips, default no-match behavior, reducer integration, and human output.
- Updates Gameplay Evolution docs and active state so #29 can use the persisted-artifact feeder before raw saved-log fallback.

## Linked issue
Refs #29
Refs #61

## Roadmap category
Runtime KPI/monitor — persisted artifact bridge for Gameplay Evolution and roadmap KPI evidence.

## Served vision layer
Territory/control visibility first, resource/economy scale second, combat/enemy-kill visibility third. This is a foundation bridge, but it directly unblocks gameplay evidence by turning persisted runtime artifacts into reducer-ready KPI output for 12h review and roadmap reporting.

## Verification
- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py`
- [x] `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py` (13 tests)

## Notes
- No `prod/` files changed.
- No secrets included.
- This does not create or schedule cron jobs. The next #29 slice should wire this command into the 12h Gameplay Evolution Review and roadmap KPI snapshot prompts.
