### PR TITLE
docs: record KPI persistence wiring checkpoint

### DIFF
--- a/docs/process/2026-04-27-kpi-persistence-wiring-checkpoint.md
+++ b/docs/process/2026-04-27-kpi-persistence-wiring-checkpoint.md
@@ -1,0 +1,69 @@
+# KPI persistence wiring checkpoint
+
+Date: 2026-04-27
+
+## Slice summary
+
+This bounded continuation slice selected issue #29 because P0 cron/monitor health was current, no open pull requests needed draining, and the highest active game-vision blocker is still territory/resource/combat KPI visibility for Gameplay Evolution and roadmap reporting.
+
+PRs #65, #67, #68, and #70 are now merged on `main`, so the in-game runtime KPI payload, reducer, persisted-artifact bridge, and static Pages report generator all exist. The remaining #29 gap is not another reducer/report page primitive; it is capturing real in-game `#runtime-summary ` console lines into persisted artifacts that the bridge can reduce.
+
+## Evidence reviewed
+
+- `/root/screeps` was clean on `main` at `c21f1bb` (`feat: add Codex-authored Pages roadmap report (#70)`).
+- `gh pr list --repo lanyusea/screeps --state open` returned no open PRs.
+- Project `screeps` still had #29 and #59 `In progress`; #28/#30/#31/#62/#63 were Ready queued or blocked as expected.
+- `/root/.hermes/cron/jobs.json` showed the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null` and recent `last_run_at` / non-overdue `next_run_at` values.
+- Default artifact bridge scan returned zero persisted runtime-summary lines:
+
+```text
+source: scanned 71528 file(s), matched 0, runtime-summary lines 0, skipped 1643
+runtime summaries: 0 (ignored 0, malformed 0)
+ticks: unknown..unknown
+territory: not instrumented
+controllers: not instrumented
+resources: not instrumented
+combat: not instrumented
+```
+
+- A dry Pages generator run succeeded and wrote `/tmp/screeps-pages-check/index.html`, `/tmp/screeps-pages-check/roadmap-data.json`, and `/tmp/screeps-roadmap-kpi-check.sqlite`, but the KPI rows remained mostly uninstrumented because no real runtime-summary lines were available. `enemy_kills` correctly remained `NULL`, `instrumented=0`, and source `future ownership-aware combat reducer`.
+
+## Exact next Codex prompt
+
+Use this prompt for the next #29 implementation slice if it touches runtime-monitor/reporting scripts. Keep it in a worktree and preserve the Codex author boundary for implementation code.
+
+```text
+Read AGENTS.md and docs/ops/codex-skills.md. Use Skill 4 (Screeps operations/documentation updates) and Skill 5 (Worktree and PR hygiene). Keep the change minimal and task-scoped.
+
+Task: implement the next #29 persisted KPI evidence bridge. The current reducer/page stack exists, but a default scan finds zero real `#runtime-summary ` lines. Add a safe, testable artifact persistence path that captures real in-game Screeps console summary lines into ignored local artifacts so `scripts/screeps_runtime_kpi_artifact_bridge.py` and `scripts/generate-roadmap-page.py` can consume territory/resource/combat KPI evidence.
+
+Context:
+- Repo: /root/screeps (run in a topic worktree, not main).
+- Official target selectors from AGENTS.md: branch main, shard shardX, room E48S28. Do not print tokens or module contents.
+- Existing scripts:
+  - scripts/screeps-runtime-monitor.py handles official room summary/alert images.
+  - scripts/screeps_runtime_kpi_reducer.py reduces saved `#runtime-summary ` lines.
+  - scripts/screeps_runtime_kpi_artifact_bridge.py scans `/root/screeps/runtime-artifacts` and `/root/.hermes/cron/output` for lines that start exactly with `#runtime-summary `.
+  - scripts/generate-roadmap-page.py already invokes the artifact bridge and writes KPI rows.
+- Current evidence: default bridge scan found 0 matched files / 0 runtime-summary lines, so Pages/Gameplay Evolution still report territory/resource/combat as not instrumented despite merged telemetry/reducer infrastructure.
+
+Requirements:
+1. Investigate the smallest safe persistence point. Prefer extending an existing script/wrapper over creating a broad new service.
+2. Add deterministic tests for any parser/persistence function. Tests must not require network or secrets.
+3. Persist only lines starting exactly `#runtime-summary `; skip embedded/quoted/noisy markers; preserve no secrets.
+4. Output artifacts under an ignored local path such as `runtime-artifacts/runtime-summary-console/` by default, with CLI flags/env vars for input/output paths where useful.
+5. Do not create or schedule cron jobs in this implementation. The next Hermes worker will update live job prompts after the PR is merged.
+6. If live official console capture requires a token/websocket endpoint and is too large for this slice, implement the offline/CLI persistence primitive plus docs/runbook instructions, and clearly report the remaining live wiring step.
+7. Update relevant docs/process/runbook text so #29's next action is unambiguous.
+8. Run verification before committing:
+   - git diff --check
+   - python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/generate-roadmap-page.py and any new/changed script/tests
+   - python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py and any new tests
+   - python3 scripts/generate-roadmap-page.py --repo . --docs-dir /tmp/screeps-pages-check --db /tmp/screeps-roadmap-kpi-check.sqlite
+   - verify no WAL/SHM sidecars exist for the temp DB
+9. Commit the verified change with author `lanyusea's bot <lanyusea@gmail.com>` and a conventional commit message. Stage only intended files; exclude `runtime-artifacts/`, `.codex`, `__pycache__`, and temporary generated files.
+```
+
+## Next worker gate
+
+The next worker should not spend the slice on another static report/reducer layer unless it first proves a real persisted `#runtime-summary ` source exists. If no source exists, run the Codex prompt above or create a narrower Codex issue/PR for the persistence primitive.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,10 +1,10 @@
 # Active Work State
 
-Last updated: 2026-04-27T12:34:28+08:00
+Last updated: 2026-04-27T14:36:00+08:00
 
 ## Current active objective
 
-P0 agent operating-system health is repaired/watch-only in the current cron window: `/root/.hermes/cron/jobs.json` shows the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null`, current `last_run_at`, and non-overdue `next_run_at` values at slice start. Normal development may proceed while routine P0 monitor watch continues. The active gameplay priority remains #29: PR #67's runtime KPI reducer is merged, and the current artifact-bridge slice is PR-ready/in review to feed persisted `#runtime-summary` logs into the reducer; the next #29 step is wiring its territory/resource/combat evidence into 12h Gameplay Evolution and roadmap reporting prompts. #61's durable finding-to-Codex bridge is done/watch. The competition-map vision ordering remains territory first, resource scale second, enemy kills third; foundation work outranks that order only when it blocks evidence, implementation, release, or rollback. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
+P0 agent operating-system health is repaired/watch-only in the current cron window: `/root/.hermes/cron/jobs.json` shows the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null`, current `last_run_at`, and non-overdue `next_run_at` values at slice start. Normal development may proceed while routine P0 monitor watch continues. The active gameplay priority remains #29: PR #65's runtime KPI telemetry, PR #67's reducer, PR #68's persisted-artifact bridge, and PR #70's Pages/KPI report are merged on `main`. A 2026-04-27 default artifact scan still found `0` persisted `#runtime-summary ` lines, so the next #29 step is not another static report layer; it is a Codex-owned persistence/wiring slice that captures real in-game console summary lines into ignored local artifacts before wiring the 12h Gameplay Evolution and roadmap jobs to consume them. #61's durable finding-to-Codex bridge is done/watch. The competition-map vision ordering remains territory first, resource scale second, enemy kills third; foundation work outranks that order only when it blocks evidence, implementation, release, or rollback. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
 
 ## Completed tasks
 
@@ -258,21 +258,21 @@ P0 agent operating-system health is repaired/watch-only in the current cron wind
 
 ### runtime-kpi-artifact-bridge
 
-- Status: PR-ready / in review for #29
-- Process note: `docs/process/2026-04-27-runtime-kpi-artifact-bridge.md`
-- Branch: `feat/kpi-artifact-bridge-29`
+- Status: merged to `main`; follow-up persistence gap documented
+- Process notes: `docs/process/2026-04-27-runtime-kpi-artifact-bridge.md`, `docs/process/2026-04-27-kpi-persistence-wiring-checkpoint.md`
+- Pull request: https://github.com/lanyusea/screeps/pull/68
 - Implemented:
   - `scripts/screeps_runtime_kpi_artifact_bridge.py` scans files/directories for persisted `#runtime-summary ` lines, defaults to `/root/screeps/runtime-artifacts` and `/root/.hermes/cron/output`, tolerates missing dirs, and skips binary/oversized files.
   - JSON output remains deterministic and adds source metadata without artifact contents: input paths, scanned files, matched files, runtime-summary line count, and skipped file paths/reasons.
   - `--format human` emits a concise source/reducer summary.
   - `scripts/test_screeps_runtime_kpi_artifact_bridge.py` covers file scanning, recursive directory scans, binary/oversized skips, default no-match/no-input behavior, reducer integration, and human output.
   - Gameplay Evolution roadmap and finding-to-Codex bridge now prefer the artifact feeder before raw saved-log reducer fallback.
-- Verification target:
-  - `git diff --check`
-  - `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py`
-  - `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py`
+- Verification:
+  - PR #68 merged at 2026-04-27T05:09:10Z as `da20ac4` after prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini no feedback, and resolved GraphQL review thread.
+  - 2026-04-27 default bridge check: scanned `71528` files, matched `0`, runtime-summary lines `0`, skipped `1643`; territory/resources/combat remain not instrumented until real in-game summary lines are persisted.
+  - 2026-04-27 Pages generator dry run wrote `/tmp/screeps-pages-check/index.html`, `/tmp/screeps-pages-check/roadmap-data.json`, and `/tmp/screeps-roadmap-kpi-check.sqlite`; `enemy_kills` stayed `NULL`, `instrumented=0`, source `future ownership-aware combat reducer`.
 - Remaining next step:
-  - In a later scheduler-management slice, wire `python3 scripts/screeps_runtime_kpi_artifact_bridge.py` into the 12h Gameplay Evolution Review and roadmap KPI snapshot job prompts. Keep #29 active until that wiring is merged and observed.
+  - Run the Codex prompt in `docs/process/2026-04-27-kpi-persistence-wiring-checkpoint.md` to implement or wire a safe persistence path for real in-game `#runtime-summary ` console lines. Only after nonzero real summary lines are captured should a worker wire `python3 scripts/screeps_runtime_kpi_artifact_bridge.py` into the 12h Gameplay Evolution Review and roadmap KPI snapshot job prompts. Keep #29 active until that wiring is merged and observed.
 
 ## General production verification reminder
 


### PR DESCRIPTION
## Summary
- Records the #29 KPI persistence checkpoint after PRs #65/#67/#68/#70 landed.
- Updates active work state so the next worker does not repeat the static reducer/report layer.
- Captures exact evidence that the default artifact bridge currently finds 0 persisted `#runtime-summary ` lines and includes the next Codex prompt for the real persistence/wiring slice.

## Linked issue
Refs #29
Refs #59

## Roadmap category
Runtime KPI/monitor — persisted runtime-summary evidence for Gameplay Evolution.

## Served vision layer
Territory/control visibility first, resource/economy scale second, combat/enemy-kill visibility third. This docs slice serves the visibility/evidence layer by preventing the next worker from wiring empty KPI sources into the 12h review and roadmap report.

## Verification
- [x] `git diff --check`
- [x] Markdown/path sanity check for updated process docs and referenced scripts
- [x] `python3 /root/screeps-worktrees/kpi-persistence-29/scripts/screeps_runtime_kpi_artifact_bridge.py --format human` confirmed current default source has 0 runtime-summary lines

## Notes
- Docs/process only; no `prod/` code changed.
- No secrets included.
- This does not create or schedule cron jobs. Next implementation should be Codex-owned if it changes runtime/reporting scripts.
