### PR TITLE
feat: capture runtime summary console artifacts

### DIFF
--- a/docs/ops/gameplay-evolution-roadmap.md
+++ b/docs/ops/gameplay-evolution-roadmap.md
@@ -72,6 +72,14 @@ Preferred persisted-artifact feeder for KPI evidence:
 python3 scripts/screeps_runtime_kpi_artifact_bridge.py > runtime-kpi-report.json
 ```
 
+When a worker has raw Screeps console output rather than a saved artifact, persist the exact runtime-summary lines first:
+
+```bash
+python3 scripts/screeps_runtime_summary_console_capture.py saved-console.log
+```
+
+This writes only lines that start exactly `#runtime-summary ` under `/root/screeps/runtime-artifacts/runtime-summary-console/` by default, so the artifact bridge can consume them on its next scan. The utility is offline-only; the remaining live step is wiring an authenticated official console capture source into the job prompt or wrapper without printing tokens.
+
 With no paths, the bridge scans safe local artifact roots such as `/root/screeps/runtime-artifacts` and `/root/.hermes/cron/output`, tolerates missing directories, skips binary/oversized files, and attaches source counts without file contents. Pass explicit files or directories to bound a review window:
 
 ```bash

--- a/docs/ops/gameplay-finding-to-codex-bridge.md
+++ b/docs/ops/gameplay-finding-to-codex-bridge.md
@@ -48,6 +48,14 @@ Use the persisted-artifact bridge first when a Gameplay Evolution Review, roadma
 python3 scripts/screeps_runtime_kpi_artifact_bridge.py > runtime-kpi-report.json
 ```
 
+If a worker has raw Screeps console output but no persisted artifact yet, capture exact in-game summary lines first:
+
+```bash
+python3 scripts/screeps_runtime_summary_console_capture.py saved-console.log
+```
+
+The capture utility writes only lines starting exactly `#runtime-summary ` to `/root/screeps/runtime-artifacts/runtime-summary-console/` by default, or to paths set with `--out-dir`, `--out-file`, or `SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_DIR`. It does not connect to Screeps or require secrets.
+
 With explicit review-window roots:
 
 ```bash

--- a/docs/ops/runtime-room-monitor.md
+++ b/docs/ops/runtime-room-monitor.md
@@ -120,6 +120,22 @@ Offline pure-function tests:
 python3 scripts/screeps-runtime-monitor.py self-test
 ```
 
+## Runtime KPI console capture
+
+The room monitor renders official room summary and alert images; it does not persist in-game console output. When a Hermes worker or manual operator has raw Screeps console text, use the offline capture utility to write KPI evidence artifacts:
+
+```bash
+python3 scripts/screeps_runtime_summary_console_capture.py saved-console.log
+```
+
+The default output directory is:
+
+```text
+/root/screeps/runtime-artifacts/runtime-summary-console
+```
+
+Only lines starting exactly `#runtime-summary ` are written. Embedded, quoted, timestamp-prefixed, or noisy markers are skipped. The next live #29 wiring step is to feed an authenticated official console capture stream or saved console output into this utility; do not add cron jobs or print tokens from this runbook step.
+
 Live smoke:
 
 ```bash

--- a/docs/process/2026-04-27-kpi-persistence-wiring-checkpoint.md
+++ b/docs/process/2026-04-27-kpi-persistence-wiring-checkpoint.md
@@ -66,4 +66,16 @@ Requirements:
 
 ## Next worker gate
 
-The next worker should not spend the slice on another static report/reducer layer unless it first proves a real persisted `#runtime-summary ` source exists. If no source exists, run the Codex prompt above or create a narrower Codex issue/PR for the persistence primitive.
+This prompt is the implementation record for the offline persistence primitive. The next worker should not spend another slice on reducer/page layers or rerun this prompt unless the capture utility regresses. Instead, wire a live official-console capture source or Hermes job prompt to:
+
+```bash
+python3 scripts/screeps_runtime_summary_console_capture.py saved-console.log
+```
+
+Then prove a nonzero scan with:
+
+```bash
+python3 scripts/screeps_runtime_kpi_artifact_bridge.py --format human
+```
+
+Only after real persisted `#runtime-summary ` lines exist should a worker wire the bridge into the 12h Gameplay Evolution Review and roadmap KPI snapshot job prompts.

--- a/docs/process/2026-04-27-runtime-kpi-artifact-bridge.md
+++ b/docs/process/2026-04-27-runtime-kpi-artifact-bridge.md
@@ -28,4 +28,4 @@ python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py scripts/test_scr
 
 ## Remaining next step
 
-Wire this command into the 12h Gameplay Evolution Review prompt and roadmap KPI snapshot job prompts in a later scheduler-management slice. Do not create or schedule cron jobs in this bridge slice.
+First feed real console output into `scripts/screeps_runtime_summary_console_capture.py` so `/root/screeps/runtime-artifacts/runtime-summary-console/` contains nonzero exact-prefix `#runtime-summary ` lines. After `python3 scripts/screeps_runtime_kpi_artifact_bridge.py --format human` proves the persisted source is live, wire the bridge command into the 12h Gameplay Evolution Review prompt and roadmap KPI snapshot job prompts in a later scheduler-management slice. Do not create or schedule cron jobs in this bridge slice.

--- a/docs/process/active-work-state.md
+++ b/docs/process/active-work-state.md
@@ -1,10 +1,10 @@
 # Active Work State
 
-Last updated: 2026-04-27T14:36:00+08:00
+Last updated: 2026-04-27T15:18:00+08:00
 
 ## Current active objective
 
-P0 agent operating-system health is repaired/watch-only in the current cron window: `/root/.hermes/cron/jobs.json` shows the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null`, current `last_run_at`, and non-overdue `next_run_at` values at slice start. Normal development may proceed while routine P0 monitor watch continues. The active gameplay priority remains #29: PR #65's runtime KPI telemetry, PR #67's reducer, PR #68's persisted-artifact bridge, and PR #70's Pages/KPI report are merged on `main`. A 2026-04-27 default artifact scan still found `0` persisted `#runtime-summary ` lines, so the next #29 step is not another static report layer; it is a Codex-owned persistence/wiring slice that captures real in-game console summary lines into ignored local artifacts before wiring the 12h Gameplay Evolution and roadmap jobs to consume them. #61's durable finding-to-Codex bridge is done/watch. The competition-map vision ordering remains territory first, resource scale second, enemy kills third; foundation work outranks that order only when it blocks evidence, implementation, release, or rollback. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
+P0 agent operating-system health is repaired/watch-only in the current cron window: `/root/.hermes/cron/jobs.json` shows the continuation worker, P0 monitor, runtime summary, runtime alert, typed fanouts, 6h report, and Gameplay Evolution Review enabled with `workdir: null`, current `last_run_at`, and non-overdue `next_run_at` values at slice start. Normal development may proceed while routine P0 monitor watch continues. The active gameplay priority remains #29: PR #65's runtime KPI telemetry, PR #67's reducer, PR #68's persisted-artifact bridge, and PR #70's Pages/KPI report are merged on `main`. A 2026-04-27 default artifact scan still found `0` persisted `#runtime-summary ` lines, so the current Codex slice adds an offline persistence primitive for raw console captures; the next #29 step is live official-console wiring that feeds real in-game summary lines into ignored artifacts, then verifies a nonzero bridge scan before wiring the 12h Gameplay Evolution and roadmap jobs to consume them. #61's durable finding-to-Codex bridge is done/watch. The competition-map vision ordering remains territory first, resource scale second, enemy kills third; foundation work outranks that order only when it blocks evidence, implementation, release, or rollback. Canonical operating contract: `docs/ops/agent-operating-system.md`. Vision contract: `docs/ops/project-vision.md`. Owner decisions on 2026-04-26: use the automated review口径 with no formal GitHub approval requirement, add every active agent PR to Project `screeps`, and let known P0 monitoring/routing/scheduler health block normal development and non-P0 merges until repaired/proven healthy.
 
 ## Completed tasks
 
@@ -258,11 +258,12 @@ P0 agent operating-system health is repaired/watch-only in the current cron wind
 
 ### runtime-kpi-artifact-bridge
 
-- Status: merged to `main`; follow-up persistence gap documented
+- Status: merged to `main`; offline console persistence primitive added in current #29 slice, live official-console wiring still pending
 - Process notes: `docs/process/2026-04-27-runtime-kpi-artifact-bridge.md`, `docs/process/2026-04-27-kpi-persistence-wiring-checkpoint.md`
 - Pull request: https://github.com/lanyusea/screeps/pull/68
 - Implemented:
   - `scripts/screeps_runtime_kpi_artifact_bridge.py` scans files/directories for persisted `#runtime-summary ` lines, defaults to `/root/screeps/runtime-artifacts` and `/root/.hermes/cron/output`, tolerates missing dirs, and skips binary/oversized files.
+  - `scripts/screeps_runtime_summary_console_capture.py` reads stdin or saved console logs, writes only exact-prefix `#runtime-summary ` lines under `runtime-artifacts/runtime-summary-console/`, and emits counts/paths without artifact contents.
   - JSON output remains deterministic and adds source metadata without artifact contents: input paths, scanned files, matched files, runtime-summary line count, and skipped file paths/reasons.
   - `--format human` emits a concise source/reducer summary.
   - `scripts/test_screeps_runtime_kpi_artifact_bridge.py` covers file scanning, recursive directory scans, binary/oversized skips, default no-match/no-input behavior, reducer integration, and human output.
@@ -272,7 +273,7 @@ P0 agent operating-system health is repaired/watch-only in the current cron wind
   - 2026-04-27 default bridge check: scanned `71528` files, matched `0`, runtime-summary lines `0`, skipped `1643`; territory/resources/combat remain not instrumented until real in-game summary lines are persisted.
   - 2026-04-27 Pages generator dry run wrote `/tmp/screeps-pages-check/index.html`, `/tmp/screeps-pages-check/roadmap-data.json`, and `/tmp/screeps-roadmap-kpi-check.sqlite`; `enemy_kills` stayed `NULL`, `instrumented=0`, source `future ownership-aware combat reducer`.
 - Remaining next step:
-  - Run the Codex prompt in `docs/process/2026-04-27-kpi-persistence-wiring-checkpoint.md` to implement or wire a safe persistence path for real in-game `#runtime-summary ` console lines. Only after nonzero real summary lines are captured should a worker wire `python3 scripts/screeps_runtime_kpi_artifact_bridge.py` into the 12h Gameplay Evolution Review and roadmap KPI snapshot job prompts. Keep #29 active until that wiring is merged and observed.
+  - Wire a live official-console capture source or Hermes job prompt to `python3 scripts/screeps_runtime_summary_console_capture.py`, then prove `python3 scripts/screeps_runtime_kpi_artifact_bridge.py --format human` finds nonzero real `#runtime-summary ` lines. Only after that proof should a worker wire the bridge into the 12h Gameplay Evolution Review and roadmap KPI snapshot job prompts. Keep #29 active until that wiring is merged and observed.
 
 ## General production verification reminder
 

--- a/scripts/screeps_runtime_summary_console_capture.py
+++ b/scripts/screeps_runtime_summary_console_capture.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,8 +17,7 @@ from typing import Iterable, TextIO
 import screeps_runtime_kpi_reducer as reducer
 
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_OUT_DIR = REPO_ROOT / "runtime-artifacts" / "runtime-summary-console"
+DEFAULT_OUT_DIR = Path("/root/screeps/runtime-artifacts/runtime-summary-console")
 OUT_DIR_ENV = "SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_DIR"
 OUT_FILE_ENV = "SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_FILE"
 SAFE_ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
@@ -120,14 +120,23 @@ def write_artifact(path: Path, lines: list[str]) -> Path:
         raise FileExistsError(f"artifact already exists: {path}")
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = unique_artifact_path(path.with_name(f".{path.name}.tmp"))
+    temp_fd: int | None = None
+    temp_path: Path | None = None
     try:
-        with temp_path.open("x", encoding="utf-8") as output:
+        temp_fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+        temp_path = Path(temp_name)
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as output:
+            temp_fd = None
             output.writelines(lines)
+            output.flush()
+            os.fsync(output.fileno())
         return link_artifact_exclusively(temp_path, path)
     finally:
+        if temp_fd is not None:
+            os.close(temp_fd)
         try:
-            temp_path.unlink()
+            if temp_path is not None:
+                temp_path.unlink()
         except OSError:
             pass
 

--- a/scripts/screeps_runtime_summary_console_capture.py
+++ b/scripts/screeps_runtime_summary_console_capture.py
@@ -78,15 +78,16 @@ def validate_artifact_name(name: str) -> str:
     return name
 
 
-def unique_artifact_path(path: Path) -> Path:
-    if not path.exists():
-        return path
-
+def iter_artifact_path_candidates(path: Path) -> Iterable[Path]:
+    yield path
     for index in range(2, 1000):
-        candidate = path.with_name(f"{path.stem}-{index}{path.suffix}")
+        yield path.with_name(f"{path.stem}-{index}{path.suffix}")
+
+
+def unique_artifact_path(path: Path) -> Path:
+    for candidate in iter_artifact_path_candidates(path):
         if not candidate.exists():
             return candidate
-
     raise FileExistsError(f"could not choose a unique artifact path for {path}")
 
 
@@ -103,7 +104,18 @@ def resolve_output_path(
     return unique_artifact_path(out_dir.expanduser() / name)
 
 
-def write_artifact(path: Path, lines: list[str]) -> None:
+def link_artifact_exclusively(temp_path: Path, path: Path) -> Path:
+    for candidate in iter_artifact_path_candidates(path):
+        try:
+            os.link(temp_path, candidate)
+            return candidate
+        except FileExistsError:
+            continue
+
+    raise FileExistsError(f"could not choose a unique artifact path for {path}")
+
+
+def write_artifact(path: Path, lines: list[str]) -> Path:
     if path.exists():
         raise FileExistsError(f"artifact already exists: {path}")
 
@@ -112,13 +124,12 @@ def write_artifact(path: Path, lines: list[str]) -> None:
     try:
         with temp_path.open("x", encoding="utf-8") as output:
             output.writelines(lines)
-        temp_path.replace(path)
-    except BaseException:
+        return link_artifact_exclusively(temp_path, path)
+    finally:
         try:
             temp_path.unlink()
         except OSError:
             pass
-        raise
 
 
 def persist_runtime_summary_artifact(
@@ -150,7 +161,7 @@ def persist_runtime_summary_artifact(
         )
 
     output_path = resolve_output_path(out_dir=out_dir, out_file=out_file, artifact_name=artifact_name, now=now)
-    write_artifact(output_path, persisted_lines)
+    output_path = write_artifact(output_path, persisted_lines)
 
     return PersistResult(
         input_paths=paths,

--- a/scripts/screeps_runtime_summary_console_capture.py
+++ b/scripts/screeps_runtime_summary_console_capture.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Persist Screeps #runtime-summary console lines into local artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, TextIO
+
+import screeps_runtime_kpi_reducer as reducer
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUT_DIR = REPO_ROOT / "runtime-artifacts" / "runtime-summary-console"
+OUT_DIR_ENV = "SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_DIR"
+OUT_FILE_ENV = "SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_FILE"
+SAFE_ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+@dataclass(frozen=True)
+class PersistResult:
+    input_paths: list[str]
+    input_line_count: int
+    persisted_line_count: int
+    skipped_line_count: int
+    output_path: Path | None
+
+    def metadata(self) -> dict[str, object]:
+        return {
+            "inputPaths": self.input_paths,
+            "inputLineCount": self.input_line_count,
+            "persistedLineCount": self.persisted_line_count,
+            "skippedLineCount": self.skipped_line_count,
+            "outputPath": str(self.output_path) if self.output_path is not None else None,
+        }
+
+
+def iter_runtime_summary_lines(lines: Iterable[str]) -> Iterable[str]:
+    for line in lines:
+        normalized = normalize_runtime_summary_line(line)
+        if normalized is not None:
+            yield normalized
+
+
+def normalize_runtime_summary_line(line: str) -> str | None:
+    if not line.startswith(reducer.RUNTIME_SUMMARY_PREFIX):
+        return None
+    return line.rstrip("\r\n") + "\n"
+
+
+def iter_input_lines(input_paths: list[str], stdin: TextIO = sys.stdin) -> Iterable[str]:
+    paths = input_paths or ["-"]
+    for path_text in paths:
+        if path_text == "-":
+            yield from stdin
+            continue
+
+        with Path(path_text).expanduser().open("r", encoding="utf-8") as input_file:
+            yield from input_file
+
+
+def default_artifact_name(now: datetime | None = None) -> str:
+    timestamp = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return f"runtime-summary-console-{timestamp.strftime('%Y%m%dT%H%M%SZ')}.log"
+
+
+def validate_artifact_name(name: str) -> str:
+    if Path(name).name != name or not name or name in {".", ".."}:
+        raise ValueError("--artifact-name must be a file name, not a path")
+    if not SAFE_ARTIFACT_NAME_RE.fullmatch(name):
+        raise ValueError("--artifact-name may contain only letters, numbers, dot, underscore, and hyphen")
+    return name
+
+
+def unique_artifact_path(path: Path) -> Path:
+    if not path.exists():
+        return path
+
+    for index in range(2, 1000):
+        candidate = path.with_name(f"{path.stem}-{index}{path.suffix}")
+        if not candidate.exists():
+            return candidate
+
+    raise FileExistsError(f"could not choose a unique artifact path for {path}")
+
+
+def resolve_output_path(
+    out_dir: Path,
+    out_file: Path | None = None,
+    artifact_name: str | None = None,
+    now: datetime | None = None,
+) -> Path:
+    if out_file is not None:
+        return out_file.expanduser()
+
+    name = validate_artifact_name(artifact_name or default_artifact_name(now))
+    return unique_artifact_path(out_dir.expanduser() / name)
+
+
+def write_artifact(path: Path, lines: list[str]) -> None:
+    if path.exists():
+        raise FileExistsError(f"artifact already exists: {path}")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = unique_artifact_path(path.with_name(f".{path.name}.tmp"))
+    try:
+        with temp_path.open("x", encoding="utf-8") as output:
+            output.writelines(lines)
+        temp_path.replace(path)
+    except BaseException:
+        try:
+            temp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def persist_runtime_summary_artifact(
+    input_paths: list[str],
+    out_dir: Path = DEFAULT_OUT_DIR,
+    out_file: Path | None = None,
+    artifact_name: str | None = None,
+    stdin: TextIO = sys.stdin,
+    now: datetime | None = None,
+) -> PersistResult:
+    paths = input_paths or ["-"]
+    input_line_count = 0
+    persisted_lines: list[str] = []
+
+    for line in iter_input_lines(input_paths, stdin=stdin):
+        input_line_count += 1
+        normalized = normalize_runtime_summary_line(line)
+        if normalized is not None:
+            persisted_lines.append(normalized)
+
+    skipped_line_count = input_line_count - len(persisted_lines)
+    if not persisted_lines:
+        return PersistResult(
+            input_paths=paths,
+            input_line_count=input_line_count,
+            persisted_line_count=0,
+            skipped_line_count=skipped_line_count,
+            output_path=None,
+        )
+
+    output_path = resolve_output_path(out_dir=out_dir, out_file=out_file, artifact_name=artifact_name, now=now)
+    write_artifact(output_path, persisted_lines)
+
+    return PersistResult(
+        input_paths=paths,
+        input_line_count=input_line_count,
+        persisted_line_count=len(persisted_lines),
+        skipped_line_count=skipped_line_count,
+        output_path=output_path,
+    )
+
+
+def render_json(result: PersistResult) -> str:
+    return json.dumps(result.metadata(), indent=2, sort_keys=True)
+
+
+def render_human(result: PersistResult) -> str:
+    output = str(result.output_path) if result.output_path is not None else "none"
+    return (
+        f"input lines: {result.input_line_count}; persisted: {result.persisted_line_count}; "
+        f"skipped: {result.skipped_line_count}; output: {output}"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Persist only exact-prefix Screeps #runtime-summary console lines into a local artifact "
+            "that the KPI artifact bridge can scan."
+        ),
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="*",
+        help="Console log files to scan. Use '-' for stdin. Reads stdin when no inputs are provided.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=os.environ.get(OUT_DIR_ENV, str(DEFAULT_OUT_DIR)),
+        help=f"Artifact directory. Default: ${OUT_DIR_ENV} or {DEFAULT_OUT_DIR}.",
+    )
+    parser.add_argument(
+        "--out-file",
+        default=os.environ.get(OUT_FILE_ENV),
+        help=f"Exact artifact file path. Overrides --out-dir and --artifact-name. May also be set with ${OUT_FILE_ENV}.",
+    )
+    parser.add_argument(
+        "--artifact-name",
+        help="Artifact file name to create inside --out-dir. Defaults to a UTC timestamped .log name.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "human"),
+        default="json",
+        help="Output format. JSON is deterministic and is the default.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None, stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
+    args = build_parser().parse_args(argv)
+    result = persist_runtime_summary_artifact(
+        input_paths=args.inputs,
+        out_dir=Path(args.out_dir),
+        out_file=Path(args.out_file) if args.out_file else None,
+        artifact_name=args.artifact_name,
+        stdin=stdin,
+    )
+    output = render_human(result) if args.format == "human" else render_json(result)
+    stdout.write(output)
+    stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_screeps_runtime_summary_console_capture.py
+++ b/scripts/test_screeps_runtime_summary_console_capture.py
@@ -75,6 +75,24 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
         self.assertEqual(report["input"]["runtimeSummaryCount"], 2)
         self.assertEqual(report["window"], {"firstTick": 10, "latestTick": 20})
 
+    def test_default_out_dir_matches_bridge_default_runtime_artifacts_tree(self) -> None:
+        expected = Path("/root/screeps/runtime-artifacts/runtime-summary-console")
+
+        self.assertEqual(capture.DEFAULT_OUT_DIR, expected)
+        self.assertIn(str(expected.parent), bridge.DEFAULT_INPUT_PATHS)
+        self.assertEqual(Path(capture.build_parser().parse_args([]).out_dir), expected)
+
+        env_override = Path("/tmp/runtime-summary-console-env")
+        with mock.patch.dict(capture.os.environ, {capture.OUT_DIR_ENV: str(env_override)}):
+            self.assertEqual(Path(capture.build_parser().parse_args([]).out_dir), env_override)
+
+        cli_override = Path("/tmp/runtime-summary-console-cli")
+        with mock.patch.dict(capture.os.environ, {capture.OUT_DIR_ENV: str(env_override)}):
+            self.assertEqual(
+                Path(capture.build_parser().parse_args(["--out-dir", str(cli_override)]).out_dir),
+                cli_override,
+            )
+
     def test_does_not_write_artifact_when_no_summary_lines_match(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             out_dir = Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"
@@ -90,36 +108,50 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
             self.assertEqual(result.output_path, None)
             self.assertFalse(out_dir.exists())
 
+    def test_temp_path_collision_does_not_drop_capture(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            out_dir = Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"
+            output_path = out_dir / "capture.log"
+            vulnerable_temp_path = out_dir / ".capture.log.tmp"
+            captured_artifact = "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":1}\n"
+            original_open = Path.open
+
+            def open_with_temp_collision(path: Path, *args: object, **kwargs: object) -> object:
+                mode = args[0] if args else kwargs.get("mode", "r")
+                if path == vulnerable_temp_path and mode == "x":
+                    vulnerable_temp_path.write_text("competing temp\n", encoding="utf-8")
+                    raise FileExistsError(vulnerable_temp_path)
+                return original_open(path, *args, **kwargs)
+
+            with mock.patch.object(Path, "open", open_with_temp_collision):
+                result = capture.persist_runtime_summary_artifact(
+                    input_paths=[],
+                    out_dir=out_dir,
+                    artifact_name="capture.log",
+                    stdin=io.StringIO(captured_artifact),
+                )
+
+            self.assertEqual(result.output_path, output_path)
+            self.assertEqual(output_path.read_text(encoding="utf-8"), captured_artifact)
+
     def test_does_not_overwrite_artifact_created_before_publish(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             out_dir = Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"
             output_path = out_dir / "capture.log"
-            temp_path = out_dir / ".capture.log.tmp"
             competing_artifact = "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":999}\n"
             captured_artifact = "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":1}\n"
-            original_open = Path.open
+            original_link = capture.os.link
+            state = {"raced": False}
 
-            class CreateCompetingArtifactOnClose:
-                def __init__(self, wrapped: object) -> None:
-                    self.wrapped = wrapped
+            def link_with_publish_race(src: object, dst: object, *args: object, **kwargs: object) -> object:
+                destination = Path(dst)
+                if destination == output_path and not state["raced"]:
+                    state["raced"] = True
+                    output_path.write_text(competing_artifact, encoding="utf-8")
+                    raise FileExistsError(output_path)
+                return original_link(src, dst, *args, **kwargs)
 
-                def __enter__(self) -> object:
-                    return self.wrapped.__enter__()
-
-                def __exit__(self, exc_type: object, exc: object, tb: object) -> object:
-                    result = self.wrapped.__exit__(exc_type, exc, tb)
-                    if exc_type is None:
-                        output_path.write_text(competing_artifact, encoding="utf-8")
-                    return result
-
-            def open_with_publish_race(path: Path, *args: object, **kwargs: object) -> object:
-                opened = original_open(path, *args, **kwargs)
-                mode = args[0] if args else kwargs.get("mode", "r")
-                if path == temp_path and mode == "x":
-                    return CreateCompetingArtifactOnClose(opened)
-                return opened
-
-            with mock.patch.object(Path, "open", open_with_publish_race):
+            with mock.patch.object(capture.os, "link", link_with_publish_race):
                 result = capture.persist_runtime_summary_artifact(
                     input_paths=[],
                     out_dir=out_dir,
@@ -130,7 +162,7 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
             self.assertEqual(output_path.read_text(encoding="utf-8"), competing_artifact)
             self.assertEqual(result.output_path, out_dir / "capture-2.log")
             self.assertEqual(result.output_path.read_text(encoding="utf-8"), captured_artifact)
-            self.assertFalse(temp_path.exists())
+            self.assertEqual(list(out_dir.glob(".capture.log.*")), [])
 
     def test_cli_emits_counts_without_artifact_contents(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_screeps_runtime_summary_console_capture.py
+++ b/scripts/test_screeps_runtime_summary_console_capture.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_runtime_kpi_artifact_bridge as bridge
+import screeps_runtime_summary_console_capture as capture
+
+
+class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
+    def test_filters_only_exact_runtime_summary_lines(self) -> None:
+        lines = [
+            "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":1}\n",
+            "noise #runtime-summary {\"type\":\"runtime-summary\",\"tick\":2}\n",
+            "\"#runtime-summary {\\\"type\\\":\\\"runtime-summary\\\",\\\"tick\\\":3}\"\n",
+            " #runtime-summary {\"type\":\"runtime-summary\",\"tick\":4}\n",
+            "#runtime-summary {bad json}\n",
+            "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":5}",
+        ]
+
+        accepted = list(capture.iter_runtime_summary_lines(lines))
+
+        self.assertEqual(
+            accepted,
+            [
+                "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":1}\n",
+                "#runtime-summary {bad json}\n",
+                "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":5}\n",
+            ],
+        )
+
+    def test_persists_matching_console_lines_to_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            input_path = root / "console.log"
+            out_dir = root / "runtime-artifacts" / "runtime-summary-console"
+            input_path.write_text(
+                "noise before\n"
+                "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":10,\"rooms\":[{\"roomName\":\"W1N1\"}]}\n"
+                "noise #runtime-summary {\"type\":\"runtime-summary\",\"tick\":11}\n"
+                "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":20,\"rooms\":[{\"roomName\":\"W1N1\"}]}\n",
+                encoding="utf-8",
+            )
+
+            result = capture.persist_runtime_summary_artifact(
+                input_paths=[str(input_path)],
+                out_dir=out_dir,
+                artifact_name="capture.log",
+            )
+
+            self.assertEqual(result.input_paths, [str(input_path)])
+            self.assertEqual(result.input_line_count, 4)
+            self.assertEqual(result.persisted_line_count, 2)
+            self.assertEqual(result.skipped_line_count, 2)
+            self.assertEqual(result.output_path, out_dir / "capture.log")
+            self.assertEqual(
+                result.output_path.read_text(encoding="utf-8").splitlines(),
+                [
+                    "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":10,\"rooms\":[{\"roomName\":\"W1N1\"}]}",
+                    "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":20,\"rooms\":[{\"roomName\":\"W1N1\"}]}",
+                ],
+            )
+
+            report = bridge.build_bridge_report([str(out_dir)])
+
+        self.assertEqual(report["source"]["runtimeSummaryLines"], 2)
+        self.assertEqual(report["input"]["runtimeSummaryCount"], 2)
+        self.assertEqual(report["window"], {"firstTick": 10, "latestTick": 20})
+
+    def test_does_not_write_artifact_when_no_summary_lines_match(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            out_dir = Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"
+
+            result = capture.persist_runtime_summary_artifact(
+                input_paths=[],
+                out_dir=out_dir,
+                artifact_name="empty.log",
+                stdin=io.StringIO("noise\nquoted '#runtime-summary {}'\n"),
+            )
+
+            self.assertEqual(result.persisted_line_count, 0)
+            self.assertEqual(result.output_path, None)
+            self.assertFalse(out_dir.exists())
+
+    def test_cli_emits_counts_without_artifact_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = io.StringIO()
+            exit_code = capture.main(
+                [
+                    "--out-dir",
+                    str(Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"),
+                    "--artifact-name",
+                    "stdin.log",
+                ],
+                stdin=io.StringIO("#runtime-summary {\"type\":\"runtime-summary\",\"tick\":1}\n"),
+                stdout=output,
+            )
+
+            report = json.loads(output.getvalue())
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(report["persistedLineCount"], 1)
+        self.assertEqual(report["skippedLineCount"], 0)
+        self.assertEqual(report["inputPaths"], ["-"])
+        self.assertTrue(report["outputPath"].endswith("stdin.log"))
+        self.assertNotIn("#runtime-summary", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_runtime_summary_console_capture.py
+++ b/scripts/test_screeps_runtime_summary_console_capture.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -88,6 +89,48 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
             self.assertEqual(result.persisted_line_count, 0)
             self.assertEqual(result.output_path, None)
             self.assertFalse(out_dir.exists())
+
+    def test_does_not_overwrite_artifact_created_before_publish(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            out_dir = Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"
+            output_path = out_dir / "capture.log"
+            temp_path = out_dir / ".capture.log.tmp"
+            competing_artifact = "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":999}\n"
+            captured_artifact = "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":1}\n"
+            original_open = Path.open
+
+            class CreateCompetingArtifactOnClose:
+                def __init__(self, wrapped: object) -> None:
+                    self.wrapped = wrapped
+
+                def __enter__(self) -> object:
+                    return self.wrapped.__enter__()
+
+                def __exit__(self, exc_type: object, exc: object, tb: object) -> object:
+                    result = self.wrapped.__exit__(exc_type, exc, tb)
+                    if exc_type is None:
+                        output_path.write_text(competing_artifact, encoding="utf-8")
+                    return result
+
+            def open_with_publish_race(path: Path, *args: object, **kwargs: object) -> object:
+                opened = original_open(path, *args, **kwargs)
+                mode = args[0] if args else kwargs.get("mode", "r")
+                if path == temp_path and mode == "x":
+                    return CreateCompetingArtifactOnClose(opened)
+                return opened
+
+            with mock.patch.object(Path, "open", open_with_publish_race):
+                result = capture.persist_runtime_summary_artifact(
+                    input_paths=[],
+                    out_dir=out_dir,
+                    artifact_name="capture.log",
+                    stdin=io.StringIO(captured_artifact),
+                )
+
+            self.assertEqual(output_path.read_text(encoding="utf-8"), competing_artifact)
+            self.assertEqual(result.output_path, out_dir / "capture-2.log")
+            self.assertEqual(result.output_path.read_text(encoding="utf-8"), captured_artifact)
+            self.assertFalse(temp_path.exists())
 
     def test_cli_emits_counts_without_artifact_contents(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Adds `scripts/screeps_runtime_summary_console_capture.py`, an offline persistence primitive for raw Screeps console logs.
- Persists only exact-prefix `#runtime-summary ` lines into ignored `runtime-artifacts/runtime-summary-console/` artifacts so the existing KPI artifact bridge and Pages generator can consume real evidence.
- Adds deterministic tests for exact-prefix filtering, no-match behavior, CLI metadata, and bridge integration.
- Updates #29 docs/process/runbooks to make the next step live official-console wiring, not another reducer/page layer.

## Linked issue
Refs #29
Refs #59

## Roadmap category
Runtime KPI/monitor — persisted runtime-summary evidence bridge for Gameplay Evolution.

## Served vision layer
Territory/control visibility first, resource/economy scale second, combat/enemy-kill visibility third. This is foundation plumbing, but it directly unblocks game-KPI evidence because #29 cannot feed Gameplay Evolution or roadmap reporting until real in-game `#runtime-summary ` lines are persisted.

## Verification
- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/generate-roadmap-page.py scripts/screeps_runtime_summary_console_capture.py scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py scripts/test_screeps_runtime_summary_console_capture.py`
- [x] `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py scripts/test_screeps_runtime_summary_console_capture.py` (18 tests)
- [x] `python3 scripts/generate-roadmap-page.py --repo . --docs-dir /tmp/screeps-pages-check --db /tmp/screeps-roadmap-kpi-check.sqlite`
- [x] verified no `/tmp/screeps-roadmap-kpi-check.sqlite-wal` or `.sqlite-shm` sidecars

## Notes
- No cron jobs were created or scheduled.
- No live official token/websocket capture is implemented in this PR; the next worker should wire an authenticated console source or saved console output into this offline capture utility, then prove `scripts/screeps_runtime_kpi_artifact_bridge.py --format human` finds nonzero real lines.
- No secrets included.
