### PR TITLE
feat: capture official console runtime summaries

### DIFF
--- a/docs/ops/gameplay-evolution-roadmap.md
+++ b/docs/ops/gameplay-evolution-roadmap.md
@@ -78,7 +78,13 @@ When a worker has raw Screeps console output rather than a saved artifact, persi
 python3 scripts/screeps_runtime_summary_console_capture.py saved-console.log
 ```
 
-This writes only lines that start exactly `#runtime-summary ` under `/root/screeps/runtime-artifacts/runtime-summary-console/` by default, so the artifact bridge can consume them on its next scan. The utility is offline-only; the remaining live step is wiring an authenticated official console capture source into the job prompt or wrapper without printing tokens.
+For a bounded live official-client console capture, load `SCREEPS_AUTH_TOKEN` from the local secret environment and run:
+
+```bash
+python3 scripts/screeps_runtime_summary_console_capture.py --live-official-console --live-timeout-seconds 20 --live-max-messages 50
+```
+
+This writes only lines that start exactly `#runtime-summary ` under `/root/screeps/runtime-artifacts/runtime-summary-console/` by default, so the artifact bridge can consume them on its next scan. `SCREEPS_API_URL` defaults to `https://screeps.com`; `SCREEPS_CONSOLE_CHANNELS` or repeated `--console-channel` values can override the default requested channel list, which includes `console`. Command output reports counts, output path, and requested channels without printing tokens, headers, or raw artifact contents.
 
 With no paths, the bridge scans safe local artifact roots such as `/root/screeps/runtime-artifacts` and `/root/.hermes/cron/output`, tolerates missing directories, skips binary/oversized files, and attaches source counts without file contents. Pass explicit files or directories to bound a review window:
 

--- a/docs/ops/gameplay-finding-to-codex-bridge.md
+++ b/docs/ops/gameplay-finding-to-codex-bridge.md
@@ -54,7 +54,13 @@ If a worker has raw Screeps console output but no persisted artifact yet, captur
 python3 scripts/screeps_runtime_summary_console_capture.py saved-console.log
 ```
 
-The capture utility writes only lines starting exactly `#runtime-summary ` to `/root/screeps/runtime-artifacts/runtime-summary-console/` by default, or to paths set with `--out-dir`, `--out-file`, or `SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_DIR`. It does not connect to Screeps or require secrets.
+For a bounded live official-client console capture, load `SCREEPS_AUTH_TOKEN` from the local secret environment and run:
+
+```bash
+python3 scripts/screeps_runtime_summary_console_capture.py --live-official-console --live-timeout-seconds 20 --live-max-messages 50
+```
+
+The capture utility writes only lines starting exactly `#runtime-summary ` to `/root/screeps/runtime-artifacts/runtime-summary-console/` by default, or to paths set with `--out-dir`, `--out-file`, or `SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_DIR`. `SCREEPS_API_URL` defaults to `https://screeps.com`; `SCREEPS_CONSOLE_CHANNELS` or repeated `--console-channel` values can override the default requested channel list, which includes `console`. Command output reports counts, output path, and requested channels without printing tokens, headers, or raw artifact contents.
 
 With explicit review-window roots:
 

--- a/docs/ops/runtime-room-monitor.md
+++ b/docs/ops/runtime-room-monitor.md
@@ -122,10 +122,16 @@ python3 scripts/screeps-runtime-monitor.py self-test
 
 ## Runtime KPI console capture
 
-The room monitor renders official room summary and alert images; it does not persist in-game console output. When a Hermes worker or manual operator has raw Screeps console text, use the offline capture utility to write KPI evidence artifacts:
+The room monitor renders official room summary and alert images; runtime KPI console summaries are persisted by the capture utility. When a Hermes worker or manual operator has raw Screeps console text, use the offline path:
 
 ```bash
 python3 scripts/screeps_runtime_summary_console_capture.py saved-console.log
+```
+
+For a bounded official-client websocket capture, load `SCREEPS_AUTH_TOKEN` from the local secret environment and run live mode. `SCREEPS_API_URL` defaults to `https://screeps.com`; `SCREEPS_CONSOLE_CHANNELS` or repeated `--console-channel` values can override the default requested channel list, which includes `console`.
+
+```bash
+python3 scripts/screeps_runtime_summary_console_capture.py --live-official-console --live-timeout-seconds 20 --live-max-messages 50
 ```
 
 The default output directory is:
@@ -134,7 +140,7 @@ The default output directory is:
 /root/screeps/runtime-artifacts/runtime-summary-console
 ```
 
-Only lines starting exactly `#runtime-summary ` are written. Embedded, quoted, timestamp-prefixed, or noisy markers are skipped. The next live #29 wiring step is to feed an authenticated official console capture stream or saved console output into this utility; do not add cron jobs or print tokens from this runbook step.
+Only lines starting exactly `#runtime-summary ` are written. Embedded, quoted, timestamp-prefixed, or noisy markers are skipped. The command output reports counts, output path, and requested websocket channels without printing tokens, headers, or raw artifact contents. Do not add cron jobs from this runbook step.
 
 Live smoke:
 

--- a/scripts/screeps_runtime_summary_console_capture.py
+++ b/scripts/screeps_runtime_summary_console_capture.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import os
 import re
@@ -12,14 +13,24 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, TextIO
+from typing import Any, Iterable, TextIO
 
 import screeps_runtime_kpi_reducer as reducer
 
 
 DEFAULT_OUT_DIR = Path("/root/screeps/runtime-artifacts/runtime-summary-console")
+DEFAULT_API_URL = "https://screeps.com"
+DEFAULT_CONSOLE_CHANNELS = ("console",)
+DEFAULT_LIVE_TIMEOUT_SECONDS = 20.0
+DEFAULT_LIVE_MAX_MESSAGES = 50
+DEFAULT_LIVE_OPEN_TIMEOUT_SECONDS = 10.0
 OUT_DIR_ENV = "SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_DIR"
 OUT_FILE_ENV = "SCREEPS_RUNTIME_SUMMARY_CONSOLE_OUT_FILE"
+AUTH_TOKEN_ENV = "SCREEPS_AUTH_TOKEN"
+API_URL_ENV = "SCREEPS_API_URL"
+CONSOLE_CHANNELS_ENV = "SCREEPS_CONSOLE_CHANNELS"
+LIVE_TIMEOUT_ENV = "SCREEPS_CONSOLE_CAPTURE_TIMEOUT_SECONDS"
+LIVE_MAX_MESSAGES_ENV = "SCREEPS_CONSOLE_CAPTURE_MAX_MESSAGES"
 SAFE_ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
@@ -30,14 +41,59 @@ class PersistResult:
     persisted_line_count: int
     skipped_line_count: int
     output_path: Path | None
+    metadata_extra: dict[str, object] | None = None
 
     def metadata(self) -> dict[str, object]:
-        return {
+        metadata = {
             "inputPaths": self.input_paths,
             "inputLineCount": self.input_line_count,
             "persistedLineCount": self.persisted_line_count,
             "skippedLineCount": self.skipped_line_count,
             "outputPath": str(self.output_path) if self.output_path is not None else None,
+        }
+        if self.metadata_extra is not None:
+            metadata.update(self.metadata_extra)
+        return metadata
+
+
+@dataclass(frozen=True)
+class LiveConsoleContext:
+    base_http: str
+    token: str
+    channels: list[str]
+    timeout_seconds: float
+    max_messages: int
+
+    @property
+    def base_ws(self) -> str:
+        if self.base_http.startswith("https://"):
+            return "wss://" + self.base_http[len("https://") :]
+        if self.base_http.startswith("http://"):
+            return "ws://" + self.base_http[len("http://") :]
+        return self.base_http
+
+    @property
+    def websocket_url(self) -> str:
+        return self.base_ws.rstrip("/") + "/socket/websocket"
+
+
+@dataclass(frozen=True)
+class LiveConsoleCapture:
+    requested_channels: list[str]
+    websocket_url: str
+    timeout_seconds: float
+    max_messages: int
+    received_message_count: int
+    console_lines: list[str]
+
+    def metadata(self) -> dict[str, object]:
+        return {
+            "source": "live-official-console",
+            "websocketUrl": self.websocket_url,
+            "requestedChannels": self.requested_channels,
+            "timeoutSeconds": self.timeout_seconds,
+            "maxMessages": self.max_messages,
+            "receivedMessageCount": self.received_message_count,
         }
 
 
@@ -63,6 +119,61 @@ def iter_input_lines(input_paths: list[str], stdin: TextIO = sys.stdin) -> Itera
 
         with Path(path_text).expanduser().open("r", encoding="utf-8") as input_file:
             yield from input_file
+
+
+def split_console_text_lines(text: str) -> list[str]:
+    if not text:
+        return []
+    return text.splitlines(keepends=True) or [text]
+
+
+def iter_string_values(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from iter_string_values(item)
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            yield from iter_string_values(item)
+
+
+def decode_websocket_text(message: object) -> str | None:
+    if isinstance(message, bytes):
+        return message.decode("utf-8", errors="replace")
+    if isinstance(message, str):
+        return message
+    return None
+
+
+def iter_console_text_lines_from_websocket_message(
+    message: object,
+    requested_channels: list[str],
+) -> Iterable[str]:
+    text = decode_websocket_text(message)
+    if text is None:
+        return
+
+    parsed: object | None = None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+
+    if (
+        isinstance(parsed, list)
+        and len(parsed) >= 2
+        and isinstance(parsed[0], str)
+        and parsed[0] in set(requested_channels)
+    ):
+        for console_text in iter_string_values(parsed[1]):
+            yield from split_console_text_lines(console_text)
+        return
+
+    if parsed is None:
+        yield from split_console_text_lines(text)
 
 
 def default_artifact_name(now: datetime | None = None) -> str:
@@ -148,12 +259,15 @@ def persist_runtime_summary_artifact(
     artifact_name: str | None = None,
     stdin: TextIO = sys.stdin,
     now: datetime | None = None,
+    input_lines: Iterable[str] | None = None,
+    metadata_extra: dict[str, object] | None = None,
 ) -> PersistResult:
     paths = input_paths or ["-"]
     input_line_count = 0
     persisted_lines: list[str] = []
 
-    for line in iter_input_lines(input_paths, stdin=stdin):
+    lines = input_lines if input_lines is not None else iter_input_lines(input_paths, stdin=stdin)
+    for line in lines:
         input_line_count += 1
         normalized = normalize_runtime_summary_line(line)
         if normalized is not None:
@@ -167,6 +281,7 @@ def persist_runtime_summary_artifact(
             persisted_line_count=0,
             skipped_line_count=skipped_line_count,
             output_path=None,
+            metadata_extra=metadata_extra,
         )
 
     output_path = resolve_output_path(out_dir=out_dir, out_file=out_file, artifact_name=artifact_name, now=now)
@@ -178,6 +293,144 @@ def persist_runtime_summary_artifact(
         persisted_line_count=len(persisted_lines),
         skipped_line_count=skipped_line_count,
         output_path=output_path,
+        metadata_extra=metadata_extra,
+    )
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than zero")
+    return parsed
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than zero")
+    return parsed
+
+
+def validate_console_channel(channel: str) -> str:
+    if not channel or any(character.isspace() for character in channel) or not channel.isprintable():
+        raise ValueError("console channel names must be non-empty printable strings without whitespace")
+    return channel
+
+
+def parse_console_channels(value: str | None) -> list[str]:
+    raw = value if value is not None and value.strip() else ",".join(DEFAULT_CONSOLE_CHANNELS)
+    channels: list[str] = []
+    seen: set[str] = set()
+    for channel in raw.split(","):
+        channel = channel.strip()
+        if not channel:
+            continue
+        channel = validate_console_channel(channel)
+        if channel not in seen:
+            channels.append(channel)
+            seen.add(channel)
+    if not channels:
+        raise ValueError("at least one console channel is required")
+    return channels
+
+
+def resolve_console_channels(cli_channels: list[str] | None) -> list[str]:
+    if cli_channels:
+        return parse_console_channels(",".join(cli_channels))
+    return parse_console_channels(os.environ.get(CONSOLE_CHANNELS_ENV))
+
+
+def live_console_context_from_args(args: argparse.Namespace) -> LiveConsoleContext:
+    token = os.environ.get(AUTH_TOKEN_ENV)
+    if not token:
+        raise RuntimeError(f"{AUTH_TOKEN_ENV} is required for --live-official-console")
+    return LiveConsoleContext(
+        base_http=str(args.api_url).rstrip("/"),
+        token=token,
+        channels=resolve_console_channels(args.console_channel),
+        timeout_seconds=args.live_timeout_seconds,
+        max_messages=args.live_max_messages,
+    )
+
+
+def import_websockets_module() -> Any:
+    try:
+        import websockets
+    except ModuleNotFoundError as exc:
+        raise RuntimeError("Python package 'websockets' is required for --live-official-console") from exc
+    return websockets
+
+
+def remaining_timeout(deadline: float) -> float:
+    return max(0.001, deadline - asyncio.get_running_loop().time())
+
+
+async def wait_for_auth_ok(websocket: Any, deadline: float) -> None:
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            message = await asyncio.wait_for(websocket.recv(), timeout=remaining_timeout(deadline))
+        except asyncio.TimeoutError:
+            break
+        text = decode_websocket_text(message)
+        if isinstance(text, str) and text.startswith("auth "):
+            if "ok" in text.lower():
+                return
+            break
+    raise RuntimeError("websocket authentication did not complete")
+
+
+async def collect_live_official_console_lines(
+    ctx: LiveConsoleContext,
+    websockets_module: Any | None = None,
+) -> LiveConsoleCapture:
+    websockets_module = websockets_module or import_websockets_module()
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + ctx.timeout_seconds
+    received_message_count = 0
+    console_lines: list[str] = []
+
+    async with websockets_module.connect(
+        ctx.websocket_url,
+        open_timeout=min(DEFAULT_LIVE_OPEN_TIMEOUT_SECONDS, ctx.timeout_seconds),
+    ) as websocket:
+        await websocket.send("auth " + ctx.token)
+        await wait_for_auth_ok(websocket, deadline)
+        for channel in ctx.channels:
+            await websocket.send(f"subscribe {channel}")
+
+        while received_message_count < ctx.max_messages and loop.time() < deadline:
+            try:
+                message = await asyncio.wait_for(websocket.recv(), timeout=remaining_timeout(deadline))
+            except asyncio.TimeoutError:
+                break
+            received_message_count += 1
+            console_lines.extend(iter_console_text_lines_from_websocket_message(message, ctx.channels))
+
+    return LiveConsoleCapture(
+        requested_channels=ctx.channels,
+        websocket_url=ctx.websocket_url,
+        timeout_seconds=ctx.timeout_seconds,
+        max_messages=ctx.max_messages,
+        received_message_count=received_message_count,
+        console_lines=console_lines,
+    )
+
+
+def persist_live_official_console_artifact(
+    ctx: LiveConsoleContext,
+    out_dir: Path = DEFAULT_OUT_DIR,
+    out_file: Path | None = None,
+    artifact_name: str | None = None,
+    websockets_module: Any | None = None,
+) -> PersistResult:
+    capture = asyncio.run(collect_live_official_console_lines(ctx, websockets_module=websockets_module))
+    return persist_runtime_summary_artifact(
+        input_paths=["live-official-console"],
+        out_dir=out_dir,
+        out_file=out_file,
+        artifact_name=artifact_name,
+        input_lines=capture.console_lines,
+        metadata_extra=capture.metadata(),
     )
 
 
@@ -187,10 +440,15 @@ def render_json(result: PersistResult) -> str:
 
 def render_human(result: PersistResult) -> str:
     output = str(result.output_path) if result.output_path is not None else "none"
-    return (
+    rendered = (
         f"input lines: {result.input_line_count}; persisted: {result.persisted_line_count}; "
         f"skipped: {result.skipped_line_count}; output: {output}"
     )
+    if result.metadata_extra and "requestedChannels" in result.metadata_extra:
+        channels = ",".join(str(channel) for channel in result.metadata_extra["requestedChannels"])
+        rendered += f"; requested channels: {channels}"
+        rendered += f"; websocket messages: {result.metadata_extra.get('receivedMessageCount', 0)}"
+    return rendered
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -225,18 +483,75 @@ def build_parser() -> argparse.ArgumentParser:
         default="json",
         help="Output format. JSON is deterministic and is the default.",
     )
+    parser.add_argument(
+        "--live-official-console",
+        action="store_true",
+        help=(
+            "Capture live official-client console websocket messages instead of stdin/files. "
+            f"Requires ${AUTH_TOKEN_ENV}; uses ${API_URL_ENV} for the base URL."
+        ),
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.environ.get(API_URL_ENV, DEFAULT_API_URL),
+        help=f"Screeps API base URL for live capture. Default: ${API_URL_ENV} or {DEFAULT_API_URL}.",
+    )
+    parser.add_argument(
+        "--console-channel",
+        action="append",
+        help=(
+            "Console websocket channel to subscribe. May be repeated or comma-separated. "
+            f"Default: ${CONSOLE_CHANNELS_ENV} or {','.join(DEFAULT_CONSOLE_CHANNELS)}."
+        ),
+    )
+    parser.add_argument(
+        "--live-timeout-seconds",
+        type=positive_float,
+        default=positive_float(os.environ.get(LIVE_TIMEOUT_ENV, str(DEFAULT_LIVE_TIMEOUT_SECONDS))),
+        help=f"Maximum live capture duration. Default: ${LIVE_TIMEOUT_ENV} or {DEFAULT_LIVE_TIMEOUT_SECONDS}.",
+    )
+    parser.add_argument(
+        "--live-max-messages",
+        type=positive_int,
+        default=positive_int(os.environ.get(LIVE_MAX_MESSAGES_ENV, str(DEFAULT_LIVE_MAX_MESSAGES))),
+        help=f"Maximum websocket messages to inspect after subscription. Default: ${LIVE_MAX_MESSAGES_ENV} or {DEFAULT_LIVE_MAX_MESSAGES}.",
+    )
     return parser
 
 
-def main(argv: list[str] | None = None, stdin: TextIO = sys.stdin, stdout: TextIO = sys.stdout) -> int:
-    args = build_parser().parse_args(argv)
-    result = persist_runtime_summary_artifact(
-        input_paths=args.inputs,
-        out_dir=Path(args.out_dir),
-        out_file=Path(args.out_file) if args.out_file else None,
-        artifact_name=args.artifact_name,
-        stdin=stdin,
-    )
+def main(
+    argv: list[str] | None = None,
+    stdin: TextIO = sys.stdin,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.live_official_console and args.inputs:
+        parser.error("inputs cannot be used with --live-official-console")
+
+    try:
+        if args.live_official_console:
+            result = persist_live_official_console_artifact(
+                ctx=live_console_context_from_args(args),
+                out_dir=Path(args.out_dir),
+                out_file=Path(args.out_file) if args.out_file else None,
+                artifact_name=args.artifact_name,
+            )
+        else:
+            result = persist_runtime_summary_artifact(
+                input_paths=args.inputs,
+                out_dir=Path(args.out_dir),
+                out_file=Path(args.out_file) if args.out_file else None,
+                artifact_name=args.artifact_name,
+                stdin=stdin,
+            )
+    except (RuntimeError, ValueError) as exc:
+        if args.live_official_console:
+            stderr.write(f"error: {exc}\n")
+            return 1
+        raise
+
     output = render_human(result) if args.format == "human" else render_json(result)
     stdout.write(output)
     stdout.write("\n")

--- a/scripts/test_screeps_runtime_summary_console_capture.py
+++ b/scripts/test_screeps_runtime_summary_console_capture.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import sys
@@ -13,6 +14,44 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 import screeps_runtime_kpi_artifact_bridge as bridge
 import screeps_runtime_summary_console_capture as capture
+
+
+class FakeWebSocket:
+    def __init__(self, messages: list[object]) -> None:
+        self.messages = list(messages)
+        self.sent: list[str] = []
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+
+    async def recv(self) -> object:
+        if not self.messages:
+            raise asyncio.TimeoutError()
+        message = self.messages.pop(0)
+        if isinstance(message, BaseException):
+            raise message
+        return message
+
+
+class FakeWebsocketConnection:
+    def __init__(self, websocket: FakeWebSocket) -> None:
+        self.websocket = websocket
+
+    async def __aenter__(self) -> FakeWebSocket:
+        return self.websocket
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+class FakeWebsocketsModule:
+    def __init__(self, websocket: FakeWebSocket) -> None:
+        self.websocket = websocket
+        self.connect_calls: list[dict[str, object]] = []
+
+    def connect(self, uri: str, **kwargs: object) -> FakeWebsocketConnection:
+        self.connect_calls.append({"uri": uri, **kwargs})
+        return FakeWebsocketConnection(self.websocket)
 
 
 class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
@@ -186,6 +225,217 @@ class RuntimeSummaryConsoleCaptureTest(unittest.TestCase):
         self.assertEqual(report["inputPaths"], ["-"])
         self.assertTrue(report["outputPath"].endswith("stdin.log"))
         self.assertNotIn("#runtime-summary", output.getvalue())
+
+    def test_live_official_console_authenticates_subscribes_and_persists_exact_prefix_lines(self) -> None:
+        secret = "SECRET_TOKEN_VALUE"
+        websocket = FakeWebSocket(
+            [
+                b"auth ok",
+                json.dumps(
+                    [
+                        "console",
+                        {
+                            "messages": {
+                                "log": [
+                                    "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":101}",
+                                    "noise #runtime-summary {\"type\":\"runtime-summary\",\"tick\":999}",
+                                ],
+                                "results": [
+                                    "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":102}\nignored result"
+                                ],
+                            },
+                        },
+                    ]
+                ),
+                json.dumps(
+                    [
+                        "console:shardX",
+                        {"data": ["#runtime-summary {\"type\":\"runtime-summary\",\"tick\":103}"]},
+                    ]
+                ),
+                json.dumps(
+                    [
+                        "other",
+                        {"messages": {"log": ["#runtime-summary {\"type\":\"runtime-summary\",\"tick\":999}"]}},
+                    ]
+                ),
+            ]
+        )
+        websockets_module = FakeWebsocketsModule(websocket)
+        ctx = capture.LiveConsoleContext(
+            base_http="https://screeps.com",
+            token=secret,
+            channels=["console", "console:shardX"],
+            timeout_seconds=5.0,
+            max_messages=2,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            out_dir = Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"
+
+            result = capture.persist_live_official_console_artifact(
+                ctx=ctx,
+                out_dir=out_dir,
+                artifact_name="live.log",
+                websockets_module=websockets_module,
+            )
+
+            self.assertEqual(result.input_paths, ["live-official-console"])
+            self.assertEqual(result.input_line_count, 5)
+            self.assertEqual(result.persisted_line_count, 3)
+            self.assertEqual(result.skipped_line_count, 2)
+            self.assertEqual(result.output_path, out_dir / "live.log")
+            self.assertEqual(
+                result.output_path.read_text(encoding="utf-8").splitlines(),
+                [
+                    "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":101}",
+                    "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":102}",
+                    "#runtime-summary {\"type\":\"runtime-summary\",\"tick\":103}",
+                ],
+            )
+
+        self.assertEqual(
+            websocket.sent,
+            [
+                f"auth {secret}",
+                "subscribe console",
+                "subscribe console:shardX",
+            ],
+        )
+        self.assertEqual(
+            websockets_module.connect_calls,
+            [{"uri": "wss://screeps.com/socket/websocket", "open_timeout": 5.0}],
+        )
+        self.assertEqual(len(websocket.messages), 1)
+        metadata = result.metadata()
+        metadata_text = json.dumps(metadata, sort_keys=True)
+        self.assertEqual(metadata["source"], "live-official-console")
+        self.assertEqual(metadata["requestedChannels"], ["console", "console:shardX"])
+        self.assertEqual(metadata["receivedMessageCount"], 2)
+        self.assertNotIn(secret, metadata_text)
+        self.assertNotIn("#runtime-summary", metadata_text)
+
+    def test_cli_live_official_console_reports_channels_without_secrets_or_artifact_contents(self) -> None:
+        secret = "VERY_SECRET_TOKEN_VALUE"
+        websocket = FakeWebSocket(
+            [
+                "auth ok",
+                json.dumps(
+                    [
+                        "console",
+                        {"messages": {"log": ["#runtime-summary {\"type\":\"runtime-summary\",\"tick\":201}"]}},
+                    ]
+                ),
+            ]
+        )
+        websockets_module = FakeWebsocketsModule(websocket)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = io.StringIO()
+            error = io.StringIO()
+            with (
+                mock.patch.dict(
+                    capture.os.environ,
+                    {
+                        capture.AUTH_TOKEN_ENV: secret,
+                        capture.API_URL_ENV: "https://screeps.com",
+                        capture.CONSOLE_CHANNELS_ENV: "console,console:shardX",
+                    },
+                ),
+                mock.patch.object(capture, "import_websockets_module", return_value=websockets_module),
+            ):
+                exit_code = capture.main(
+                    [
+                        "--live-official-console",
+                        "--out-dir",
+                        str(Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"),
+                        "--artifact-name",
+                        "live.log",
+                        "--live-timeout-seconds",
+                        "4",
+                        "--live-max-messages",
+                        "1",
+                    ],
+                    stdout=output,
+                    stderr=error,
+                )
+
+            report = json.loads(output.getvalue())
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(error.getvalue(), "")
+        self.assertEqual(report["persistedLineCount"], 1)
+        self.assertEqual(report["requestedChannels"], ["console", "console:shardX"])
+        self.assertEqual(report["websocketUrl"], "wss://screeps.com/socket/websocket")
+        self.assertEqual(websocket.sent, [f"auth {secret}", "subscribe console", "subscribe console:shardX"])
+        self.assertNotIn(secret, output.getvalue())
+        self.assertNotIn("#runtime-summary", output.getvalue())
+
+    def test_live_official_console_timeout_without_match_does_not_write_artifact(self) -> None:
+        websocket = FakeWebSocket(
+            [
+                "auth ok",
+                json.dumps(["console", {"messages": {"log": ["noise only"]}}]),
+                asyncio.TimeoutError(),
+            ]
+        )
+        websockets_module = FakeWebsocketsModule(websocket)
+        ctx = capture.LiveConsoleContext(
+            base_http="https://screeps.com",
+            token="SECRET_TOKEN_VALUE",
+            channels=["console"],
+            timeout_seconds=5.0,
+            max_messages=10,
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            out_dir = Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"
+
+            result = capture.persist_live_official_console_artifact(
+                ctx=ctx,
+                out_dir=out_dir,
+                artifact_name="empty.log",
+                websockets_module=websockets_module,
+            )
+
+            self.assertEqual(result.input_line_count, 1)
+            self.assertEqual(result.persisted_line_count, 0)
+            self.assertEqual(result.skipped_line_count, 1)
+            self.assertEqual(result.output_path, None)
+            self.assertFalse(out_dir.exists())
+            self.assertEqual(result.metadata()["receivedMessageCount"], 1)
+
+    def test_live_official_console_missing_websockets_package_reports_sanitized_error(self) -> None:
+        secret = "SECRET_TOKEN_VALUE"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = io.StringIO()
+            error = io.StringIO()
+            with (
+                mock.patch.dict(capture.os.environ, {capture.AUTH_TOKEN_ENV: secret}),
+                mock.patch.object(
+                    capture,
+                    "import_websockets_module",
+                    side_effect=RuntimeError("Python package 'websockets' is required for --live-official-console"),
+                ),
+            ):
+                exit_code = capture.main(
+                    [
+                        "--live-official-console",
+                        "--out-dir",
+                        str(Path(temp_dir) / "runtime-artifacts" / "runtime-summary-console"),
+                        "--live-timeout-seconds",
+                        "1",
+                        "--live-max-messages",
+                        "1",
+                    ],
+                    stdout=output,
+                    stderr=error,
+                )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(output.getvalue(), "")
+        self.assertIn("websockets", error.getvalue())
+        self.assertNotIn(secret, error.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds bounded `--live-official-console` capture mode to `scripts/screeps_runtime_summary_console_capture.py`.
- Authenticates to the official-client websocket with `SCREEPS_AUTH_TOKEN`, subscribes to configurable console channel(s), and persists only exact-prefix `#runtime-summary ` lines through the existing artifact path.
- Keeps stdin/file capture compatibility and updates runtime/Game Evolution docs so #29's next step is a short live capture window plus nonzero bridge proof, not another reducer/static layer.

## Linked issue
Refs #29
Refs #59

## Roadmap category
Runtime KPI/monitor — live official-console capture source for Gameplay Evolution evidence.

## Served vision layer
Territory/control visibility first, resource/economy scale second, combat/enemy-kill visibility third. This is foundation plumbing, but it directly unblocks game-KPI evidence because the reducer/Pages path cannot inform territory/resource/combat decisions until real in-game `#runtime-summary ` lines are persisted.

## Verification
- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/screeps_runtime_kpi_reducer.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/generate-roadmap-page.py scripts/screeps_runtime_summary_console_capture.py scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py scripts/test_screeps_runtime_summary_console_capture.py`
- [x] `python3 -m unittest scripts/test_screeps_runtime_kpi_reducer.py scripts/test_screeps_runtime_kpi_artifact_bridge.py scripts/test_screeps_runtime_summary_console_capture.py` (25 tests)
- [x] Live bounded smoke with local token loaded but not printed: `python3 scripts/screeps_runtime_summary_console_capture.py --live-official-console --live-timeout-seconds 8 --live-max-messages 5 --format json` returned successfully with `receivedMessageCount=0`, `persistedLineCount=0`, requested channel `console`, and no artifact content printed.

## Notes
- No `prod/` files changed.
- No cron jobs were created or scheduled.
- No secrets included.
- The first live smoke did not observe console messages in the 8-second window; #29 remains active until a worker captures nonzero real `#runtime-summary ` lines and the artifact bridge reports them.
