### PR TITLE
fix: polish roadmap page visual fidelity

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -479,7 +479,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-04-27 19:19:46 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-04-27 19:23:09 CST</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -596,7 +596,7 @@ main {
               <span class="progress-value">58%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 58%"></span></span>
             </div>
-            <div class="roadmap-status">#59 In progress · GitHub · cached</div>
+            <div class="roadmap-status">#59 In progress · GitHub</div>
           </a>
 
 
@@ -610,7 +610,7 @@ main {
               <span class="progress-value">0%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 0%"></span></span>
             </div>
-            <div class="roadmap-status">GitHub snapshot cached</div>
+            <div class="roadmap-status">No matching Project item</div>
           </article>
 
 
@@ -624,7 +624,7 @@ main {
               <span class="progress-value">58%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 58%"></span></span>
             </div>
-            <div class="roadmap-status">#29 In progress · GitHub · cached</div>
+            <div class="roadmap-status">#29 In progress · GitHub</div>
           </a>
 
 
@@ -638,7 +638,7 @@ main {
               <span class="progress-value">35%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 35%"></span></span>
             </div>
-            <div class="roadmap-status">#62 Ready · GitHub · cached</div>
+            <div class="roadmap-status">#62 Ready · GitHub</div>
           </a>
 
 
@@ -652,7 +652,7 @@ main {
               <span class="progress-value">100%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 100%"></span></span>
             </div>
-            <div class="roadmap-status">#27 Done · Agent OS · cached</div>
+            <div class="roadmap-status">#27 Done · Agent OS</div>
           </a>
 
 
@@ -666,7 +666,7 @@ main {
               <span class="progress-value">58%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 58%"></span></span>
             </div>
-            <div class="roadmap-status">#28 In progress · GitHub · cached</div>
+            <div class="roadmap-status">#28 In progress · GitHub</div>
           </a>
 
         </div>
@@ -792,7 +792,7 @@ main {
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/77">
               <span class="kanban-priority">P1</span>
               <h4>#77 fix: polish roadmap page visual fidelity</h4>
-              <p>2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visua...</p>
+              <p>2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path]</p>
             </a>
 
 
@@ -878,7 +878,7 @@ main {
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">124</p>
+            <p class="process-value">128</p>
             <p class="process-label">Total commits</p>
             <p class="process-detail">repository history <span class="process-chip">+1</span></p>
           </article>
@@ -887,14 +887,14 @@ main {
           <article class="process-card">
             <p class="process-value">55</p>
             <p class="process-label">Total PRs</p>
-            <p class="process-detail">50 merged · cached <span class="process-chip">+1</span></p>
+            <p class="process-detail">50 merged <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
             <p class="process-value">24</p>
             <p class="process-label">Total issues</p>
-            <p class="process-detail">9 open · cached <span class="process-chip">+0</span></p>
+            <p class="process-detail">9 open <span class="process-chip">+0</span></p>
           </article>
 
 
@@ -915,7 +915,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-27T11:19:46Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-27T11:23:09Z</footer>
   </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -479,7 +479,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-04-27 19:23:09 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-04-27 19:50:20 CST</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -593,10 +593,10 @@ main {
               <span class="roadmap-label">Next</span><span>Use game-result evidence to drive roadmap, task, and release updates.</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">58%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 58%"></span></span>
+              <span class="progress-value">35%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 35%"></span></span>
             </div>
-            <div class="roadmap-status">#59 In progress · GitHub</div>
+            <div class="roadmap-status">#59 Ready · Runtime monitor</div>
           </a>
 
 
@@ -621,10 +621,10 @@ main {
               <span class="roadmap-label">Next</span><span>Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor rep...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">58%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 58%"></span></span>
+              <span class="progress-value">35%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 35%"></span></span>
             </div>
-            <div class="roadmap-status">#29 In progress · GitHub</div>
+            <div class="roadmap-status">#29 Ready · Runtime monitor</div>
           </a>
 
 
@@ -638,21 +638,21 @@ main {
               <span class="progress-value">35%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 35%"></span></span>
             </div>
-            <div class="roadmap-status">#62 Ready · GitHub</div>
+            <div class="roadmap-status">#62 Ready · Runtime monitor</div>
           </a>
 
 
-          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/27">
+          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/63">
             <h3>Reliability / P0</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Let automation health override game goals only when it blocks delivery.</span>
-              <span class="roadmap-label">Next</span><span>Keep watch-only P0 monitor evidence current.</span>
+              <span class="roadmap-label">Next</span><span>Record expected KPI movement and proof for gameplay releases and hotfixes.</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">100%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 100%"></span></span>
+              <span class="progress-value">35%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 35%"></span></span>
             </div>
-            <div class="roadmap-status">#27 Done · Agent OS</div>
+            <div class="roadmap-status">#63 Ready · Change-control</div>
           </a>
 
 
@@ -663,10 +663,10 @@ main {
               <span class="roadmap-label">Next</span><span>Run a clean private-server smoke check and publish redacted evidence.</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">58%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 58%"></span></span>
+              <span class="progress-value">12%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 12%"></span></span>
             </div>
-            <div class="roadmap-status">#28 In progress · GitHub</div>
+            <div class="roadmap-status">#28 Backlog · Private smoke</div>
           </a>
 
         </div>
@@ -689,20 +689,13 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Active</h3>
-              <span class="column-count">2</span>
+              <span class="column-count">1</span>
             </div>
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/59">
               <span class="kanban-priority">P1</span>
               <h4>#59 Gameplay Evolution: game-result review to roadmap loop</h4>
               <p>Use game-result evidence to drive roadmap, task, and release updates.</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/31">
-              <span class="kanban-priority">P1</span>
-              <h4>#31 Zero-creep emergency recovery coverage</h4>
-              <p>Confirm worker recovery when creeps are gone or energy is insufficient.</p>
             </a>
 
           </article>
@@ -720,36 +713,9 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Done</h3>
-              <span class="column-count">4</span>
+              <span class="column-count">0</span>
             </div>
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/78">
-              <span class="kanban-priority">P0</span>
-              <h4>#78 P0: Agent OS continuation worker autonomous scheduler migration</h4>
-              <p>2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after &gt;=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no a...</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/61">
-              <span class="kanban-priority">P1</span>
-              <h4>#61 Runtime KPI artifact bridge</h4>
-              <p>Bridge runtime KPI artifacts into the Pages report data flow.</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/60">
-              <span class="kanban-priority">P1</span>
-              <h4>#60 Gameplay review cadence</h4>
-              <p>Keep game-result review evidence tied to roadmap decisions.</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/30">
-              <span class="kanban-priority">P1</span>
-              <h4>#30 Mock harness multi-tick spawn lifecycle</h4>
-              <p>Cover spawn.spawning lifecycle behavior across multiple simulated ticks.</p>
-            </a>
-
+            <div class="kanban-empty">—</div>
           </article>
 
         </div>
@@ -775,10 +741,17 @@ main {
               <span class="column-count">4</span>
             </div>
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/29">
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/77">
               <span class="kanban-priority">P1</span>
-              <h4>#29 Runtime summary and alert scheduled monitor delivery</h4>
-              <p>Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.</p>
+              <h4>#77 Roadmap report public artifact polish</h4>
+              <p>Polish the generated roadmap page and publish sanitized public artifacts.</p>
+            </a>
+
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/63">
+              <span class="kanban-priority">P1</span>
+              <h4>#63 Gameplay release cadence and emergency hotfix evidence</h4>
+              <p>Record expected KPI movement and proof for gameplay releases and hotfixes.</p>
             </a>
 
 
@@ -789,17 +762,10 @@ main {
             </a>
 
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/77">
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/29">
               <span class="kanban-priority">P1</span>
-              <h4>#77 fix: polish roadmap page visual fidelity</h4>
-              <p>2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path]</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/62">
-              <span class="kanban-priority">P1</span>
-              <h4>#62 Tactical emergency response wiring</h4>
-              <p>Connect alert signals to bounded tactical emergency triage.</p>
+              <h4>#29 Runtime summary and alert scheduled monitor delivery</h4>
+              <p>Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.</p>
             </a>
 
           </article>
@@ -811,10 +777,10 @@ main {
               <span class="column-count">3</span>
             </div>
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/28">
-              <span class="kanban-priority">P1</span>
-              <h4>#28 Private smoke harness clean live rerun</h4>
-              <p>Run a clean private-server smoke check and publish redacted evidence.</p>
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/32">
+              <span class="kanban-priority">P2</span>
+              <h4>#32 Alert-level telemetry from private smoke failures</h4>
+              <p>Backfill alert telemetry based on private-smoke failure modes.</p>
             </a>
 
 
@@ -825,10 +791,10 @@ main {
             </a>
 
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/32">
-              <span class="kanban-priority">P2</span>
-              <h4>#32 Alert-level telemetry from private smoke failures</h4>
-              <p>Backfill alert telemetry based on private-smoke failure modes.</p>
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/28">
+              <span class="kanban-priority">P1</span>
+              <h4>#28 Private smoke harness clean live rerun</h4>
+              <p>Run a clean private-server smoke check and publish redacted evidence.</p>
             </a>
 
           </article>
@@ -837,36 +803,9 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Done</h3>
-              <span class="column-count">4</span>
+              <span class="column-count">0</span>
             </div>
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/41">
-              <span class="kanban-priority">P0</span>
-              <h4>#41 Establish dedicated QA acceptance-check agent gate</h4>
-              <p>PR #42 merged at 2026-04-26T08:26:48Z after QA PASS; issue #41 closed; docs-only QA acceptance gate landed wi...</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/27">
-              <span class="kanban-priority">P0</span>
-              <h4>#27 P0 monitoring and Discord route health</h4>
-              <p>Keep watch-only P0 monitor evidence current.</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/36">
-              <span class="kanban-priority">P0</span>
-              <h4>#36 Change-control</h4>
-              <p>PR documenting GitHub roadmap management contract; verifies milestones/project fields/items</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/26">
-              <span class="kanban-priority">P0</span>
-              <h4>#26 Main branch protection and required CI gate</h4>
-              <p>Keep required checks and merge gates enforceable before bot changes land.</p>
-            </a>
-
+            <div class="kanban-empty">—</div>
           </article>
 
         </div>
@@ -878,23 +817,23 @@ main {
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">128</p>
+            <p class="process-value">129</p>
             <p class="process-label">Total commits</p>
             <p class="process-detail">repository history <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">55</p>
+            <p class="process-value">56</p>
             <p class="process-label">Total PRs</p>
-            <p class="process-detail">50 merged <span class="process-chip">+1</span></p>
+            <p class="process-detail">51 merged <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
             <p class="process-value">24</p>
             <p class="process-label">Total issues</p>
-            <p class="process-detail">9 open <span class="process-chip">+0</span></p>
+            <p class="process-detail">8 open <span class="process-chip">+0</span></p>
           </article>
 
 
@@ -915,7 +854,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-27T11:23:09Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-27T11:50:20Z</footer>
   </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-Hans">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -46,7 +46,7 @@ a {
 .hero {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 390px;
+  grid-template-columns: minmax(0, 1fr) 410px;
   align-items: center;
   min-height: 390px;
   gap: 40px;
@@ -70,11 +70,11 @@ a {
 
 h1 {
   margin: 0;
-  max-width: 930px;
-  font-size: clamp(4.3rem, 5.7vw, 5.6rem);
+  max-width: 820px;
+  font-size: clamp(3.35rem, 4.35vw, 4.45rem);
   font-weight: 900;
   letter-spacing: 0;
-  line-height: 0.91;
+  line-height: 0.96;
 }
 
 h1 span {
@@ -114,27 +114,24 @@ h1 span {
   justify-content: center;
 }
 
-.brand-logo {
-  position: relative;
-  z-index: 1;
-  width: 288px;
-  height: 288px;
-  justify-self: center;
-  object-fit: cover;
+.brand-logo-frame {
+  display: grid;
+  width: 334px;
+  height: 334px;
+  place-items: center;
+  border: 1px solid rgba(189, 159, 123, 0.72);
+  border-radius: 50%;
+  padding: 18px;
+  background: rgba(255, 250, 240, 0.82);
   box-shadow: 0 25px 36px rgba(46, 31, 17, 0.18);
 }
 
-.logo-badge {
-  position: absolute;
-  right: 18px;
-  bottom: 24px;
-  z-index: 2;
-  border-radius: 999px;
-  padding: 8px 17px;
-  background: rgba(255, 243, 220, 0.86);
-  color: var(--copper-dark);
-  font-weight: 900;
-  box-shadow: 0 8px 20px rgba(73, 48, 24, 0.12);
+.brand-logo {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
 }
 
 main {
@@ -184,12 +181,19 @@ main {
 }
 
 .chart-card h3,
-.roadmap-card h3,
-.kanban-column h3 {
+.roadmap-card h3 {
   margin: 0;
   font-size: 1.48rem;
   line-height: 1.12;
   font-weight: 900;
+}
+
+.kanban-column h3 {
+  margin: 0;
+  font-size: 0.96rem;
+  line-height: 1.12;
+  font-weight: 900;
+  text-transform: uppercase;
 }
 
 .chart-card p {
@@ -301,7 +305,7 @@ main {
 
 .column-count {
   color: var(--copper-dark);
-  font-size: 1.08rem;
+  font-size: 0.88rem;
   font-weight: 900;
 }
 
@@ -347,7 +351,7 @@ main {
   border: 1px dashed #d7bea4;
   border-radius: 12px;
   color: #9f846a;
-  font-size: 1.08rem;
+  font-size: 0.9rem;
 }
 
 .process-grid {
@@ -413,8 +417,13 @@ main {
   }
 
   .brand-logo {
-    width: 230px;
-    height: 230px;
+    width: 100%;
+    height: 100%;
+  }
+
+  .brand-logo-frame {
+    width: 268px;
+    height: 268px;
   }
 
   .kanban-grid {
@@ -442,23 +451,17 @@ main {
   }
 
   h1 {
-    font-size: 3.3rem;
+    font-size: 2.78rem;
   }
 
   .summary {
     font-size: 1.1rem;
   }
 
-  .brand-logo {
+  .brand-logo-frame {
     justify-self: start;
-    width: 190px;
-    height: 190px;
-  }
-
-  .logo-badge {
-    left: 126px;
-    right: auto;
-    bottom: 14px;
+    width: 212px;
+    height: 212px;
   }
 }
 
@@ -471,36 +474,34 @@ main {
       <div>
         <p class="eyebrow">PERSISTENT MMO AI COLONY · AUTONOMOUS ROADMAP</p>
         <h1><span>Hermes Screeps Project</span><span>Roadmap Report</span></h1>
-        <p class="summary">用真实游戏 KPI 驱动 bot 能力、策略开发、基建门禁和发版节奏。</p>
+        <p class="summary">Harness live Screeps KPI evidence for Agentic strategy, bot capability growth, delivery gates, and release cadence.</p>
         <div class="hero-meta">
-          <p><strong>Project</strong> · 长期运行的 Screeps: World AI / 自动化运营项目。</p>
-          <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a> · <a href="https://screeps.com/">https://screeps.com/</a></p>
-          <p><strong>Target</strong> · <a href="https://screeps.com/a/#!/room/shardX/E48S28" title="Target room from the AGENTS.md official deployment target.">shardX/E48S28</a> · official target · 地盘 &gt; 资源 &gt; 击杀。</p>
+          <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
+          <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-04-27 15:54:37 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-04-27 16:58:52 CST</p>
       </div>
       <div class="hero-art">
-        <img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo">
-        <div class="logo-badge">KPI/Kanban · v5</div>
+        <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
       </div>
     </header>
 
     <main>
 
       <section class="section" id="kpi">
-        <h2 class="section-title">01 游戏内部 KPI · 7d 趋势</h2>
+        <h2 class="section-title">01 Game KPI - 7d Trend</h2>
         <div class="kpi-report-grid">
 
           <article class="chart-card">
             <div class="card-heading">
               <div>
-                <h3>地盘 / Territory</h3>
+                <h3>Territory</h3>
                 <p>owned rooms · RCL · room gain</p>
               </div>
               <span class="mini-pill">rooms/RCL</span>
             </div>
 
-            <svg class="chart-svg" role="img" aria-label="地盘 / Territory 7 day trend" viewBox="0 0 560 260">
+            <svg class="chart-svg" role="img" aria-label="Territory 7 day trend" viewBox="0 0 560 260">
               <text x="70.0" y="12" fill="#9a5d25" font-size="14" font-weight="900">rooms/RCL</text>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">1.5</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">3</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
@@ -523,13 +524,13 @@ main {
           <article class="chart-card">
             <div class="card-heading">
               <div>
-                <h3>资源 / Resources</h3>
+                <h3>Resources</h3>
                 <p>stored energy · harvest delta · carried energy</p>
               </div>
               <span class="mini-pill">energy</span>
             </div>
 
-            <svg class="chart-svg" role="img" aria-label="资源 / Resources 7 day trend" viewBox="0 0 560 260">
+            <svg class="chart-svg" role="img" aria-label="Resources 7 day trend" viewBox="0 0 560 260">
               <text x="70.0" y="12" fill="#9a5d25" font-size="14" font-weight="900">energy</text>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">0.5</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">1</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
@@ -552,13 +553,13 @@ main {
           <article class="chart-card">
             <div class="card-heading">
               <div>
-                <h3>击杀 / Combat</h3>
+                <h3>Combat</h3>
                 <p>enemy kills · hostile count · own loss</p>
               </div>
               <span class="mini-pill">events</span>
             </div>
 
-            <svg class="chart-svg" role="img" aria-label="击杀 / Combat 7 day trend" viewBox="0 0 560 260">
+            <svg class="chart-svg" role="img" aria-label="Combat 7 day trend" viewBox="0 0 560 260">
               <text x="70.0" y="12" fill="#9a5d25" font-size="14" font-weight="900">events</text>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">0.5</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">1</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
@@ -582,14 +583,14 @@ main {
 
 
       <section class="section" id="roadmap">
-        <h2 class="section-title">02 开发 Roadmap · 六项状态</h2>
+        <h2 class="section-title">02 Development Roadmap - Six Tracks</h2>
         <div class="roadmap-grid">
 
           <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/59">
             <h3>Gameplay Evolution</h3>
             <div class="roadmap-table">
-              <span class="roadmap-label">目标</span><span>真实游戏结果驱动 roadmap / task / release</span>
-              <span class="roadmap-label">下个点</span><span>P1: Gameplay Evolution专项：vision-driven game-result review to roadmap/task loop</span>
+              <span class="roadmap-label">Goal</span><span>Use real game outcomes to drive roadmap, task, and release decisions.</span>
+              <span class="roadmap-label">Next</span><span>PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/K...</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">58%</span>
@@ -600,10 +601,10 @@ main {
 
 
           <article class="roadmap-card">
-            <h3>Territory / 占地</h3>
+            <h3>Territory</h3>
             <div class="roadmap-table">
-              <span class="roadmap-label">目标</span><span>先拿下并守住更大版图</span>
-              <span class="roadmap-label">下个点</span><span>No current GitHub/Project evidence available.</span>
+              <span class="roadmap-label">Goal</span><span>Claim, hold, and grow the controlled room footprint first.</span>
+              <span class="roadmap-label">Next</span><span>No current GitHub/Project evidence available.</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">0%</span>
@@ -616,8 +617,8 @@ main {
           <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/29">
             <h3>Resource Economy</h3>
             <div class="roadmap-table">
-              <span class="roadmap-label">目标</span><span>把占地转换成能量、矿物、物流规模</span>
-              <span class="roadmap-label">下个点</span><span>PR #73 merged as 9762b7a: offline exact-prefix runtime-summary console capture is on...</span>
+              <span class="roadmap-label">Goal</span><span>Convert territory into energy, minerals, logistics, and spawn scale.</span>
+              <span class="roadmap-label">Next</span><span>PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after &gt;=15m gate, prod-ci SUCCESS, Code...</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">58%</span>
@@ -628,10 +629,10 @@ main {
 
 
           <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/62">
-            <h3>Combat / 敌人击杀</h3>
+            <h3>Combat</h3>
             <div class="roadmap-table">
-              <span class="roadmap-label">目标</span><span>防御/进攻服务于领土和经济控制</span>
-              <span class="roadmap-label">下个点</span><span>Issue created to connect runtime-alert signals to bounded tactical emergency triage.</span>
+              <span class="roadmap-label">Goal</span><span>Make defense and offense serve territorial and economic control.</span>
+              <span class="roadmap-label">Next</span><span>Issue created to connect runtime-alert signals to bounded tactical emergency triage.</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">35%</span>
@@ -644,8 +645,8 @@ main {
           <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/27">
             <h3>Reliability / P0</h3>
             <div class="roadmap-table">
-              <span class="roadmap-label">目标</span><span>自动化系统健康只在阻塞时压过游戏目标</span>
-              <span class="roadmap-label">下个点</span><span>P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monit...</span>
+              <span class="roadmap-label">Goal</span><span>Let automation health override game goals only when it blocks delivery.</span>
+              <span class="roadmap-label">Next</span><span>P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monit...</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">100%</span>
@@ -658,8 +659,8 @@ main {
           <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/28">
             <h3>Foundation Gates</h3>
             <div class="roadmap-table">
-              <span class="roadmap-label">目标</span><span>私服验证 / release gate / official MMO</span>
-              <span class="roadmap-label">下个点</span><span>Fresh clean live run redacted report</span>
+              <span class="roadmap-label">Goal</span><span>Private smoke proof, release gates, and official MMO deployment evidence.</span>
+              <span class="roadmap-label">Next</span><span>Fresh clean live run redacted report</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">35%</span>
@@ -673,7 +674,7 @@ main {
 
 
       <section class="section" id="gameplay-kanban">
-        <h2 class="section-title">03 游戏策略开发 Kanban</h2>
+        <h2 class="section-title">03 Gameplay Strategy Kanban</h2>
         <div class="kanban-grid">
 
           <article class="kanban-column">
@@ -687,27 +688,34 @@ main {
 
           <article class="kanban-column">
             <div class="column-heading">
-              <h3>开发中</h3>
-              <span class="column-count">3</span>
+              <h3>Active</h3>
+              <span class="column-count">4</span>
             </div>
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/59">
               <span class="kanban-priority">P1</span>
-              <h4>#59 P1: Gameplay Evolution专项：vision-driven game-result review to road...</h4>
-              <p>Docs/process</p>
+              <h4>#59 Gameplay Evolution: game-result review to roadmap loop</h4>
+              <p>PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus o...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/30">
               <span class="kanban-priority">P1</span>
-              <h4>#30 P1:Phase B:mock harness 缺少多 tick spawn.spawning 生命周期仿真</h4>
-              <p>Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation w...</p>
+              <h4>#30 Mock harness multi-tick spawn lifecycle</h4>
+              <p>PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification pas...</p>
+            </a>
+
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/76">
+              <span class="kanban-priority">P1</span>
+              <h4>#76 test: add multi-tick spawn lifecycle coverage</h4>
+              <p>PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod &amp;&amp; npm run typecheck...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/31">
               <span class="kanban-priority">P1</span>
-              <h4>#31 P1:Phase B:zero-creep/insufficient-energy emergency recovery 覆盖需确认</h4>
+              <h4>#31 Zero-creep emergency recovery coverage</h4>
               <p>Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation w...</p>
             </a>
 
@@ -716,7 +724,7 @@ main {
 
           <article class="kanban-column">
             <div class="column-heading">
-              <h3>私服验证中</h3>
+              <h3>Private Smoke</h3>
               <span class="column-count">0</span>
             </div>
             <div class="kanban-empty">—</div>
@@ -725,20 +733,20 @@ main {
 
           <article class="kanban-column">
             <div class="column-heading">
-              <h3>已上线</h3>
+              <h3>Done</h3>
               <span class="column-count">3</span>
             </div>
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/61">
               <span class="kanban-priority">P1</span>
-              <h4>#61 P1: Phase B: gameplay findings do not yet bridge into Codex task...</h4>
+              <h4>#61 Runtime KPI artifact bridge</h4>
               <p>Completed by merged PR #66 / 1f41670: durable Gameplay finding → GitHub issue/Project/Codex prompt bridge run...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/60">
               <span class="kanban-priority">P1</span>
-              <h4>#60 P1: Phase C: 12h gameplay evolution review loop is not automated</h4>
+              <h4>#60 Gameplay review cadence</h4>
               <p>One-shot Gameplay Evolution dry run produced useful advisory output in session_cron_be2c21e9fd73; recurring 1...</p>
             </a>
 
@@ -756,7 +764,7 @@ main {
 
 
       <section class="section" id="foundation-kanban">
-        <h2 class="section-title">04 基建开发 Kanban</h2>
+        <h2 class="section-title">04 Foundation Delivery Kanban</h2>
         <div class="kanban-grid">
 
           <article class="kanban-column">
@@ -770,34 +778,34 @@ main {
 
           <article class="kanban-column">
             <div class="column-heading">
-              <h3>开发中</h3>
+              <h3>Active</h3>
               <span class="column-count">4</span>
             </div>
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/29">
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/75">
               <span class="kanban-priority">P1</span>
-              <h4>#29 P1:Phase C:runtime-summary/runtime-alert 定时监控投递尚未完成</h4>
-              <p>PR #73 merged as 9762b7a: offline exact-prefix runtime-summary console capture is on main with bridge-compati...</p>
+              <h4>#75 Pages roadmap visual fidelity follow-up</h4>
+              <p>Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/p...</p>
             </a>
 
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/72">
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/29">
               <span class="kanban-priority">P1</span>
-              <h4>#72 fix: restore roadmap Pages report layout</h4>
-              <p>PR #72 head 28f1e17 fixes generator arity/blank KPI buckets, preserves approved v5 visible layout, regenerate...</p>
+              <h4>#29 Runtime summary and alert scheduled monitor delivery</h4>
+              <p>PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after &gt;=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no action...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/62">
               <span class="kanban-priority">P1</span>
-              <h4>#62 P1: Phase C: tactical emergency response is not wired to runtime...</h4>
+              <h4>#62 Tactical emergency response wiring</h4>
               <p>Issue created to connect runtime-alert signals to bounded tactical emergency triage.</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/63">
               <span class="kanban-priority">P1</span>
-              <h4>#63 P1: Phase E: gameplay release cadence and emergency hotfix gate a...</h4>
+              <h4>#63 Gameplay release cadence and emergency hotfix evidence</h4>
               <p>Issue created to enforce gameplay-aware normal release cadence and emergency hotfix gates.</p>
             </a>
 
@@ -806,27 +814,27 @@ main {
 
           <article class="kanban-column">
             <div class="column-heading">
-              <h3>私服验证中</h3>
+              <h3>Private Smoke</h3>
               <span class="column-count">3</span>
             </div>
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/28">
               <span class="kanban-priority">P1</span>
-              <h4>#28 P1:Phase D:私服 smoke harness clean live rerun 未完成</h4>
+              <h4>#28 Private smoke harness clean live rerun</h4>
               <p>Fresh clean live run redacted report</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/33">
               <span class="kanban-priority">P1</span>
-              <h4>#33 P1:Phase E:官方 MMO 部署仍受私服 smoke release gate 阻塞</h4>
+              <h4>#33 Official MMO deployment blocked by private smoke gate</h4>
               <p>Deploy preflight, private-smoke gate, monitor proof, official API verification</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/32">
               <span class="kanban-priority">P2</span>
-              <h4>#32 P2:Phase C:alert-level telemetry 需要基于私服 smoke 失败模式补齐</h4>
+              <h4>#32 Alert-level telemetry from private smoke failures</h4>
               <p>Private smoke failure modes mapped into alert-level telemetry</p>
             </a>
 
@@ -835,7 +843,7 @@ main {
 
           <article class="kanban-column">
             <div class="column-heading">
-              <h3>已上线</h3>
+              <h3>Done</h3>
               <span class="column-count">4</span>
             </div>
 
@@ -848,21 +856,21 @@ main {
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/27">
               <span class="kanban-priority">P0</span>
-              <h4>#27 P0:P0 agent-ops:P0 监控与 Discord 路由健康需要持续验证</h4>
+              <h4>#27 P0 monitoring and Discord route health</h4>
               <p>P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monitor, typed fanouts, runti...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/36">
               <span class="kanban-priority">P0</span>
-              <h4>#36 P0:P0 change-control:GitHub Milestones/Project roadmap source-of-...</h4>
+              <h4>#36 Change-control</h4>
               <p>PR documenting GitHub roadmap management contract; verifies milestones/project fields/items</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/26">
               <span class="kanban-priority">P0</span>
-              <h4>#26 P0:P0 change-control:main 分支保护与 CI 必过门禁尚未确认</h4>
+              <h4>#26 Main branch protection and required CI gate</h4>
               <p>Read-only inspection: main protected=false; branch protection API 404; active ruleset &#x27;defualt&#x27; has no rules;...</p>
             </a>
 
@@ -873,40 +881,40 @@ main {
 
 
       <section class="section" id="process">
-        <h2 class="section-title">05 开发过程数据</h2>
+        <h2 class="section-title">05 Development Process Data</h2>
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">125</p>
-            <p class="process-label">总 commit 数</p>
+            <p class="process-value">122</p>
+            <p class="process-label">Total commits</p>
             <p class="process-detail">repository history <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">51</p>
-            <p class="process-label">总 PR 数</p>
-            <p class="process-detail">46 merged <span class="process-chip">+1</span></p>
+            <p class="process-value">53</p>
+            <p class="process-label">Total PRs</p>
+            <p class="process-detail">48 merged <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">22</p>
-            <p class="process-label">总 issue 数</p>
-            <p class="process-detail">9 open <span class="process-chip">+0</span></p>
+            <p class="process-value">23</p>
+            <p class="process-label">Total issues</p>
+            <p class="process-detail">10 open <span class="process-chip">+0</span></p>
           </article>
 
 
           <article class="process-card">
             <p class="process-value">0</p>
-            <p class="process-label">发版到官方游戏</p>
+            <p class="process-label">Official deploys</p>
             <p class="process-detail">official deploy evidence <span class="process-chip">+0</span></p>
           </article>
 
 
           <article class="process-card">
             <p class="process-value">1</p>
-            <p class="process-label">私服内总测试次数</p>
+            <p class="process-label">Private smoke tests</p>
             <p class="process-detail">smoke/report evidence <span class="process-chip">+0</span></p>
           </article>
 
@@ -914,7 +922,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-27T07:54:37Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-27T08:58:52Z</footer>
   </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -479,7 +479,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-04-27 16:58:52 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-04-27 19:19:46 CST</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -590,13 +590,13 @@ main {
             <h3>Gameplay Evolution</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Use real game outcomes to drive roadmap, task, and release decisions.</span>
-              <span class="roadmap-label">Next</span><span>PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/K...</span>
+              <span class="roadmap-label">Next</span><span>Use game-result evidence to drive roadmap, task, and release updates.</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">58%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 58%"></span></span>
             </div>
-            <div class="roadmap-status">#59 In progress · Docs/process</div>
+            <div class="roadmap-status">#59 In progress · GitHub · cached</div>
           </a>
 
 
@@ -610,7 +610,7 @@ main {
               <span class="progress-value">0%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 0%"></span></span>
             </div>
-            <div class="roadmap-status">No matching Project item</div>
+            <div class="roadmap-status">GitHub snapshot cached</div>
           </article>
 
 
@@ -618,13 +618,13 @@ main {
             <h3>Resource Economy</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Convert territory into energy, minerals, logistics, and spawn scale.</span>
-              <span class="roadmap-label">Next</span><span>PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after &gt;=15m gate, prod-ci SUCCESS, Code...</span>
+              <span class="roadmap-label">Next</span><span>Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor rep...</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">58%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 58%"></span></span>
             </div>
-            <div class="roadmap-status">#29 In progress · GitHub</div>
+            <div class="roadmap-status">#29 In progress · GitHub · cached</div>
           </a>
 
 
@@ -632,13 +632,13 @@ main {
             <h3>Combat</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Make defense and offense serve territorial and economic control.</span>
-              <span class="roadmap-label">Next</span><span>Issue created to connect runtime-alert signals to bounded tactical emergency triage.</span>
+              <span class="roadmap-label">Next</span><span>Connect alert signals to bounded tactical emergency triage.</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">35%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 35%"></span></span>
             </div>
-            <div class="roadmap-status">#62 Ready · GitHub</div>
+            <div class="roadmap-status">#62 Ready · GitHub · cached</div>
           </a>
 
 
@@ -646,13 +646,13 @@ main {
             <h3>Reliability / P0</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Let automation health override game goals only when it blocks delivery.</span>
-              <span class="roadmap-label">Next</span><span>P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monit...</span>
+              <span class="roadmap-label">Next</span><span>Keep watch-only P0 monitor evidence current.</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">100%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 100%"></span></span>
             </div>
-            <div class="roadmap-status">#27 Done · Agent OS</div>
+            <div class="roadmap-status">#27 Done · Agent OS · cached</div>
           </a>
 
 
@@ -660,13 +660,13 @@ main {
             <h3>Foundation Gates</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Private smoke proof, release gates, and official MMO deployment evidence.</span>
-              <span class="roadmap-label">Next</span><span>Fresh clean live run redacted report</span>
+              <span class="roadmap-label">Next</span><span>Run a clean private-server smoke check and publish redacted evidence.</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">35%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 35%"></span></span>
+              <span class="progress-value">58%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 58%"></span></span>
             </div>
-            <div class="roadmap-status">#28 Ready · GitHub</div>
+            <div class="roadmap-status">#28 In progress · GitHub · cached</div>
           </a>
 
         </div>
@@ -689,34 +689,20 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Active</h3>
-              <span class="column-count">4</span>
+              <span class="column-count">2</span>
             </div>
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/59">
               <span class="kanban-priority">P1</span>
               <h4>#59 Gameplay Evolution: game-result review to roadmap loop</h4>
-              <p>PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus o...</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/30">
-              <span class="kanban-priority">P1</span>
-              <h4>#30 Mock harness multi-tick spawn lifecycle</h4>
-              <p>PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification pas...</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/76">
-              <span class="kanban-priority">P1</span>
-              <h4>#76 test: add multi-tick spawn lifecycle coverage</h4>
-              <p>PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod &amp;&amp; npm run typecheck...</p>
+              <p>Use game-result evidence to drive roadmap, task, and release updates.</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/31">
               <span class="kanban-priority">P1</span>
               <h4>#31 Zero-creep emergency recovery coverage</h4>
-              <p>Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation w...</p>
+              <p>Confirm worker recovery when creeps are gone or energy is insufficient.</p>
             </a>
 
           </article>
@@ -734,27 +720,34 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Done</h3>
-              <span class="column-count">3</span>
+              <span class="column-count">4</span>
             </div>
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/78">
+              <span class="kanban-priority">P0</span>
+              <h4>#78 P0: Agent OS continuation worker autonomous scheduler migration</h4>
+              <p>2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after &gt;=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no a...</p>
+            </a>
+
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/61">
               <span class="kanban-priority">P1</span>
               <h4>#61 Runtime KPI artifact bridge</h4>
-              <p>Completed by merged PR #66 / 1f41670: durable Gameplay finding → GitHub issue/Project/Codex prompt bridge run...</p>
+              <p>Bridge runtime KPI artifacts into the Pages report data flow.</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/60">
               <span class="kanban-priority">P1</span>
               <h4>#60 Gameplay review cadence</h4>
-              <p>One-shot Gameplay Evolution dry run produced useful advisory output in session_cron_be2c21e9fd73; recurring 1...</p>
+              <p>Keep game-result review evidence tied to roadmap decisions.</p>
             </a>
 
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/64">
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/30">
               <span class="kanban-priority">P1</span>
-              <h4>#64 docs: add gameplay evolution roadmap</h4>
-              <p>PR #64 merged at 2026-04-27T02:09Z as 0377388; prod-ci and CodeRabbit green, Gemini no feedback, review threa...</p>
+              <h4>#30 Mock harness multi-tick spawn lifecycle</h4>
+              <p>Cover spawn.spawning lifecycle behavior across multiple simulated ticks.</p>
             </a>
 
           </article>
@@ -782,31 +775,31 @@ main {
               <span class="column-count">4</span>
             </div>
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/75">
-              <span class="kanban-priority">P1</span>
-              <h4>#75 Pages roadmap visual fidelity follow-up</h4>
-              <p>Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/p...</p>
-            </a>
-
-
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/29">
               <span class="kanban-priority">P1</span>
               <h4>#29 Runtime summary and alert scheduled monitor delivery</h4>
-              <p>PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after &gt;=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no action...</p>
+              <p>Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.</p>
+            </a>
+
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/75">
+              <span class="kanban-priority">P1</span>
+              <h4>#75 Pages roadmap visual fidelity follow-up</h4>
+              <p>Refine the public roadmap report presentation and English visible copy.</p>
+            </a>
+
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/77">
+              <span class="kanban-priority">P1</span>
+              <h4>#77 fix: polish roadmap page visual fidelity</h4>
+              <p>2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visua...</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/62">
               <span class="kanban-priority">P1</span>
               <h4>#62 Tactical emergency response wiring</h4>
-              <p>Issue created to connect runtime-alert signals to bounded tactical emergency triage.</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/63">
-              <span class="kanban-priority">P1</span>
-              <h4>#63 Gameplay release cadence and emergency hotfix evidence</h4>
-              <p>Issue created to enforce gameplay-aware normal release cadence and emergency hotfix gates.</p>
+              <p>Connect alert signals to bounded tactical emergency triage.</p>
             </a>
 
           </article>
@@ -821,21 +814,21 @@ main {
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/28">
               <span class="kanban-priority">P1</span>
               <h4>#28 Private smoke harness clean live rerun</h4>
-              <p>Fresh clean live run redacted report</p>
+              <p>Run a clean private-server smoke check and publish redacted evidence.</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/33">
               <span class="kanban-priority">P1</span>
               <h4>#33 Official MMO deployment blocked by private smoke gate</h4>
-              <p>Deploy preflight, private-smoke gate, monitor proof, official API verification</p>
+              <p>Hold official deploys until private-smoke and monitor proof are complete.</p>
             </a>
 
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/32">
               <span class="kanban-priority">P2</span>
               <h4>#32 Alert-level telemetry from private smoke failures</h4>
-              <p>Private smoke failure modes mapped into alert-level telemetry</p>
+              <p>Backfill alert telemetry based on private-smoke failure modes.</p>
             </a>
 
           </article>
@@ -857,7 +850,7 @@ main {
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/27">
               <span class="kanban-priority">P0</span>
               <h4>#27 P0 monitoring and Discord route health</h4>
-              <p>P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monitor, typed fanouts, runti...</p>
+              <p>Keep watch-only P0 monitor evidence current.</p>
             </a>
 
 
@@ -871,7 +864,7 @@ main {
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/26">
               <span class="kanban-priority">P0</span>
               <h4>#26 Main branch protection and required CI gate</h4>
-              <p>Read-only inspection: main protected=false; branch protection API 404; active ruleset &#x27;defualt&#x27; has no rules;...</p>
+              <p>Keep required checks and merge gates enforceable before bot changes land.</p>
             </a>
 
           </article>
@@ -885,23 +878,23 @@ main {
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">122</p>
+            <p class="process-value">124</p>
             <p class="process-label">Total commits</p>
             <p class="process-detail">repository history <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">53</p>
+            <p class="process-value">55</p>
             <p class="process-label">Total PRs</p>
-            <p class="process-detail">48 merged <span class="process-chip">+1</span></p>
+            <p class="process-detail">50 merged · cached <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">23</p>
+            <p class="process-value">24</p>
             <p class="process-label">Total issues</p>
-            <p class="process-detail">10 open <span class="process-chip">+0</span></p>
+            <p class="process-detail">9 open · cached <span class="process-chip">+0</span></p>
           </article>
 
 
@@ -922,7 +915,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-27T08:58:52Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-27T11:19:46Z</footer>
   </div>
 </body>
 </html>

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,12 +3,32 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-04-27T07:54:37Z",
-  "generatedAtCst": "2026-04-27 15:54:37 CST",
+  "generatedAt": "2026-04-27T08:58:52Z",
+  "generatedAtCst": "2026-04-27 16:58:52 CST",
   "github": {
     "fetchErrors": [],
     "fetched": true,
     "issues": [
+      {
+        "createdAt": "2026-04-27T08:23:27Z",
+        "domain": "Runtime monitor",
+        "kind": "docs",
+        "labels": [
+          "kind:docs",
+          "priority:p1",
+          "roadmap",
+          "roadmap:phase-c-telemetry"
+        ],
+        "milestone": "",
+        "number": 75,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
+        "type": "Issue",
+        "updatedAt": "2026-04-27T08:34:10Z",
+        "url": "https://github.com/lanyusea/screeps/issues/75"
+      },
       {
         "createdAt": "2026-04-26T17:09:40Z",
         "domain": "Change-control",
@@ -66,7 +86,7 @@
         "status": "Ready",
         "title": "P1: Gameplay Evolution\u4e13\u9879\uff1avision-driven game-result review to roadmap/task loop",
         "type": "Issue",
-        "updatedAt": "2026-04-27T06:10:29Z",
+        "updatedAt": "2026-04-27T08:00:51Z",
         "url": "https://github.com/lanyusea/screeps/issues/59"
       },
       {
@@ -147,7 +167,7 @@
         "status": "Ready",
         "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
         "type": "Issue",
-        "updatedAt": "2026-04-27T02:10:03Z",
+        "updatedAt": "2026-04-27T08:57:44Z",
         "url": "https://github.com/lanyusea/screeps/issues/30"
       },
       {
@@ -167,7 +187,7 @@
         "status": "Ready",
         "title": "P1:Phase C:runtime-summary/runtime-alert \u5b9a\u65f6\u76d1\u63a7\u6295\u9012\u5c1a\u672a\u5b8c\u6210",
         "type": "Issue",
-        "updatedAt": "2026-04-27T07:51:54Z",
+        "updatedAt": "2026-04-27T08:52:25Z",
         "url": "https://github.com/lanyusea/screeps/issues/29"
       },
       {
@@ -194,8 +214,24 @@
     "kanban": {
       "cards": [
         {
+          "domain": "Docs/process",
+          "evidence": "Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/pages-visual-fidelity-75, background session proc_a08963cab71b. Scope: Pages roadmap visual/content fidelity follow-up independent of #29 and #30.",
+          "kind": "docs",
+          "lane": "Foundation",
+          "nextAction": "",
+          "number": 75,
+          "priority": "P1",
+          "state": "",
+          "status": "In progress",
+          "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/75",
+          "visionLayer": "foundation blocker"
+        },
+        {
           "domain": "Runtime monitor",
-          "evidence": "PR #73 merged as 9762b7a: offline exact-prefix runtime-summary console capture is on main with bridge-compatible default output, mkstemp temp files, exclusive/no-overwrite publishing, tests, prod-ci SUCCESS, CodeRabbit SUCCESS, all review threads resolved.",
+          "evidence": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty active review threads, controller diff-check + py_compile + 25 unittests PASS. Main fast-forwarded and PR branch/worktree cleaned.",
           "kind": "ops",
           "lane": "Foundation",
           "nextAction": "",
@@ -207,22 +243,6 @@
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/29",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Bot capability",
-          "evidence": "PR #72 head 28f1e17 fixes generator arity/blank KPI buckets, preserves approved v5 visible layout, regenerates docs/index.html + docs/roadmap-data.json + LFS SQLite. Verification PASS: py_compile, generator, HTML required/forbidden/3 KPI cards, SQLite 528 samples/33 metrics/latest enemy_kills NULL instrumented=0, no WAL/SHM, LFS pointer, cached diff-check, secret scan; prod-ci and CodeRabbit status green.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 72,
-          "priority": "P1",
-          "state": "",
-          "status": "In review",
-          "title": "fix: restore roadmap Pages report layout",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/72",
           "visionLayer": "foundation blocker"
         },
         {
@@ -867,6 +887,22 @@
         },
         {
           "domain": "Runtime monitor",
+          "evidence": "Merged as 57b4b3a at 2026-04-27T08:49Z. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL active review threads, >=15m elapsed, controller diff-check + py_compile + 25 unittests PASS. Local main fast-forwarded; remote/local branch deleted.",
+          "kind": "code",
+          "lane": "Foundation",
+          "nextAction": "",
+          "number": 74,
+          "priority": "P1",
+          "state": "",
+          "status": "Done",
+          "title": "feat: capture official console runtime summaries",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/74",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Runtime monitor",
           "evidence": "Merged PR #73 as 9762b7a at 2026-04-27T07:51Z after prod-ci SUCCESS, CodeRabbit SUCCESS, all review threads resolved, and >=15m gate.",
           "kind": "code",
           "lane": "Foundation",
@@ -879,6 +915,22 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/73",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Runtime monitor",
+          "evidence": "PR #72 final head 99eb926 merged at 2026-04-27T07:57:41Z as merge commit 366cfdc. Evidence: py_compile PASS; current artifacts verify SQLite 660 rows/33 metrics/latest enemy_kills NULL instrumented=0, no WAL/SHM, HTML title+five sections+3 KPI cards/forbidden strings absent, LFS attrs/pointer, diff-check main..HEAD, secret scan over 4 PR-diff files. Checks green: CodeRabbit pass, prod-ci pass.",
+          "kind": "code",
+          "lane": "Foundation",
+          "nextAction": "",
+          "number": 72,
+          "priority": "P1",
+          "state": "",
+          "status": "Done",
+          "title": "fix: restore roadmap Pages report layout",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/72",
           "visionLayer": "foundation blocker"
         },
         {
@@ -899,7 +951,7 @@
         },
         {
           "domain": "Docs/process",
-          "evidence": "PR #70 merged as c21f1bb; Gameplay Evolution now has a static Pages/KPI reporting surface plus KPI artifact reducer/bridge on main. #60/#61 are done; #29 remains active for real runtime-summary persistence/wiring; #62/#63 remain Ready.",
+          "evidence": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus offline console capture primitive. #29 remains active for real runtime-summary persistence/wiring; #62/#63/#30/#31 remain queued.",
           "kind": "ops",
           "lane": "Gameplay",
           "nextAction": "",
@@ -915,18 +967,34 @@
         },
         {
           "domain": "Bot capability",
-          "evidence": "Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation work; kept Ready queued for parallel worker coverage.",
+          "evidence": "PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification passed: git diff --check; prod typecheck/Jest/build passed (70 tests).",
           "kind": "test",
           "lane": "Gameplay",
           "nextAction": "",
           "number": 30,
           "priority": "P1",
           "state": "",
-          "status": "Ready",
+          "status": "In review",
           "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/30",
+          "visionLayer": "resources"
+        },
+        {
+          "domain": "Bot capability",
+          "evidence": "PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod && npm run typecheck && npm test -- --runInBand (70 tests) && npm run build.",
+          "kind": "test",
+          "lane": "Gameplay",
+          "nextAction": "",
+          "number": 76,
+          "priority": "P1",
+          "state": "",
+          "status": "In review",
+          "title": "test: add multi-tick spawn lifecycle coverage",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/76",
           "visionLayer": "resources"
         },
         {
@@ -1010,22 +1078,6 @@
                   "kind": "test",
                   "lane": "Gameplay",
                   "nextAction": "",
-                  "number": 30,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Ready",
-                  "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/30",
-                  "visionLayer": "resources"
-                },
-                {
-                  "domain": "Bot capability",
-                  "evidence": "Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation work; kept Ready queued for parallel worker coverage.",
-                  "kind": "test",
-                  "lane": "Gameplay",
-                  "nextAction": "",
                   "number": 31,
                   "priority": "P1",
                   "state": "",
@@ -1043,7 +1095,7 @@
               "cards": [
                 {
                   "domain": "Docs/process",
-                  "evidence": "PR #70 merged as c21f1bb; Gameplay Evolution now has a static Pages/KPI reporting surface plus KPI artifact reducer/bridge on main. #60/#61 are done; #29 remains active for real runtime-summary persistence/wiring; #62/#63 remain Ready.",
+                  "evidence": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus offline console capture primitive. #29 remains active for real runtime-summary persistence/wiring; #62/#63/#30/#31 remain queued.",
                   "kind": "ops",
                   "lane": "Gameplay",
                   "nextAction": "",
@@ -1061,7 +1113,40 @@
               "status": "In progress"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "domain": "Bot capability",
+                  "evidence": "PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification passed: git diff --check; prod typecheck/Jest/build passed (70 tests).",
+                  "kind": "test",
+                  "lane": "Gameplay",
+                  "nextAction": "",
+                  "number": 30,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "In review",
+                  "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/30",
+                  "visionLayer": "resources"
+                },
+                {
+                  "domain": "Bot capability",
+                  "evidence": "PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod && npm run typecheck && npm test -- --runInBand (70 tests) && npm run build.",
+                  "kind": "test",
+                  "lane": "Gameplay",
+                  "nextAction": "",
+                  "number": 76,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "In review",
+                  "title": "test: add multi-tick spawn lifecycle coverage",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/76",
+                  "visionLayer": "resources"
+                }
+              ],
               "status": "In review"
             },
             {
@@ -1215,8 +1300,24 @@
             {
               "cards": [
                 {
+                  "domain": "Docs/process",
+                  "evidence": "Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/pages-visual-fidelity-75, background session proc_a08963cab71b. Scope: Pages roadmap visual/content fidelity follow-up independent of #29 and #30.",
+                  "kind": "docs",
+                  "lane": "Foundation",
+                  "nextAction": "",
+                  "number": 75,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "In progress",
+                  "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/75",
+                  "visionLayer": "foundation blocker"
+                },
+                {
                   "domain": "Runtime monitor",
-                  "evidence": "PR #73 merged as 9762b7a: offline exact-prefix runtime-summary console capture is on main with bridge-compatible default output, mkstemp temp files, exclusive/no-overwrite publishing, tests, prod-ci SUCCESS, CodeRabbit SUCCESS, all review threads resolved.",
+                  "evidence": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty active review threads, controller diff-check + py_compile + 25 unittests PASS. Main fast-forwarded and PR branch/worktree cleaned.",
                   "kind": "ops",
                   "lane": "Foundation",
                   "nextAction": "",
@@ -1234,24 +1335,7 @@
               "status": "In progress"
             },
             {
-              "cards": [
-                {
-                  "domain": "Bot capability",
-                  "evidence": "PR #72 head 28f1e17 fixes generator arity/blank KPI buckets, preserves approved v5 visible layout, regenerates docs/index.html + docs/roadmap-data.json + LFS SQLite. Verification PASS: py_compile, generator, HTML required/forbidden/3 KPI cards, SQLite 528 samples/33 metrics/latest enemy_kills NULL instrumented=0, no WAL/SHM, LFS pointer, cached diff-check, secret scan; prod-ci and CodeRabbit status green.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 72,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "In review",
-                  "title": "fix: restore roadmap Pages report layout",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/72",
-                  "visionLayer": "foundation blocker"
-                }
-              ],
+              "cards": [],
               "status": "In review"
             },
             {
@@ -1818,6 +1902,22 @@
                 },
                 {
                   "domain": "Runtime monitor",
+                  "evidence": "Merged as 57b4b3a at 2026-04-27T08:49Z. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL active review threads, >=15m elapsed, controller diff-check + py_compile + 25 unittests PASS. Local main fast-forwarded; remote/local branch deleted.",
+                  "kind": "code",
+                  "lane": "Foundation",
+                  "nextAction": "",
+                  "number": 74,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "Done",
+                  "title": "feat: capture official console runtime summaries",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/74",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Runtime monitor",
                   "evidence": "Merged PR #73 as 9762b7a at 2026-04-27T07:51Z after prod-ci SUCCESS, CodeRabbit SUCCESS, all review threads resolved, and >=15m gate.",
                   "kind": "code",
                   "lane": "Foundation",
@@ -1830,6 +1930,22 @@
                   "type": "PullRequest",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/73",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Runtime monitor",
+                  "evidence": "PR #72 final head 99eb926 merged at 2026-04-27T07:57:41Z as merge commit 366cfdc. Evidence: py_compile PASS; current artifacts verify SQLite 660 rows/33 metrics/latest enemy_kills NULL instrumented=0, no WAL/SHM, HTML title+five sections+3 KPI cards/forbidden strings absent, LFS attrs/pointer, diff-check main..HEAD, secret scan over 4 PR-diff files. Checks green: CodeRabbit pass, prod-ci pass.",
+                  "kind": "code",
+                  "lane": "Foundation",
+                  "nextAction": "",
+                  "number": 72,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: restore roadmap Pages report layout",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/72",
                   "visionLayer": "foundation blocker"
                 },
                 {
@@ -1859,7 +1975,7 @@
       {
         "instrumented": true,
         "label": "Open roadmap issues",
-        "value": 9
+        "value": 10
       },
       {
         "instrumented": true,
@@ -1874,17 +1990,17 @@
       {
         "instrumented": true,
         "label": "Project cards",
-        "value": 50
+        "value": 53
       },
       {
         "instrumented": true,
         "label": "In progress",
-        "value": 2
+        "value": 3
       },
       {
         "instrumented": true,
         "label": "In review",
-        "value": 1
+        "value": 2
       }
     ],
     "projectItems": [
@@ -2022,7 +2138,7 @@
       {
         "blockedBy": "",
         "domain": "Runtime monitor",
-        "evidence": "PR #73 merged as 9762b7a: offline exact-prefix runtime-summary console capture is on main with bridge-compatible default output, mkstemp temp files, exclusive/no-overwrite publishing, tests, prod-ci SUCCESS, CodeRabbit SUCCESS, all review threads resolved.",
+        "evidence": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty active review threads, controller diff-check + py_compile + 25 unittests PASS. Main fast-forwarded and PR branch/worktree cleaned.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -2044,7 +2160,7 @@
       {
         "blockedBy": "",
         "domain": "Bot capability",
-        "evidence": "Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation work; kept Ready queued for parallel worker coverage.",
+        "evidence": "PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification passed: git diff --check; prod typecheck/Jest/build passed (70 tests).",
         "kind": "test",
         "labels": [
           "kind:test",
@@ -2057,7 +2173,7 @@
         "number": 30,
         "priority": "P1",
         "state": "",
-        "status": "Ready",
+        "status": "In review",
         "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
         "type": "Issue",
         "updatedAt": "",
@@ -2561,7 +2677,7 @@
       {
         "blockedBy": "",
         "domain": "Docs/process",
-        "evidence": "PR #70 merged as c21f1bb; Gameplay Evolution now has a static Pages/KPI reporting surface plus KPI artifact reducer/bridge on main. #60/#61 are done; #29 remains active for real runtime-summary persistence/wiring; #62/#63 remain Ready.",
+        "evidence": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus offline console capture primitive. #29 remains active for real runtime-summary persistence/wiring; #62/#63/#30/#31 remain queued.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -2806,8 +2922,8 @@
       },
       {
         "blockedBy": "",
-        "domain": "Bot capability",
-        "evidence": "PR #72 head 28f1e17 fixes generator arity/blank KPI buckets, preserves approved v5 visible layout, regenerates docs/index.html + docs/roadmap-data.json + LFS SQLite. Verification PASS: py_compile, generator, HTML required/forbidden/3 KPI cards, SQLite 528 samples/33 metrics/latest enemy_kills NULL instrumented=0, no WAL/SHM, LFS pointer, cached diff-check, secret scan; prod-ci and CodeRabbit status green.",
+        "domain": "Runtime monitor",
+        "evidence": "PR #72 final head 99eb926 merged at 2026-04-27T07:57:41Z as merge commit 366cfdc. Evidence: py_compile PASS; current artifacts verify SQLite 660 rows/33 metrics/latest enemy_kills NULL instrumented=0, no WAL/SHM, HTML title+five sections+3 KPI cards/forbidden strings absent, LFS attrs/pointer, diff-check main..HEAD, secret scan over 4 PR-diff files. Checks green: CodeRabbit pass, prod-ci pass.",
         "kind": "code",
         "labels": [],
         "milestone": "",
@@ -2815,7 +2931,7 @@
         "number": 72,
         "priority": "P1",
         "state": "",
-        "status": "In review",
+        "status": "Done",
         "title": "fix: restore roadmap Pages report layout",
         "type": "PullRequest",
         "updatedAt": "",
@@ -2837,31 +2953,87 @@
         "type": "PullRequest",
         "updatedAt": "",
         "url": "https://github.com/lanyusea/screeps/pull/73"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Runtime monitor",
+        "evidence": "Merged as 57b4b3a at 2026-04-27T08:49Z. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL active review threads, >=15m elapsed, controller diff-check + py_compile + 25 unittests PASS. Local main fast-forwarded; remote/local branch deleted.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 74,
+        "priority": "P1",
+        "state": "",
+        "status": "Done",
+        "title": "feat: capture official console runtime summaries",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/74"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Docs/process",
+        "evidence": "Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/pages-visual-fidelity-75, background session proc_a08963cab71b. Scope: Pages roadmap visual/content fidelity follow-up independent of #29 and #30.",
+        "kind": "docs",
+        "labels": [
+          "kind:docs",
+          "priority:p1",
+          "roadmap",
+          "roadmap:phase-c-telemetry"
+        ],
+        "milestone": "",
+        "nextAction": "",
+        "number": 75,
+        "priority": "P1",
+        "state": "",
+        "status": "In progress",
+        "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/75"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Bot capability",
+        "evidence": "PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod && npm run typecheck && npm test -- --runInBand (70 tests) && npm run build.",
+        "kind": "test",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 76,
+        "priority": "P1",
+        "state": "",
+        "status": "In review",
+        "title": "test: add multi-tick spawn lifecycle coverage",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/76"
       }
     ],
     "pullRequests": [
       {
         "checks": {
           "failure": 0,
-          "pending": 0,
-          "success": 2,
+          "pending": 1,
+          "success": 1,
           "total": 2
         },
-        "createdAt": "2026-04-27T07:16:54Z",
+        "createdAt": "2026-04-27T08:57:10Z",
         "domain": "Bot capability",
         "isDraft": false,
         "kind": "code",
         "labels": [],
         "milestone": "",
-        "number": 72,
+        "number": 76,
         "priority": "P1",
         "reviewDecision": "",
         "state": "OPEN",
         "status": "In review",
-        "title": "fix: restore roadmap Pages report layout",
+        "title": "test: add multi-tick spawn lifecycle coverage",
         "type": "PullRequest",
-        "updatedAt": "2026-04-27T07:54:01Z",
-        "url": "https://github.com/lanyusea/screeps/pull/72"
+        "updatedAt": "2026-04-27T08:57:20Z",
+        "url": "https://github.com/lanyusea/screeps/pull/76"
       }
     ],
     "roadmapCards": [
@@ -3010,7 +3182,7 @@
       },
       {
         "domain": "Docs/process",
-        "evidence": "PR #70 merged as c21f1bb; Gameplay Evolution now has a static Pages/KPI reporting surface plus KPI artifact reducer/bridge on main. #60/#61 are done; #29 remains active for real runtime-summary persistence/wiring; #62/#63 remain Ready.",
+        "evidence": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus offline console capture primitive. #29 remains active for real runtime-summary persistence/wiring; #62/#63/#30/#31 remain queued.",
         "milestone": "Phase C: Runtime telemetry / monitor gate",
         "nextAction": "",
         "number": 59,
@@ -3023,7 +3195,8 @@
       }
     ],
     "seededFallbackIssueCount": 0,
-    "sourceMode": "live"
+    "sourceMode": "live",
+    "usedCachedSnapshot": false
   },
   "kpis": {
     "categories": [
@@ -3793,6 +3966,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "alert_false_positives": [
@@ -3933,6 +4134,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4077,6 +4306,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "attack_damage": [
@@ -4217,6 +4474,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4361,6 +4646,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "controller_level_sum": [
@@ -4501,6 +4814,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4645,6 +4986,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "cpu_bucket": [
@@ -4785,6 +5154,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4929,6 +5326,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "creeps_destroyed_generic": [
@@ -5069,6 +5494,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5213,6 +5666,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "enemy_kills": [
@@ -5353,6 +5834,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5497,6 +6006,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "harvested_energy": [
@@ -5637,6 +6174,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5781,6 +6346,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "hostile_structures": [
@@ -5921,6 +6514,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6065,6 +6686,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "observed",
           "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "objects_destroyed": [
@@ -6205,6 +6854,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6349,6 +7026,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "owned_room_delta": [
@@ -6489,6 +7194,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6633,6 +7366,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "reserved_remote_rooms": [
@@ -6773,6 +7534,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6917,6 +7706,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "runtime_summary_samples": [
@@ -7057,6 +7874,34 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "observed",
           "value": 0.0
         }
@@ -7201,6 +8046,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "spawn_queue_pressure": [
@@ -7341,6 +8214,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7485,6 +8386,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "stored_energy": [
@@ -7625,6 +8554,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7769,6 +8726,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "telemetry_silence_minutes": [
@@ -7909,6 +8894,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8053,6 +9066,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "worker_carried_energy": [
@@ -8193,6 +9234,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T07:54:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8337,6 +9406,34 @@
           "sampledAt": "2026-04-27T07:54:37Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:38:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:43:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:52:56Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
         }
       ]
     }
@@ -8370,35 +9467,35 @@
       {
         "items": [
           {
-            "description": "PR #73 merged as 9762b7a: offline exact-prefix runtime-summary console capture is on main with bridge-compati...",
-            "number": 29,
+            "description": "Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/p...",
+            "number": 75,
             "priority": "P1",
-            "title": "#29 P1:Phase C:runtime-summary/runtime-alert \u5b9a\u65f6\u76d1\u63a7\u6295\u9012\u5c1a\u672a\u5b8c\u6210",
-            "url": "https://github.com/lanyusea/screeps/issues/29"
+            "title": "#75 Pages roadmap visual fidelity follow-up",
+            "url": "https://github.com/lanyusea/screeps/issues/75"
           },
           {
-            "description": "PR #72 head 28f1e17 fixes generator arity/blank KPI buckets, preserves approved v5 visible layout, regenerate...",
-            "number": 72,
+            "description": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no action...",
+            "number": 29,
             "priority": "P1",
-            "title": "#72 fix: restore roadmap Pages report layout",
-            "url": "https://github.com/lanyusea/screeps/pull/72"
+            "title": "#29 Runtime summary and alert scheduled monitor delivery",
+            "url": "https://github.com/lanyusea/screeps/issues/29"
           },
           {
             "description": "Issue created to connect runtime-alert signals to bounded tactical emergency triage.",
             "number": 62,
             "priority": "P1",
-            "title": "#62 P1: Phase C: tactical emergency response is not wired to runtime...",
+            "title": "#62 Tactical emergency response wiring",
             "url": "https://github.com/lanyusea/screeps/issues/62"
           },
           {
             "description": "Issue created to enforce gameplay-aware normal release cadence and emergency hotfix gates.",
             "number": 63,
             "priority": "P1",
-            "title": "#63 P1: Phase E: gameplay release cadence and emergency hotfix gate a...",
+            "title": "#63 Gameplay release cadence and emergency hotfix evidence",
             "url": "https://github.com/lanyusea/screeps/issues/63"
           }
         ],
-        "title": "\u5f00\u53d1\u4e2d"
+        "title": "Active"
       },
       {
         "items": [
@@ -8406,25 +9503,25 @@
             "description": "Fresh clean live run redacted report",
             "number": 28,
             "priority": "P1",
-            "title": "#28 P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
+            "title": "#28 Private smoke harness clean live rerun",
             "url": "https://github.com/lanyusea/screeps/issues/28"
           },
           {
             "description": "Deploy preflight, private-smoke gate, monitor proof, official API verification",
             "number": 33,
             "priority": "P1",
-            "title": "#33 P1:Phase E:\u5b98\u65b9 MMO \u90e8\u7f72\u4ecd\u53d7\u79c1\u670d smoke release gate \u963b\u585e",
+            "title": "#33 Official MMO deployment blocked by private smoke gate",
             "url": "https://github.com/lanyusea/screeps/issues/33"
           },
           {
             "description": "Private smoke failure modes mapped into alert-level telemetry",
             "number": 32,
             "priority": "P2",
-            "title": "#32 P2:Phase C:alert-level telemetry \u9700\u8981\u57fa\u4e8e\u79c1\u670d smoke \u5931\u8d25\u6a21\u5f0f\u8865\u9f50",
+            "title": "#32 Alert-level telemetry from private smoke failures",
             "url": "https://github.com/lanyusea/screeps/issues/32"
           }
         ],
-        "title": "\u79c1\u670d\u9a8c\u8bc1\u4e2d"
+        "title": "Private Smoke"
       },
       {
         "items": [
@@ -8439,25 +9536,25 @@
             "description": "P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monitor, typed fanouts, runti...",
             "number": 27,
             "priority": "P0",
-            "title": "#27 P0:P0 agent-ops:P0 \u76d1\u63a7\u4e0e Discord \u8def\u7531\u5065\u5eb7\u9700\u8981\u6301\u7eed\u9a8c\u8bc1",
+            "title": "#27 P0 monitoring and Discord route health",
             "url": "https://github.com/lanyusea/screeps/issues/27"
           },
           {
             "description": "PR documenting GitHub roadmap management contract; verifies milestones/project fields/items",
             "number": 36,
             "priority": "P0",
-            "title": "#36 P0:P0 change-control:GitHub Milestones/Project roadmap source-of-...",
+            "title": "#36 Change-control",
             "url": "https://github.com/lanyusea/screeps/issues/36"
           },
           {
             "description": "Read-only inspection: main protected=false; branch protection API 404; active ruleset 'defualt' has no rules;...",
             "number": 26,
             "priority": "P0",
-            "title": "#26 P0:P0 change-control:main \u5206\u652f\u4fdd\u62a4\u4e0e CI \u5fc5\u8fc7\u95e8\u7981\u5c1a\u672a\u786e\u8ba4",
+            "title": "#26 Main branch protection and required CI gate",
             "url": "https://github.com/lanyusea/screeps/issues/26"
           }
         ],
-        "title": "\u5df2\u4e0a\u7ebf"
+        "title": "Done"
       }
     ],
     "gameplayKanban": [
@@ -8468,32 +9565,39 @@
       {
         "items": [
           {
-            "description": "Docs/process",
+            "description": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus o...",
             "number": 59,
             "priority": "P1",
-            "title": "#59 P1: Gameplay Evolution\u4e13\u9879\uff1avision-driven game-result review to road...",
+            "title": "#59 Gameplay Evolution: game-result review to roadmap loop",
             "url": "https://github.com/lanyusea/screeps/issues/59"
           },
           {
-            "description": "Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation w...",
+            "description": "PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification pas...",
             "number": 30,
             "priority": "P1",
-            "title": "#30 P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
+            "title": "#30 Mock harness multi-tick spawn lifecycle",
             "url": "https://github.com/lanyusea/screeps/issues/30"
+          },
+          {
+            "description": "PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod && npm run typecheck...",
+            "number": 76,
+            "priority": "P1",
+            "title": "#76 test: add multi-tick spawn lifecycle coverage",
+            "url": "https://github.com/lanyusea/screeps/pull/76"
           },
           {
             "description": "Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation w...",
             "number": 31,
             "priority": "P1",
-            "title": "#31 P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
+            "title": "#31 Zero-creep emergency recovery coverage",
             "url": "https://github.com/lanyusea/screeps/issues/31"
           }
         ],
-        "title": "\u5f00\u53d1\u4e2d"
+        "title": "Active"
       },
       {
         "items": [],
-        "title": "\u79c1\u670d\u9a8c\u8bc1\u4e2d"
+        "title": "Private Smoke"
       },
       {
         "items": [
@@ -8501,14 +9605,14 @@
             "description": "Completed by merged PR #66 / 1f41670: durable Gameplay finding \u2192 GitHub issue/Project/Codex prompt bridge run...",
             "number": 61,
             "priority": "P1",
-            "title": "#61 P1: Phase B: gameplay findings do not yet bridge into Codex task...",
+            "title": "#61 Runtime KPI artifact bridge",
             "url": "https://github.com/lanyusea/screeps/issues/61"
           },
           {
             "description": "One-shot Gameplay Evolution dry run produced useful advisory output in session_cron_be2c21e9fd73; recurring 1...",
             "number": 60,
             "priority": "P1",
-            "title": "#60 P1: Phase C: 12h gameplay evolution review loop is not automated",
+            "title": "#60 Gameplay review cadence",
             "url": "https://github.com/lanyusea/screeps/issues/60"
           },
           {
@@ -8519,7 +9623,7 @@
             "url": "https://github.com/lanyusea/screeps/pull/64"
           }
         ],
-        "title": "\u5df2\u4e0a\u7ebf"
+        "title": "Done"
       }
     ],
     "id": "roadmap-portrait-kpi-kanban-v5",
@@ -8619,7 +9723,7 @@
           1.5,
           3
         ],
-        "title": "\u5730\u76d8 / Territory"
+        "title": "Territory"
       },
       {
         "dates": [
@@ -8716,7 +9820,7 @@
           0.5,
           1
         ],
-        "title": "\u8d44\u6e90 / Resources"
+        "title": "Resources"
       },
       {
         "dates": [
@@ -8813,79 +9917,79 @@
           0.5,
           1
         ],
-        "title": "\u51fb\u6740 / Combat"
+        "title": "Combat"
       }
     ],
     "processCards": [
       {
         "delta": "+1",
         "detail": "repository history",
-        "label": "\u603b commit \u6570",
-        "value": 125
+        "label": "Total commits",
+        "value": 122
       },
       {
         "delta": "+1",
-        "detail": "46 merged",
-        "label": "\u603b PR \u6570",
+        "detail": "48 merged",
+        "label": "Total PRs",
         "source": "github",
-        "value": 51
+        "value": 53
       },
       {
         "delta": "+0",
-        "detail": "9 open",
-        "label": "\u603b issue \u6570",
+        "detail": "10 open",
+        "label": "Total issues",
         "source": "github",
-        "value": 22
+        "value": 23
       },
       {
         "delta": "+0",
         "detail": "official deploy evidence",
-        "label": "\u53d1\u7248\u5230\u5b98\u65b9\u6e38\u620f",
+        "label": "Official deploys",
         "value": 0
       },
       {
         "delta": "+0",
         "detail": "smoke/report evidence",
-        "label": "\u79c1\u670d\u5185\u603b\u6d4b\u8bd5\u6b21\u6570",
+        "label": "Private smoke tests",
         "source": "approved process report count",
         "value": 1
       }
     ],
     "roadmapCards": [
       {
-        "goal": "\u771f\u5b9e\u6e38\u620f\u7ed3\u679c\u9a71\u52a8 roadmap / task / release",
-        "next": "P1: Gameplay Evolution\u4e13\u9879\uff1avision-driven game-result review to roadmap/task loop",
+        "goal": "Use real game outcomes to drive roadmap, task, and release decisions.",
+        "next": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/K...",
         "progress": 58,
         "status": "#59 In progress \u00b7 Docs/process",
         "title": "Gameplay Evolution",
         "url": "https://github.com/lanyusea/screeps/issues/59"
       },
       {
-        "goal": "\u5148\u62ff\u4e0b\u5e76\u5b88\u4f4f\u66f4\u5927\u7248\u56fe",
+        "goal": "Claim, hold, and grow the controlled room footprint first.",
         "next": "No current GitHub/Project evidence available.",
         "progress": 0,
         "status": "No matching Project item",
-        "title": "Territory / \u5360\u5730",
+        "title": "Territory",
         "url": ""
       },
       {
-        "goal": "\u628a\u5360\u5730\u8f6c\u6362\u6210\u80fd\u91cf\u3001\u77ff\u7269\u3001\u7269\u6d41\u89c4\u6a21",
-        "next": "PR #73 merged as 9762b7a: offline exact-prefix runtime-summary console capture is on...",
+        "goal": "Convert territory into energy, minerals, logistics, and spawn scale.",
+        "next": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, Code...",
         "progress": 58,
         "status": "#29 In progress \u00b7 GitHub",
         "title": "Resource Economy",
         "url": "https://github.com/lanyusea/screeps/issues/29"
       },
       {
-        "goal": "\u9632\u5fa1/\u8fdb\u653b\u670d\u52a1\u4e8e\u9886\u571f\u548c\u7ecf\u6d4e\u63a7\u5236",
+        "goal": "Make defense and offense serve territorial and economic control.",
         "next": "Issue created to connect runtime-alert signals to bounded tactical emergency triage.",
         "progress": 35,
         "status": "#62 Ready \u00b7 GitHub",
-        "title": "Combat / \u654c\u4eba\u51fb\u6740",
+        "title": "Combat",
         "url": "https://github.com/lanyusea/screeps/issues/62"
       },
       {
-        "goal": "\u81ea\u52a8\u5316\u7cfb\u7edf\u5065\u5eb7\u53ea\u5728\u963b\u585e\u65f6\u538b\u8fc7\u6e38\u620f\u76ee\u6807",
+        "goal": "Let automation health override game goals only when it blocks delivery.",
         "next": "P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monit...",
         "progress": 100,
         "status": "#27 Done \u00b7 Agent OS",
@@ -8893,7 +9997,7 @@
         "url": "https://github.com/lanyusea/screeps/issues/27"
       },
       {
-        "goal": "\u79c1\u670d\u9a8c\u8bc1 / release gate / official MMO",
+        "goal": "Private smoke proof, release gates, and official MMO deployment evidence.",
         "next": "Fresh clean live run redacted report",
         "progress": 35,
         "status": "#28 Ready \u00b7 GitHub",
@@ -8911,7 +10015,7 @@
       "matchedFiles": 0,
       "reason": "",
       "runtimeSummaryLines": 0,
-      "scannedFiles": 71547,
+      "scannedFiles": 71564,
       "skippedFileCount": 1643
     },
     "window": {

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,11 +3,45 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-04-27T08:58:52Z",
-  "generatedAtCst": "2026-04-27 16:58:52 CST",
+  "generatedAt": "2026-04-27T11:19:46Z",
+  "generatedAtCst": "2026-04-27 19:19:46 CST",
   "github": {
-    "fetchErrors": [],
-    "fetched": true,
+    "fetchErrors": [
+      {
+        "command": [
+          "gh",
+          "issue",
+          "list",
+          "--repo"
+        ],
+        "exitCode": 1,
+        "message": "command failed",
+        "source": "issues"
+      },
+      {
+        "command": [
+          "gh",
+          "pr",
+          "list",
+          "--repo"
+        ],
+        "exitCode": 1,
+        "message": "command failed",
+        "source": "pullRequests"
+      },
+      {
+        "command": [
+          "gh",
+          "project",
+          "item-list",
+          "3"
+        ],
+        "exitCode": 1,
+        "message": "command failed",
+        "source": "project"
+      }
+    ],
+    "fetched": false,
     "issues": [
       {
         "createdAt": "2026-04-27T08:23:27Z",
@@ -26,7 +60,7 @@
         "status": "Ready",
         "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
         "type": "Issue",
-        "updatedAt": "2026-04-27T08:34:10Z",
+        "updatedAt": "2026-04-27T10:30:20Z",
         "url": "https://github.com/lanyusea/screeps/issues/75"
       },
       {
@@ -147,28 +181,8 @@
         "status": "Ready",
         "title": "P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
         "type": "Issue",
-        "updatedAt": "2026-04-27T02:10:05Z",
+        "updatedAt": "2026-04-27T11:10:02Z",
         "url": "https://github.com/lanyusea/screeps/issues/31"
-      },
-      {
-        "createdAt": "2026-04-26T06:39:11Z",
-        "domain": "Bot capability",
-        "kind": "test",
-        "labels": [
-          "kind:test",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-b-spawn-lifecycle"
-        ],
-        "milestone": "Phase B: Bot capability hardening gate",
-        "number": 30,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
-        "type": "Issue",
-        "updatedAt": "2026-04-27T08:57:44Z",
-        "url": "https://github.com/lanyusea/screeps/issues/30"
       },
       {
         "createdAt": "2026-04-26T06:39:09Z",
@@ -195,6 +209,7 @@
         "domain": "Private smoke",
         "kind": "ops",
         "labels": [
+          "blocked",
           "kind:ops",
           "priority:p1",
           "roadmap",
@@ -204,31 +219,15 @@
         "number": 28,
         "priority": "P1",
         "state": "OPEN",
-        "status": "Ready",
+        "status": "Backlog",
         "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
         "type": "Issue",
-        "updatedAt": "2026-04-26T06:57:16Z",
+        "updatedAt": "2026-04-27T11:14:55Z",
         "url": "https://github.com/lanyusea/screeps/issues/28"
       }
     ],
     "kanban": {
       "cards": [
-        {
-          "domain": "Docs/process",
-          "evidence": "Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/pages-visual-fidelity-75, background session proc_a08963cab71b. Scope: Pages roadmap visual/content fidelity follow-up independent of #29 and #30.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 75,
-          "priority": "P1",
-          "state": "",
-          "status": "In progress",
-          "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/75",
-          "visionLayer": "foundation blocker"
-        },
         {
           "domain": "Runtime monitor",
           "evidence": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty active review threads, controller diff-check + py_compile + 25 unittests PASS. Main fast-forwarded and PR branch/worktree cleaned.",
@@ -243,6 +242,54 @@
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/29",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Private smoke",
+          "evidence": "2026-04-27T19:14:48+08:00 live private-smoke rerun attempted after self-test/dry-run PASS. Result REQUEST_CHANGES/BLOCKED: docker compose failed before screeps container start because 127.0.0.1:21025 and :21026 are already allocated by existing container screeps-private-smoke-pinned-screeps-1. Failed stack screeps-private-smoke-83dd9462 cleaned with docker compose down -v. No secrets printed; report path private-smoke-report-20260427T111321Z.json.",
+          "kind": "ops",
+          "lane": "Foundation",
+          "nextAction": "",
+          "number": 28,
+          "priority": "P1",
+          "state": "",
+          "status": "In progress",
+          "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/28",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Docs/process",
+          "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
+          "kind": "docs",
+          "lane": "Foundation",
+          "nextAction": "",
+          "number": 75,
+          "priority": "P1",
+          "state": "",
+          "status": "In review",
+          "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/75",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Docs/process",
+          "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
+          "kind": "docs",
+          "lane": "Foundation",
+          "nextAction": "",
+          "number": 77,
+          "priority": "P1",
+          "state": "",
+          "status": "In review",
+          "title": "fix: polish roadmap page visual fidelity",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/77",
           "visionLayer": "foundation blocker"
         },
         {
@@ -275,22 +322,6 @@
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/63",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Private smoke",
-          "evidence": "Fresh clean live run redacted report",
-          "kind": "ops",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 28,
-          "priority": "P1",
-          "state": "",
-          "status": "Ready",
-          "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/28",
           "visionLayer": "foundation blocker"
         },
         {
@@ -483,6 +514,22 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/42",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Agent OS",
+          "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
+          "kind": "docs",
+          "lane": "Foundation",
+          "nextAction": "",
+          "number": 79,
+          "priority": "P0",
+          "state": "",
+          "status": "Done",
+          "title": "docs: define autonomous scheduler contract",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/79",
           "visionLayer": "foundation blocker"
         },
         {
@@ -967,50 +1014,34 @@
         },
         {
           "domain": "Bot capability",
-          "evidence": "PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification passed: git diff --check; prod typecheck/Jest/build passed (70 tests).",
-          "kind": "test",
-          "lane": "Gameplay",
-          "nextAction": "",
-          "number": 30,
-          "priority": "P1",
-          "state": "",
-          "status": "In review",
-          "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/30",
-          "visionLayer": "resources"
-        },
-        {
-          "domain": "Bot capability",
-          "evidence": "PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod && npm run typecheck && npm test -- --runInBand (70 tests) && npm run build.",
-          "kind": "test",
-          "lane": "Gameplay",
-          "nextAction": "",
-          "number": 76,
-          "priority": "P1",
-          "state": "",
-          "status": "In review",
-          "title": "test: add multi-tick spawn lifecycle coverage",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/76",
-          "visionLayer": "resources"
-        },
-        {
-          "domain": "Bot capability",
-          "evidence": "Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation work; kept Ready queued for parallel worker coverage.",
+          "evidence": "2026-04-27T19:09:52+08:00 scheduler claim: dispatched Codex dev agent in [redacted-path] on branch feat/zero-creep-emergency-31. File scope prod/src/** prod/test/** prod/dist/main.js. Acceptance: verify zero-creep/insufficient-energy emergency recovery behavior with tests; no secrets.",
           "kind": "test",
           "lane": "Gameplay",
           "nextAction": "",
           "number": 31,
           "priority": "P1",
           "state": "",
-          "status": "Ready",
+          "status": "In progress",
           "title": "P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/31",
+          "visionLayer": "resources"
+        },
+        {
+          "domain": "Agent OS",
+          "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
+          "kind": "ops",
+          "lane": "Gameplay",
+          "nextAction": "",
+          "number": 78,
+          "priority": "P0",
+          "state": "",
+          "status": "Done",
+          "title": "P0: Agent OS continuation worker autonomous scheduler migration",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/78",
           "visionLayer": "resources"
         },
         {
@@ -1046,6 +1077,22 @@
           "visionLayer": "territory"
         },
         {
+          "domain": "Bot capability",
+          "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
+          "kind": "test",
+          "lane": "Gameplay",
+          "nextAction": "",
+          "number": 30,
+          "priority": "P1",
+          "state": "",
+          "status": "Done",
+          "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/30",
+          "visionLayer": "resources"
+        },
+        {
           "domain": "Docs/process",
           "evidence": "PR #64 merged at 2026-04-27T02:09Z as 0377388; prod-ci and CodeRabbit green, Gemini no feedback, review threads empty, QA blocker resolved before merge.",
           "kind": "docs",
@@ -1060,6 +1107,22 @@
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/64",
           "visionLayer": "territory"
+        },
+        {
+          "domain": "Bot capability",
+          "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
+          "kind": "test",
+          "lane": "Gameplay",
+          "nextAction": "",
+          "number": 76,
+          "priority": "P1",
+          "state": "",
+          "status": "Done",
+          "title": "test: add multi-tick spawn lifecycle coverage",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/76",
+          "visionLayer": "resources"
         }
       ],
       "columns": [
@@ -1071,24 +1134,7 @@
               "status": "Backlog"
             },
             {
-              "cards": [
-                {
-                  "domain": "Bot capability",
-                  "evidence": "Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation work; kept Ready queued for parallel worker coverage.",
-                  "kind": "test",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 31,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Ready",
-                  "title": "P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/31",
-                  "visionLayer": "resources"
-                }
-              ],
+              "cards": [],
               "status": "Ready"
             },
             {
@@ -1108,49 +1154,48 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/59",
                   "visionLayer": "territory"
+                },
+                {
+                  "domain": "Bot capability",
+                  "evidence": "2026-04-27T19:09:52+08:00 scheduler claim: dispatched Codex dev agent in [redacted-path] on branch feat/zero-creep-emergency-31. File scope prod/src/** prod/test/** prod/dist/main.js. Acceptance: verify zero-creep/insufficient-energy emergency recovery behavior with tests; no secrets.",
+                  "kind": "test",
+                  "lane": "Gameplay",
+                  "nextAction": "",
+                  "number": 31,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "In progress",
+                  "title": "P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/31",
+                  "visionLayer": "resources"
                 }
               ],
               "status": "In progress"
             },
             {
-              "cards": [
-                {
-                  "domain": "Bot capability",
-                  "evidence": "PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification passed: git diff --check; prod typecheck/Jest/build passed (70 tests).",
-                  "kind": "test",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 30,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "In review",
-                  "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/30",
-                  "visionLayer": "resources"
-                },
-                {
-                  "domain": "Bot capability",
-                  "evidence": "PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod && npm run typecheck && npm test -- --runInBand (70 tests) && npm run build.",
-                  "kind": "test",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 76,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "In review",
-                  "title": "test: add multi-tick spawn lifecycle coverage",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/76",
-                  "visionLayer": "resources"
-                }
-              ],
+              "cards": [],
               "status": "In review"
             },
             {
               "cards": [
+                {
+                  "domain": "Agent OS",
+                  "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
+                  "kind": "ops",
+                  "lane": "Gameplay",
+                  "nextAction": "",
+                  "number": 78,
+                  "priority": "P0",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P0: Agent OS continuation worker autonomous scheduler migration",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/78",
+                  "visionLayer": "resources"
+                },
                 {
                   "domain": "Bot capability",
                   "evidence": "Completed by merged PR #66 / 1f41670: durable Gameplay finding \u2192 GitHub issue/Project/Codex prompt bridge runbook with QA acceptance and first #29/#61 task examples.",
@@ -1184,6 +1229,22 @@
                   "visionLayer": "territory"
                 },
                 {
+                  "domain": "Bot capability",
+                  "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
+                  "kind": "test",
+                  "lane": "Gameplay",
+                  "nextAction": "",
+                  "number": 30,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/30",
+                  "visionLayer": "resources"
+                },
+                {
                   "domain": "Docs/process",
                   "evidence": "PR #64 merged at 2026-04-27T02:09Z as 0377388; prod-ci and CodeRabbit green, Gemini no feedback, review threads empty, QA blocker resolved before merge.",
                   "kind": "docs",
@@ -1198,6 +1259,22 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/64",
                   "visionLayer": "territory"
+                },
+                {
+                  "domain": "Bot capability",
+                  "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
+                  "kind": "test",
+                  "lane": "Gameplay",
+                  "nextAction": "",
+                  "number": 76,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "Done",
+                  "title": "test: add multi-tick spawn lifecycle coverage",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/76",
+                  "visionLayer": "resources"
                 }
               ],
               "status": "Done"
@@ -1277,44 +1354,12 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/63",
                   "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Private smoke",
-                  "evidence": "Fresh clean live run redacted report",
-                  "kind": "ops",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 28,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Ready",
-                  "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/28",
-                  "visionLayer": "foundation blocker"
                 }
               ],
               "status": "Ready"
             },
             {
               "cards": [
-                {
-                  "domain": "Docs/process",
-                  "evidence": "Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/pages-visual-fidelity-75, background session proc_a08963cab71b. Scope: Pages roadmap visual/content fidelity follow-up independent of #29 and #30.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 75,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "In progress",
-                  "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/75",
-                  "visionLayer": "foundation blocker"
-                },
                 {
                   "domain": "Runtime monitor",
                   "evidence": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty active review threads, controller diff-check + py_compile + 25 unittests PASS. Main fast-forwarded and PR branch/worktree cleaned.",
@@ -1330,12 +1375,61 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/29",
                   "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Private smoke",
+                  "evidence": "2026-04-27T19:14:48+08:00 live private-smoke rerun attempted after self-test/dry-run PASS. Result REQUEST_CHANGES/BLOCKED: docker compose failed before screeps container start because 127.0.0.1:21025 and :21026 are already allocated by existing container screeps-private-smoke-pinned-screeps-1. Failed stack screeps-private-smoke-83dd9462 cleaned with docker compose down -v. No secrets printed; report path private-smoke-report-20260427T111321Z.json.",
+                  "kind": "ops",
+                  "lane": "Foundation",
+                  "nextAction": "",
+                  "number": 28,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "In progress",
+                  "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/28",
+                  "visionLayer": "foundation blocker"
                 }
               ],
               "status": "In progress"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "domain": "Docs/process",
+                  "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
+                  "kind": "docs",
+                  "lane": "Foundation",
+                  "nextAction": "",
+                  "number": 75,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "In review",
+                  "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/75",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Docs/process",
+                  "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
+                  "kind": "docs",
+                  "lane": "Foundation",
+                  "nextAction": "",
+                  "number": 77,
+                  "priority": "P1",
+                  "state": "",
+                  "status": "In review",
+                  "title": "fix: polish roadmap page visual fidelity",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/77",
+                  "visionLayer": "foundation blocker"
+                }
+              ],
               "status": "In review"
             },
             {
@@ -1498,6 +1592,22 @@
                   "type": "PullRequest",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/42",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Agent OS",
+                  "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
+                  "kind": "docs",
+                  "lane": "Foundation",
+                  "nextAction": "",
+                  "number": 79,
+                  "priority": "P0",
+                  "state": "",
+                  "status": "Done",
+                  "title": "docs: define autonomous scheduler contract",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/79",
                   "visionLayer": "foundation blocker"
                 },
                 {
@@ -1973,34 +2083,34 @@
     },
     "processMetrics": [
       {
-        "instrumented": true,
+        "instrumented": false,
         "label": "Open roadmap issues",
-        "value": 10
+        "value": "insufficient evidence"
       },
       {
-        "instrumented": true,
+        "instrumented": false,
         "label": "Open PRs",
-        "value": 1
+        "value": "insufficient evidence"
       },
       {
-        "instrumented": true,
+        "instrumented": false,
         "label": "Blocked cards",
-        "value": 2
+        "value": "insufficient evidence"
       },
       {
-        "instrumented": true,
+        "instrumented": false,
         "label": "Project cards",
-        "value": 53
+        "value": "insufficient evidence"
       },
       {
-        "instrumented": true,
+        "instrumented": false,
         "label": "In progress",
-        "value": 3
+        "value": "insufficient evidence"
       },
       {
-        "instrumented": true,
+        "instrumented": false,
         "label": "In review",
-        "value": 2
+        "value": "insufficient evidence"
       }
     ],
     "projectItems": [
@@ -2116,9 +2226,10 @@
       {
         "blockedBy": "",
         "domain": "Private smoke",
-        "evidence": "Fresh clean live run redacted report",
+        "evidence": "2026-04-27T19:14:48+08:00 live private-smoke rerun attempted after self-test/dry-run PASS. Result REQUEST_CHANGES/BLOCKED: docker compose failed before screeps container start because 127.0.0.1:21025 and :21026 are already allocated by existing container screeps-private-smoke-pinned-screeps-1. Failed stack screeps-private-smoke-83dd9462 cleaned with docker compose down -v. No secrets printed; report path private-smoke-report-20260427T111321Z.json.",
         "kind": "ops",
         "labels": [
+          "blocked",
           "kind:ops",
           "priority:p1",
           "roadmap",
@@ -2129,7 +2240,7 @@
         "number": 28,
         "priority": "P1",
         "state": "",
-        "status": "Ready",
+        "status": "In progress",
         "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
         "type": "Issue",
         "updatedAt": "",
@@ -2160,7 +2271,7 @@
       {
         "blockedBy": "",
         "domain": "Bot capability",
-        "evidence": "PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification passed: git diff --check; prod typecheck/Jest/build passed (70 tests).",
+        "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
         "kind": "test",
         "labels": [
           "kind:test",
@@ -2173,7 +2284,7 @@
         "number": 30,
         "priority": "P1",
         "state": "",
-        "status": "In review",
+        "status": "Done",
         "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
         "type": "Issue",
         "updatedAt": "",
@@ -2182,7 +2293,7 @@
       {
         "blockedBy": "",
         "domain": "Bot capability",
-        "evidence": "Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation work; kept Ready queued for parallel worker coverage.",
+        "evidence": "2026-04-27T19:09:52+08:00 scheduler claim: dispatched Codex dev agent in [redacted-path] on branch feat/zero-creep-emergency-31. File scope prod/src/** prod/test/** prod/dist/main.js. Acceptance: verify zero-creep/insufficient-energy emergency recovery behavior with tests; no secrets.",
         "kind": "test",
         "labels": [
           "kind:test",
@@ -2195,7 +2306,7 @@
         "number": 31,
         "priority": "P1",
         "state": "",
-        "status": "Ready",
+        "status": "In progress",
         "title": "P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
         "type": "Issue",
         "updatedAt": "",
@@ -2974,7 +3085,7 @@
       {
         "blockedBy": "",
         "domain": "Docs/process",
-        "evidence": "Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/pages-visual-fidelity-75, background session proc_a08963cab71b. Scope: Pages roadmap visual/content fidelity follow-up independent of #29 and #30.",
+        "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
         "kind": "docs",
         "labels": [
           "kind:docs",
@@ -2987,7 +3098,7 @@
         "number": 75,
         "priority": "P1",
         "state": "",
-        "status": "In progress",
+        "status": "In review",
         "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
         "type": "Issue",
         "updatedAt": "",
@@ -2996,7 +3107,7 @@
       {
         "blockedBy": "",
         "domain": "Bot capability",
-        "evidence": "PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod && npm run typecheck && npm test -- --runInBand (70 tests) && npm run build.",
+        "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
         "kind": "test",
         "labels": [],
         "milestone": "",
@@ -3004,36 +3115,92 @@
         "number": 76,
         "priority": "P1",
         "state": "",
-        "status": "In review",
+        "status": "Done",
         "title": "test: add multi-tick spawn lifecycle coverage",
         "type": "PullRequest",
         "updatedAt": "",
         "url": "https://github.com/lanyusea/screeps/pull/76"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Docs/process",
+        "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
+        "kind": "docs",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 77,
+        "priority": "P1",
+        "state": "",
+        "status": "In review",
+        "title": "fix: polish roadmap page visual fidelity",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/77"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Agent OS",
+        "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
+        "kind": "ops",
+        "labels": [
+          "kind:ops",
+          "priority:p0",
+          "roadmap",
+          "roadmap:p0-agent-ops"
+        ],
+        "milestone": "",
+        "nextAction": "",
+        "number": 78,
+        "priority": "P0",
+        "state": "",
+        "status": "Done",
+        "title": "P0: Agent OS continuation worker autonomous scheduler migration",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/78"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Agent OS",
+        "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
+        "kind": "docs",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 79,
+        "priority": "P0",
+        "state": "",
+        "status": "Done",
+        "title": "docs: define autonomous scheduler contract",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/79"
       }
     ],
     "pullRequests": [
       {
         "checks": {
           "failure": 0,
-          "pending": 1,
-          "success": 1,
+          "pending": 0,
+          "success": 2,
           "total": 2
         },
-        "createdAt": "2026-04-27T08:57:10Z",
+        "createdAt": "2026-04-27T09:01:51Z",
         "domain": "Bot capability",
         "isDraft": false,
         "kind": "code",
         "labels": [],
         "milestone": "",
-        "number": 76,
+        "number": 77,
         "priority": "P1",
         "reviewDecision": "",
         "state": "OPEN",
         "status": "In review",
-        "title": "test: add multi-tick spawn lifecycle coverage",
+        "title": "fix: polish roadmap page visual fidelity",
         "type": "PullRequest",
-        "updatedAt": "2026-04-27T08:57:20Z",
-        "url": "https://github.com/lanyusea/screeps/pull/76"
+        "updatedAt": "2026-04-27T11:10:04Z",
+        "url": "https://github.com/lanyusea/screeps/pull/77"
       }
     ],
     "roadmapCards": [
@@ -3049,6 +3216,19 @@
         "type": "Issue",
         "url": "https://github.com/lanyusea/screeps/issues/41",
         "visionLayer": "foundation blocker"
+      },
+      {
+        "domain": "Agent OS",
+        "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
+        "milestone": "",
+        "nextAction": "",
+        "number": 78,
+        "priority": "P0",
+        "status": "Done",
+        "title": "P0: Agent OS continuation worker autonomous scheduler migration",
+        "type": "Issue",
+        "url": "https://github.com/lanyusea/screeps/issues/78",
+        "visionLayer": "resources"
       },
       {
         "domain": "Agent OS",
@@ -3179,24 +3359,11 @@
         "type": "PullRequest",
         "url": "https://github.com/lanyusea/screeps/pull/21",
         "visionLayer": "foundation blocker"
-      },
-      {
-        "domain": "Docs/process",
-        "evidence": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus offline console capture primitive. #29 remains active for real runtime-summary persistence/wiring; #62/#63/#30/#31 remain queued.",
-        "milestone": "Phase C: Runtime telemetry / monitor gate",
-        "nextAction": "",
-        "number": 59,
-        "priority": "P1",
-        "status": "In progress",
-        "title": "P1: Gameplay Evolution\u4e13\u9879\uff1avision-driven game-result review to roadmap/task loop",
-        "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/59",
-        "visionLayer": "territory"
       }
     ],
     "seededFallbackIssueCount": 0,
-    "sourceMode": "live",
-    "usedCachedSnapshot": false
+    "sourceMode": "cached",
+    "usedCachedSnapshot": true
   },
   "kpis": {
     "categories": [
@@ -3830,27 +3997,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -3992,6 +4138,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4000,27 +4167,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -4162,6 +4308,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4170,27 +4337,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -4332,6 +4478,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4340,27 +4507,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -4502,6 +4648,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4510,27 +4677,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -4672,6 +4818,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4680,27 +4847,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -4842,6 +4988,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4850,27 +5017,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -5012,6 +5158,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5020,27 +5187,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -5182,6 +5328,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5190,27 +5357,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -5352,6 +5498,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5360,27 +5527,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -5522,6 +5668,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5530,27 +5697,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -5692,6 +5838,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5700,27 +5867,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -5862,6 +6008,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5870,27 +6037,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -6032,6 +6178,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6040,27 +6207,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -6202,6 +6348,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6210,27 +6377,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -6372,6 +6518,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6380,27 +6547,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -6542,6 +6688,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6550,27 +6717,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "observed",
           "value": 0.0
@@ -6712,6 +6858,27 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "observed",
           "value": 0.0
         }
@@ -6720,27 +6887,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -6882,6 +7028,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6890,27 +7057,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -7052,6 +7198,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7060,27 +7227,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -7222,6 +7368,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7230,27 +7397,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -7392,6 +7538,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7400,27 +7567,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -7562,6 +7708,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7570,27 +7737,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -7732,6 +7878,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7740,27 +7907,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "observed",
           "value": 0.0
@@ -7902,6 +8048,27 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "observed",
           "value": 0.0
         }
@@ -7910,27 +8077,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -8072,6 +8218,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8080,27 +8247,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -8242,6 +8388,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8250,27 +8417,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -8412,6 +8558,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8420,27 +8587,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -8582,6 +8728,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8590,27 +8757,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -8752,6 +8898,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8760,27 +8927,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -8922,6 +9068,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8930,27 +9097,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -9092,6 +9238,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9100,27 +9267,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -9262,6 +9408,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9270,27 +9437,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:35:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:40:04Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T05:47:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:54:48Z",
           "status": "not instrumented",
           "value": null
@@ -9432,6 +9578,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T08:58:52Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:16:22Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:37Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:19:46Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9467,32 +9634,32 @@
       {
         "items": [
           {
-            "description": "Parallel Codex coding slice started: branch feat/pages-visual-fidelity-75, worktree /root/screeps-worktrees/p...",
-            "number": 75,
-            "priority": "P1",
-            "title": "#75 Pages roadmap visual fidelity follow-up",
-            "url": "https://github.com/lanyusea/screeps/issues/75"
-          },
-          {
-            "description": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no action...",
+            "description": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.",
             "number": 29,
             "priority": "P1",
             "title": "#29 Runtime summary and alert scheduled monitor delivery",
             "url": "https://github.com/lanyusea/screeps/issues/29"
           },
           {
-            "description": "Issue created to connect runtime-alert signals to bounded tactical emergency triage.",
+            "description": "Refine the public roadmap report presentation and English visible copy.",
+            "number": 75,
+            "priority": "P1",
+            "title": "#75 Pages roadmap visual fidelity follow-up",
+            "url": "https://github.com/lanyusea/screeps/issues/75"
+          },
+          {
+            "description": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visua...",
+            "number": 77,
+            "priority": "P1",
+            "title": "#77 fix: polish roadmap page visual fidelity",
+            "url": "https://github.com/lanyusea/screeps/pull/77"
+          },
+          {
+            "description": "Connect alert signals to bounded tactical emergency triage.",
             "number": 62,
             "priority": "P1",
             "title": "#62 Tactical emergency response wiring",
             "url": "https://github.com/lanyusea/screeps/issues/62"
-          },
-          {
-            "description": "Issue created to enforce gameplay-aware normal release cadence and emergency hotfix gates.",
-            "number": 63,
-            "priority": "P1",
-            "title": "#63 Gameplay release cadence and emergency hotfix evidence",
-            "url": "https://github.com/lanyusea/screeps/issues/63"
           }
         ],
         "title": "Active"
@@ -9500,21 +9667,21 @@
       {
         "items": [
           {
-            "description": "Fresh clean live run redacted report",
+            "description": "Run a clean private-server smoke check and publish redacted evidence.",
             "number": 28,
             "priority": "P1",
             "title": "#28 Private smoke harness clean live rerun",
             "url": "https://github.com/lanyusea/screeps/issues/28"
           },
           {
-            "description": "Deploy preflight, private-smoke gate, monitor proof, official API verification",
+            "description": "Hold official deploys until private-smoke and monitor proof are complete.",
             "number": 33,
             "priority": "P1",
             "title": "#33 Official MMO deployment blocked by private smoke gate",
             "url": "https://github.com/lanyusea/screeps/issues/33"
           },
           {
-            "description": "Private smoke failure modes mapped into alert-level telemetry",
+            "description": "Backfill alert telemetry based on private-smoke failure modes.",
             "number": 32,
             "priority": "P2",
             "title": "#32 Alert-level telemetry from private smoke failures",
@@ -9533,7 +9700,7 @@
             "url": "https://github.com/lanyusea/screeps/issues/41"
           },
           {
-            "description": "P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monitor, typed fanouts, runti...",
+            "description": "Keep watch-only P0 monitor evidence current.",
             "number": 27,
             "priority": "P0",
             "title": "#27 P0 monitoring and Discord route health",
@@ -9547,7 +9714,7 @@
             "url": "https://github.com/lanyusea/screeps/issues/36"
           },
           {
-            "description": "Read-only inspection: main protected=false; branch protection API 404; active ruleset 'defualt' has no rules;...",
+            "description": "Keep required checks and merge gates enforceable before bot changes land.",
             "number": 26,
             "priority": "P0",
             "title": "#26 Main branch protection and required CI gate",
@@ -9565,28 +9732,14 @@
       {
         "items": [
           {
-            "description": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus o...",
+            "description": "Use game-result evidence to drive roadmap, task, and release updates.",
             "number": 59,
             "priority": "P1",
             "title": "#59 Gameplay Evolution: game-result review to roadmap loop",
             "url": "https://github.com/lanyusea/screeps/issues/59"
           },
           {
-            "description": "PR #76 opened from Codex commit 2fba222 adding multi-tick spawn.spawning lifecycle coverage. Verification pas...",
-            "number": 30,
-            "priority": "P1",
-            "title": "#30 Mock harness multi-tick spawn lifecycle",
-            "url": "https://github.com/lanyusea/screeps/issues/30"
-          },
-          {
-            "description": "PR #76 opened from Codex commit 2fba222. Verification passed: git diff --check; cd prod && npm run typecheck...",
-            "number": 76,
-            "priority": "P1",
-            "title": "#76 test: add multi-tick spawn lifecycle coverage",
-            "url": "https://github.com/lanyusea/screeps/pull/76"
-          },
-          {
-            "description": "Owner priority correction: direct bot-capability/gameplay reliability items outrank non-blocking foundation w...",
+            "description": "Confirm worker recovery when creeps are gone or energy is insufficient.",
             "number": 31,
             "priority": "P1",
             "title": "#31 Zero-creep emergency recovery coverage",
@@ -9602,25 +9755,32 @@
       {
         "items": [
           {
-            "description": "Completed by merged PR #66 / 1f41670: durable Gameplay finding \u2192 GitHub issue/Project/Codex prompt bridge run...",
+            "description": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no a...",
+            "number": 78,
+            "priority": "P0",
+            "title": "#78 P0: Agent OS continuation worker autonomous scheduler migration",
+            "url": "https://github.com/lanyusea/screeps/issues/78"
+          },
+          {
+            "description": "Bridge runtime KPI artifacts into the Pages report data flow.",
             "number": 61,
             "priority": "P1",
             "title": "#61 Runtime KPI artifact bridge",
             "url": "https://github.com/lanyusea/screeps/issues/61"
           },
           {
-            "description": "One-shot Gameplay Evolution dry run produced useful advisory output in session_cron_be2c21e9fd73; recurring 1...",
+            "description": "Keep game-result review evidence tied to roadmap decisions.",
             "number": 60,
             "priority": "P1",
             "title": "#60 Gameplay review cadence",
             "url": "https://github.com/lanyusea/screeps/issues/60"
           },
           {
-            "description": "PR #64 merged at 2026-04-27T02:09Z as 0377388; prod-ci and CodeRabbit green, Gemini no feedback, review threa...",
-            "number": 64,
+            "description": "Cover spawn.spawning lifecycle behavior across multiple simulated ticks.",
+            "number": 30,
             "priority": "P1",
-            "title": "#64 docs: add gameplay evolution roadmap",
-            "url": "https://github.com/lanyusea/screeps/pull/64"
+            "title": "#30 Mock harness multi-tick spawn lifecycle",
+            "url": "https://github.com/lanyusea/screeps/issues/30"
           }
         ],
         "title": "Done"
@@ -9925,21 +10085,21 @@
         "delta": "+1",
         "detail": "repository history",
         "label": "Total commits",
-        "value": 122
+        "value": 124
       },
       {
         "delta": "+1",
-        "detail": "48 merged",
+        "detail": "50 merged \u00b7 cached",
         "label": "Total PRs",
-        "source": "github",
-        "value": 53
+        "source": "cached",
+        "value": 55
       },
       {
         "delta": "+0",
-        "detail": "10 open",
+        "detail": "9 open \u00b7 cached",
         "label": "Total issues",
-        "source": "github",
-        "value": 23
+        "source": "cached",
+        "value": 24
       },
       {
         "delta": "+0",
@@ -9958,9 +10118,9 @@
     "roadmapCards": [
       {
         "goal": "Use real game outcomes to drive roadmap, task, and release decisions.",
-        "next": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/K...",
+        "next": "Use game-result evidence to drive roadmap, task, and release updates.",
         "progress": 58,
-        "status": "#59 In progress \u00b7 Docs/process",
+        "status": "#59 In progress \u00b7 GitHub \u00b7 cached",
         "title": "Gameplay Evolution",
         "url": "https://github.com/lanyusea/screeps/issues/59"
       },
@@ -9968,39 +10128,39 @@
         "goal": "Claim, hold, and grow the controlled room footprint first.",
         "next": "No current GitHub/Project evidence available.",
         "progress": 0,
-        "status": "No matching Project item",
+        "status": "GitHub snapshot cached",
         "title": "Territory",
         "url": ""
       },
       {
         "goal": "Convert territory into energy, minerals, logistics, and spawn scale.",
-        "next": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, Code...",
+        "next": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor rep...",
         "progress": 58,
-        "status": "#29 In progress \u00b7 GitHub",
+        "status": "#29 In progress \u00b7 GitHub \u00b7 cached",
         "title": "Resource Economy",
         "url": "https://github.com/lanyusea/screeps/issues/29"
       },
       {
         "goal": "Make defense and offense serve territorial and economic control.",
-        "next": "Issue created to connect runtime-alert signals to bounded tactical emergency triage.",
+        "next": "Connect alert signals to bounded tactical emergency triage.",
         "progress": 35,
-        "status": "#62 Ready \u00b7 GitHub",
+        "status": "#62 Ready \u00b7 GitHub \u00b7 cached",
         "title": "Combat",
         "url": "https://github.com/lanyusea/screeps/issues/62"
       },
       {
         "goal": "Let automation health override game goals only when it blocks delivery.",
-        "next": "P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monit...",
+        "next": "Keep watch-only P0 monitor evidence current.",
         "progress": 100,
-        "status": "#27 Done \u00b7 Agent OS",
+        "status": "#27 Done \u00b7 Agent OS \u00b7 cached",
         "title": "Reliability / P0",
         "url": "https://github.com/lanyusea/screeps/issues/27"
       },
       {
         "goal": "Private smoke proof, release gates, and official MMO deployment evidence.",
-        "next": "Fresh clean live run redacted report",
-        "progress": 35,
-        "status": "#28 Ready \u00b7 GitHub",
+        "next": "Run a clean private-server smoke check and publish redacted evidence.",
+        "progress": 58,
+        "status": "#28 In progress \u00b7 GitHub \u00b7 cached",
         "title": "Foundation Gates",
         "url": "https://github.com/lanyusea/screeps/issues/28"
       }
@@ -10009,13 +10169,13 @@
   "runtimeReport": {
     "source": {
       "inputPaths": [
-        "/root/screeps/runtime-artifacts",
-        "/root/.hermes/cron/output"
+        "[redacted-path]",
+        "[redacted-path]"
       ],
       "matchedFiles": 0,
       "reason": "",
       "runtimeSummaryLines": 0,
-      "scannedFiles": 71564,
+      "scannedFiles": 71607,
       "skippedFileCount": 1643
     },
     "window": {

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,45 +3,11 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-04-27T11:19:46Z",
-  "generatedAtCst": "2026-04-27 19:19:46 CST",
+  "generatedAt": "2026-04-27T11:23:09Z",
+  "generatedAtCst": "2026-04-27 19:23:09 CST",
   "github": {
-    "fetchErrors": [
-      {
-        "command": [
-          "gh",
-          "issue",
-          "list",
-          "--repo"
-        ],
-        "exitCode": 1,
-        "message": "command failed",
-        "source": "issues"
-      },
-      {
-        "command": [
-          "gh",
-          "pr",
-          "list",
-          "--repo"
-        ],
-        "exitCode": 1,
-        "message": "command failed",
-        "source": "pullRequests"
-      },
-      {
-        "command": [
-          "gh",
-          "project",
-          "item-list",
-          "3"
-        ],
-        "exitCode": 1,
-        "message": "command failed",
-        "source": "project"
-      }
-    ],
-    "fetched": false,
+    "fetchErrors": [],
+    "fetched": true,
     "issues": [
       {
         "createdAt": "2026-04-27T08:23:27Z",
@@ -2083,34 +2049,34 @@
     },
     "processMetrics": [
       {
-        "instrumented": false,
+        "instrumented": true,
         "label": "Open roadmap issues",
-        "value": "insufficient evidence"
+        "value": 9
       },
       {
-        "instrumented": false,
+        "instrumented": true,
         "label": "Open PRs",
-        "value": "insufficient evidence"
+        "value": 1
       },
       {
-        "instrumented": false,
+        "instrumented": true,
         "label": "Blocked cards",
-        "value": "insufficient evidence"
+        "value": 4
       },
       {
-        "instrumented": false,
+        "instrumented": true,
         "label": "Project cards",
-        "value": "insufficient evidence"
+        "value": 56
       },
       {
-        "instrumented": false,
+        "instrumented": true,
         "label": "In progress",
-        "value": "insufficient evidence"
+        "value": 4
       },
       {
-        "instrumented": false,
+        "instrumented": true,
         "label": "In review",
-        "value": "insufficient evidence"
+        "value": 2
       }
     ],
     "projectItems": [
@@ -3362,8 +3328,8 @@
       }
     ],
     "seededFallbackIssueCount": 0,
-    "sourceMode": "cached",
-    "usedCachedSnapshot": true
+    "sourceMode": "live",
+    "usedCachedSnapshot": false
   },
   "kpis": {
     "categories": [
@@ -3997,13 +3963,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -4159,6 +4118,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4167,13 +4133,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -4329,6 +4288,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4337,13 +4303,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -4499,6 +4458,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4507,13 +4473,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -4669,6 +4628,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4677,13 +4643,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -4839,6 +4798,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4847,13 +4813,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -5009,6 +4968,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5017,13 +4983,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -5179,6 +5138,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5187,13 +5153,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -5349,6 +5308,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5357,13 +5323,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -5519,6 +5478,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5527,13 +5493,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -5689,6 +5648,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5697,13 +5663,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -5859,6 +5818,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5867,13 +5833,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -6029,6 +5988,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6037,13 +6003,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -6199,6 +6158,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6207,13 +6173,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -6369,6 +6328,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6377,13 +6343,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -6539,6 +6498,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6547,13 +6513,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -6709,6 +6668,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6717,13 +6683,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "observed",
           "value": 0.0
@@ -6879,6 +6838,13 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "observed",
           "value": 0.0
         }
@@ -6887,13 +6853,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -7049,6 +7008,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7057,13 +7023,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -7219,6 +7178,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7227,13 +7193,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -7389,6 +7348,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7397,13 +7363,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -7559,6 +7518,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7567,13 +7533,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -7729,6 +7688,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7737,13 +7703,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -7899,6 +7858,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7907,13 +7873,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "observed",
           "value": 0.0
@@ -8069,6 +8028,13 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "observed",
           "value": 0.0
         }
@@ -8077,13 +8043,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -8239,6 +8198,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8247,13 +8213,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -8409,6 +8368,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8417,13 +8383,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -8579,6 +8538,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8587,13 +8553,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -8749,6 +8708,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8757,13 +8723,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -8919,6 +8878,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8927,13 +8893,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -9089,6 +9048,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9097,13 +9063,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -9259,6 +9218,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9267,13 +9233,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -9429,6 +9388,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9437,13 +9403,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:54:48Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T05:56:21Z",
           "status": "not instrumented",
           "value": null
@@ -9599,6 +9558,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:19:46Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:23:09Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9648,7 +9614,7 @@
             "url": "https://github.com/lanyusea/screeps/issues/75"
           },
           {
-            "description": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visua...",
+            "description": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path]",
             "number": 77,
             "priority": "P1",
             "title": "#77 fix: polish roadmap page visual fidelity",
@@ -10085,20 +10051,20 @@
         "delta": "+1",
         "detail": "repository history",
         "label": "Total commits",
-        "value": 124
+        "value": 128
       },
       {
         "delta": "+1",
-        "detail": "50 merged \u00b7 cached",
+        "detail": "50 merged",
         "label": "Total PRs",
-        "source": "cached",
+        "source": "github",
         "value": 55
       },
       {
         "delta": "+0",
-        "detail": "9 open \u00b7 cached",
+        "detail": "9 open",
         "label": "Total issues",
-        "source": "cached",
+        "source": "github",
         "value": 24
       },
       {
@@ -10120,7 +10086,7 @@
         "goal": "Use real game outcomes to drive roadmap, task, and release decisions.",
         "next": "Use game-result evidence to drive roadmap, task, and release updates.",
         "progress": 58,
-        "status": "#59 In progress \u00b7 GitHub \u00b7 cached",
+        "status": "#59 In progress \u00b7 GitHub",
         "title": "Gameplay Evolution",
         "url": "https://github.com/lanyusea/screeps/issues/59"
       },
@@ -10128,7 +10094,7 @@
         "goal": "Claim, hold, and grow the controlled room footprint first.",
         "next": "No current GitHub/Project evidence available.",
         "progress": 0,
-        "status": "GitHub snapshot cached",
+        "status": "No matching Project item",
         "title": "Territory",
         "url": ""
       },
@@ -10136,7 +10102,7 @@
         "goal": "Convert territory into energy, minerals, logistics, and spawn scale.",
         "next": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor rep...",
         "progress": 58,
-        "status": "#29 In progress \u00b7 GitHub \u00b7 cached",
+        "status": "#29 In progress \u00b7 GitHub",
         "title": "Resource Economy",
         "url": "https://github.com/lanyusea/screeps/issues/29"
       },
@@ -10144,7 +10110,7 @@
         "goal": "Make defense and offense serve territorial and economic control.",
         "next": "Connect alert signals to bounded tactical emergency triage.",
         "progress": 35,
-        "status": "#62 Ready \u00b7 GitHub \u00b7 cached",
+        "status": "#62 Ready \u00b7 GitHub",
         "title": "Combat",
         "url": "https://github.com/lanyusea/screeps/issues/62"
       },
@@ -10152,7 +10118,7 @@
         "goal": "Let automation health override game goals only when it blocks delivery.",
         "next": "Keep watch-only P0 monitor evidence current.",
         "progress": 100,
-        "status": "#27 Done \u00b7 Agent OS \u00b7 cached",
+        "status": "#27 Done \u00b7 Agent OS",
         "title": "Reliability / P0",
         "url": "https://github.com/lanyusea/screeps/issues/27"
       },
@@ -10160,7 +10126,7 @@
         "goal": "Private smoke proof, release gates, and official MMO deployment evidence.",
         "next": "Run a clean private-server smoke check and publish redacted evidence.",
         "progress": 58,
-        "status": "#28 In progress \u00b7 GitHub \u00b7 cached",
+        "status": "#28 In progress \u00b7 GitHub",
         "title": "Foundation Gates",
         "url": "https://github.com/lanyusea/screeps/issues/28"
       }

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,8 +3,8 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-04-27T11:23:09Z",
-  "generatedAtCst": "2026-04-27 19:23:09 CST",
+  "generatedAt": "2026-04-27T11:50:20Z",
+  "generatedAtCst": "2026-04-27 19:50:20 CST",
   "github": {
     "fetchErrors": [],
     "fetched": true,
@@ -26,7 +26,7 @@
         "status": "Ready",
         "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
         "type": "Issue",
-        "updatedAt": "2026-04-27T10:30:20Z",
+        "updatedAt": "2026-04-27T11:31:38Z",
         "url": "https://github.com/lanyusea/screeps/issues/75"
       },
       {
@@ -66,7 +66,7 @@
         "status": "Ready",
         "title": "P1: Phase C: tactical emergency response is not wired to runtime alerts",
         "type": "Issue",
-        "updatedAt": "2026-04-26T17:09:38Z",
+        "updatedAt": "2026-04-27T11:33:51Z",
         "url": "https://github.com/lanyusea/screeps/issues/62"
       },
       {
@@ -131,26 +131,6 @@
         "url": "https://github.com/lanyusea/screeps/issues/32"
       },
       {
-        "createdAt": "2026-04-26T06:39:13Z",
-        "domain": "Change-control",
-        "kind": "test",
-        "labels": [
-          "kind:test",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-b-spawn-lifecycle"
-        ],
-        "milestone": "Phase B: Bot capability hardening gate",
-        "number": 31,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
-        "type": "Issue",
-        "updatedAt": "2026-04-27T11:10:02Z",
-        "url": "https://github.com/lanyusea/screeps/issues/31"
-      },
-      {
         "createdAt": "2026-04-26T06:39:09Z",
         "domain": "Runtime monitor",
         "kind": "ops",
@@ -188,907 +168,155 @@
         "status": "Backlog",
         "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
         "type": "Issue",
-        "updatedAt": "2026-04-27T11:14:55Z",
+        "updatedAt": "2026-04-27T11:31:36Z",
         "url": "https://github.com/lanyusea/screeps/issues/28"
       }
     ],
     "kanban": {
       "cards": [
         {
-          "domain": "Runtime monitor",
-          "evidence": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty active review threads, controller diff-check + py_compile + 25 unittests PASS. Main fast-forwarded and PR branch/worktree cleaned.",
-          "kind": "ops",
+          "domain": "Bot capability",
+          "evidence": "",
+          "kind": "code",
           "lane": "Foundation",
-          "nextAction": "",
-          "number": 29,
-          "priority": "P1",
-          "state": "",
-          "status": "In progress",
-          "title": "P1:Phase C:runtime-summary/runtime-alert \u5b9a\u65f6\u76d1\u63a7\u6295\u9012\u5c1a\u672a\u5b8c\u6210",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/29",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Private smoke",
-          "evidence": "2026-04-27T19:14:48+08:00 live private-smoke rerun attempted after self-test/dry-run PASS. Result REQUEST_CHANGES/BLOCKED: docker compose failed before screeps container start because 127.0.0.1:21025 and :21026 are already allocated by existing container screeps-private-smoke-pinned-screeps-1. Failed stack screeps-private-smoke-83dd9462 cleaned with docker compose down -v. No secrets printed; report path private-smoke-report-20260427T111321Z.json.",
-          "kind": "ops",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 28,
-          "priority": "P1",
-          "state": "",
-          "status": "In progress",
-          "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/28",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Docs/process",
-          "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 75,
-          "priority": "P1",
-          "state": "",
-          "status": "In review",
-          "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/75",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Docs/process",
-          "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
+          "nextAction": "Polish the generated roadmap page and publish sanitized public artifacts.",
           "number": 77,
           "priority": "P1",
-          "state": "",
+          "state": "OPEN",
           "status": "In review",
-          "title": "fix: polish roadmap page visual fidelity",
+          "title": "Roadmap report public artifact polish",
           "type": "PullRequest",
-          "updatedAt": "",
+          "updatedAt": "2026-04-27T11:31:40Z",
           "url": "https://github.com/lanyusea/screeps/pull/77",
           "visionLayer": "foundation blocker"
         },
         {
-          "domain": "Runtime monitor",
-          "evidence": "Issue created to connect runtime-alert signals to bounded tactical emergency triage.",
+          "domain": "Change-control",
+          "evidence": "",
           "kind": "ops",
           "lane": "Foundation",
-          "nextAction": "",
-          "number": 62,
-          "priority": "P1",
-          "state": "",
-          "status": "Ready",
-          "title": "P1: Phase C: tactical emergency response is not wired to runtime alerts",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/62",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Official MMO",
-          "evidence": "Issue created to enforce gameplay-aware normal release cadence and emergency hotfix gates.",
-          "kind": "ops",
-          "lane": "Foundation",
-          "nextAction": "",
+          "nextAction": "Record expected KPI movement and proof for gameplay releases and hotfixes.",
           "number": 63,
           "priority": "P1",
-          "state": "",
+          "state": "OPEN",
           "status": "Ready",
-          "title": "P1: Phase E: gameplay release cadence and emergency hotfix gate are not enforced",
+          "title": "Gameplay release cadence and emergency hotfix evidence",
           "type": "Issue",
-          "updatedAt": "",
+          "updatedAt": "2026-04-26T17:09:40Z",
           "url": "https://github.com/lanyusea/screeps/issues/63",
           "visionLayer": "foundation blocker"
         },
         {
-          "domain": "Official MMO",
-          "evidence": "Deploy preflight, private-smoke gate, monitor proof, official API verification",
-          "kind": "ops",
+          "domain": "Runtime monitor",
+          "evidence": "",
+          "kind": "docs",
           "lane": "Foundation",
-          "nextAction": "",
-          "number": 33,
+          "nextAction": "Refine the public roadmap report presentation and English visible copy.",
+          "number": 75,
           "priority": "P1",
-          "state": "",
-          "status": "Backlog",
-          "title": "P1:Phase E:\u5b98\u65b9 MMO \u90e8\u7f72\u4ecd\u53d7\u79c1\u670d smoke release gate \u963b\u585e",
+          "state": "OPEN",
+          "status": "Ready",
+          "title": "Pages roadmap visual fidelity follow-up",
           "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/33",
+          "updatedAt": "2026-04-27T11:31:38Z",
+          "url": "https://github.com/lanyusea/screeps/issues/75",
           "visionLayer": "foundation blocker"
         },
         {
           "domain": "Runtime monitor",
-          "evidence": "Private smoke failure modes mapped into alert-level telemetry",
+          "evidence": "",
           "kind": "ops",
           "lane": "Foundation",
-          "nextAction": "",
-          "number": 32,
-          "priority": "P2",
-          "state": "",
-          "status": "Backlog",
-          "title": "P2:Phase C:alert-level telemetry \u9700\u8981\u57fa\u4e8e\u79c1\u670d smoke \u5931\u8d25\u6a21\u5f0f\u8865\u9f50",
+          "nextAction": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.",
+          "number": 29,
+          "priority": "P1",
+          "state": "OPEN",
+          "status": "Ready",
+          "title": "Runtime summary and alert scheduled monitor delivery",
           "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/32",
+          "updatedAt": "2026-04-27T08:52:25Z",
+          "url": "https://github.com/lanyusea/screeps/issues/29",
           "visionLayer": "foundation blocker"
         },
         {
-          "domain": "Agent OS",
-          "evidence": "PR #42 merged at 2026-04-26T08:26:48Z after QA PASS; issue #41 closed; docs-only QA acceptance gate landed without touching PR #40-owned files.",
+          "domain": "Runtime monitor",
+          "evidence": "",
           "kind": "ops",
           "lane": "Foundation",
-          "nextAction": "",
-          "number": 41,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "Establish dedicated QA acceptance-check agent gate",
+          "nextAction": "Connect alert signals to bounded tactical emergency triage.",
+          "number": 62,
+          "priority": "P1",
+          "state": "OPEN",
+          "status": "Ready",
+          "title": "Tactical emergency response wiring",
           "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/41",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monitor, typed fanouts, runtime summary, and resumed bounded continuation worker all finalized with fresh output artifacts/no delivery errors; continuation restored to 5m cadence.",
-          "kind": "ops",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 27,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "P0:P0 agent-ops:P0 \u76d1\u63a7\u4e0e Discord \u8def\u7531\u5065\u5eb7\u9700\u8981\u6301\u7eed\u9a8c\u8bc1",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/27",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "PR documenting GitHub roadmap management contract; verifies milestones/project fields/items",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 36,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "P0:P0 change-control:GitHub Milestones/Project roadmap source-of-truth \u5408\u540c\u672a\u5165\u5e93",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/36",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "Read-only inspection: main protected=false; branch protection API 404; active ruleset 'defualt' has no rules; prod-ci exists but path filters made it unsuitable as universal required check. PR #45 opened to make check always present.",
-          "kind": "ops",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 26,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "P0:P0 change-control:main \u5206\u652f\u4fdd\u62a4\u4e0e CI \u5fc5\u8fc7\u95e8\u7981\u5c1a\u672a\u786e\u8ba4",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/26",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "PR #48 merged at 2026-04-26T10:17:39Z; merge commit 955a0df records owner governance decisions in docs/AGENTS.",
-          "kind": "ops",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 47,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "P0:P0 change-control:owner roadmap governance decisions need durable contract sync",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/47",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "PR #34; issue form + PR template + docs contract",
-          "kind": "ops",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 22,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "P0:P0 change-control:\u5df2\u77e5\u95ee\u9898\u672a\u5f3a\u5236\u8fdb\u5165 GitHub issue \u4e0e PR \u5173\u8054\u6d41\u7a0b",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/22",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "PR #40 merged at 2026-04-26T08:19:33Z; issue closed via Fixes #39; main fast-forwarded to d64f30a.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 39,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "P0:P0 change-control:\u6240\u6709 agent \u4efb\u52a1\u5b8c\u6210\u6807\u51c6\u7f3a\u5c11 GitHub \u72b6\u6001\u66f4\u65b0\u95e8\u7981",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/39",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "Fixes #22; PR templates/issue form docs",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 34,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "chore: add issue and PR management templates",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/34",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "Merged PR #45 made prod verification required-check friendly; main ruleset now requires Verify prod TypeScript, Jest, and bundle.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 45,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "ci: make prod verification required-check friendly",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/45",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "PR #42 establishes dedicated QA acceptance gate; merged 2026-04-26.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 42,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: add QA acceptance gate",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/42",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 79,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: define autonomous scheduler contract",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/79",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "Fixes #36; docs-only roadmap management contract",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 37,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record GitHub roadmap management contract",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/37",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "PR #53 merged at 2026-04-26T13:03:35Z as 0bca111 after >=15m, prod-ci SUCCESS, CodeRabbit no actionable comments, Gemini no feedback, no review threads.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 53,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record P0 cron finalization gap",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/53",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "PR #54 merged via squash at 2026-04-26T13:40:29Z; merge commit 0ebed16931f044bd4ab02800f0425cdaac7c3d0d; required check Verify prod TypeScript, Jest, and bundle SUCCESS; CodeRabbit status SUCCESS; review thread PRRT_kwDOSMSsO859qLyO resolved.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 54,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record P0 scheduler recovery",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/54",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "P0 visibility repair process note PR",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 21,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record P0 visibility repair",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/21",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Docs/process",
-          "evidence": "PR #38 records PR #37 merge checkpoint; merged 2026-04-26.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 38,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record PR 37 merge checkpoint",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/38",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "Merged PR #46 records CI/ruleset gate completion; checks green (prod-ci SUCCESS, CodeRabbit SUCCESS); Gemini no feedback; merge commit 459a528.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 46,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record ci required gate completion",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/46",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Change-control",
-          "evidence": "Merged PR #48 at 2026-04-26T10:17:39Z after >=15m, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, QA PASS; merge commit 955a0df.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 48,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record owner governance decisions",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/48",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "PR #43 documents scheduler alert gap audit; merged 2026-04-26.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 43,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record scheduler alert gap audit",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/43",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "2026-04-26T18:26+08: PR #49 merged at 2026-04-26T10:23:37Z as 0343354734a48f173efa38f365c4cc12d76f2cc5 after gates passed: prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini COMMENTED with no feedback, review threads empty.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 49,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record scheduler cadence audit",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/49",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "PR #52 documents 19:48 metadata-only scheduler cadence audit; prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini no feedback, no review threads; linked to #27.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 52,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record scheduler cadence audit at 1948",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/52",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "PR #50 merged at 2026-04-26T10:49:25Z as 87512b615cc03e5364044dea41776a0b381c682c. Gates: >=15m wait satisfied, prod-ci SUCCESS, CodeRabbit SUCCESS status, Gemini no feedback, no unresolved live review threads.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 50,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record scheduler cadence audit follow-up",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/50",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "Merged PR #44 documents scheduler cadence follow-up and links issue #27/#29; CodeRabbit SUCCESS; Gemini no critical feedback.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 44,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record scheduler cadence follow-up",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/44",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "PR #56 documents renewed scheduler cadence regression; prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback; body patched with Related to #27.",
-          "kind": "review",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 56,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record scheduler cadence regression",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/56",
+          "updatedAt": "2026-04-27T11:33:51Z",
+          "url": "https://github.com/lanyusea/screeps/issues/62",
           "visionLayer": "foundation blocker"
         },
         {
           "domain": "Private smoke",
-          "evidence": "Linked PR #16 / smoke harness verification evidence",
-          "kind": "bug",
+          "evidence": "",
+          "kind": "ops",
           "lane": "Foundation",
-          "nextAction": "",
-          "number": 23,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "P1:Phase D:\u79c1\u670d smoke STEAM_KEY \u6587\u4ef6\u6743\u9650\u66fe\u5bfc\u81f4\u5bb9\u5668\u4e0d\u53ef\u8bfb",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/23",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Docs/process",
-          "evidence": "PR #66 merged at 2026-04-27T03:29:27Z as 1f41670 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, and empty GraphQL review threads.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 66,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "docs: define gameplay finding Codex bridge",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/66",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Docs/process",
-          "evidence": "PR #55 merged after green checks/reviews; README now has formal community-facing description, logo asset, Discord invite, and docs lane mapping.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 55,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "docs: prepare community-facing README",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/55",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Runtime monitor",
-          "evidence": "Merged PR #71 as 454e2cf after >=15m gate, green prod-ci/CodeRabbit, Gemini no-feedback review, and no active review threads; remote/local branch cleaned.",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 71,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record KPI persistence wiring checkpoint",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/71",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Docs/process",
-          "evidence": "PR #57 merged at 2026-04-26T15:17:58Z as cbe3641 after >=15m, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, and no unresolved review threads.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 57,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record P0 scheduler recovery checkpoint",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/57",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Docs/process",
-          "evidence": "PR #58 merged at 2026-04-26T15:41:46Z as c6120dc after prod-ci success, CodeRabbit success, Gemini no feedback, and resolved/outdated review thread.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 58,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "docs: record P0 scheduler repair completion",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/58",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "PR #40 merged at 2026-04-26T08:19:33Z; CodeRabbit success; review threads empty; main at d64f30a.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 40,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "docs: require GitHub state updates before agent completion",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/40",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Runtime monitor",
-          "evidence": "Merged PR #70 as c21f1bb at 2026-04-27T06:09:41Z. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after 391d572, three prior review threads resolved/outdated, >=15m elapsed, controller QA checks passed.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 70,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "feat: add Codex-authored Pages roadmap report",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/70",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Runtime monitor",
-          "evidence": "Closed as superseded by Codex-authored PR #70 because PR #69 contained direct Hermes-authored implementation commits and an unresolved Python 3.10 compatibility review thread.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 69,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "feat: add GitHub Pages roadmap live report",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/69",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Runtime monitor",
-          "evidence": "PR #68 merged at 2026-04-27T05:09:10Z as da20ac4 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini no feedback, and GraphQL review thread resolved.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 68,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "feat: add runtime KPI artifact bridge",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/68",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Runtime monitor",
-          "evidence": "Merged PR #67 as f32cdc3 after review fixes 10d588a/ee5e852; checks passed (prod-ci, CodeRabbit), review threads resolved, main fast-forwarded and PR branch deleted.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 67,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "feat: add runtime KPI reducer",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/67",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Runtime monitor",
-          "evidence": "Merged PR #65 at 2026-04-27T02:49:49Z as 4d90ecd. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, GraphQL review threads empty, >=15m elapsed, controller-side typecheck/test/build PASS.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 65,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "feat: add runtime KPI telemetry",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/65",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Runtime monitor",
-          "evidence": "Merged as 57b4b3a at 2026-04-27T08:49Z. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL active review threads, >=15m elapsed, controller diff-check + py_compile + 25 unittests PASS. Local main fast-forwarded; remote/local branch deleted.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 74,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "feat: capture official console runtime summaries",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/74",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Runtime monitor",
-          "evidence": "Merged PR #73 as 9762b7a at 2026-04-27T07:51Z after prod-ci SUCCESS, CodeRabbit SUCCESS, all review threads resolved, and >=15m gate.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 73,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "feat: capture runtime summary console artifacts",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/73",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Runtime monitor",
-          "evidence": "PR #72 final head 99eb926 merged at 2026-04-27T07:57:41Z as merge commit 366cfdc. Evidence: py_compile PASS; current artifacts verify SQLite 660 rows/33 metrics/latest enemy_kills NULL instrumented=0, no WAL/SHM, HTML title+five sections+3 KPI cards/forbidden strings absent, LFS attrs/pointer, diff-check main..HEAD, secret scan over 4 PR-diff files. Checks green: CodeRabbit pass, prod-ci pass.",
-          "kind": "code",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 72,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "fix: restore roadmap Pages report layout",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/72",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Docs/process",
-          "evidence": "Closed issue / PR #19",
-          "kind": "docs",
-          "lane": "Foundation",
-          "nextAction": "",
-          "number": 24,
+          "nextAction": "Backfill alert telemetry based on private-smoke failure modes.",
+          "number": 32,
           "priority": "P2",
-          "state": "",
-          "status": "Done",
-          "title": "P2:Phase A:\u6839\u76ee\u5f55 AGENT.md \u6307\u9488\u6587\u4ef6\u5df2\u5e9f\u5f03\u4f46\u66fe\u6b8b\u7559",
+          "state": "OPEN",
+          "status": "Ready",
+          "title": "Alert-level telemetry from private smoke failures",
           "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/24",
+          "updatedAt": "2026-04-26T06:57:12Z",
+          "url": "https://github.com/lanyusea/screeps/issues/32",
           "visionLayer": "foundation blocker"
         },
         {
-          "domain": "Docs/process",
-          "evidence": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus offline console capture primitive. #29 remains active for real runtime-summary persistence/wiring; #62/#63/#30/#31 remain queued.",
+          "domain": "Change-control",
+          "evidence": "",
+          "kind": "ops",
+          "lane": "Foundation",
+          "nextAction": "Hold official deploys until private-smoke and monitor proof are complete.",
+          "number": 33,
+          "priority": "P1",
+          "state": "OPEN",
+          "status": "Backlog",
+          "title": "Official MMO deployment blocked by private smoke gate",
+          "type": "Issue",
+          "updatedAt": "2026-04-26T06:57:18Z",
+          "url": "https://github.com/lanyusea/screeps/issues/33",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Private smoke",
+          "evidence": "",
+          "kind": "ops",
+          "lane": "Foundation",
+          "nextAction": "Run a clean private-server smoke check and publish redacted evidence.",
+          "number": 28,
+          "priority": "P1",
+          "state": "OPEN",
+          "status": "Backlog",
+          "title": "Private smoke harness clean live rerun",
+          "type": "Issue",
+          "updatedAt": "2026-04-27T11:31:36Z",
+          "url": "https://github.com/lanyusea/screeps/issues/28",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Runtime monitor",
+          "evidence": "",
           "kind": "ops",
           "lane": "Gameplay",
-          "nextAction": "",
+          "nextAction": "Use game-result evidence to drive roadmap, task, and release updates.",
           "number": 59,
           "priority": "P1",
-          "state": "",
-          "status": "In progress",
-          "title": "P1: Gameplay Evolution\u4e13\u9879\uff1avision-driven game-result review to roadmap/task loop",
+          "state": "OPEN",
+          "status": "Ready",
+          "title": "Gameplay Evolution: game-result review to roadmap loop",
           "type": "Issue",
-          "updatedAt": "",
+          "updatedAt": "2026-04-27T08:00:51Z",
           "url": "https://github.com/lanyusea/screeps/issues/59",
           "visionLayer": "territory"
-        },
-        {
-          "domain": "Bot capability",
-          "evidence": "2026-04-27T19:09:52+08:00 scheduler claim: dispatched Codex dev agent in [redacted-path] on branch feat/zero-creep-emergency-31. File scope prod/src/** prod/test/** prod/dist/main.js. Acceptance: verify zero-creep/insufficient-energy emergency recovery behavior with tests; no secrets.",
-          "kind": "test",
-          "lane": "Gameplay",
-          "nextAction": "",
-          "number": 31,
-          "priority": "P1",
-          "state": "",
-          "status": "In progress",
-          "title": "P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/31",
-          "visionLayer": "resources"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
-          "kind": "ops",
-          "lane": "Gameplay",
-          "nextAction": "",
-          "number": 78,
-          "priority": "P0",
-          "state": "",
-          "status": "Done",
-          "title": "P0: Agent OS continuation worker autonomous scheduler migration",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/78",
-          "visionLayer": "resources"
-        },
-        {
-          "domain": "Bot capability",
-          "evidence": "Completed by merged PR #66 / 1f41670: durable Gameplay finding \u2192 GitHub issue/Project/Codex prompt bridge runbook with QA acceptance and first #29/#61 task examples.",
-          "kind": "ops",
-          "lane": "Gameplay",
-          "nextAction": "",
-          "number": 61,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "P1: Phase B: gameplay findings do not yet bridge into Codex task pipeline",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/61",
-          "visionLayer": "resources"
-        },
-        {
-          "domain": "Agent OS",
-          "evidence": "One-shot Gameplay Evolution dry run produced useful advisory output in session_cron_be2c21e9fd73; recurring 12h Screeps Gameplay Evolution Review job c7b3dda8f1ac created for #task-queue delivery.",
-          "kind": "ops",
-          "lane": "Gameplay",
-          "nextAction": "",
-          "number": 60,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "P1: Phase C: 12h gameplay evolution review loop is not automated",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/60",
-          "visionLayer": "territory"
-        },
-        {
-          "domain": "Bot capability",
-          "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
-          "kind": "test",
-          "lane": "Gameplay",
-          "nextAction": "",
-          "number": 30,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/30",
-          "visionLayer": "resources"
-        },
-        {
-          "domain": "Docs/process",
-          "evidence": "PR #64 merged at 2026-04-27T02:09Z as 0377388; prod-ci and CodeRabbit green, Gemini no feedback, review threads empty, QA blocker resolved before merge.",
-          "kind": "docs",
-          "lane": "Gameplay",
-          "nextAction": "",
-          "number": 64,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "docs: add gameplay evolution roadmap",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/64",
-          "visionLayer": "territory"
-        },
-        {
-          "domain": "Bot capability",
-          "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
-          "kind": "test",
-          "lane": "Gameplay",
-          "nextAction": "",
-          "number": 76,
-          "priority": "P1",
-          "state": "",
-          "status": "Done",
-          "title": "test: add multi-tick spawn lifecycle coverage",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/76",
-          "visionLayer": "resources"
         }
       ],
       "columns": [
@@ -1100,44 +328,28 @@
               "status": "Backlog"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "domain": "Runtime monitor",
+                  "evidence": "",
+                  "kind": "ops",
+                  "lane": "Gameplay",
+                  "nextAction": "Use game-result evidence to drive roadmap, task, and release updates.",
+                  "number": 59,
+                  "priority": "P1",
+                  "state": "OPEN",
+                  "status": "Ready",
+                  "title": "Gameplay Evolution: game-result review to roadmap loop",
+                  "type": "Issue",
+                  "updatedAt": "2026-04-27T08:00:51Z",
+                  "url": "https://github.com/lanyusea/screeps/issues/59",
+                  "visionLayer": "territory"
+                }
+              ],
               "status": "Ready"
             },
             {
-              "cards": [
-                {
-                  "domain": "Docs/process",
-                  "evidence": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus offline console capture primitive. #29 remains active for real runtime-summary persistence/wiring; #62/#63/#30/#31 remain queued.",
-                  "kind": "ops",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 59,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "In progress",
-                  "title": "P1: Gameplay Evolution\u4e13\u9879\uff1avision-driven game-result review to roadmap/task loop",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/59",
-                  "visionLayer": "territory"
-                },
-                {
-                  "domain": "Bot capability",
-                  "evidence": "2026-04-27T19:09:52+08:00 scheduler claim: dispatched Codex dev agent in [redacted-path] on branch feat/zero-creep-emergency-31. File scope prod/src/** prod/test/** prod/dist/main.js. Acceptance: verify zero-creep/insufficient-energy emergency recovery behavior with tests; no secrets.",
-                  "kind": "test",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 31,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "In progress",
-                  "title": "P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/31",
-                  "visionLayer": "resources"
-                }
-              ],
+              "cards": [],
               "status": "In progress"
             },
             {
@@ -1145,104 +357,7 @@
               "status": "In review"
             },
             {
-              "cards": [
-                {
-                  "domain": "Agent OS",
-                  "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
-                  "kind": "ops",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 78,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P0: Agent OS continuation worker autonomous scheduler migration",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/78",
-                  "visionLayer": "resources"
-                },
-                {
-                  "domain": "Bot capability",
-                  "evidence": "Completed by merged PR #66 / 1f41670: durable Gameplay finding \u2192 GitHub issue/Project/Codex prompt bridge runbook with QA acceptance and first #29/#61 task examples.",
-                  "kind": "ops",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 61,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P1: Phase B: gameplay findings do not yet bridge into Codex task pipeline",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/61",
-                  "visionLayer": "resources"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "One-shot Gameplay Evolution dry run produced useful advisory output in session_cron_be2c21e9fd73; recurring 12h Screeps Gameplay Evolution Review job c7b3dda8f1ac created for #task-queue delivery.",
-                  "kind": "ops",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 60,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P1: Phase C: 12h gameplay evolution review loop is not automated",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/60",
-                  "visionLayer": "territory"
-                },
-                {
-                  "domain": "Bot capability",
-                  "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
-                  "kind": "test",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 30,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/30",
-                  "visionLayer": "resources"
-                },
-                {
-                  "domain": "Docs/process",
-                  "evidence": "PR #64 merged at 2026-04-27T02:09Z as 0377388; prod-ci and CodeRabbit green, Gemini no feedback, review threads empty, QA blocker resolved before merge.",
-                  "kind": "docs",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 64,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: add gameplay evolution roadmap",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/64",
-                  "visionLayer": "territory"
-                },
-                {
-                  "domain": "Bot capability",
-                  "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
-                  "kind": "test",
-                  "lane": "Gameplay",
-                  "nextAction": "",
-                  "number": 76,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "test: add multi-tick spawn lifecycle coverage",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/76",
-                  "visionLayer": "resources"
-                }
-              ],
+              "cards": [],
               "status": "Done"
             }
           ]
@@ -1253,35 +368,35 @@
             {
               "cards": [
                 {
-                  "domain": "Official MMO",
-                  "evidence": "Deploy preflight, private-smoke gate, monitor proof, official API verification",
+                  "domain": "Change-control",
+                  "evidence": "",
                   "kind": "ops",
                   "lane": "Foundation",
-                  "nextAction": "",
+                  "nextAction": "Hold official deploys until private-smoke and monitor proof are complete.",
                   "number": 33,
                   "priority": "P1",
-                  "state": "",
+                  "state": "OPEN",
                   "status": "Backlog",
-                  "title": "P1:Phase E:\u5b98\u65b9 MMO \u90e8\u7f72\u4ecd\u53d7\u79c1\u670d smoke release gate \u963b\u585e",
+                  "title": "Official MMO deployment blocked by private smoke gate",
                   "type": "Issue",
-                  "updatedAt": "",
+                  "updatedAt": "2026-04-26T06:57:18Z",
                   "url": "https://github.com/lanyusea/screeps/issues/33",
                   "visionLayer": "foundation blocker"
                 },
                 {
-                  "domain": "Runtime monitor",
-                  "evidence": "Private smoke failure modes mapped into alert-level telemetry",
+                  "domain": "Private smoke",
+                  "evidence": "",
                   "kind": "ops",
                   "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 32,
-                  "priority": "P2",
-                  "state": "",
+                  "nextAction": "Run a clean private-server smoke check and publish redacted evidence.",
+                  "number": 28,
+                  "priority": "P1",
+                  "state": "OPEN",
                   "status": "Backlog",
-                  "title": "P2:Phase C:alert-level telemetry \u9700\u8981\u57fa\u4e8e\u79c1\u670d smoke \u5931\u8d25\u6a21\u5f0f\u8865\u9f50",
+                  "title": "Private smoke harness clean live rerun",
                   "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/32",
+                  "updatedAt": "2026-04-27T11:31:36Z",
+                  "url": "https://github.com/lanyusea/screeps/issues/28",
                   "visionLayer": "foundation blocker"
                 }
               ],
@@ -1290,108 +405,107 @@
             {
               "cards": [
                 {
-                  "domain": "Runtime monitor",
-                  "evidence": "Issue created to connect runtime-alert signals to bounded tactical emergency triage.",
+                  "domain": "Change-control",
+                  "evidence": "",
                   "kind": "ops",
                   "lane": "Foundation",
-                  "nextAction": "",
+                  "nextAction": "Record expected KPI movement and proof for gameplay releases and hotfixes.",
+                  "number": 63,
+                  "priority": "P1",
+                  "state": "OPEN",
+                  "status": "Ready",
+                  "title": "Gameplay release cadence and emergency hotfix evidence",
+                  "type": "Issue",
+                  "updatedAt": "2026-04-26T17:09:40Z",
+                  "url": "https://github.com/lanyusea/screeps/issues/63",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Runtime monitor",
+                  "evidence": "",
+                  "kind": "docs",
+                  "lane": "Foundation",
+                  "nextAction": "Refine the public roadmap report presentation and English visible copy.",
+                  "number": 75,
+                  "priority": "P1",
+                  "state": "OPEN",
+                  "status": "Ready",
+                  "title": "Pages roadmap visual fidelity follow-up",
+                  "type": "Issue",
+                  "updatedAt": "2026-04-27T11:31:38Z",
+                  "url": "https://github.com/lanyusea/screeps/issues/75",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Runtime monitor",
+                  "evidence": "",
+                  "kind": "ops",
+                  "lane": "Foundation",
+                  "nextAction": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.",
+                  "number": 29,
+                  "priority": "P1",
+                  "state": "OPEN",
+                  "status": "Ready",
+                  "title": "Runtime summary and alert scheduled monitor delivery",
+                  "type": "Issue",
+                  "updatedAt": "2026-04-27T08:52:25Z",
+                  "url": "https://github.com/lanyusea/screeps/issues/29",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Runtime monitor",
+                  "evidence": "",
+                  "kind": "ops",
+                  "lane": "Foundation",
+                  "nextAction": "Connect alert signals to bounded tactical emergency triage.",
                   "number": 62,
                   "priority": "P1",
-                  "state": "",
+                  "state": "OPEN",
                   "status": "Ready",
-                  "title": "P1: Phase C: tactical emergency response is not wired to runtime alerts",
+                  "title": "Tactical emergency response wiring",
                   "type": "Issue",
-                  "updatedAt": "",
+                  "updatedAt": "2026-04-27T11:33:51Z",
                   "url": "https://github.com/lanyusea/screeps/issues/62",
                   "visionLayer": "foundation blocker"
                 },
                 {
-                  "domain": "Official MMO",
-                  "evidence": "Issue created to enforce gameplay-aware normal release cadence and emergency hotfix gates.",
+                  "domain": "Private smoke",
+                  "evidence": "",
                   "kind": "ops",
                   "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 63,
-                  "priority": "P1",
-                  "state": "",
+                  "nextAction": "Backfill alert telemetry based on private-smoke failure modes.",
+                  "number": 32,
+                  "priority": "P2",
+                  "state": "OPEN",
                   "status": "Ready",
-                  "title": "P1: Phase E: gameplay release cadence and emergency hotfix gate are not enforced",
+                  "title": "Alert-level telemetry from private smoke failures",
                   "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/63",
+                  "updatedAt": "2026-04-26T06:57:12Z",
+                  "url": "https://github.com/lanyusea/screeps/issues/32",
                   "visionLayer": "foundation blocker"
                 }
               ],
               "status": "Ready"
             },
             {
-              "cards": [
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty active review threads, controller diff-check + py_compile + 25 unittests PASS. Main fast-forwarded and PR branch/worktree cleaned.",
-                  "kind": "ops",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 29,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "In progress",
-                  "title": "P1:Phase C:runtime-summary/runtime-alert \u5b9a\u65f6\u76d1\u63a7\u6295\u9012\u5c1a\u672a\u5b8c\u6210",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/29",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Private smoke",
-                  "evidence": "2026-04-27T19:14:48+08:00 live private-smoke rerun attempted after self-test/dry-run PASS. Result REQUEST_CHANGES/BLOCKED: docker compose failed before screeps container start because 127.0.0.1:21025 and :21026 are already allocated by existing container screeps-private-smoke-pinned-screeps-1. Failed stack screeps-private-smoke-83dd9462 cleaned with docker compose down -v. No secrets printed; report path private-smoke-report-20260427T111321Z.json.",
-                  "kind": "ops",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 28,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "In progress",
-                  "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/28",
-                  "visionLayer": "foundation blocker"
-                }
-              ],
+              "cards": [],
               "status": "In progress"
             },
             {
               "cards": [
                 {
-                  "domain": "Docs/process",
-                  "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
-                  "kind": "docs",
+                  "domain": "Bot capability",
+                  "evidence": "",
+                  "kind": "code",
                   "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 75,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "In review",
-                  "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/75",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Docs/process",
-                  "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
+                  "nextAction": "Polish the generated roadmap page and publish sanitized public artifacts.",
                   "number": 77,
                   "priority": "P1",
-                  "state": "",
+                  "state": "OPEN",
                   "status": "In review",
-                  "title": "fix: polish roadmap page visual fidelity",
+                  "title": "Roadmap report public artifact polish",
                   "type": "PullRequest",
-                  "updatedAt": "",
+                  "updatedAt": "2026-04-27T11:31:40Z",
                   "url": "https://github.com/lanyusea/screeps/pull/77",
                   "visionLayer": "foundation blocker"
                 }
@@ -1399,648 +513,7 @@
               "status": "In review"
             },
             {
-              "cards": [
-                {
-                  "domain": "Agent OS",
-                  "evidence": "PR #42 merged at 2026-04-26T08:26:48Z after QA PASS; issue #41 closed; docs-only QA acceptance gate landed without touching PR #40-owned files.",
-                  "kind": "ops",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 41,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "Establish dedicated QA acceptance-check agent gate",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/41",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monitor, typed fanouts, runtime summary, and resumed bounded continuation worker all finalized with fresh output artifacts/no delivery errors; continuation restored to 5m cadence.",
-                  "kind": "ops",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 27,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P0:P0 agent-ops:P0 \u76d1\u63a7\u4e0e Discord \u8def\u7531\u5065\u5eb7\u9700\u8981\u6301\u7eed\u9a8c\u8bc1",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/27",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "PR documenting GitHub roadmap management contract; verifies milestones/project fields/items",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 36,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P0:P0 change-control:GitHub Milestones/Project roadmap source-of-truth \u5408\u540c\u672a\u5165\u5e93",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/36",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "Read-only inspection: main protected=false; branch protection API 404; active ruleset 'defualt' has no rules; prod-ci exists but path filters made it unsuitable as universal required check. PR #45 opened to make check always present.",
-                  "kind": "ops",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 26,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P0:P0 change-control:main \u5206\u652f\u4fdd\u62a4\u4e0e CI \u5fc5\u8fc7\u95e8\u7981\u5c1a\u672a\u786e\u8ba4",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/26",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "PR #48 merged at 2026-04-26T10:17:39Z; merge commit 955a0df records owner governance decisions in docs/AGENTS.",
-                  "kind": "ops",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 47,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P0:P0 change-control:owner roadmap governance decisions need durable contract sync",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/47",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "PR #34; issue form + PR template + docs contract",
-                  "kind": "ops",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 22,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P0:P0 change-control:\u5df2\u77e5\u95ee\u9898\u672a\u5f3a\u5236\u8fdb\u5165 GitHub issue \u4e0e PR \u5173\u8054\u6d41\u7a0b",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/22",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "PR #40 merged at 2026-04-26T08:19:33Z; issue closed via Fixes #39; main fast-forwarded to d64f30a.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 39,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P0:P0 change-control:\u6240\u6709 agent \u4efb\u52a1\u5b8c\u6210\u6807\u51c6\u7f3a\u5c11 GitHub \u72b6\u6001\u66f4\u65b0\u95e8\u7981",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/39",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "Fixes #22; PR templates/issue form docs",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 34,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "chore: add issue and PR management templates",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/34",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "Merged PR #45 made prod verification required-check friendly; main ruleset now requires Verify prod TypeScript, Jest, and bundle.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 45,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "ci: make prod verification required-check friendly",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/45",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "PR #42 establishes dedicated QA acceptance gate; merged 2026-04-26.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 42,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: add QA acceptance gate",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/42",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 79,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: define autonomous scheduler contract",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/79",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "Fixes #36; docs-only roadmap management contract",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 37,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record GitHub roadmap management contract",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/37",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "PR #53 merged at 2026-04-26T13:03:35Z as 0bca111 after >=15m, prod-ci SUCCESS, CodeRabbit no actionable comments, Gemini no feedback, no review threads.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 53,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record P0 cron finalization gap",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/53",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "PR #54 merged via squash at 2026-04-26T13:40:29Z; merge commit 0ebed16931f044bd4ab02800f0425cdaac7c3d0d; required check Verify prod TypeScript, Jest, and bundle SUCCESS; CodeRabbit status SUCCESS; review thread PRRT_kwDOSMSsO859qLyO resolved.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 54,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record P0 scheduler recovery",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/54",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "P0 visibility repair process note PR",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 21,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record P0 visibility repair",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/21",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Docs/process",
-                  "evidence": "PR #38 records PR #37 merge checkpoint; merged 2026-04-26.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 38,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record PR 37 merge checkpoint",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/38",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "Merged PR #46 records CI/ruleset gate completion; checks green (prod-ci SUCCESS, CodeRabbit SUCCESS); Gemini no feedback; merge commit 459a528.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 46,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record ci required gate completion",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/46",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Change-control",
-                  "evidence": "Merged PR #48 at 2026-04-26T10:17:39Z after >=15m, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, QA PASS; merge commit 955a0df.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 48,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record owner governance decisions",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/48",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "PR #43 documents scheduler alert gap audit; merged 2026-04-26.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 43,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record scheduler alert gap audit",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/43",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "2026-04-26T18:26+08: PR #49 merged at 2026-04-26T10:23:37Z as 0343354734a48f173efa38f365c4cc12d76f2cc5 after gates passed: prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini COMMENTED with no feedback, review threads empty.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 49,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record scheduler cadence audit",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/49",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "PR #52 documents 19:48 metadata-only scheduler cadence audit; prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini no feedback, no review threads; linked to #27.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 52,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record scheduler cadence audit at 1948",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/52",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "PR #50 merged at 2026-04-26T10:49:25Z as 87512b615cc03e5364044dea41776a0b381c682c. Gates: >=15m wait satisfied, prod-ci SUCCESS, CodeRabbit SUCCESS status, Gemini no feedback, no unresolved live review threads.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 50,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record scheduler cadence audit follow-up",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/50",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "Merged PR #44 documents scheduler cadence follow-up and links issue #27/#29; CodeRabbit SUCCESS; Gemini no critical feedback.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 44,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record scheduler cadence follow-up",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/44",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "PR #56 documents renewed scheduler cadence regression; prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback; body patched with Related to #27.",
-                  "kind": "review",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 56,
-                  "priority": "P0",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record scheduler cadence regression",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/56",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Private smoke",
-                  "evidence": "Linked PR #16 / smoke harness verification evidence",
-                  "kind": "bug",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 23,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P1:Phase D:\u79c1\u670d smoke STEAM_KEY \u6587\u4ef6\u6743\u9650\u66fe\u5bfc\u81f4\u5bb9\u5668\u4e0d\u53ef\u8bfb",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/23",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Docs/process",
-                  "evidence": "PR #66 merged at 2026-04-27T03:29:27Z as 1f41670 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, and empty GraphQL review threads.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 66,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: define gameplay finding Codex bridge",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/66",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Docs/process",
-                  "evidence": "PR #55 merged after green checks/reviews; README now has formal community-facing description, logo asset, Discord invite, and docs lane mapping.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 55,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: prepare community-facing README",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/55",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "Merged PR #71 as 454e2cf after >=15m gate, green prod-ci/CodeRabbit, Gemini no-feedback review, and no active review threads; remote/local branch cleaned.",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 71,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record KPI persistence wiring checkpoint",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/71",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Docs/process",
-                  "evidence": "PR #57 merged at 2026-04-26T15:17:58Z as cbe3641 after >=15m, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, and no unresolved review threads.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 57,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record P0 scheduler recovery checkpoint",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/57",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Docs/process",
-                  "evidence": "PR #58 merged at 2026-04-26T15:41:46Z as c6120dc after prod-ci success, CodeRabbit success, Gemini no feedback, and resolved/outdated review thread.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 58,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: record P0 scheduler repair completion",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/58",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "evidence": "PR #40 merged at 2026-04-26T08:19:33Z; CodeRabbit success; review threads empty; main at d64f30a.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 40,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "docs: require GitHub state updates before agent completion",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/40",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "Merged PR #70 as c21f1bb at 2026-04-27T06:09:41Z. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after 391d572, three prior review threads resolved/outdated, >=15m elapsed, controller QA checks passed.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 70,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "feat: add Codex-authored Pages roadmap report",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/70",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "Closed as superseded by Codex-authored PR #70 because PR #69 contained direct Hermes-authored implementation commits and an unresolved Python 3.10 compatibility review thread.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 69,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "feat: add GitHub Pages roadmap live report",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/69",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "PR #68 merged at 2026-04-27T05:09:10Z as da20ac4 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini no feedback, and GraphQL review thread resolved.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 68,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "feat: add runtime KPI artifact bridge",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/68",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "Merged PR #67 as f32cdc3 after review fixes 10d588a/ee5e852; checks passed (prod-ci, CodeRabbit), review threads resolved, main fast-forwarded and PR branch deleted.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 67,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "feat: add runtime KPI reducer",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/67",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "Merged PR #65 at 2026-04-27T02:49:49Z as 4d90ecd. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, GraphQL review threads empty, >=15m elapsed, controller-side typecheck/test/build PASS.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 65,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "feat: add runtime KPI telemetry",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/65",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "Merged as 57b4b3a at 2026-04-27T08:49Z. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL active review threads, >=15m elapsed, controller diff-check + py_compile + 25 unittests PASS. Local main fast-forwarded; remote/local branch deleted.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 74,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "feat: capture official console runtime summaries",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/74",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "Merged PR #73 as 9762b7a at 2026-04-27T07:51Z after prod-ci SUCCESS, CodeRabbit SUCCESS, all review threads resolved, and >=15m gate.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 73,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "feat: capture runtime summary console artifacts",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/73",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Runtime monitor",
-                  "evidence": "PR #72 final head 99eb926 merged at 2026-04-27T07:57:41Z as merge commit 366cfdc. Evidence: py_compile PASS; current artifacts verify SQLite 660 rows/33 metrics/latest enemy_kills NULL instrumented=0, no WAL/SHM, HTML title+five sections+3 KPI cards/forbidden strings absent, LFS attrs/pointer, diff-check main..HEAD, secret scan over 4 PR-diff files. Checks green: CodeRabbit pass, prod-ci pass.",
-                  "kind": "code",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 72,
-                  "priority": "P1",
-                  "state": "",
-                  "status": "Done",
-                  "title": "fix: restore roadmap Pages report layout",
-                  "type": "PullRequest",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/pull/72",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Docs/process",
-                  "evidence": "Closed issue / PR #19",
-                  "kind": "docs",
-                  "lane": "Foundation",
-                  "nextAction": "",
-                  "number": 24,
-                  "priority": "P2",
-                  "state": "",
-                  "status": "Done",
-                  "title": "P2:Phase A:\u6839\u76ee\u5f55 AGENT.md \u6307\u9488\u6587\u4ef6\u5df2\u5e9f\u5f03\u4f46\u66fe\u6b8b\u7559",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/24",
-                  "visionLayer": "foundation blocker"
-                }
-              ],
+              "cards": [],
               "status": "Done"
             }
           ]
@@ -2051,7 +524,7 @@
       {
         "instrumented": true,
         "label": "Open roadmap issues",
-        "value": 9
+        "value": 8
       },
       {
         "instrumented": true,
@@ -2061,1089 +534,25 @@
       {
         "instrumented": true,
         "label": "Blocked cards",
-        "value": 4
+        "value": 2
       },
       {
         "instrumented": true,
         "label": "Project cards",
-        "value": 56
+        "value": 0
       },
       {
         "instrumented": true,
         "label": "In progress",
-        "value": 4
+        "value": 0
       },
       {
         "instrumented": true,
         "label": "In review",
-        "value": 2
+        "value": 0
       }
     ],
-    "projectItems": [
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "PR #34; issue form + PR template + docs contract",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p0",
-          "roadmap",
-          "roadmap:p0-change-control"
-        ],
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 22,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "P0:P0 change-control:\u5df2\u77e5\u95ee\u9898\u672a\u5f3a\u5236\u8fdb\u5165 GitHub issue \u4e0e PR \u5173\u8054\u6d41\u7a0b",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/22"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Private smoke",
-        "evidence": "Linked PR #16 / smoke harness verification evidence",
-        "kind": "bug",
-        "labels": [
-          "kind:bug",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-d-private-smoke"
-        ],
-        "milestone": "Phase D: Private-server smoke release gate",
-        "nextAction": "",
-        "number": 23,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "P1:Phase D:\u79c1\u670d smoke STEAM_KEY \u6587\u4ef6\u6743\u9650\u66fe\u5bfc\u81f4\u5bb9\u5668\u4e0d\u53ef\u8bfb",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/23"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "Closed issue / PR #19",
-        "kind": "docs",
-        "labels": [
-          "kind:docs",
-          "priority:p2",
-          "roadmap:phase-a-docs-sync"
-        ],
-        "milestone": "",
-        "nextAction": "",
-        "number": 24,
-        "priority": "P2",
-        "state": "",
-        "status": "Done",
-        "title": "P2:Phase A:\u6839\u76ee\u5f55 AGENT.md \u6307\u9488\u6587\u4ef6\u5df2\u5e9f\u5f03\u4f46\u66fe\u6b8b\u7559",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/24"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "Read-only inspection: main protected=false; branch protection API 404; active ruleset 'defualt' has no rules; prod-ci exists but path filters made it unsuitable as universal required check. PR #45 opened to make check always present.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p0",
-          "roadmap",
-          "roadmap:p0-change-control"
-        ],
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 26,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "P0:P0 change-control:main \u5206\u652f\u4fdd\u62a4\u4e0e CI \u5fc5\u8fc7\u95e8\u7981\u5c1a\u672a\u786e\u8ba4",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/26"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monitor, typed fanouts, runtime summary, and resumed bounded continuation worker all finalized with fresh output artifacts/no delivery errors; continuation restored to 5m cadence.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p0",
-          "roadmap",
-          "roadmap:p0-agent-ops"
-        ],
-        "milestone": "P0: Agent OS / Discord visibility gate",
-        "nextAction": "",
-        "number": 27,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "P0:P0 agent-ops:P0 \u76d1\u63a7\u4e0e Discord \u8def\u7531\u5065\u5eb7\u9700\u8981\u6301\u7eed\u9a8c\u8bc1",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/27"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Private smoke",
-        "evidence": "2026-04-27T19:14:48+08:00 live private-smoke rerun attempted after self-test/dry-run PASS. Result REQUEST_CHANGES/BLOCKED: docker compose failed before screeps container start because 127.0.0.1:21025 and :21026 are already allocated by existing container screeps-private-smoke-pinned-screeps-1. Failed stack screeps-private-smoke-83dd9462 cleaned with docker compose down -v. No secrets printed; report path private-smoke-report-20260427T111321Z.json.",
-        "kind": "ops",
-        "labels": [
-          "blocked",
-          "kind:ops",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-d-private-smoke"
-        ],
-        "milestone": "Phase D: Private-server smoke release gate",
-        "nextAction": "",
-        "number": 28,
-        "priority": "P1",
-        "state": "",
-        "status": "In progress",
-        "title": "P1:Phase D:\u79c1\u670d smoke harness clean live rerun \u672a\u5b8c\u6210",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/28"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "PR #74 merged as 57b4b3a at 2026-04-27T08:49Z after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty active review threads, controller diff-check + py_compile + 25 unittests PASS. Main fast-forwarded and PR branch/worktree cleaned.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-c-telemetry"
-        ],
-        "milestone": "Phase C: Runtime telemetry / monitor gate",
-        "nextAction": "",
-        "number": 29,
-        "priority": "P1",
-        "state": "",
-        "status": "In progress",
-        "title": "P1:Phase C:runtime-summary/runtime-alert \u5b9a\u65f6\u76d1\u63a7\u6295\u9012\u5c1a\u672a\u5b8c\u6210",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/29"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Bot capability",
-        "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
-        "kind": "test",
-        "labels": [
-          "kind:test",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-b-spawn-lifecycle"
-        ],
-        "milestone": "Phase B: Bot capability hardening gate",
-        "nextAction": "",
-        "number": 30,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "P1:Phase B:mock harness \u7f3a\u5c11\u591a tick spawn.spawning \u751f\u547d\u5468\u671f\u4eff\u771f",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/30"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Bot capability",
-        "evidence": "2026-04-27T19:09:52+08:00 scheduler claim: dispatched Codex dev agent in [redacted-path] on branch feat/zero-creep-emergency-31. File scope prod/src/** prod/test/** prod/dist/main.js. Acceptance: verify zero-creep/insufficient-energy emergency recovery behavior with tests; no secrets.",
-        "kind": "test",
-        "labels": [
-          "kind:test",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-b-spawn-lifecycle"
-        ],
-        "milestone": "Phase B: Bot capability hardening gate",
-        "nextAction": "",
-        "number": 31,
-        "priority": "P1",
-        "state": "",
-        "status": "In progress",
-        "title": "P1:Phase B:zero-creep/insufficient-energy emergency recovery \u8986\u76d6\u9700\u786e\u8ba4",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/31"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "Private smoke failure modes mapped into alert-level telemetry",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p2",
-          "roadmap",
-          "roadmap:phase-c-telemetry"
-        ],
-        "milestone": "Phase C: Runtime telemetry / monitor gate",
-        "nextAction": "",
-        "number": 32,
-        "priority": "P2",
-        "state": "",
-        "status": "Backlog",
-        "title": "P2:Phase C:alert-level telemetry \u9700\u8981\u57fa\u4e8e\u79c1\u670d smoke \u5931\u8d25\u6a21\u5f0f\u8865\u9f50",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/32"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Official MMO",
-        "evidence": "Deploy preflight, private-smoke gate, monitor proof, official API verification",
-        "kind": "ops",
-        "labels": [
-          "blocked",
-          "kind:ops",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-e-mmo-deploy"
-        ],
-        "milestone": "Phase E: Official MMO deployment gate",
-        "nextAction": "",
-        "number": 33,
-        "priority": "P1",
-        "state": "",
-        "status": "Backlog",
-        "title": "P1:Phase E:\u5b98\u65b9 MMO \u90e8\u7f72\u4ecd\u53d7\u79c1\u670d smoke release gate \u963b\u585e",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/33"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "Fixes #22; PR templates/issue form docs",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 34,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "chore: add issue and PR management templates",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/34"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "P0 visibility repair process note PR",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 21,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record P0 visibility repair",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/21"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "PR documenting GitHub roadmap management contract; verifies milestones/project fields/items",
-        "kind": "docs",
-        "labels": [
-          "kind:docs",
-          "priority:p0",
-          "roadmap",
-          "roadmap:p0-change-control"
-        ],
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 36,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "P0:P0 change-control:GitHub Milestones/Project roadmap source-of-truth \u5408\u540c\u672a\u5165\u5e93",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/36"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "Fixes #36; docs-only roadmap management contract",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 37,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record GitHub roadmap management contract",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/37"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "PR #40 merged at 2026-04-26T08:19:33Z; issue closed via Fixes #39; main fast-forwarded to d64f30a.",
-        "kind": "docs",
-        "labels": [
-          "kind:docs",
-          "priority:p0",
-          "roadmap",
-          "roadmap:p0-change-control"
-        ],
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 39,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "P0:P0 change-control:\u6240\u6709 agent \u4efb\u52a1\u5b8c\u6210\u6807\u51c6\u7f3a\u5c11 GitHub \u72b6\u6001\u66f4\u65b0\u95e8\u7981",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/39"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "PR #40 merged at 2026-04-26T08:19:33Z; CodeRabbit success; review threads empty; main at d64f30a.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 40,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "docs: require GitHub state updates before agent completion",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/40"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "PR #42 merged at 2026-04-26T08:26:48Z after QA PASS; issue #41 closed; docs-only QA acceptance gate landed without touching PR #40-owned files.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p0",
-          "roadmap",
-          "roadmap:p0-agent-ops"
-        ],
-        "milestone": "P0: Agent OS / Discord visibility gate",
-        "nextAction": "",
-        "number": 41,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "Establish dedicated QA acceptance-check agent gate",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/41"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "Merged PR #44 documents scheduler cadence follow-up and links issue #27/#29; CodeRabbit SUCCESS; Gemini no critical feedback.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 44,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record scheduler cadence follow-up",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/44"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "Merged PR #45 made prod verification required-check friendly; main ruleset now requires Verify prod TypeScript, Jest, and bundle.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 45,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "ci: make prod verification required-check friendly",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/45"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "Merged PR #46 records CI/ruleset gate completion; checks green (prod-ci SUCCESS, CodeRabbit SUCCESS); Gemini no feedback; merge commit 459a528.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 46,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record ci required gate completion",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/46"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "PR #43 documents scheduler alert gap audit; merged 2026-04-26.",
-        "kind": "docs",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 43,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record scheduler alert gap audit",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/43"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "PR #42 establishes dedicated QA acceptance gate; merged 2026-04-26.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 42,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: add QA acceptance gate",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/42"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "PR #38 records PR #37 merge checkpoint; merged 2026-04-26.",
-        "kind": "docs",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 38,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record PR 37 merge checkpoint",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/38"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "PR #48 merged at 2026-04-26T10:17:39Z; merge commit 955a0df records owner governance decisions in docs/AGENTS.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p0",
-          "roadmap",
-          "roadmap:p0-change-control"
-        ],
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 47,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "P0:P0 change-control:owner roadmap governance decisions need durable contract sync",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/47"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Change-control",
-        "evidence": "Merged PR #48 at 2026-04-26T10:17:39Z after >=15m, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, QA PASS; merge commit 955a0df.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 48,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record owner governance decisions",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/48"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "2026-04-26T18:26+08: PR #49 merged at 2026-04-26T10:23:37Z as 0343354734a48f173efa38f365c4cc12d76f2cc5 after gates passed: prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini COMMENTED with no feedback, review threads empty.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 49,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record scheduler cadence audit",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/49"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "PR #50 merged at 2026-04-26T10:49:25Z as 87512b615cc03e5364044dea41776a0b381c682c. Gates: >=15m wait satisfied, prod-ci SUCCESS, CodeRabbit SUCCESS status, Gemini no feedback, no unresolved live review threads.",
-        "kind": "docs",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 50,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record scheduler cadence audit follow-up",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/50"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "PR #52 documents 19:48 metadata-only scheduler cadence audit; prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini no feedback, no review threads; linked to #27.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 52,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record scheduler cadence audit at 1948",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/52"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "PR #53 merged at 2026-04-26T13:03:35Z as 0bca111 after >=15m, prod-ci SUCCESS, CodeRabbit no actionable comments, Gemini no feedback, no review threads.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 53,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record P0 cron finalization gap",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/53"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "PR #54 merged via squash at 2026-04-26T13:40:29Z; merge commit 0ebed16931f044bd4ab02800f0425cdaac7c3d0d; required check Verify prod TypeScript, Jest, and bundle SUCCESS; CodeRabbit status SUCCESS; review thread PRRT_kwDOSMSsO859qLyO resolved.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 54,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record P0 scheduler recovery",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/54"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "PR #55 merged after green checks/reviews; README now has formal community-facing description, logo asset, Discord invite, and docs lane mapping.",
-        "kind": "docs",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 55,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "docs: prepare community-facing README",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/55"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "PR #56 documents renewed scheduler cadence regression; prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback; body patched with Related to #27.",
-        "kind": "review",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 56,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record scheduler cadence regression",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/56"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "PR #57 merged at 2026-04-26T15:17:58Z as cbe3641 after >=15m, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, and no unresolved review threads.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 57,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record P0 scheduler recovery checkpoint",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/57"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "PR #58 merged at 2026-04-26T15:41:46Z as c6120dc after prod-ci success, CodeRabbit success, Gemini no feedback, and resolved/outdated review thread.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 58,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record P0 scheduler repair completion",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/58"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "PR #73 merged as 9762b7a and PR #72 merged as 366cfdc; Gameplay Evolution has Pages/KPI report surface plus offline console capture primitive. #29 remains active for real runtime-summary persistence/wiring; #62/#63/#30/#31 remain queued.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-c-telemetry"
-        ],
-        "milestone": "Phase C: Runtime telemetry / monitor gate",
-        "nextAction": "",
-        "number": 59,
-        "priority": "P1",
-        "state": "",
-        "status": "In progress",
-        "title": "P1: Gameplay Evolution\u4e13\u9879\uff1avision-driven game-result review to roadmap/task loop",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/59"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "One-shot Gameplay Evolution dry run produced useful advisory output in session_cron_be2c21e9fd73; recurring 12h Screeps Gameplay Evolution Review job c7b3dda8f1ac created for #task-queue delivery.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-c-telemetry"
-        ],
-        "milestone": "Phase C: Runtime telemetry / monitor gate",
-        "nextAction": "",
-        "number": 60,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "P1: Phase C: 12h gameplay evolution review loop is not automated",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/60"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Bot capability",
-        "evidence": "Completed by merged PR #66 / 1f41670: durable Gameplay finding \u2192 GitHub issue/Project/Codex prompt bridge runbook with QA acceptance and first #29/#61 task examples.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-b-spawn-lifecycle"
-        ],
-        "milestone": "Phase B: Bot capability hardening gate",
-        "nextAction": "",
-        "number": 61,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "P1: Phase B: gameplay findings do not yet bridge into Codex task pipeline",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/61"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "Issue created to connect runtime-alert signals to bounded tactical emergency triage.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-c-telemetry"
-        ],
-        "milestone": "Phase C: Runtime telemetry / monitor gate",
-        "nextAction": "",
-        "number": 62,
-        "priority": "P1",
-        "state": "",
-        "status": "Ready",
-        "title": "P1: Phase C: tactical emergency response is not wired to runtime alerts",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/62"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Official MMO",
-        "evidence": "Issue created to enforce gameplay-aware normal release cadence and emergency hotfix gates.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-e-mmo-deploy"
-        ],
-        "milestone": "Phase E: Official MMO deployment gate",
-        "nextAction": "",
-        "number": 63,
-        "priority": "P1",
-        "state": "",
-        "status": "Ready",
-        "title": "P1: Phase E: gameplay release cadence and emergency hotfix gate are not enforced",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/63"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "PR #64 merged at 2026-04-27T02:09Z as 0377388; prod-ci and CodeRabbit green, Gemini no feedback, review threads empty, QA blocker resolved before merge.",
-        "kind": "docs",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 64,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "docs: add gameplay evolution roadmap",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/64"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "Merged PR #65 at 2026-04-27T02:49:49Z as 4d90ecd. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, GraphQL review threads empty, >=15m elapsed, controller-side typecheck/test/build PASS.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 65,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "feat: add runtime KPI telemetry",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/65"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "PR #66 merged at 2026-04-27T03:29:27Z as 1f41670 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, and empty GraphQL review threads.",
-        "kind": "docs",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 66,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "docs: define gameplay finding Codex bridge",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/66"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "Merged PR #67 as f32cdc3 after review fixes 10d588a/ee5e852; checks passed (prod-ci, CodeRabbit), review threads resolved, main fast-forwarded and PR branch deleted.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 67,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "feat: add runtime KPI reducer",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/67"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "PR #68 merged at 2026-04-27T05:09:10Z as da20ac4 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS, Gemini no feedback, and GraphQL review thread resolved.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 68,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "feat: add runtime KPI artifact bridge",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/68"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "Closed as superseded by Codex-authored PR #70 because PR #69 contained direct Hermes-authored implementation commits and an unresolved Python 3.10 compatibility review thread.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 69,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "feat: add GitHub Pages roadmap live report",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/69"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "Merged PR #70 as c21f1bb at 2026-04-27T06:09:41Z. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after 391d572, three prior review threads resolved/outdated, >=15m elapsed, controller QA checks passed.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 70,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "feat: add Codex-authored Pages roadmap report",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/70"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "Merged PR #71 as 454e2cf after >=15m gate, green prod-ci/CodeRabbit, Gemini no-feedback review, and no active review threads; remote/local branch cleaned.",
-        "kind": "docs",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 71,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "docs: record KPI persistence wiring checkpoint",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/71"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "PR #72 final head 99eb926 merged at 2026-04-27T07:57:41Z as merge commit 366cfdc. Evidence: py_compile PASS; current artifacts verify SQLite 660 rows/33 metrics/latest enemy_kills NULL instrumented=0, no WAL/SHM, HTML title+five sections+3 KPI cards/forbidden strings absent, LFS attrs/pointer, diff-check main..HEAD, secret scan over 4 PR-diff files. Checks green: CodeRabbit pass, prod-ci pass.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 72,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "fix: restore roadmap Pages report layout",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/72"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "Merged PR #73 as 9762b7a at 2026-04-27T07:51Z after prod-ci SUCCESS, CodeRabbit SUCCESS, all review threads resolved, and >=15m gate.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 73,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "feat: capture runtime summary console artifacts",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/73"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Runtime monitor",
-        "evidence": "Merged as 57b4b3a at 2026-04-27T08:49Z. Gates: prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL active review threads, >=15m elapsed, controller diff-check + py_compile + 25 unittests PASS. Local main fast-forwarded; remote/local branch deleted.",
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 74,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "feat: capture official console runtime summaries",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/74"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
-        "kind": "docs",
-        "labels": [
-          "kind:docs",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-c-telemetry"
-        ],
-        "milestone": "",
-        "nextAction": "",
-        "number": 75,
-        "priority": "P1",
-        "state": "",
-        "status": "In review",
-        "title": "P1: GitHub Pages roadmap report visual fidelity follow-up",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/75"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Bot capability",
-        "evidence": "PR #76 merged at 2026-04-27T09:29:51Z as e02095a after prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, empty GraphQL review threads, and >=15m gate. [redacted-path] fast-forwarded to e02095a with clean status.",
-        "kind": "test",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 76,
-        "priority": "P1",
-        "state": "",
-        "status": "Done",
-        "title": "test: add multi-tick spawn lifecycle coverage",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/76"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Docs/process",
-        "evidence": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path] on branch feat/pages-visual-fidelity-75 for PR #77. Scope scripts/generate-roadmap-page.py docs/index.html docs/roadmap-data.json docs/roadmap-kpi.sqlite. Blocker: unresolved CodeRabbit public-artifact leak thread and branch BEHIND.",
-        "kind": "docs",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 77,
-        "priority": "P1",
-        "state": "",
-        "status": "In review",
-        "title": "fix: polish roadmap page visual fidelity",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/77"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p0",
-          "roadmap",
-          "roadmap:p0-agent-ops"
-        ],
-        "milestone": "",
-        "nextAction": "",
-        "number": 78,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "P0: Agent OS continuation worker autonomous scheduler migration",
-        "type": "Issue",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/issues/78"
-      },
-      {
-        "blockedBy": "",
-        "domain": "Agent OS",
-        "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
-        "kind": "docs",
-        "labels": [],
-        "milestone": "",
-        "nextAction": "",
-        "number": 79,
-        "priority": "P0",
-        "state": "",
-        "status": "Done",
-        "title": "docs: define autonomous scheduler contract",
-        "type": "PullRequest",
-        "updatedAt": "",
-        "url": "https://github.com/lanyusea/screeps/pull/79"
-      }
-    ],
+    "projectItems": [],
     "pullRequests": [
       {
         "checks": {
@@ -3165,165 +574,113 @@
         "status": "In review",
         "title": "fix: polish roadmap page visual fidelity",
         "type": "PullRequest",
-        "updatedAt": "2026-04-27T11:10:04Z",
+        "updatedAt": "2026-04-27T11:31:40Z",
         "url": "https://github.com/lanyusea/screeps/pull/77"
       }
     ],
     "roadmapCards": [
       {
-        "domain": "Agent OS",
-        "evidence": "PR #42 merged at 2026-04-26T08:26:48Z after QA PASS; issue #41 closed; docs-only QA acceptance gate landed without touching PR #40-owned files.",
-        "milestone": "P0: Agent OS / Discord visibility gate",
-        "nextAction": "",
-        "number": 41,
-        "priority": "P0",
-        "status": "Done",
-        "title": "Establish dedicated QA acceptance-check agent gate",
+        "domain": "Runtime monitor",
+        "evidence": "",
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "nextAction": "Use game-result evidence to drive roadmap, task, and release updates.",
+        "number": 59,
+        "priority": "P1",
+        "status": "Ready",
+        "title": "Gameplay Evolution: game-result review to roadmap loop",
         "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/41",
+        "url": "https://github.com/lanyusea/screeps/issues/59",
+        "visionLayer": "territory"
+      },
+      {
+        "domain": "Change-control",
+        "evidence": "",
+        "milestone": "Phase E: Official MMO deployment gate",
+        "nextAction": "Record expected KPI movement and proof for gameplay releases and hotfixes.",
+        "number": 63,
+        "priority": "P1",
+        "status": "Ready",
+        "title": "Gameplay release cadence and emergency hotfix evidence",
+        "type": "Issue",
+        "url": "https://github.com/lanyusea/screeps/issues/63",
         "visionLayer": "foundation blocker"
       },
       {
-        "domain": "Agent OS",
-        "evidence": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments after fix, Gemini no feedback, active review threads=0. [redacted-path] fast-forwarded to db25074; continuation scheduler prompt already live/resumed.",
+        "domain": "Runtime monitor",
+        "evidence": "",
         "milestone": "",
-        "nextAction": "",
-        "number": 78,
-        "priority": "P0",
-        "status": "Done",
-        "title": "P0: Agent OS continuation worker autonomous scheduler migration",
+        "nextAction": "Refine the public roadmap report presentation and English visible copy.",
+        "number": 75,
+        "priority": "P1",
+        "status": "Ready",
+        "title": "Pages roadmap visual fidelity follow-up",
         "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/78",
-        "visionLayer": "resources"
+        "url": "https://github.com/lanyusea/screeps/issues/75",
+        "visionLayer": "foundation blocker"
       },
       {
-        "domain": "Agent OS",
-        "evidence": "P0 repair completed: PR #58 merged as c6120dc; 4h checkpoint, runtime-alert, P0 monitor, typed fanouts, runtime summary, and resumed bounded continuation worker all finalized with fresh output artifacts/no delivery errors; continuation restored to 5m cadence.",
-        "milestone": "P0: Agent OS / Discord visibility gate",
-        "nextAction": "",
-        "number": 27,
-        "priority": "P0",
-        "status": "Done",
-        "title": "P0:P0 agent-ops:P0 \u76d1\u63a7\u4e0e Discord \u8def\u7531\u5065\u5eb7\u9700\u8981\u6301\u7eed\u9a8c\u8bc1",
+        "domain": "Runtime monitor",
+        "evidence": "",
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "nextAction": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.",
+        "number": 29,
+        "priority": "P1",
+        "status": "Ready",
+        "title": "Runtime summary and alert scheduled monitor delivery",
         "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/27",
+        "url": "https://github.com/lanyusea/screeps/issues/29",
+        "visionLayer": "foundation blocker"
+      },
+      {
+        "domain": "Runtime monitor",
+        "evidence": "",
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "nextAction": "Connect alert signals to bounded tactical emergency triage.",
+        "number": 62,
+        "priority": "P1",
+        "status": "Ready",
+        "title": "Tactical emergency response wiring",
+        "type": "Issue",
+        "url": "https://github.com/lanyusea/screeps/issues/62",
         "visionLayer": "foundation blocker"
       },
       {
         "domain": "Change-control",
-        "evidence": "PR documenting GitHub roadmap management contract; verifies milestones/project fields/items",
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 36,
-        "priority": "P0",
-        "status": "Done",
-        "title": "P0:P0 change-control:GitHub Milestones/Project roadmap source-of-truth \u5408\u540c\u672a\u5165\u5e93",
+        "evidence": "",
+        "milestone": "Phase E: Official MMO deployment gate",
+        "nextAction": "Hold official deploys until private-smoke and monitor proof are complete.",
+        "number": 33,
+        "priority": "P1",
+        "status": "Backlog",
+        "title": "Official MMO deployment blocked by private smoke gate",
         "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/36",
+        "url": "https://github.com/lanyusea/screeps/issues/33",
         "visionLayer": "foundation blocker"
       },
       {
-        "domain": "Change-control",
-        "evidence": "Read-only inspection: main protected=false; branch protection API 404; active ruleset 'defualt' has no rules; prod-ci exists but path filters made it unsuitable as universal required check. PR #45 opened to make check always present.",
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 26,
-        "priority": "P0",
-        "status": "Done",
-        "title": "P0:P0 change-control:main \u5206\u652f\u4fdd\u62a4\u4e0e CI \u5fc5\u8fc7\u95e8\u7981\u5c1a\u672a\u786e\u8ba4",
+        "domain": "Private smoke",
+        "evidence": "",
+        "milestone": "Phase D: Private-server smoke release gate",
+        "nextAction": "Run a clean private-server smoke check and publish redacted evidence.",
+        "number": 28,
+        "priority": "P1",
+        "status": "Backlog",
+        "title": "Private smoke harness clean live rerun",
         "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/26",
+        "url": "https://github.com/lanyusea/screeps/issues/28",
         "visionLayer": "foundation blocker"
       },
       {
-        "domain": "Change-control",
-        "evidence": "PR #48 merged at 2026-04-26T10:17:39Z; merge commit 955a0df records owner governance decisions in docs/AGENTS.",
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 47,
-        "priority": "P0",
-        "status": "Done",
-        "title": "P0:P0 change-control:owner roadmap governance decisions need durable contract sync",
+        "domain": "Private smoke",
+        "evidence": "",
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "nextAction": "Backfill alert telemetry based on private-smoke failure modes.",
+        "number": 32,
+        "priority": "P2",
+        "status": "Ready",
+        "title": "Alert-level telemetry from private smoke failures",
         "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/47",
-        "visionLayer": "foundation blocker"
-      },
-      {
-        "domain": "Change-control",
-        "evidence": "PR #34; issue form + PR template + docs contract",
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 22,
-        "priority": "P0",
-        "status": "Done",
-        "title": "P0:P0 change-control:\u5df2\u77e5\u95ee\u9898\u672a\u5f3a\u5236\u8fdb\u5165 GitHub issue \u4e0e PR \u5173\u8054\u6d41\u7a0b",
-        "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/22",
-        "visionLayer": "foundation blocker"
-      },
-      {
-        "domain": "Change-control",
-        "evidence": "PR #40 merged at 2026-04-26T08:19:33Z; issue closed via Fixes #39; main fast-forwarded to d64f30a.",
-        "milestone": "P0: Change-control / CI / branch protection gate",
-        "nextAction": "",
-        "number": 39,
-        "priority": "P0",
-        "status": "Done",
-        "title": "P0:P0 change-control:\u6240\u6709 agent \u4efb\u52a1\u5b8c\u6210\u6807\u51c6\u7f3a\u5c11 GitHub \u72b6\u6001\u66f4\u65b0\u95e8\u7981",
-        "type": "Issue",
-        "url": "https://github.com/lanyusea/screeps/issues/39",
-        "visionLayer": "foundation blocker"
-      },
-      {
-        "domain": "Change-control",
-        "evidence": "Fixes #36; docs-only roadmap management contract",
-        "milestone": "",
-        "nextAction": "",
-        "number": 37,
-        "priority": "P0",
-        "status": "Done",
-        "title": "docs: record GitHub roadmap management contract",
-        "type": "PullRequest",
-        "url": "https://github.com/lanyusea/screeps/pull/37",
-        "visionLayer": "foundation blocker"
-      },
-      {
-        "domain": "Agent OS",
-        "evidence": "PR #53 merged at 2026-04-26T13:03:35Z as 0bca111 after >=15m, prod-ci SUCCESS, CodeRabbit no actionable comments, Gemini no feedback, no review threads.",
-        "milestone": "",
-        "nextAction": "",
-        "number": 53,
-        "priority": "P0",
-        "status": "Done",
-        "title": "docs: record P0 cron finalization gap",
-        "type": "PullRequest",
-        "url": "https://github.com/lanyusea/screeps/pull/53",
-        "visionLayer": "foundation blocker"
-      },
-      {
-        "domain": "Agent OS",
-        "evidence": "PR #54 merged via squash at 2026-04-26T13:40:29Z; merge commit 0ebed16931f044bd4ab02800f0425cdaac7c3d0d; required check Verify prod TypeScript, Jest, and bundle SUCCESS; CodeRabbit status SUCCESS; review thread PRRT_kwDOSMSsO859qLyO resolved.",
-        "milestone": "",
-        "nextAction": "",
-        "number": 54,
-        "priority": "P0",
-        "status": "Done",
-        "title": "docs: record P0 scheduler recovery",
-        "type": "PullRequest",
-        "url": "https://github.com/lanyusea/screeps/pull/54",
-        "visionLayer": "foundation blocker"
-      },
-      {
-        "domain": "Agent OS",
-        "evidence": "P0 visibility repair process note PR",
-        "milestone": "",
-        "nextAction": "",
-        "number": 21,
-        "priority": "P0",
-        "status": "Done",
-        "title": "docs: record P0 visibility repair",
-        "type": "PullRequest",
-        "url": "https://github.com/lanyusea/screeps/pull/21",
+        "url": "https://github.com/lanyusea/screeps/issues/32",
         "visionLayer": "foundation blocker"
       }
     ],
@@ -3963,55 +1320,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -4125,6 +1433,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4133,55 +1490,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -4295,6 +1603,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4303,55 +1660,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -4465,6 +1773,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4473,55 +1830,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -4635,6 +1943,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4643,55 +2000,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -4805,6 +2113,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4813,55 +2170,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -4975,6 +2283,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -4983,55 +2340,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -5145,6 +2453,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5153,55 +2510,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -5315,6 +2623,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5323,55 +2680,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -5485,6 +2793,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5493,55 +2850,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -5655,6 +2963,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5663,55 +3020,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -5825,6 +3133,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -5833,55 +3190,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -5995,6 +3303,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6003,55 +3360,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -6165,6 +3473,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6173,55 +3530,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -6335,6 +3643,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6343,55 +3700,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -6505,6 +3813,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6513,55 +3870,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -6675,6 +3983,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6683,55 +4040,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "observed",
           "value": 0.0
@@ -6845,6 +4153,55 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "observed",
           "value": 0.0
         }
@@ -6853,55 +4210,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -7015,6 +4323,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7023,55 +4380,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -7185,6 +4493,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7193,55 +4550,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -7355,6 +4663,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7363,55 +4720,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -7525,6 +4833,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7533,55 +4890,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -7695,6 +5003,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7703,55 +5060,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -7865,6 +5173,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7873,55 +5230,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "observed",
           "value": 0.0
@@ -8035,6 +5343,55 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "observed",
           "value": 0.0
         }
@@ -8043,55 +5400,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -8205,6 +5513,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8213,55 +5570,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -8375,6 +5683,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8383,55 +5740,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -8545,6 +5853,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8553,55 +5910,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -8715,6 +6023,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8723,55 +6080,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -8885,6 +6193,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8893,55 +6250,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -9055,6 +6363,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9063,55 +6420,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -9225,6 +6533,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9233,55 +6590,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -9395,6 +6703,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9403,55 +6760,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T05:56:21Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:02:45Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T06:03:19Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:11:06Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:14:03Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:37:50Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:38:26Z",
           "status": "not instrumented",
           "value": null
@@ -9565,6 +6873,55 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-27T11:23:09Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:32:40Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:33:34Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:34:53Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:36:11Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:39:51Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:41:05Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-27T11:50:20Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9600,11 +6957,18 @@
       {
         "items": [
           {
-            "description": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.",
-            "number": 29,
+            "description": "Polish the generated roadmap page and publish sanitized public artifacts.",
+            "number": 77,
             "priority": "P1",
-            "title": "#29 Runtime summary and alert scheduled monitor delivery",
-            "url": "https://github.com/lanyusea/screeps/issues/29"
+            "title": "#77 Roadmap report public artifact polish",
+            "url": "https://github.com/lanyusea/screeps/pull/77"
+          },
+          {
+            "description": "Record expected KPI movement and proof for gameplay releases and hotfixes.",
+            "number": 63,
+            "priority": "P1",
+            "title": "#63 Gameplay release cadence and emergency hotfix evidence",
+            "url": "https://github.com/lanyusea/screeps/issues/63"
           },
           {
             "description": "Refine the public roadmap report presentation and English visible copy.",
@@ -9614,18 +6978,11 @@
             "url": "https://github.com/lanyusea/screeps/issues/75"
           },
           {
-            "description": "2026-04-27T19:09:52+08:00 scheduler dispatched Codex review-fix in [redacted-path]",
-            "number": 77,
+            "description": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.",
+            "number": 29,
             "priority": "P1",
-            "title": "#77 fix: polish roadmap page visual fidelity",
-            "url": "https://github.com/lanyusea/screeps/pull/77"
-          },
-          {
-            "description": "Connect alert signals to bounded tactical emergency triage.",
-            "number": 62,
-            "priority": "P1",
-            "title": "#62 Tactical emergency response wiring",
-            "url": "https://github.com/lanyusea/screeps/issues/62"
+            "title": "#29 Runtime summary and alert scheduled monitor delivery",
+            "url": "https://github.com/lanyusea/screeps/issues/29"
           }
         ],
         "title": "Active"
@@ -9633,11 +6990,11 @@
       {
         "items": [
           {
-            "description": "Run a clean private-server smoke check and publish redacted evidence.",
-            "number": 28,
-            "priority": "P1",
-            "title": "#28 Private smoke harness clean live rerun",
-            "url": "https://github.com/lanyusea/screeps/issues/28"
+            "description": "Backfill alert telemetry based on private-smoke failure modes.",
+            "number": 32,
+            "priority": "P2",
+            "title": "#32 Alert-level telemetry from private smoke failures",
+            "url": "https://github.com/lanyusea/screeps/issues/32"
           },
           {
             "description": "Hold official deploys until private-smoke and monitor proof are complete.",
@@ -9647,46 +7004,17 @@
             "url": "https://github.com/lanyusea/screeps/issues/33"
           },
           {
-            "description": "Backfill alert telemetry based on private-smoke failure modes.",
-            "number": 32,
-            "priority": "P2",
-            "title": "#32 Alert-level telemetry from private smoke failures",
-            "url": "https://github.com/lanyusea/screeps/issues/32"
+            "description": "Run a clean private-server smoke check and publish redacted evidence.",
+            "number": 28,
+            "priority": "P1",
+            "title": "#28 Private smoke harness clean live rerun",
+            "url": "https://github.com/lanyusea/screeps/issues/28"
           }
         ],
         "title": "Private Smoke"
       },
       {
-        "items": [
-          {
-            "description": "PR #42 merged at 2026-04-26T08:26:48Z after QA PASS; issue #41 closed; docs-only QA acceptance gate landed wi...",
-            "number": 41,
-            "priority": "P0",
-            "title": "#41 Establish dedicated QA acceptance-check agent gate",
-            "url": "https://github.com/lanyusea/screeps/issues/41"
-          },
-          {
-            "description": "Keep watch-only P0 monitor evidence current.",
-            "number": 27,
-            "priority": "P0",
-            "title": "#27 P0 monitoring and Discord route health",
-            "url": "https://github.com/lanyusea/screeps/issues/27"
-          },
-          {
-            "description": "PR documenting GitHub roadmap management contract; verifies milestones/project fields/items",
-            "number": 36,
-            "priority": "P0",
-            "title": "#36 Change-control",
-            "url": "https://github.com/lanyusea/screeps/issues/36"
-          },
-          {
-            "description": "Keep required checks and merge gates enforceable before bot changes land.",
-            "number": 26,
-            "priority": "P0",
-            "title": "#26 Main branch protection and required CI gate",
-            "url": "https://github.com/lanyusea/screeps/issues/26"
-          }
-        ],
+        "items": [],
         "title": "Done"
       }
     ],
@@ -9703,13 +7031,6 @@
             "priority": "P1",
             "title": "#59 Gameplay Evolution: game-result review to roadmap loop",
             "url": "https://github.com/lanyusea/screeps/issues/59"
-          },
-          {
-            "description": "Confirm worker recovery when creeps are gone or energy is insufficient.",
-            "number": 31,
-            "priority": "P1",
-            "title": "#31 Zero-creep emergency recovery coverage",
-            "url": "https://github.com/lanyusea/screeps/issues/31"
           }
         ],
         "title": "Active"
@@ -9719,36 +7040,7 @@
         "title": "Private Smoke"
       },
       {
-        "items": [
-          {
-            "description": "2026-04-27T19:12:08+08:00 PR #79 merged as db25074 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no a...",
-            "number": 78,
-            "priority": "P0",
-            "title": "#78 P0: Agent OS continuation worker autonomous scheduler migration",
-            "url": "https://github.com/lanyusea/screeps/issues/78"
-          },
-          {
-            "description": "Bridge runtime KPI artifacts into the Pages report data flow.",
-            "number": 61,
-            "priority": "P1",
-            "title": "#61 Runtime KPI artifact bridge",
-            "url": "https://github.com/lanyusea/screeps/issues/61"
-          },
-          {
-            "description": "Keep game-result review evidence tied to roadmap decisions.",
-            "number": 60,
-            "priority": "P1",
-            "title": "#60 Gameplay review cadence",
-            "url": "https://github.com/lanyusea/screeps/issues/60"
-          },
-          {
-            "description": "Cover spawn.spawning lifecycle behavior across multiple simulated ticks.",
-            "number": 30,
-            "priority": "P1",
-            "title": "#30 Mock harness multi-tick spawn lifecycle",
-            "url": "https://github.com/lanyusea/screeps/issues/30"
-          }
-        ],
+        "items": [],
         "title": "Done"
       }
     ],
@@ -10051,18 +7343,18 @@
         "delta": "+1",
         "detail": "repository history",
         "label": "Total commits",
-        "value": 128
+        "value": 129
       },
       {
         "delta": "+1",
-        "detail": "50 merged",
+        "detail": "51 merged",
         "label": "Total PRs",
         "source": "github",
-        "value": 55
+        "value": 56
       },
       {
         "delta": "+0",
-        "detail": "9 open",
+        "detail": "8 open",
         "label": "Total issues",
         "source": "github",
         "value": 24
@@ -10085,8 +7377,8 @@
       {
         "goal": "Use real game outcomes to drive roadmap, task, and release decisions.",
         "next": "Use game-result evidence to drive roadmap, task, and release updates.",
-        "progress": 58,
-        "status": "#59 In progress \u00b7 GitHub",
+        "progress": 35,
+        "status": "#59 Ready \u00b7 Runtime monitor",
         "title": "Gameplay Evolution",
         "url": "https://github.com/lanyusea/screeps/issues/59"
       },
@@ -10101,8 +7393,8 @@
       {
         "goal": "Convert territory into energy, minerals, logistics, and spawn scale.",
         "next": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor rep...",
-        "progress": 58,
-        "status": "#29 In progress \u00b7 GitHub",
+        "progress": 35,
+        "status": "#29 Ready \u00b7 Runtime monitor",
         "title": "Resource Economy",
         "url": "https://github.com/lanyusea/screeps/issues/29"
       },
@@ -10110,23 +7402,23 @@
         "goal": "Make defense and offense serve territorial and economic control.",
         "next": "Connect alert signals to bounded tactical emergency triage.",
         "progress": 35,
-        "status": "#62 Ready \u00b7 GitHub",
+        "status": "#62 Ready \u00b7 Runtime monitor",
         "title": "Combat",
         "url": "https://github.com/lanyusea/screeps/issues/62"
       },
       {
         "goal": "Let automation health override game goals only when it blocks delivery.",
-        "next": "Keep watch-only P0 monitor evidence current.",
-        "progress": 100,
-        "status": "#27 Done \u00b7 Agent OS",
+        "next": "Record expected KPI movement and proof for gameplay releases and hotfixes.",
+        "progress": 35,
+        "status": "#63 Ready \u00b7 Change-control",
         "title": "Reliability / P0",
-        "url": "https://github.com/lanyusea/screeps/issues/27"
+        "url": "https://github.com/lanyusea/screeps/issues/63"
       },
       {
         "goal": "Private smoke proof, release gates, and official MMO deployment evidence.",
         "next": "Run a clean private-server smoke check and publish redacted evidence.",
-        "progress": 58,
-        "status": "#28 In progress \u00b7 GitHub",
+        "progress": 12,
+        "status": "#28 Backlog \u00b7 Private smoke",
         "title": "Foundation Gates",
         "url": "https://github.com/lanyusea/screeps/issues/28"
       }
@@ -10135,13 +7427,13 @@
   "runtimeReport": {
     "source": {
       "inputPaths": [
-        "[redacted-path]",
-        "[redacted-path]"
+        "",
+        ""
       ],
       "matchedFiles": 0,
       "reason": "",
       "runtimeSummaryLines": 0,
-      "scannedFiles": 71607,
+      "scannedFiles": 71619,
       "skippedFileCount": 1643
     },
     "window": {

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0cf9cce70772ae0176898db71941fee932b999dab39258ea4e90218e54cc350
-size 225280
+oid sha256:b05ec7c3e424290bb87ab7b34908c9d15c82e16fde037a0cad26884b0a28f22b
+size 237568

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:423a22618e59b56362ce996b91ff83a742e946646c1cebd0efe1c4340c5d2760
-size 208896
+oid sha256:f0cf9cce70772ae0176898db71941fee932b999dab39258ea4e90218e54cc350
+size 225280

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8907f88b1e1b52005ca8df39ab9db131e8421483b4dc1a856fb34672a54f2b9
-size 184320
+oid sha256:423a22618e59b56362ce996b91ff83a742e946646c1cebd0efe1c4340c5d2760
+size 208896

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b05ec7c3e424290bb87ab7b34908c9d15c82e16fde037a0cad26884b0a28f22b
-size 237568
+oid sha256:a1917e91f01b7718c6c7271b74afd270f6dc504ff5f5edb5098e000c1f38b4d3
+size 278528

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -40,6 +40,14 @@ HOST_ABSOLUTE_PATH_RE = re.compile(
     r"(?<![A-Za-z0-9_:/.-])/(?:root|home|Users|tmp|var|mnt|opt|Volumes)(?:/[^\s\"'<>`,;)]*)*"
 )
 WINDOWS_DRIVE_ROOT_PATH_RE = re.compile(r"(?<![A-Za-z0-9_:/.-])[A-Za-z]:[\\/][^\s\"'<>`,;)]*")
+PUBLIC_CONTROLLER_TEXT_RE = re.compile(
+    r"\b(?:scheduler dispatched|scheduler prompt|codex review-fix|review-fix task|"
+    r"next scheduler action|reconcile codex|process_session|codex session|"
+    r"controller workflow|controller evidence|controller diff-check|controller-side|controller qa|"
+    r"operator-only|worktree|branch feat/|branch behind|local main fast-forwarded|remote/local branch)\b",
+    re.IGNORECASE,
+)
+CACHED_SUFFIX_RE = re.compile(r"(?:\s*·\s*cached)+\s*$")
 
 OBSERVED = "observed"
 NOT_OBSERVED = "not observed"
@@ -702,6 +710,10 @@ REPORT_ISSUE_DISPLAY_OVERRIDES: dict[int, JsonObject] = {
         "title": "Pages roadmap visual fidelity follow-up",
         "description": "Refine the public roadmap report presentation and English visible copy.",
     },
+    77: {
+        "title": "Roadmap report public artifact polish",
+        "description": "Polish the generated roadmap page and publish sanitized public artifacts.",
+    },
 }
 
 
@@ -828,7 +840,17 @@ def sanitize_public_data(value: Any) -> Any:
 def sanitize_public_text(value: str) -> str:
     text = INTERNAL_PROCESS_ID_RE.sub("proc_[redacted]", value)
     text = HOST_ABSOLUTE_PATH_RE.sub("[redacted-path]", text)
-    return WINDOWS_DRIVE_ROOT_PATH_RE.sub("[redacted-path]", text)
+    text = WINDOWS_DRIVE_ROOT_PATH_RE.sub("[redacted-path]", text)
+    if "[redacted-path]" in text or PUBLIC_CONTROLLER_TEXT_RE.search(text):
+        return ""
+    return text
+
+
+def public_visible_report_text(value: Any) -> str:
+    text = sanitize_public_text(str(value or "")).strip()
+    if not text or has_stale_visible_report_marker(text) or has_cjk_text(text):
+        return ""
+    return text
 
 
 def build_repo_snapshot(repo_full_name: str) -> JsonObject:
@@ -1682,9 +1704,17 @@ def build_roadmap_cards(project_items: Sequence[JsonObject], issues: Sequence[Js
 
     cards = []
     for item in source_items:
+        override = report_issue_display_override(item.get("number"))
+        title = first_visible_report_text(override.get("title"), item.get("title"), item.get("domain"), "Roadmap item")
+        if override.get("description"):
+            next_action = first_visible_report_text(override.get("description"))
+            evidence = ""
+        else:
+            next_action = first_visible_report_text(item.get("nextAction"))
+            evidence = first_visible_report_text(item.get("evidence"))
         cards.append(
             {
-                "title": item.get("title", ""),
+                "title": title,
                 "url": item.get("url", ""),
                 "type": item.get("type", ""),
                 "number": item.get("number"),
@@ -1693,8 +1723,8 @@ def build_roadmap_cards(project_items: Sequence[JsonObject], issues: Sequence[Js
                 "domain": item.get("domain", "Bot capability"),
                 "milestone": item.get("milestone", ""),
                 "visionLayer": classify_vision_layer(item),
-                "nextAction": item.get("nextAction", ""),
-                "evidence": item.get("evidence", ""),
+                "nextAction": next_action,
+                "evidence": evidence,
             }
         )
     return sorted(cards, key=roadmap_sort_key)[:12]
@@ -1711,9 +1741,17 @@ def build_kanban_cards(
         if not item.get("title"):
             continue
         vision_layer = classify_vision_layer(item)
+        override = report_issue_display_override(item.get("number"))
+        title = first_visible_report_text(override.get("title"), item.get("title"), item.get("domain"), "Roadmap item")
+        if override.get("description"):
+            next_action = first_visible_report_text(override.get("description"))
+            evidence = ""
+        else:
+            next_action = first_visible_report_text(item.get("nextAction"))
+            evidence = first_visible_report_text(item.get("evidence"))
         cards.append(
             {
-                "title": item.get("title", ""),
+                "title": title,
                 "url": item.get("url", ""),
                 "type": item.get("type", ""),
                 "number": item.get("number"),
@@ -1723,8 +1761,8 @@ def build_kanban_cards(
                 "kind": item.get("kind", "code"),
                 "visionLayer": vision_layer,
                 "lane": "Gameplay" if vision_layer in {"territory", "resources", "enemy kills"} else "Foundation",
-                "nextAction": item.get("nextAction", ""),
-                "evidence": item.get("evidence", ""),
+                "nextAction": next_action,
+                "evidence": evidence,
                 "state": item.get("state", ""),
                 "updatedAt": item.get("updatedAt", ""),
             }
@@ -2204,8 +2242,8 @@ def first_text(*values: Any) -> str:
 
 def first_visible_report_text(*values: Any) -> str:
     for value in values:
-        text = str(value or "").strip()
-        if text and not has_stale_visible_report_marker(text) and not has_cjk_text(text):
+        text = public_visible_report_text(value)
+        if text:
             return text
     return ""
 
@@ -2499,6 +2537,7 @@ def process_detail(
         return live_detail
     cached_detail = str(cached_card.get("detail") or "").strip()
     if cached_detail:
+        cached_detail = CACHED_SUFFIX_RE.sub("", cached_detail).strip()
         return f"{cached_detail} · cached"
     return format_fetch_error(command_label, error)
 

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -35,6 +35,11 @@ LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
 SCREEPS_SHARD_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 SCREEPS_ROOM_RE = re.compile(r"^[WE]\d+[NS]\d+$")
 CJK_TEXT_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
+INTERNAL_PROCESS_ID_RE = re.compile(r"\bproc_[a-z0-9]+\b")
+HOST_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.-])/(?:root|home|Users|tmp|var|mnt|opt|Volumes)(?:/[^\s\"'<>`,;)]*)*"
+)
+WINDOWS_DRIVE_ROOT_PATH_RE = re.compile(r"(?<![A-Za-z0-9_:/.-])[A-Za-z]:[\\/][^\s\"'<>`,;)]*")
 
 OBSERVED = "observed"
 NOT_OBSERVED = "not observed"
@@ -753,6 +758,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         repo_root=repo_root,
         cached_page_data=cached_page_data,
     )
+    data = sanitize_public_data(data)
 
     json_path = docs_dir / "roadmap-data.json"
     html_path = docs_dir / "index.html"
@@ -805,6 +811,24 @@ def parse_github_remote(remote_url: str) -> str | None:
 
 def strip_trailing_whitespace(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.splitlines()) + "\n"
+
+
+def sanitize_public_data(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: sanitize_public_data(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [sanitize_public_data(item) for item in value]
+    if isinstance(value, tuple):
+        return [sanitize_public_data(item) for item in value]
+    if isinstance(value, str):
+        return sanitize_public_text(value)
+    return value
+
+
+def sanitize_public_text(value: str) -> str:
+    text = INTERNAL_PROCESS_ID_RE.sub("proc_[redacted]", value)
+    text = HOST_ABSOLUTE_PATH_RE.sub("[redacted-path]", text)
+    return WINDOWS_DRIVE_ROOT_PATH_RE.sub("[redacted-path]", text)
 
 
 def build_repo_snapshot(repo_full_name: str) -> JsonObject:
@@ -2156,9 +2180,9 @@ def build_report_roadmap_card(
     override = report_issue_display_override(item.get("number"))
     card["next"] = shorten_text(
         first_visible_report_text(
+            override.get("description"),
             item.get("nextAction"),
             item.get("evidence"),
-            override.get("description"),
             item.get("title"),
             template.get("next"),
             "Track current GitHub/Project evidence.",
@@ -2278,9 +2302,9 @@ def report_kanban_item(card: JsonObject) -> JsonObject:
     number = f"#{card['number']} " if isinstance(card.get("number"), int) else ""
     title = first_visible_report_text(override.get("title"), card.get("title"), card.get("domain"), "Roadmap item")
     description = first_visible_report_text(
+        override.get("description"),
         card.get("nextAction"),
         card.get("evidence"),
-        override.get("description"),
         card.get("domain"),
         card.get("status"),
         "Track Project evidence and next action.",

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -34,6 +34,7 @@ DISCORD_URL = "https://discord.gg/XenFZG9bCE"
 LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
 SCREEPS_SHARD_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 SCREEPS_ROOM_RE = re.compile(r"^[WE]\d+[NS]\d+$")
+CJK_TEXT_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
 
 OBSERVED = "observed"
 NOT_OBSERVED = "not observed"
@@ -461,7 +462,7 @@ KPI_DATES: tuple[str, ...] = ("4/21", "4/22", "4/23", "4/24", "4/25", "4/26", "4
 REPORT_KPI_CARDS: tuple[JsonObject, ...] = (
     {
         "key": "territory",
-        "title": "地盘 / Territory",
+        "title": "Territory",
         "subtitle": "owned rooms · RCL · room gain",
         "pill": "rooms/RCL",
         "ticks": (0, 1.5, 3),
@@ -471,11 +472,11 @@ REPORT_KPI_CARDS: tuple[JsonObject, ...] = (
             {"label": "RCL", "values": (None, None, None, None, None, None, None), "color": "#77716a", "width": 4},
             {"label": "Room gain", "values": (None, None, None, None, None, None, None), "color": "#c8945a", "width": 3, "dash": "6 6"},
         ),
-        "footer": "7d 历史仍在接入；当前点来自 official room monitor / Project evidence。",
+        "footer": "7d history is still being connected; current points come from official room monitor and Project evidence.",
     },
     {
         "key": "resources",
-        "title": "资源 / Resources",
+        "title": "Resources",
         "subtitle": "stored energy · harvest delta · carried energy",
         "pill": "energy",
         "ticks": (0, 0.5, 1),
@@ -485,11 +486,11 @@ REPORT_KPI_CARDS: tuple[JsonObject, ...] = (
             {"label": "Harvest delta", "values": (None, None, None, None, None, None, None), "color": "#66605a", "width": 2},
             {"label": "Worker carried", "values": (None, None, None, None, None, None, None), "color": "#c8945a", "width": 3, "dash": "6 6"},
         ),
-        "footer": "PR #65 已加入资源字段；reducer/7d 聚合仍属 #29。",
+        "footer": "PR #65 added resource fields; reducer and 7d aggregation remain part of #29.",
     },
     {
         "key": "combat",
-        "title": "击杀 / Combat",
+        "title": "Combat",
         "subtitle": "enemy kills · hostile count · own loss",
         "pill": "events",
         "ticks": (0, 0.5, 1),
@@ -499,56 +500,56 @@ REPORT_KPI_CARDS: tuple[JsonObject, ...] = (
             {"label": "Hostiles seen", "values": (None, None, None, None, None, None, None), "color": "#77716a", "width": 4},
             {"label": "Own loss", "values": (None, None, None, None, None, None, None), "color": "#c8945a", "width": 3, "dash": "6 6"},
         ),
-        "footer": "kill/loss 事件 7d reducer 未接入；当前 hostile monitor no-alert。",
+        "footer": "Kill/loss 7d reducers are not connected yet; the current hostile monitor reports no alerts.",
     },
 )
 
 REPORT_ROADMAP_CARDS: tuple[JsonObject, ...] = (
     {
         "title": "Gameplay Evolution",
-        "goal": "真实游戏结果驱动 roadmap / task / release",
-        "next": "#59 统筹；#60 done；#61 bridge in progress",
+        "goal": "Use real game outcomes to drive roadmap, task, and release decisions.",
+        "next": "#59 coordinates the review loop; #60 is done; #61 bridge work is in progress.",
         "progress": 10,
-        "status": "✓ 12h review job 已建；PR #66 已合并",
+        "status": "12h review job created; PR #66 merged.",
         "issue": 59,
     },
     {
-        "title": "Territory / 占地",
-        "goal": "先拿下并守住更大版图",
+        "title": "Territory",
+        "goal": "Claim, hold, and grow the controlled room footprint first.",
         "next": "owned/reserved/room gain/RCL KPI",
         "progress": 15,
-        "status": "✓ E48S28 Spawn1；多房间策略待开发",
+        "status": "E48S28 Spawn1 observed; multi-room strategy is pending.",
     },
     {
         "title": "Resource Economy",
-        "goal": "把占地转换成能量、矿物、物流规模",
+        "goal": "Convert territory into energy, minerals, logistics, and spawn scale.",
         "next": "harvest/transfer/store deltas",
         "progress": 15,
-        "status": "✓ PR #65 payload；#29 reducer 待接入",
+        "status": "PR #65 payload merged; #29 reducer remains pending.",
         "issue": 29,
     },
     {
-        "title": "Combat / 敌人击杀",
-        "goal": "防御/进攻服务于领土和经济控制",
+        "title": "Combat",
+        "goal": "Make defense and offense serve territorial and economic control.",
         "next": "event-log kills/losses + tactical bridge",
         "progress": 5,
-        "status": "✓ #62 Ready；kill KPI reducer 未接入",
+        "status": "#62 Ready; kill KPI reducer remains pending.",
         "issue": 62,
     },
     {
         "title": "Reliability / P0",
-        "goal": "自动化系统健康只在阻塞时压过游戏目标",
+        "goal": "Let automation health override game goals only when it blocks delivery.",
         "next": "P0 monitor watch / no silent scheduler failures",
         "progress": 100,
-        "status": "✓ #27 Done watch-only",
+        "status": "#27 Done watch-only.",
         "issue": 27,
     },
     {
         "title": "Foundation Gates",
-        "goal": "私服验证 / release gate / official MMO",
+        "goal": "Private smoke proof, release gates, and official MMO deployment evidence.",
         "next": "private smoke + release/hotfix evidence",
         "progress": 85,
-        "status": "✓ #28 Ready；#63 Ready；#33 blocked",
+        "status": "#28 Ready; #63 Ready; #33 blocked.",
         "issue": 28,
     },
 )
@@ -560,42 +561,42 @@ REPORT_GAMEPLAY_KANBAN: tuple[JsonObject, ...] = (
             {
                 "number": 30,
                 "priority": "P1",
-                "title": "#30 P1:Phase B:mock harness 缺少多 tick spawn.spawning 生命周期仿真",
-                "description": "Queue bounded Codex/test slice after the current KPI telemetry bridge (#29) or when a worke…",
+                "title": "#30 Mock harness multi-tick spawn lifecycle",
+                "description": "Queue a bounded Codex/test slice after the current KPI telemetry bridge (#29).",
             },
             {
                 "number": 31,
                 "priority": "P1",
-                "title": "#31 P1:Phase B:zero-creep/insufficient-energy emergency r…",
-                "description": "Queue bounded Codex/test slice after the current KPI telemetry bridge (#29) or when a worke…",
+                "title": "#31 Zero-creep emergency recovery coverage",
+                "description": "Confirm worker recovery when creeps are gone or energy is insufficient.",
             },
             {
                 "number": 62,
                 "priority": "P1",
-                "title": "#62 P1: Phase C: tactical emergency response is not wired…",
-                "description": "Define trigger matrix, report template, and no-alert/simulated dry-run before automatic eme…",
+                "title": "#62 Tactical emergency response wiring",
+                "description": "Define trigger matrix, report template, and no-alert dry-run before emergency routing.",
             },
         ),
     },
     {
-        "title": "开发中",
+        "title": "Active",
         "items": (
             {
                 "number": 59,
                 "priority": "P1",
-                "title": "#59 P1: Gameplay Evolution专项：vision-driven game-result re…",
-                "description": "Use merged PR #70 static report plus PR #68 artifact bridge in the next #29 reporting-wirin…",
+                "title": "#59 Gameplay Evolution review loop",
+                "description": "Use game-result evidence to drive roadmap, task, and release updates.",
             },
             {
                 "number": 29,
                 "priority": "P1",
-                "title": "#29 P1:Phase C:runtime-summary/runtime-alert 定时监控投递尚未完成",
-                "description": "Codex-owned prod slice: persist emitted runtime-summary console lines into ignored local ar…",
+                "title": "#29 Runtime summary and alert scheduled delivery",
+                "description": "Persist runtime-summary lines, reduce KPI evidence, and deliver monitor reports.",
             },
         ),
     },
-    {"title": "私服验证中", "items": ()},
-    {"title": "已上线", "items": ()},
+    {"title": "Private Smoke", "items": ()},
+    {"title": "Done", "items": ()},
 )
 
 REPORT_KPI_SERIES_METRICS: dict[str, tuple[str, ...]] = {
@@ -613,31 +614,90 @@ REPORT_FOUNDATION_KANBAN: tuple[JsonObject, ...] = (
             {
                 "number": 33,
                 "priority": "P1",
-                "title": "#33 P1:Phase E:官方 MMO 部署仍受私服 smoke release gate 阻塞",
-                "description": "Do not deploy until Phase D private-smoke gate and monitor proof are complete, unless owner…",
+                "title": "#33 Official MMO deployment gate",
+                "description": "Do not deploy until private-smoke gate and monitor proof are complete.",
             },
             {
                 "number": 63,
                 "priority": "P1",
-                "title": "#63 P1: Phase E: gameplay release cadence and emergency h…",
-                "description": "Update release docs/checklist so every gameplay release records expected KPI movement and p…",
+                "title": "#63 Gameplay release cadence and hotfix evidence",
+                "description": "Record expected KPI movement and proof for gameplay releases and emergency hotfixes.",
             },
         ),
     },
-    {"title": "开发中", "items": ()},
+    {"title": "Active", "items": ()},
     {
-        "title": "私服验证中",
+        "title": "Private Smoke",
         "items": (
             {
                 "number": 28,
                 "priority": "P1",
-                "title": "#28 P1:Phase D:私服 smoke harness clean live rerun 未完成",
+                "title": "#28 Private smoke harness clean live rerun",
                 "description": "Run clean ignored-workdir private smoke harness and attach/report redacted evidence.",
             },
         ),
     },
-    {"title": "已上线", "items": ()},
+    {"title": "Done", "items": ()},
 )
+
+REPORT_ISSUE_DISPLAY_OVERRIDES: dict[int, JsonObject] = {
+    26: {
+        "title": "Main branch protection and required CI gate",
+        "description": "Keep required checks and merge gates enforceable before bot changes land.",
+    },
+    27: {
+        "title": "P0 monitoring and Discord route health",
+        "description": "Keep watch-only P0 monitor evidence current.",
+    },
+    28: {
+        "title": "Private smoke harness clean live rerun",
+        "description": "Run a clean private-server smoke check and publish redacted evidence.",
+    },
+    29: {
+        "title": "Runtime summary and alert scheduled monitor delivery",
+        "description": "Persist runtime-summary lines, reduce KPI evidence, and deliver scheduled monitor reports.",
+    },
+    30: {
+        "title": "Mock harness multi-tick spawn lifecycle",
+        "description": "Cover spawn.spawning lifecycle behavior across multiple simulated ticks.",
+    },
+    31: {
+        "title": "Zero-creep emergency recovery coverage",
+        "description": "Confirm worker recovery when creeps are gone or energy is insufficient.",
+    },
+    32: {
+        "title": "Alert-level telemetry from private smoke failures",
+        "description": "Backfill alert telemetry based on private-smoke failure modes.",
+    },
+    33: {
+        "title": "Official MMO deployment blocked by private smoke gate",
+        "description": "Hold official deploys until private-smoke and monitor proof are complete.",
+    },
+    59: {
+        "title": "Gameplay Evolution: game-result review to roadmap loop",
+        "description": "Use game-result evidence to drive roadmap, task, and release updates.",
+    },
+    60: {
+        "title": "Gameplay review cadence",
+        "description": "Keep game-result review evidence tied to roadmap decisions.",
+    },
+    61: {
+        "title": "Runtime KPI artifact bridge",
+        "description": "Bridge runtime KPI artifacts into the Pages report data flow.",
+    },
+    62: {
+        "title": "Tactical emergency response wiring",
+        "description": "Connect alert signals to bounded tactical emergency triage.",
+    },
+    63: {
+        "title": "Gameplay release cadence and emergency hotfix evidence",
+        "description": "Record expected KPI movement and proof for gameplay releases and hotfixes.",
+    },
+    75: {
+        "title": "Pages roadmap visual fidelity follow-up",
+        "description": "Refine the public roadmap report presentation and English visible copy.",
+    },
+}
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -663,6 +723,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     runtime_report = load_runtime_kpi_report(repo_root)
     metrics = build_current_metrics(runtime_report)
+    cached_page_data = load_cached_page_data(docs_dir / "roadmap-data.json")
     conn = open_history_db(db_path)
     try:
         write_metric_definitions(conn)
@@ -678,6 +739,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         repo_full_name=repo_full_name,
         project_owner=args.project_owner,
         project_number=args.project_number,
+        cached_snapshot=cached_page_data.get("github") if isinstance(cached_page_data.get("github"), dict) else None,
     )
     repo_snapshot = build_repo_snapshot(repo_full_name)
     data = build_page_data(
@@ -689,6 +751,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         github_snapshot=github_snapshot,
         docs_dir=docs_dir,
         repo_root=repo_root,
+        cached_page_data=cached_page_data,
     )
 
     json_path = docs_dir / "roadmap-data.json"
@@ -707,6 +770,16 @@ def relative_to_cwd(path: Path) -> str:
         return str(path.relative_to(Path.cwd()))
     except ValueError:
         return str(path)
+
+
+def load_cached_page_data(json_path: Path) -> JsonObject:
+    if not json_path.exists():
+        return {}
+    try:
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def detect_repo_full_name(repo_root: Path) -> str:
@@ -1290,6 +1363,7 @@ def fetch_github_snapshot(
     repo_full_name: str,
     project_owner: str,
     project_number: int,
+    cached_snapshot: JsonObject | None = None,
 ) -> JsonObject:
     errors: list[JsonObject] = []
 
@@ -1338,18 +1412,35 @@ def fetch_github_snapshot(
     if project_error:
         errors.append({"source": "project", **project_error})
 
+    used_cache = False
     issues = [normalize_issue(item) for item in issues_json] if isinstance(issues_json, list) else []
+    if issue_error and cached_snapshot is not None:
+        cached_issues = cached_github_collection(cached_snapshot, "issues")
+        if cached_issues:
+            issues = cached_issues
+            used_cache = True
     seeded_issue_count = 0
     if issue_error or not issues:
         issues, seeded_issue_count = merge_static_support_issues(issues, repo_full_name)
     pull_requests = [normalize_pull_request(item) for item in prs_json] if isinstance(prs_json, list) else []
+    if pr_error and cached_snapshot is not None:
+        cached_prs = cached_github_collection(cached_snapshot, "pullRequests")
+        if cached_prs:
+            pull_requests = cached_prs
+            used_cache = True
     project_items = normalize_project_items(project_json)
+    if project_error and cached_snapshot is not None:
+        cached_project_items = cached_github_collection(cached_snapshot, "projectItems")
+        if cached_project_items:
+            project_items = cached_project_items
+            used_cache = True
 
     roadmap_cards = build_roadmap_cards(project_items, issues, pull_requests)
     kanban_cards = build_kanban_cards(project_items, issues, pull_requests)
     return {
         "fetched": not errors,
-        "sourceMode": github_source_mode(errors, seeded_issue_count),
+        "sourceMode": github_source_mode(errors, seeded_issue_count, used_cache),
+        "usedCachedSnapshot": used_cache,
         "seededFallbackIssueCount": seeded_issue_count,
         "fetchErrors": errors,
         "issues": issues,
@@ -1362,6 +1453,13 @@ def fetch_github_snapshot(
         },
         "processMetrics": build_process_metrics(issues, pull_requests, project_items, errors),
     }
+
+
+def cached_github_collection(cached_snapshot: JsonObject, key: str) -> list[JsonObject]:
+    value = cached_snapshot.get(key)
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
 
 
 def merge_static_support_issues(issues: Sequence[JsonObject], repo_full_name: str) -> tuple[list[JsonObject], int]:
@@ -1381,9 +1479,11 @@ def merge_static_support_issues(issues: Sequence[JsonObject], repo_full_name: st
     return merged, added
 
 
-def github_source_mode(errors: Sequence[JsonObject], seeded_issue_count: int) -> str:
+def github_source_mode(errors: Sequence[JsonObject], seeded_issue_count: int, used_cache: bool) -> str:
     if not errors:
         return "live"
+    if used_cache:
+        return "cached"
     if seeded_issue_count:
         return "fallback"
     return "incomplete"
@@ -1743,6 +1843,7 @@ def build_page_data(
     github_snapshot: JsonObject,
     docs_dir: Path,
     repo_root: Path,
+    cached_page_data: JsonObject | None = None,
 ) -> JsonObject:
     logo_path = docs_dir / "assets" / "screeps-community-logo.png"
     return {
@@ -1775,7 +1876,14 @@ def build_page_data(
             "source": summarize_runtime_source(runtime_report.get("source")),
         },
         "github": github_snapshot,
-        "report": build_approved_report_model(generated_at, history, github_snapshot, repo_root, repo),
+        "report": build_approved_report_model(
+            generated_at,
+            history,
+            github_snapshot,
+            repo_root,
+            repo,
+            cached_page_data or {},
+        ),
     }
 
 
@@ -1798,6 +1906,7 @@ def build_approved_report_model(
     github_snapshot: JsonObject,
     repo_root: Path,
     repo: JsonObject,
+    cached_page_data: JsonObject,
 ) -> JsonObject:
     return {
         "id": APPROVED_REPORT_MODEL_ID,
@@ -1809,7 +1918,7 @@ def build_approved_report_model(
         "roadmapCards": build_report_roadmap_cards(github_snapshot, repo),
         "gameplayKanban": build_report_kanban(github_snapshot, "Gameplay"),
         "foundationKanban": build_report_kanban(github_snapshot, "Foundation"),
-        "processCards": build_report_process_cards(repo_root, repo, github_snapshot),
+        "processCards": build_report_process_cards(repo_root, repo, github_snapshot, cached_page_data),
     }
 
 
@@ -2044,11 +2153,14 @@ def build_report_roadmap_card(
     item_url = item.get("url")
     if isinstance(item_url, str) and item_url:
         card["url"] = item_url
+    override = report_issue_display_override(item.get("number"))
     card["next"] = shorten_text(
         first_visible_report_text(
             item.get("nextAction"),
             item.get("evidence"),
+            override.get("description"),
             item.get("title"),
+            template.get("next"),
             "Track current GitHub/Project evidence.",
         ),
         88,
@@ -2069,7 +2181,7 @@ def first_text(*values: Any) -> str:
 def first_visible_report_text(*values: Any) -> str:
     for value in values:
         text = str(value or "").strip()
-        if text and not has_stale_visible_report_marker(text):
+        if text and not has_stale_visible_report_marker(text) and not has_cjk_text(text):
             return text
     return ""
 
@@ -2077,6 +2189,16 @@ def first_visible_report_text(*values: Any) -> str:
 def has_stale_visible_report_marker(value: str) -> bool:
     text = value.lower()
     return any(marker in text for marker in STALE_VISIBLE_REPORT_MARKERS)
+
+
+def has_cjk_text(value: Any) -> bool:
+    return bool(CJK_TEXT_RE.search(str(value or "")))
+
+
+def report_issue_display_override(number: Any) -> JsonObject:
+    if not isinstance(number, int):
+        return {}
+    return REPORT_ISSUE_DISPLAY_OVERRIDES.get(number, {})
 
 
 def shorten_text(value: str, limit: int) -> str:
@@ -2103,7 +2225,7 @@ def report_progress(item: JsonObject) -> int:
 def report_item_status(item: JsonObject, github_snapshot: JsonObject) -> str:
     number = f"#{item['number']} " if isinstance(item.get("number"), int) else ""
     status = normalize_status(item.get("status"))
-    domain = str(item.get("domain") or item.get("visionLayer") or "GitHub")
+    domain = first_visible_report_text(item.get("domain"), item.get("visionLayer"), "GitHub")
     suffix = ""
     if github_snapshot.get("sourceMode") != "live":
         suffix = f" · {github_snapshot.get('sourceMode') or 'snapshot'}"
@@ -2125,9 +2247,9 @@ def build_report_kanban(github_snapshot: JsonObject, lane: str) -> list[JsonObje
     ]
     columns = [
         {"title": "Backlog", "items": []},
-        {"title": "开发中", "items": []},
-        {"title": "私服验证中", "items": []},
-        {"title": "已上线", "items": []},
+        {"title": "Active", "items": []},
+        {"title": "Private Smoke", "items": []},
+        {"title": "Done", "items": []},
     ]
     columns_by_title = {column["title"]: column for column in columns}
     for card in cards:
@@ -2141,26 +2263,33 @@ def build_report_kanban(github_snapshot: JsonObject, lane: str) -> list[JsonObje
 def report_kanban_column_title(card: JsonObject) -> str:
     state = str(card.get("state") or "").upper()
     if state in {"CLOSED", "MERGED"} or normalize_status(card.get("status")) == "Done":
-        return "已上线"
+        return "Done"
     haystack = roadmap_item_haystack(card)
     if "private" in haystack or "smoke" in haystack:
-        return "私服验证中"
+        return "Private Smoke"
     status = normalize_status(card.get("status"))
     if status in {"In progress", "In review", "Ready"}:
-        return "开发中"
+        return "Active"
     return "Backlog"
 
 
 def report_kanban_item(card: JsonObject) -> JsonObject:
+    override = report_issue_display_override(card.get("number"))
     number = f"#{card['number']} " if isinstance(card.get("number"), int) else ""
+    title = first_visible_report_text(override.get("title"), card.get("title"), card.get("domain"), "Roadmap item")
+    description = first_visible_report_text(
+        card.get("nextAction"),
+        card.get("evidence"),
+        override.get("description"),
+        card.get("domain"),
+        card.get("status"),
+        "Track Project evidence and next action.",
+    )
     return {
         "number": card.get("number"),
         "priority": card.get("priority") or "P1",
-        "title": shorten_text(f"{number}{card.get('title') or 'Untitled'}", 72),
-        "description": shorten_text(
-            first_visible_report_text(card.get("nextAction"), card.get("evidence"), card.get("domain"), card.get("status")),
-            112,
-        ),
+        "title": shorten_text(f"{number}{title}", 72),
+        "description": shorten_text(description, 112),
         "url": card.get("url") or "",
     }
 
@@ -2241,22 +2370,34 @@ def issue_url(repo: JsonObject, number: int) -> str:
     return f"{repo['url']}/issues/{number}"
 
 
-def build_report_process_cards(repo_root: Path, repo: JsonObject, github_snapshot: JsonObject) -> list[JsonObject]:
+def build_report_process_cards(
+    repo_root: Path,
+    repo: JsonObject,
+    github_snapshot: JsonObject,
+    cached_page_data: JsonObject,
+) -> list[JsonObject]:
     commit_count = parse_count(run_text(["git", "rev-list", "--count", "HEAD"], repo_root))
     prs, pr_error = fetch_all_prs(repo_root, str(repo["fullName"]))
     issues, issue_error = fetch_all_issues(repo_root, str(repo["fullName"]))
+    cached_process_cards = cached_report_process_cards(cached_page_data)
+    cached_pr_card = cached_process_card(cached_process_cards, "Total PRs", "\u603b PR \u6570")
+    cached_issue_card = cached_process_card(cached_process_cards, "Total issues", "\u603b issue \u6570")
     total_prs: int | str = len(prs) if pr_error is None else INSUFFICIENT_EVIDENCE
     merged_prs: int | str = (
         sum(1 for item in prs if str(item.get("state") or "").upper() == "MERGED")
         if pr_error is None
         else INSUFFICIENT_EVIDENCE
     )
+    if pr_error is not None and cached_pr_card:
+        total_prs = cached_pr_card.get("value", INSUFFICIENT_EVIDENCE)
     total_issues: int | str = len(issues) if issue_error is None else INSUFFICIENT_EVIDENCE
     open_issues: int | str = (
         sum(1 for item in issues if str(item.get("state") or "").upper() == "OPEN")
         if issue_error is None
         else INSUFFICIENT_EVIDENCE
     )
+    if issue_error is not None and cached_issue_card:
+        total_issues = cached_issue_card.get("value", INSUFFICIENT_EVIDENCE)
     official_deploy_count = count_process_evidence(
         repo_root,
         required_terms=("official", "deploy evidence"),
@@ -2265,35 +2406,77 @@ def build_report_process_cards(repo_root: Path, repo: JsonObject, github_snapsho
     private_smoke_count = count_private_smoke_process_reports(repo_root)
 
     return [
-        {"value": commit_count, "label": "总 commit 数", "detail": "repository history", "delta": "+1"},
+        {"value": commit_count, "label": "Total commits", "detail": "repository history", "delta": "+1"},
         {
             "value": total_prs,
-            "label": "总 PR 数",
-            "detail": f"{merged_prs} merged" if pr_error is None else format_fetch_error("gh pr list", pr_error),
-            "delta": "+1" if pr_error is None else "n/a",
-            "source": "github" if pr_error is None else "unavailable",
+            "label": "Total PRs",
+            "detail": process_detail(
+                pr_error,
+                "gh pr list",
+                f"{merged_prs} merged",
+                cached_pr_card,
+            ),
+            "delta": "+1" if pr_error is None else cached_pr_card.get("delta", "cached") if cached_pr_card else "n/a",
+            "source": "github" if pr_error is None else "cached" if cached_pr_card else "unavailable",
         },
         {
             "value": total_issues,
-            "label": "总 issue 数",
-            "detail": f"{open_issues} open" if issue_error is None else format_fetch_error("gh issue list", issue_error),
-            "delta": "+0" if issue_error is None else "n/a",
-            "source": "github" if issue_error is None else "unavailable",
+            "label": "Total issues",
+            "detail": process_detail(
+                issue_error,
+                "gh issue list",
+                f"{open_issues} open",
+                cached_issue_card,
+            ),
+            "delta": "+0" if issue_error is None else cached_issue_card.get("delta", "cached") if cached_issue_card else "n/a",
+            "source": "github" if issue_error is None else "cached" if cached_issue_card else "unavailable",
         },
         {
             "value": official_deploy_count,
-            "label": "发版到官方游戏",
+            "label": "Official deploys",
             "detail": "official deploy evidence",
             "delta": "+0",
         },
         {
             "value": private_smoke_count,
-            "label": "私服内总测试次数",
+            "label": "Private smoke tests",
             "detail": "smoke/report evidence",
             "delta": "+0",
             "source": "approved process report count",
         },
     ]
+
+
+def cached_report_process_cards(cached_page_data: JsonObject) -> list[JsonObject]:
+    report = cached_page_data.get("report")
+    if not isinstance(report, dict):
+        return []
+    cards = report.get("processCards")
+    if not isinstance(cards, list):
+        return []
+    return [dict(card) for card in cards if isinstance(card, dict)]
+
+
+def cached_process_card(cards: Sequence[JsonObject], *labels: str) -> JsonObject:
+    label_set = set(labels)
+    for card in cards:
+        if str(card.get("label") or "") in label_set:
+            return card
+    return {}
+
+
+def process_detail(
+    error: JsonObject | None,
+    command_label: str,
+    live_detail: str,
+    cached_card: JsonObject,
+) -> str:
+    if error is None:
+        return live_detail
+    cached_detail = str(cached_card.get("detail") or "").strip()
+    if cached_detail:
+        return f"{cached_detail} · cached"
+    return format_fetch_error(command_label, error)
 
 
 def fetch_all_prs(repo_root: Path, repo_full_name: str) -> tuple[list[JsonObject], JsonObject | None]:
@@ -3050,7 +3233,7 @@ def render_html(data: JsonObject) -> str:
     repo = data["repo"]
     generated_at = esc(data["generatedAt"])
     return f"""<!doctype html>
-<html lang="zh-Hans">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -3065,8 +3248,8 @@ def render_html(data: JsonObject) -> str:
     <main>
       {render_report_kpis(data)}
       {render_report_roadmap(data)}
-      {render_kanban_section("gameplay-kanban", "03 游戏策略开发 Kanban", data["report"]["gameplayKanban"])}
-      {render_kanban_section("foundation-kanban", "04 基建开发 Kanban", data["report"]["foundationKanban"])}
+      {render_kanban_section("gameplay-kanban", "03 Gameplay Strategy Kanban", data["report"]["gameplayKanban"])}
+      {render_kanban_section("foundation-kanban", "04 Foundation Delivery Kanban", data["report"]["foundationKanban"])}
       {render_report_process(data)}
     </main>
     <footer class="report-footer">format {esc(data["format"])} · repo {esc(repo["url"])} · generated {generated_at}</footer>
@@ -3118,7 +3301,7 @@ a {
 .hero {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 390px;
+  grid-template-columns: minmax(0, 1fr) 410px;
   align-items: center;
   min-height: 390px;
   gap: 40px;
@@ -3142,11 +3325,11 @@ a {
 
 h1 {
   margin: 0;
-  max-width: 930px;
-  font-size: clamp(4.3rem, 5.7vw, 5.6rem);
+  max-width: 820px;
+  font-size: clamp(3.35rem, 4.35vw, 4.45rem);
   font-weight: 900;
   letter-spacing: 0;
-  line-height: 0.91;
+  line-height: 0.96;
 }
 
 h1 span {
@@ -3186,27 +3369,24 @@ h1 span {
   justify-content: center;
 }
 
-.brand-logo {
-  position: relative;
-  z-index: 1;
-  width: 288px;
-  height: 288px;
-  justify-self: center;
-  object-fit: cover;
+.brand-logo-frame {
+  display: grid;
+  width: 334px;
+  height: 334px;
+  place-items: center;
+  border: 1px solid rgba(189, 159, 123, 0.72);
+  border-radius: 50%;
+  padding: 18px;
+  background: rgba(255, 250, 240, 0.82);
   box-shadow: 0 25px 36px rgba(46, 31, 17, 0.18);
 }
 
-.logo-badge {
-  position: absolute;
-  right: 18px;
-  bottom: 24px;
-  z-index: 2;
-  border-radius: 999px;
-  padding: 8px 17px;
-  background: rgba(255, 243, 220, 0.86);
-  color: var(--copper-dark);
-  font-weight: 900;
-  box-shadow: 0 8px 20px rgba(73, 48, 24, 0.12);
+.brand-logo {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
 }
 
 main {
@@ -3256,12 +3436,19 @@ main {
 }
 
 .chart-card h3,
-.roadmap-card h3,
-.kanban-column h3 {
+.roadmap-card h3 {
   margin: 0;
   font-size: 1.48rem;
   line-height: 1.12;
   font-weight: 900;
+}
+
+.kanban-column h3 {
+  margin: 0;
+  font-size: 0.96rem;
+  line-height: 1.12;
+  font-weight: 900;
+  text-transform: uppercase;
 }
 
 .chart-card p {
@@ -3373,7 +3560,7 @@ main {
 
 .column-count {
   color: var(--copper-dark);
-  font-size: 1.08rem;
+  font-size: 0.88rem;
   font-weight: 900;
 }
 
@@ -3419,7 +3606,7 @@ main {
   border: 1px dashed #d7bea4;
   border-radius: 12px;
   color: #9f846a;
-  font-size: 1.08rem;
+  font-size: 0.9rem;
 }
 
 .process-grid {
@@ -3485,8 +3672,13 @@ main {
   }
 
   .brand-logo {
-    width: 230px;
-    height: 230px;
+    width: 100%;
+    height: 100%;
+  }
+
+  .brand-logo-frame {
+    width: 268px;
+    height: 268px;
   }
 
   .kanban-grid {
@@ -3514,23 +3706,17 @@ main {
   }
 
   h1 {
-    font-size: 3.3rem;
+    font-size: 2.78rem;
   }
 
   .summary {
     font-size: 1.1rem;
   }
 
-  .brand-logo {
+  .brand-logo-frame {
     justify-self: start;
-    width: 190px;
-    height: 190px;
-  }
-
-  .logo-badge {
-    left: 126px;
-    right: auto;
-    bottom: 14px;
+    width: 212px;
+    height: 212px;
   }
 }
 """
@@ -3538,33 +3724,26 @@ main {
 
 def render_report_hero(data: JsonObject) -> str:
     repo = data["repo"]
-    room_target = repo.get("screepsRoom") if isinstance(repo.get("screepsRoom"), dict) else {}
-    target_label = str(room_target.get("label") or "unknown")
-    target_status = str(room_target.get("status") or "unknown")
-    target_message = str(room_target.get("message") or "")
-    target_url = str(room_target.get("url") or "")
-    if target_url:
-        target_html = f'<a href="{esc(target_url)}" title="{esc(target_message)}">{esc(target_label)}</a>'
-    else:
-        target_html = f'<span title="{esc(target_message)}">{esc(target_label)}</span>'
     logo = data["assets"].get("logo") or ""
-    logo_html = f'<img class="brand-logo" src="{esc(logo)}" alt="Screeps community logo">' if logo else ""
+    logo_html = (
+        f'<div class="brand-logo-frame"><img class="brand-logo" src="{esc(logo)}" alt="Screeps community logo"></div>'
+        if logo
+        else ""
+    )
     return f"""
     <header class="hero">
       <div>
         <p class="eyebrow">PERSISTENT MMO AI COLONY · AUTONOMOUS ROADMAP</p>
         <h1><span>Hermes Screeps Project</span><span>Roadmap Report</span></h1>
-        <p class="summary">用真实游戏 KPI 驱动 bot 能力、策略开发、基建门禁和发版节奏。</p>
+        <p class="summary">Harness live Screeps KPI evidence for Agentic strategy, bot capability growth, delivery gates, and release cadence.</p>
         <div class="hero-meta">
-          <p><strong>Project</strong> · 长期运行的 Screeps: World AI / 自动化运营项目。</p>
-          <p><strong>Links</strong> · <a href="{esc(repo['url'])}">{esc(repo['url'])}</a> · <a href="https://screeps.com/">https://screeps.com/</a></p>
-          <p><strong>Target</strong> · {target_html} · {esc(target_status)} · 地盘 &gt; 资源 &gt; 击杀。</p>
+          <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
+          <p><strong>Links</strong> · <a href="{esc(repo['url'])}">{esc(repo['url'])}</a></p>
         </div>
         <p class="published"><strong>PUBLISHED</strong> · {esc(data["generatedAtCst"])}</p>
       </div>
       <div class="hero-art">
         {logo_html}
-        <div class="logo-badge">KPI/Kanban · v5</div>
       </div>
     </header>
 """
@@ -3574,7 +3753,7 @@ def render_report_kpis(data: JsonObject) -> str:
     cards = "\n".join(render_kpi_chart_card(card) for card in data["report"]["kpiCards"])
     return f"""
       <section class="section" id="kpi">
-        <h2 class="section-title">01 游戏内部 KPI · 7d 趋势</h2>
+        <h2 class="section-title">01 Game KPI - 7d Trend</h2>
         <div class="kpi-report-grid">
           {cards}
         </div>
@@ -3705,7 +3884,7 @@ def render_report_roadmap(data: JsonObject) -> str:
     cards = "\n".join(render_report_roadmap_card(card) for card in data["report"]["roadmapCards"])
     return f"""
       <section class="section" id="roadmap">
-        <h2 class="section-title">02 开发 Roadmap · 六项状态</h2>
+        <h2 class="section-title">02 Development Roadmap - Six Tracks</h2>
         <div class="roadmap-grid">
           {cards}
         </div>
@@ -3721,8 +3900,8 @@ def render_report_roadmap_card(card: JsonObject) -> str:
           <{tag} class="roadmap-card"{href}>
             <h3>{esc(card["title"])}</h3>
             <div class="roadmap-table">
-              <span class="roadmap-label">目标</span><span>{esc(card["goal"])}</span>
-              <span class="roadmap-label">下个点</span><span>{esc(card["next"])}</span>
+              <span class="roadmap-label">Goal</span><span>{esc(card["goal"])}</span>
+              <span class="roadmap-label">Next</span><span>{esc(card["next"])}</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">{progress}%</span>
@@ -3776,7 +3955,7 @@ def render_report_process(data: JsonObject) -> str:
     cards = "\n".join(render_process_card(card) for card in data["report"]["processCards"])
     return f"""
       <section class="section" id="process">
-        <h2 class="section-title">05 开发过程数据</h2>
+        <h2 class="section-title">05 Development Process Data</h2>
         <div class="process-grid">
           {cards}
         </div>


### PR DESCRIPTION
## Summary
- Polishes the public roadmap page per issue #75 visual/content follow-up.
- Removes the KPI/Kanban badge, restores a larger centered circular logo treatment, and reduces title scale.
- Converts rendered page UI to English, keeps only the GitHub link, removes the target-room line, and preserves only the three visible game KPI cards.
- Regenerates `docs/roadmap-data.json` and the LFS-managed KPI SQLite file from the updated generator.

## Linked issue
Refs #75

## Roadmap category
Runtime monitor / public roadmap visual fidelity

## Served vision layer
Engineering governance and external visibility: this does not outrank immediate #29 KPI capture, but it keeps the public roadmap surface accurate and owner-approved while #29/#30 continue in parallel.

## Verification
- [x] `git diff --check`
- [x] `python3 -m py_compile scripts/generate-roadmap-page.py`
- [x] `python3 scripts/generate-roadmap-page.py --repo . --docs-dir docs --db docs/roadmap-kpi.sqlite`
- [x] Acceptance checks: no `KPI/Kanban · v5`; summary contains `Harness` and `Agentic`; only GitHub links remain; target-room line absent; no CJK text in `docs/index.html`; visible KPI cards are exactly Territory/Resources/Combat; forbidden dashboard strings absent; SQLite `enemy_kills` remains NULL and instrumented=0; no WAL/SHM sidecars; SQLite remains LFS-managed.

## Notes
- Codex-authored commit: `d3b6a0c lanyusea's bot <lanyusea@gmail.com> fix: polish roadmap page visual fidelity`
- No secrets included.
