### PR TITLE
docs: define autonomous scheduler contract

### DIFF
--- a/docs/ops/agent-operating-system.md
+++ b/docs/ops/agent-operating-system.md
@@ -1,6 +1,6 @@
 # Screeps Agent Operating System
 
-Last updated: 2026-04-26T16:08:57+08:00
+Last updated: 2026-04-27T18:55:00+08:00
 
 ## Purpose
 
@@ -142,11 +142,114 @@ For every meaningful task:
 
 ## Scheduled worker roles
 
-### Continuation worker
+### Continuation worker / autonomous scheduler
 
-Purpose: execute one bounded research/development slice from `docs/process/active-work-state.md`.
+Purpose: act as the autonomous scheduler/dispatcher for roadmap execution, not as a single-task worker. Each run must reconcile GitHub state, active agent state, open PRs, and safe capacity; then it should start, monitor, QA-route, or close as many non-conflicting executable tasks as the current capacity and gates allow.
 
 Delivery: `discord:#task-queue`.
+
+The scheduler remains bounded: it must not wait on long-running Codex/QA processes, sleep through review windows, or perform unbounded implementation inside the cron run. It should dispatch independent agents, record their state, and let the next scheduler run reconcile progress.
+
+#### Scheduler phase goals
+
+The scheduler runs these phases in order on every invocation:
+
+1. **Reconcile state.** Inspect `cronjob list`, background processes, `/root/.hermes/screeps-agent-registry.json` when present, git worktrees, open PRs, open roadmap issues, and GitHub Project `screeps` fields. Repair stale GitHub state before dispatching new work.
+2. **Close ready loops.** If a PR has completed QA, green required checks, resolved/outdated review threads, and the >=15 minute automated review gate, merge it, fast-forward `/root/screeps`, and set the linked issue/PR Project items to `Done` with evidence.
+3. **Handle completed dev agents.** For each finished dev/Codex process, verify commit/authorship, run required checks, push, create or update the PR, add the PR to Project `screeps`, set issue/PR status to `In review`, and dispatch on-demand QA.
+4. **Handle QA results.** If QA returns `PASS`, update the PR/issue Evidence and move the PR to merge-gate watch. If QA returns `REQUEST_CHANGES`, dispatch a review-fix dev/Codex agent and record the blocker.
+5. **Maximize safe parallelism.** Claim executable `Ready` issues up to capacity, preferring P0 blockers first, then game-goal work in the order territory > resources > kills, then non-blocking foundation. Default assumption: different roadmap submodules are non-conflicting and should run in parallel via separate worktrees unless a concrete file/runtime/resource conflict is observed.
+6. **Refresh owner-visible state.** Update Issue/Project `Evidence` and `Next action`, write concise scheduler checkpoint output, and trigger/allow typed reporters to refresh roadmap/task views from GitHub state.
+
+#### Parallelism and conflict policy
+
+Default capacity targets:
+
+| Lane | Default cap | Notes |
+| --- | ---: | --- |
+| Active dev/Codex agents | 4 | May include code and docs workers. Do not exceed if PR review backlog is unhealthy. |
+| Active QA agents | 2 | QA is on-demand and short-lived; never persistent. |
+| Open PRs waiting for review/merge gate | 6 | If exceeded, drain PRs before dispatching lower-priority new work. |
+| Same roadmap submodule | 1 by default | Allow more only when file scopes are explicitly disjoint. |
+
+Conflict rules:
+
+- Different roadmap domains/submodules are presumed independent.
+- Worktrees are mandatory for every repo mutation; use `/root/screeps-worktrees/<topic>`.
+- File-scope overlap blocks parallel dispatch only when concrete paths collide, for example two tasks both editing `prod/src/spawn*`, the same generated artifact, the same cron prompt, or the same deploy/runbook file.
+- Generated artifacts such as Pages output, bundled `prod/dist/main.js`, and committed SQLite artifacts should be serialized unless the task owns that artifact.
+- If a conflict is uncertain, dispatch the higher-priority task and leave the other `Ready` with `Next action` explaining the dependency.
+
+#### Claim, registry, and GitHub state protocol
+
+Before starting a dev or QA agent, the scheduler must claim the issue/PR by updating GitHub Project `screeps`:
+
+- Issue `Status`: `Ready` -> `In progress` for dev, or PR `Status`: `In review` for review/QA.
+- `Evidence`: include scheduler run timestamp, worktree, branch, process/session id if known, file scope, and current verification state.
+- `Next action`: include the exact next scheduler action, not a vague summary.
+
+The local registry is a runtime cache, not the source of truth. Preferred path:
+
+```text
+/root/.hermes/screeps-agent-registry.json
+```
+
+Each entry should record at least:
+
+```json
+{
+  "issue": 78,
+  "pr": null,
+  "kind": "dev|qa|review-fix|merge-watch",
+  "domain": "Agent OS",
+  "worktree": "/root/screeps-worktrees/autonomous-scheduler-78",
+  "branch": "docs/autonomous-scheduler-78",
+  "process_session": "proc_xxx",
+  "file_scope": ["docs/ops/agent-operating-system.md"],
+  "state": "running|finished|failed|qa_pending|merge_gate|done",
+  "claimed_at": "ISO-8601 timestamp",
+  "last_seen": "ISO-8601 timestamp"
+}
+```
+
+Every run must reconcile registry and GitHub:
+
+- Registry running + process missing -> inspect worktree/PR and classify finished, failed, or stale.
+- GitHub `In progress` + no registry/process -> recover from worktree/branch/PR evidence or mark blocked with exact reason.
+- PR merged + issue not Done -> update issue and PR Project fields immediately.
+- Registry says done + GitHub stale -> fix GitHub before final report.
+
+#### Dev-agent and Codex dispatch rules
+
+- Documentation-only tasks may be implemented by a docs dev agent/Hermes in a worktree, but still require PR, QA, Project updates, and review gate.
+- Production/test/build code, scripts, workflow/config behavior, generated runtime behavior, and review-fix code changes must be implemented by Codex CLI in the task worktree.
+- Each task prompt must include issue link, priority reason, file scope, acceptance criteria, verification commands, commit requirements, no-secret rule, and Project update requirements.
+- The scheduler should start agents in background and stop; it should not wait for long-running completion inside the same cron run.
+
+#### On-demand QA trigger
+
+QA is not a standing worker. Trigger it when a PR or dev result is ready for acceptance:
+
+- after a dev/Codex agent has committed and controller verification has passed;
+- after a review-fix commit has been pushed;
+- before merge when the only remaining question is acceptance/readiness;
+- after merge for a lightweight state reconciliation check when the task materially changes roadmap/process/deploy state.
+
+QA output must be exactly one of:
+
+```text
+PASS
+<evidence bullets>
+```
+
+or
+
+```text
+REQUEST_CHANGES
+<blocking findings and required fixes>
+```
+
+The scheduler must not treat a deliverable as complete without QA `PASS`, current GitHub Project fields, and satisfied PR gates.
 
 It should include labelled sections for other channels, but it does not replace main-agent fanout. If it produces significant detail in a final report, the next main-agent/manual review should route the relevant pieces to the typed channels.
 

--- a/docs/ops/agent-operating-system.md
+++ b/docs/ops/agent-operating-system.md
@@ -100,7 +100,7 @@ Subagents must not independently update `#decisions`, `#roadmap`, or `#task-queu
 The main agent must maintain an internal operations monitor that checks:
 
 - scheduled jobs exist and are enabled;
-- continuation worker is running at the expected cadence;
+- continuation worker is running at the expected cadence, or is intentionally paused for maintenance/migration with that pause mirrored in GitHub Project `Status`, `Evidence`, and `Next action`;
 - checkpoint job exists;
 - job delivery targets are still correct;
 - last run status is not failed/stale;
@@ -108,9 +108,9 @@ The main agent must maintain an internal operations monitor that checks:
 - git working tree is not unsafe for autonomous workers;
 - obvious routing contradictions have not reappeared.
 
-If this monitoring detects an abnormal state, it must report to the dedicated P0 operations channel `discord:1497820688843800776` and preserve a durable process note if the issue is non-trivial.
+If this monitoring detects an abnormal state, it must report to the dedicated P0 operations channel `discord:1497820688843800776` and preserve a durable process note if the issue is non-trivial. An intentionally paused continuation worker is healthy only when the pause is mirrored in Project metadata: `Status`, `Evidence`, and `Next action`, plus `blocked`/`Blocked by` when the pause is caused by an external blocker. If those artifacts are missing or stale, the monitor must escalate to the P0 operations channel and create/refresh durable process evidence.
 
-Owner decision on 2026-04-26: P0 monitoring/routing/scheduler health blocks normal development and non-P0 merges. If P0 health is known unhealthy, the main agent must repair or prove the P0 monitor and affected scheduled jobs before starting unrelated implementation slices.
+Owner decision on 2026-04-26: P0 monitoring/routing/scheduler health blocks normal development and non-P0 merges. If P0 health is known unhealthy, the main agent must repair or prove the P0 monitor and affected scheduled jobs before starting unrelated implementation slices. This repair requirement excludes intentionally paused maintenance/migration states only when the Project metadata conditions above are current; otherwise the pause is treated as an abnormal P0 state.
 
 ## Priority model
 

--- a/docs/process/2026-04-27-autonomous-scheduler-migration-plan.md
+++ b/docs/process/2026-04-27-autonomous-scheduler-migration-plan.md
@@ -1,0 +1,93 @@
+# 2026-04-27 Autonomous Scheduler Migration Plan
+
+> **For Hermes:** This is the main-agent implementation plan for issue #78. The current continuation worker is paused while this migration is applied directly by the main agent.
+
+**Goal:** Upgrade the Screeps autonomous continuation worker from a bounded single-slice executor into a scheduler/dispatcher that maximizes safe parallelism, dispatches independent development agents, triggers on-demand QA, and keeps GitHub Project state authoritative.
+
+**Architecture:** GitHub Issues/Project remain the source of truth. A local registry under `/root/.hermes/screeps-agent-registry.json` acts only as runtime cache for active dev/QA/merge-watch sessions. The scheduler cron run reconciles state, dispatches background agents up to capacity, and exits without long waits.
+
+**Tech Stack:** Hermes cron scheduler, GitHub CLI/Projects, git worktrees, Codex CLI, on-demand delegated QA agents, Discord typed-channel reporters.
+
+---
+
+## Phase 1 — Freeze and inventory
+
+**Objective:** Prevent concurrent continuation-worker mutations while the scheduler contract changes.
+
+**Completed actions:**
+
+- Paused `Screeps autonomous continuation worker` (`f66ed36d7be0`) at 2026-04-27T18:50+08.
+- Confirmed active Codex sessions from #30/#75 had exited.
+- Confirmed open PR backlog: PR #77 remains open and PR #76 had merged into current main.
+- Created GitHub issue #78 and Project item `PVTI_lAHOACo3ic4BVvO4zgrG_Ns`.
+- Created worktree `/root/screeps-worktrees/autonomous-scheduler-78` on branch `docs/autonomous-scheduler-78`.
+
+## Phase 2 — Durable operating contract
+
+**Objective:** Make the scheduler behavior durable in repo docs before changing live cron behavior.
+
+**Files:**
+
+- Modify: `docs/ops/agent-operating-system.md`
+- Create: `docs/process/2026-04-27-autonomous-scheduler-migration-plan.md`
+
+**Acceptance criteria:**
+
+- The continuation worker section describes scheduler/dispatcher behavior rather than one bounded development slice.
+- The doc states max-parallel defaults, conflict assumptions, registry/cache behavior, GitHub claim protocol, dev/Codex dispatch rules, and on-demand QA trigger rules.
+- The plan records phased goals and implementation evidence for recovery.
+
+## Phase 3 — Live continuation prompt migration
+
+**Objective:** Replace the live continuation worker prompt with scheduler-mode instructions.
+
+**Live job:** `Screeps autonomous continuation worker` (`f66ed36d7be0`)
+
+**Acceptance criteria:**
+
+- Prompt says the worker is an autonomous scheduler/dispatcher.
+- Prompt requires each run to reconcile GitHub Project/registry/process/worktree/PR state.
+- Prompt requires dispatching safe Ready tasks up to capacity, not merely listing queued coverage.
+- Prompt requires on-demand QA after controller verification and before completion.
+- Prompt keeps the same safety constraints: no recursive cron creation, no secrets, no main edits, Codex for production/test/build/script/workflow behavior, no long sleeps.
+- Prompt final report includes scheduler inventory, dispatch decisions, active agents, QA state, GitHub updates, and next scheduler action.
+
+## Phase 4 — GitHub state reconciliation
+
+**Objective:** Ensure GitHub state is complete enough to support automated dispatch.
+
+**Acceptance criteria:**
+
+- Issue #78 is `In progress`, P0, Agent OS, ops, with Evidence and Next action.
+- Open PRs and active issues have enough Evidence/Next action for the scheduler to resume without chat context.
+- The paused continuation worker state is explicitly recorded as intentional migration pause, not abnormal delivery failure.
+
+## Phase 5 — Verification and PR
+
+**Objective:** Make the durable change reviewable and keep live scheduler state safe.
+
+**Verification commands:**
+
+```bash
+git diff --check
+git status --short --branch
+gh issue view 78 --repo lanyusea/screeps --json number,title,projectItems
+cronjob list  # via Hermes tool, verify f66ed36d7be0 paused until prompt update is complete
+```
+
+**PR gate:**
+
+- Push `docs/autonomous-scheduler-78`.
+- Open PR linked with `Fixes #78`.
+- Add PR to Project `screeps` as `In review`.
+- Run QA acceptance against docs + live prompt + GitHub state.
+- Resume continuation worker only after the live prompt has been updated and verified.
+
+## Scheduler policy summary
+
+- Maximum safe parallelism is the default, not an exception.
+- Different roadmap submodules are presumed independent unless a concrete conflict is identified.
+- Every repo mutation uses a worktree.
+- Code/script/workflow behavior changes are Codex-owned; docs-only contract changes may be Hermes-owned.
+- QA is on-demand per deliverable/PR, not a standing cron worker.
+- GitHub Project state is the dispatch source of truth; local registry is only a runtime cache.

--- a/docs/process/2026-04-27-autonomous-scheduler-migration-plan.md
+++ b/docs/process/2026-04-27-autonomous-scheduler-migration-plan.md
@@ -60,7 +60,8 @@
 
 - Issue #78 is `In progress`, P0, Agent OS, ops, with Evidence and Next action.
 - Open PRs and active issues have enough Evidence/Next action for the scheduler to resume without chat context.
-- The paused continuation worker state is explicitly recorded as intentional migration pause, not abnormal delivery failure.
+- If any tracked item is blocked, it also has explicit `blocked` status and `Blocked by` linkage before resume.
+- The paused continuation worker state is explicitly recorded as an intentional migration pause, not abnormal delivery failure; if the pause is caused by an external blocker, the same `blocked` / `Blocked by` metadata is populated.
 
 ## Phase 5 — Verification and PR
 


### PR DESCRIPTION
## Summary
- Documents the continuation worker migration from bounded single-slice worker to autonomous scheduler/dispatcher.
- Adds max-parallel capacity targets, conflict assumptions, GitHub claim protocol, runtime registry cache, dev/Codex dispatch rules, and on-demand QA trigger rules.
- Records the main-agent migration plan and live-prompt update evidence while the continuation worker is intentionally paused.

## Verification
- [x] `git diff --check`
- [x] Live continuation worker prompt updated to scheduler/dispatcher mode
- [x] Continuation worker `f66ed36d7be0` intentionally paused during migration
- [x] Issue #78 Project fields set to P0 / Agent OS / ops / In progress with Evidence and Next action

Fixes #78
