### PR TITLE
test: cover zero-creep emergency recovery

### DIFF
--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -39,6 +39,69 @@ describe('runEconomy', () => {
     });
   });
 
+  it('spawns an emergency worker when an owned colony has zero creeps and only basic worker energy', () => {
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 200,
+      energyCapacityAvailable: 400,
+      controller: { my: true } as StructureController
+    } as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(0)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 125,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: {}
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-125', {
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
+  it('waits through critical energy without invalid spawn attempts and recovers when an emergency body is affordable', () => {
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 199,
+      energyCapacityAvailable: 400,
+      controller: { my: true } as StructureController
+    } as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(0)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 126,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: {}
+    };
+
+    runEconomy();
+    Game.time = 127;
+    runEconomy();
+
+    expect(spawn.spawnCreep).not.toHaveBeenCalled();
+
+    room.energyAvailable = 200;
+    Game.time = 128;
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledTimes(1);
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-128', {
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
   it('retries another idle spawn when the planned spawn reports busy and emits both outcomes', () => {
     const room = {
       name: 'W1N1',


### PR DESCRIPTION
## Summary
- Adds deterministic economy-loop coverage for zero-creep emergency recovery.
- Verifies the bot spawns the smallest worker body when only 200 energy is available.
- Verifies the bot does not issue invalid spawn attempts below 200 energy and recovers once the emergency body is affordable.

## Linked issue
Fixes #31

## Roadmap category
Bot capability / spawn lifecycle and emergency recovery

## Served vision layer
Resource/economy reliability that supports territory expansion: avoiding zero-creep bootstrap deadlocks keeps the colony able to rebuild workers before broader territory/resource strategy.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (72 tests)
- [x] `cd prod && npm run build`

## Notes
- Codex-authored commit: `3bb6396 lanyusea's bot <lanyusea@gmail.com> test: cover zero-creep emergency worker recovery`
- No secrets included.
