### PR TITLE
feat: add automatic extension planning

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -55,6 +55,101 @@ function getOwnedColonies() {
   }));
 }
 
+// src/construction/extensionPlanner.ts
+var EXTENSION_LIMITS_BY_RCL = {
+  2: 5,
+  3: 10,
+  4: 20,
+  5: 30,
+  6: 40,
+  7: 50,
+  8: 60
+};
+var MAX_EXTENSION_PLANNER_RADIUS = 6;
+var ROOM_EDGE_MIN = 1;
+var ROOM_EDGE_MAX = 48;
+var DEFAULT_TERRAIN_WALL_MASK = 1;
+function planExtensionConstruction(colony) {
+  var _a;
+  const allowedExtensions = getExtensionLimitForRcl((_a = colony.room.controller) == null ? void 0 : _a.level);
+  if (allowedExtensions <= 0) {
+    return null;
+  }
+  const plannedExtensions = countExistingAndPendingExtensions(colony.room);
+  if (plannedExtensions >= allowedExtensions) {
+    return null;
+  }
+  const anchor = selectExtensionAnchor(colony);
+  if (!anchor) {
+    return null;
+  }
+  const position = findNextExtensionPosition(colony.room, anchor);
+  if (!position) {
+    return null;
+  }
+  return colony.room.createConstructionSite(position.x, position.y, STRUCTURE_EXTENSION);
+}
+function getExtensionLimitForRcl(level) {
+  var _a;
+  return level ? (_a = EXTENSION_LIMITS_BY_RCL[level]) != null ? _a : 0 : 0;
+}
+function countExistingAndPendingExtensions(room) {
+  const existingExtensions = room.find(FIND_MY_STRUCTURES, {
+    filter: (structure) => structure.structureType === STRUCTURE_EXTENSION
+  });
+  const pendingExtensions = room.find(FIND_MY_CONSTRUCTION_SITES, {
+    filter: (site) => site.structureType === STRUCTURE_EXTENSION
+  });
+  return existingExtensions.length + pendingExtensions.length;
+}
+function selectExtensionAnchor(colony) {
+  var _a, _b, _c;
+  const [primarySpawn] = colony.spawns.filter((spawn) => spawn.pos).sort((left, right) => left.name.localeCompare(right.name));
+  return (_c = (_b = primarySpawn == null ? void 0 : primarySpawn.pos) != null ? _b : (_a = colony.room.controller) == null ? void 0 : _a.pos) != null ? _c : null;
+}
+function findNextExtensionPosition(room, anchor) {
+  for (let radius = 1; radius <= MAX_EXTENSION_PLANNER_RADIUS; radius += 1) {
+    for (let dy = -radius; dy <= radius; dy += 1) {
+      for (let dx = -radius; dx <= radius; dx += 1) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== radius) {
+          continue;
+        }
+        const position = { x: anchor.x + dx, y: anchor.y + dy };
+        if (canPlaceExtension(room, position)) {
+          return position;
+        }
+      }
+    }
+  }
+  return null;
+}
+function canPlaceExtension(room, position) {
+  if (position.x < ROOM_EDGE_MIN || position.x > ROOM_EDGE_MAX || position.y < ROOM_EDGE_MIN || position.y > ROOM_EDGE_MAX) {
+    return false;
+  }
+  if (isTerrainWall(room, position)) {
+    return false;
+  }
+  return !hasBlockingObject(room, position);
+}
+function isTerrainWall(room, position) {
+  var _a;
+  const terrain = (_a = Game.map) == null ? void 0 : _a.getRoomTerrain(room.name).get(position.x, position.y);
+  return terrain === getTerrainWallMask();
+}
+function hasBlockingObject(room, position) {
+  var _a;
+  const lookAt = room.lookAt;
+  const lookEntries = (_a = lookAt == null ? void 0 : lookAt.call(room, position.x, position.y)) != null ? _a : [];
+  return lookEntries.some((entry) => entry.terrain === "wall" || hasNonTerrainLookResult(entry));
+}
+function hasNonTerrainLookResult(entry) {
+  return Object.entries(entry).some(([key, value]) => key !== "type" && key !== "terrain" && value !== void 0);
+}
+function getTerrainWallMask() {
+  return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK;
+}
+
 // src/creeps/roleCounts.ts
 var WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
 function countCreepsByRole(creeps, colonyName) {
@@ -543,6 +638,7 @@ function runEconomy() {
   const colonies = getOwnedColonies();
   const telemetryEvents = [];
   for (const colony of colonies) {
+    planExtensionConstruction(colony);
     const roleCounts = countCreepsByRole(creeps, colony.room.name);
     const spawnRequest = planSpawn(colony, roleCounts, Game.time);
     if (spawnRequest) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -108,6 +108,8 @@ function selectExtensionAnchor(colony) {
   return (_c = (_b = primarySpawn == null ? void 0 : primarySpawn.pos) != null ? _b : (_a = colony.room.controller) == null ? void 0 : _a.pos) != null ? _c : null;
 }
 function findNextExtensionPosition(room, anchor) {
+  const lookups = createPlannerLookups(room, anchor);
+  const anchorParity = getPositionParity(anchor);
   for (let radius = 1; radius <= MAX_EXTENSION_PLANNER_RADIUS; radius += 1) {
     for (let dy = -radius; dy <= radius; dy += 1) {
       for (let dx = -radius; dx <= radius; dx += 1) {
@@ -115,7 +117,7 @@ function findNextExtensionPosition(room, anchor) {
           continue;
         }
         const position = { x: anchor.x + dx, y: anchor.y + dy };
-        if (canPlaceExtension(room, position)) {
+        if (canPlaceExtension(lookups, anchorParity, position)) {
           return position;
         }
       }
@@ -123,28 +125,53 @@ function findNextExtensionPosition(room, anchor) {
   }
   return null;
 }
-function canPlaceExtension(room, position) {
+function createPlannerLookups(room, anchor) {
+  const bounds = getScanBounds(anchor);
+  return {
+    terrain: Game.map.getRoomTerrain(room.name),
+    blockingPositions: getBlockingPositions(room, bounds)
+  };
+}
+function getScanBounds(anchor) {
+  return {
+    top: Math.max(ROOM_EDGE_MIN, anchor.y - MAX_EXTENSION_PLANNER_RADIUS),
+    left: Math.max(ROOM_EDGE_MIN, anchor.x - MAX_EXTENSION_PLANNER_RADIUS),
+    bottom: Math.min(ROOM_EDGE_MAX, anchor.y + MAX_EXTENSION_PLANNER_RADIUS),
+    right: Math.min(ROOM_EDGE_MAX, anchor.x + MAX_EXTENSION_PLANNER_RADIUS)
+  };
+}
+function getBlockingPositions(room, bounds) {
+  const blockingPositions = /* @__PURE__ */ new Set();
+  const structures = room.lookForAtArea(LOOK_STRUCTURES, bounds.top, bounds.left, bounds.bottom, bounds.right, true);
+  const constructionSites = room.lookForAtArea(LOOK_CONSTRUCTION_SITES, bounds.top, bounds.left, bounds.bottom, bounds.right, true);
+  for (const structure of structures) {
+    blockingPositions.add(getPositionKey(structure));
+  }
+  for (const constructionSite of constructionSites) {
+    blockingPositions.add(getPositionKey(constructionSite));
+  }
+  return blockingPositions;
+}
+function canPlaceExtension(lookups, anchorParity, position) {
   if (position.x < ROOM_EDGE_MIN || position.x > ROOM_EDGE_MAX || position.y < ROOM_EDGE_MIN || position.y > ROOM_EDGE_MAX) {
     return false;
   }
-  if (isTerrainWall(room, position)) {
+  if (getPositionParity(position) !== anchorParity) {
     return false;
   }
-  return !hasBlockingObject(room, position);
+  if (isTerrainWall(lookups.terrain, position)) {
+    return false;
+  }
+  return !lookups.blockingPositions.has(getPositionKey(position));
 }
-function isTerrainWall(room, position) {
-  var _a;
-  const terrain = (_a = Game.map) == null ? void 0 : _a.getRoomTerrain(room.name).get(position.x, position.y);
-  return terrain === getTerrainWallMask();
+function getPositionParity(position) {
+  return (position.x + position.y) % 2;
 }
-function hasBlockingObject(room, position) {
-  var _a;
-  const lookAt = room.lookAt;
-  const lookEntries = (_a = lookAt == null ? void 0 : lookAt.call(room, position.x, position.y)) != null ? _a : [];
-  return lookEntries.some((entry) => entry.terrain === "wall" || hasNonTerrainLookResult(entry));
+function isTerrainWall(terrain, position) {
+  return (terrain.get(position.x, position.y) & getTerrainWallMask()) !== 0;
 }
-function hasNonTerrainLookResult(entry) {
-  return Object.entries(entry).some(([key, value]) => key !== "type" && key !== "terrain" && value !== void 0);
+function getPositionKey(position) {
+  return `${position.x},${position.y}`;
 }
 function getTerrainWallMask() {
   return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK;

--- a/prod/src/construction/extensionPlanner.ts
+++ b/prod/src/construction/extensionPlanner.ts
@@ -20,9 +20,16 @@ interface CandidatePosition {
   y: number;
 }
 
-interface LookEntry {
-  [key: string]: unknown;
-  terrain?: string;
+interface ScanBounds {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+}
+
+interface PlannerLookups {
+  terrain: RoomTerrain;
+  blockingPositions: Set<string>;
 }
 
 export function planExtensionConstruction(colony: ColonySnapshot): ScreepsReturnCode | null {
@@ -73,6 +80,9 @@ function selectExtensionAnchor(colony: ColonySnapshot): RoomPosition | null {
 }
 
 function findNextExtensionPosition(room: Room, anchor: RoomPosition): CandidatePosition | null {
+  const lookups = createPlannerLookups(room, anchor);
+  const anchorParity = getPositionParity(anchor);
+
   for (let radius = 1; radius <= MAX_EXTENSION_PLANNER_RADIUS; radius += 1) {
     for (let dy = -radius; dy <= radius; dy += 1) {
       for (let dx = -radius; dx <= radius; dx += 1) {
@@ -81,7 +91,7 @@ function findNextExtensionPosition(room: Room, anchor: RoomPosition): CandidateP
         }
 
         const position = { x: anchor.x + dx, y: anchor.y + dy };
-        if (canPlaceExtension(room, position)) {
+        if (canPlaceExtension(lookups, anchorParity, position)) {
           return position;
         }
       }
@@ -91,32 +101,66 @@ function findNextExtensionPosition(room: Room, anchor: RoomPosition): CandidateP
   return null;
 }
 
-function canPlaceExtension(room: Room, position: CandidatePosition): boolean {
+function createPlannerLookups(room: Room, anchor: RoomPosition): PlannerLookups {
+  const bounds = getScanBounds(anchor);
+
+  return {
+    terrain: Game.map.getRoomTerrain(room.name),
+    blockingPositions: getBlockingPositions(room, bounds)
+  };
+}
+
+function getScanBounds(anchor: RoomPosition): ScanBounds {
+  return {
+    top: Math.max(ROOM_EDGE_MIN, anchor.y - MAX_EXTENSION_PLANNER_RADIUS),
+    left: Math.max(ROOM_EDGE_MIN, anchor.x - MAX_EXTENSION_PLANNER_RADIUS),
+    bottom: Math.min(ROOM_EDGE_MAX, anchor.y + MAX_EXTENSION_PLANNER_RADIUS),
+    right: Math.min(ROOM_EDGE_MAX, anchor.x + MAX_EXTENSION_PLANNER_RADIUS)
+  };
+}
+
+function getBlockingPositions(room: Room, bounds: ScanBounds): Set<string> {
+  const blockingPositions = new Set<string>();
+  const structures = room.lookForAtArea(LOOK_STRUCTURES, bounds.top, bounds.left, bounds.bottom, bounds.right, true);
+  const constructionSites = room.lookForAtArea(LOOK_CONSTRUCTION_SITES, bounds.top, bounds.left, bounds.bottom, bounds.right, true);
+
+  for (const structure of structures) {
+    blockingPositions.add(getPositionKey(structure));
+  }
+
+  for (const constructionSite of constructionSites) {
+    blockingPositions.add(getPositionKey(constructionSite));
+  }
+
+  return blockingPositions;
+}
+
+function canPlaceExtension(lookups: PlannerLookups, anchorParity: number, position: CandidatePosition): boolean {
   if (position.x < ROOM_EDGE_MIN || position.x > ROOM_EDGE_MAX || position.y < ROOM_EDGE_MIN || position.y > ROOM_EDGE_MAX) {
     return false;
   }
 
-  if (isTerrainWall(room, position)) {
+  if (getPositionParity(position) !== anchorParity) {
     return false;
   }
 
-  return !hasBlockingObject(room, position);
+  if (isTerrainWall(lookups.terrain, position)) {
+    return false;
+  }
+
+  return !lookups.blockingPositions.has(getPositionKey(position));
 }
 
-function isTerrainWall(room: Room, position: CandidatePosition): boolean {
-  const terrain = Game.map?.getRoomTerrain(room.name).get(position.x, position.y);
-  return terrain === getTerrainWallMask();
+function getPositionParity(position: CandidatePosition): number {
+  return (position.x + position.y) % 2;
 }
 
-function hasBlockingObject(room: Room, position: CandidatePosition): boolean {
-  const lookAt = (room as unknown as { lookAt?: (x: number, y: number) => LookEntry[] }).lookAt;
-  const lookEntries = lookAt?.call(room, position.x, position.y) ?? [];
-
-  return lookEntries.some((entry) => entry.terrain === 'wall' || hasNonTerrainLookResult(entry));
+function isTerrainWall(terrain: RoomTerrain, position: CandidatePosition): boolean {
+  return (terrain.get(position.x, position.y) & getTerrainWallMask()) !== 0;
 }
 
-function hasNonTerrainLookResult(entry: LookEntry): boolean {
-  return Object.entries(entry).some(([key, value]) => key !== 'type' && key !== 'terrain' && value !== undefined);
+function getPositionKey(position: CandidatePosition): string {
+  return `${position.x},${position.y}`;
 }
 
 function getTerrainWallMask(): number {

--- a/prod/src/construction/extensionPlanner.ts
+++ b/prod/src/construction/extensionPlanner.ts
@@ -1,0 +1,124 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+
+const EXTENSION_LIMITS_BY_RCL: Record<number, number> = {
+  2: 5,
+  3: 10,
+  4: 20,
+  5: 30,
+  6: 40,
+  7: 50,
+  8: 60
+};
+
+const MAX_EXTENSION_PLANNER_RADIUS = 6;
+const ROOM_EDGE_MIN = 1;
+const ROOM_EDGE_MAX = 48;
+const DEFAULT_TERRAIN_WALL_MASK = 1;
+
+interface CandidatePosition {
+  x: number;
+  y: number;
+}
+
+interface LookEntry {
+  [key: string]: unknown;
+  terrain?: string;
+}
+
+export function planExtensionConstruction(colony: ColonySnapshot): ScreepsReturnCode | null {
+  const allowedExtensions = getExtensionLimitForRcl(colony.room.controller?.level);
+  if (allowedExtensions <= 0) {
+    return null;
+  }
+
+  const plannedExtensions = countExistingAndPendingExtensions(colony.room);
+  if (plannedExtensions >= allowedExtensions) {
+    return null;
+  }
+
+  const anchor = selectExtensionAnchor(colony);
+  if (!anchor) {
+    return null;
+  }
+
+  const position = findNextExtensionPosition(colony.room, anchor);
+  if (!position) {
+    return null;
+  }
+
+  return colony.room.createConstructionSite(position.x, position.y, STRUCTURE_EXTENSION);
+}
+
+export function getExtensionLimitForRcl(level: number | undefined): number {
+  return level ? EXTENSION_LIMITS_BY_RCL[level] ?? 0 : 0;
+}
+
+function countExistingAndPendingExtensions(room: Room): number {
+  const existingExtensions = room.find(FIND_MY_STRUCTURES, {
+    filter: (structure) => structure.structureType === STRUCTURE_EXTENSION
+  });
+  const pendingExtensions = room.find(FIND_MY_CONSTRUCTION_SITES, {
+    filter: (site) => site.structureType === STRUCTURE_EXTENSION
+  });
+
+  return existingExtensions.length + pendingExtensions.length;
+}
+
+function selectExtensionAnchor(colony: ColonySnapshot): RoomPosition | null {
+  const [primarySpawn] = colony.spawns
+    .filter((spawn) => spawn.pos)
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  return primarySpawn?.pos ?? colony.room.controller?.pos ?? null;
+}
+
+function findNextExtensionPosition(room: Room, anchor: RoomPosition): CandidatePosition | null {
+  for (let radius = 1; radius <= MAX_EXTENSION_PLANNER_RADIUS; radius += 1) {
+    for (let dy = -radius; dy <= radius; dy += 1) {
+      for (let dx = -radius; dx <= radius; dx += 1) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) !== radius) {
+          continue;
+        }
+
+        const position = { x: anchor.x + dx, y: anchor.y + dy };
+        if (canPlaceExtension(room, position)) {
+          return position;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function canPlaceExtension(room: Room, position: CandidatePosition): boolean {
+  if (position.x < ROOM_EDGE_MIN || position.x > ROOM_EDGE_MAX || position.y < ROOM_EDGE_MIN || position.y > ROOM_EDGE_MAX) {
+    return false;
+  }
+
+  if (isTerrainWall(room, position)) {
+    return false;
+  }
+
+  return !hasBlockingObject(room, position);
+}
+
+function isTerrainWall(room: Room, position: CandidatePosition): boolean {
+  const terrain = Game.map?.getRoomTerrain(room.name).get(position.x, position.y);
+  return terrain === getTerrainWallMask();
+}
+
+function hasBlockingObject(room: Room, position: CandidatePosition): boolean {
+  const lookAt = (room as unknown as { lookAt?: (x: number, y: number) => LookEntry[] }).lookAt;
+  const lookEntries = lookAt?.call(room, position.x, position.y) ?? [];
+
+  return lookEntries.some((entry) => entry.terrain === 'wall' || hasNonTerrainLookResult(entry));
+}
+
+function hasNonTerrainLookResult(entry: LookEntry): boolean {
+  return Object.entries(entry).some(([key, value]) => key !== 'type' && key !== 'terrain' && value !== undefined);
+}
+
+function getTerrainWallMask(): number {
+  return typeof TERRAIN_MASK_WALL === 'number' ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK;
+}

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -1,4 +1,5 @@
 import { getOwnedColonies } from '../colony/colonyRegistry';
+import { planExtensionConstruction } from '../construction/extensionPlanner';
 import { countCreepsByRole } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
 import { planSpawn, type SpawnRequest } from '../spawn/spawnPlanner';
@@ -12,6 +13,8 @@ export function runEconomy(): void {
   const telemetryEvents: RuntimeTelemetryEvent[] = [];
 
   for (const colony of colonies) {
+    planExtensionConstruction(colony);
+
     const roleCounts = countCreepsByRole(creeps, colony.room.name);
     const spawnRequest = planSpawn(colony, roleCounts, Game.time);
 

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -209,6 +209,65 @@ describe('runEconomy', () => {
     expect(creeps['worker-W1N1-200']?.memory).toEqual({ role: 'worker', colony: 'W1N1' });
   });
 
+  it('plans extension construction before workers select build targets', () => {
+    (globalThis as unknown as {
+      FIND_MY_STRUCTURES: number;
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      RESOURCE_ENERGY: ResourceConstant;
+      STRUCTURE_EXTENSION: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+    }).FIND_MY_STRUCTURES = 1;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 3;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+
+    const constructionSites: ConstructionSite[] = [];
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: { my: true, level: 2, id: 'controller1' } as StructureController,
+      find: jest.fn((type: number) => (type === 3 ? constructionSites : [])),
+      lookAt: jest.fn().mockReturnValue([]),
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        constructionSites.push({ id: `site-${x}-${y}`, structureType } as ConstructionSite);
+        return OK_CODE;
+      })
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      pos: { x: 25, y: 25, roomName: 'W1N1' },
+      spawning: null,
+      spawnCreep: jest.fn()
+    } as unknown as StructureSpawn;
+    const worker = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 250,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: { Worker1: worker },
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as Game['map']
+    };
+
+    runEconomy();
+
+    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 24, STRUCTURE_EXTENSION);
+    expect(worker.memory.task).toEqual({ type: 'build', targetId: 'site-24-24' });
+  });
+
   it('runs existing worker creeps', () => {
     const creep = {
       memory: { role: 'worker', colony: 'W1N1' },

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -217,12 +217,16 @@ describe('runEconomy', () => {
       RESOURCE_ENERGY: ResourceConstant;
       STRUCTURE_EXTENSION: StructureConstant;
       TERRAIN_MASK_WALL: number;
+      LOOK_STRUCTURES: LOOK_STRUCTURES;
+      LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
     }).FIND_MY_STRUCTURES = 1;
     (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 3;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
     (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+    (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES = 'constructionSite';
 
     const constructionSites: ConstructionSite[] = [];
     const room = {
@@ -231,9 +235,12 @@ describe('runEconomy', () => {
       energyCapacityAvailable: 0,
       controller: { my: true, level: 2, id: 'controller1' } as StructureController,
       find: jest.fn((type: number) => (type === 3 ? constructionSites : [])),
-      lookAt: jest.fn().mockReturnValue([]),
+      lookForAt: jest.fn(() => {
+        throw new Error('extension planner should use cached occupancy instead of per-candidate lookups');
+      }),
+      lookForAtArea: jest.fn().mockReturnValue([]),
       createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
-        constructionSites.push({ id: `site-${x}-${y}`, structureType } as ConstructionSite);
+        constructionSites.push({ id: `site-${x}-${y}`, structureType, pos: { x, y, roomName: 'W1N1' } as RoomPosition } as ConstructionSite);
         return OK_CODE;
       })
     } as unknown as Room;

--- a/prod/test/extensionPlanner.test.ts
+++ b/prod/test/extensionPlanner.test.ts
@@ -5,7 +5,9 @@ const TEST_GLOBALS = {
   FIND_MY_STRUCTURES: 1,
   FIND_MY_CONSTRUCTION_SITES: 2,
   STRUCTURE_EXTENSION: 'extension',
-  TERRAIN_MASK_WALL: 1
+  TERRAIN_MASK_WALL: 1,
+  LOOK_STRUCTURES: 'structure',
+  LOOK_CONSTRUCTION_SITES: 'constructionSite'
 } as const;
 
 describe('extension construction planner', () => {
@@ -69,23 +71,49 @@ describe('extension construction planner', () => {
   it('avoids occupied, wall, and duplicate positions before choosing the next candidate', () => {
     const { room, colony } = makeColony({
       controllerLevel: 2,
-      wallPositions: new Set(['25,24']),
-      lookEntriesByPosition: {
-        '24,24': [{ structure: makeExtension('existing-at-first-candidate') }],
-        '26,24': [{ constructionSite: makeExtensionSite('pending-at-third-candidate') }]
-      }
+      wallPositions: new Set(['24,26']),
+      structures: [makeExtension('existing-at-first-candidate', { x: 24, y: 24 })],
+      constructionSites: [makeExtensionSite('pending-at-second-candidate', { x: 26, y: 24 })]
     });
 
     expect(planExtensionConstruction(colony)).toBe(0);
 
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
-    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 25, STRUCTURE_EXTENSION);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(26, 26, STRUCTURE_EXTENSION);
+    expect(room.lookForAt).not.toHaveBeenCalled();
+    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_STRUCTURES, 19, 19, 31, 31, true);
+    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_CONSTRUCTION_SITES, 19, 19, 31, 31, true);
+    expect(room.lookForAtArea).toHaveBeenCalledTimes(2);
+    expect((Game.map.getRoomTerrain as jest.Mock).mock.calls).toHaveLength(1);
+  });
+
+  it('keeps adjacent cardinal paths open while filling RCL2 extension sites', () => {
+    const { room, colony } = makeColony({ controllerLevel: 2 });
+
+    for (let site = 0; site < 5; site += 1) {
+      expect(planExtensionConstruction(colony)).toBe(0);
+    }
+
+    const placedPositions = new Set(room.createConstructionSite.mock.calls.map(([x, y]) => `${x},${y}`));
+
+    expect(placedPositions).toEqual(new Set(['24,24', '26,24', '24,26', '26,26', '23,23']));
+    expect(placedPositions.has('25,24')).toBe(false);
+    expect(placedPositions.has('24,25')).toBe(false);
+    expect(placedPositions.has('26,25')).toBe(false);
+    expect(placedPositions.has('25,26')).toBe(false);
   });
 });
 
 interface MockRoom extends Room {
   find: jest.Mock;
   createConstructionSite: jest.Mock;
+  lookForAt: jest.Mock;
+  lookForAtArea: jest.Mock;
+}
+
+interface TestPosition {
+  x: number;
+  y: number;
 }
 
 function makeColony(options: {
@@ -93,12 +121,10 @@ function makeColony(options: {
   structures?: Structure[];
   constructionSites?: ConstructionSite[];
   wallPositions?: Set<string>;
-  lookEntriesByPosition?: Record<string, Array<Partial<LookAtResult>>>;
 }): { room: MockRoom; colony: ColonySnapshot } {
   const structures = options.structures ?? [];
-  const constructionSites = options.constructionSites ?? [];
+  const constructionSites = [...(options.constructionSites ?? [])];
   const wallPositions = options.wallPositions ?? new Set<string>();
-  const lookEntriesByPosition = options.lookEntriesByPosition ?? {};
   const roomName = 'W1N1';
   const controller = {
     my: true,
@@ -120,8 +146,29 @@ function makeColony(options: {
 
       return findOptions?.filter ? targets.filter(findOptions.filter) : targets;
     }),
-    lookAt: jest.fn((x: number, y: number) => lookEntriesByPosition[`${x},${y}`] ?? []),
-    createConstructionSite: jest.fn().mockReturnValue(0)
+    lookForAt: jest.fn(() => {
+      throw new Error('extension planner should use cached occupancy instead of per-candidate lookups');
+    }),
+    lookForAtArea: jest.fn((lookType: string, top: number, left: number, bottom: number, right: number) => {
+      if (lookType === TEST_GLOBALS.LOOK_STRUCTURES) {
+        return getStructureLookResults(structures, top, left, bottom, right);
+      }
+
+      if (lookType === TEST_GLOBALS.LOOK_CONSTRUCTION_SITES) {
+        return getConstructionSiteLookResults(constructionSites, top, left, bottom, right);
+      }
+
+      return [];
+    }),
+    createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+      constructionSites.push({
+        id: `site-${x}-${y}`,
+        structureType,
+        pos: { x, y, roomName } as RoomPosition
+      } as ConstructionSite);
+
+      return 0;
+    })
   } as unknown as MockRoom;
   const spawn = {
     name: 'Spawn1',
@@ -148,16 +195,50 @@ function makeColony(options: {
   };
 }
 
-function makeExtension(id: string): Structure {
+function makeExtension(id: string, position: TestPosition = { x: 40, y: 40 }): Structure {
   return {
     id,
-    structureType: TEST_GLOBALS.STRUCTURE_EXTENSION
+    structureType: TEST_GLOBALS.STRUCTURE_EXTENSION,
+    pos: makeRoomPosition(position)
   } as unknown as Structure;
 }
 
-function makeExtensionSite(id: string): ConstructionSite {
+function makeExtensionSite(id: string, position: TestPosition = { x: 41, y: 41 }): ConstructionSite {
   return {
     id,
-    structureType: TEST_GLOBALS.STRUCTURE_EXTENSION
+    structureType: TEST_GLOBALS.STRUCTURE_EXTENSION,
+    pos: makeRoomPosition(position)
   } as unknown as ConstructionSite;
+}
+
+function makeRoomPosition(position: TestPosition): RoomPosition {
+  return { ...position, roomName: 'W1N1' } as RoomPosition;
+}
+
+function getStructureLookResults(structures: Structure[], top: number, left: number, bottom: number, right: number): LookAtResultWithPos[] {
+  return structures.flatMap((structure) => {
+    const position = (structure as { pos?: RoomPosition }).pos;
+    return position && isWithinBounds(position, top, left, bottom, right)
+      ? [{ x: position.x, y: position.y, structure } as LookAtResultWithPos]
+      : [];
+  });
+}
+
+function getConstructionSiteLookResults(
+  constructionSites: ConstructionSite[],
+  top: number,
+  left: number,
+  bottom: number,
+  right: number
+): LookAtResultWithPos[] {
+  return constructionSites.flatMap((constructionSite) => {
+    const position = (constructionSite as { pos?: RoomPosition }).pos;
+    return position && isWithinBounds(position, top, left, bottom, right)
+      ? [{ x: position.x, y: position.y, constructionSite } as LookAtResultWithPos]
+      : [];
+  });
+}
+
+function isWithinBounds(position: TestPosition, top: number, left: number, bottom: number, right: number): boolean {
+  return position.x >= left && position.x <= right && position.y >= top && position.y <= bottom;
 }

--- a/prod/test/extensionPlanner.test.ts
+++ b/prod/test/extensionPlanner.test.ts
@@ -1,0 +1,163 @@
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import { getExtensionLimitForRcl, planExtensionConstruction } from '../src/construction/extensionPlanner';
+
+const TEST_GLOBALS = {
+  FIND_MY_STRUCTURES: 1,
+  FIND_MY_CONSTRUCTION_SITES: 2,
+  STRUCTURE_EXTENSION: 'extension',
+  TERRAIN_MASK_WALL: 1
+} as const;
+
+describe('extension construction planner', () => {
+  beforeEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const [key, value] of Object.entries(TEST_GLOBALS)) {
+      globals[key] = value;
+    }
+  });
+
+  afterEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const key of Object.keys(TEST_GLOBALS)) {
+      delete globals[key];
+    }
+    delete globals.Game;
+  });
+
+  it('maps extension limits by RCL and no-ops below RCL2', () => {
+    expect(getExtensionLimitForRcl(1)).toBe(0);
+    expect(getExtensionLimitForRcl(undefined)).toBe(0);
+    expect(getExtensionLimitForRcl(2)).toBe(5);
+    expect(getExtensionLimitForRcl(3)).toBe(10);
+    expect(getExtensionLimitForRcl(4)).toBe(20);
+    expect(getExtensionLimitForRcl(5)).toBe(30);
+    expect(getExtensionLimitForRcl(6)).toBe(40);
+    expect(getExtensionLimitForRcl(7)).toBe(50);
+    expect(getExtensionLimitForRcl(8)).toBe(60);
+    expect(getExtensionLimitForRcl(9)).toBe(0);
+
+    const { room, colony } = makeColony({ controllerLevel: 1 });
+
+    expect(planExtensionConstruction(colony)).toBeNull();
+    expect(room.find).not.toHaveBeenCalled();
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+
+  it('creates the first deterministic extension site at RCL2', () => {
+    const { room, colony } = makeColony({ controllerLevel: 2 });
+
+    expect(planExtensionConstruction(colony)).toBe(0);
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 24, STRUCTURE_EXTENSION);
+  });
+
+  it('does not create when current and pending extensions already meet the allowed count', () => {
+    const existingExtensions = Array.from({ length: 3 }, (_, index) => makeExtension(`extension-${index}`));
+    const pendingExtensions = Array.from({ length: 2 }, (_, index) => makeExtensionSite(`site-${index}`));
+    const { room, colony } = makeColony({
+      controllerLevel: 2,
+      structures: existingExtensions,
+      constructionSites: pendingExtensions
+    });
+
+    expect(planExtensionConstruction(colony)).toBeNull();
+
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+
+  it('avoids occupied, wall, and duplicate positions before choosing the next candidate', () => {
+    const { room, colony } = makeColony({
+      controllerLevel: 2,
+      wallPositions: new Set(['25,24']),
+      lookEntriesByPosition: {
+        '24,24': [{ structure: makeExtension('existing-at-first-candidate') }],
+        '26,24': [{ constructionSite: makeExtensionSite('pending-at-third-candidate') }]
+      }
+    });
+
+    expect(planExtensionConstruction(colony)).toBe(0);
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 25, STRUCTURE_EXTENSION);
+  });
+});
+
+interface MockRoom extends Room {
+  find: jest.Mock;
+  createConstructionSite: jest.Mock;
+}
+
+function makeColony(options: {
+  controllerLevel: number;
+  structures?: Structure[];
+  constructionSites?: ConstructionSite[];
+  wallPositions?: Set<string>;
+  lookEntriesByPosition?: Record<string, Array<Partial<LookAtResult>>>;
+}): { room: MockRoom; colony: ColonySnapshot } {
+  const structures = options.structures ?? [];
+  const constructionSites = options.constructionSites ?? [];
+  const wallPositions = options.wallPositions ?? new Set<string>();
+  const lookEntriesByPosition = options.lookEntriesByPosition ?? {};
+  const roomName = 'W1N1';
+  const controller = {
+    my: true,
+    level: options.controllerLevel,
+    pos: { x: 20, y: 20, roomName }
+  } as unknown as StructureController;
+  const room = {
+    name: roomName,
+    controller,
+    energyAvailable: 300,
+    energyCapacityAvailable: 300,
+    find: jest.fn((findType: number, findOptions?: { filter?: (target: Structure | ConstructionSite) => boolean }) => {
+      const targets =
+        findType === TEST_GLOBALS.FIND_MY_STRUCTURES
+          ? structures
+          : findType === TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES
+            ? constructionSites
+            : [];
+
+      return findOptions?.filter ? targets.filter(findOptions.filter) : targets;
+    }),
+    lookAt: jest.fn((x: number, y: number) => lookEntriesByPosition[`${x},${y}`] ?? []),
+    createConstructionSite: jest.fn().mockReturnValue(0)
+  } as unknown as MockRoom;
+  const spawn = {
+    name: 'Spawn1',
+    room,
+    pos: { x: 25, y: 25, roomName }
+  } as unknown as StructureSpawn;
+
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    map: {
+      getRoomTerrain: jest.fn().mockReturnValue({
+        get: (x: number, y: number) => (wallPositions.has(`${x},${y}`) ? TEST_GLOBALS.TERRAIN_MASK_WALL : 0)
+      })
+    } as unknown as Game['map']
+  };
+
+  return {
+    room,
+    colony: {
+      room,
+      spawns: [spawn],
+      energyAvailable: room.energyAvailable,
+      energyCapacityAvailable: room.energyCapacityAvailable
+    }
+  };
+}
+
+function makeExtension(id: string): Structure {
+  return {
+    id,
+    structureType: TEST_GLOBALS.STRUCTURE_EXTENSION
+  } as unknown as Structure;
+}
+
+function makeExtensionSite(id: string): ConstructionSite {
+  return {
+    id,
+    structureType: TEST_GLOBALS.STRUCTURE_EXTENSION
+  } as unknown as ConstructionSite;
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic extension construction planner for early RCL extension growth.
- Calls the planner from the economy loop before workers choose build targets so new extension sites become immediately actionable.
- Adds unit/integration coverage for RCL gates, extension limits, occupied/wall avoidance, and build-target handoff.

## Linked issue
Fixes #84

## Roadmap category
Bot capability / resource-economy scaling

## Served vision layer
Resource/economy scale supporting future territory expansion: automatic extension planning raises energy capacity after RCL progress instead of leaving growth manual.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (77 tests)
- [x] `cd prod && npm run build`

## Notes
- Codex-authored commits: `9585aa2`, `c93ebce` by `lanyusea's bot <lanyusea@gmail.com>`.
- No secrets included.
- PR requires automated review gate, independent QA PASS, current Project fields, and >=15 minute elapsed gate before merge.