### PR TITLE
feat: balance worker source assignments

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -80,7 +80,7 @@ function selectWorkerTask(creep) {
   var _a;
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
   if (carriedEnergy === 0) {
-    const [source] = creep.room.find(FIND_SOURCES);
+    const source = selectHarvestSource(creep);
     return source ? { type: "harvest", targetId: source.id } : null;
   }
   const [energySink] = creep.room.find(FIND_MY_STRUCTURES, {
@@ -97,6 +97,50 @@ function selectWorkerTask(creep) {
     return { type: "upgrade", targetId: creep.room.controller.id };
   }
   return null;
+}
+function selectHarvestSource(creep) {
+  var _a, _b;
+  const sources = creep.room.find(FIND_SOURCES);
+  if (sources.length === 0) {
+    return null;
+  }
+  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, sources);
+  let selectedSource = sources[0];
+  let selectedCount = (_a = assignmentCounts.get(selectedSource.id)) != null ? _a : 0;
+  for (const source of sources.slice(1)) {
+    const count = (_b = assignmentCounts.get(source.id)) != null ? _b : 0;
+    if (count < selectedCount) {
+      selectedSource = source;
+      selectedCount = count;
+    }
+  }
+  return selectedSource;
+}
+function countSameRoomWorkerHarvestAssignments(roomName, sources) {
+  var _a, _b, _c, _d;
+  const assignmentCounts = /* @__PURE__ */ new Map();
+  for (const source of sources) {
+    assignmentCounts.set(source.id, 0);
+  }
+  if (!roomName) {
+    return assignmentCounts;
+  }
+  const sourceIds = new Set(sources.map((source) => source.id));
+  for (const assignedCreep of getGameCreeps()) {
+    const task = (_a = assignedCreep.memory) == null ? void 0 : _a.task;
+    const targetId = typeof (task == null ? void 0 : task.targetId) === "string" ? task.targetId : void 0;
+    if (((_b = assignedCreep.memory) == null ? void 0 : _b.role) !== "worker" || ((_c = assignedCreep.room) == null ? void 0 : _c.name) !== roomName || (task == null ? void 0 : task.type) !== "harvest" || !targetId || !sourceIds.has(targetId)) {
+      continue;
+    }
+    const sourceId = targetId;
+    assignmentCounts.set(sourceId, ((_d = assignmentCounts.get(sourceId)) != null ? _d : 0) + 1);
+  }
+  return assignmentCounts;
+}
+function getGameCreeps() {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  return creeps ? Object.values(creeps) : [];
 }
 
 // src/creeps/workerRunner.ts

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2,7 +2,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
 
   if (carriedEnergy === 0) {
-    const [source] = creep.room.find(FIND_SOURCES);
+    const source = selectHarvestSource(creep);
     return source ? { type: 'harvest', targetId: source.id } : null;
   }
 
@@ -26,4 +26,63 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   return null;
+}
+
+function selectHarvestSource(creep: Creep): Source | null {
+  const sources = creep.room.find(FIND_SOURCES);
+  if (sources.length === 0) {
+    return null;
+  }
+
+  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, sources);
+  let selectedSource = sources[0];
+  let selectedCount = assignmentCounts.get(selectedSource.id) ?? 0;
+
+  // Ties intentionally keep room.find(FIND_SOURCES) order stable.
+  for (const source of sources.slice(1)) {
+    const count = assignmentCounts.get(source.id) ?? 0;
+    if (count < selectedCount) {
+      selectedSource = source;
+      selectedCount = count;
+    }
+  }
+
+  return selectedSource;
+}
+
+function countSameRoomWorkerHarvestAssignments(roomName: string | undefined, sources: Source[]): Map<Id<Source>, number> {
+  const assignmentCounts = new Map<Id<Source>, number>();
+  for (const source of sources) {
+    assignmentCounts.set(source.id, 0);
+  }
+
+  if (!roomName) {
+    return assignmentCounts;
+  }
+
+  const sourceIds = new Set(sources.map((source) => source.id as string));
+  for (const assignedCreep of getGameCreeps()) {
+    const task = assignedCreep.memory?.task as Partial<CreepTaskMemory> | undefined;
+    const targetId = typeof task?.targetId === 'string' ? task.targetId : undefined;
+
+    if (
+      assignedCreep.memory?.role !== 'worker' ||
+      assignedCreep.room?.name !== roomName ||
+      task?.type !== 'harvest' ||
+      !targetId ||
+      !sourceIds.has(targetId)
+    ) {
+      continue;
+    }
+
+    const sourceId = targetId as Id<Source>;
+    assignmentCounts.set(sourceId, (assignmentCounts.get(sourceId) ?? 0) + 1);
+  }
+
+  return assignmentCounts;
+}
+
+function getGameCreeps(): Creep[] {
+  const creeps = (globalThis as unknown as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  return creeps ? Object.values(creeps) : [];
 }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -25,6 +25,38 @@ describe('runWorker', () => {
     expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('splits empty workers across sources as harvest assignments change', () => {
+    const source1 = { id: 'source1' } as Source;
+    const source2 = { id: 'source2' } as Source;
+    const room = {
+      name: 'W1N1',
+      find: jest.fn().mockReturnValue([source1, source2])
+    } as unknown as Room;
+    const assigned = {
+      memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+      room
+    } as unknown as Creep;
+    const worker1 = {
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    const worker2 = {
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Assigned: assigned, Worker1: worker1, Worker2: worker2 }
+    };
+
+    runWorker(worker1);
+    runWorker(worker2);
+
+    expect(worker1.memory.task).toEqual({ type: 'harvest', targetId: 'source2' });
+    expect(worker2.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
   it('leaves worker untasked when it has no energy and no sources', () => {
     const creep = {
       memory: {},

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -8,6 +8,7 @@ describe('selectWorkerTask', () => {
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { Game?: Partial<Game> }).Game = { creeps: {} };
   });
 
   it('selects harvest when worker has no energy', () => {
@@ -18,6 +19,52 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('selects the least-assigned harvest source for same-room workers', () => {
+    const source1 = { id: 'source1' } as Source;
+    const source2 = { id: 'source2' } as Source;
+    const room = {
+      name: 'W1N1',
+      find: jest.fn().mockReturnValue([source1, source2])
+    } as unknown as Room;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        Assigned: {
+          memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+          room
+        } as unknown as Creep,
+        OtherRoom: {
+          memory: { role: 'worker', task: { type: 'harvest', targetId: 'source2' as Id<Source> } },
+          room: { name: 'W2N2' } as Room
+        } as unknown as Creep,
+        Miner: {
+          memory: { role: 'miner', task: { type: 'harvest', targetId: 'source2' as Id<Source> } },
+          room
+        } as unknown as Creep,
+        Partial: {
+          memory: { role: 'worker', task: { type: 'harvest' } as CreepTaskMemory },
+          room
+        } as unknown as Creep
+      }
+    };
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
+  });
+
+  it('keeps room.find source order as the stable tie-breaker', () => {
+    const source2 = { id: 'source2' } as Source;
+    const source1 = { id: 'source1' } as Source;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room: { name: 'W1N1', find: jest.fn().mockReturnValue([source2, source1]) }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
   it('selects no task when worker has no energy and no sources', () => {
@@ -65,6 +112,57 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps carried-energy fallback order as transfer, build, then upgrade', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const fullSpawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const site = { id: 'site1' } as ConstructionSite;
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const makeCreep = (room: Room): Creep =>
+      ({
+        store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+        room
+      }) as unknown as Creep;
+
+    const roomWithSink = {
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+        if (type === 3) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return type === 2 ? [site] : [];
+      })
+    } as unknown as Room;
+    const roomWithSite = {
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+        if (type === 3) {
+          const structures = [fullSpawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return type === 2 ? [site] : [];
+      })
+    } as unknown as Room;
+    const roomWithController = {
+      controller,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+
+    expect(selectWorkerTask(makeCreep(roomWithSink))).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(selectWorkerTask(makeCreep(roomWithSite))).toEqual({ type: 'build', targetId: 'site1' });
+    expect(selectWorkerTask(makeCreep(roomWithController))).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('selects no task when worker has energy and the room has no spending targets or controller', () => {


### PR DESCRIPTION
## Summary
- Balances worker harvest assignments across available sources using current harvest-task counts and deterministic tie-breaking.
- Preserves existing task behavior while improving source utilization when workers are empty.
- Adds deterministic coverage for two-source balancing, stable tie-breaking, missing-source fallback, and worker-runner behavior.

## Linked issue
Fixes #85

## Roadmap category
Bot capability / resource throughput

## Served vision layer
Resource/economy scale: distributing workers across sources reduces early-room harvest congestion and improves throughput before broader territory/resource strategy.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (76 tests)
- [x] `cd prod && npm run build`

## Notes
- Codex-authored commit: `a5f5198` by `lanyusea's bot <lanyusea@gmail.com>`.
- No secrets included.
- PR requires automated review gate, independent QA PASS, current Project fields, and >=15 minute elapsed gate before merge.