### PR TITLE
feat: add controller downgrade guard

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -198,8 +198,8 @@ function canSatisfyWorkerCapacity(creep) {
 }
 
 // src/tasks/workerTasks.ts
+var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 function selectWorkerTask(creep) {
-  var _a;
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
   if (carriedEnergy === 0) {
     const source = selectHarvestSource(creep);
@@ -211,14 +211,21 @@ function selectWorkerTask(creep) {
   if (energySink) {
     return { type: "transfer", targetId: energySink.id };
   }
+  const controller = creep.room.controller;
+  if (controller && shouldGuardControllerDowngrade(controller)) {
+    return { type: "upgrade", targetId: controller.id };
+  }
   const [constructionSite] = creep.room.find(FIND_CONSTRUCTION_SITES);
   if (constructionSite) {
     return { type: "build", targetId: constructionSite.id };
   }
-  if ((_a = creep.room.controller) == null ? void 0 : _a.my) {
-    return { type: "upgrade", targetId: creep.room.controller.id };
+  if (controller == null ? void 0 : controller.my) {
+    return { type: "upgrade", targetId: controller.id };
   }
   return null;
+}
+function shouldGuardControllerDowngrade(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
 }
 function selectHarvestSource(creep) {
   var _a, _b;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1,3 +1,6 @@
+// Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
+export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
+
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
 
@@ -16,16 +19,29 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'transfer', targetId: energySink.id as Id<AnyStoreStructure> };
   }
 
+  const controller = creep.room.controller;
+  if (controller && shouldGuardControllerDowngrade(controller)) {
+    return { type: 'upgrade', targetId: controller.id };
+  }
+
   const [constructionSite] = creep.room.find(FIND_CONSTRUCTION_SITES);
   if (constructionSite) {
     return { type: 'build', targetId: constructionSite.id };
   }
 
-  if (creep.room.controller?.my) {
-    return { type: 'upgrade', targetId: creep.room.controller.id };
+  if (controller?.my) {
+    return { type: 'upgrade', targetId: controller.id };
   }
 
   return null;
+}
+
+function shouldGuardControllerDowngrade(controller: StructureController | undefined): boolean {
+  return (
+    controller?.my === true &&
+    typeof controller.ticksToDowngrade === 'number' &&
+    controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS
+  );
 }
 
 function selectHarvestSource(creep: Creep): Source | null {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1,4 +1,4 @@
-import { selectWorkerTask } from '../src/tasks/workerTasks';
+import { CONTROLLER_DOWNGRADE_GUARD_TICKS, selectWorkerTask } from '../src/tasks/workerTasks';
 
 describe('selectWorkerTask', () => {
   beforeEach(() => {
@@ -102,6 +102,108 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('keeps normal build-before-upgrade priority when controller downgrade is safe', () => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === 2 ? [site] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('selects upgrade before build when an owned controller is near downgrade', () => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === 2 ? [site] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps spawn refill priority over the downgrade guard', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const site = { id: 'site1' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+          if (type === 3) {
+            const structures = [spawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          return type === 2 ? [site] : [];
+        })
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('keeps build priority for low downgrade data on unowned controllers', () => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: false,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === 2 ? [site] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('keeps build priority when owned controller downgrade data is missing', () => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === 2 ? [site] : []))
+      }
+    } as unknown as Creep;
+    let task: CreepTaskMemory | null | undefined;
+
+    expect(() => {
+      task = selectWorkerTask(creep);
+    }).not.toThrow();
+    expect(task).toEqual({ type: 'build', targetId: 'site1' });
   });
 
   it('selects upgrade when worker has energy and no construction sites exist', () => {


### PR DESCRIPTION
## Summary
- Adds a deterministic low-downgrade controller guard to worker task selection.
- Preserves normal refill/build/upgrade priority when controller downgrade risk is healthy.
- Keeps spawn/extension refill ahead of the guard and handles unowned/missing downgrade data safely.

## Linked issue
Fixes #89

## Roadmap category
Bot capability / territory-control safety

## Served vision layer
Territory/control: prevents construction work from starving urgent controller refreshes when the owned controller is near downgrade.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (87 tests)
- [x] `cd prod && npm run build`

## Notes
- Codex-authored commit: `b1c82c8 lanyusea's bot <lanyusea@gmail.com> feat: add controller downgrade guard`
- No secrets included.
- Requires independent QA PASS, green checks/reviews, no active review threads, current Project fields, and >=15 minute elapsed review gate before merge.
