### PR TITLE
feat: add source-aware worker target

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -376,6 +376,7 @@ function getBodyCost(body) {
 var MIN_WORKER_TARGET = 3;
 var WORKERS_PER_SOURCE = 2;
 var MAX_WORKER_TARGET = 6;
+var sourceCountByRoomName = /* @__PURE__ */ new Map();
 function planSpawn(colony, roleCounts, gameTime) {
   if (roleCounts.worker >= getWorkerTarget(colony)) {
     return null;
@@ -414,7 +415,21 @@ function getWorkerTarget(colony) {
   return Math.min(MAX_WORKER_TARGET, Math.max(MIN_WORKER_TARGET, sourceAwareTarget));
 }
 function getSourceCount(room) {
-  if (typeof FIND_SOURCES === "undefined") {
+  const roomName = typeof room.name === "string" && room.name.length > 0 ? room.name : void 0;
+  if (roomName) {
+    const cachedSourceCount = sourceCountByRoomName.get(roomName);
+    if (cachedSourceCount !== void 0) {
+      return cachedSourceCount;
+    }
+  }
+  const sourceCount = findSourceCount(room);
+  if (roomName) {
+    sourceCountByRoomName.set(roomName, sourceCount);
+  }
+  return sourceCount;
+}
+function findSourceCount(room) {
+  if (typeof FIND_SOURCES === "undefined" || typeof room.find !== "function") {
     return 1;
   }
   return room.find(FIND_SOURCES).length;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -366,9 +366,11 @@ function getBodyCost(body) {
 }
 
 // src/spawn/spawnPlanner.ts
-var TARGET_WORKERS = 3;
+var MIN_WORKER_TARGET = 3;
+var WORKERS_PER_SOURCE = 2;
+var MAX_WORKER_TARGET = 6;
 function planSpawn(colony, roleCounts, gameTime) {
-  if (roleCounts.worker >= TARGET_WORKERS) {
+  if (roleCounts.worker >= getWorkerTarget(colony)) {
     return null;
   }
   const spawn = colony.spawns.find((candidate) => !candidate.spawning);
@@ -398,6 +400,17 @@ function selectWorkerBody(colony, roleCounts) {
 }
 function canAffordBody(body, energyAvailable) {
   return body.length > 0 && getBodyCost(body) <= energyAvailable;
+}
+function getWorkerTarget(colony) {
+  const sourceCount = getSourceCount(colony.room);
+  const sourceAwareTarget = sourceCount * WORKERS_PER_SOURCE;
+  return Math.min(MAX_WORKER_TARGET, Math.max(MIN_WORKER_TARGET, sourceAwareTarget));
+}
+function getSourceCount(room) {
+  if (typeof FIND_SOURCES === "undefined") {
+    return 1;
+  }
+  return room.find(FIND_SOURCES).length;
 }
 
 // src/telemetry/runtimeSummary.ts

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -13,6 +13,7 @@ const MIN_WORKER_TARGET = 3;
 const WORKERS_PER_SOURCE = 2;
 // Keep source-aware scaling bounded so unusual source data cannot create runaway early-room spawn pressure.
 const MAX_WORKER_TARGET = 6;
+const sourceCountByRoomName = new Map<string, number>();
 
 export function planSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTime: number): SpawnRequest | null {
   if (roleCounts.worker >= getWorkerTarget(colony)) {
@@ -62,7 +63,24 @@ function getWorkerTarget(colony: ColonySnapshot): number {
 }
 
 function getSourceCount(room: Room): number {
-  if (typeof FIND_SOURCES === 'undefined') {
+  const roomName = typeof room.name === 'string' && room.name.length > 0 ? room.name : undefined;
+  if (roomName) {
+    const cachedSourceCount = sourceCountByRoomName.get(roomName);
+    if (cachedSourceCount !== undefined) {
+      return cachedSourceCount;
+    }
+  }
+
+  const sourceCount = findSourceCount(room);
+  if (roomName) {
+    sourceCountByRoomName.set(roomName, sourceCount);
+  }
+
+  return sourceCount;
+}
+
+function findSourceCount(room: Room): number {
+  if (typeof FIND_SOURCES === 'undefined' || typeof room.find !== 'function') {
     return 1;
   }
 

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -9,10 +9,13 @@ export interface SpawnRequest {
   memory: CreepMemory;
 }
 
-const TARGET_WORKERS = 3;
+const MIN_WORKER_TARGET = 3;
+const WORKERS_PER_SOURCE = 2;
+// Keep source-aware scaling bounded so unusual source data cannot create runaway early-room spawn pressure.
+const MAX_WORKER_TARGET = 6;
 
 export function planSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTime: number): SpawnRequest | null {
-  if (roleCounts.worker >= TARGET_WORKERS) {
+  if (roleCounts.worker >= getWorkerTarget(colony)) {
     return null;
   }
 
@@ -49,4 +52,19 @@ function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyP
 
 function canAffordBody(body: BodyPartConstant[], energyAvailable: number): boolean {
   return body.length > 0 && getBodyCost(body) <= energyAvailable;
+}
+
+function getWorkerTarget(colony: ColonySnapshot): number {
+  const sourceCount = getSourceCount(colony.room);
+  const sourceAwareTarget = sourceCount * WORKERS_PER_SOURCE;
+
+  return Math.min(MAX_WORKER_TARGET, Math.max(MIN_WORKER_TARGET, sourceAwareTarget));
+}
+
+function getSourceCount(room: Room): number {
+  if (typeof FIND_SOURCES === 'undefined') {
+    return 1;
+  }
+
+  return room.find(FIND_SOURCES).length;
 }

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -2,20 +2,41 @@ import { planSpawn } from '../src/spawn/spawnPlanner';
 import { ColonySnapshot } from '../src/colony/colonyRegistry';
 
 describe('planSpawn', () => {
-  const room = {
-    name: 'W1N1',
-    energyAvailable: 300,
-    energyCapacityAvailable: 300
-  } as Room;
+  beforeEach(() => {
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+  });
 
-  it('plans a worker when the colony has no workers and an idle spawn', () => {
-    const spawn = { name: 'Spawn1', room, spawning: null } as StructureSpawn;
+  function makeColony({
+    sourceCount = 1,
+    energyAvailable = 300,
+    energyCapacityAvailable = 300,
+    spawning = null
+  }: {
+    sourceCount?: number;
+    energyAvailable?: number;
+    energyCapacityAvailable?: number;
+    spawning?: Spawning | null;
+  } = {}): { colony: ColonySnapshot; spawn: StructureSpawn } {
+    const sources = Array.from({ length: sourceCount }, (_, index) => ({ id: `source${index}` }) as Source);
+    const room = {
+      name: 'W1N1',
+      energyAvailable,
+      energyCapacityAvailable,
+      find: jest.fn((type: number) => (type === FIND_SOURCES ? sources : []))
+    } as unknown as Room;
+    const spawn = { name: 'Spawn1', room, spawning } as StructureSpawn;
     const colony: ColonySnapshot = {
       room,
       spawns: [spawn],
-      energyAvailable: 300,
-      energyCapacityAvailable: 300
+      energyAvailable,
+      energyCapacityAvailable
     };
+
+    return { colony, spawn };
+  }
+
+  it('plans a worker when the colony has no workers and an idle spawn', () => {
+    const { colony, spawn } = makeColony();
 
     expect(planSpawn(colony, { worker: 0 }, 123)).toEqual({
       spawn,
@@ -25,26 +46,14 @@ describe('planSpawn', () => {
     });
   });
 
-  it('does not plan when target workers already exist', () => {
-    const spawn = { name: 'Spawn1', room, spawning: null } as StructureSpawn;
-    const colony: ColonySnapshot = {
-      room,
-      spawns: [spawn],
-      energyAvailable: 300,
-      energyCapacityAvailable: 300
-    };
+  it('keeps one-source rooms at the three-worker target', () => {
+    const { colony } = makeColony({ sourceCount: 1 });
 
     expect(planSpawn(colony, { worker: 3 }, 123)).toBeNull();
   });
 
   it('plans one replacement when steady-state worker capacity is below target', () => {
-    const spawn = { name: 'Spawn1', room, spawning: null } as StructureSpawn;
-    const colony: ColonySnapshot = {
-      room,
-      spawns: [spawn],
-      energyAvailable: 300,
-      energyCapacityAvailable: 300
-    };
+    const { colony, spawn } = makeColony();
 
     expect(planSpawn(colony, { worker: 2 }, 124)).toEqual({
       spawn,
@@ -55,25 +64,37 @@ describe('planSpawn', () => {
   });
 
   it('does not overbuild when replacement-aware worker capacity is at target', () => {
-    const spawn = { name: 'Spawn1', room, spawning: null } as StructureSpawn;
-    const colony: ColonySnapshot = {
-      room,
-      spawns: [spawn],
-      energyAvailable: 300,
-      energyCapacityAvailable: 300
-    };
+    const { colony } = makeColony();
 
     expect(planSpawn(colony, { worker: 3 }, 124)).toBeNull();
   });
 
+  it('targets a fourth worker for two-source rooms', () => {
+    const { colony, spawn } = makeColony({ sourceCount: 2 });
+
+    expect(planSpawn(colony, { worker: 3 }, 126)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W1N1-126',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+    expect(planSpawn(colony, { worker: 4 }, 126)).toBeNull();
+  });
+
+  it('caps the source-aware worker target', () => {
+    const { colony, spawn } = makeColony({ sourceCount: 10 });
+
+    expect(planSpawn(colony, { worker: 5 }, 127)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W1N1-127',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+    expect(planSpawn(colony, { worker: 6 }, 127)).toBeNull();
+  });
+
   it('plans an emergency basic worker when zero active workers cannot afford the normal worker body', () => {
-    const spawn = { name: 'Spawn1', room, spawning: null } as StructureSpawn;
-    const colony: ColonySnapshot = {
-      room,
-      spawns: [spawn],
-      energyAvailable: 200,
-      energyCapacityAvailable: 400
-    };
+    const { colony, spawn } = makeColony({ energyAvailable: 200, energyCapacityAvailable: 400 });
 
     expect(planSpawn(colony, { worker: 0 }, 125)).toEqual({
       spawn,
@@ -84,37 +105,19 @@ describe('planSpawn', () => {
   });
 
   it('waits for normal worker energy instead of using the emergency body for replacements', () => {
-    const spawn = { name: 'Spawn1', room, spawning: null } as StructureSpawn;
-    const colony: ColonySnapshot = {
-      room,
-      spawns: [spawn],
-      energyAvailable: 200,
-      energyCapacityAvailable: 400
-    };
+    const { colony } = makeColony({ energyAvailable: 200, energyCapacityAvailable: 400 });
 
     expect(planSpawn(colony, { worker: 2 }, 125)).toBeNull();
   });
 
   it('does not plan an emergency body that costs more than available energy', () => {
-    const spawn = { name: 'Spawn1', room, spawning: null } as StructureSpawn;
-    const colony: ColonySnapshot = {
-      room,
-      spawns: [spawn],
-      energyAvailable: 199,
-      energyCapacityAvailable: 400
-    };
+    const { colony } = makeColony({ energyAvailable: 199, energyCapacityAvailable: 400 });
 
     expect(planSpawn(colony, { worker: 0 }, 125)).toBeNull();
   });
 
   it('does not plan when all spawns are busy', () => {
-    const spawn = { name: 'Spawn1', room, spawning: {} as Spawning } as StructureSpawn;
-    const colony: ColonySnapshot = {
-      room,
-      spawns: [spawn],
-      energyAvailable: 300,
-      energyCapacityAvailable: 300
-    };
+    const { colony } = makeColony({ spawning: {} as Spawning });
 
     expect(planSpawn(colony, { worker: 0 }, 123)).toBeNull();
   });

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -10,19 +10,22 @@ describe('planSpawn', () => {
     sourceCount = 1,
     energyAvailable = 300,
     energyCapacityAvailable = 300,
+    roomName = 'W1N1',
     spawning = null
   }: {
     sourceCount?: number;
     energyAvailable?: number;
     energyCapacityAvailable?: number;
+    roomName?: string;
     spawning?: Spawning | null;
-  } = {}): { colony: ColonySnapshot; spawn: StructureSpawn } {
+  } = {}): { colony: ColonySnapshot; spawn: StructureSpawn; find: jest.Mock<Source[], [number]> } {
     const sources = Array.from({ length: sourceCount }, (_, index) => ({ id: `source${index}` }) as Source);
+    const find = jest.fn((type: number) => (type === FIND_SOURCES ? sources : []));
     const room = {
-      name: 'W1N1',
+      name: roomName,
       energyAvailable,
       energyCapacityAvailable,
-      find: jest.fn((type: number) => (type === FIND_SOURCES ? sources : []))
+      find
     } as unknown as Room;
     const spawn = { name: 'Spawn1', room, spawning } as StructureSpawn;
     const colony: ColonySnapshot = {
@@ -32,7 +35,7 @@ describe('planSpawn', () => {
       energyCapacityAvailable
     };
 
-    return { colony, spawn };
+    return { colony, spawn, find };
   }
 
   it('plans a worker when the colony has no workers and an idle spawn', () => {
@@ -70,27 +73,65 @@ describe('planSpawn', () => {
   });
 
   it('targets a fourth worker for two-source rooms', () => {
-    const { colony, spawn } = makeColony({ sourceCount: 2 });
+    const { colony, spawn } = makeColony({ roomName: 'W1N2', sourceCount: 2 });
 
     expect(planSpawn(colony, { worker: 3 }, 126)).toEqual({
       spawn,
       body: ['work', 'carry', 'move'],
-      name: 'worker-W1N1-126',
-      memory: { role: 'worker', colony: 'W1N1' }
+      name: 'worker-W1N2-126',
+      memory: { role: 'worker', colony: 'W1N2' }
     });
     expect(planSpawn(colony, { worker: 4 }, 126)).toBeNull();
   });
 
   it('caps the source-aware worker target', () => {
-    const { colony, spawn } = makeColony({ sourceCount: 10 });
+    const { colony, spawn } = makeColony({ roomName: 'W1N3', sourceCount: 10 });
 
     expect(planSpawn(colony, { worker: 5 }, 127)).toEqual({
       spawn,
       body: ['work', 'carry', 'move'],
-      name: 'worker-W1N1-127',
-      memory: { role: 'worker', colony: 'W1N1' }
+      name: 'worker-W1N3-127',
+      memory: { role: 'worker', colony: 'W1N3' }
     });
     expect(planSpawn(colony, { worker: 6 }, 127)).toBeNull();
+  });
+
+  it('caches source counts for repeated planning in the same room', () => {
+    const { colony, find } = makeColony({ roomName: 'W1N4', sourceCount: 2 });
+
+    planSpawn(colony, { worker: 3 }, 128);
+    planSpawn(colony, { worker: 3 }, 129);
+
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(find).toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('computes source counts once for each newly encountered room', () => {
+    const first = makeColony({ roomName: 'W1N5', sourceCount: 1 });
+    const second = makeColony({ roomName: 'W1N6', sourceCount: 2 });
+
+    planSpawn(first.colony, { worker: 2 }, 130);
+    planSpawn(second.colony, { worker: 3 }, 131);
+    planSpawn(second.colony, { worker: 3 }, 132);
+
+    expect(first.find).toHaveBeenCalledTimes(1);
+    expect(second.find).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back safely when room name and find are absent in a mock', () => {
+    const room = {
+      energyAvailable: 300,
+      energyCapacityAvailable: 300
+    } as unknown as Room;
+    const spawn = { name: 'Spawn1', room, spawning: null } as StructureSpawn;
+    const colony: ColonySnapshot = {
+      room,
+      spawns: [spawn],
+      energyAvailable: 300,
+      energyCapacityAvailable: 300
+    };
+
+    expect(planSpawn(colony, { worker: 3 }, 133)).toBeNull();
   });
 
   it('plans an emergency basic worker when zero active workers cannot afford the normal worker body', () => {


### PR DESCRIPTION
## Summary
- Adds a deterministic source-aware worker target for the spawn planner.
- Keeps one-source rooms at the existing 3-worker target while scaling two-source rooms to at least 4 workers.
- Preserves zero-creep emergency recovery and insufficient-energy behavior.

## Linked issue
Fixes #91

## Roadmap category
Bot capability / resource-economy throughput

## Served vision layer
Resource/economy: scales worker count with available sources so early rooms can improve harvest/build/upgrade throughput after source balancing and extension planning.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (89 tests)
- [x] `cd prod && npm run build`
- [x] `git merge-base --is-ancestor origin/main HEAD`

## Notes
- Codex-authored implementation commit: `cd04f82 lanyusea's bot <lanyusea@gmail.com> feat: add source-aware worker target`
- Branch was merged with current `origin/main` after PR #90 landed; final head includes merge commit `81f86d8`.
- No secrets included.
- Requires independent QA PASS, green checks/reviews, no active review threads, current Project fields, and >=15 minute elapsed review gate before merge.
