### PR TITLE
feat: add RCL1 controller rush guard

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -206,7 +206,7 @@ function selectWorkerTask(creep) {
     return source ? { type: "harvest", targetId: source.id } : null;
   }
   const [energySink] = creep.room.find(FIND_MY_STRUCTURES, {
-    filter: (structure) => (structure.structureType === STRUCTURE_SPAWN || structure.structureType === STRUCTURE_EXTENSION) && "store" in structure && structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0
+    filter: isFillableEnergySink
   });
   if (energySink) {
     return { type: "transfer", targetId: energySink.id };
@@ -215,17 +215,32 @@ function selectWorkerTask(creep) {
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
+  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
+  const spawnConstructionSite = constructionSites.find(isSpawnConstructionSite);
+  if (spawnConstructionSite) {
+    return { type: "build", targetId: spawnConstructionSite.id };
+  }
   if (controller && shouldRushRcl1Controller(controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
-  const [constructionSite] = creep.room.find(FIND_CONSTRUCTION_SITES);
-  if (constructionSite) {
-    return { type: "build", targetId: constructionSite.id };
+  if (constructionSites[0]) {
+    return { type: "build", targetId: constructionSites[0].id };
   }
   if (controller == null ? void 0 : controller.my) {
     return { type: "upgrade", targetId: controller.id };
   }
   return null;
+}
+function isFillableEnergySink(structure) {
+  return (matchesStructureType(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure && structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
+}
+function isSpawnConstructionSite(site) {
+  return matchesStructureType(site.structureType, "STRUCTURE_SPAWN", "spawn");
+}
+function matchesStructureType(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 function shouldGuardControllerDowngrade(controller) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -215,6 +215,9 @@ function selectWorkerTask(creep) {
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
+  if (controller && shouldRushRcl1Controller(controller)) {
+    return { type: "upgrade", targetId: controller.id };
+  }
   const [constructionSite] = creep.room.find(FIND_CONSTRUCTION_SITES);
   if (constructionSite) {
     return { type: "build", targetId: constructionSite.id };
@@ -226,6 +229,9 @@ function selectWorkerTask(creep) {
 }
 function shouldGuardControllerDowngrade(controller) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
+}
+function shouldRushRcl1Controller(controller) {
+  return controller.my === true && controller.level === 1;
 }
 function selectHarvestSource(creep) {
   var _a, _b;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -24,6 +24,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'upgrade', targetId: controller.id };
   }
 
+  if (controller && shouldRushRcl1Controller(controller)) {
+    return { type: 'upgrade', targetId: controller.id };
+  }
+
   const [constructionSite] = creep.room.find(FIND_CONSTRUCTION_SITES);
   if (constructionSite) {
     return { type: 'build', targetId: constructionSite.id };
@@ -42,6 +46,10 @@ function shouldGuardControllerDowngrade(controller: StructureController | undefi
     typeof controller.ticksToDowngrade === 'number' &&
     controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS
   );
+}
+
+function shouldRushRcl1Controller(controller: StructureController): boolean {
+  return controller.my === true && controller.level === 1;
 }
 
 function selectHarvestSource(creep: Creep): Source | null {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -10,10 +10,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const [energySink] = creep.room.find(FIND_MY_STRUCTURES, {
-    filter: (structure) =>
-      (structure.structureType === STRUCTURE_SPAWN || structure.structureType === STRUCTURE_EXTENSION) &&
-      'store' in structure &&
-      structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0
+    filter: isFillableEnergySink
   });
   if (energySink) {
     return { type: 'transfer', targetId: energySink.id as Id<AnyStoreStructure> };
@@ -24,13 +21,18 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'upgrade', targetId: controller.id };
   }
 
+  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
+  const spawnConstructionSite = constructionSites.find(isSpawnConstructionSite);
+  if (spawnConstructionSite) {
+    return { type: 'build', targetId: spawnConstructionSite.id };
+  }
+
   if (controller && shouldRushRcl1Controller(controller)) {
     return { type: 'upgrade', targetId: controller.id };
   }
 
-  const [constructionSite] = creep.room.find(FIND_CONSTRUCTION_SITES);
-  if (constructionSite) {
-    return { type: 'build', targetId: constructionSite.id };
+  if (constructionSites[0]) {
+    return { type: 'build', targetId: constructionSites[0].id };
   }
 
   if (controller?.my) {
@@ -38,6 +40,26 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   return null;
+}
+
+function isFillableEnergySink(structure: AnyOwnedStructure): structure is StructureSpawn | StructureExtension {
+  return (
+    (matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+      matchesStructureType(structure.structureType, 'STRUCTURE_EXTENSION', 'extension')) &&
+    'store' in structure &&
+    structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0
+  );
+}
+
+function isSpawnConstructionSite(site: ConstructionSite): boolean {
+  return matchesStructureType(site.structureType, 'STRUCTURE_SPAWN', 'spawn');
+}
+
+type StructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION';
+
+function matchesStructureType(actual: string | undefined, globalName: StructureConstantGlobal, fallback: string): boolean {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, string>>;
+  return actual === (constants[globalName] ?? fallback);
 }
 
 function shouldGuardControllerDowngrade(controller: StructureController | undefined): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -104,11 +104,31 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
   });
 
-  it('keeps normal build-before-upgrade priority when controller downgrade is safe', () => {
+  it('selects RCL1 controller upgrade before construction when downgrade is safe', () => {
     const site = { id: 'site1' } as ConstructionSite;
     const controller = {
       id: 'controller1',
       my: true,
+      level: 1,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === 2 ? [site] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps RCL2 build-before-upgrade priority when controller downgrade is safe', () => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
     } as StructureController;
     const creep = {
@@ -122,11 +142,12 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
   });
 
-  it('selects upgrade before build when an owned controller is near downgrade', () => {
+  it('keeps low-downgrade guard above construction at RCL2', () => {
     const site = { id: 'site1' } as ConstructionSite;
     const controller = {
       id: 'controller1',
       my: true,
+      level: 2,
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
     } as StructureController;
     const creep = {
@@ -138,6 +159,37 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps spawn refill priority over RCL1 controller rush', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const site = { id: 'site1' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 1,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+          if (type === 3) {
+            const structures = [spawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          return type === 2 ? [site] : [];
+        })
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
   it('keeps spawn refill priority over the downgrade guard', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -104,8 +104,39 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
   });
 
-  it('selects RCL1 controller upgrade before construction when downgrade is safe', () => {
-    const site = { id: 'site1' } as ConstructionSite;
+  it('selects RCL1 controller upgrade before non-spawn construction when downgrade is safe', () => {
+    const fullSpawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const site = { id: 'site1', structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 1,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+          if (type === 3) {
+            const structures = [fullSpawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          return type === 2 ? [site] : [];
+        })
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('builds spawn construction before RCL1 controller rush', () => {
+    const site = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;
     const controller = {
       id: 'controller1',
       my: true,
@@ -120,7 +151,31 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
+  });
+
+  it('builds spawn construction before RCL1 rush when STRUCTURE_SPAWN is missing from the mock globals', () => {
+    delete (globalThis as unknown as { STRUCTURE_SPAWN?: StructureConstant }).STRUCTURE_SPAWN;
+    const site = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 1,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === 2 ? [site] : []))
+      }
+    } as unknown as Creep;
+    let task: CreepTaskMemory | null | undefined;
+
+    expect(() => {
+      task = selectWorkerTask(creep);
+    }).not.toThrow();
+    expect(task).toEqual({ type: 'build', targetId: 'spawn-site1' });
   });
 
   it('keeps RCL2 build-before-upgrade priority when controller downgrade is safe', () => {


### PR DESCRIPTION
## Summary
- Adds a deterministic RCL1 controller-rush guard to worker task selection.
- Keeps spawn/extension refill before controller-rush logic.
- Preserves RCL2+ build-before-upgrade behavior and the low-downgrade safety guard.

## Linked issue
Fixes #93

## Roadmap category
Bot capability / territory-control

## Served vision layer
Territory/control: helps owned RCL1 rooms reach RCL2 sooner so extension construction and early expansion capacity can come online instead of spending energy on non-critical construction first.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (89 tests)
- [x] `cd prod && npm run build`

## Notes
- Codex-authored commit: `3765b75 lanyusea's bot <lanyusea@gmail.com> feat: add rcl1 controller rush guard`
- No secrets included.
- Requires independent QA PASS, green checks/reviews, no active review threads, current Project fields, and >=15 minute elapsed review gate before merge.
