### PR TITLE
feat: add RCL2 controller progress guard

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -223,6 +223,13 @@ function selectWorkerTask(creep) {
   if (controller && shouldRushRcl1Controller(controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
+  const extensionConstructionSite = constructionSites.find(isExtensionConstructionSite);
+  if (extensionConstructionSite) {
+    return { type: "build", targetId: extensionConstructionSite.id };
+  }
+  if (controller && shouldGuardRcl2ControllerProgress(controller)) {
+    return { type: "upgrade", targetId: controller.id };
+  }
   if (constructionSites[0]) {
     return { type: "build", targetId: constructionSites[0].id };
   }
@@ -237,6 +244,9 @@ function isFillableEnergySink(structure) {
 function isSpawnConstructionSite(site) {
   return matchesStructureType(site.structureType, "STRUCTURE_SPAWN", "spawn");
 }
+function isExtensionConstructionSite(site) {
+  return matchesStructureType(site.structureType, "STRUCTURE_EXTENSION", "extension");
+}
 function matchesStructureType(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
@@ -247,6 +257,9 @@ function shouldGuardControllerDowngrade(controller) {
 }
 function shouldRushRcl1Controller(controller) {
   return controller.my === true && controller.level === 1;
+}
+function shouldGuardRcl2ControllerProgress(controller) {
+  return controller.my === true && controller.level === 2;
 }
 function selectHarvestSource(creep) {
   var _a, _b;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -31,6 +31,15 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'upgrade', targetId: controller.id };
   }
 
+  const extensionConstructionSite = constructionSites.find(isExtensionConstructionSite);
+  if (extensionConstructionSite) {
+    return { type: 'build', targetId: extensionConstructionSite.id };
+  }
+
+  if (controller && shouldGuardRcl2ControllerProgress(controller)) {
+    return { type: 'upgrade', targetId: controller.id };
+  }
+
   if (constructionSites[0]) {
     return { type: 'build', targetId: constructionSites[0].id };
   }
@@ -55,6 +64,10 @@ function isSpawnConstructionSite(site: ConstructionSite): boolean {
   return matchesStructureType(site.structureType, 'STRUCTURE_SPAWN', 'spawn');
 }
 
+function isExtensionConstructionSite(site: ConstructionSite): boolean {
+  return matchesStructureType(site.structureType, 'STRUCTURE_EXTENSION', 'extension');
+}
+
 type StructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION';
 
 function matchesStructureType(actual: string | undefined, globalName: StructureConstantGlobal, fallback: string): boolean {
@@ -72,6 +85,10 @@ function shouldGuardControllerDowngrade(controller: StructureController | undefi
 
 function shouldRushRcl1Controller(controller: StructureController): boolean {
   return controller.my === true && controller.level === 1;
+}
+
+function shouldGuardRcl2ControllerProgress(controller: StructureController): boolean {
+  return controller.my === true && controller.level === 2;
 }
 
 function selectHarvestSource(creep: Creep): Source | null {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -80,18 +80,21 @@ describe('selectWorkerTask', () => {
     expect(task).toBeNull();
   });
 
-  it('selects transfer when worker has energy and spawn needs energy', () => {
-    const spawn = {
-      id: 'spawn1',
-      structureType: 'spawn',
+  it.each([
+    ['spawn', 'spawn1'],
+    ['extension', 'extension1']
+  ])('selects transfer when worker has energy and %s needs energy', (structureType, id) => {
+    const energySink = {
+      id,
+      structureType,
       store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
-    } as unknown as StructureSpawn;
+    } as unknown as StructureSpawn | StructureExtension;
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: { find: jest.fn((type) => (type === 3 ? [spawn] : [])) }
+      room: { find: jest.fn((type) => (type === 3 ? [energySink] : [])) }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
   });
 
   it('selects build when worker has energy and construction sites exist', () => {
@@ -178,8 +181,11 @@ describe('selectWorkerTask', () => {
     expect(task).toEqual({ type: 'build', targetId: 'spawn-site1' });
   });
 
-  it('keeps RCL2 build-before-upgrade priority when controller downgrade is safe', () => {
-    const site = { id: 'site1' } as ConstructionSite;
+  it.each([
+    ['road', 'road-site1'],
+    ['container', 'container-site1']
+  ])('selects RCL2 controller upgrade before non-critical %s construction when downgrade is safe', (structureType, id) => {
+    const site = { id, structureType } as ConstructionSite;
     const controller = {
       id: 'controller1',
       my: true,
@@ -194,11 +200,76 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it.each([
+    ['spawn', 'spawn-site1'],
+    ['extension', 'extension-site1']
+  ])('builds RCL2 critical %s construction before controller progress guard', (structureType, id) => {
+    const site = { id, structureType } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === 2 ? [site] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: id });
+  });
+
+  it('builds RCL2 extension construction before controller progress guard when STRUCTURE_EXTENSION is missing', () => {
+    delete (globalThis as unknown as { STRUCTURE_EXTENSION?: StructureConstant }).STRUCTURE_EXTENSION;
+    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === 2 ? [site] : []))
+      }
+    } as unknown as Creep;
+    let task: CreepTaskMemory | null | undefined;
+
+    expect(() => {
+      task = selectWorkerTask(creep);
+    }).not.toThrow();
+    expect(task).toEqual({ type: 'build', targetId: 'extension-site1' });
+  });
+
+  it('keeps RCL3 build-before-upgrade priority when controller downgrade is safe', () => {
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === 2 ? [site] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
   it('keeps low-downgrade guard above construction at RCL2', () => {
-    const site = { id: 'site1' } as ConstructionSite;
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
     const controller = {
       id: 'controller1',
       my: true,


### PR DESCRIPTION
## Summary
- Adds a deterministic RCL2 controller-progress guard to worker task selection.
- Keeps spawn/extension refill and critical spawn/extension construction before the RCL2 guard.
- Preserves RCL3+ build-before-upgrade behavior and the low-downgrade guard.

## Linked issue
Fixes #98

## Roadmap category
Bot capability / territory-control

## Served vision layer
Territory/control: pushes owned RCL2 rooms toward the next controller milestone instead of spending energy on non-critical construction first, while preserving critical extension/spawn construction.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (102 tests)
- [x] `cd prod && npm run build`

## Notes
- Codex-authored commit: `fa4981c lanyusea's bot <lanyusea@gmail.com> feat: add RCL2 controller progress guard`
- No secrets included.
- Requires independent QA PASS, green checks/reviews, no active review threads, current Project fields, and >=15 minute elapsed review gate before merge.
