### PR TITLE
ci: validate npm install output

### DIFF
--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -31,10 +31,21 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: prod/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+          NPM_CONFIG_REPLACE_REGISTRY_HOST: always
+        run: |
+          set -o pipefail
+          npm ci 2>&1 | tee "$RUNNER_TEMP/npm-ci.log"
+          if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+            echo "::error::npm ci emitted npm error output; aborting before verification."
+            exit 1
+          fi
 
       - name: Verify dependency tree
         run: |

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -37,7 +37,26 @@ jobs:
         run: npm ci
 
       - name: Verify dependency tree
-        run: npm ls typescript jest @types/jest @types/screeps esbuild
+        run: |
+          node - <<'NODE'
+          const fs = require("fs");
+          const path = require("path");
+
+          const packages = [
+            "typescript",
+            "jest",
+            "ts-jest",
+            "@types/jest",
+            "@types/screeps",
+            "esbuild",
+          ];
+
+          for (const name of packages) {
+            const packageJsonPath = path.join(process.cwd(), "node_modules", ...name.split("/"), "package.json");
+            const { version } = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+            console.log(`${name}@${version}`);
+          }
+          NODE
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -47,6 +47,14 @@ jobs:
           set -o pipefail
           max_attempts=3
           npm_ci_status=1
+          required_package_files=(
+            node_modules/typescript/package.json
+            node_modules/jest/package.json
+            node_modules/ts-jest/package.json
+            node_modules/@types/jest/package.json
+            node_modules/@types/screeps/package.json
+            node_modules/esbuild/package.json
+          )
 
           for attempt in 1 2 3; do
             log_path="$RUNNER_TEMP/npm-ci-attempt-${attempt}.log"
@@ -59,32 +67,56 @@ jobs:
 
             cp "$log_path" "$RUNNER_TEMP/npm-ci.log"
 
-            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-              if [ "$npm_ci_status" -eq 0 ]; then
-                echo "::warning::npm ci exited 0 but emitted npm error output during attempt ${attempt}/${max_attempts}; treating attempt as failed."
-                npm_ci_status=1
-              else
-                echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
-              fi
+            attempt_failed=0
+            failure_reasons=()
+
+            if [ "$npm_ci_status" -ne 0 ]; then
+              attempt_failed=1
+              failure_reasons+=("exit code ${npm_ci_status}")
             fi
 
-            if [ "$npm_ci_status" -eq 0 ]; then
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              attempt_failed=1
+              failure_reasons+=("npm error output")
+            fi
+
+            missing_package_files=()
+            for package_file in "${required_package_files[@]}"; do
+              if [ ! -f "$package_file" ]; then
+                missing_package_files+=("$package_file")
+              fi
+            done
+
+            if [ "${#missing_package_files[@]}" -gt 0 ]; then
+              attempt_failed=1
+              failure_reasons+=("missing required package files")
+              echo "::warning::npm ci attempt ${attempt}/${max_attempts} left required package files missing:"
+              printf '  %s\n' "${missing_package_files[@]}"
+            fi
+
+            if [ "$attempt_failed" -eq 0 ]; then
               break
             fi
 
             if [ "$attempt" -lt "$max_attempts" ]; then
-              echo "npm ci attempt ${attempt}/${max_attempts} failed with exit code ${npm_ci_status}; retrying shortly."
+              IFS=", "
+              echo "npm ci attempt ${attempt}/${max_attempts} failed validation: ${failure_reasons[*]}; retrying shortly."
+              unset IFS
               sleep 10
             fi
           done
 
-          if [ "$npm_ci_status" -ne 0 ]; then
-            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-              echo "::error::npm ci failed after ${max_attempts} attempts; latest log contains npm error output."
-            else
-              echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
+          if [ "$attempt_failed" -ne 0 ]; then
+            IFS=", "
+            echo "::error::npm ci failed validation after ${max_attempts} attempts: ${failure_reasons[*]}."
+            unset IFS
+
+            if [ "${#missing_package_files[@]}" -gt 0 ]; then
+              echo "::error::Latest attempt is missing required package files:"
+              printf '  %s\n' "${missing_package_files[@]}"
             fi
-            exit "$npm_ci_status"
+
+            exit 1
           fi
 
       - name: Verify dependency tree

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -61,10 +61,13 @@ jobs:
 
             if [ "$npm_ci_status" -eq 0 ]; then
               if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-                echo "::error::npm ci emitted npm error output; aborting before verification."
-                exit 1
+                echo "::warning::npm ci exited 0 but emitted npm error-looking output; continuing to dependency verification."
               fi
               break
+            fi
+
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
             fi
 
             if [ "$attempt" -lt "$max_attempts" ]; then
@@ -74,9 +77,7 @@ jobs:
           done
 
           if [ "$npm_ci_status" -ne 0 ]; then
-            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-              echo "::error::npm ci emitted npm error output; aborting before verification."
-            fi
+            echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
             exit "$npm_ci_status"
           fi
 

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Install dependencies
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
-          NPM_CONFIG_REPLACE_REGISTRY_HOST: always
         run: |
           set -o pipefail
           npm ci 2>&1 | tee "$RUNNER_TEMP/npm-ci.log"

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -46,7 +46,37 @@ jobs:
         run: |
           set -o pipefail
           max_attempts=3
-          npm_ci_status=1
+          install_succeeded=0
+          last_failure_reason="npm ci did not run"
+
+          required_packages=(
+            "typescript"
+            "jest"
+            "ts-jest"
+            "@types/jest"
+            "@types/screeps"
+            "esbuild"
+          )
+
+          has_npm_error_output() {
+            grep -Eiq "^npm[[:space:]]+(ERR!|error)([[:space:]:]|$)" "$1"
+          }
+
+          required_packages_present() {
+            local missing=0
+            local package_name
+            local package_json
+
+            for package_name in "${required_packages[@]}"; do
+              package_json="node_modules/${package_name}/package.json"
+              if [ ! -f "$package_json" ]; then
+                echo "::warning::Required dependency package.json is missing: prod/${package_json}"
+                missing=1
+              fi
+            done
+
+            return "$missing"
+          }
 
           for attempt in 1 2 3; do
             log_path="$RUNNER_TEMP/npm-ci-attempt-${attempt}.log"
@@ -59,32 +89,45 @@ jobs:
 
             cp "$log_path" "$RUNNER_TEMP/npm-ci.log"
 
-            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-              if [ "$npm_ci_status" -eq 0 ]; then
-                echo "::warning::npm ci exited 0 but emitted npm error output during attempt ${attempt}/${max_attempts}; treating attempt as failed."
-                npm_ci_status=1
-              else
-                echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
-              fi
+            npm_error_output=0
+            if has_npm_error_output "$RUNNER_TEMP/npm-ci.log"; then
+              npm_error_output=1
+              echo "::warning::npm ci attempt ${attempt}/${max_attempts} emitted npm error-looking output."
             fi
 
-            if [ "$npm_ci_status" -eq 0 ]; then
+            missing_packages=0
+            if ! required_packages_present; then
+              missing_packages=1
+            fi
+
+            if [ "$npm_ci_status" -eq 0 ] && [ "$npm_error_output" -eq 0 ] && [ "$missing_packages" -eq 0 ]; then
+              install_succeeded=1
+              echo "npm ci attempt ${attempt}/${max_attempts} completed and required package files are present."
               break
             fi
 
+            failure_reasons=()
+            if [ "$npm_ci_status" -ne 0 ]; then
+              failure_reasons+=("exit code ${npm_ci_status}")
+            fi
+            if [ "$npm_error_output" -ne 0 ]; then
+              failure_reasons+=("npm error-looking output")
+            fi
+            if [ "$missing_packages" -ne 0 ]; then
+              failure_reasons+=("missing required package files")
+            fi
+            last_failure_reason=$(printf "%s; " "${failure_reasons[@]}")
+            last_failure_reason="${last_failure_reason%; }"
+
             if [ "$attempt" -lt "$max_attempts" ]; then
-              echo "npm ci attempt ${attempt}/${max_attempts} failed with exit code ${npm_ci_status}; retrying shortly."
+              echo "::warning::npm ci attempt ${attempt}/${max_attempts} failed install validation (${last_failure_reason}); retrying shortly."
               sleep 10
             fi
           done
 
-          if [ "$npm_ci_status" -ne 0 ]; then
-            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-              echo "::error::npm ci failed after ${max_attempts} attempts; latest log contains npm error output."
-            else
-              echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
-            fi
-            exit "$npm_ci_status"
+          if [ "$install_succeeded" -ne 1 ]; then
+            echo "::error::npm ci failed install validation after ${max_attempts} attempts (${last_failure_reason})."
+            exit 1
           fi
 
       - name: Verify dependency tree

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -34,10 +34,10 @@ jobs:
           node-version: "20"
 
       - name: Install dependencies
-        run: yarn install --non-interactive --no-progress
+        run: npm ci
 
       - name: Verify dependency tree
-        run: yarn list --pattern "typescript|jest|@types/jest|@types/screeps|esbuild"
+        run: npm ls typescript jest @types/jest @types/screeps esbuild
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -31,15 +31,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "20"
           cache: "npm"
           cache-dependency-path: prod/package-lock.json
 
-      - name: Pin npm CLI
-        env:
-          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+      - name: Report Node.js toolchain
         run: |
-          npm install --global npm@11.13.0
           node --version
           npm --version
 

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -59,17 +59,15 @@ jobs:
 
             cp "$log_path" "$RUNNER_TEMP/npm-ci.log"
 
-            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-              if [ "$npm_ci_status" -eq 0 ]; then
-                echo "::warning::npm ci exited 0 but emitted npm error-looking output during attempt ${attempt}/${max_attempts}; treating attempt as failed."
-                npm_ci_status=1
-              else
-                echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
+            if [ "$npm_ci_status" -eq 0 ]; then
+              if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+                echo "::warning::npm ci exited 0 but emitted npm error-looking output; continuing to dependency verification."
               fi
+              break
             fi
 
-            if [ "$npm_ci_status" -eq 0 ]; then
-              break
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
             fi
 
             if [ "$attempt" -lt "$max_attempts" ]; then
@@ -79,11 +77,7 @@ jobs:
           done
 
           if [ "$npm_ci_status" -ne 0 ]; then
-            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-              echo "::error::npm ci failed after ${max_attempts} attempts; latest log contains npm error output."
-            else
-              echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
-            fi
+            echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
             exit "$npm_ci_status"
           fi
 

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -46,37 +46,7 @@ jobs:
         run: |
           set -o pipefail
           max_attempts=3
-          install_succeeded=0
-          last_failure_reason="npm ci did not run"
-
-          required_packages=(
-            "typescript"
-            "jest"
-            "ts-jest"
-            "@types/jest"
-            "@types/screeps"
-            "esbuild"
-          )
-
-          has_npm_error_output() {
-            grep -Eiq "^npm[[:space:]]+(ERR!|error)([[:space:]:]|$)" "$1"
-          }
-
-          required_packages_present() {
-            local missing=0
-            local package_name
-            local package_json
-
-            for package_name in "${required_packages[@]}"; do
-              package_json="node_modules/${package_name}/package.json"
-              if [ ! -f "$package_json" ]; then
-                echo "::warning::Required dependency package.json is missing: prod/${package_json}"
-                missing=1
-              fi
-            done
-
-            return "$missing"
-          }
+          npm_ci_status=1
 
           for attempt in 1 2 3; do
             log_path="$RUNNER_TEMP/npm-ci-attempt-${attempt}.log"
@@ -89,45 +59,32 @@ jobs:
 
             cp "$log_path" "$RUNNER_TEMP/npm-ci.log"
 
-            npm_error_output=0
-            if has_npm_error_output "$RUNNER_TEMP/npm-ci.log"; then
-              npm_error_output=1
-              echo "::warning::npm ci attempt ${attempt}/${max_attempts} emitted npm error-looking output."
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              if [ "$npm_ci_status" -eq 0 ]; then
+                echo "::warning::npm ci exited 0 but emitted npm error output during attempt ${attempt}/${max_attempts}; treating attempt as failed."
+                npm_ci_status=1
+              else
+                echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
+              fi
             fi
 
-            missing_packages=0
-            if ! required_packages_present; then
-              missing_packages=1
-            fi
-
-            if [ "$npm_ci_status" -eq 0 ] && [ "$npm_error_output" -eq 0 ] && [ "$missing_packages" -eq 0 ]; then
-              install_succeeded=1
-              echo "npm ci attempt ${attempt}/${max_attempts} completed and required package files are present."
+            if [ "$npm_ci_status" -eq 0 ]; then
               break
             fi
 
-            failure_reasons=()
-            if [ "$npm_ci_status" -ne 0 ]; then
-              failure_reasons+=("exit code ${npm_ci_status}")
-            fi
-            if [ "$npm_error_output" -ne 0 ]; then
-              failure_reasons+=("npm error-looking output")
-            fi
-            if [ "$missing_packages" -ne 0 ]; then
-              failure_reasons+=("missing required package files")
-            fi
-            last_failure_reason=$(printf "%s; " "${failure_reasons[@]}")
-            last_failure_reason="${last_failure_reason%; }"
-
             if [ "$attempt" -lt "$max_attempts" ]; then
-              echo "::warning::npm ci attempt ${attempt}/${max_attempts} failed install validation (${last_failure_reason}); retrying shortly."
+              echo "npm ci attempt ${attempt}/${max_attempts} failed with exit code ${npm_ci_status}; retrying shortly."
               sleep 10
             fi
           done
 
-          if [ "$install_succeeded" -ne 1 ]; then
-            echo "::error::npm ci failed install validation after ${max_attempts} attempts (${last_failure_reason})."
-            exit 1
+          if [ "$npm_ci_status" -ne 0 ]; then
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              echo "::error::npm ci failed after ${max_attempts} attempts; latest log contains npm error output."
+            else
+              echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
+            fi
+            exit "$npm_ci_status"
           fi
 
       - name: Verify dependency tree

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -35,6 +35,14 @@ jobs:
           cache: "npm"
           cache-dependency-path: prod/package-lock.json
 
+      - name: Pin npm CLI
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: |
+          npm install --global npm@11.13.0
+          node --version
+          npm --version
+
       - name: Install dependencies
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -40,7 +40,11 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
           set -o pipefail
-          npm ci 2>&1 | tee "$RUNNER_TEMP/npm-ci.log"
+          npm ci --ignore-scripts 2>&1 | tee "$RUNNER_TEMP/npm-ci.log"
+          npm_ci_status=${PIPESTATUS[0]}
+          if [ "$npm_ci_status" -ne 0 ]; then
+            exit "$npm_ci_status"
+          fi
           if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
             echo "::error::npm ci emitted npm error output; aborting before verification."
             exit 1
@@ -67,6 +71,7 @@ jobs:
             console.log(`${name}@${version}`);
           }
           NODE
+          npx esbuild --version
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -59,15 +59,17 @@ jobs:
 
             cp "$log_path" "$RUNNER_TEMP/npm-ci.log"
 
-            if [ "$npm_ci_status" -eq 0 ]; then
-              if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-                echo "::warning::npm ci exited 0 but emitted npm error-looking output; continuing to dependency verification."
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              if [ "$npm_ci_status" -eq 0 ]; then
+                echo "::warning::npm ci exited 0 but emitted npm error output during attempt ${attempt}/${max_attempts}; treating attempt as failed."
+                npm_ci_status=1
+              else
+                echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
               fi
-              break
             fi
 
-            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-              echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
+            if [ "$npm_ci_status" -eq 0 ]; then
+              break
             fi
 
             if [ "$attempt" -lt "$max_attempts" ]; then
@@ -77,7 +79,11 @@ jobs:
           done
 
           if [ "$npm_ci_status" -ne 0 ]; then
-            echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              echo "::error::npm ci failed after ${max_attempts} attempts; latest log contains npm error output."
+            else
+              echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
+            fi
             exit "$npm_ci_status"
           fi
 

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -40,14 +40,39 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
           set -o pipefail
-          npm ci --ignore-scripts 2>&1 | tee "$RUNNER_TEMP/npm-ci.log"
-          npm_ci_status=${PIPESTATUS[0]}
+          max_attempts=3
+          npm_ci_status=1
+
+          for attempt in 1 2 3; do
+            log_path="$RUNNER_TEMP/npm-ci-attempt-${attempt}.log"
+            echo "Running npm ci attempt ${attempt}/${max_attempts}"
+
+            set +e
+            npm ci 2>&1 | tee "$log_path"
+            npm_ci_status=${PIPESTATUS[0]}
+            set -e
+
+            cp "$log_path" "$RUNNER_TEMP/npm-ci.log"
+
+            if [ "$npm_ci_status" -eq 0 ]; then
+              if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+                echo "::error::npm ci emitted npm error output; aborting before verification."
+                exit 1
+              fi
+              break
+            fi
+
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "npm ci attempt ${attempt}/${max_attempts} failed with exit code ${npm_ci_status}; retrying shortly."
+              sleep 10
+            fi
+          done
+
           if [ "$npm_ci_status" -ne 0 ]; then
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              echo "::error::npm ci emitted npm error output; aborting before verification."
+            fi
             exit "$npm_ci_status"
-          fi
-          if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-            echo "::error::npm ci emitted npm error output; aborting before verification."
-            exit 1
           fi
 
       - name: Verify dependency tree

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -59,15 +59,17 @@ jobs:
 
             cp "$log_path" "$RUNNER_TEMP/npm-ci.log"
 
-            if [ "$npm_ci_status" -eq 0 ]; then
-              if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-                echo "::warning::npm ci exited 0 but emitted npm error-looking output; continuing to dependency verification."
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              if [ "$npm_ci_status" -eq 0 ]; then
+                echo "::warning::npm ci exited 0 but emitted npm error-looking output during attempt ${attempt}/${max_attempts}; treating attempt as failed."
+                npm_ci_status=1
+              else
+                echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
               fi
-              break
             fi
 
-            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
-              echo "::warning::npm ci emitted npm error output during failed attempt ${attempt}/${max_attempts}."
+            if [ "$npm_ci_status" -eq 0 ]; then
+              break
             fi
 
             if [ "$attempt" -lt "$max_attempts" ]; then
@@ -77,7 +79,11 @@ jobs:
           done
 
           if [ "$npm_ci_status" -ne 0 ]; then
-            echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
+            if grep -Eq "^npm (ERR!|error) " "$RUNNER_TEMP/npm-ci.log"; then
+              echo "::error::npm ci failed after ${max_attempts} attempts; latest log contains npm error output."
+            else
+              echo "::error::npm ci failed after ${max_attempts} attempts; latest exit code ${npm_ci_status}."
+            fi
             exit "$npm_ci_status"
           fi
 

--- a/prod/package-lock.json
+++ b/prod/package-lock.json
@@ -18,7 +18,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "dependencies": {
@@ -32,7 +32,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
@@ -42,7 +42,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/core/-/core-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "dependencies": {
@@ -72,7 +72,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/generator/-/generator-7.29.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "dependencies": {
@@ -88,7 +88,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "dependencies": {
@@ -104,7 +104,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "engines": {
@@ -113,7 +113,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.28.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "dependencies": {
@@ -126,7 +126,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "dependencies": {
@@ -143,7 +143,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "engines": {
@@ -152,7 +152,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
@@ -162,7 +162,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "engines": {
@@ -171,7 +171,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "engines": {
@@ -180,7 +180,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/helpers/-/helpers-7.29.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "dependencies": {
@@ -193,7 +193,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/parser/-/parser-7.29.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
@@ -209,7 +209,7 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
       "dependencies": {
@@ -221,7 +221,7 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "dev": true,
       "dependencies": {
@@ -233,7 +233,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "dev": true,
       "dependencies": {
@@ -245,7 +245,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "dev": true,
       "dependencies": {
@@ -260,7 +260,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.28.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
       "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "dev": true,
       "dependencies": {
@@ -275,7 +275,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "dev": true,
       "dependencies": {
@@ -287,7 +287,7 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
       "dependencies": {
@@ -299,7 +299,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.28.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
       "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "dev": true,
       "dependencies": {
@@ -314,7 +314,7 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "dev": true,
       "dependencies": {
@@ -326,7 +326,7 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
       "dependencies": {
@@ -338,7 +338,7 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "dev": true,
       "dependencies": {
@@ -350,7 +350,7 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "license": "MIT",
@@ -363,7 +363,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
       "dependencies": {
@@ -375,7 +375,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
       "dependencies": {
@@ -387,7 +387,7 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "dev": true,
       "license": "MIT",
@@ -403,7 +403,7 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
       "dev": true,
       "dependencies": {
@@ -418,7 +418,7 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.28.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
       "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
       "dev": true,
       "dependencies": {
@@ -433,7 +433,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.28.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/template/-/template-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "dependencies": {
@@ -447,7 +447,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/traverse/-/traverse-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "dependencies": {
@@ -465,7 +465,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@babel/types/-/types-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
@@ -479,13 +479,13 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
       "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
@@ -502,7 +502,7 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
       "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
@@ -519,7 +519,7 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
       "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
@@ -535,7 +535,7 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
       "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
@@ -552,7 +552,7 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
       "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
@@ -569,7 +569,7 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
       "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
@@ -585,7 +585,7 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
       "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
@@ -601,7 +601,7 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
       "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
@@ -618,7 +618,7 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
       "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
@@ -634,7 +634,7 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
       "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
@@ -651,7 +651,7 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
       "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
@@ -668,7 +668,7 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
       "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
@@ -685,7 +685,7 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
       "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
@@ -702,7 +702,7 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
       "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
@@ -719,7 +719,7 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
       "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
@@ -735,7 +735,7 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
       "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
@@ -752,7 +752,7 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
       "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
@@ -768,7 +768,7 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
       "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
@@ -785,7 +785,7 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
       "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
@@ -802,7 +802,7 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
       "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
@@ -818,7 +818,7 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
       "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
@@ -835,7 +835,7 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
       "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
@@ -852,7 +852,7 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
       "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
@@ -869,7 +869,7 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
       "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
@@ -886,7 +886,7 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
       "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
@@ -902,7 +902,7 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
       "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
@@ -919,7 +919,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
       "dependencies": {
@@ -935,7 +935,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
       "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "engines": {
@@ -944,7 +944,7 @@
     },
     "node_modules/@jest/console": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/console/-/console-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
       "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
       "dev": true,
       "dependencies": {
@@ -961,7 +961,7 @@
     },
     "node_modules/@jest/core": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/core/-/core-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
       "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
       "dev": true,
       "dependencies": {
@@ -1008,7 +1008,7 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/environment/-/environment-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
       "dependencies": {
@@ -1023,7 +1023,7 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/expect/-/expect-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "dev": true,
       "dependencies": {
@@ -1036,7 +1036,7 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "dev": true,
       "dependencies": {
@@ -1048,7 +1048,7 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
       "dependencies": {
@@ -1065,7 +1065,7 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/globals/-/globals-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
       "dependencies": {
@@ -1080,7 +1080,7 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/reporters/-/reporters-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
       "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
       "dev": true,
       "dependencies": {
@@ -1123,7 +1123,7 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/schemas/-/schemas-29.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "dependencies": {
@@ -1135,7 +1135,7 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/source-map/-/source-map-29.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
       "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
       "dev": true,
       "dependencies": {
@@ -1149,7 +1149,7 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/test-result/-/test-result-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
       "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
       "dev": true,
       "dependencies": {
@@ -1164,7 +1164,7 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
       "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
       "dev": true,
       "dependencies": {
@@ -1179,7 +1179,7 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/transform/-/transform-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
       "dependencies": {
@@ -1205,7 +1205,7 @@
     },
     "node_modules/@jest/types": {
       "version": "29.6.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jest/types/-/types-29.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "dependencies": {
@@ -1222,7 +1222,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "dependencies": {
@@ -1232,7 +1232,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "dependencies": {
@@ -1242,7 +1242,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "engines": {
@@ -1251,13 +1251,13 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "http://mirrors.tencentyun.com/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "dependencies": {
@@ -1267,13 +1267,13 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
-      "resolved": "http://mirrors.tencentyun.com/npm/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "dependencies": {
@@ -1282,7 +1282,7 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "dependencies": {
@@ -1291,7 +1291,7 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "dependencies": {
@@ -1304,7 +1304,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "dependencies": {
@@ -1313,7 +1313,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "dependencies": {
@@ -1323,7 +1323,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "dependencies": {
@@ -1332,7 +1332,7 @@
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "dev": true,
       "dependencies": {
@@ -1341,13 +1341,13 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "dev": true,
       "dependencies": {
@@ -1356,7 +1356,7 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "dev": true,
       "dependencies": {
@@ -1365,7 +1365,7 @@
     },
     "node_modules/@types/jest": {
       "version": "29.5.14",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/jest/-/jest-29.5.14.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
       "dependencies": {
@@ -1375,7 +1375,7 @@
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/node/-/node-25.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
@@ -1385,19 +1385,19 @@
     },
     "node_modules/@types/screeps": {
       "version": "3.3.8",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/screeps/-/screeps-3.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/screeps/-/screeps-3.3.8.tgz",
       "integrity": "sha512-PlZRi5l0RaYNI67BgH4AUxhPeK9fKOyPNdFOVYiT66Olj1RtTjEaPY/REUNTSFKREczKM4oeLuVebJh6uorxzw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/yargs/-/yargs-17.0.35.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
       "dependencies": {
@@ -1406,13 +1406,13 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "dependencies": {
@@ -1427,7 +1427,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
@@ -1436,7 +1436,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
@@ -1452,7 +1452,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/anymatch/-/anymatch-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "dependencies": {
@@ -1465,7 +1465,7 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "http://mirrors.tencentyun.com/npm/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "dependencies": {
@@ -1474,7 +1474,7 @@
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/babel-jest/-/babel-jest-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
       "dependencies": {
@@ -1495,7 +1495,7 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
       "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
       "dev": true,
       "dependencies": {
@@ -1511,7 +1511,7 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "dev": true,
       "dependencies": {
@@ -1527,7 +1527,7 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
       "dev": true,
       "dependencies": {
@@ -1542,7 +1542,7 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "dependencies": {
@@ -1568,7 +1568,7 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.6.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
       "dev": true,
       "dependencies": {
@@ -1584,14 +1584,14 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.22",
-      "resolved": "http://mirrors.tencentyun.com/npm/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
       "integrity": "sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==",
       "dev": true,
       "bin": {
@@ -1603,7 +1603,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
-      "resolved": "http://mirrors.tencentyun.com/npm/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "dependencies": {
@@ -1613,7 +1613,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/braces/-/braces-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
@@ -1625,7 +1625,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/browserslist/-/browserslist-4.28.2.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
@@ -1658,7 +1658,7 @@
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/bs-logger/-/bs-logger-0.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
       "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
       "dev": true,
       "dependencies": {
@@ -1670,7 +1670,7 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/bser/-/bser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dev": true,
       "dependencies": {
@@ -1679,14 +1679,14 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/buffer-from/-/buffer-from-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "engines": {
@@ -1695,7 +1695,7 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "engines": {
@@ -1704,7 +1704,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001790",
-      "resolved": "http://mirrors.tencentyun.com/npm/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
       "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "dev": true,
       "funding": [
@@ -1724,7 +1724,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -1741,7 +1741,7 @@
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/char-regex/-/char-regex-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
       "engines": {
@@ -1750,7 +1750,7 @@
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/ci-info/-/ci-info-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
       "funding": [
@@ -1766,13 +1766,13 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
@@ -1787,7 +1787,7 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
       "engines": {
@@ -1797,13 +1797,13 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
@@ -1816,26 +1816,26 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/create-jest/-/create-jest-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
       "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
       "dev": true,
       "dependencies": {
@@ -1856,7 +1856,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -1871,7 +1871,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -1889,7 +1889,7 @@
     },
     "node_modules/dedent": {
       "version": "1.7.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/dedent/-/dedent-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "peerDependencies": {
@@ -1903,7 +1903,7 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/deepmerge/-/deepmerge-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "engines": {
@@ -1912,7 +1912,7 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/detect-newline/-/detect-newline-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true,
       "engines": {
@@ -1921,7 +1921,7 @@
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
       "engines": {
@@ -1930,13 +1930,13 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
-      "resolved": "http://mirrors.tencentyun.com/npm/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true
     },
     "node_modules/emittery": {
       "version": "0.13.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/emittery/-/emittery-0.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true,
       "engines": {
@@ -1948,14 +1948,14 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/error-ex/-/error-ex-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "dependencies": {
@@ -1964,7 +1964,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "engines": {
@@ -1973,7 +1973,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/esbuild/-/esbuild-0.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
@@ -2014,7 +2014,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
@@ -2024,7 +2024,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "dev": true,
       "engines": {
@@ -2033,7 +2033,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "bin": {
@@ -2046,7 +2046,7 @@
     },
     "node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/execa/-/execa-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "dependencies": {
@@ -2069,7 +2069,7 @@
     },
     "node_modules/exit": {
       "version": "0.1.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "dev": true,
       "engines": {
@@ -2078,7 +2078,7 @@
     },
     "node_modules/expect": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/expect/-/expect-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
       "dependencies": {
@@ -2094,13 +2094,13 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "dev": true,
       "dependencies": {
@@ -2109,7 +2109,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/fill-range/-/fill-range-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
@@ -2121,7 +2121,7 @@
     },
     "node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/find-up/-/find-up-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
@@ -2135,13 +2135,13 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -2155,7 +2155,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "funding": {
@@ -2164,7 +2164,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "engines": {
@@ -2173,7 +2173,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
@@ -2183,7 +2183,7 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/get-package-type/-/get-package-type-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true,
       "engines": {
@@ -2192,7 +2192,7 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/get-stream/-/get-stream-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
@@ -2205,7 +2205,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/glob/-/glob-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
@@ -2227,14 +2227,14 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "http://mirrors.tencentyun.com/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
-      "resolved": "http://mirrors.tencentyun.com/npm/handlebars/-/handlebars-4.7.9.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "dependencies": {
@@ -2255,7 +2255,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
@@ -2264,7 +2264,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/hasown/-/hasown-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
@@ -2277,13 +2277,13 @@
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/html-escaper/-/html-escaper-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/human-signals/-/human-signals-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true,
       "engines": {
@@ -2292,7 +2292,7 @@
     },
     "node_modules/import-local": {
       "version": "3.2.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/import-local/-/import-local-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "dev": true,
       "dependencies": {
@@ -2311,7 +2311,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "engines": {
@@ -2320,7 +2320,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
@@ -2331,19 +2331,19 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/is-core-module/-/is-core-module-2.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
@@ -2359,7 +2359,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
@@ -2369,7 +2369,7 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true,
       "license": "MIT",
@@ -2379,7 +2379,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "engines": {
@@ -2388,7 +2388,7 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/is-stream/-/is-stream-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
@@ -2401,14 +2401,14 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2418,7 +2418,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "dependencies": {
@@ -2434,7 +2434,7 @@
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -2447,7 +2447,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2462,7 +2462,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
       "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "dependencies": {
@@ -2476,7 +2476,7 @@
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -2490,7 +2490,7 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest/-/jest-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "dependencies": {
@@ -2516,7 +2516,7 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
       "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
       "dev": true,
       "dependencies": {
@@ -2530,7 +2530,7 @@
     },
     "node_modules/jest-circus": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-circus/-/jest-circus-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
       "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
       "dev": true,
       "dependencies": {
@@ -2561,7 +2561,7 @@
     },
     "node_modules/jest-cli": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-cli/-/jest-cli-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
       "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
       "dev": true,
       "dependencies": {
@@ -2594,7 +2594,7 @@
     },
     "node_modules/jest-config": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-config/-/jest-config-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
       "dev": true,
       "dependencies": {
@@ -2639,7 +2639,7 @@
     },
     "node_modules/jest-diff": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-diff/-/jest-diff-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
       "dependencies": {
@@ -2654,7 +2654,7 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
       "dependencies": {
@@ -2666,7 +2666,7 @@
     },
     "node_modules/jest-each": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-each/-/jest-each-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
       "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
       "dev": true,
       "dependencies": {
@@ -2682,7 +2682,7 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
       "dev": true,
       "dependencies": {
@@ -2699,7 +2699,7 @@
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
       "engines": {
@@ -2708,7 +2708,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
       "dependencies": {
@@ -2733,7 +2733,7 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
       "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
       "dev": true,
       "dependencies": {
@@ -2746,7 +2746,7 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
       "dependencies": {
@@ -2761,7 +2761,7 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
       "dependencies": {
@@ -2781,7 +2781,7 @@
     },
     "node_modules/jest-mock": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-mock/-/jest-mock-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
       "dependencies": {
@@ -2795,7 +2795,7 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "dev": true,
       "engines": {
@@ -2812,7 +2812,7 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
       "engines": {
@@ -2821,7 +2821,7 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
       "dev": true,
       "dependencies": {
@@ -2841,7 +2841,7 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
       "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
       "dev": true,
       "dependencies": {
@@ -2854,7 +2854,7 @@
     },
     "node_modules/jest-runner": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-runner/-/jest-runner-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
       "dependencies": {
@@ -2886,7 +2886,7 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
       "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
       "dev": true,
       "dependencies": {
@@ -2919,7 +2919,7 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
       "dependencies": {
@@ -2950,7 +2950,7 @@
     },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -2963,7 +2963,7 @@
     },
     "node_modules/jest-util": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-util/-/jest-util-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
       "dependencies": {
@@ -2980,7 +2980,7 @@
     },
     "node_modules/jest-validate": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-validate/-/jest-validate-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
       "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "dev": true,
       "dependencies": {
@@ -2997,7 +2997,7 @@
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/camelcase/-/camelcase-6.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "engines": {
@@ -3009,7 +3009,7 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
       "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
       "dev": true,
       "dependencies": {
@@ -3028,7 +3028,7 @@
     },
     "node_modules/jest-worker": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jest-worker/-/jest-worker-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
       "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "dependencies": {
@@ -3043,7 +3043,7 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/supports-color/-/supports-color-8.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
@@ -3059,13 +3059,13 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/js-yaml/-/js-yaml-3.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "dependencies": {
@@ -3078,7 +3078,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/jsesc/-/jsesc-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "bin": {
@@ -3090,14 +3090,14 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
@@ -3110,7 +3110,7 @@
     },
     "node_modules/kleur": {
       "version": "3.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/kleur/-/kleur-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true,
       "engines": {
@@ -3119,7 +3119,7 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/leven/-/leven-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true,
       "engines": {
@@ -3128,13 +3128,13 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/locate-path/-/locate-path-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "license": "MIT",
@@ -3147,13 +3147,13 @@
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
@@ -3163,7 +3163,7 @@
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/make-dir/-/make-dir-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "dependencies": {
@@ -3178,7 +3178,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -3191,13 +3191,13 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/make-error/-/make-error-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "resolved": "http://mirrors.tencentyun.com/npm/makeerror/-/makeerror-1.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "dev": true,
       "dependencies": {
@@ -3206,13 +3206,13 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "http://mirrors.tencentyun.com/npm/micromatch/-/micromatch-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
@@ -3225,7 +3225,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
@@ -3235,7 +3235,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
@@ -3248,7 +3248,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "http://mirrors.tencentyun.com/npm/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "funding": {
@@ -3257,40 +3257,40 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/neo-async/-/neo-async-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
     "node_modules/node-releases": {
       "version": "2.0.38",
-      "resolved": "http://mirrors.tencentyun.com/npm/node-releases/-/node-releases-2.0.38.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "engines": {
@@ -3299,7 +3299,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "license": "MIT",
@@ -3312,7 +3312,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
@@ -3322,7 +3322,7 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/onetime/-/onetime-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
@@ -3338,7 +3338,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -3354,7 +3354,7 @@
     },
     "node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/p-locate/-/p-locate-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "dependencies": {
@@ -3366,7 +3366,7 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "license": "MIT",
@@ -3382,7 +3382,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "engines": {
@@ -3391,7 +3391,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "dependencies": {
@@ -3409,7 +3409,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "engines": {
@@ -3418,7 +3418,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
@@ -3427,7 +3427,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -3437,20 +3437,20 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "http://mirrors.tencentyun.com/npm/path-parse/-/path-parse-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/picomatch/-/picomatch-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
@@ -3463,7 +3463,7 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "resolved": "http://mirrors.tencentyun.com/npm/pirates/-/pirates-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "engines": {
@@ -3472,7 +3472,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "dependencies": {
@@ -3484,7 +3484,7 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/pretty-format/-/pretty-format-29.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
@@ -3498,7 +3498,7 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
@@ -3511,7 +3511,7 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/prompts/-/prompts-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "dev": true,
       "dependencies": {
@@ -3524,7 +3524,7 @@
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/pure-rand/-/pure-rand-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
       "dev": true,
       "funding": [
@@ -3540,13 +3540,13 @@
     },
     "node_modules/react-is": {
       "version": "18.3.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/react-is/-/react-is-18.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
@@ -3556,7 +3556,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.12",
-      "resolved": "http://mirrors.tencentyun.com/npm/resolve/-/resolve-1.22.12.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "dependencies": {
@@ -3577,7 +3577,7 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "dependencies": {
@@ -3589,7 +3589,7 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/resolve-from/-/resolve-from-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "engines": {
@@ -3598,7 +3598,7 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
       "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
       "dev": true,
       "engines": {
@@ -3607,7 +3607,7 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -3617,7 +3617,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -3630,7 +3630,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -3640,20 +3640,20 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "http://mirrors.tencentyun.com/npm/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/sisteransi/-/sisteransi-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "engines": {
@@ -3662,7 +3662,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3672,7 +3672,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "resolved": "http://mirrors.tencentyun.com/npm/source-map-support/-/source-map-support-0.5.13.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "license": "MIT",
@@ -3683,13 +3683,13 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "resolved": "http://mirrors.tencentyun.com/npm/stack-utils/-/stack-utils-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
       "dependencies": {
@@ -3701,7 +3701,7 @@
     },
     "node_modules/string-length": {
       "version": "4.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/string-length/-/string-length-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
       "dev": true,
       "dependencies": {
@@ -3714,7 +3714,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
@@ -3728,7 +3728,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
@@ -3740,7 +3740,7 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/strip-bom/-/strip-bom-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
       "engines": {
@@ -3749,7 +3749,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
       "engines": {
@@ -3758,7 +3758,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
@@ -3771,7 +3771,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -3784,7 +3784,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
@@ -3797,7 +3797,7 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/test-exclude/-/test-exclude-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "dev": true,
       "dependencies": {
@@ -3811,13 +3811,13 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "resolved": "http://mirrors.tencentyun.com/npm/tmpl/-/tmpl-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "dependencies": {
@@ -3829,7 +3829,7 @@
     },
     "node_modules/ts-jest": {
       "version": "29.4.9",
-      "resolved": "http://mirrors.tencentyun.com/npm/ts-jest/-/ts-jest-29.4.9.tgz",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
       "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "dependencies": {
@@ -3881,7 +3881,7 @@
     },
     "node_modules/ts-jest/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "http://mirrors.tencentyun.com/npm/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -3894,7 +3894,7 @@
     },
     "node_modules/ts-jest/node_modules/type-fest": {
       "version": "4.41.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/type-fest/-/type-fest-4.41.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "engines": {
@@ -3906,7 +3906,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "resolved": "http://mirrors.tencentyun.com/npm/type-detect/-/type-detect-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
       "engines": {
@@ -3915,7 +3915,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/type-fest/-/type-fest-0.21.3.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
       "engines": {
@@ -3927,7 +3927,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/typescript/-/typescript-5.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "bin": {
@@ -3940,7 +3940,7 @@
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/uglify-js/-/uglify-js-3.19.3.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "optional": true,
@@ -3953,14 +3953,14 @@
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/undici-types/-/undici-types-7.19.2.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "http://mirrors.tencentyun.com/npm/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
@@ -3990,7 +3990,7 @@
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
       "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
       "dev": true,
       "dependencies": {
@@ -4004,7 +4004,7 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
-      "resolved": "http://mirrors.tencentyun.com/npm/walker/-/walker-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dev": true,
       "dependencies": {
@@ -4013,7 +4013,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -4029,13 +4029,13 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "dependencies": {
@@ -4052,14 +4052,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "dependencies": {
@@ -4072,7 +4072,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "http://mirrors.tencentyun.com/npm/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "engines": {
@@ -4081,13 +4081,13 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "http://mirrors.tencentyun.com/npm/yargs/-/yargs-17.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
@@ -4106,7 +4106,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "http://mirrors.tencentyun.com/npm/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
@@ -4116,7 +4116,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "http://mirrors.tencentyun.com/npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #101 / issue #100.
- Keeps deterministic npm ci path and adds install-step validation for required package files so a zero-exit but incomplete npm install is retried before dependency diagnostics.
- Merges current main, including gameplay PR #99.

## Verification
- [x] git diff --check
- [x] workflow YAML parse
- [x] bash -n for 7 workflow run blocks
- [x] git merge-base --is-ancestor origin/main HEAD

Fixes #100

No secrets.