### PR TITLE
docs: add Discord attachment redaction guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ This repository builds and operates a Screeps: World bot. Use this file as the c
 - Preferred commit identity for Codex-authored coding commits: `lanyusea's bot <lanyusea@gmail.com>`.
 - Documentation-only and review-configuration changes may be authored directly by the orchestrating agent.
 - Never print or commit secrets. Screeps auth tokens, Steam keys, private-server credentials, and local selectors belong only in ignored/local env files.
+- Never quote or reproduce gateway attachment trigger lines in owner-facing prose, logs, examples, or code fences unless the intent is to attach a file. When discussing an attachment directive, redact or split the trigger prefix and describe it as a media attachment line plus path. This prevents explanatory text from being parsed as a real Discord file upload in the current thread.
 
 ## Verification commands
 

--- a/docs/ops/discord-attachment-redaction.md
+++ b/docs/ops/discord-attachment-redaction.md
@@ -1,0 +1,21 @@
+# Discord attachment redaction guard
+
+Last updated: 2026-04-28
+
+## Problem
+
+Hermes gateway responses can treat a specially formatted media attachment directive as an instruction to upload a file. If an assistant includes such a directive verbatim while merely explaining logs, the current Discord thread can receive an unintended image attachment.
+
+## Guardrail
+
+For all Screeps agents, reporters, schedulers, reviewers, and docs updates:
+
+1. Do not quote a complete attachment directive in owner-facing prose, examples, logs, code fences, or final responses unless the intended action is to attach that file.
+2. When discussing a prior directive, redact or split the trigger prefix and describe it as "a media attachment line" plus the path or artifact name.
+3. Prefer channel names, artifact paths, cron job IDs, and message IDs as evidence; do not include the complete upload directive.
+4. Keep roadmap/reporting cron cadence unchanged. This guard only changes explanatory text and process documentation.
+5. If gateway code later learns to ignore quoted directives safely, keep this document as a conservative no-surprise reporting rule unless the owner explicitly relaxes it.
+
+## Verification for issue #102
+
+A docs/process PR satisfies the immediate operational guard if it updates `AGENTS.md` and this runbook without reproducing a complete attachment directive. A deeper gateway parser fix can supersede this guard later, but agents must still avoid leaking secrets and accidental upload directives in owner-visible text.


### PR DESCRIPTION
## Summary
- Adds an AGENTS.md guard forbidding owner-facing reproduction of complete gateway attachment directives unless intentionally attaching a file.
- Adds a Discord attachment redaction runbook for Screeps agents/reporters.
- Keeps roadmap/reporting cadence unchanged; this is a process guard for issue #102.

## Verification
- [x] git diff --check
- [x] docs-only change inspected for no complete attachment directive reproduction

Fixes #102

No secrets.
