### PR TITLE
feat: wait for full worker bodies outside emergency

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -438,7 +438,7 @@ function selectWorkerBody(colony, roleCounts) {
   if (roleCounts.worker === 0) {
     return buildEmergencyWorkerBody(colony.energyAvailable);
   }
-  return [];
+  return roleCounts.worker < MIN_WORKER_TARGET ? buildWorkerBody(colony.energyAvailable) : [];
 }
 function canAffordBody(body, energyAvailable) {
   return body.length > 0 && getBodyCost(body) <= energyAvailable;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -438,7 +438,7 @@ function selectWorkerBody(colony, roleCounts) {
   if (roleCounts.worker === 0) {
     return buildEmergencyWorkerBody(colony.energyAvailable);
   }
-  return buildWorkerBody(colony.energyAvailable);
+  return [];
 }
 function canAffordBody(body, energyAvailable) {
   return body.length > 0 && getBodyCost(body) <= energyAvailable;

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -48,7 +48,7 @@ function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyP
     return buildEmergencyWorkerBody(colony.energyAvailable);
   }
 
-  return [];
+  return roleCounts.worker < MIN_WORKER_TARGET ? buildWorkerBody(colony.energyAvailable) : [];
 }
 
 function canAffordBody(body: BodyPartConstant[], energyAvailable: number): boolean {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -48,7 +48,7 @@ function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyP
     return buildEmergencyWorkerBody(colony.energyAvailable);
   }
 
-  return buildWorkerBody(colony.energyAvailable);
+  return [];
 }
 
 function canAffordBody(body: BodyPartConstant[], energyAvailable: number): boolean {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -156,15 +156,10 @@ describe('planSpawn', () => {
     });
   });
 
-  it('plans the best currently affordable worker body when full capacity body is not affordable', () => {
-    const { colony, spawn } = makeColony({ energyAvailable: 400, energyCapacityAvailable: 600 });
+  it('waits for the full planned worker body when existing workers can keep harvesting', () => {
+    const { colony } = makeColony({ energyAvailable: 400, energyCapacityAvailable: 600 });
 
-    expect(planSpawn(colony, { worker: 2 }, 135)).toEqual({
-      spawn,
-      body: ['work', 'carry', 'move', 'work', 'carry', 'move'],
-      name: 'worker-W1N1-135',
-      memory: { role: 'worker', colony: 'W1N1' }
-    });
+    expect(planSpawn(colony, { worker: 2 }, 135)).toBeNull();
   });
 
   it('does not plan an emergency body that costs more than available energy', () => {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -156,10 +156,37 @@ describe('planSpawn', () => {
     });
   });
 
-  it('waits for the full planned worker body when existing workers can keep harvesting', () => {
-    const { colony } = makeColony({ energyAvailable: 400, energyCapacityAvailable: 600 });
+  it('keeps zero-worker recovery on the emergency basic worker body when full body is unavailable', () => {
+    const { colony, spawn } = makeColony({ energyAvailable: 400, energyCapacityAvailable: 600 });
 
-    expect(planSpawn(colony, { worker: 2 }, 135)).toBeNull();
+    expect(planSpawn(colony, { worker: 0 }, 135)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W1N1-135',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
+  it('plans an affordable worker body below the minimum functional worker target', () => {
+    const { colony, spawn } = makeColony({ energyAvailable: 400, energyCapacityAvailable: 600 });
+
+    expect(planSpawn(colony, { worker: 2 }, 136)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move'],
+      name: 'worker-W1N1-136',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
+  it('waits for the full planned worker body when existing workers can keep harvesting', () => {
+    const { colony } = makeColony({
+      roomName: 'W1N7',
+      sourceCount: 2,
+      energyAvailable: 400,
+      energyCapacityAvailable: 600
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 137)).toBeNull();
   });
 
   it('does not plan an emergency body that costs more than available energy', () => {
@@ -171,7 +198,7 @@ describe('planSpawn', () => {
   it('does not plan a non-emergency worker body below the minimum worker energy', () => {
     const { colony } = makeColony({ energyAvailable: 199, energyCapacityAvailable: 400 });
 
-    expect(planSpawn(colony, { worker: 2 }, 136)).toBeNull();
+    expect(planSpawn(colony, { worker: 2 }, 138)).toBeNull();
   });
 
   it('does not plan when all spawns are busy', () => {


### PR DESCRIPTION
## Summary
- Waits for the full planned worker body when existing workers can keep the room alive.
- Preserves zero-worker emergency spawning and source-aware worker target behavior.
- Regenerates `prod/dist/main.js` from the build.

## Verification
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand`
- [x] `cd prod && npm run build`
- [x] `git diff --check -- prod/src/spawn/spawnPlanner.ts prod/test/spawnPlanner.test.ts prod/dist/main.js`

Closes #107

No secrets.
