### PR TITLE
feat: sustain controller progress during building

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -199,6 +199,7 @@ function canSatisfyWorkerCapacity(creep) {
 
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
+var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 function selectWorkerTask(creep) {
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
   if (carriedEnergy === 0) {
@@ -227,7 +228,7 @@ function selectWorkerTask(creep) {
   if (extensionConstructionSite) {
     return { type: "build", targetId: extensionConstructionSite.id };
   }
-  if (controller && shouldGuardRcl2ControllerProgress(controller)) {
+  if (controller && shouldSustainControllerProgress(creep, controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
   if (constructionSites[0]) {
@@ -258,8 +259,39 @@ function shouldGuardControllerDowngrade(controller) {
 function shouldRushRcl1Controller(controller) {
   return controller.my === true && controller.level === 1;
 }
-function shouldGuardRcl2ControllerProgress(controller) {
-  return controller.my === true && controller.level === 2;
+function shouldSustainControllerProgress(creep, controller) {
+  if (controller.my !== true || controller.level < 2) {
+    return false;
+  }
+  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  return loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS && !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller));
+}
+function getSameRoomLoadedWorkers(creep) {
+  const loadedWorkers = getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
+  if (!loadedWorkers.includes(creep) && getUsedEnergy(creep) > 0) {
+    loadedWorkers.push(creep);
+  }
+  return loadedWorkers;
+}
+function isSameRoomWorkerWithEnergy(creep, room) {
+  var _a;
+  return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom(creep, room) && getUsedEnergy(creep) > 0;
+}
+function isInRoom(creep, room) {
+  var _a;
+  if (typeof room.name === "string" && room.name.length > 0) {
+    return ((_a = creep.room) == null ? void 0 : _a.name) === room.name;
+  }
+  return creep.room === room;
+}
+function getUsedEnergy(creep) {
+  var _a, _b, _c;
+  return (_c = (_b = (_a = creep.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY)) != null ? _c : 0;
+}
+function isUpgradingController(creep, controller) {
+  var _a;
+  const task = (_a = creep.memory) == null ? void 0 : _a.task;
+  return (task == null ? void 0 : task.type) === "upgrade" && task.targetId === controller.id;
 }
 function selectHarvestSource(creep) {
   var _a, _b;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1,5 +1,6 @@
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
+const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
@@ -36,7 +37,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'build', targetId: extensionConstructionSite.id };
   }
 
-  if (controller && shouldGuardRcl2ControllerProgress(controller)) {
+  if (controller && shouldSustainControllerProgress(creep, controller)) {
     return { type: 'upgrade', targetId: controller.id };
   }
 
@@ -87,8 +88,47 @@ function shouldRushRcl1Controller(controller: StructureController): boolean {
   return controller.my === true && controller.level === 1;
 }
 
-function shouldGuardRcl2ControllerProgress(controller: StructureController): boolean {
-  return controller.my === true && controller.level === 2;
+function shouldSustainControllerProgress(creep: Creep, controller: StructureController): boolean {
+  if (controller.my !== true || controller.level < 2) {
+    return false;
+  }
+
+  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  return (
+    loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS &&
+    !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller))
+  );
+}
+
+function getSameRoomLoadedWorkers(creep: Creep): Creep[] {
+  const loadedWorkers = getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
+
+  if (!loadedWorkers.includes(creep) && getUsedEnergy(creep) > 0) {
+    loadedWorkers.push(creep);
+  }
+
+  return loadedWorkers;
+}
+
+function isSameRoomWorkerWithEnergy(creep: Creep, room: Room): boolean {
+  return creep.memory?.role === 'worker' && isInRoom(creep, room) && getUsedEnergy(creep) > 0;
+}
+
+function isInRoom(creep: Creep, room: Room): boolean {
+  if (typeof room.name === 'string' && room.name.length > 0) {
+    return creep.room?.name === room.name;
+  }
+
+  return creep.room === room;
+}
+
+function getUsedEnergy(creep: Creep): number {
+  return creep.store?.getUsedCapacity?.(RESOURCE_ENERGY) ?? 0;
+}
+
+function isUpgradingController(creep: Creep, controller: StructureController): boolean {
+  const task = creep.memory?.task as Partial<CreepTaskMemory> | undefined;
+  return task?.type === 'upgrade' && task.targetId === controller.id;
 }
 
 function selectHarvestSource(creep: Creep): Source | null {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1,5 +1,17 @@
 import { CONTROLLER_DOWNGRADE_GUARD_TICKS, selectWorkerTask } from '../src/tasks/workerTasks';
 
+function makeLoadedWorker(room: Room, task?: CreepTaskMemory): Creep {
+  return {
+    memory: { role: 'worker', ...(task ? { task } : {}) },
+    store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+    room
+  } as unknown as Creep;
+}
+
+function setGameCreeps(creeps: Record<string, Creep>): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps };
+}
+
 describe('selectWorkerTask', () => {
   beforeEach(() => {
     (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant }).FIND_SOURCES = 1;
@@ -184,7 +196,7 @@ describe('selectWorkerTask', () => {
   it.each([
     ['road', 'road-site1'],
     ['container', 'container-site1']
-  ])('selects RCL2 controller upgrade before non-critical %s construction when downgrade is safe', (structureType, id) => {
+  ])('selects RCL2 controller upgrade before non-critical %s construction when another loaded worker can build', (structureType, id) => {
     const site = { id, structureType } as ConstructionSite;
     const controller = {
       id: 'controller1',
@@ -192,13 +204,16 @@ describe('selectWorkerTask', () => {
       level: 2,
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
     } as StructureController;
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type) => (type === 2 ? [site] : []))
+    } as unknown as Room;
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: {
-        controller,
-        find: jest.fn((type) => (type === 2 ? [site] : []))
-      }
+      room
     } as unknown as Creep;
+    setGameCreeps({ Builder: makeLoadedWorker(room) });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
@@ -214,13 +229,16 @@ describe('selectWorkerTask', () => {
       level: 2,
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
     } as StructureController;
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type) => (type === 2 ? [site] : []))
+    } as unknown as Room;
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: {
-        controller,
-        find: jest.fn((type) => (type === 2 ? [site] : []))
-      }
+      room
     } as unknown as Creep;
+    setGameCreeps({ Worker2: makeLoadedWorker(room) });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: id });
   });
@@ -249,7 +267,7 @@ describe('selectWorkerTask', () => {
     expect(task).toEqual({ type: 'build', targetId: 'extension-site1' });
   });
 
-  it('keeps RCL3 build-before-upgrade priority when controller downgrade is safe', () => {
+  it('keeps RCL3 build-before-upgrade priority when only one loaded worker is available', () => {
     const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
     const controller = {
       id: 'controller1',
@@ -264,6 +282,52 @@ describe('selectWorkerTask', () => {
         find: jest.fn((type) => (type === 2 ? [site] : []))
       }
     } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('selects RCL3 controller upgrade before non-critical construction when another loaded worker can build', () => {
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type) => (type === 2 ? [site] : []))
+    } as unknown as Room;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Builder: makeLoadedWorker(room) });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps non-critical build priority when another loaded worker is already upgrading the controller', () => {
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type) => (type === 2 ? [site] : []))
+    } as unknown as Room;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> })
+    });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
   });


### PR DESCRIPTION
## Summary
- Adds controller-progress sustain behavior so an RCL2+ room assigns a loaded worker to upgrade before non-critical construction when another loaded worker can keep building.
- Preserves emergency downgrade guard, spawn-fill, spawn-site, RCL1 rush, extension-build, and one-worker build behavior.
- Regenerates `prod/dist/main.js` from the build.

## Verification
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand`
- [x] `cd prod && npm run build`
- [x] `git diff --check -- prod/src/tasks/workerTasks.ts prod/test/workerTasks.test.ts prod/dist/main.js`

Closes #106

No secrets.
