### PR TITLE
feat: add official Screeps deploy path

### DIFF
--- a/.github/workflows/official-screeps-deploy.yml
+++ b/.github/workflows/official-screeps-deploy.yml
@@ -32,7 +32,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: official-screeps-deploy-${{ github.ref }}
+  group: official-screeps-deploy-main-shardX-E48S28
   cancel-in-progress: false
 
 jobs:
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: refs/heads/main
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/official-screeps-deploy.yml
+++ b/.github/workflows/official-screeps-deploy.yml
@@ -1,0 +1,132 @@
+name: official-screeps-deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Run a metadata-only dry run or perform the official upload."
+        required: true
+        type: choice
+        default: dry-run
+        options:
+          - dry-run
+          - deploy
+      environment:
+        description: "GitHub environment holding the official deploy secret and approvals."
+        required: true
+        type: choice
+        default: official-screeps
+        options:
+          - official-screeps
+      activate_world:
+        description: "Set main as activeWorld after upload."
+        required: true
+        type: boolean
+        default: false
+      confirmation:
+        description: "Required for deploy mode: deploy main to shardX/E48S28"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: official-screeps-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify-and-deploy:
+    name: Verify and manually deploy official Screeps
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: ${{ inputs.environment }}
+    env:
+      SCREEPS_API_URL: https://screeps.com
+      SCREEPS_BRANCH: main
+      SCREEPS_SHARD: shardX
+      SCREEPS_ROOM: E48S28
+      EVIDENCE_DIR: runtime-artifacts/official-screeps-deploy
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: prod/package-lock.json
+
+      - name: Run deploy helper unit tests
+        run: python3 -m unittest scripts/test_screeps_official_deploy.py
+
+      - name: Install production dependencies
+        working-directory: prod
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: prod
+        run: npm run typecheck
+
+      - name: Run Jest in-band
+        working-directory: prod
+        run: npm test -- --runInBand
+
+      - name: Build bundled Screeps artifact
+        working-directory: prod
+        run: npm run build
+
+      - name: Dry-run official deploy evidence
+        if: ${{ inputs.mode == 'dry-run' }}
+        env:
+          ACTIVATE_WORLD: ${{ inputs.activate_world }}
+        run: |
+          mkdir -p "$EVIDENCE_DIR"
+          activate_flag=""
+          if [ "$ACTIVATE_WORLD" = "true" ]; then
+            activate_flag="--activate-world"
+          fi
+          python3 scripts/screeps_official_deploy.py \
+            --dry-run \
+            $activate_flag \
+            --evidence-path "$EVIDENCE_DIR/official-screeps-deploy-dry-run.json"
+
+      - name: Check deploy confirmation
+        if: ${{ inputs.mode == 'deploy' }}
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          if [ "$CONFIRMATION" != "deploy main to shardX/E48S28" ]; then
+            echo "::error::Deploy mode requires exact confirmation: deploy main to shardX/E48S28"
+            exit 1
+          fi
+
+      - name: Deploy to official Screeps
+        if: ${{ inputs.mode == 'deploy' }}
+        env:
+          ACTIVATE_WORLD: ${{ inputs.activate_world }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          SCREEPS_AUTH_TOKEN: ${{ secrets.SCREEPS_AUTH_TOKEN }}
+        run: |
+          mkdir -p "$EVIDENCE_DIR"
+          activate_flag=""
+          if [ "$ACTIVATE_WORLD" = "true" ]; then
+            activate_flag="--activate-world"
+          fi
+          python3 scripts/screeps_official_deploy.py \
+            --deploy \
+            $activate_flag \
+            --confirm "$CONFIRMATION" \
+            --evidence-path "$EVIDENCE_DIR/official-screeps-deploy.json"
+
+      - name: Upload deploy evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: official-screeps-deploy-evidence
+          path: runtime-artifacts/official-screeps-deploy/
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Make official/private runtime state visible without noisy spam. This domain cove
 
 Deploy to the official Screeps MMO only after release-quality evidence exists. The current official target is branch `main`, shard `shardX`, room `E48S28`, with deployment gated by deterministic tests, build verification, private-server smoke evidence, safe token handling, and post-deploy observation.
 
+Runbook: `docs/ops/official-mmo-deploy.md`.
+
 ### 7. Expansion, resources, and combat
 
 Move beyond single-room survival toward the competition vision: expansion scouting, room scoring, claim/reserve planning, remote-room logistics, road/container/storage/repair systems, minerals and market readiness, defensive telemetry, and eventually coordinated combat.

--- a/docs/ops/official-mmo-deploy.md
+++ b/docs/ops/official-mmo-deploy.md
@@ -1,0 +1,121 @@
+# Official Screeps MMO Deploy Runbook
+
+Date: 2026-04-28
+
+Issue: refs #33. Do not close #33 from a PR body until this path is merged, dispatched, and the live deploy plus post-deploy monitoring evidence are verified.
+
+## Purpose
+
+This runbook is the safe release path for the current official target:
+
+- API: `https://screeps.com`
+- Code branch: `main`
+- World shard/room: `shardX/E48S28`
+- Artifact: `prod/dist/main.js`
+
+The deploy path uploads only module `main`, verifies round-trip SHA-256 hashes, optionally sets `main` as `activeWorld`, and emits JSON evidence without auth tokens, request headers, local bundle contents, or remote module contents.
+
+## Local Gate
+
+Run from the repository root:
+
+```bash
+python3 -m unittest scripts/test_screeps_official_deploy.py
+
+cd prod
+npm run typecheck
+npm test -- --runInBand
+npm run build
+cd ..
+
+python3 scripts/screeps_official_deploy.py --dry-run --activate-world
+```
+
+The dry run does not read `SCREEPS_AUTH_TOKEN` and does not call the Screeps API. It checks that the artifact exists and prints planned request shapes plus artifact size/SHA-256.
+
+## Live Deploy
+
+Load `SCREEPS_AUTH_TOKEN` into the environment through local secret storage or CI secrets. Do not print it.
+
+```bash
+mkdir -p runtime-artifacts/official-screeps-deploy
+
+python3 scripts/screeps_official_deploy.py \
+  --deploy \
+  --activate-world \
+  --confirm "deploy main to shardX/E48S28" \
+  --evidence-path runtime-artifacts/official-screeps-deploy/official-screeps-deploy.json
+```
+
+The script:
+
+1. Reads `SCREEPS_AUTH_TOKEN` from the environment only.
+2. Lists code branches through `GET /api/user/branches`.
+3. Clones the active World branch, or `default`, to `main` only if `main` is missing.
+4. Uploads `prod/dist/main.js` to `POST /api/user/code` as module `main`.
+5. Verifies `GET /api/user/code?branch=main` by SHA-256 and size only.
+6. When `--activate-world` is set, calls `POST /api/user/set-active-branch`, verifies branch metadata, and verifies `GET /api/user/code?branch=$activeWorld` by SHA-256 and size only.
+
+The command exits non-zero if the token is missing, the confirmation phrase is wrong, an API request fails, or local/remote hashes do not match.
+
+## GitHub Actions
+
+Workflow: `.github/workflows/official-screeps-deploy.yml`
+
+Manual dispatch inputs:
+
+- `mode`: `dry-run` by default; `deploy` performs writes.
+- `environment`: `official-screeps`; configure this GitHub environment with required reviewers if desired.
+- `activate_world`: sets `main` as `activeWorld` after upload.
+- `confirmation`: required for deploy mode, exactly `deploy main to shardX/E48S28`.
+
+Required secret:
+
+```text
+SCREEPS_AUTH_TOKEN
+```
+
+The workflow runs the Python deploy-helper tests, production typecheck, Jest, and build before any deploy write. It uploads the deploy evidence JSON as a workflow artifact.
+
+If a controller cannot push the workflow file because its GitHub token lacks `workflow` scope, keep the script/docs/tests commit, state the workflow-scope blocker in the PR body and issue evidence, and have a controller with `workflow` scope add the workflow file.
+
+## Evidence Contract
+
+Deploy evidence JSON must include:
+
+- local git commit SHA and dirty flag
+- safe API URL, branch, shard, and room
+- artifact path, byte size, and SHA-256
+- request method/path/status summaries without auth headers
+- branch creation/activeWorld metadata
+- branch and activeWorld code verification status by SHA-256
+
+Evidence JSON must not include:
+
+- `SCREEPS_AUTH_TOKEN`
+- `Authorization`, `X-Token`, or other auth headers
+- `prod/dist/main.js` contents
+- remote module contents
+
+## Post-Deploy Monitoring
+
+After a successful live deploy, capture runtime evidence for `shardX/E48S28`:
+
+```bash
+python3 scripts/screeps-runtime-monitor.py summary --room shardX/E48S28
+python3 scripts/screeps-runtime-monitor.py alert --room shardX/E48S28
+
+python3 scripts/screeps_runtime_summary_console_capture.py \
+  --live-official-console \
+  --console-channel console \
+  --console-channel console:shardX
+```
+
+Attach or reference:
+
+- deploy evidence JSON path or workflow artifact
+- runtime summary/alert JSON and any generated room images
+- runtime-summary console capture artifact, or a clear telemetry-silence finding
+- deployed git commit SHA
+
+Escalate through `docs/ops/runtime-room-monitor.md` if alerts show hostiles, damage, spawn collapse, downgrade risk, telemetry silence, or loop exceptions.

--- a/docs/ops/screeps-access-and-deployment-auth.md
+++ b/docs/ops/screeps-access-and-deployment-auth.md
@@ -24,6 +24,8 @@ The documented code API endpoint is:
 
 The deploy artifact is the bundled JavaScript module set, normally our generated `prod/dist/main.js` or equivalent.
 
+Current safe deploy procedure: `docs/ops/official-mmo-deploy.md`.
+
 ## What the user needs to provide
 
 ### Required for public MMO deployment
@@ -51,6 +53,8 @@ Current public MMO deployment target confirmed by user:
 SCREEPS_AUTH_TOKEN=***
 SCREEPS_BRANCH=main
 SCREEPS_API_URL=https://screeps.com
+SCREEPS_SHARD=shardX
+SCREEPS_ROOM=E48S28
 ```
 
 For private-server smoke tests:
@@ -90,11 +94,11 @@ Likely private-server inputs:
 
 1. Build/test locally without any Screeps token.
 2. Run private-server smoke when local/private-server secrets are available.
-3. Add a deploy script that reads token/config from untracked local env only.
+3. Use `scripts/screeps_official_deploy.py --dry-run` to verify artifact metadata without reading a token.
 4. User creates Screeps auth token in account settings.
-5. User installs token into local secret storage, not Discord.
-6. We verify deploy with a harmless branch or limited release branch before touching the live active branch.
-7. After deployment is stable, document the exact command and keep secrets out of committed files.
+5. User installs token into local secret storage or GitHub environment secret `SCREEPS_AUTH_TOKEN`, not Discord.
+6. Run the gated live deploy command only with exact confirmation and record the emitted evidence JSON.
+7. After deployment, run the runtime monitor and console capture checks from `docs/ops/official-mmo-deploy.md`.
 
 ## Confirmed public MMO decisions
 

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -155,6 +155,12 @@ def normalize_api_url(raw_url: str) -> str:
     return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
 
 
+def require_https_api_url(api_url: str) -> None:
+    """Reject non-HTTPS API URLs before authenticated deploy requests."""
+    if urllib.parse.urlparse(api_url).scheme != "https":
+        raise DeployError("SCREEPS_API_URL must use https for --deploy")
+
+
 def validate_selector(name: str, value: str, pattern: re.Pattern[str]) -> str:
     """Validate a non-secret branch/shard/room selector."""
     if not pattern.fullmatch(value):
@@ -267,6 +273,19 @@ def summarize_request_payload(path: str, payload: dict[str, Any] | None) -> dict
     return redact(payload)
 
 
+CODE_LEAK_MARKERS = ("module.exports", "exports.loop")
+CODE_LIKE_TEXT_KEYS = {"main", "message", "error", "body", "detail"}
+
+
+def looks_like_code_leak(text: str, parent_key: str) -> bool:
+    """Return whether a free-text API field appears to contain uploaded code."""
+    if parent_key == "main":
+        return len(text) > 120 or any(marker in text for marker in CODE_LEAK_MARKERS)
+    if parent_key in CODE_LIKE_TEXT_KEYS:
+        return any(marker in text for marker in CODE_LEAK_MARKERS)
+    return False
+
+
 def redact(value: Any, secrets_to_hide: list[str] | None = None, parent_key: str = "") -> Any:
     """Recursively redact secret-like keys and explicit secret values."""
     secrets = [secret for secret in (secrets_to_hide or []) if secret]
@@ -287,7 +306,7 @@ def redact(value: Any, secrets_to_hide: list[str] | None = None, parent_key: str
         text = value
         for secret in secrets:
             text = text.replace(secret, "[REDACTED]")
-        if parent_key == "main" and (len(text) > 120 or "module.exports" in text):
+        if looks_like_code_leak(text, parent_key):
             return f"[REDACTED_CODE sizeBytes={len(value.encode('utf-8'))}]"
         return text
     return value
@@ -488,6 +507,8 @@ def run_deploy(
     """Execute dry-run or deploy mode and return safe evidence."""
     if env is None:
         env = os.environ
+    if cfg.deploy:
+        require_https_api_url(cfg.api_url)
     artifact_bytes, artifact = read_artifact(cfg.artifact_path)
     evidence = base_evidence(cfg, artifact)
     if not cfg.deploy:
@@ -654,6 +675,8 @@ def build_parser() -> argparse.ArgumentParser:
 def config_from_args(args: argparse.Namespace) -> DeployConfig:
     """Create a validated deploy config from CLI arguments."""
     api_url = normalize_api_url(args.api_url)
+    if args.deploy:
+        require_https_api_url(api_url)
     branch = validate_selector("SCREEPS_BRANCH", args.branch, BRANCH_RE)
     shard = validate_selector("SCREEPS_SHARD", args.shard, SHARD_RE)
     room = validate_selector("SCREEPS_ROOM", args.room, ROOM_RE)

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -100,15 +100,18 @@ class ScreepsApi:
             "payload": summarize_request_payload(path, payload),
         }
         transport = self.transport or http_json
-        result = transport(
-            method=method,
-            base_url=self.base_url,
-            path=path,
-            payload=payload,
-            headers=headers,
-            params=params,
-            timeout=self.timeout_seconds,
-        )
+        try:
+            result = transport(
+                method=method,
+                base_url=self.base_url,
+                path=path,
+                payload=payload,
+                headers=headers,
+                params=params,
+                timeout=self.timeout_seconds,
+            )
+        except DeployError as exc:
+            raise DeployError(short_text(redact(str(exc), [self.token]), 500)) from None
         request_summary["status"] = result.status
         request_summary["apiOk"] = api_payload_succeeded(result)
         self.requests.append(request_summary)
@@ -312,10 +315,10 @@ def api_payload_succeeded(result: HttpResult) -> bool:
     return ok_value is None or ok_value is True or ok_value == 1
 
 
-def require_api_success(name: str, result: HttpResult) -> None:
+def require_api_success(name: str, result: HttpResult, secrets: list[str] | None = None) -> None:
     """Raise a sanitized error when an API request failed."""
     if not api_payload_succeeded(result):
-        raise DeployError(f"{name} failed: HTTP {result.status}: {short_text(redact(result.payload), 500)}")
+        raise DeployError(f"{name} failed: HTTP {result.status}: {short_text(redact(result.payload, secrets), 500)}")
 
 
 def upload_succeeded(result: HttpResult) -> bool:
@@ -508,7 +511,7 @@ def run_deploy(
     client = ScreepsApi(cfg.api_url, token, cfg.timeout_seconds, transport)
 
     first_branches_result = client.list_branches()
-    require_api_success("list branches", first_branches_result)
+    require_api_success("list branches", first_branches_result, [token])
     first_branches = extract_branches(first_branches_result.payload)
     target_exists_before = find_branch(first_branches, cfg.branch) is not None
     clone_source = cfg.clone_source_branch or active_world_branch_name(first_branches) or "default"
@@ -516,19 +519,21 @@ def run_deploy(
 
     if not target_exists_before:
         clone_result = client.clone_branch(clone_source, cfg.branch)
-        require_api_success("clone branch", clone_result)
+        require_api_success("clone branch", clone_result, [token])
         branch_created = True
 
     second_branches_result = client.list_branches()
-    require_api_success("refresh branches", second_branches_result)
+    require_api_success("refresh branches", second_branches_result, [token])
     second_branches = extract_branches(second_branches_result.payload)
 
     upload_result = client.upload_code(cfg.branch, module)
     if not upload_succeeded(upload_result):
-        raise DeployError(f"upload code failed: HTTP {upload_result.status}: {short_text(redact(upload_result.payload), 500)}")
+        raise DeployError(
+            f"upload code failed: HTTP {upload_result.status}: {short_text(redact(upload_result.payload, [token]), 500)}"
+        )
 
     branch_code_result = client.get_code(cfg.branch)
-    require_api_success("verify branch code", branch_code_result)
+    require_api_success("verify branch code", branch_code_result, [token])
     branch_verify = verify_remote_module(branch_code_result.payload, artifact["sha256"])
     if not branch_verify["matched"]:
         raise DeployError("uploaded branch hash verification failed")
@@ -537,17 +542,17 @@ def run_deploy(
     active_verify: dict[str, Any] = {"requested": cfg.activate_world, "status": "not-requested"}
     if cfg.activate_world:
         active_result = client.set_active_world_branch(cfg.branch)
-        require_api_success("set activeWorld branch", active_result)
+        require_api_success("set activeWorld branch", active_result, [token])
 
         active_branches_result = client.list_branches()
-        require_api_success("verify active branch metadata", active_branches_result)
+        require_api_success("verify active branch metadata", active_branches_result, [token])
         final_branches = extract_branches(active_branches_result.payload)
         active_name = active_world_branch_name(final_branches)
         if active_name != cfg.branch:
             raise DeployError(f"activeWorld branch mismatch: expected {cfg.branch}, got {active_name or 'none'}")
 
         active_code_result = client.get_code("$activeWorld")
-        require_api_success("verify activeWorld code", active_code_result)
+        require_api_success("verify activeWorld code", active_code_result, [token])
         active_code_verify = verify_remote_module(active_code_result.payload, artifact["sha256"])
         if not active_code_verify["matched"]:
             raise DeployError("activeWorld hash verification failed")

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+"""Safe official Screeps MMO deploy helper.
+
+The script uploads the built Screeps bundle as one ``main`` module and reports
+only metadata and hashes. It intentionally never logs tokens, auth headers, or
+module contents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT_PATH = REPO_ROOT / "prod" / "dist" / "main.js"
+DEFAULT_API_URL = "https://screeps.com"
+DEFAULT_BRANCH = "main"
+DEFAULT_SHARD = "shardX"
+DEFAULT_ROOM = "E48S28"
+DEFAULT_TIMEOUT_SECONDS = 30
+AUTH_TOKEN_ENV = "SCREEPS_AUTH_TOKEN"
+SECRET_KEY_RE = re.compile(r"(authorization|password|secret|steam[_-]?key|token|x[_-]?token|x[_-]?username)", re.I)
+BRANCH_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+SHARD_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+ROOM_RE = re.compile(r"^[WE]\d+[NS]\d+$")
+
+
+class DeployError(RuntimeError):
+    """A sanitized deploy failure that can be printed safely."""
+
+
+@dataclass(frozen=True)
+class DeployConfig:
+    """Configuration for a dry-run or live official deploy."""
+
+    api_url: str
+    branch: str
+    shard: str
+    room: str
+    artifact_path: Path
+    deploy: bool
+    activate_world: bool
+    confirm: str | None = None
+    clone_source_branch: str | None = None
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+    evidence_path: Path | None = None
+    repo_root: Path = REPO_ROOT
+
+    @property
+    def expected_confirmation(self) -> str:
+        """Return the exact confirmation phrase required for writes."""
+        return f"deploy {self.branch} to {self.shard}/{self.room}"
+
+
+@dataclass
+class HttpResult:
+    """HTTP response status, decoded payload, and headers."""
+
+    status: int
+    payload: Any
+    headers: dict[str, str]
+
+
+@dataclass
+class ScreepsApi:
+    """Small authenticated Screeps API client with safe request summaries."""
+
+    base_url: str
+    token: str
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+    transport: Callable[..., HttpResult] | None = None
+    requests: list[dict[str, Any]] = field(default_factory=list)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> HttpResult:
+        """Send an authenticated JSON request and record a safe summary."""
+        headers = {"X-Token": self.token}
+        request_summary: dict[str, Any] = {
+            "method": method,
+            "path": path,
+            "params": params or {},
+            "payload": summarize_request_payload(path, payload),
+        }
+        transport = self.transport or http_json
+        result = transport(
+            method=method,
+            base_url=self.base_url,
+            path=path,
+            payload=payload,
+            headers=headers,
+            params=params,
+            timeout=self.timeout_seconds,
+        )
+        request_summary["status"] = result.status
+        request_summary["apiOk"] = api_payload_succeeded(result)
+        self.requests.append(request_summary)
+        return result
+
+    def list_branches(self) -> HttpResult:
+        """Return the current Screeps code branches."""
+        return self.request("GET", "/api/user/branches")
+
+    def clone_branch(self, source_branch: str, new_name: str) -> HttpResult:
+        """Clone an existing code branch to a new branch name."""
+        return self.request("POST", "/api/user/clone-branch", {"branch": source_branch, "newName": new_name})
+
+    def upload_code(self, branch: str, code: str) -> HttpResult:
+        """Upload the ``main`` module to a Screeps code branch."""
+        return self.request("POST", "/api/user/code", build_code_payload(branch, code))
+
+    def get_code(self, branch: str) -> HttpResult:
+        """Fetch code for a branch or Screeps pseudo-branch such as ``$activeWorld``."""
+        return self.request("GET", "/api/user/code", params={"branch": branch})
+
+    def set_active_world_branch(self, branch: str) -> HttpResult:
+        """Set the active World branch without exposing the module body."""
+        return self.request(
+            "POST",
+            "/api/user/set-active-branch",
+            {"activeName": "activeWorld", "branch": branch},
+        )
+
+
+def normalize_api_url(raw_url: str) -> str:
+    """Normalize and validate a safe HTTP API base URL."""
+    parsed = urllib.parse.urlparse(raw_url.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise DeployError("SCREEPS_API_URL must be an http(s) URL")
+    if parsed.username or parsed.password:
+        raise DeployError("SCREEPS_API_URL must not include credentials")
+    if parsed.query or parsed.fragment:
+        raise DeployError("SCREEPS_API_URL must not include query strings or fragments")
+    path = parsed.path.rstrip("/")
+    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+
+
+def validate_selector(name: str, value: str, pattern: re.Pattern[str]) -> str:
+    """Validate a non-secret branch/shard/room selector."""
+    if not pattern.fullmatch(value):
+        raise DeployError(f"{name} has an unsupported value: {value}")
+    return value
+
+
+def git_output(repo_root: Path, *args: str) -> str:
+    """Return git command stdout, or ``unknown`` when git metadata is unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def git_metadata(repo_root: Path) -> dict[str, Any]:
+    """Return local commit metadata suitable for deploy evidence."""
+    status = git_output(repo_root, "status", "--short")
+    return {
+        "commit": git_output(repo_root, "rev-parse", "HEAD"),
+        "branch": git_output(repo_root, "branch", "--show-current"),
+        "dirty": bool(status and status != "unknown"),
+    }
+
+
+def read_artifact(path: Path) -> tuple[bytes, dict[str, Any]]:
+    """Read a deploy artifact and return safe metadata."""
+    if not path.exists():
+        raise DeployError(f"artifact does not exist: {path}")
+    if not path.is_file():
+        raise DeployError(f"artifact is not a file: {path}")
+    data = path.read_bytes()
+    if not data:
+        raise DeployError(f"artifact is empty: {path}")
+    return data, artifact_metadata_from_bytes(path, data)
+
+
+def artifact_metadata_from_bytes(path: Path, data: bytes) -> dict[str, Any]:
+    """Return non-secret artifact evidence for bytes."""
+    return {
+        "path": safe_path(path),
+        "sizeBytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def safe_path(path: Path) -> str:
+    """Return a stable repo-relative path when possible."""
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def decode_module(data: bytes, path: Path) -> str:
+    """Decode the bundle as UTF-8 for Screeps module upload."""
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise DeployError(f"artifact must be UTF-8 JavaScript: {path}") from exc
+
+
+def build_code_payload(branch: str, code: str) -> dict[str, Any]:
+    """Build the official Screeps code upload payload."""
+    return {
+        "branch": branch,
+        "modules": {
+            "main": code,
+        },
+    }
+
+
+def summarize_modules(modules: dict[str, Any]) -> dict[str, Any]:
+    """Summarize module names, sizes, and hashes without returning contents."""
+    summary: dict[str, Any] = {}
+    for name, value in modules.items():
+        if isinstance(value, str):
+            encoded = value.encode("utf-8")
+            summary[name] = {
+                "redacted": True,
+                "sizeBytes": len(encoded),
+                "sha256": hashlib.sha256(encoded).hexdigest(),
+            }
+        else:
+            summary[name] = {"redacted": True, "type": type(value).__name__}
+    return summary
+
+
+def summarize_request_payload(path: str, payload: dict[str, Any] | None) -> dict[str, Any]:
+    """Return a request-body summary that cannot contain code or tokens."""
+    if not payload:
+        return {}
+    if path == "/api/user/code":
+        modules = payload.get("modules")
+        return {
+            "branch": payload.get("branch"),
+            "modules": summarize_modules(modules) if isinstance(modules, dict) else {"redacted": True},
+        }
+    return redact(payload)
+
+
+def redact(value: Any, secrets_to_hide: list[str] | None = None, parent_key: str = "") -> Any:
+    """Recursively redact secret-like keys and explicit secret values."""
+    secrets = [secret for secret in (secrets_to_hide or []) if secret]
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if SECRET_KEY_RE.search(key_text):
+                redacted[key_text] = "[REDACTED]"
+            elif key_text == "modules" and isinstance(item, dict):
+                redacted[key_text] = summarize_modules(item)
+            else:
+                redacted[key_text] = redact(item, secrets, key_text)
+        return redacted
+    if isinstance(value, list):
+        return [redact(item, secrets, parent_key) for item in value]
+    if isinstance(value, str):
+        text = value
+        for secret in secrets:
+            text = text.replace(secret, "[REDACTED]")
+        if parent_key == "main" and (len(text) > 120 or "module.exports" in text):
+            return f"[REDACTED_CODE sizeBytes={len(value.encode('utf-8'))}]"
+        return text
+    return value
+
+
+def assert_no_secret_or_code_leak(payload: Any, secrets_to_hide: list[str]) -> None:
+    """Fail closed if evidence contains secrets or bundle contents."""
+    encoded = json.dumps(payload, sort_keys=True)
+    for secret in secrets_to_hide:
+        if secret and secret in encoded:
+            raise DeployError("evidence contains a secret value")
+    if "module.exports" in encoded or "exports.loop" in encoded:
+        raise DeployError("evidence contains uploaded code contents")
+
+
+def api_payload_succeeded(result: HttpResult) -> bool:
+    """Return whether a Screeps API payload looks successful."""
+    if result.status < 200 or result.status >= 300:
+        return False
+    if not isinstance(result.payload, dict):
+        return True
+    ok_value = result.payload.get("ok")
+    if "error" in result.payload and ok_value not in (1, True):
+        return False
+    return ok_value is None or ok_value is True or ok_value == 1
+
+
+def require_api_success(name: str, result: HttpResult) -> None:
+    """Raise a sanitized error when an API request failed."""
+    if not api_payload_succeeded(result):
+        raise DeployError(f"{name} failed: HTTP {result.status}: {short_text(redact(result.payload), 500)}")
+
+
+def upload_succeeded(result: HttpResult) -> bool:
+    """Return whether ``POST /api/user/code`` accepted the bundle."""
+    if not api_payload_succeeded(result):
+        return False
+    return isinstance(result.payload, dict) and (
+        result.payload.get("ok") in (1, True) or "timestamp" in result.payload
+    )
+
+
+def short_text(value: Any, max_len: int) -> str:
+    """Return bounded text for sanitized errors."""
+    text = str(value)
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "..."
+
+
+def extract_branches(payload: Any) -> list[dict[str, Any]]:
+    """Extract branch records from known Screeps branch-list shapes."""
+    raw_list: Any
+    if isinstance(payload, list):
+        raw_list = payload
+    elif isinstance(payload, dict):
+        raw_list = payload.get("list", payload.get("branches", payload.get("data")))
+        if raw_list is None:
+            raw_list = [
+                {"branch": key, **value}
+                for key, value in payload.items()
+                if isinstance(value, dict) and key not in {"ok", "error"}
+            ]
+    else:
+        raw_list = []
+
+    branches: list[dict[str, Any]] = []
+    if not isinstance(raw_list, list):
+        return branches
+    for item in raw_list:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("branch", item.get("name"))
+        if isinstance(name, str):
+            branches.append({"name": name, **item})
+    return branches
+
+
+def find_branch(branches: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    """Find one branch record by normalized name."""
+    for branch in branches:
+        if branch.get("name") == name or branch.get("branch") == name:
+            return branch
+    return None
+
+
+def active_world_branch_name(branches: list[dict[str, Any]]) -> str | None:
+    """Return the current active World branch name from branch metadata."""
+    for branch in branches:
+        if bool(branch.get("activeWorld")):
+            name = branch.get("name", branch.get("branch"))
+            if isinstance(name, str):
+                return name
+    return None
+
+
+def branch_evidence(branches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return branch names and safe active flags only."""
+    return [
+        {
+            "name": branch.get("name", branch.get("branch")),
+            "activeWorld": bool(branch.get("activeWorld")),
+            "activeSim": bool(branch.get("activeSim")),
+        }
+        for branch in branches
+    ]
+
+
+def verify_remote_module(payload: Any, expected_sha256: str) -> dict[str, Any]:
+    """Compare remote ``main`` module by hash without returning code."""
+    modules = payload.get("modules") if isinstance(payload, dict) else None
+    if not isinstance(modules, dict):
+        return {"status": "missing-modules", "matched": False}
+    main = modules.get("main")
+    if not isinstance(main, str):
+        return {"status": "missing-main-module", "matched": False}
+    encoded = main.encode("utf-8")
+    sha256 = hashlib.sha256(encoded).hexdigest()
+    matched = sha256 == expected_sha256
+    return {
+        "status": "matched" if matched else "mismatch",
+        "matched": matched,
+        "remote": {
+            "module": "main",
+            "sizeBytes": len(encoded),
+            "sha256": sha256,
+        },
+    }
+
+
+def base_evidence(cfg: DeployConfig, artifact: dict[str, Any]) -> dict[str, Any]:
+    """Build common deploy evidence fields."""
+    return {
+        "ok": False,
+        "mode": "deploy" if cfg.deploy else "dry-run",
+        "timestampUtc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "git": git_metadata(cfg.repo_root),
+        "target": {
+            "apiUrl": cfg.api_url,
+            "branch": cfg.branch,
+            "shard": cfg.shard,
+            "room": cfg.room,
+        },
+        "artifact": artifact,
+        "verification": {},
+        "requests": [],
+        "postDeployMonitoring": {
+            "room": f"{cfg.shard}/{cfg.room}",
+            "evidenceNeeded": [
+                "deploy evidence JSON from this script",
+                "runtime monitor summary/alert JSON for the target room",
+                "runtime-summary console capture or explicit telemetry-silence finding",
+            ],
+        },
+    }
+
+
+def planned_requests(cfg: DeployConfig, artifact: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the dry-run request plan without making network calls."""
+    requests = [
+        {"method": "GET", "path": "/api/user/branches", "params": {}, "payload": {}},
+        {
+            "method": "POST",
+            "path": "/api/user/clone-branch",
+            "params": {},
+            "payload": {"branch": cfg.clone_source_branch or "<activeWorld-or-default>", "newName": cfg.branch},
+            "condition": "only when target branch is missing",
+        },
+        {
+            "method": "POST",
+            "path": "/api/user/code",
+            "params": {},
+            "payload": {"branch": cfg.branch, "modules": {"main": {"redacted": True, **artifact}}},
+        },
+        {"method": "GET", "path": "/api/user/code", "params": {"branch": cfg.branch}, "payload": {}},
+    ]
+    if cfg.activate_world:
+        requests.extend(
+            [
+                {
+                    "method": "POST",
+                    "path": "/api/user/set-active-branch",
+                    "params": {},
+                    "payload": {"activeName": "activeWorld", "branch": cfg.branch},
+                },
+                {"method": "GET", "path": "/api/user/branches", "params": {}, "payload": {}},
+                {"method": "GET", "path": "/api/user/code", "params": {"branch": "$activeWorld"}, "payload": {}},
+            ]
+        )
+    return requests
+
+
+def run_deploy(
+    cfg: DeployConfig,
+    env: dict[str, str] | None = None,
+    transport: Callable[..., HttpResult] | None = None,
+) -> dict[str, Any]:
+    """Execute dry-run or deploy mode and return safe evidence."""
+    if env is None:
+        env = os.environ
+    artifact_bytes, artifact = read_artifact(cfg.artifact_path)
+    evidence = base_evidence(cfg, artifact)
+    if not cfg.deploy:
+        evidence["ok"] = True
+        evidence["verification"] = {
+            "dryRun": {
+                "status": "passed",
+                "message": "artifact exists; no token read and no network writes attempted",
+            }
+        }
+        evidence["requests"] = planned_requests(cfg, artifact)
+        return evidence
+
+    token = env.get(AUTH_TOKEN_ENV, "")
+    if not token:
+        raise DeployError(f"{AUTH_TOKEN_ENV} is required for --deploy")
+    if cfg.confirm != cfg.expected_confirmation:
+        raise DeployError(f'--confirm must exactly equal "{cfg.expected_confirmation}"')
+
+    module = decode_module(artifact_bytes, cfg.artifact_path)
+    client = ScreepsApi(cfg.api_url, token, cfg.timeout_seconds, transport)
+
+    first_branches_result = client.list_branches()
+    require_api_success("list branches", first_branches_result)
+    first_branches = extract_branches(first_branches_result.payload)
+    target_exists_before = find_branch(first_branches, cfg.branch) is not None
+    clone_source = cfg.clone_source_branch or active_world_branch_name(first_branches) or "default"
+    branch_created = False
+
+    if not target_exists_before:
+        clone_result = client.clone_branch(clone_source, cfg.branch)
+        require_api_success("clone branch", clone_result)
+        branch_created = True
+
+    second_branches_result = client.list_branches()
+    require_api_success("refresh branches", second_branches_result)
+    second_branches = extract_branches(second_branches_result.payload)
+
+    upload_result = client.upload_code(cfg.branch, module)
+    if not upload_succeeded(upload_result):
+        raise DeployError(f"upload code failed: HTTP {upload_result.status}: {short_text(redact(upload_result.payload), 500)}")
+
+    branch_code_result = client.get_code(cfg.branch)
+    require_api_success("verify branch code", branch_code_result)
+    branch_verify = verify_remote_module(branch_code_result.payload, artifact["sha256"])
+    if not branch_verify["matched"]:
+        raise DeployError("uploaded branch hash verification failed")
+
+    final_branches = second_branches
+    active_verify: dict[str, Any] = {"requested": cfg.activate_world, "status": "not-requested"}
+    if cfg.activate_world:
+        active_result = client.set_active_world_branch(cfg.branch)
+        require_api_success("set activeWorld branch", active_result)
+
+        active_branches_result = client.list_branches()
+        require_api_success("verify active branch metadata", active_branches_result)
+        final_branches = extract_branches(active_branches_result.payload)
+        active_name = active_world_branch_name(final_branches)
+        if active_name != cfg.branch:
+            raise DeployError(f"activeWorld branch mismatch: expected {cfg.branch}, got {active_name or 'none'}")
+
+        active_code_result = client.get_code("$activeWorld")
+        require_api_success("verify activeWorld code", active_code_result)
+        active_code_verify = verify_remote_module(active_code_result.payload, artifact["sha256"])
+        if not active_code_verify["matched"]:
+            raise DeployError("activeWorld hash verification failed")
+        active_verify = {
+            "requested": True,
+            "status": "matched",
+            "activeWorldBranch": active_name,
+            "code": active_code_verify,
+        }
+
+    evidence["ok"] = True
+    evidence["requests"] = client.requests
+    evidence["verification"] = {
+        "branches": {
+            "targetExistsBefore": target_exists_before,
+            "targetCreated": branch_created,
+            "cloneSourceBranch": clone_source if branch_created else None,
+            "targetExistsAfter": find_branch(final_branches, cfg.branch) is not None,
+            "activeWorldBranch": active_world_branch_name(final_branches),
+            "observed": branch_evidence(final_branches),
+        },
+        "branchCode": branch_verify,
+        "activeWorld": active_verify,
+    }
+    assert_no_secret_or_code_leak(evidence, [token, module])
+    return evidence
+
+
+def http_json(
+    method: str,
+    base_url: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> HttpResult:
+    """Send a JSON HTTP request to the Screeps API."""
+    url = base_url.rstrip("/") + path
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    request_headers = {"Accept": "application/json", "User-Agent": "screeps-official-deploy/1.0"}
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+    if headers:
+        request_headers.update(headers)
+
+    request = urllib.request.Request(url, data=data, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return HttpResult(response.status, decode_json_body(response.read()), dict(response.headers.items()))
+    except urllib.error.HTTPError as exc:
+        return HttpResult(exc.code, decode_json_body(exc.read()), dict(exc.headers.items()))
+    except urllib.error.URLError as exc:
+        raise DeployError(f"request failed: {short_text(exc.reason, 300)}") from exc
+
+
+def decode_json_body(raw: bytes) -> Any:
+    """Decode a JSON response body with a bounded fallback."""
+    text = raw.decode("utf-8", errors="replace")
+    if not text:
+        return {}
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return {"error": short_text(text, 500)}
+
+
+def write_evidence(evidence: dict[str, Any], path: Path | None) -> None:
+    """Write evidence JSON to stdout and optionally a file."""
+    rendered = json.dumps(evidence, indent=2, sort_keys=True)
+    if path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(description="Deploy prod/dist/main.js to the official Screeps API safely.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Verify artifact metadata only; default when --deploy is omitted.")
+    mode.add_argument("--deploy", action="store_true", help="Perform authenticated API writes.")
+    parser.add_argument("--activate-world", action="store_true", help="Set the deployed branch as activeWorld and verify it by hash.")
+    parser.add_argument("--confirm", help='Required for --deploy, e.g. "deploy main to shardX/E48S28".')
+    parser.add_argument("--api-url", default=os.environ.get("SCREEPS_API_URL", DEFAULT_API_URL))
+    parser.add_argument("--branch", default=os.environ.get("SCREEPS_BRANCH", DEFAULT_BRANCH))
+    parser.add_argument("--shard", default=os.environ.get("SCREEPS_SHARD", DEFAULT_SHARD))
+    parser.add_argument("--room", default=os.environ.get("SCREEPS_ROOM", DEFAULT_ROOM))
+    parser.add_argument("--artifact", type=Path, default=Path(os.environ.get("SCREEPS_ARTIFACT_PATH", DEFAULT_ARTIFACT_PATH)))
+    parser.add_argument("--clone-source-branch", default=os.environ.get("SCREEPS_CLONE_SOURCE_BRANCH"))
+    parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--evidence-path", type=Path)
+    return parser
+
+
+def config_from_args(args: argparse.Namespace) -> DeployConfig:
+    """Create a validated deploy config from CLI arguments."""
+    api_url = normalize_api_url(args.api_url)
+    branch = validate_selector("SCREEPS_BRANCH", args.branch, BRANCH_RE)
+    shard = validate_selector("SCREEPS_SHARD", args.shard, SHARD_RE)
+    room = validate_selector("SCREEPS_ROOM", args.room, ROOM_RE)
+    clone_source = args.clone_source_branch
+    if clone_source:
+        clone_source = validate_selector("SCREEPS_CLONE_SOURCE_BRANCH", clone_source, BRANCH_RE)
+    if args.timeout_seconds <= 0:
+        raise DeployError("--timeout-seconds must be positive")
+    return DeployConfig(
+        api_url=api_url,
+        branch=branch,
+        shard=shard,
+        room=room,
+        artifact_path=args.artifact,
+        deploy=bool(args.deploy),
+        activate_world=bool(args.activate_world),
+        confirm=args.confirm,
+        clone_source_branch=clone_source,
+        timeout_seconds=args.timeout_seconds,
+        evidence_path=args.evidence_path,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        cfg = config_from_args(args)
+        evidence = run_deploy(cfg)
+        write_evidence(evidence, cfg.evidence_path)
+        return 0
+    except DeployError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -151,8 +151,9 @@ def normalize_api_url(raw_url: str) -> str:
         raise DeployError("SCREEPS_API_URL must not include credentials")
     if parsed.query or parsed.fragment:
         raise DeployError("SCREEPS_API_URL must not include query strings or fragments")
-    path = parsed.path.rstrip("/")
-    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+    if parsed.path.rstrip("/"):
+        raise DeployError("SCREEPS_API_URL must not include path prefixes")
+    return urllib.parse.urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
 
 
 def require_https_api_url(api_url: str) -> None:

--- a/scripts/screeps_official_deploy.py
+++ b/scripts/screeps_official_deploy.py
@@ -143,10 +143,10 @@ class ScreepsApi:
 
 
 def normalize_api_url(raw_url: str) -> str:
-    """Normalize and validate a safe HTTP API base URL."""
+    """Normalize and validate the official HTTPS API base URL."""
     parsed = urllib.parse.urlparse(raw_url.strip())
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise DeployError("SCREEPS_API_URL must be an http(s) URL")
+    if parsed.scheme != "https" or parsed.netloc != "screeps.com":
+        raise DeployError("SCREEPS_API_URL must be https://screeps.com for official deploys")
     if parsed.username or parsed.password:
         raise DeployError("SCREEPS_API_URL must not include credentials")
     if parsed.query or parsed.fragment:
@@ -156,9 +156,10 @@ def normalize_api_url(raw_url: str) -> str:
 
 
 def require_https_api_url(api_url: str) -> None:
-    """Reject non-HTTPS API URLs before authenticated deploy requests."""
-    if urllib.parse.urlparse(api_url).scheme != "https":
-        raise DeployError("SCREEPS_API_URL must use https for --deploy")
+    """Reject non-official API URLs before authenticated deploy requests."""
+    parsed = urllib.parse.urlparse(api_url)
+    if parsed.scheme != "https" or parsed.netloc != "screeps.com":
+        raise DeployError("SCREEPS_API_URL must be https://screeps.com for --deploy")
 
 
 def validate_selector(name: str, value: str, pattern: re.Pattern[str]) -> str:

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -88,7 +88,9 @@ class OfficialDeployTest(unittest.TestCase):
         with self.assertRaisesRegex(deploy.DeployError, "https://screeps.com"):
             deploy.normalize_api_url("http://localhost:21025/")
         with self.assertRaisesRegex(deploy.DeployError, "https://screeps.com"):
-            deploy.normalize_api_url("ftp://screeps.com")
+            deploy.normalize_api_url("https://example.com")
+        with self.assertRaisesRegex(deploy.DeployError, "path prefixes"):
+            deploy.normalize_api_url("https://screeps.com/api")
 
     def test_artifact_metadata_reports_hash_and_size(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -36,13 +36,14 @@ class OfficialDeployTest(unittest.TestCase):
         self,
         artifact: Path,
         *,
+        api_url: str = "https://screeps.com",
         deploy_mode: bool = False,
         activate_world: bool = False,
         confirm: str | None = None,
         repo_root: Path | None = None,
     ) -> deploy.DeployConfig:
         return deploy.DeployConfig(
-            api_url="https://screeps.com",
+            api_url=api_url,
             branch="main",
             shard="shardX",
             room="E48S28",
@@ -59,7 +60,7 @@ class OfficialDeployTest(unittest.TestCase):
         self.assertEqual(payload, {"branch": "main", "modules": {"main": "module text"}})
 
     def test_redacts_secret_values_and_module_contents(self) -> None:
-        secret = "token-value"
+        secret = "fixture-value"
         redacted = deploy.redact(
             {
                 "headers": {"X-Token": secret},
@@ -75,6 +76,18 @@ class OfficialDeployTest(unittest.TestCase):
         self.assertEqual(redacted["headers"]["X-Token"], "[REDACTED]")
         self.assertTrue(redacted["modules"]["main"]["redacted"])
         self.assertIn("sha256", redacted["modules"]["main"])
+
+    def test_redacts_code_like_api_error_text(self) -> None:
+        redacted = deploy.redact({"message": "API echoed module.exports.loop = function () {};"})
+
+        self.assertNotIn("module.exports", json.dumps(redacted))
+        self.assertIn("[REDACTED_CODE", redacted["message"])
+
+    def test_normalize_api_url_allows_http_for_non_deploy_configuration(self) -> None:
+        self.assertEqual(deploy.normalize_api_url("https://screeps.com/"), "https://screeps.com")
+        self.assertEqual(deploy.normalize_api_url("http://localhost:21025/"), "http://localhost:21025")
+        with self.assertRaisesRegex(deploy.DeployError, "http\\(s\\) URL"):
+            deploy.normalize_api_url("ftp://screeps.com")
 
     def test_artifact_metadata_reports_hash_and_size(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -102,6 +115,34 @@ class OfficialDeployTest(unittest.TestCase):
         self.assertIn("/api/user/code", encoded)
         self.assertNotIn("SCREEPS_AUTH_TOKEN", encoded)
         self.assertNotIn("module.exports.loop", encoded)
+
+    def test_dry_run_allows_plaintext_local_api_url_without_http(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp))
+            cfg = self.config(artifact, api_url="http://localhost:21025")
+
+            evidence = deploy.run_deploy(cfg, env={}, transport=lambda **_kwargs: self.fail("no HTTP expected"))
+
+        self.assertTrue(evidence["ok"])
+        self.assertEqual(evidence["mode"], "dry-run")
+        self.assertEqual(evidence["target"]["apiUrl"], "http://localhost:21025")
+
+    def test_deploy_rejects_plaintext_api_url_before_authenticated_requests(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp))
+            cfg = self.config(
+                artifact,
+                api_url="http://localhost:21025",
+                deploy_mode=True,
+                confirm="deploy main to shardX/E48S28",
+            )
+
+            with self.assertRaisesRegex(deploy.DeployError, "SCREEPS_API_URL must use https"):
+                deploy.run_deploy(
+                    cfg,
+                    env={deploy.AUTH_TOKEN_ENV: "fixture-value"},
+                    transport=lambda **_kwargs: self.fail("no HTTP expected"),
+                )
 
     def test_deploy_requests_expected_endpoints_and_verifies_hashes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -134,7 +175,7 @@ class OfficialDeployTest(unittest.TestCase):
                 confirm="deploy main to shardX/E48S28",
             )
 
-            evidence = deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=fake)
+            evidence = deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "fixture-value"}, transport=fake)
 
         self.assertTrue(evidence["ok"])
         self.assertEqual(evidence["verification"]["branchCode"]["status"], "matched")
@@ -155,9 +196,9 @@ class OfficialDeployTest(unittest.TestCase):
         )
         self.assertEqual(fake.calls[1]["payload"], {"branch": "default", "newName": "main"})
         self.assertEqual(fake.calls[3]["payload"]["modules"]["main"], artifact_body)
-        self.assertEqual(fake.calls[0]["headers"], {"X-Token": "secret-token"})
+        self.assertEqual(fake.calls[0]["headers"], {"X-Token": "fixture-value"})
         encoded_evidence = json.dumps(evidence, sort_keys=True)
-        self.assertNotIn("secret-token", encoded_evidence)
+        self.assertNotIn("fixture-value", encoded_evidence)
         self.assertNotIn(artifact_body, encoded_evidence)
 
     def test_api_failures_redact_token_value_from_error_text(self) -> None:
@@ -167,7 +208,7 @@ class OfficialDeployTest(unittest.TestCase):
                 [
                     deploy.HttpResult(
                         500,
-                        {"ok": 0, "message": "upstream echoed secret-token in a non-standard field"},
+                        {"ok": 0, "message": "upstream echoed fixture-value in a non-standard field"},
                         {},
                     )
                 ]
@@ -175,9 +216,9 @@ class OfficialDeployTest(unittest.TestCase):
             cfg = self.config(artifact, deploy_mode=True, confirm="deploy main to shardX/E48S28")
 
             with self.assertRaisesRegex(deploy.DeployError, "list branches failed") as raised:
-                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=fake)
+                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "fixture-value"}, transport=fake)
 
-        self.assertNotIn("secret-token", str(raised.exception))
+        self.assertNotIn("fixture-value", str(raised.exception))
         self.assertIn("[REDACTED]", str(raised.exception))
 
     def test_upload_failure_redacts_token_value_from_error_text(self) -> None:
@@ -187,15 +228,15 @@ class OfficialDeployTest(unittest.TestCase):
                 [
                     deploy.HttpResult(200, {"ok": 1, "list": [{"branch": "main", "activeWorld": True}]}, {}),
                     deploy.HttpResult(200, {"ok": 1, "list": [{"branch": "main", "activeWorld": True}]}, {}),
-                    deploy.HttpResult(500, {"ok": 0, "message": "upload rejected for secret-token"}, {}),
+                    deploy.HttpResult(500, {"ok": 0, "message": "upload rejected for fixture-value"}, {}),
                 ]
             )
             cfg = self.config(artifact, deploy_mode=True, confirm="deploy main to shardX/E48S28")
 
             with self.assertRaisesRegex(deploy.DeployError, "upload code failed") as raised:
-                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=fake)
+                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "fixture-value"}, transport=fake)
 
-        self.assertNotIn("secret-token", str(raised.exception))
+        self.assertNotIn("fixture-value", str(raised.exception))
         self.assertIn("[REDACTED]", str(raised.exception))
 
     def test_transport_failures_redact_token_value_from_error_text(self) -> None:
@@ -203,14 +244,14 @@ class OfficialDeployTest(unittest.TestCase):
             artifact = self.write_artifact(Path(tmp), "module.exports.loop = function () { return 1; };\n")
 
             def failing_transport(**_kwargs: Any) -> deploy.HttpResult:
-                raise deploy.DeployError("request failed after echoing secret-token")
+                raise deploy.DeployError("request failed after echoing fixture-value")
 
             cfg = self.config(artifact, deploy_mode=True, confirm="deploy main to shardX/E48S28")
 
             with self.assertRaisesRegex(deploy.DeployError, "request failed") as raised:
-                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=failing_transport)
+                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "fixture-value"}, transport=failing_transport)
 
-        self.assertNotIn("secret-token", str(raised.exception))
+        self.assertNotIn("fixture-value", str(raised.exception))
         self.assertIn("[REDACTED]", str(raised.exception))
 
     def test_remote_hash_mismatch_fails_without_printing_remote_code(self) -> None:
@@ -227,7 +268,7 @@ class OfficialDeployTest(unittest.TestCase):
             cfg = self.config(artifact, deploy_mode=True, confirm="deploy main to shardX/E48S28")
 
             with self.assertRaisesRegex(deploy.DeployError, "hash verification failed") as raised:
-                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=fake)
+                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "fixture-value"}, transport=fake)
 
         self.assertNotIn("return 2", str(raised.exception))
 

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -59,19 +59,19 @@ class OfficialDeployTest(unittest.TestCase):
 
         self.assertEqual(payload, {"branch": "main", "modules": {"main": "module text"}})
 
-    def test_redacts_secret_values_and_module_contents(self) -> None:
-        secret = "fixture-value"
+    def test_redacts_sensitive_values_and_module_contents(self) -> None:
+        sentinel = "redaction-marker"
         redacted = deploy.redact(
             {
-                "headers": {"X-Token": secret},
+                "headers": {"X-Token": sentinel},
                 "modules": {"main": "module.exports.loop = function () { return 1; };"},
-                "message": f"safe prefix {secret} safe suffix",
+                "message": f"safe prefix {sentinel} safe suffix",
             },
-            [secret],
+            [sentinel],
         )
         encoded = json.dumps(redacted, sort_keys=True)
 
-        self.assertNotIn(secret, encoded)
+        self.assertNotIn(sentinel, encoded)
         self.assertNotIn("module.exports.loop", encoded)
         self.assertEqual(redacted["headers"]["X-Token"], "[REDACTED]")
         self.assertTrue(redacted["modules"]["main"]["redacted"])
@@ -83,10 +83,11 @@ class OfficialDeployTest(unittest.TestCase):
         self.assertNotIn("module.exports", json.dumps(redacted))
         self.assertIn("[REDACTED_CODE", redacted["message"])
 
-    def test_normalize_api_url_allows_http_for_non_deploy_configuration(self) -> None:
+    def test_normalize_api_url_requires_official_https_origin(self) -> None:
         self.assertEqual(deploy.normalize_api_url("https://screeps.com/"), "https://screeps.com")
-        self.assertEqual(deploy.normalize_api_url("http://localhost:21025/"), "http://localhost:21025")
-        with self.assertRaisesRegex(deploy.DeployError, "http\\(s\\) URL"):
+        with self.assertRaisesRegex(deploy.DeployError, "https://screeps.com"):
+            deploy.normalize_api_url("http://localhost:21025/")
+        with self.assertRaisesRegex(deploy.DeployError, "https://screeps.com"):
             deploy.normalize_api_url("ftp://screeps.com")
 
     def test_artifact_metadata_reports_hash_and_size(self) -> None:
@@ -137,7 +138,7 @@ class OfficialDeployTest(unittest.TestCase):
                 confirm="deploy main to shardX/E48S28",
             )
 
-            with self.assertRaisesRegex(deploy.DeployError, "SCREEPS_API_URL must use https"):
+            with self.assertRaisesRegex(deploy.DeployError, "https://screeps.com"):
                 deploy.run_deploy(
                     cfg,
                     env={deploy.AUTH_TOKEN_ENV: "fixture-value"},

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_official_deploy as deploy
+
+
+class FakeTransport:
+    def __init__(self, responses: list[deploy.HttpResult]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> deploy.HttpResult:
+        self.calls.append(kwargs)
+        if not self.responses:
+            raise AssertionError("unexpected HTTP call")
+        return self.responses.pop(0)
+
+
+class OfficialDeployTest(unittest.TestCase):
+    def write_artifact(self, directory: Path, body: str = "module.exports.loop = function () { return 1; };\n") -> Path:
+        artifact = directory / "main.js"
+        artifact.write_text(body, encoding="utf-8")
+        return artifact
+
+    def config(
+        self,
+        artifact: Path,
+        *,
+        deploy_mode: bool = False,
+        activate_world: bool = False,
+        confirm: str | None = None,
+        repo_root: Path | None = None,
+    ) -> deploy.DeployConfig:
+        return deploy.DeployConfig(
+            api_url="https://screeps.com",
+            branch="main",
+            shard="shardX",
+            room="E48S28",
+            artifact_path=artifact,
+            deploy=deploy_mode,
+            activate_world=activate_world,
+            confirm=confirm,
+            repo_root=repo_root or artifact.parent,
+        )
+
+    def test_build_code_payload_uses_main_module(self) -> None:
+        payload = deploy.build_code_payload("main", "module text")
+
+        self.assertEqual(payload, {"branch": "main", "modules": {"main": "module text"}})
+
+    def test_redacts_secret_values_and_module_contents(self) -> None:
+        secret = "token-value"
+        redacted = deploy.redact(
+            {
+                "headers": {"X-Token": secret},
+                "modules": {"main": "module.exports.loop = function () { return 1; };"},
+                "message": f"safe prefix {secret} safe suffix",
+            },
+            [secret],
+        )
+        encoded = json.dumps(redacted, sort_keys=True)
+
+        self.assertNotIn(secret, encoded)
+        self.assertNotIn("module.exports.loop", encoded)
+        self.assertEqual(redacted["headers"]["X-Token"], "[REDACTED]")
+        self.assertTrue(redacted["modules"]["main"]["redacted"])
+        self.assertIn("sha256", redacted["modules"]["main"])
+
+    def test_artifact_metadata_reports_hash_and_size(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            data = b"abc"
+            path = Path(tmp) / "main.js"
+            path.write_bytes(data)
+
+            read, metadata = deploy.read_artifact(path)
+
+        self.assertEqual(read, data)
+        self.assertEqual(metadata["sizeBytes"], 3)
+        self.assertEqual(metadata["sha256"], hashlib.sha256(data).hexdigest())
+
+    def test_dry_run_does_not_require_token_or_http(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp))
+            cfg = self.config(artifact, activate_world=True)
+
+            evidence = deploy.run_deploy(cfg, env={}, transport=lambda **_kwargs: self.fail("no HTTP expected"))
+
+        encoded = json.dumps(evidence, sort_keys=True)
+        self.assertTrue(evidence["ok"])
+        self.assertEqual(evidence["mode"], "dry-run")
+        self.assertEqual(evidence["verification"]["dryRun"]["status"], "passed")
+        self.assertIn("/api/user/code", encoded)
+        self.assertNotIn("SCREEPS_AUTH_TOKEN", encoded)
+        self.assertNotIn("module.exports.loop", encoded)
+
+    def test_deploy_requests_expected_endpoints_and_verifies_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact_body = "module.exports.loop = function () { return 1; };\n"
+            artifact = self.write_artifact(Path(tmp), artifact_body)
+            expected_hash = hashlib.sha256(artifact_body.encode("utf-8")).hexdigest()
+            responses = [
+                deploy.HttpResult(200, {"ok": 1, "list": [{"branch": "default", "activeWorld": True}]}, {}),
+                deploy.HttpResult(200, {"ok": 1}, {}),
+                deploy.HttpResult(
+                    200,
+                    {"ok": 1, "list": [{"branch": "default", "activeWorld": True}, {"branch": "main"}]},
+                    {},
+                ),
+                deploy.HttpResult(200, {"ok": 1, "timestamp": 123}, {}),
+                deploy.HttpResult(200, {"ok": 1, "modules": {"main": artifact_body}}, {}),
+                deploy.HttpResult(200, {"ok": 1}, {}),
+                deploy.HttpResult(
+                    200,
+                    {"ok": 1, "list": [{"branch": "default"}, {"branch": "main", "activeWorld": True}]},
+                    {},
+                ),
+                deploy.HttpResult(200, {"ok": 1, "modules": {"main": artifact_body}}, {}),
+            ]
+            fake = FakeTransport(responses)
+            cfg = self.config(
+                artifact,
+                deploy_mode=True,
+                activate_world=True,
+                confirm="deploy main to shardX/E48S28",
+            )
+
+            evidence = deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=fake)
+
+        self.assertTrue(evidence["ok"])
+        self.assertEqual(evidence["verification"]["branchCode"]["status"], "matched")
+        self.assertEqual(evidence["verification"]["branchCode"]["remote"]["sha256"], expected_hash)
+        self.assertEqual(evidence["verification"]["activeWorld"]["status"], "matched")
+        self.assertEqual(
+            [(call["method"], call["path"], call["params"]) for call in fake.calls],
+            [
+                ("GET", "/api/user/branches", None),
+                ("POST", "/api/user/clone-branch", None),
+                ("GET", "/api/user/branches", None),
+                ("POST", "/api/user/code", None),
+                ("GET", "/api/user/code", {"branch": "main"}),
+                ("POST", "/api/user/set-active-branch", None),
+                ("GET", "/api/user/branches", None),
+                ("GET", "/api/user/code", {"branch": "$activeWorld"}),
+            ],
+        )
+        self.assertEqual(fake.calls[1]["payload"], {"branch": "default", "newName": "main"})
+        self.assertEqual(fake.calls[3]["payload"]["modules"]["main"], artifact_body)
+        self.assertEqual(fake.calls[0]["headers"], {"X-Token": "secret-token"})
+        encoded_evidence = json.dumps(evidence, sort_keys=True)
+        self.assertNotIn("secret-token", encoded_evidence)
+        self.assertNotIn(artifact_body, encoded_evidence)
+
+    def test_remote_hash_mismatch_fails_without_printing_remote_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp), "module.exports.loop = function () { return 1; };\n")
+            fake = FakeTransport(
+                [
+                    deploy.HttpResult(200, {"ok": 1, "list": [{"branch": "main", "activeWorld": True}]}, {}),
+                    deploy.HttpResult(200, {"ok": 1, "list": [{"branch": "main", "activeWorld": True}]}, {}),
+                    deploy.HttpResult(200, {"ok": 1, "timestamp": 123}, {}),
+                    deploy.HttpResult(200, {"ok": 1, "modules": {"main": "module.exports.loop = function () { return 2; };\n"}}, {}),
+                ]
+            )
+            cfg = self.config(artifact, deploy_mode=True, confirm="deploy main to shardX/E48S28")
+
+            with self.assertRaisesRegex(deploy.DeployError, "hash verification failed") as raised:
+                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=fake)
+
+        self.assertNotIn("return 2", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_official_deploy.py
+++ b/scripts/test_screeps_official_deploy.py
@@ -160,6 +160,59 @@ class OfficialDeployTest(unittest.TestCase):
         self.assertNotIn("secret-token", encoded_evidence)
         self.assertNotIn(artifact_body, encoded_evidence)
 
+    def test_api_failures_redact_token_value_from_error_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp), "module.exports.loop = function () { return 1; };\n")
+            fake = FakeTransport(
+                [
+                    deploy.HttpResult(
+                        500,
+                        {"ok": 0, "message": "upstream echoed secret-token in a non-standard field"},
+                        {},
+                    )
+                ]
+            )
+            cfg = self.config(artifact, deploy_mode=True, confirm="deploy main to shardX/E48S28")
+
+            with self.assertRaisesRegex(deploy.DeployError, "list branches failed") as raised:
+                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=fake)
+
+        self.assertNotIn("secret-token", str(raised.exception))
+        self.assertIn("[REDACTED]", str(raised.exception))
+
+    def test_upload_failure_redacts_token_value_from_error_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp), "module.exports.loop = function () { return 1; };\n")
+            fake = FakeTransport(
+                [
+                    deploy.HttpResult(200, {"ok": 1, "list": [{"branch": "main", "activeWorld": True}]}, {}),
+                    deploy.HttpResult(200, {"ok": 1, "list": [{"branch": "main", "activeWorld": True}]}, {}),
+                    deploy.HttpResult(500, {"ok": 0, "message": "upload rejected for secret-token"}, {}),
+                ]
+            )
+            cfg = self.config(artifact, deploy_mode=True, confirm="deploy main to shardX/E48S28")
+
+            with self.assertRaisesRegex(deploy.DeployError, "upload code failed") as raised:
+                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=fake)
+
+        self.assertNotIn("secret-token", str(raised.exception))
+        self.assertIn("[REDACTED]", str(raised.exception))
+
+    def test_transport_failures_redact_token_value_from_error_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = self.write_artifact(Path(tmp), "module.exports.loop = function () { return 1; };\n")
+
+            def failing_transport(**_kwargs: Any) -> deploy.HttpResult:
+                raise deploy.DeployError("request failed after echoing secret-token")
+
+            cfg = self.config(artifact, deploy_mode=True, confirm="deploy main to shardX/E48S28")
+
+            with self.assertRaisesRegex(deploy.DeployError, "request failed") as raised:
+                deploy.run_deploy(cfg, env={deploy.AUTH_TOKEN_ENV: "secret-token"}, transport=failing_transport)
+
+        self.assertNotIn("secret-token", str(raised.exception))
+        self.assertIn("[REDACTED]", str(raised.exception))
+
     def test_remote_hash_mismatch_fails_without_printing_remote_code(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             artifact = self.write_artifact(Path(tmp), "module.exports.loop = function () { return 1; };\n")


### PR DESCRIPTION
## Summary
- Adds a gated official Screeps MMO deploy script for uploading `prod/dist/main.js` to the official API.
- Supports dry-run evidence by default, explicit deploy confirmation, branch creation/upload, active-world activation, and hash-based verification without printing tokens or bundle contents.
- Adds mocked HTTP unit tests and an official deploy runbook.
- Adds a manual `workflow_dispatch` deploy workflow for owner-authorized dry-run/deploy execution.

Fixes #33.

## Verification
- `python3 -m py_compile scripts/screeps_official_deploy.py scripts/test_screeps_official_deploy.py`
- `python3 scripts/test_screeps_official_deploy.py`
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Safety notes
- No Screeps token or Authorization header is printed or committed.
- Dry-run is the default mode.
- Real deploy requires an auth token and an explicit confirmation string for the target branch/shard/room.
- Evidence reports hashes/sizes/statuses only; it does not print local or remote module contents.