### PR TITLE
feat: scale worker bodies by capacity

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -377,6 +377,7 @@ function executeTask(creep, task, target) {
 var WORKER_PATTERN = ["work", "carry", "move"];
 var WORKER_PATTERN_COST = 200;
 var MAX_CREEP_PARTS = 50;
+var MAX_WORKER_PATTERN_COUNT = 4;
 var BODY_PART_COSTS = {
   move: 50,
   work: 100,
@@ -393,7 +394,7 @@ function buildWorkerBody(energyAvailable) {
   }
   const maxPatternCountByEnergy = Math.floor(energyAvailable / WORKER_PATTERN_COST);
   const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS / WORKER_PATTERN.length);
-  const patternCount = Math.min(maxPatternCountByEnergy, maxPatternCountBySize);
+  const patternCount = Math.min(maxPatternCountByEnergy, maxPatternCountBySize, MAX_WORKER_PATTERN_COUNT);
   return Array.from({ length: patternCount }).flatMap(() => WORKER_PATTERN);
 }
 function buildEmergencyWorkerBody(energyAvailable) {

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -1,6 +1,10 @@
 const WORKER_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move'];
 const WORKER_PATTERN_COST = 200;
 const MAX_CREEP_PARTS = 50;
+// General workers cover harvest, haul, build, and upgrade duties. Cap them at
+// four 200-energy patterns (800 energy) so early rooms do not sink capacity into
+// oversized unspecialized bodies before dedicated roles exist.
+const MAX_WORKER_PATTERN_COUNT = 4;
 const BODY_PART_COSTS: Record<BodyPartConstant, number> = {
   move: 50,
   work: 100,
@@ -19,7 +23,7 @@ export function buildWorkerBody(energyAvailable: number): BodyPartConstant[] {
 
   const maxPatternCountByEnergy = Math.floor(energyAvailable / WORKER_PATTERN_COST);
   const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS / WORKER_PATTERN.length);
-  const patternCount = Math.min(maxPatternCountByEnergy, maxPatternCountBySize);
+  const patternCount = Math.min(maxPatternCountByEnergy, maxPatternCountBySize, MAX_WORKER_PATTERN_COUNT);
 
   return Array.from({ length: patternCount }).flatMap(() => WORKER_PATTERN);
 }

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -13,24 +13,34 @@ const BODY_PART_COST_CASES: Array<[BodyPartConstant, number]> = [
   ['tough', 10]
 ];
 
+function repeatWorkerPattern(patternCount: number): BodyPartConstant[] {
+  return Array.from({ length: patternCount }).flatMap(() => WORKER_PATTERN);
+}
+
 describe('buildWorkerBody', () => {
   it('builds the smallest worker body at 200 energy', () => {
     expect(buildWorkerBody(200)).toEqual(WORKER_PATTERN);
   });
 
-  it('scales worker bodies by repeating work/carry/move sets', () => {
-    expect(buildWorkerBody(400)).toEqual([...WORKER_PATTERN, ...WORKER_PATTERN]);
+  it('scales intermediate worker bodies by repeating work/carry/move sets', () => {
+    expect(buildWorkerBody(600)).toEqual(repeatWorkerPattern(3));
+  });
+
+  it('caps general-purpose worker bodies at 800 energy', () => {
+    expect(buildWorkerBody(800)).toEqual(repeatWorkerPattern(4));
+    expect(buildWorkerBody(10000)).toEqual(repeatWorkerPattern(4));
+    expect(getBodyCost(buildWorkerBody(10000))).toBe(800);
   });
 
   it('returns an empty body when there is not enough energy for a worker set', () => {
     expect(buildWorkerBody(199)).toEqual([]);
   });
 
-  it('builds only complete affordable worker patterns within the creep part limit', () => {
+  it('builds only complete affordable worker patterns within the safe cap', () => {
     for (const energyAvailable of [0, 199, 200, 201, 399, 400, 1000, 10000]) {
       const body = buildWorkerBody(energyAvailable);
 
-      expect(body.length).toBeLessThanOrEqual(50);
+      expect(body.length).toBeLessThanOrEqual(repeatWorkerPattern(4).length);
       expect(body.length % WORKER_PATTERN.length).toBe(0);
       expect(getBodyCost(body)).toBeLessThanOrEqual(energyAvailable);
 


### PR DESCRIPTION
## Summary
- Scales worker body construction beyond the 200-energy baseline when room capacity allows.
- Preserves low-energy bootstrap and existing emergency behavior.
- Adds deterministic coverage for baseline, intermediate, and cap behavior.

## Verification
- [x] git diff --check
- [x] cd prod && npm run typecheck
- [x] cd prod && npm test -- --runInBand
- [x] cd prod && npm run build

Closes #104

No secrets.