### PR TITLE
feat: prioritize RCL2 energy capacity construction

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -317,6 +317,11 @@ function runWorker(creep) {
     assignNextTask(creep);
     return;
   }
+  if (shouldPreemptRcl2UpgradeTask(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
   const task = creep.memory.task;
   const target = Game.getObjectById(task.targetId);
   if (!target) {
@@ -356,6 +361,18 @@ function shouldReplaceTask(creep, task) {
     return freeEnergyCapacity === 0;
   }
   return usedEnergy === 0;
+}
+function shouldPreemptRcl2UpgradeTask(creep, task) {
+  var _a;
+  if (task.type !== "upgrade") {
+    return false;
+  }
+  const controller = (_a = creep.room) == null ? void 0 : _a.controller;
+  if ((controller == null ? void 0 : controller.my) !== true || controller.level !== 2) {
+    return false;
+  }
+  const nextTask = selectWorkerTask(creep);
+  return nextTask !== null && (nextTask.type !== task.type || nextTask.targetId !== task.targetId);
 }
 function shouldReplaceTarget(task, target) {
   return task.type === "transfer" && "store" in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -12,6 +12,12 @@ export function runWorker(creep: Creep): void {
     return;
   }
 
+  if (shouldPreemptRcl2UpgradeTask(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+
   const task = creep.memory.task;
   const target = Game.getObjectById(task.targetId);
   if (!target) {
@@ -58,6 +64,20 @@ function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
   }
 
   return usedEnergy === 0;
+}
+
+function shouldPreemptRcl2UpgradeTask(creep: Creep, task: CreepTaskMemory): boolean {
+  if (task.type !== 'upgrade') {
+    return false;
+  }
+
+  const controller = creep.room?.controller;
+  if (controller?.my !== true || controller.level !== 2) {
+    return false;
+  }
+
+  const nextTask = selectWorkerTask(creep);
+  return nextTask !== null && (nextTask.type !== task.type || nextTask.targetId !== task.targetId);
 }
 
 function shouldReplaceTarget(task: CreepTaskMemory, target: Source | AnyStoreStructure | ConstructionSite | StructureController): boolean {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1,4 +1,5 @@
 import { runEconomy } from '../src/economy/economyLoop';
+import { CONTROLLER_DOWNGRADE_GUARD_TICKS } from '../src/tasks/workerTasks';
 import { RUNTIME_SUMMARY_PREFIX } from '../src/telemetry/runtimeSummary';
 
 const OK_CODE = 0 as ScreepsReturnCode;
@@ -273,6 +274,87 @@ describe('runEconomy', () => {
 
     expect(room.createConstructionSite).toHaveBeenCalledWith(24, 24, STRUCTURE_EXTENSION);
     expect(worker.memory.task).toEqual({ type: 'build', targetId: 'site-24-24' });
+  });
+
+  it('preempts an existing RCL2 upgrade task for newly planned extension construction', () => {
+    (globalThis as unknown as {
+      FIND_MY_STRUCTURES: number;
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      RESOURCE_ENERGY: ResourceConstant;
+      STRUCTURE_EXTENSION: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      LOOK_STRUCTURES: LOOK_STRUCTURES;
+      LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
+    }).FIND_MY_STRUCTURES = 1;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 3;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+    (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES = 'constructionSite';
+
+    const constructionSites: ConstructionSite[] = [];
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller,
+      find: jest.fn((type: number) => (type === 3 ? constructionSites : [])),
+      lookForAt: jest.fn(() => {
+        throw new Error('extension planner should use cached occupancy instead of per-candidate lookups');
+      }),
+      lookForAtArea: jest.fn().mockReturnValue([]),
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        constructionSites.push({ id: `site-${x}-${y}`, structureType, pos: { x, y, roomName: 'W1N1' } as RoomPosition } as ConstructionSite);
+        return OK_CODE;
+      })
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      pos: { x: 25, y: 25, roomName: 'W1N1' },
+      spawning: null,
+      spawnCreep: jest.fn()
+    } as unknown as StructureSpawn;
+    const worker = {
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      upgradeController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 251,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: { Worker1: worker },
+      getObjectById: jest.fn().mockReturnValue(controller),
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as Game['map']
+    };
+
+    runEconomy();
+
+    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 24, STRUCTURE_EXTENSION);
+    expect(worker.memory.task).toEqual({ type: 'build', targetId: 'site-24-24' });
+    expect(worker.upgradeController).not.toHaveBeenCalled();
+    expect(worker.moveTo).not.toHaveBeenCalled();
   });
 
   it('runs existing worker creeps', () => {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1,4 +1,5 @@
 import { runWorker } from '../src/creeps/workerRunner';
+import { CONTROLLER_DOWNGRADE_GUARD_TICKS } from '../src/tasks/workerTasks';
 
 describe('runWorker', () => {
   beforeEach(() => {
@@ -161,6 +162,103 @@ describe('runWorker', () => {
     expect(getObjectById).toHaveBeenCalledWith('controller1');
     expect(upgradeController).toHaveBeenCalledWith(controller);
     expect(moveTo).toHaveBeenCalledWith(controller);
+  });
+
+  it('preempts an RCL2 upgrade task for extension construction when downgrade is safe', () => {
+    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_CONSTRUCTION_SITES ? [site] : []))
+      },
+      upgradeController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn()
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'extension-site1' });
+    expect(Game.getObjectById).not.toHaveBeenCalled();
+    expect(creep.upgradeController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps the RCL2 downgrade guard above upgrade preemption', () => {
+    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const creep = {
+      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_CONSTRUCTION_SITES ? [site] : []))
+      },
+      upgradeController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(creep.upgradeController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing RCL3 upgrade execution for assigned upgrade tasks', () => {
+    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_CONSTRUCTION_SITES ? [site] : []))
+      },
+      upgradeController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(creep.upgradeController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
   it('clears missing build targets and reassigns without building the stale target', () => {


### PR DESCRIPTION
## Summary
- Prioritizes RCL2 energy-capacity construction when appropriate so controller progress turns into spawn throughput.
- Adds worker-runner/economy loop tests for the new construction behavior.
- Rebuilds the Screeps bundle artifact.

## Verification
- [x] git diff --check
- [x] cd prod && npm run typecheck
- [x] cd prod && npm test -- --runInBand
- [x] cd prod && npm run build

Closes #105

No secrets.