### PR TITLE
feat: plan territory claim and reserve tasks

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1122,6 +1122,7 @@ function runTerritoryControllerCreep(creep) {
   }
   const controller = selectTargetController(creep, assignment);
   if (!controller) {
+    suppressTerritoryAssignment(creep, assignment);
     return;
   }
   if (controller.my === true) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -548,6 +548,9 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   return plan;
 }
 function shouldSpawnTerritoryControllerCreep(plan, roleCounts) {
+  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action)) {
+    return false;
+  }
   if (isClaimTargetAlreadyOwned(plan.targetRoom, plan.action, plan.controllerId)) {
     return false;
   }
@@ -563,6 +566,26 @@ function buildTerritoryCreepMemory(plan) {
       ...plan.controllerId ? { controllerId: plan.controllerId } : {}
     }
   };
+}
+function suppressTerritoryIntent(colony, assignment, gameTime) {
+  if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || !isTerritoryAction(assignment.action)) {
+    return;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const suppressedIntent = {
+    colony,
+    targetRoom: assignment.targetRoom,
+    action: assignment.action,
+    status: "suppressed",
+    updatedAt: gameTime,
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
+  };
+  upsertTerritoryIntent(intents, suppressedIntent);
 }
 function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   if (roleCounts.worker < workerTarget) {
@@ -582,9 +605,10 @@ function selectTerritoryTarget(colonyName) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return null;
   }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
-    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isClaimTargetAlreadyOwned(target.roomName, target.action, target.controllerId)) {
+    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents) && !isClaimTargetAlreadyOwned(target.roomName, target.action, target.controllerId)) {
       return target;
     }
   }
@@ -610,10 +634,7 @@ function recordTerritoryIntent(plan, status, gameTime) {
   if (!territoryMemory) {
     return;
   }
-  const intents = Array.isArray(territoryMemory.intents) ? territoryMemory.intents.flatMap((intent) => {
-    const normalizedIntent = normalizeTerritoryIntent(intent);
-    return normalizedIntent ? [normalizedIntent] : [];
-  }) : [];
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const nextIntent = {
     colony: plan.colony,
@@ -623,6 +644,15 @@ function recordTerritoryIntent(plan, status, gameTime) {
     updatedAt: gameTime,
     ...plan.controllerId ? { controllerId: plan.controllerId } : {}
   };
+  upsertTerritoryIntent(intents, nextIntent);
+}
+function normalizeTerritoryIntents(rawIntents) {
+  return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
+    const normalizedIntent = normalizeTerritoryIntent(intent);
+    return normalizedIntent ? [normalizedIntent] : [];
+  }) : [];
+}
+function upsertTerritoryIntent(intents, nextIntent) {
   const existingIndex = intents.findIndex(
     (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action
   );
@@ -651,6 +681,20 @@ function normalizeTerritoryIntent(rawIntent) {
 function getTerritoryCreepCountForTarget(roleCounts, targetRoom) {
   var _a, _b;
   return (_b = (_a = roleCounts.claimersByTargetRoom) == null ? void 0 : _a[targetRoom]) != null ? _b : 0;
+}
+function isTerritoryTargetSuppressed(target, intents) {
+  return intents.some(
+    (intent) => intent.status === "suppressed" && intent.colony === target.colony && intent.targetRoom === target.roomName && intent.action === target.action
+  );
+}
+function isTerritoryIntentSuppressed(colony, targetRoom, action) {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return false;
+  }
+  return normalizeTerritoryIntents(territoryMemory.intents).some(
+    (intent) => intent.status === "suppressed" && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
+  );
 }
 function isClaimTargetAlreadyOwned(targetRoom, action, controllerId) {
   var _a;
@@ -697,7 +741,7 @@ function isTerritoryAction(action) {
   return action === "claim" || action === "reserve";
 }
 function isTerritoryIntentStatus(status) {
-  return status === "planned" || status === "active";
+  return status === "planned" || status === "active" || status === "suppressed";
 }
 function isNonEmptyString(value) {
   return typeof value === "string" && value.length > 0;
@@ -1050,7 +1094,13 @@ function getGameTime() {
 
 // src/territory/territoryRunner.ts
 var ERR_NOT_IN_RANGE_CODE = -9;
+var ERR_INVALID_TARGET_CODE = -7;
+var ERR_GCL_NOT_ENOUGH_CODE = -15;
 var OK_CODE = 0;
+var CLAIM_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([
+  ERR_INVALID_TARGET_CODE,
+  ERR_GCL_NOT_ENOUGH_CODE
+]);
 function runTerritoryControllerCreep(creep) {
   var _a;
   const assignment = creep.memory.territory;
@@ -1068,6 +1118,11 @@ function runTerritoryControllerCreep(creep) {
   const result = assignment.action === "claim" ? executeControllerAction(creep, controller, "claimController") : executeControllerAction(creep, controller, "reserveController");
   if (result === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === "function") {
     creep.moveTo(controller);
+    return;
+  }
+  if (assignment.action === "claim" && CLAIM_FATAL_RESULT_CODES.has(result)) {
+    suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime2());
+    delete creep.memory.territory;
   }
 }
 function selectTargetController(creep, assignment) {
@@ -1097,6 +1152,11 @@ function moveTowardTargetRoom(creep, targetRoom) {
     return;
   }
   creep.moveTo(new RoomPositionCtor(25, 25, targetRoom));
+}
+function getGameTime2() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" ? gameTime : 0;
 }
 function isTerritoryAssignment(assignment) {
   return typeof (assignment == null ? void 0 : assignment.targetRoom) === "string" && assignment.targetRoom.length > 0 && (assignment.action === "claim" || assignment.action === "reserve");

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -182,18 +182,31 @@ var WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
 function countCreepsByRole(creeps, colonyName) {
   return creeps.reduce(
     (counts, creep) => {
-      if (isColonyWorker(creep, colonyName) && canSatisfyWorkerCapacity(creep)) {
+      var _a, _b, _c, _d;
+      if (isColonyWorker(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
         counts.worker += 1;
+      }
+      if (isColonyClaimer(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
+        counts.claimer = ((_a = counts.claimer) != null ? _a : 0) + 1;
+        const targetRoom = (_b = creep.memory.territory) == null ? void 0 : _b.targetRoom;
+        if (targetRoom) {
+          const claimersByTargetRoom = (_c = counts.claimersByTargetRoom) != null ? _c : {};
+          claimersByTargetRoom[targetRoom] = ((_d = claimersByTargetRoom[targetRoom]) != null ? _d : 0) + 1;
+          counts.claimersByTargetRoom = claimersByTargetRoom;
+        }
       }
       return counts;
     },
-    { worker: 0 }
+    { worker: 0, claimer: 0, claimersByTargetRoom: {} }
   );
 }
 function isColonyWorker(creep, colonyName) {
   return creep.memory.colony === colonyName && creep.memory.role === "worker";
 }
-function canSatisfyWorkerCapacity(creep) {
+function isColonyClaimer(creep, colonyName) {
+  return creep.memory.colony === colonyName && creep.memory.role === "claimer";
+}
+function canSatisfyRoleCapacity(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
 
@@ -425,6 +438,8 @@ function executeTask(creep, task, target) {
 // src/spawn/bodyBuilder.ts
 var WORKER_PATTERN = ["work", "carry", "move"];
 var WORKER_PATTERN_COST = 200;
+var TERRITORY_CONTROLLER_BODY = ["claim", "move"];
+var TERRITORY_CONTROLLER_BODY_COST = 650;
 var MAX_CREEP_PARTS = 50;
 var MAX_WORKER_PATTERN_COUNT = 4;
 var BODY_PART_COSTS = {
@@ -452,8 +467,146 @@ function buildEmergencyWorkerBody(energyAvailable) {
   }
   return [...WORKER_PATTERN];
 }
+function buildTerritoryControllerBody(energyAvailable) {
+  if (energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return [];
+  }
+  return [...TERRITORY_CONTROLLER_BODY];
+}
 function getBodyCost(body) {
   return body.reduce((cost, part) => cost + BODY_PART_COSTS[part], 0);
+}
+
+// src/territory/territoryPlanner.ts
+var TERRITORY_CLAIMER_ROLE = "claimer";
+var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
+function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
+  const target = selectTerritoryTarget(colony.room.name);
+  if (!target || !isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
+    return null;
+  }
+  const plan = {
+    colony: colony.room.name,
+    targetRoom: target.roomName,
+    action: target.action,
+    ...target.controllerId ? { controllerId: target.controllerId } : {}
+  };
+  const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) > 0 ? "active" : "planned";
+  recordTerritoryIntent(plan, status, gameTime);
+  return plan;
+}
+function shouldSpawnTerritoryControllerCreep(plan, roleCounts) {
+  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) === 0;
+}
+function buildTerritoryCreepMemory(plan) {
+  return {
+    role: TERRITORY_CLAIMER_ROLE,
+    colony: plan.colony,
+    territory: {
+      targetRoom: plan.targetRoom,
+      action: plan.action,
+      ...plan.controllerId ? { controllerId: plan.controllerId } : {}
+    }
+  };
+}
+function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
+  if (roleCounts.worker < workerTarget) {
+    return false;
+  }
+  if (colony.energyCapacityAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return false;
+  }
+  const controller = colony.room.controller;
+  if ((controller == null ? void 0 : controller.my) !== true || typeof controller.level !== "number" || controller.level < 2) {
+    return false;
+  }
+  return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
+}
+function selectTerritoryTarget(colonyName) {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return null;
+  }
+  for (const rawTarget of territoryMemory.targets) {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName) {
+      return target;
+    }
+  }
+  return null;
+}
+function normalizeTerritoryTarget(rawTarget) {
+  if (!isRecord(rawTarget)) {
+    return null;
+  }
+  if (!isNonEmptyString(rawTarget.colony) || !isNonEmptyString(rawTarget.roomName) || !isTerritoryAction(rawTarget.action)) {
+    return null;
+  }
+  return {
+    colony: rawTarget.colony,
+    roomName: rawTarget.roomName,
+    action: rawTarget.action,
+    ...typeof rawTarget.controllerId === "string" ? { controllerId: rawTarget.controllerId } : {},
+    ...rawTarget.enabled === false ? { enabled: false } : {}
+  };
+}
+function recordTerritoryIntent(plan, status, gameTime) {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+  const intents = Array.isArray(territoryMemory.intents) ? territoryMemory.intents : [];
+  territoryMemory.intents = intents;
+  const nextIntent = {
+    colony: plan.colony,
+    targetRoom: plan.targetRoom,
+    action: plan.action,
+    status,
+    updatedAt: gameTime,
+    ...plan.controllerId ? { controllerId: plan.controllerId } : {}
+  };
+  const existingIndex = intents.findIndex(
+    (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action
+  );
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+  intents.push(nextIntent);
+}
+function getTerritoryCreepCountForTarget(roleCounts, targetRoom) {
+  var _a, _b;
+  return (_b = (_a = roleCounts.claimersByTargetRoom) == null ? void 0 : _a[targetRoom]) != null ? _b : 0;
+}
+function getWritableTerritoryMemoryRecord() {
+  const memory = getMemoryRecord();
+  if (!memory) {
+    return null;
+  }
+  if (!isRecord(memory.territory)) {
+    memory.territory = {};
+  }
+  return memory.territory;
+}
+function getTerritoryMemoryRecord() {
+  const memory = getMemoryRecord();
+  if (!memory || !isRecord(memory.territory)) {
+    return null;
+  }
+  return memory.territory;
+}
+function getMemoryRecord() {
+  const memory = globalThis.Memory;
+  return memory != null ? memory : null;
+}
+function isTerritoryAction(action) {
+  return action === "claim" || action === "reserve";
+}
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
 }
 
 // src/spawn/spawnPlanner.ts
@@ -462,9 +615,30 @@ var WORKERS_PER_SOURCE = 2;
 var MAX_WORKER_TARGET = 6;
 var sourceCountByRoomName = /* @__PURE__ */ new Map();
 function planSpawn(colony, roleCounts, gameTime) {
-  if (roleCounts.worker >= getWorkerTarget(colony)) {
+  const workerTarget = getWorkerTarget(colony);
+  if (roleCounts.worker < workerTarget) {
+    return planWorkerSpawn(colony, roleCounts, gameTime);
+  }
+  const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
+  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts)) {
     return null;
   }
+  const spawn = colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+  const body = buildTerritoryControllerBody(colony.energyAvailable);
+  if (body.length === 0) {
+    return null;
+  }
+  return {
+    spawn,
+    body,
+    name: `claimer-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`,
+    memory: buildTerritoryCreepMemory(territoryIntent)
+  };
+}
+function planWorkerSpawn(colony, roleCounts, gameTime) {
   const spawn = colony.spawns.find((candidate) => !candidate.spawning);
   if (!spawn) {
     return null;
@@ -661,10 +835,10 @@ function summarizeRoomEventMetrics(room) {
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord(entry) || typeof entry.event !== "number") {
+    if (!isRecord2(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord(entry.data) ? entry.data : {};
+    const data = isRecord2(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -720,7 +894,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord(object) || !isRecord(object.store)) {
+  if (!isRecord2(object) || !isRecord2(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -734,7 +908,7 @@ function getEnergyInStore(object) {
 function sumDroppedEnergy(droppedResources) {
   const energyResource = getEnergyResource();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord2(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -755,7 +929,7 @@ function getEnergyResource() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord(value) {
+function isRecord2(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -775,6 +949,60 @@ function buildCpuSummary() {
 }
 function getGameTime() {
   return typeof Game.time === "number" ? Game.time : 0;
+}
+
+// src/territory/territoryRunner.ts
+var ERR_NOT_IN_RANGE_CODE = -9;
+var OK_CODE = 0;
+function runTerritoryControllerCreep(creep) {
+  var _a;
+  const assignment = creep.memory.territory;
+  if (!isTerritoryAssignment(assignment)) {
+    return;
+  }
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
+    moveTowardTargetRoom(creep, assignment.targetRoom);
+    return;
+  }
+  const controller = selectTargetController(creep, assignment);
+  if (!controller || controller.my === true) {
+    return;
+  }
+  const result = assignment.action === "claim" ? executeControllerAction(creep, controller, "claimController") : executeControllerAction(creep, controller, "reserveController");
+  if (result === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === "function") {
+    creep.moveTo(controller);
+  }
+}
+function selectTargetController(creep, assignment) {
+  var _a, _b;
+  if (assignment.controllerId) {
+    const game = globalThis.Game;
+    const getObjectById = game == null ? void 0 : game.getObjectById;
+    if (typeof getObjectById === "function") {
+      const controller = getObjectById.call(game, assignment.controllerId);
+      if (controller) {
+        return controller;
+      }
+    }
+  }
+  return (_b = (_a = creep.room) == null ? void 0 : _a.controller) != null ? _b : null;
+}
+function executeControllerAction(creep, controller, action) {
+  const controllerAction = creep[action];
+  if (typeof controllerAction !== "function") {
+    return OK_CODE;
+  }
+  return controllerAction.call(creep, controller);
+}
+function moveTowardTargetRoom(creep, targetRoom) {
+  const RoomPositionCtor = globalThis.RoomPosition;
+  if (typeof RoomPositionCtor !== "function" || typeof creep.moveTo !== "function") {
+    return;
+  }
+  creep.moveTo(new RoomPositionCtor(25, 25, targetRoom));
+}
+function isTerritoryAssignment(assignment) {
+  return typeof (assignment == null ? void 0 : assignment.targetRoom) === "string" && assignment.targetRoom.length > 0 && (assignment.action === "claim" || assignment.action === "reserve");
 }
 
 // src/economy/economyLoop.ts
@@ -799,6 +1027,8 @@ function runEconomy() {
   for (const creep of creeps) {
     if (creep.memory.role === "worker") {
       runWorker(creep);
+    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE) {
+      runTerritoryControllerCreep(creep);
     }
   }
   emitRuntimeSummary(colonies, creeps, telemetryEvents);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -531,6 +531,9 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   return plan;
 }
 function shouldSpawnTerritoryControllerCreep(plan, roleCounts) {
+  if (isClaimTargetAlreadyOwned(plan.targetRoom, plan.action, plan.controllerId)) {
+    return false;
+  }
   return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) === 0;
 }
 function buildTerritoryCreepMemory(plan) {
@@ -564,7 +567,7 @@ function selectTerritoryTarget(colonyName) {
   }
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
-    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName) {
+    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isClaimTargetAlreadyOwned(target.roomName, target.action, target.controllerId)) {
       return target;
     }
   }
@@ -612,6 +615,26 @@ function recordTerritoryIntent(plan, status, gameTime) {
 function getTerritoryCreepCountForTarget(roleCounts, targetRoom) {
   var _a, _b;
   return (_b = (_a = roleCounts.claimersByTargetRoom) == null ? void 0 : _a[targetRoom]) != null ? _b : 0;
+}
+function isClaimTargetAlreadyOwned(targetRoom, action, controllerId) {
+  var _a;
+  if (action !== "claim") {
+    return false;
+  }
+  return ((_a = getVisibleController(targetRoom, controllerId)) == null ? void 0 : _a.my) === true;
+}
+function getVisibleController(targetRoom, controllerId) {
+  var _a, _b;
+  const game = globalThis.Game;
+  const roomController = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom]) == null ? void 0 : _b.controller;
+  if (roomController) {
+    return roomController;
+  }
+  const getObjectById = game == null ? void 0 : game.getObjectById;
+  if (controllerId && typeof getObjectById === "function") {
+    return getObjectById.call(game, controllerId);
+  }
+  return null;
 }
 function getWritableTerritoryMemoryRecord() {
   const memory = getMemoryRecord();

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -556,7 +556,7 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts) {
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action)) {
     return false;
   }
-  if (isClaimTargetAlreadyOwned(plan.targetRoom, plan.action, plan.controllerId)) {
+  if (isVisibleTerritoryTargetUnavailable(plan.targetRoom, plan.controllerId)) {
     return false;
   }
   return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) === 0;
@@ -613,7 +613,7 @@ function selectTerritoryTarget(colonyName) {
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
-    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents) && !isClaimTargetAlreadyOwned(target.roomName, target.action, target.controllerId)) {
+    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents) && !isVisibleTerritoryTargetUnavailable(target.roomName, target.controllerId)) {
       return target;
     }
   }
@@ -701,12 +701,15 @@ function isTerritoryIntentSuppressed(colony, targetRoom, action) {
     (intent) => intent.status === "suppressed" && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
-function isClaimTargetAlreadyOwned(targetRoom, action, controllerId) {
-  var _a;
-  if (action !== "claim") {
+function isVisibleTerritoryTargetUnavailable(targetRoom, controllerId) {
+  const controller = getVisibleController(targetRoom, controllerId);
+  if (!controller) {
     return false;
   }
-  return ((_a = getVisibleController(targetRoom, controllerId)) == null ? void 0 : _a.my) === true;
+  return isControllerOwned(controller);
+}
+function isControllerOwned(controller) {
+  return controller.owner != null || controller.my === true;
 }
 function getVisibleController(targetRoom, controllerId) {
   var _a, _b;
@@ -1106,6 +1109,7 @@ var CLAIM_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([
   ERR_INVALID_TARGET_CODE,
   ERR_GCL_NOT_ENOUGH_CODE
 ]);
+var RESERVE_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([ERR_INVALID_TARGET_CODE]);
 function runTerritoryControllerCreep(creep) {
   var _a;
   const assignment = creep.memory.territory;
@@ -1117,7 +1121,13 @@ function runTerritoryControllerCreep(creep) {
     return;
   }
   const controller = selectTargetController(creep, assignment);
-  if (!controller || controller.my === true) {
+  if (!controller) {
+    return;
+  }
+  if (controller.my === true) {
+    if (assignment.action === "reserve") {
+      suppressTerritoryAssignment(creep, assignment);
+    }
     return;
   }
   const result = assignment.action === "claim" ? executeControllerAction(creep, controller, "claimController") : executeControllerAction(creep, controller, "reserveController");
@@ -1125,10 +1135,13 @@ function runTerritoryControllerCreep(creep) {
     creep.moveTo(controller);
     return;
   }
-  if (assignment.action === "claim" && CLAIM_FATAL_RESULT_CODES.has(result)) {
-    suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime2());
-    delete creep.memory.territory;
+  if (assignment.action === "claim" && CLAIM_FATAL_RESULT_CODES.has(result) || assignment.action === "reserve" && RESERVE_FATAL_RESULT_CODES.has(result)) {
+    suppressTerritoryAssignment(creep, assignment);
   }
+}
+function suppressTerritoryAssignment(creep, assignment) {
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime2());
+  delete creep.memory.territory;
 }
 function selectTargetController(creep, assignment) {
   var _a, _b;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -610,7 +610,10 @@ function recordTerritoryIntent(plan, status, gameTime) {
   if (!territoryMemory) {
     return;
   }
-  const intents = Array.isArray(territoryMemory.intents) ? territoryMemory.intents : [];
+  const intents = Array.isArray(territoryMemory.intents) ? territoryMemory.intents.flatMap((intent) => {
+    const normalizedIntent = normalizeTerritoryIntent(intent);
+    return normalizedIntent ? [normalizedIntent] : [];
+  }) : [];
   territoryMemory.intents = intents;
   const nextIntent = {
     colony: plan.colony,
@@ -628,6 +631,22 @@ function recordTerritoryIntent(plan, status, gameTime) {
     return;
   }
   intents.push(nextIntent);
+}
+function normalizeTerritoryIntent(rawIntent) {
+  if (!isRecord(rawIntent)) {
+    return null;
+  }
+  if (!isNonEmptyString(rawIntent.colony) || !isNonEmptyString(rawIntent.targetRoom) || !isTerritoryAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
+    return null;
+  }
+  return {
+    colony: rawIntent.colony,
+    targetRoom: rawIntent.targetRoom,
+    action: rawIntent.action,
+    status: rawIntent.status,
+    updatedAt: rawIntent.updatedAt,
+    ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {}
+  };
 }
 function getTerritoryCreepCountForTarget(roleCounts, targetRoom) {
   var _a, _b;
@@ -676,6 +695,9 @@ function getMemoryRecord() {
 }
 function isTerritoryAction(action) {
   return action === "claim" || action === "reserve";
+}
+function isTerritoryIntentStatus(status) {
+  return status === "planned" || status === "active";
 }
 function isNonEmptyString(value) {
   return typeof value === "string" && value.length > 0;

--- a/prod/src/creeps/roleCounts.ts
+++ b/prod/src/creeps/roleCounts.ts
@@ -1,5 +1,7 @@
 export interface RoleCounts {
   worker: number;
+  claimer?: number;
+  claimersByTargetRoom?: Record<string, number>;
 }
 
 export const WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
@@ -7,12 +9,21 @@ export const WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
 export function countCreepsByRole(creeps: Creep[], colonyName: string): RoleCounts {
   return creeps.reduce<RoleCounts>(
     (counts, creep) => {
-      if (isColonyWorker(creep, colonyName) && canSatisfyWorkerCapacity(creep)) {
+      if (isColonyWorker(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
         counts.worker += 1;
+      }
+      if (isColonyClaimer(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
+        counts.claimer = (counts.claimer ?? 0) + 1;
+        const targetRoom = creep.memory.territory?.targetRoom;
+        if (targetRoom) {
+          const claimersByTargetRoom = counts.claimersByTargetRoom ?? {};
+          claimersByTargetRoom[targetRoom] = (claimersByTargetRoom[targetRoom] ?? 0) + 1;
+          counts.claimersByTargetRoom = claimersByTargetRoom;
+        }
       }
       return counts;
     },
-    { worker: 0 }
+    { worker: 0, claimer: 0, claimersByTargetRoom: {} }
   );
 }
 
@@ -20,6 +31,10 @@ function isColonyWorker(creep: Creep, colonyName: string): boolean {
   return creep.memory.colony === colonyName && creep.memory.role === 'worker';
 }
 
-function canSatisfyWorkerCapacity(creep: Creep): boolean {
+function isColonyClaimer(creep: Creep, colonyName: string): boolean {
+  return creep.memory.colony === colonyName && creep.memory.role === 'claimer';
+}
+
+function canSatisfyRoleCapacity(creep: Creep): boolean {
   return creep.ticksToLive === undefined || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -4,6 +4,8 @@ import { countCreepsByRole } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
 import { planSpawn, type SpawnRequest } from '../spawn/spawnPlanner';
 import { emitRuntimeSummary, type RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
+import { TERRITORY_CLAIMER_ROLE } from '../territory/territoryPlanner';
+import { runTerritoryControllerCreep } from '../territory/territoryRunner';
 
 const ERR_BUSY_CODE = -4 as ScreepsReturnCode;
 
@@ -31,6 +33,8 @@ export function runEconomy(): void {
   for (const creep of creeps) {
     if (creep.memory.role === 'worker') {
       runWorker(creep);
+    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE) {
+      runTerritoryControllerCreep(creep);
     }
   }
 

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -1,5 +1,7 @@
 const WORKER_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move'];
 const WORKER_PATTERN_COST = 200;
+const TERRITORY_CONTROLLER_BODY: BodyPartConstant[] = ['claim', 'move'];
+export const TERRITORY_CONTROLLER_BODY_COST = 650;
 const MAX_CREEP_PARTS = 50;
 // General workers cover harvest, haul, build, and upgrade duties. Cap them at
 // four 200-energy patterns (800 energy) so early rooms do not sink capacity into
@@ -34,6 +36,14 @@ export function buildEmergencyWorkerBody(energyAvailable: number): BodyPartConst
   }
 
   return [...WORKER_PATTERN];
+}
+
+export function buildTerritoryControllerBody(energyAvailable: number): BodyPartConstant[] {
+  if (energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return [];
+  }
+
+  return [...TERRITORY_CONTROLLER_BODY];
 }
 
 export function getBodyCost(body: BodyPartConstant[]): number {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -1,6 +1,16 @@
 import { ColonySnapshot } from '../colony/colonyRegistry';
 import type { RoleCounts } from '../creeps/roleCounts';
-import { buildEmergencyWorkerBody, buildWorkerBody, getBodyCost } from './bodyBuilder';
+import {
+  buildEmergencyWorkerBody,
+  buildTerritoryControllerBody,
+  buildWorkerBody,
+  getBodyCost
+} from './bodyBuilder';
+import {
+  buildTerritoryCreepMemory,
+  planTerritoryIntent,
+  shouldSpawnTerritoryControllerCreep
+} from '../territory/territoryPlanner';
 
 export interface SpawnRequest {
   spawn: StructureSpawn;
@@ -16,10 +26,35 @@ const MAX_WORKER_TARGET = 6;
 const sourceCountByRoomName = new Map<string, number>();
 
 export function planSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTime: number): SpawnRequest | null {
-  if (roleCounts.worker >= getWorkerTarget(colony)) {
+  const workerTarget = getWorkerTarget(colony);
+  if (roleCounts.worker < workerTarget) {
+    return planWorkerSpawn(colony, roleCounts, gameTime);
+  }
+
+  const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
+  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts)) {
     return null;
   }
 
+  const spawn = colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+
+  const body = buildTerritoryControllerBody(colony.energyAvailable);
+  if (body.length === 0) {
+    return null;
+  }
+
+  return {
+    spawn,
+    body,
+    name: `claimer-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`,
+    memory: buildTerritoryCreepMemory(territoryIntent)
+  };
+}
+
+function planWorkerSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTime: number): SpawnRequest | null {
   const spawn = colony.spawns.find((candidate) => !candidate.spawning);
   if (!spawn) {
     return null;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -40,6 +40,10 @@ export function planTerritoryIntent(
 }
 
 export function shouldSpawnTerritoryControllerCreep(plan: TerritoryIntentPlan, roleCounts: RoleCounts): boolean {
+  if (isClaimTargetAlreadyOwned(plan.targetRoom, plan.action, plan.controllerId)) {
+    return false;
+  }
+
   return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) === 0;
 }
 
@@ -87,7 +91,8 @@ function selectTerritoryTarget(colonyName: string): TerritoryTargetMemory | null
       target &&
       target.enabled !== false &&
       target.colony === colonyName &&
-      target.roomName !== colonyName
+      target.roomName !== colonyName &&
+      !isClaimTargetAlreadyOwned(target.roomName, target.action, target.controllerId)
     ) {
       return target;
     }
@@ -153,6 +158,33 @@ function recordTerritoryIntent(plan: TerritoryIntentPlan, status: TerritoryInten
 
 function getTerritoryCreepCountForTarget(roleCounts: RoleCounts, targetRoom: string): number {
   return roleCounts.claimersByTargetRoom?.[targetRoom] ?? 0;
+}
+
+function isClaimTargetAlreadyOwned(
+  targetRoom: string,
+  action: TerritoryControlAction,
+  controllerId?: Id<StructureController>
+): boolean {
+  if (action !== 'claim') {
+    return false;
+  }
+
+  return getVisibleController(targetRoom, controllerId)?.my === true;
+}
+
+function getVisibleController(targetRoom: string, controllerId?: Id<StructureController>): StructureController | null {
+  const game = (globalThis as { Game?: Partial<Game> }).Game;
+  const roomController = game?.rooms?.[targetRoom]?.controller;
+  if (roomController) {
+    return roomController;
+  }
+
+  const getObjectById = game?.getObjectById;
+  if (controllerId && typeof getObjectById === 'function') {
+    return getObjectById.call(game, controllerId) as StructureController | null;
+  }
+
+  return null;
 }
 
 function getWritableTerritoryMemoryRecord(): TerritoryMemory | null {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -40,6 +40,10 @@ export function planTerritoryIntent(
 }
 
 export function shouldSpawnTerritoryControllerCreep(plan: TerritoryIntentPlan, roleCounts: RoleCounts): boolean {
+  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action)) {
+    return false;
+  }
+
   if (isClaimTargetAlreadyOwned(plan.targetRoom, plan.action, plan.controllerId)) {
     return false;
   }
@@ -57,6 +61,38 @@ export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemor
       ...(plan.controllerId ? { controllerId: plan.controllerId } : {})
     }
   };
+}
+
+export function suppressTerritoryIntent(
+  colony: string | undefined,
+  assignment: CreepTerritoryMemory,
+  gameTime: number
+): void {
+  if (
+    !isNonEmptyString(colony) ||
+    !isNonEmptyString(assignment.targetRoom) ||
+    !isTerritoryAction(assignment.action)
+  ) {
+    return;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const suppressedIntent: TerritoryIntentMemory = {
+    colony,
+    targetRoom: assignment.targetRoom,
+    action: assignment.action,
+    status: 'suppressed',
+    updatedAt: gameTime,
+    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {})
+  };
+
+  upsertTerritoryIntent(intents, suppressedIntent);
 }
 
 export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {
@@ -85,6 +121,7 @@ function selectTerritoryTarget(colonyName: string): TerritoryTargetMemory | null
     return null;
   }
 
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
     if (
@@ -92,6 +129,7 @@ function selectTerritoryTarget(colonyName: string): TerritoryTargetMemory | null
       target.enabled !== false &&
       target.colony === colonyName &&
       target.roomName !== colonyName &&
+      !isTerritoryTargetSuppressed(target, intents) &&
       !isClaimTargetAlreadyOwned(target.roomName, target.action, target.controllerId)
     ) {
       return target;
@@ -131,12 +169,7 @@ function recordTerritoryIntent(plan: TerritoryIntentPlan, status: TerritoryInten
     return;
   }
 
-  const intents = Array.isArray(territoryMemory.intents)
-    ? territoryMemory.intents.flatMap((intent) => {
-        const normalizedIntent = normalizeTerritoryIntent(intent);
-        return normalizedIntent ? [normalizedIntent] : [];
-      })
-    : [];
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const nextIntent: TerritoryIntentMemory = {
     colony: plan.colony,
@@ -146,6 +179,20 @@ function recordTerritoryIntent(plan: TerritoryIntentPlan, status: TerritoryInten
     updatedAt: gameTime,
     ...(plan.controllerId ? { controllerId: plan.controllerId } : {})
   };
+
+  upsertTerritoryIntent(intents, nextIntent);
+}
+
+function normalizeTerritoryIntents(rawIntents: TerritoryMemory['intents'] | unknown): TerritoryIntentMemory[] {
+  return Array.isArray(rawIntents)
+    ? rawIntents.flatMap((intent) => {
+        const normalizedIntent = normalizeTerritoryIntent(intent);
+        return normalizedIntent ? [normalizedIntent] : [];
+      })
+    : [];
+}
+
+function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: TerritoryIntentMemory): void {
   const existingIndex = intents.findIndex(
     (intent) =>
       intent.colony === nextIntent.colony &&
@@ -190,6 +237,35 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
 
 function getTerritoryCreepCountForTarget(roleCounts: RoleCounts, targetRoom: string): number {
   return roleCounts.claimersByTargetRoom?.[targetRoom] ?? 0;
+}
+
+function isTerritoryTargetSuppressed(target: TerritoryTargetMemory, intents: TerritoryIntentMemory[]): boolean {
+  return intents.some(
+    (intent) =>
+      intent.status === 'suppressed' &&
+      intent.colony === target.colony &&
+      intent.targetRoom === target.roomName &&
+      intent.action === target.action
+  );
+}
+
+function isTerritoryIntentSuppressed(
+  colony: string,
+  targetRoom: string,
+  action: TerritoryControlAction
+): boolean {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return false;
+  }
+
+  return normalizeTerritoryIntents(territoryMemory.intents).some(
+    (intent) =>
+      intent.status === 'suppressed' &&
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      intent.action === action
+  );
 }
 
 function isClaimTargetAlreadyOwned(
@@ -251,7 +327,7 @@ function isTerritoryAction(action: unknown): action is TerritoryControlAction {
 }
 
 function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {
-  return status === 'planned' || status === 'active';
+  return status === 'planned' || status === 'active' || status === 'suppressed';
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1,0 +1,195 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import type { RoleCounts } from '../creeps/roleCounts';
+import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
+
+export const TERRITORY_CLAIMER_ROLE = 'claimer';
+export const TERRITORY_DOWNGRADE_GUARD_TICKS = 5_000;
+
+export interface TerritoryIntentPlan {
+  colony: string;
+  targetRoom: string;
+  action: TerritoryControlAction;
+  controllerId?: Id<StructureController>;
+}
+
+interface MemoryRecord {
+  territory?: unknown;
+}
+
+export function planTerritoryIntent(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  workerTarget: number,
+  gameTime: number
+): TerritoryIntentPlan | null {
+  const target = selectTerritoryTarget(colony.room.name);
+  if (!target || !isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
+    return null;
+  }
+
+  const plan: TerritoryIntentPlan = {
+    colony: colony.room.name,
+    targetRoom: target.roomName,
+    action: target.action,
+    ...(target.controllerId ? { controllerId: target.controllerId } : {})
+  };
+  const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) > 0 ? 'active' : 'planned';
+  recordTerritoryIntent(plan, status, gameTime);
+
+  return plan;
+}
+
+export function shouldSpawnTerritoryControllerCreep(plan: TerritoryIntentPlan, roleCounts: RoleCounts): boolean {
+  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) === 0;
+}
+
+export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemory {
+  return {
+    role: TERRITORY_CLAIMER_ROLE,
+    colony: plan.colony,
+    territory: {
+      targetRoom: plan.targetRoom,
+      action: plan.action,
+      ...(plan.controllerId ? { controllerId: plan.controllerId } : {})
+    }
+  };
+}
+
+export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {
+  if (roleCounts.worker < workerTarget) {
+    return false;
+  }
+
+  if (colony.energyCapacityAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return false;
+  }
+
+  const controller = colony.room.controller;
+  if (controller?.my !== true || typeof controller.level !== 'number' || controller.level < 2) {
+    return false;
+  }
+
+  return (
+    typeof controller.ticksToDowngrade !== 'number' ||
+    controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS
+  );
+}
+
+function selectTerritoryTarget(colonyName: string): TerritoryTargetMemory | null {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return null;
+  }
+
+  for (const rawTarget of territoryMemory.targets) {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (
+      target &&
+      target.enabled !== false &&
+      target.colony === colonyName &&
+      target.roomName !== colonyName
+    ) {
+      return target;
+    }
+  }
+
+  return null;
+}
+
+function normalizeTerritoryTarget(rawTarget: unknown): TerritoryTargetMemory | null {
+  if (!isRecord(rawTarget)) {
+    return null;
+  }
+
+  if (
+    !isNonEmptyString(rawTarget.colony) ||
+    !isNonEmptyString(rawTarget.roomName) ||
+    !isTerritoryAction(rawTarget.action)
+  ) {
+    return null;
+  }
+
+  return {
+    colony: rawTarget.colony,
+    roomName: rawTarget.roomName,
+    action: rawTarget.action,
+    ...(typeof rawTarget.controllerId === 'string'
+      ? { controllerId: rawTarget.controllerId as Id<StructureController> }
+      : {}),
+    ...(rawTarget.enabled === false ? { enabled: false } : {})
+  };
+}
+
+function recordTerritoryIntent(plan: TerritoryIntentPlan, status: TerritoryIntentMemory['status'], gameTime: number): void {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const intents = Array.isArray(territoryMemory.intents) ? territoryMemory.intents : [];
+  territoryMemory.intents = intents;
+  const nextIntent: TerritoryIntentMemory = {
+    colony: plan.colony,
+    targetRoom: plan.targetRoom,
+    action: plan.action,
+    status,
+    updatedAt: gameTime,
+    ...(plan.controllerId ? { controllerId: plan.controllerId } : {})
+  };
+  const existingIndex = intents.findIndex(
+    (intent) =>
+      intent.colony === nextIntent.colony &&
+      intent.targetRoom === nextIntent.targetRoom &&
+      intent.action === nextIntent.action
+  );
+
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+
+  intents.push(nextIntent);
+}
+
+function getTerritoryCreepCountForTarget(roleCounts: RoleCounts, targetRoom: string): number {
+  return roleCounts.claimersByTargetRoom?.[targetRoom] ?? 0;
+}
+
+function getWritableTerritoryMemoryRecord(): TerritoryMemory | null {
+  const memory = getMemoryRecord();
+  if (!memory) {
+    return null;
+  }
+
+  if (!isRecord(memory.territory)) {
+    memory.territory = {};
+  }
+
+  return memory.territory as TerritoryMemory;
+}
+
+function getTerritoryMemoryRecord(): Record<string, unknown> | null {
+  const memory = getMemoryRecord();
+  if (!memory || !isRecord(memory.territory)) {
+    return null;
+  }
+
+  return memory.territory;
+}
+
+function getMemoryRecord(): MemoryRecord | null {
+  const memory = (globalThis as { Memory?: MemoryRecord }).Memory;
+  return memory ?? null;
+}
+
+function isTerritoryAction(action: unknown): action is TerritoryControlAction {
+  return action === 'claim' || action === 'reserve';
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -131,7 +131,12 @@ function recordTerritoryIntent(plan: TerritoryIntentPlan, status: TerritoryInten
     return;
   }
 
-  const intents = Array.isArray(territoryMemory.intents) ? territoryMemory.intents : [];
+  const intents = Array.isArray(territoryMemory.intents)
+    ? territoryMemory.intents.flatMap((intent) => {
+        const normalizedIntent = normalizeTerritoryIntent(intent);
+        return normalizedIntent ? [normalizedIntent] : [];
+      })
+    : [];
   territoryMemory.intents = intents;
   const nextIntent: TerritoryIntentMemory = {
     colony: plan.colony,
@@ -154,6 +159,33 @@ function recordTerritoryIntent(plan: TerritoryIntentPlan, status: TerritoryInten
   }
 
   intents.push(nextIntent);
+}
+
+function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | null {
+  if (!isRecord(rawIntent)) {
+    return null;
+  }
+
+  if (
+    !isNonEmptyString(rawIntent.colony) ||
+    !isNonEmptyString(rawIntent.targetRoom) ||
+    !isTerritoryAction(rawIntent.action) ||
+    !isTerritoryIntentStatus(rawIntent.status) ||
+    typeof rawIntent.updatedAt !== 'number'
+  ) {
+    return null;
+  }
+
+  return {
+    colony: rawIntent.colony,
+    targetRoom: rawIntent.targetRoom,
+    action: rawIntent.action,
+    status: rawIntent.status,
+    updatedAt: rawIntent.updatedAt,
+    ...(typeof rawIntent.controllerId === 'string'
+      ? { controllerId: rawIntent.controllerId as Id<StructureController> }
+      : {})
+  };
 }
 
 function getTerritoryCreepCountForTarget(roleCounts: RoleCounts, targetRoom: string): number {
@@ -216,6 +248,10 @@ function getMemoryRecord(): MemoryRecord | null {
 
 function isTerritoryAction(action: unknown): action is TerritoryControlAction {
   return action === 'claim' || action === 'reserve';
+}
+
+function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {
+  return status === 'planned' || status === 'active';
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -44,7 +44,7 @@ export function shouldSpawnTerritoryControllerCreep(plan: TerritoryIntentPlan, r
     return false;
   }
 
-  if (isClaimTargetAlreadyOwned(plan.targetRoom, plan.action, plan.controllerId)) {
+  if (isVisibleTerritoryTargetUnavailable(plan.targetRoom, plan.controllerId)) {
     return false;
   }
 
@@ -130,7 +130,7 @@ function selectTerritoryTarget(colonyName: string): TerritoryTargetMemory | null
       target.colony === colonyName &&
       target.roomName !== colonyName &&
       !isTerritoryTargetSuppressed(target, intents) &&
-      !isClaimTargetAlreadyOwned(target.roomName, target.action, target.controllerId)
+      !isVisibleTerritoryTargetUnavailable(target.roomName, target.controllerId)
     ) {
       return target;
     }
@@ -268,16 +268,20 @@ function isTerritoryIntentSuppressed(
   );
 }
 
-function isClaimTargetAlreadyOwned(
+function isVisibleTerritoryTargetUnavailable(
   targetRoom: string,
-  action: TerritoryControlAction,
   controllerId?: Id<StructureController>
 ): boolean {
-  if (action !== 'claim') {
+  const controller = getVisibleController(targetRoom, controllerId);
+  if (!controller) {
     return false;
   }
 
-  return getVisibleController(targetRoom, controllerId)?.my === true;
+  return isControllerOwned(controller);
+}
+
+function isControllerOwned(controller: StructureController): boolean {
+  return controller.owner != null || controller.my === true;
 }
 
 function getVisibleController(targetRoom: string, controllerId?: Id<StructureController>): StructureController | null {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -1,0 +1,75 @@
+const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+const OK_CODE = 0 as ScreepsReturnCode;
+
+type RoomPositionConstructor = new (x: number, y: number, roomName: string) => RoomPosition;
+
+export function runTerritoryControllerCreep(creep: Creep): void {
+  const assignment = creep.memory.territory;
+  if (!isTerritoryAssignment(assignment)) {
+    return;
+  }
+
+  if (creep.room?.name !== assignment.targetRoom) {
+    moveTowardTargetRoom(creep, assignment.targetRoom);
+    return;
+  }
+
+  const controller = selectTargetController(creep, assignment);
+  if (!controller || controller.my === true) {
+    return;
+  }
+
+  const result =
+    assignment.action === 'claim'
+      ? executeControllerAction(creep, controller, 'claimController')
+      : executeControllerAction(creep, controller, 'reserveController');
+
+  if (result === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {
+    creep.moveTo(controller);
+  }
+}
+
+function selectTargetController(creep: Creep, assignment: CreepTerritoryMemory): StructureController | null {
+  if (assignment.controllerId) {
+    const game = (globalThis as { Game?: Partial<Game> }).Game;
+    const getObjectById = game?.getObjectById;
+    if (typeof getObjectById === 'function') {
+      const controller = getObjectById.call(game, assignment.controllerId) as StructureController | null;
+      if (controller) {
+        return controller;
+      }
+    }
+  }
+
+  return creep.room?.controller ?? null;
+}
+
+function executeControllerAction(
+  creep: Creep,
+  controller: StructureController,
+  action: 'claimController' | 'reserveController'
+): ScreepsReturnCode {
+  const controllerAction = creep[action];
+  if (typeof controllerAction !== 'function') {
+    return OK_CODE;
+  }
+
+  return controllerAction.call(creep, controller);
+}
+
+function moveTowardTargetRoom(creep: Creep, targetRoom: string): void {
+  const RoomPositionCtor = (globalThis as { RoomPosition?: RoomPositionConstructor }).RoomPosition;
+  if (typeof RoomPositionCtor !== 'function' || typeof creep.moveTo !== 'function') {
+    return;
+  }
+
+  creep.moveTo(new RoomPositionCtor(25, 25, targetRoom));
+}
+
+function isTerritoryAssignment(assignment: CreepTerritoryMemory | undefined): assignment is CreepTerritoryMemory {
+  return (
+    typeof assignment?.targetRoom === 'string' &&
+    assignment.targetRoom.length > 0 &&
+    (assignment.action === 'claim' || assignment.action === 'reserve')
+  );
+}

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -8,6 +8,7 @@ const CLAIM_FATAL_RESULT_CODES = new Set<ScreepsReturnCode>([
   ERR_INVALID_TARGET_CODE,
   ERR_GCL_NOT_ENOUGH_CODE
 ]);
+const RESERVE_FATAL_RESULT_CODES = new Set<ScreepsReturnCode>([ERR_INVALID_TARGET_CODE]);
 
 type RoomPositionConstructor = new (x: number, y: number, roomName: string) => RoomPosition;
 
@@ -23,7 +24,14 @@ export function runTerritoryControllerCreep(creep: Creep): void {
   }
 
   const controller = selectTargetController(creep, assignment);
-  if (!controller || controller.my === true) {
+  if (!controller) {
+    return;
+  }
+
+  if (controller.my === true) {
+    if (assignment.action === 'reserve') {
+      suppressTerritoryAssignment(creep, assignment);
+    }
     return;
   }
 
@@ -37,10 +45,17 @@ export function runTerritoryControllerCreep(creep: Creep): void {
     return;
   }
 
-  if (assignment.action === 'claim' && CLAIM_FATAL_RESULT_CODES.has(result)) {
-    suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime());
-    delete creep.memory.territory;
+  if (
+    (assignment.action === 'claim' && CLAIM_FATAL_RESULT_CODES.has(result)) ||
+    (assignment.action === 'reserve' && RESERVE_FATAL_RESULT_CODES.has(result))
+  ) {
+    suppressTerritoryAssignment(creep, assignment);
   }
+}
+
+function suppressTerritoryAssignment(creep: Creep, assignment: CreepTerritoryMemory): void {
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime());
+  delete creep.memory.territory;
 }
 
 function selectTargetController(creep: Creep, assignment: CreepTerritoryMemory): StructureController | null {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -1,5 +1,13 @@
+import { suppressTerritoryIntent } from './territoryPlanner';
+
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
+const ERR_GCL_NOT_ENOUGH_CODE = -15 as ScreepsReturnCode;
 const OK_CODE = 0 as ScreepsReturnCode;
+const CLAIM_FATAL_RESULT_CODES = new Set<ScreepsReturnCode>([
+  ERR_INVALID_TARGET_CODE,
+  ERR_GCL_NOT_ENOUGH_CODE
+]);
 
 type RoomPositionConstructor = new (x: number, y: number, roomName: string) => RoomPosition;
 
@@ -26,6 +34,12 @@ export function runTerritoryControllerCreep(creep: Creep): void {
 
   if (result === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {
     creep.moveTo(controller);
+    return;
+  }
+
+  if (assignment.action === 'claim' && CLAIM_FATAL_RESULT_CODES.has(result)) {
+    suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime());
+    delete creep.memory.territory;
   }
 }
 
@@ -64,6 +78,11 @@ function moveTowardTargetRoom(creep: Creep, targetRoom: string): void {
   }
 
   creep.moveTo(new RoomPositionCtor(25, 25, targetRoom));
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof gameTime === 'number' ? gameTime : 0;
 }
 
 function isTerritoryAssignment(assignment: CreepTerritoryMemory | undefined): assignment is CreepTerritoryMemory {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -25,6 +25,7 @@ export function runTerritoryControllerCreep(creep: Creep): void {
 
   const controller = selectTargetController(creep, assignment);
   if (!controller) {
+    suppressTerritoryAssignment(creep, assignment);
     return;
   }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -34,7 +34,7 @@ declare global {
     colony: string;
     targetRoom: string;
     action: TerritoryControlAction;
-    status: 'planned' | 'active';
+    status: 'planned' | 'active' | 'suppressed';
     updatedAt: number;
     controllerId?: Id<StructureController>;
   }

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -5,12 +5,44 @@ declare global {
     meta: {
       version: number;
     };
+    territory?: TerritoryMemory;
   }
 
   interface CreepMemory {
     role?: string;
     colony?: string;
     task?: CreepTaskMemory;
+    territory?: CreepTerritoryMemory;
+  }
+
+  type TerritoryControlAction = 'claim' | 'reserve';
+
+  interface TerritoryMemory {
+    targets?: TerritoryTargetMemory[];
+    intents?: TerritoryIntentMemory[];
+  }
+
+  interface TerritoryTargetMemory {
+    colony: string;
+    roomName: string;
+    action: TerritoryControlAction;
+    controllerId?: Id<StructureController>;
+    enabled?: boolean;
+  }
+
+  interface TerritoryIntentMemory {
+    colony: string;
+    targetRoom: string;
+    action: TerritoryControlAction;
+    status: 'planned' | 'active';
+    updatedAt: number;
+    controllerId?: Id<StructureController>;
+  }
+
+  interface CreepTerritoryMemory {
+    targetRoom: string;
+    action: TerritoryControlAction;
+    controllerId?: Id<StructureController>;
   }
 
   type CreepTaskMemory =

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -1,4 +1,9 @@
-import { buildEmergencyWorkerBody, buildWorkerBody, getBodyCost } from '../src/spawn/bodyBuilder';
+import {
+  buildEmergencyWorkerBody,
+  buildTerritoryControllerBody,
+  buildWorkerBody,
+  getBodyCost
+} from '../src/spawn/bodyBuilder';
 
 const WORKER_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move'];
 
@@ -58,6 +63,16 @@ describe('buildEmergencyWorkerBody', () => {
 
   it('returns one worker pattern at the worker pattern energy cost', () => {
     expect(buildEmergencyWorkerBody(200)).toEqual(WORKER_PATTERN);
+  });
+});
+
+describe('buildTerritoryControllerBody', () => {
+  it('returns an empty body below one claim and move part', () => {
+    expect(buildTerritoryControllerBody(649)).toEqual([]);
+  });
+
+  it('builds one claim and move part when affordable', () => {
+    expect(buildTerritoryControllerBody(650)).toEqual(['claim', 'move']);
   });
 });
 

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -377,6 +377,26 @@ describe('runEconomy', () => {
 
     expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
   });
+
+  it('runs existing territory controller creeps', () => {
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      reserveController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 300,
+      rooms: {},
+      spawns: {},
+      creeps: { Reserver1: creep }
+    };
+
+    runEconomy();
+
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+  });
 });
 
 interface LifecycleSpawn extends StructureSpawn {

--- a/prod/test/roleCounts.test.ts
+++ b/prod/test/roleCounts.test.ts
@@ -3,11 +3,16 @@ import { countCreepsByRole, WORKER_REPLACEMENT_TICKS_TO_LIVE } from '../src/cree
 describe('countCreepsByRole', () => {
   it('counts creeps by memory role and colony', () => {
     const worker = { memory: { role: 'worker', colony: 'W1N1' } } as Creep;
+    const claimer = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'reserve' } }
+    } as Creep;
     const otherColonyWorker = { memory: { role: 'worker', colony: 'W2N2' } } as Creep;
     const unassigned = { memory: {} } as Creep;
 
-    expect(countCreepsByRole([worker, otherColonyWorker, unassigned], 'W1N1')).toEqual({
-      worker: 1
+    expect(countCreepsByRole([worker, claimer, otherColonyWorker, unassigned], 'W1N1')).toEqual({
+      worker: 1,
+      claimer: 1,
+      claimersByTargetRoom: { W2N1: 1 }
     });
   });
 
@@ -36,7 +41,30 @@ describe('countCreepsByRole', () => {
         'W1N1'
       )
     ).toEqual({
-      worker: 2
+      worker: 2,
+      claimer: 0,
+      claimersByTargetRoom: {}
+    });
+  });
+
+  it('excludes colony claimers at replacement age from territory capacity', () => {
+    const healthyClaimer = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'claim' } },
+      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1
+    } as Creep;
+    const expiringClaimer = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'claim' } },
+      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE
+    } as Creep;
+    const foreignClaimer = {
+      memory: { role: 'claimer', colony: 'W2N2', territory: { targetRoom: 'W2N1', action: 'claim' } },
+      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1
+    } as Creep;
+
+    expect(countCreepsByRole([healthyClaimer, expiringClaimer, foreignClaimer], 'W1N1')).toEqual({
+      worker: 0,
+      claimer: 1,
+      claimersByTargetRoom: { W2N1: 1 }
     });
   });
 });

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -4,6 +4,8 @@ import { ColonySnapshot } from '../src/colony/colonyRegistry';
 describe('planSpawn', () => {
   beforeEach(() => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
   });
 
   function makeColony({
@@ -11,13 +13,15 @@ describe('planSpawn', () => {
     energyAvailable = 300,
     energyCapacityAvailable = 300,
     roomName = 'W1N1',
-    spawning = null
+    spawning = null,
+    controller
   }: {
     sourceCount?: number;
     energyAvailable?: number;
     energyCapacityAvailable?: number;
     roomName?: string;
     spawning?: Spawning | null;
+    controller?: StructureController;
   } = {}): { colony: ColonySnapshot; spawn: StructureSpawn; find: jest.Mock<Source[], [number]> } {
     const sources = Array.from({ length: sourceCount }, (_, index) => ({ id: `source${index}` }) as Source);
     const find = jest.fn((type: number) => (type === FIND_SOURCES ? sources : []));
@@ -25,7 +29,8 @@ describe('planSpawn', () => {
       name: roomName,
       energyAvailable,
       energyCapacityAvailable,
-      find
+      find,
+      ...(controller ? { controller } : {})
     } as unknown as Room;
     const spawn = { name: 'Spawn1', room, spawning } as StructureSpawn;
     const colony: ColonySnapshot = {
@@ -81,6 +86,109 @@ describe('planSpawn', () => {
     const { colony } = makeColony();
 
     expect(planSpawn(colony, { worker: 3 }, 124)).toBeNull();
+  });
+
+  it('plans a claimer-role reserver for an explicit memory target when home survival is safe', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 139)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N1-139',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve' }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 139
+      }
+    ]);
+  });
+
+  it('records territory intent while waiting for claim body energy', () => {
+    const { colony } = makeColony({
+      energyAvailable: 600,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim', controllerId: 'controller2' as Id<StructureController> }]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 141)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 141,
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
+  it('keeps territory control absent when the home worker floor is unsafe', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 140)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      name: 'worker-W1N1-140',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('does not plan another claimer while one has active target capacity', () => {
+    const { colony } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 1, claimersByTargetRoom: { W2N1: 1 } }, 143)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 143
+      }
+    ]);
   });
 
   it('targets a fourth worker for two-source rooms', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1,0 +1,96 @@
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import { planTerritoryIntent, TERRITORY_DOWNGRADE_GUARD_TICKS } from '../src/territory/territoryPlanner';
+
+describe('planTerritoryIntent', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  it('records the first valid enabled target for the colony', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve', enabled: false },
+          { colony: 'W9N9', roomName: 'W9N8', action: 'claim' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'claim', controllerId: 'controller3' as Id<StructureController> }
+        ]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 500)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      controllerId: 'controller3'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 500,
+        controllerId: 'controller3'
+      }
+    ]);
+  });
+
+  it('ignores malformed territory memory without throwing', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          null,
+          { colony: 'W1N1', roomName: 'W2N1' },
+          { colony: 'W1N1', roomName: 'W1N1', action: 'reserve' }
+        ] as unknown as TerritoryTargetMemory[]
+      }
+    };
+    let intent: ReturnType<typeof planTerritoryIntent>;
+
+    expect(() => {
+      intent = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 501);
+    }).not.toThrow();
+    expect(intent!).toBeNull();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('does not emit territory intent when the home controller is near downgrade', () => {
+    const colony = makeSafeColony({
+      controller: { my: true, level: 3, ticksToDowngrade: TERRITORY_DOWNGRADE_GUARD_TICKS } as StructureController
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 502)).toBeNull();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+});
+
+function makeSafeColony({
+  roomName = 'W1N1',
+  controller = { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+}: {
+  roomName?: string;
+  controller?: StructureController;
+} = {}): ColonySnapshot {
+  const room = {
+    name: roomName,
+    controller,
+    energyAvailable: 650,
+    energyCapacityAvailable: 650
+  } as unknown as Room;
+
+  return {
+    room,
+    spawns: [],
+    energyAvailable: 650,
+    energyCapacityAvailable: 650
+  };
+}

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -112,6 +112,87 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('does not emit or spawn suppressed claim targets', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'suppressed',
+            updatedAt: 510
+          }
+        ]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 511)).toBeNull();
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'claim' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 510
+      }
+    ]);
+  });
+
+  it('preserves suppressed intents while planning the next eligible target', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'claim' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ],
+        intents: [
+          null,
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'suppressed',
+            updatedAt: 512
+          }
+        ] as unknown as TerritoryIntentMemory[]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 513)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 512
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 513
+      }
+    ]);
+  });
+
   it('does not emit territory intent when the home controller is near downgrade', () => {
     const colony = makeSafeColony({
       controller: { my: true, level: 3, ticksToDowngrade: TERRITORY_DOWNGRADE_GUARD_TICKS } as StructureController

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1,9 +1,14 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
-import { planTerritoryIntent, TERRITORY_DOWNGRADE_GUARD_TICKS } from '../src/territory/territoryPlanner';
+import {
+  planTerritoryIntent,
+  shouldSpawnTerritoryControllerCreep,
+  TERRITORY_DOWNGRADE_GUARD_TICKS
+} from '../src/territory/territoryPlanner';
 
 describe('planTerritoryIntent', () => {
   beforeEach(() => {
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    delete (globalThis as { Game?: Partial<Game> }).Game;
   });
 
   it('records the first valid enabled target for the colony', () => {
@@ -70,6 +75,81 @@ describe('planTerritoryIntent', () => {
 
     expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 502)).toBeNull();
     expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('does not request replacement claimers after a visible claim target is owned', () => {
+    const colony = makeSafeColony();
+    const ownedController = { my: true } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: { name: 'W2N1', controller: ownedController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 503)).toBeNull();
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'claim' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('still requests claimers for visible unowned claim targets', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 504);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
+    ).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 504
+      }
+    ]);
+  });
+
+  it('leaves reserve targets eligible even when the visible controller is owned', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: true } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 505);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
+    ).toBe(true);
   });
 });
 

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -63,6 +63,55 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
+  it('normalizes malformed existing intents before updating a matching intent', () => {
+    const colony = makeSafeColony();
+    const unrelatedIntent: TerritoryIntentMemory = {
+      colony: 'W9N9',
+      targetRoom: 'W9N8',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 400
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }],
+        intents: [
+          null,
+          undefined,
+          { colony: 'W1N1', targetRoom: 'W2N1', status: 'planned', updatedAt: 450 },
+          unrelatedIntent,
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 451
+          }
+        ] as unknown as TerritoryIntentMemory[]
+      }
+    };
+
+    expect(() => {
+      expect(
+        planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 506)
+      ).toEqual({
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve'
+      });
+    }).not.toThrow();
+    expect(Memory.territory?.intents).toEqual([
+      unrelatedIntent,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 506
+      }
+    ]);
+  });
+
   it('does not emit territory intent when the home controller is near downgrade', () => {
     const colony = makeSafeColony({
       controller: { my: true, level: 3, ticksToDowngrade: TERRITORY_DOWNGRADE_GUARD_TICKS } as StructureController

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -207,9 +207,9 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
-  it('does not request replacement claimers after a visible claim target is owned', () => {
+  it('does not request replacement claimers after a visible claim target is self-owned', () => {
     const colony = makeSafeColony();
-    const ownedController = { my: true } as StructureController;
+    const ownedController = { my: true, owner: { username: 'me' } } as StructureController;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {
         W2N1: { name: 'W2N1', controller: ownedController } as Room
@@ -229,6 +229,49 @@ describe('planTerritoryIntent', () => {
       )
     ).toBe(false);
     expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('skips visible hostile-owned claim targets and plans the next eligible target', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false, owner: { username: 'enemy' } } as StructureController
+        } as Room,
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'claim' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'claim' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 508);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'claim' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'claim' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
+    ).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 508
+      }
+    ]);
   });
 
   it('still requests claimers for visible unowned claim targets', () => {
@@ -261,11 +304,14 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('leaves reserve targets eligible even when the visible controller is owned', () => {
+  it('does not request reserve claimers after a visible reserve target is self-owned', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {
-        W2N1: { name: 'W2N1', controller: { my: true } as StructureController } as Room
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: true, owner: { username: 'me' } } as StructureController
+        } as Room
       }
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
@@ -274,7 +320,73 @@ describe('planTerritoryIntent', () => {
       }
     };
 
-    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 505);
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 505)).toBeNull();
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('skips visible hostile-owned reserve targets and plans the next eligible target', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false, owner: { username: 'enemy' } } as StructureController
+        } as Room,
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 506);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
+    ).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 506
+      }
+    ]);
+  });
+
+  it('still requests claimers for visible unowned reserve targets', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 507);
 
     expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
     expect(

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -125,6 +125,90 @@ describe('runTerritoryControllerCreep', () => {
     ]);
   });
 
+  it('suppresses a reserve target and stops the creep assignment when reserve is impossible', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 504,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 500
+          }
+        ]
+      }
+    };
+    const controller = { id: 'controller1', my: false, owner: { username: 'enemy' } } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      reserveController: jest.fn().mockReturnValue(-7),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: 504
+      }
+    ]);
+  });
+
+  it('suppresses a reserve assignment when the target controller is already self-owned', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 505,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 501
+          }
+        ]
+      }
+    };
+    const controller = { id: 'controller1', my: true, owner: { username: 'me' } } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      reserveController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: 505
+      }
+    ]);
+  });
+
   it('ignores incomplete territory memory without throwing', () => {
     const creep = {
       memory: { role: 'claimer', colony: 'W1N1' },

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -1,0 +1,78 @@
+import { runTerritoryControllerCreep } from '../src/territory/territoryRunner';
+
+describe('runTerritoryControllerCreep', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { RoomPosition: typeof RoomPosition }).RoomPosition = jest.fn(
+      (x: number, y: number, roomName: string) => ({ x, y, roomName }) as RoomPosition
+    ) as unknown as typeof RoomPosition;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+  });
+
+  it('moves toward the target room before touching the controller', () => {
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N1' },
+      moveTo: jest.fn(),
+      reserveController: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W1N2' });
+    expect(creep.reserveController).not.toHaveBeenCalled();
+  });
+
+  it('reserves the target room controller and moves into range when needed', () => {
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      reserveController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+  });
+
+  it('claims a configured controller id when claim action is requested', () => {
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const getObjectById = jest.fn().mockReturnValue(controller);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { getObjectById };
+    const creep = {
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W1N2', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W1N2', controller: { id: 'fallback', my: false } as StructureController },
+      claimController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(getObjectById).toHaveBeenCalledWith('controller1');
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('ignores incomplete territory memory without throwing', () => {
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1' },
+      room: { name: 'W1N1' },
+      moveTo: jest.fn(),
+      reserveController: jest.fn(),
+      claimController: jest.fn()
+    } as unknown as Creep;
+
+    expect(() => runTerritoryControllerCreep(creep)).not.toThrow();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.claimController).not.toHaveBeenCalled();
+  });
+});

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -80,6 +80,88 @@ describe('runTerritoryControllerCreep', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
+  it('suppresses a claim assignment when the target room has no controller', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 506,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 500
+          }
+        ]
+      }
+    };
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim' } },
+      room: { name: 'W1N2' },
+      claimController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 506
+      }
+    ]);
+  });
+
+  it('suppresses a reserve assignment when the target room has no controller', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 507,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 500
+          }
+        ]
+      }
+    };
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2' },
+      reserveController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: 507
+      }
+    ]);
+  });
+
   it('suppresses a claim target and stops the creep assignment when claim is impossible', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 503,

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -6,8 +6,10 @@ describe('runTerritoryControllerCreep', () => {
       (x: number, y: number, roomName: string) => ({ x, y, roomName }) as RoomPosition
     ) as unknown as typeof RoomPosition;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 500,
       getObjectById: jest.fn().mockReturnValue(null)
     };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
   });
 
   it('moves toward the target room before touching the controller', () => {
@@ -42,7 +44,7 @@ describe('runTerritoryControllerCreep', () => {
   it('claims a configured controller id when claim action is requested', () => {
     const controller = { id: 'controller1', my: false } as StructureController;
     const getObjectById = jest.fn().mockReturnValue(controller);
-    (globalThis as unknown as { Game: Partial<Game> }).Game = { getObjectById };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { time: 502, getObjectById };
     const creep = {
       memory: {
         role: 'claimer',
@@ -59,6 +61,68 @@ describe('runTerritoryControllerCreep', () => {
     expect(getObjectById).toHaveBeenCalledWith('controller1');
     expect(creep.claimController).toHaveBeenCalledWith(controller);
     expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('moves a claimer into range without suppressing the target', () => {
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim' } },
+      room: { name: 'W1N2', controller },
+      claimController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'claim' });
+    expect(Memory.territory).toBeUndefined();
+  });
+
+  it('suppresses a claim target and stops the creep assignment when claim is impossible', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 503,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          null,
+          { colony: 'W9N9', targetRoom: 'W9N8', action: 'reserve', status: 'active', updatedAt: 400 },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 499
+          }
+        ] as unknown as TerritoryIntentMemory[]
+      }
+    };
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim' } },
+      room: { name: 'W1N2', controller },
+      claimController: jest.fn().mockReturnValue(-15),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      { colony: 'W9N9', targetRoom: 'W9N8', action: 'reserve', status: 'active', updatedAt: 400 },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 503
+      }
+    ]);
   });
 
   it('ignores incomplete territory memory without throwing', () => {


### PR DESCRIPTION
## Summary
- Adds territory claim/reserve planning and runner behavior for safe expansion intent.
- Gates claimer/reserver spawning behind home-room safety so local worker recovery is not starved.
- Adds deterministic Jest coverage for planner, runner, spawn/body interactions, role counts, and economy loop integration.
- Regenerates `prod/dist/main.js` via `npm run build`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (15 suites, 128 tests)
- `cd prod && npm run build`
- `git diff --check`

No secrets were touched.

Closes #115
