### PR TITLE
feat: pick up dropped energy before harvesting

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -200,9 +200,16 @@ function canSatisfyWorkerCapacity(creep) {
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
+var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
 function selectWorkerTask(creep) {
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
   if (carriedEnergy === 0) {
+    if (getFreeEnergyCapacity(creep) > 0) {
+      const droppedEnergy = selectDroppedEnergy(creep);
+      if (droppedEnergy) {
+        return { type: "pickup", targetId: droppedEnergy.id };
+      }
+    }
     const source = selectHarvestSource(creep);
     return source ? { type: "harvest", targetId: source.id } : null;
   }
@@ -288,10 +295,36 @@ function getUsedEnergy(creep) {
   var _a, _b, _c;
   return (_c = (_b = (_a = creep.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY)) != null ? _c : 0;
 }
+function getFreeEnergyCapacity(creep) {
+  var _a, _b, _c;
+  return (_c = (_b = (_a = creep.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY)) != null ? _c : 0;
+}
 function isUpgradingController(creep, controller) {
   var _a;
   const task = (_a = creep.memory) == null ? void 0 : _a.task;
   return (task == null ? void 0 : task.type) === "upgrade" && task.targetId === controller.id;
+}
+function selectDroppedEnergy(creep) {
+  const droppedEnergy = findDroppedResources(creep.room).filter(isUsefulDroppedEnergy);
+  if (droppedEnergy.length === 0) {
+    return null;
+  }
+  const closestDroppedEnergy = findClosestByRange(creep, droppedEnergy);
+  return closestDroppedEnergy != null ? closestDroppedEnergy : droppedEnergy[0];
+}
+function findDroppedResources(room) {
+  if (typeof FIND_DROPPED_RESOURCES !== "number") {
+    return [];
+  }
+  return room.find(FIND_DROPPED_RESOURCES);
+}
+function isUsefulDroppedEnergy(resource) {
+  return resource.resourceType === RESOURCE_ENERGY && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
+}
+function findClosestByRange(creep, resources) {
+  var _a, _b;
+  const position = creep.pos;
+  return (_b = (_a = position == null ? void 0 : position.findClosestByRange) == null ? void 0 : _a.call(position, resources)) != null ? _b : null;
 }
 function selectHarvestSource(creep) {
   var _a, _b;
@@ -389,7 +422,7 @@ function shouldReplaceTask(creep, task) {
   }
   const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
   const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
-  if (task.type === "harvest") {
+  if (task.type === "harvest" || task.type === "pickup") {
     return freeEnergyCapacity === 0;
   }
   return usedEnergy === 0;
@@ -413,6 +446,8 @@ function executeTask(creep, task, target) {
   switch (task.type) {
     case "harvest":
       return creep.harvest(target);
+    case "pickup":
+      return creep.pickup(target);
     case "transfer":
       return creep.transfer(target, RESOURCE_ENERGY);
     case "build":

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -59,7 +59,7 @@ function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
   const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
   const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
 
-  if (task.type === 'harvest') {
+  if (task.type === 'harvest' || task.type === 'pickup') {
     return freeEnergyCapacity === 0;
   }
 
@@ -80,14 +80,23 @@ function shouldPreemptRcl2UpgradeTask(creep: Creep, task: CreepTaskMemory): bool
   return nextTask !== null && (nextTask.type !== task.type || nextTask.targetId !== task.targetId);
 }
 
-function shouldReplaceTarget(task: CreepTaskMemory, target: Source | AnyStoreStructure | ConstructionSite | StructureController): boolean {
+function shouldReplaceTarget(
+  task: CreepTaskMemory,
+  target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController
+): boolean {
   return task.type === 'transfer' && 'store' in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0;
 }
 
-function executeTask(creep: Creep, task: CreepTaskMemory, target: Source | AnyStoreStructure | ConstructionSite | StructureController): ScreepsReturnCode {
+function executeTask(
+  creep: Creep,
+  task: CreepTaskMemory,
+  target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController
+): ScreepsReturnCode {
   switch (task.type) {
     case 'harvest':
       return creep.harvest(target as Source);
+    case 'pickup':
+      return creep.pickup(target as Resource<ResourceConstant>);
     case 'transfer':
       return creep.transfer(target as AnyStoreStructure, RESOURCE_ENERGY);
     case 'build':

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1,11 +1,19 @@
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
+const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
 
   if (carriedEnergy === 0) {
+    if (getFreeEnergyCapacity(creep) > 0) {
+      const droppedEnergy = selectDroppedEnergy(creep);
+      if (droppedEnergy) {
+        return { type: 'pickup', targetId: droppedEnergy.id };
+      }
+    }
+
     const source = selectHarvestSource(creep);
     return source ? { type: 'harvest', targetId: source.id } : null;
   }
@@ -126,9 +134,45 @@ function getUsedEnergy(creep: Creep): number {
   return creep.store?.getUsedCapacity?.(RESOURCE_ENERGY) ?? 0;
 }
 
+function getFreeEnergyCapacity(creep: Creep): number {
+  return creep.store?.getFreeCapacity?.(RESOURCE_ENERGY) ?? 0;
+}
+
 function isUpgradingController(creep: Creep, controller: StructureController): boolean {
   const task = creep.memory?.task as Partial<CreepTaskMemory> | undefined;
   return task?.type === 'upgrade' && task.targetId === controller.id;
+}
+
+function selectDroppedEnergy(creep: Creep): Resource<RESOURCE_ENERGY> | null {
+  const droppedEnergy = findDroppedResources(creep.room).filter(isUsefulDroppedEnergy);
+  if (droppedEnergy.length === 0) {
+    return null;
+  }
+
+  const closestDroppedEnergy = findClosestByRange(creep, droppedEnergy);
+  return closestDroppedEnergy ?? droppedEnergy[0];
+}
+
+function findDroppedResources(room: Room): Resource[] {
+  if (typeof FIND_DROPPED_RESOURCES !== 'number') {
+    return [];
+  }
+
+  return room.find(FIND_DROPPED_RESOURCES);
+}
+
+function isUsefulDroppedEnergy(resource: Resource): resource is Resource<RESOURCE_ENERGY> {
+  return resource.resourceType === RESOURCE_ENERGY && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
+}
+
+function findClosestByRange(creep: Creep, resources: Resource<RESOURCE_ENERGY>[]): Resource<RESOURCE_ENERGY> | null {
+  const position = (creep as Creep & {
+    pos?: {
+      findClosestByRange?: (objects: Resource<RESOURCE_ENERGY>[]) => Resource<RESOURCE_ENERGY> | null;
+    };
+  }).pos;
+
+  return position?.findClosestByRange?.(resources) ?? null;
 }
 
 function selectHarvestSource(creep: Creep): Source | null {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -15,6 +15,7 @@ declare global {
 
   type CreepTaskMemory =
     | { type: 'harvest'; targetId: Id<Source> }
+    | { type: 'pickup'; targetId: Id<Resource<ResourceConstant>> }
     | { type: 'transfer'; targetId: Id<AnyStoreStructure> }
     | { type: 'build'; targetId: Id<ConstructionSite> }
     | { type: 'upgrade'; targetId: Id<StructureController> };

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -3,12 +3,13 @@ import { CONTROLLER_DOWNGRADE_GUARD_TICKS } from '../src/tasks/workerTasks';
 
 describe('runWorker', () => {
   beforeEach(() => {
-    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant }).ERR_NOT_IN_RANGE = -9;
+    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant }).ERR_NOT_IN_RANGE = -9;
     (globalThis as unknown as { ERR_FULL: number }).ERR_FULL = -8;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
+    (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
   });
@@ -95,6 +96,27 @@ describe('runWorker', () => {
 
     expect(creep.harvest).toHaveBeenCalledWith(source);
     expect(creep.moveTo).toHaveBeenCalledWith(source);
+  });
+
+  it('picks up dropped energy and moves when not in range', () => {
+    const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
+    const creep = {
+      memory: { task: { type: 'pickup', targetId: 'drop1' as Id<Resource<ResourceConstant>> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pickup: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(droppedEnergy)
+    };
+
+    runWorker(creep);
+
+    expect(creep.pickup).toHaveBeenCalledWith(droppedEnergy);
+    expect(creep.moveTo).toHaveBeenCalledWith(droppedEnergy);
   });
 
   it('transfers energy to a transfer target and moves when not in range', () => {
@@ -332,6 +354,7 @@ describe('runWorker', () => {
 
   it.each([
     { type: 'harvest', targetId: 'missing-source' as Id<Source> },
+    { type: 'pickup', targetId: 'missing-drop' as Id<Resource<ResourceConstant>> },
     { type: 'transfer', targetId: 'missing-transfer' as Id<AnyStoreStructure> },
     { type: 'build', targetId: 'missing-site' as Id<ConstructionSite> },
     { type: 'upgrade', targetId: 'missing-controller' as Id<StructureController> }
@@ -346,6 +369,7 @@ describe('runWorker', () => {
         },
         room: { find: jest.fn().mockReturnValue([]) },
         harvest: jest.fn(),
+        pickup: jest.fn(),
         build: jest.fn(),
         transfer: jest.fn(),
         upgradeController: jest.fn(),
@@ -359,6 +383,7 @@ describe('runWorker', () => {
       expect(getObjectById).toHaveBeenCalledWith(task.targetId);
       expect(creep.memory.task).toBeUndefined();
       expect(creep.harvest).not.toHaveBeenCalled();
+      expect(creep.pickup).not.toHaveBeenCalled();
       expect(creep.build).not.toHaveBeenCalled();
       expect(creep.transfer).not.toHaveBeenCalled();
       expect(creep.upgradeController).not.toHaveBeenCalled();

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -14,9 +14,10 @@ function setGameCreeps(creeps: Record<string, Creep>): void {
 
 describe('selectWorkerTask', () => {
   beforeEach(() => {
-    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
+    (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
@@ -31,6 +32,67 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('selects nearby useful dropped energy before harvesting when worker has free capacity', () => {
+    const farDroppedEnergy = { id: 'drop-far', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
+    const nearDroppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
+    const source = { id: 'source1' } as Source;
+    const findClosestByRange = jest.fn().mockReturnValue(nearDroppedEnergy);
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [farDroppedEnergy, nearDroppedEnergy];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { findClosestByRange },
+      room: { find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
+    expect(findClosestByRange).toHaveBeenCalledWith([farDroppedEnergy, nearDroppedEnergy]);
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('ignores non-energy and trivial dropped resources before falling back to balanced harvesting', () => {
+    const source1 = { id: 'source1' } as Source;
+    const source2 = { id: 'source2' } as Source;
+    const droppedMineral = { id: 'drop-mineral', resourceType: 'H' as ResourceConstant, amount: 100 } as Resource<ResourceConstant>;
+    const zeroEnergy = { id: 'drop-zero', resourceType: 'energy', amount: 0 } as Resource<ResourceConstant>;
+    const trivialEnergy = { id: 'drop-trivial', resourceType: 'energy', amount: 1 } as Resource<ResourceConstant>;
+    const room = {
+      name: 'W1N1',
+      find: jest.fn((type: number) => {
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [droppedMineral, zeroEnergy, trivialEnergy];
+        }
+
+        return type === FIND_SOURCES ? [source1, source2] : [];
+      })
+    } as unknown as Room;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        Assigned: {
+          memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+          room
+        } as unknown as Creep
+      }
+    };
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
   it('selects the least-assigned harvest source for same-room workers', () => {


### PR DESCRIPTION
## Summary
- Adds dropped-energy pickup selection before harvesting for workers with free capacity.
- Ignores non-energy and trivial dropped resources, preserving source-balanced harvest fallback.
- Extends worker task and runner tests and regenerates `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (13 suites, 117 tests)
- `cd prod && npm run build`
- `git diff --check`

No secrets were touched.

Closes #116
