### PR TITLE
feat: preserve extension planner walkways

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -129,7 +129,8 @@ function createPlannerLookups(room, anchor) {
   const bounds = getScanBounds(anchor);
   return {
     terrain: Game.map.getRoomTerrain(room.name),
-    blockingPositions: getBlockingPositions(room, bounds)
+    blockingPositions: getBlockingPositions(room, bounds),
+    reservedWalkwayPositions: getReservedWalkwayPositions(anchor)
   };
 }
 function getScanBounds(anchor) {
@@ -156,6 +157,9 @@ function canPlaceExtension(lookups, anchorParity, position) {
   if (position.x < ROOM_EDGE_MIN || position.x > ROOM_EDGE_MAX || position.y < ROOM_EDGE_MIN || position.y > ROOM_EDGE_MAX) {
     return false;
   }
+  if (lookups.reservedWalkwayPositions.has(getPositionKey(position))) {
+    return false;
+  }
   if (getPositionParity(position) !== anchorParity) {
     return false;
   }
@@ -163,6 +167,19 @@ function canPlaceExtension(lookups, anchorParity, position) {
     return false;
   }
   return !lookups.blockingPositions.has(getPositionKey(position));
+}
+function getReservedWalkwayPositions(anchor) {
+  return new Set(
+    [
+      { x: anchor.x, y: anchor.y - 1 },
+      { x: anchor.x + 1, y: anchor.y },
+      { x: anchor.x, y: anchor.y + 1 },
+      { x: anchor.x - 1, y: anchor.y }
+    ].filter((position) => isWithinRoomBounds(position)).map(getPositionKey)
+  );
+}
+function isWithinRoomBounds(position) {
+  return position.x >= ROOM_EDGE_MIN && position.x <= ROOM_EDGE_MAX && position.y >= ROOM_EDGE_MIN && position.y <= ROOM_EDGE_MAX;
 }
 function getPositionParity(position) {
   return (position.x + position.y) % 2;

--- a/prod/src/construction/extensionPlanner.ts
+++ b/prod/src/construction/extensionPlanner.ts
@@ -30,6 +30,7 @@ interface ScanBounds {
 interface PlannerLookups {
   terrain: RoomTerrain;
   blockingPositions: Set<string>;
+  reservedWalkwayPositions: Set<string>;
 }
 
 export function planExtensionConstruction(colony: ColonySnapshot): ScreepsReturnCode | null {
@@ -106,7 +107,8 @@ function createPlannerLookups(room: Room, anchor: RoomPosition): PlannerLookups 
 
   return {
     terrain: Game.map.getRoomTerrain(room.name),
-    blockingPositions: getBlockingPositions(room, bounds)
+    blockingPositions: getBlockingPositions(room, bounds),
+    reservedWalkwayPositions: getReservedWalkwayPositions(anchor)
   };
 }
 
@@ -140,6 +142,10 @@ function canPlaceExtension(lookups: PlannerLookups, anchorParity: number, positi
     return false;
   }
 
+  if (lookups.reservedWalkwayPositions.has(getPositionKey(position))) {
+    return false;
+  }
+
   if (getPositionParity(position) !== anchorParity) {
     return false;
   }
@@ -149,6 +155,28 @@ function canPlaceExtension(lookups: PlannerLookups, anchorParity: number, positi
   }
 
   return !lookups.blockingPositions.has(getPositionKey(position));
+}
+
+function getReservedWalkwayPositions(anchor: RoomPosition): Set<string> {
+  return new Set(
+    [
+      { x: anchor.x, y: anchor.y - 1 },
+      { x: anchor.x + 1, y: anchor.y },
+      { x: anchor.x, y: anchor.y + 1 },
+      { x: anchor.x - 1, y: anchor.y }
+    ]
+      .filter((position) => isWithinRoomBounds(position))
+      .map(getPositionKey)
+  );
+}
+
+function isWithinRoomBounds(position: CandidatePosition): boolean {
+  return (
+    position.x >= ROOM_EDGE_MIN &&
+    position.x <= ROOM_EDGE_MAX &&
+    position.y >= ROOM_EDGE_MIN &&
+    position.y <= ROOM_EDGE_MAX
+  );
 }
 
 function getPositionParity(position: CandidatePosition): number {

--- a/prod/test/extensionPlanner.test.ts
+++ b/prod/test/extensionPlanner.test.ts
@@ -87,6 +87,23 @@ describe('extension construction planner', () => {
     expect((Game.map.getRoomTerrain as jest.Mock).mock.calls).toHaveLength(1);
   });
 
+  it('continues scanning when the nearby extension ring is blocked', () => {
+    const { room, colony } = makeColony({
+      controllerLevel: 2,
+      wallPositions: new Set(['26,26']),
+      structures: [
+        makeExtension('existing-at-first-candidate', { x: 24, y: 24 }),
+        makeExtension('existing-at-second-candidate', { x: 26, y: 24 })
+      ],
+      constructionSites: [makeExtensionSite('pending-at-third-candidate', { x: 24, y: 26 })]
+    });
+
+    expect(planExtensionConstruction(colony)).toBe(0);
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(23, 23, STRUCTURE_EXTENSION);
+  });
+
   it('keeps adjacent cardinal paths open while filling RCL2 extension sites', () => {
     const { room, colony } = makeColony({ controllerLevel: 2 });
 


### PR DESCRIPTION
## Summary
- Preserves direct cardinal-adjacent walkways around the extension planner anchor so early workers keep traffic lanes.
- Keeps deterministic extension placement while continuing to scan outward when nearby valid-looking positions are blocked.
- Adds extension planner coverage for blocked nearby rings and regenerates `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (13 suites, 118 tests)
- `cd prod && npm run build`
- `git diff --check`

No secrets were touched.

Closes #119
