### PR TITLE
feat: avoid depleted harvest sources

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -349,10 +349,11 @@ function selectHarvestSource(creep) {
   if (sources.length === 0) {
     return null;
   }
-  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, sources);
-  let selectedSource = sources[0];
+  const viableSources = selectViableHarvestSources(sources);
+  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
+  let selectedSource = viableSources[0];
   let selectedCount = (_a = assignmentCounts.get(selectedSource.id)) != null ? _a : 0;
-  for (const source of sources.slice(1)) {
+  for (const source of viableSources.slice(1)) {
     const count = (_b = assignmentCounts.get(source.id)) != null ? _b : 0;
     if (count < selectedCount) {
       selectedSource = source;
@@ -360,6 +361,10 @@ function selectHarvestSource(creep) {
     }
   }
   return selectedSource;
+}
+function selectViableHarvestSources(sources) {
+  const sourcesWithEnergy = sources.filter((source) => typeof source.energy === "number" && source.energy > 0);
+  return sourcesWithEnergy.length > 0 ? sourcesWithEnergy : sources;
 }
 function countSameRoomWorkerHarvestAssignments(roomName, sources) {
   var _a, _b, _c, _d;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -181,12 +181,13 @@ function selectHarvestSource(creep: Creep): Source | null {
     return null;
   }
 
-  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, sources);
-  let selectedSource = sources[0];
+  const viableSources = selectViableHarvestSources(sources);
+  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
+  let selectedSource = viableSources[0];
   let selectedCount = assignmentCounts.get(selectedSource.id) ?? 0;
 
   // Ties intentionally keep room.find(FIND_SOURCES) order stable.
-  for (const source of sources.slice(1)) {
+  for (const source of viableSources.slice(1)) {
     const count = assignmentCounts.get(source.id) ?? 0;
     if (count < selectedCount) {
       selectedSource = source;
@@ -195,6 +196,11 @@ function selectHarvestSource(creep: Creep): Source | null {
   }
 
   return selectedSource;
+}
+
+function selectViableHarvestSources(sources: Source[]): Source[] {
+  const sourcesWithEnergy = sources.filter((source) => typeof source.energy === 'number' && source.energy > 0);
+  return sourcesWithEnergy.length > 0 ? sourcesWithEnergy : sources;
 }
 
 function countSameRoomWorkerHarvestAssignments(roomName: string | undefined, sources: Source[]): Map<Id<Source>, number> {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -130,7 +130,60 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
-  it('keeps room.find source order as the stable tie-breaker', () => {
+  it('avoids depleted harvest sources when another source has energy', () => {
+    const depletedSource = { id: 'source-empty', energy: 0 } as Source;
+    const viableSource = { id: 'source-full', energy: 300 } as Source;
+    const room = {
+      name: 'W1N1',
+      find: jest.fn().mockReturnValue([depletedSource, viableSource])
+    } as unknown as Room;
+    setGameCreeps({
+      Assigned: {
+        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source-full' as Id<Source> } },
+        room
+      } as unknown as Creep
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-full' });
+  });
+
+  it('keeps room.find source order as the stable tie-breaker for viable sources', () => {
+    const source2 = { id: 'source2', energy: 100 } as Source;
+    const source1 = { id: 'source1', energy: 100 } as Source;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room: { name: 'W1N1', find: jest.fn().mockReturnValue([source2, source1]) }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
+  });
+
+  it('falls back deterministically when all sources are empty', () => {
+    const source1 = { id: 'source1', energy: 0 } as Source;
+    const source2 = { id: 'source2', energy: 0 } as Source;
+    const room = {
+      name: 'W1N1',
+      find: jest.fn().mockReturnValue([source1, source2])
+    } as unknown as Room;
+    setGameCreeps({
+      Assigned: {
+        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+        room
+      } as unknown as Creep
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
+  });
+
+  it('keeps room.find source order as the stable fallback when source energy is unknown', () => {
     const source2 = { id: 'source2' } as Source;
     const source1 = { id: 'source1' } as Source;
     const creep = {


### PR DESCRIPTION
## Summary
- Makes worker harvest target selection skip depleted sources when at least one source still has energy.
- Preserves deterministic assignment balancing among viable sources.
- Falls back to stable source-order/assignment behavior when all sources are depleted or energy is unavailable in mocks.

## Linked issue
Fixes #122

## Roadmap category
Gameplay Evolution / resources-economy

## Served vision layer
Resources/economy: avoids sending workers to empty harvest sources while usable energy remains elsewhere, improving early-room energy collection and throughput.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (121 tests)
- [x] `cd prod && npm run build`

## Notes
- Codex-authored commit: `d8738cf lanyusea's bot <lanyusea@gmail.com> feat: avoid depleted harvest sources`
- No secrets included.
- Requires independent QA PASS, green checks/reviews, no active review threads, current Project fields, and >=15 minute elapsed review gate before merge.
