### PR TITLE
feat: repair early roads when workers are idle

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -258,6 +258,10 @@ function selectWorkerTask(creep) {
   if (constructionSites[0]) {
     return { type: "build", targetId: constructionSites[0].id };
   }
+  const repairTarget = selectRepairTarget(creep);
+  if (repairTarget) {
+    return { type: "repair", targetId: repairTarget.id };
+  }
   if (controller == null ? void 0 : controller.my) {
     return { type: "upgrade", targetId: controller.id };
   }
@@ -276,6 +280,50 @@ function matchesStructureType(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+function selectRepairTarget(creep) {
+  var _a;
+  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
+    return null;
+  }
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+function findVisibleRoomStructures(room) {
+  if (typeof FIND_STRUCTURES !== "number") {
+    return [];
+  }
+  return room.find(FIND_STRUCTURES);
+}
+function isSafeRepairTarget(structure) {
+  if (structure.hits >= structure.hitsMax) {
+    return false;
+  }
+  if (matchesStructureType(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+    return true;
+  }
+  return matchesStructureType(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+}
+function isOwnedRampart(structure) {
+  return structure.my === true;
+}
+function compareRepairTargets(left, right) {
+  return getRepairPriority(left) - getRepairPriority(right) || getHitsRatio(left) - getHitsRatio(right) || left.hits - right.hits || String(left.id).localeCompare(String(right.id));
+}
+function getRepairPriority(structure) {
+  if (matchesStructureType(structure.structureType, "STRUCTURE_ROAD", "road")) {
+    return 0;
+  }
+  if (matchesStructureType(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+    return 1;
+  }
+  return 2;
+}
+function getHitsRatio(structure) {
+  return structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
 }
 function shouldGuardControllerDowngrade(controller) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
@@ -404,7 +452,7 @@ function runWorker(creep) {
     assignNextTask(creep);
     return;
   }
-  if (shouldPreemptRcl2UpgradeTask(creep, creep.memory.task)) {
+  if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
     return;
@@ -449,20 +497,26 @@ function shouldReplaceTask(creep, task) {
   }
   return usedEnergy === 0;
 }
-function shouldPreemptRcl2UpgradeTask(creep, task) {
+function shouldPreemptUpgradeTask(creep, task) {
   var _a;
   if (task.type !== "upgrade") {
     return false;
   }
   const controller = (_a = creep.room) == null ? void 0 : _a.controller;
-  if ((controller == null ? void 0 : controller.my) !== true || controller.level !== 2) {
+  if ((controller == null ? void 0 : controller.my) !== true) {
     return false;
   }
   const nextTask = selectWorkerTask(creep);
-  return nextTask !== null && (nextTask.type !== task.type || nextTask.targetId !== task.targetId);
+  if (nextTask === null || nextTask.type === task.type && nextTask.targetId === task.targetId) {
+    return false;
+  }
+  return nextTask.type === "repair" || controller.level === 2;
 }
 function shouldReplaceTarget(task, target) {
-  return task.type === "transfer" && "store" in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0;
+  if (task.type === "transfer" && "store" in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
+    return true;
+  }
+  return task.type === "repair" && "hits" in target && target.hits >= target.hitsMax;
 }
 function executeTask(creep, task, target) {
   switch (task.type) {
@@ -474,6 +528,8 @@ function executeTask(creep, task, target) {
       return creep.transfer(target, RESOURCE_ENERGY);
     case "build":
       return creep.build(target);
+    case "repair":
+      return creep.repair(target);
     case "upgrade":
       return creep.upgradeController(target);
   }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -216,6 +216,7 @@ function canSatisfyWorkerCapacity(creep) {
 
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
+var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
 function selectWorkerTask(creep) {
@@ -299,13 +300,22 @@ function findVisibleRoomStructures(room) {
   return room.find(FIND_STRUCTURES);
 }
 function isSafeRepairTarget(structure) {
-  if (structure.hits >= structure.hitsMax) {
+  if (isWorkerRepairTargetComplete(structure)) {
     return false;
   }
   if (matchesStructureType(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
     return true;
   }
   return matchesStructureType(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+}
+function isWorkerRepairTargetComplete(structure) {
+  return structure.hits >= getWorkerRepairHitsCeiling(structure);
+}
+function getWorkerRepairHitsCeiling(structure) {
+  if (matchesStructureType(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
+    return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING);
+  }
+  return structure.hitsMax;
 }
 function isOwnedRampart(structure) {
   return structure.my === true;
@@ -510,13 +520,13 @@ function shouldPreemptUpgradeTask(creep, task) {
   if (nextTask === null || nextTask.type === task.type && nextTask.targetId === task.targetId) {
     return false;
   }
-  return nextTask.type === "repair" || controller.level === 2;
+  return true;
 }
 function shouldReplaceTarget(task, target) {
   if (task.type === "transfer" && "store" in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
     return true;
   }
-  return task.type === "repair" && "hits" in target && target.hits >= target.hitsMax;
+  return task.type === "repair" && "hits" in target && isWorkerRepairTargetComplete(target);
 }
 function executeTask(creep, task, target) {
   switch (task.type) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -12,7 +12,7 @@ export function runWorker(creep: Creep): void {
     return;
   }
 
-  if (shouldPreemptRcl2UpgradeTask(creep, creep.memory.task)) {
+  if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
     return;
@@ -66,31 +66,39 @@ function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
   return usedEnergy === 0;
 }
 
-function shouldPreemptRcl2UpgradeTask(creep: Creep, task: CreepTaskMemory): boolean {
+function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean {
   if (task.type !== 'upgrade') {
     return false;
   }
 
   const controller = creep.room?.controller;
-  if (controller?.my !== true || controller.level !== 2) {
+  if (controller?.my !== true) {
     return false;
   }
 
   const nextTask = selectWorkerTask(creep);
-  return nextTask !== null && (nextTask.type !== task.type || nextTask.targetId !== task.targetId);
+  if (nextTask === null || (nextTask.type === task.type && nextTask.targetId === task.targetId)) {
+    return false;
+  }
+
+  return nextTask.type === 'repair' || controller.level === 2;
 }
 
 function shouldReplaceTarget(
   task: CreepTaskMemory,
-  target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController
+  target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController | Structure
 ): boolean {
-  return task.type === 'transfer' && 'store' in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0;
+  if (task.type === 'transfer' && 'store' in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
+    return true;
+  }
+
+  return task.type === 'repair' && 'hits' in target && target.hits >= target.hitsMax;
 }
 
 function executeTask(
   creep: Creep,
   task: CreepTaskMemory,
-  target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController
+  target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController | Structure
 ): ScreepsReturnCode {
   switch (task.type) {
     case 'harvest':
@@ -101,6 +109,8 @@ function executeTask(
       return creep.transfer(target as AnyStoreStructure, RESOURCE_ENERGY);
     case 'build':
       return creep.build(target as ConstructionSite);
+    case 'repair':
+      return creep.repair(target as Structure);
     case 'upgrade':
       return creep.upgradeController(target as StructureController);
   }

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1,4 +1,4 @@
-import { selectWorkerTask } from '../tasks/workerTasks';
+import { isWorkerRepairTargetComplete, selectWorkerTask } from '../tasks/workerTasks';
 
 export function runWorker(creep: Creep): void {
   if (!creep.memory.task) {
@@ -81,7 +81,7 @@ function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean 
     return false;
   }
 
-  return nextTask.type === 'repair' || controller.level === 2;
+  return true;
 }
 
 function shouldReplaceTarget(
@@ -92,7 +92,7 @@ function shouldReplaceTarget(
     return true;
   }
 
-  return task.type === 'repair' && 'hits' in target && target.hits >= target.hitsMax;
+  return task.type === 'repair' && 'hits' in target && isWorkerRepairTargetComplete(target);
 }
 
 function executeTask(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1,5 +1,6 @@
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
+export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
 
@@ -118,7 +119,7 @@ function findVisibleRoomStructures(room: Room): AnyStructure[] {
 }
 
 function isSafeRepairTarget(structure: AnyStructure): structure is RepairableWorkerStructure {
-  if (structure.hits >= structure.hitsMax) {
+  if (isWorkerRepairTargetComplete(structure)) {
     return false;
   }
 
@@ -132,7 +133,19 @@ function isSafeRepairTarget(structure: AnyStructure): structure is RepairableWor
   return matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') && isOwnedRampart(structure);
 }
 
-function isOwnedRampart(structure: AnyStructure): structure is StructureRampart {
+export function isWorkerRepairTargetComplete(structure: Structure): boolean {
+  return structure.hits >= getWorkerRepairHitsCeiling(structure);
+}
+
+function getWorkerRepairHitsCeiling(structure: Structure): number {
+  if (matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') && isOwnedRampart(structure)) {
+    return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING);
+  }
+
+  return structure.hitsMax;
+}
+
+function isOwnedRampart(structure: Structure): structure is StructureRampart {
   return (structure as Partial<StructureRampart>).my === true;
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3,6 +3,8 @@ export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
 
+type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
+
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
 
@@ -53,6 +55,11 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'build', targetId: constructionSites[0].id };
   }
 
+  const repairTarget = selectRepairTarget(creep);
+  if (repairTarget) {
+    return { type: 'repair', targetId: repairTarget.id as Id<Structure> };
+  }
+
   if (controller?.my) {
     return { type: 'upgrade', targetId: controller.id };
   }
@@ -77,11 +84,81 @@ function isExtensionConstructionSite(site: ConstructionSite): boolean {
   return matchesStructureType(site.structureType, 'STRUCTURE_EXTENSION', 'extension');
 }
 
-type StructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION';
+type StructureConstantGlobal =
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_ROAD'
+  | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_RAMPART';
 
 function matchesStructureType(actual: string | undefined, globalName: StructureConstantGlobal, fallback: string): boolean {
   const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, string>>;
   return actual === (constants[globalName] ?? fallback);
+}
+
+function selectRepairTarget(creep: Creep): RepairableWorkerStructure | null {
+  if (creep.room.controller?.my !== true) {
+    return null;
+  }
+
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+
+function findVisibleRoomStructures(room: Room): AnyStructure[] {
+  if (typeof FIND_STRUCTURES !== 'number') {
+    return [];
+  }
+
+  return room.find(FIND_STRUCTURES);
+}
+
+function isSafeRepairTarget(structure: AnyStructure): structure is RepairableWorkerStructure {
+  if (structure.hits >= structure.hitsMax) {
+    return false;
+  }
+
+  if (
+    matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')
+  ) {
+    return true;
+  }
+
+  return matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') && isOwnedRampart(structure);
+}
+
+function isOwnedRampart(structure: AnyStructure): structure is StructureRampart {
+  return (structure as Partial<StructureRampart>).my === true;
+}
+
+function compareRepairTargets(left: RepairableWorkerStructure, right: RepairableWorkerStructure): number {
+  return (
+    getRepairPriority(left) - getRepairPriority(right) ||
+    getHitsRatio(left) - getHitsRatio(right) ||
+    left.hits - right.hits ||
+    String(left.id).localeCompare(String(right.id))
+  );
+}
+
+function getRepairPriority(structure: RepairableWorkerStructure): number {
+  if (matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road')) {
+    return 0;
+  }
+
+  if (matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')) {
+    return 1;
+  }
+
+  return 2;
+}
+
+function getHitsRatio(structure: Structure): number {
+  return structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
 }
 
 function shouldGuardControllerDowngrade(controller: StructureController | undefined): boolean {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -18,5 +18,6 @@ declare global {
     | { type: 'pickup'; targetId: Id<Resource<ResourceConstant>> }
     | { type: 'transfer'; targetId: Id<AnyStoreStructure> }
     | { type: 'build'; targetId: Id<ConstructionSite> }
+    | { type: 'repair'; targetId: Id<Structure> }
     | { type: 'upgrade'; targetId: Id<StructureController> };
 }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1,5 +1,5 @@
 import { runWorker } from '../src/creeps/workerRunner';
-import { CONTROLLER_DOWNGRADE_GUARD_TICKS } from '../src/tasks/workerTasks';
+import { CONTROLLER_DOWNGRADE_GUARD_TICKS, IDLE_RAMPART_REPAIR_HITS_CEILING } from '../src/tasks/workerTasks';
 
 describe('runWorker', () => {
   beforeEach(() => {
@@ -280,7 +280,7 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
-  it('preserves existing RCL3 upgrade execution for assigned upgrade tasks', () => {
+  it('preempts an RCL3 upgrade task for extension construction when downgrade is safe', () => {
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {
       id: 'controller1',
@@ -297,6 +297,38 @@ describe('runWorker', () => {
       room: {
         controller,
         find: jest.fn((type) => (type === FIND_CONSTRUCTION_SITES ? [site] : []))
+      },
+      upgradeController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'extension-site1' });
+    expect(Game.getObjectById).not.toHaveBeenCalled();
+    expect(creep.upgradeController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps an RCL3 upgrade task when selection still prefers the same controller', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        controller,
+        find: jest.fn().mockReturnValue([])
       },
       upgradeController: jest.fn().mockReturnValue(0),
       moveTo: jest.fn()
@@ -372,7 +404,7 @@ describe('runWorker', () => {
     expect(moveTo).not.toHaveBeenCalled();
   });
 
-  it('clears missing upgrade targets and reassigns without upgrading the stale target', () => {
+  it('reassigns stale upgrade tasks when selection chooses a different controller', () => {
     const controller = { id: 'controller2', my: true } as StructureController;
     const upgradeController = jest.fn();
     const moveTo = jest.fn();
@@ -393,7 +425,7 @@ describe('runWorker', () => {
 
     runWorker(creep);
 
-    expect(getObjectById).toHaveBeenCalledWith('missing');
+    expect(getObjectById).not.toHaveBeenCalled();
     expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller2' });
     expect(upgradeController).not.toHaveBeenCalled();
     expect(moveTo).not.toHaveBeenCalled();
@@ -425,6 +457,43 @@ describe('runWorker', () => {
     runWorker(creep);
 
     expect(getObjectById).toHaveBeenCalledWith('road-full');
+    expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'road-damaged' });
+    expect(repair).not.toHaveBeenCalled();
+    expect(moveTo).not.toHaveBeenCalled();
+  });
+
+  it('clears owned rampart repair targets at the idle ceiling and reassigns without repairing them', () => {
+    const rampart = {
+      id: 'rampart-ceiling',
+      structureType: 'rampart',
+      hits: IDLE_RAMPART_REPAIR_HITS_CEILING,
+      hitsMax: 300_000_000,
+      my: true
+    } as StructureRampart;
+    const damagedRoad = { id: 'road-damaged', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const repair = jest.fn();
+    const moveTo = jest.fn();
+    const creep = {
+      memory: { task: { type: 'repair', targetId: 'rampart-ceiling' as Id<Structure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        controller: { id: 'controller1', my: true } as StructureController,
+        find: jest.fn((type) => (type === FIND_STRUCTURES ? [rampart, damagedRoad] : []))
+      },
+      repair,
+      moveTo
+    } as unknown as Creep;
+    const getObjectById = jest.fn().mockReturnValue(rampart);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).toHaveBeenCalledWith('rampart-ceiling');
     expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'road-damaged' });
     expect(repair).not.toHaveBeenCalled();
     expect(moveTo).not.toHaveBeenCalled();

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -3,15 +3,19 @@ import { CONTROLLER_DOWNGRADE_GUARD_TICKS } from '../src/tasks/workerTasks';
 
 describe('runWorker', () => {
   beforeEach(() => {
-    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant }).ERR_NOT_IN_RANGE = -9;
+    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).ERR_NOT_IN_RANGE = -9;
     (globalThis as unknown as { ERR_FULL: number }).ERR_FULL = -8;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
     (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
+    (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
   });
 
   it('assigns a task when the creep has none', () => {
@@ -161,6 +165,31 @@ describe('runWorker', () => {
     expect(moveTo).toHaveBeenCalledWith(site);
   });
 
+  it('repairs an existing repair target and moves when not in range', () => {
+    const road = { id: 'road1', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const repair = jest.fn().mockReturnValue(-9);
+    const moveTo = jest.fn();
+    const getObjectById = jest.fn().mockReturnValue(road);
+    const creep = {
+      memory: { task: { type: 'repair', targetId: 'road1' as Id<Structure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      repair,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).toHaveBeenCalledWith('road1');
+    expect(repair).toHaveBeenCalledWith(road);
+    expect(moveTo).toHaveBeenCalledWith(road);
+  });
+
   it('upgrades an existing upgrade target and moves when not in range', () => {
     const controller = { id: 'controller1' } as StructureController;
     const upgradeController = jest.fn().mockReturnValue(-9);
@@ -283,6 +312,39 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts a low-value upgrade task for damaged road repair', () => {
+    const road = { id: 'road1', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_STRUCTURES ? [road] : []))
+      },
+      upgradeController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn()
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'road1' });
+    expect(Game.getObjectById).not.toHaveBeenCalled();
+    expect(creep.upgradeController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('clears missing build targets and reassigns without building the stale target', () => {
     const site = { id: 'site2' } as ConstructionSite;
     const build = jest.fn();
@@ -337,6 +399,37 @@ describe('runWorker', () => {
     expect(moveTo).not.toHaveBeenCalled();
   });
 
+  it('clears completed repair targets and reassigns without repairing the stale target', () => {
+    const fullRoad = { id: 'road-full', structureType: 'road', hits: 5_000, hitsMax: 5_000 } as StructureRoad;
+    const damagedRoad = { id: 'road-damaged', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;
+    const repair = jest.fn();
+    const moveTo = jest.fn();
+    const creep = {
+      memory: { task: { type: 'repair', targetId: 'road-full' as Id<Structure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        controller: { id: 'controller1', my: true } as StructureController,
+        find: jest.fn((type) => (type === FIND_STRUCTURES ? [fullRoad, damagedRoad] : []))
+      },
+      repair,
+      moveTo
+    } as unknown as Creep;
+    const getObjectById = jest.fn().mockReturnValue(fullRoad);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).toHaveBeenCalledWith('road-full');
+    expect(creep.memory.task).toEqual({ type: 'repair', targetId: 'road-damaged' });
+    expect(repair).not.toHaveBeenCalled();
+    expect(moveTo).not.toHaveBeenCalled();
+  });
+
   it('clears invalid task targets', () => {
     const creep = {
       memory: { task: { type: 'build', targetId: 'missing' as Id<ConstructionSite> } },
@@ -357,6 +450,7 @@ describe('runWorker', () => {
     { type: 'pickup', targetId: 'missing-drop' as Id<Resource<ResourceConstant>> },
     { type: 'transfer', targetId: 'missing-transfer' as Id<AnyStoreStructure> },
     { type: 'build', targetId: 'missing-site' as Id<ConstructionSite> },
+    { type: 'repair', targetId: 'missing-repair' as Id<Structure> },
     { type: 'upgrade', targetId: 'missing-controller' as Id<StructureController> }
   ] satisfies CreepTaskMemory[])(
     'clears stale $type task in a controllerless room without executing it',
@@ -371,6 +465,7 @@ describe('runWorker', () => {
         harvest: jest.fn(),
         pickup: jest.fn(),
         build: jest.fn(),
+        repair: jest.fn(),
         transfer: jest.fn(),
         upgradeController: jest.fn(),
         moveTo: jest.fn()
@@ -385,6 +480,7 @@ describe('runWorker', () => {
       expect(creep.harvest).not.toHaveBeenCalled();
       expect(creep.pickup).not.toHaveBeenCalled();
       expect(creep.build).not.toHaveBeenCalled();
+      expect(creep.repair).not.toHaveBeenCalled();
       expect(creep.transfer).not.toHaveBeenCalled();
       expect(creep.upgradeController).not.toHaveBeenCalled();
       expect(creep.moveTo).not.toHaveBeenCalled();

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1,4 +1,8 @@
-import { CONTROLLER_DOWNGRADE_GUARD_TICKS, selectWorkerTask } from '../src/tasks/workerTasks';
+import {
+  CONTROLLER_DOWNGRADE_GUARD_TICKS,
+  IDLE_RAMPART_REPAIR_HITS_CEILING,
+  selectWorkerTask
+} from '../src/tasks/workerTasks';
 
 function makeLoadedWorker(room: Room, task?: CreepTaskMemory): Creep {
   return {
@@ -619,6 +623,67 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-a' });
+  });
+
+  it('selects owned ramparts below the idle repair ceiling', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const rampart = makeStructure(
+      'rampart-low',
+      'rampart' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING - 1,
+      300_000_000,
+      { my: true }
+    );
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_STRUCTURES ? [rampart] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'rampart-low' });
+  });
+
+  it('skips owned ramparts at the idle repair ceiling without blocking container repair', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const rampart = makeStructure(
+      'rampart-ceiling',
+      'rampart' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING,
+      300_000_000,
+      { my: true }
+    );
+    const container = makeStructure('container-damaged', 'container' as StructureConstant, 1_000, 2_000);
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_STRUCTURES ? [rampart, container] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'container-damaged' });
+  });
+
+  it('falls back to upgrade when only owned ramparts above the idle repair ceiling are damaged', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const rampart = makeStructure(
+      'rampart-high',
+      'rampart' as StructureConstant,
+      IDLE_RAMPART_REPAIR_HITS_CEILING + 1,
+      300_000_000,
+      { my: true }
+    );
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_STRUCTURES ? [rampart] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('falls back to upgrade when no safe damaged repair targets exist', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -12,15 +12,29 @@ function setGameCreeps(creeps: Record<string, Creep>): void {
   (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps };
 }
 
+function makeStructure(
+  id: string,
+  structureType: StructureConstant,
+  hits: number,
+  hitsMax: number,
+  extra: Partial<StructureRampart> = {}
+): AnyStructure {
+  return { id, structureType, hits, hitsMax, ...extra } as unknown as AnyStructure;
+}
+
 describe('selectWorkerTask', () => {
   beforeEach(() => {
-    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
     (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
+    (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
     (globalThis as unknown as { Game?: Partial<Game> }).Game = { creeps: {} };
   });
 
@@ -573,7 +587,58 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
-  it('keeps carried-energy fallback order as transfer, build, then upgrade', () => {
+  it('selects damaged road repair before idle controller upgrading', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const fullRoad = makeStructure('road-full', 'road' as StructureConstant, 5_000, 5_000);
+    const damagedRoad = makeStructure('road-damaged', 'road' as StructureConstant, 3_000, 5_000);
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_STRUCTURES ? [fullRoad, damagedRoad] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-damaged' });
+  });
+
+  it('chooses repair targets deterministically and avoids hostile structures', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const hostileRampart = makeStructure('rampart-hostile', 'rampart' as StructureConstant, 100, 1_000, {
+      my: false
+    });
+    const damagedContainer = makeStructure('container-damaged', 'container' as StructureConstant, 100, 2_000);
+    const roadB = makeStructure('road-b', 'road' as StructureConstant, 2_500, 5_000);
+    const roadA = makeStructure('road-a', 'road' as StructureConstant, 2_500, 5_000);
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_STRUCTURES ? [hostileRampart, damagedContainer, roadB, roadA] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-a' });
+  });
+
+  it('falls back to upgrade when no safe damaged repair targets exist', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const fullRoad = makeStructure('road-full', 'road' as StructureConstant, 5_000, 5_000);
+    const hostileRampart = makeStructure('rampart-hostile', 'rampart' as StructureConstant, 100, 1_000, {
+      my: false
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        controller,
+        find: jest.fn((type) => (type === FIND_STRUCTURES ? [fullRoad, hostileRampart] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps carried-energy fallback order as transfer, build, repair, then upgrade', () => {
     const spawn = {
       id: 'spawn1',
       structureType: 'spawn',
@@ -586,6 +651,7 @@ describe('selectWorkerTask', () => {
     } as unknown as StructureSpawn;
     const site = { id: 'site1' } as ConstructionSite;
     const controller = { id: 'controller1', my: true } as StructureController;
+    const road = makeStructure('road-damaged', 'road' as StructureConstant, 3_000, 5_000);
     const makeCreep = (room: Room): Creep =>
       ({
         store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
@@ -614,6 +680,10 @@ describe('selectWorkerTask', () => {
         return type === 2 ? [site] : [];
       })
     } as unknown as Room;
+    const roomWithRepair = {
+      controller,
+      find: jest.fn((type: number) => (type === FIND_STRUCTURES ? [road] : []))
+    } as unknown as Room;
     const roomWithController = {
       controller,
       find: jest.fn().mockReturnValue([])
@@ -621,6 +691,7 @@ describe('selectWorkerTask', () => {
 
     expect(selectWorkerTask(makeCreep(roomWithSink))).toEqual({ type: 'transfer', targetId: 'spawn1' });
     expect(selectWorkerTask(makeCreep(roomWithSite))).toEqual({ type: 'build', targetId: 'site1' });
+    expect(selectWorkerTask(makeCreep(roomWithRepair))).toEqual({ type: 'repair', targetId: 'road-damaged' });
     expect(selectWorkerTask(makeCreep(roomWithController))).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 


### PR DESCRIPTION
## Summary
- Adds idle-worker repair selection for early roads/containers/owned ramparts after higher-priority spawn, controller, extension, build, and upgrade work.
- Replaces completed/stale repair tasks so workers return to productive work instead of staying on repaired targets.
- Regenerates `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (13 suites, 128 tests)
- `cd prod && npm run build`

## Safety
- No secrets added.
- Untracked `prod/node_modules` was not staged.

Closes #124
