### PR TITLE
feat: seed adjacent territory targets

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -683,6 +683,9 @@ function selectTerritoryTarget(colonyName) {
   if (configuredTarget) {
     return { target: configuredTarget, seeded: false };
   }
+  if (hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName)) {
+    return null;
+  }
   const seededTarget = seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
   return seededTarget ? { target: seededTarget, seeded: true } : null;
 }
@@ -697,6 +700,9 @@ function selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents) {
     }
   }
   return null;
+}
+function hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName) {
+  return getConfiguredTargetRoomsForColony(territoryMemory, colonyName).size > 0;
 }
 function seedAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   const adjacentRooms = getAdjacentRoomNames(colonyName);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1110,6 +1110,9 @@ function isTerritoryIntentSuppressed(colony, targetRoom, action) {
   );
 }
 function isVisibleTerritoryTargetUnavailable(targetRoom, controllerId) {
+  if (isVisibleRoomMissingController(targetRoom)) {
+    return true;
+  }
   const controller = getVisibleController(targetRoom, controllerId);
   if (!controller) {
     return false;
@@ -1119,6 +1122,12 @@ function isVisibleTerritoryTargetUnavailable(targetRoom, controllerId) {
 function isVisibleTerritoryTargetReserved(targetRoom) {
   var _a;
   return ((_a = getVisibleController(targetRoom)) == null ? void 0 : _a.reservation) != null;
+}
+function isVisibleRoomMissingController(targetRoom) {
+  var _a;
+  const game = globalThis.Game;
+  const room = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom];
+  return room != null && room.controller == null;
 }
 function isControllerOwned(controller) {
   return controller.owner != null || controller.my === true;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -608,10 +608,11 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
   }
-  const target = selectTerritoryTarget(colony.room.name);
-  if (!target) {
+  const selection = selectTerritoryTarget(colony.room.name);
+  if (!selection) {
     return null;
   }
+  const target = selection.target;
   const plan = {
     colony: colony.room.name,
     targetRoom: target.roomName,
@@ -619,7 +620,7 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
     ...target.controllerId ? { controllerId: target.controllerId } : {}
   };
   const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) > 0 ? "active" : "planned";
-  recordTerritoryIntent(plan, status, gameTime);
+  recordTerritoryIntent(plan, status, gameTime, selection.seeded ? target : null);
   return plan;
 }
 function shouldSpawnTerritoryControllerCreep(plan, roleCounts) {
@@ -680,9 +681,10 @@ function selectTerritoryTarget(colonyName) {
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
   const configuredTarget = selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents);
   if (configuredTarget) {
-    return configuredTarget;
+    return { target: configuredTarget, seeded: false };
   }
-  return seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
+  const seededTarget = seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
+  return seededTarget ? { target: seededTarget, seeded: true } : null;
 }
 function selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -705,7 +707,6 @@ function seedAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   for (const roomName of adjacentRooms) {
     const target = { colony: colonyName, roomName, action: "reserve" };
     if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && !isVisibleTerritoryTargetUnavailable(roomName)) {
-      appendTerritoryTarget(target);
       return target;
     }
   }
@@ -722,11 +723,7 @@ function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
     })
   );
 }
-function appendTerritoryTarget(target) {
-  const territoryMemory = getWritableTerritoryMemoryRecord();
-  if (!territoryMemory) {
-    return;
-  }
+function appendTerritoryTarget(territoryMemory, target) {
   if (!Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = [];
   }
@@ -738,7 +735,7 @@ function getAdjacentRoomNames(roomName) {
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
-  const exits = gameMap.describeExits.call(gameMap, roomName);
+  const exits = gameMap.describeExits(roomName);
   if (!isRecord(exits)) {
     return [];
   }
@@ -762,10 +759,13 @@ function normalizeTerritoryTarget(rawTarget) {
     ...rawTarget.enabled === false ? { enabled: false } : {}
   };
 }
-function recordTerritoryIntent(plan, status, gameTime) {
+function recordTerritoryIntent(plan, status, gameTime, seededTarget = null) {
   const territoryMemory = getWritableTerritoryMemoryRecord();
   if (!territoryMemory) {
     return;
+  }
+  if (seededTarget) {
+    appendTerritoryTarget(territoryMemory, seededTarget);
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -603,9 +603,13 @@ function getBodyCost(body) {
 // src/territory/territoryPlanner.ts
 var TERRITORY_CLAIMER_ROLE = "claimer";
 var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
+var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
+  if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
+    return null;
+  }
   const target = selectTerritoryTarget(colony.room.name);
-  if (!target || !isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
+  if (!target) {
     return null;
   }
   const plan = {
@@ -673,10 +677,17 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
 }
 function selectTerritoryTarget(colonyName) {
   const territoryMemory = getTerritoryMemoryRecord();
+  const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
+  const configuredTarget = selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents);
+  if (configuredTarget) {
+    return configuredTarget;
+  }
+  return seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
+}
+function selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return null;
   }
-  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
     if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents) && !isVisibleTerritoryTargetUnavailable(target.roomName, target.controllerId)) {
@@ -684,6 +695,57 @@ function selectTerritoryTarget(colonyName) {
     }
   }
   return null;
+}
+function seedAdjacentReserveTarget(colonyName, territoryMemory, intents) {
+  const adjacentRooms = getAdjacentRoomNames(colonyName);
+  if (adjacentRooms.length === 0) {
+    return null;
+  }
+  const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
+  for (const roomName of adjacentRooms) {
+    const target = { colony: colonyName, roomName, action: "reserve" };
+    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && !isVisibleTerritoryTargetUnavailable(roomName)) {
+      appendTerritoryTarget(target);
+      return target;
+    }
+  }
+  return null;
+}
+function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return /* @__PURE__ */ new Set();
+  }
+  return new Set(
+    territoryMemory.targets.flatMap((rawTarget) => {
+      const target = normalizeTerritoryTarget(rawTarget);
+      return (target == null ? void 0 : target.colony) === colonyName ? [target.roomName] : [];
+    })
+  );
+}
+function appendTerritoryTarget(target) {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+  if (!Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = [];
+  }
+  territoryMemory.targets.push(target);
+}
+function getAdjacentRoomNames(roomName) {
+  const game = globalThis.Game;
+  const gameMap = game == null ? void 0 : game.map;
+  if (!gameMap || typeof gameMap.describeExits !== "function") {
+    return [];
+  }
+  const exits = gameMap.describeExits.call(gameMap, roomName);
+  if (!isRecord(exits)) {
+    return [];
+  }
+  return EXIT_DIRECTION_ORDER.flatMap((direction) => {
+    const exitRoom = exits[direction];
+    return isNonEmptyString(exitRoom) ? [exitRoom] : [];
+  });
 }
 function normalizeTerritoryTarget(rawTarget) {
   if (!isRecord(rawTarget)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -706,7 +706,7 @@ function seedAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   for (const roomName of adjacentRooms) {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && !isVisibleTerritoryTargetUnavailable(roomName)) {
+    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && !isVisibleTerritoryTargetUnavailable(roomName) && !isVisibleTerritoryTargetReserved(roomName)) {
       return target;
     }
   }
@@ -835,6 +835,10 @@ function isVisibleTerritoryTargetUnavailable(targetRoom, controllerId) {
     return false;
   }
   return isControllerOwned(controller);
+}
+function isVisibleTerritoryTargetReserved(targetRoom) {
+  var _a;
+  return ((_a = getVisibleController(targetRoom)) == null ? void 0 : _a.reservation) != null;
 }
 function isControllerOwned(controller) {
   return controller.owner != null || controller.my === true;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1004,12 +1004,21 @@ function seedAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   for (const roomName of adjacentRooms) {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    const controller = getVisibleController(roomName);
-    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && controller != null && !isControllerOwned(controller) && controller.reservation == null) {
+    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && isAdjacentReserveTargetSeedable(roomName)) {
       return target;
     }
   }
   return null;
+}
+function isAdjacentReserveTargetSeedable(targetRoom) {
+  if (isVisibleRoomMissingController(targetRoom)) {
+    return false;
+  }
+  const controller = getVisibleController(targetRoom);
+  if (!controller) {
+    return true;
+  }
+  return !isControllerOwned(controller) && controller.reservation == null;
 }
 function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -986,7 +986,8 @@ function seedAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   for (const roomName of adjacentRooms) {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && !isVisibleTerritoryTargetUnavailable(roomName) && !isVisibleTerritoryTargetReserved(roomName)) {
+    const controller = getVisibleController(roomName);
+    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && controller != null && !isControllerOwned(controller) && controller.reservation == null) {
       return target;
     }
   }
@@ -1118,10 +1119,6 @@ function isVisibleTerritoryTargetUnavailable(targetRoom, controllerId) {
     return false;
   }
   return isControllerOwned(controller);
-}
-function isVisibleTerritoryTargetReserved(targetRoom) {
-  var _a;
-  return ((_a = getVisibleController(targetRoom)) == null ? void 0 : _a.reservation) != null;
 }
 function isVisibleRoomMissingController(targetRoom) {
   var _a;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -182,7 +182,8 @@ function seedAdjacentReserveTarget(
       roomName !== colonyName &&
       !existingTargetRooms.has(roomName) &&
       !isTerritoryTargetSuppressed(target, intents) &&
-      !isVisibleTerritoryTargetUnavailable(roomName)
+      !isVisibleTerritoryTargetUnavailable(roomName) &&
+      !isVisibleTerritoryTargetReserved(roomName)
     ) {
       return target;
     }
@@ -381,6 +382,10 @@ function isVisibleTerritoryTargetUnavailable(
   }
 
   return isControllerOwned(controller);
+}
+
+function isVisibleTerritoryTargetReserved(targetRoom: string): boolean {
+  return getVisibleController(targetRoom)?.reservation != null;
 }
 
 function isControllerOwned(controller: StructureController): boolean {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -189,12 +189,14 @@ function seedAdjacentReserveTarget(
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   for (const roomName of adjacentRooms) {
     const target: TerritoryTargetMemory = { colony: colonyName, roomName, action: 'reserve' };
+    const controller = getVisibleController(roomName);
     if (
       roomName !== colonyName &&
       !existingTargetRooms.has(roomName) &&
       !isTerritoryTargetSuppressed(target, intents) &&
-      !isVisibleTerritoryTargetUnavailable(roomName) &&
-      !isVisibleTerritoryTargetReserved(roomName)
+      controller != null &&
+      !isControllerOwned(controller) &&
+      controller.reservation == null
     ) {
       return target;
     }
@@ -397,10 +399,6 @@ function isVisibleTerritoryTargetUnavailable(
   }
 
   return isControllerOwned(controller);
-}
-
-function isVisibleTerritoryTargetReserved(targetRoom: string): boolean {
-  return getVisibleController(targetRoom)?.reservation != null;
 }
 
 function isVisibleRoomMissingController(targetRoom: string): boolean {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -5,6 +5,8 @@ import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_DOWNGRADE_GUARD_TICKS = 5_000;
 
+const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
+
 export interface TerritoryIntentPlan {
   colony: string;
   targetRoom: string;
@@ -22,8 +24,12 @@ export function planTerritoryIntent(
   workerTarget: number,
   gameTime: number
 ): TerritoryIntentPlan | null {
+  if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
+    return null;
+  }
+
   const target = selectTerritoryTarget(colony.room.name);
-  if (!target || !isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
+  if (!target) {
     return null;
   }
 
@@ -117,11 +123,24 @@ export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCoun
 
 function selectTerritoryTarget(colonyName: string): TerritoryTargetMemory | null {
   const territoryMemory = getTerritoryMemoryRecord();
+  const intents = normalizeTerritoryIntents(territoryMemory?.intents);
+  const configuredTarget = selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents);
+  if (configuredTarget) {
+    return configuredTarget;
+  }
+
+  return seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
+}
+
+function selectConfiguredTerritoryTarget(
+  colonyName: string,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[]
+): TerritoryTargetMemory | null {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return null;
   }
 
-  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
     if (
@@ -137,6 +156,80 @@ function selectTerritoryTarget(colonyName: string): TerritoryTargetMemory | null
   }
 
   return null;
+}
+
+function seedAdjacentReserveTarget(
+  colonyName: string,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[]
+): TerritoryTargetMemory | null {
+  const adjacentRooms = getAdjacentRoomNames(colonyName);
+  if (adjacentRooms.length === 0) {
+    return null;
+  }
+
+  const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
+  for (const roomName of adjacentRooms) {
+    const target: TerritoryTargetMemory = { colony: colonyName, roomName, action: 'reserve' };
+    if (
+      roomName !== colonyName &&
+      !existingTargetRooms.has(roomName) &&
+      !isTerritoryTargetSuppressed(target, intents) &&
+      !isVisibleTerritoryTargetUnavailable(roomName)
+    ) {
+      appendTerritoryTarget(target);
+      return target;
+    }
+  }
+
+  return null;
+}
+
+function getConfiguredTargetRoomsForColony(
+  territoryMemory: Record<string, unknown> | null,
+  colonyName: string
+): Set<string> {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return new Set();
+  }
+
+  return new Set(
+    territoryMemory.targets.flatMap((rawTarget) => {
+      const target = normalizeTerritoryTarget(rawTarget);
+      return target?.colony === colonyName ? [target.roomName] : [];
+    })
+  );
+}
+
+function appendTerritoryTarget(target: TerritoryTargetMemory): void {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  if (!Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = [];
+  }
+
+  territoryMemory.targets.push(target);
+}
+
+function getAdjacentRoomNames(roomName: string): string[] {
+  const game = (globalThis as { Game?: Partial<Game> }).Game;
+  const gameMap = game?.map;
+  if (!gameMap || typeof gameMap.describeExits !== 'function') {
+    return [];
+  }
+
+  const exits = gameMap.describeExits.call(gameMap, roomName) as ExitsInformation | null;
+  if (!isRecord(exits)) {
+    return [];
+  }
+
+  return EXIT_DIRECTION_ORDER.flatMap((direction) => {
+    const exitRoom = exits[direction];
+    return isNonEmptyString(exitRoom) ? [exitRoom] : [];
+  });
 }
 
 function normalizeTerritoryTarget(rawTarget: unknown): TerritoryTargetMemory | null {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -189,20 +189,30 @@ function seedAdjacentReserveTarget(
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   for (const roomName of adjacentRooms) {
     const target: TerritoryTargetMemory = { colony: colonyName, roomName, action: 'reserve' };
-    const controller = getVisibleController(roomName);
     if (
       roomName !== colonyName &&
       !existingTargetRooms.has(roomName) &&
       !isTerritoryTargetSuppressed(target, intents) &&
-      controller != null &&
-      !isControllerOwned(controller) &&
-      controller.reservation == null
+      isAdjacentReserveTargetSeedable(roomName)
     ) {
       return target;
     }
   }
 
   return null;
+}
+
+function isAdjacentReserveTargetSeedable(targetRoom: string): boolean {
+  if (isVisibleRoomMissingController(targetRoom)) {
+    return false;
+  }
+
+  const controller = getVisibleController(targetRoom);
+  if (!controller) {
+    return true;
+  }
+
+  return !isControllerOwned(controller) && controller.reservation == null;
 }
 
 function getConfiguredTargetRoomsForColony(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -18,6 +18,11 @@ interface MemoryRecord {
   territory?: unknown;
 }
 
+interface SelectedTerritoryTarget {
+  target: TerritoryTargetMemory;
+  seeded: boolean;
+}
+
 export function planTerritoryIntent(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
@@ -28,11 +33,12 @@ export function planTerritoryIntent(
     return null;
   }
 
-  const target = selectTerritoryTarget(colony.room.name);
-  if (!target) {
+  const selection = selectTerritoryTarget(colony.room.name);
+  if (!selection) {
     return null;
   }
 
+  const target = selection.target;
   const plan: TerritoryIntentPlan = {
     colony: colony.room.name,
     targetRoom: target.roomName,
@@ -40,7 +46,7 @@ export function planTerritoryIntent(
     ...(target.controllerId ? { controllerId: target.controllerId } : {})
   };
   const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) > 0 ? 'active' : 'planned';
-  recordTerritoryIntent(plan, status, gameTime);
+  recordTerritoryIntent(plan, status, gameTime, selection.seeded ? target : null);
 
   return plan;
 }
@@ -121,15 +127,16 @@ export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCoun
   );
 }
 
-function selectTerritoryTarget(colonyName: string): TerritoryTargetMemory | null {
+function selectTerritoryTarget(colonyName: string): SelectedTerritoryTarget | null {
   const territoryMemory = getTerritoryMemoryRecord();
   const intents = normalizeTerritoryIntents(territoryMemory?.intents);
   const configuredTarget = selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents);
   if (configuredTarget) {
-    return configuredTarget;
+    return { target: configuredTarget, seeded: false };
   }
 
-  return seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
+  const seededTarget = seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
+  return seededTarget ? { target: seededTarget, seeded: true } : null;
 }
 
 function selectConfiguredTerritoryTarget(
@@ -177,7 +184,6 @@ function seedAdjacentReserveTarget(
       !isTerritoryTargetSuppressed(target, intents) &&
       !isVisibleTerritoryTargetUnavailable(roomName)
     ) {
-      appendTerritoryTarget(target);
       return target;
     }
   }
@@ -201,12 +207,7 @@ function getConfiguredTargetRoomsForColony(
   );
 }
 
-function appendTerritoryTarget(target: TerritoryTargetMemory): void {
-  const territoryMemory = getWritableTerritoryMemoryRecord();
-  if (!territoryMemory) {
-    return;
-  }
-
+function appendTerritoryTarget(territoryMemory: TerritoryMemory, target: TerritoryTargetMemory): void {
   if (!Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = [];
   }
@@ -221,7 +222,7 @@ function getAdjacentRoomNames(roomName: string): string[] {
     return [];
   }
 
-  const exits = gameMap.describeExits.call(gameMap, roomName) as ExitsInformation | null;
+  const exits = gameMap.describeExits(roomName) as ExitsInformation | null;
   if (!isRecord(exits)) {
     return [];
   }
@@ -256,10 +257,19 @@ function normalizeTerritoryTarget(rawTarget: unknown): TerritoryTargetMemory | n
   };
 }
 
-function recordTerritoryIntent(plan: TerritoryIntentPlan, status: TerritoryIntentMemory['status'], gameTime: number): void {
+function recordTerritoryIntent(
+  plan: TerritoryIntentPlan,
+  status: TerritoryIntentMemory['status'],
+  gameTime: number,
+  seededTarget: TerritoryTargetMemory | null = null
+): void {
   const territoryMemory = getWritableTerritoryMemoryRecord();
   if (!territoryMemory) {
     return;
+  }
+
+  if (seededTarget) {
+    appendTerritoryTarget(territoryMemory, seededTarget);
   }
 
   const intents = normalizeTerritoryIntents(territoryMemory.intents);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -387,6 +387,10 @@ function isVisibleTerritoryTargetUnavailable(
   targetRoom: string,
   controllerId?: Id<StructureController>
 ): boolean {
+  if (isVisibleRoomMissingController(targetRoom)) {
+    return true;
+  }
+
   const controller = getVisibleController(targetRoom, controllerId);
   if (!controller) {
     return false;
@@ -397,6 +401,12 @@ function isVisibleTerritoryTargetUnavailable(
 
 function isVisibleTerritoryTargetReserved(targetRoom: string): boolean {
   return getVisibleController(targetRoom)?.reservation != null;
+}
+
+function isVisibleRoomMissingController(targetRoom: string): boolean {
+  const game = (globalThis as { Game?: Partial<Game> }).Game;
+  const room = game?.rooms?.[targetRoom];
+  return room != null && room.controller == null;
 }
 
 function isControllerOwned(controller: StructureController): boolean {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -135,6 +135,10 @@ function selectTerritoryTarget(colonyName: string): SelectedTerritoryTarget | nu
     return { target: configuredTarget, seeded: false };
   }
 
+  if (hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName)) {
+    return null;
+  }
+
   const seededTarget = seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
   return seededTarget ? { target: seededTarget, seeded: true } : null;
 }
@@ -163,6 +167,13 @@ function selectConfiguredTerritoryTarget(
   }
 
   return null;
+}
+
+function hasConfiguredTerritoryTargetForColony(
+  territoryMemory: Record<string, unknown> | null,
+  colonyName: string
+): boolean {
+  return getConfiguredTargetRoomsForColony(territoryMemory, colonyName).size > 0;
 }
 
 function seedAdjacentReserveTarget(

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -121,6 +121,45 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('plans a claimer-role reserver for a seeded adjacent reserve target when home survival is safe', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits: jest.fn(() => ({ '3': 'W2N1' })) } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 142)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N1-142',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve' }
+      }
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 142
+      }
+    ]);
+  });
+
   it('records territory intent while waiting for claim body energy', () => {
     const { colony } = makeColony({
       energyAvailable: 600,

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -128,7 +128,10 @@ describe('planSpawn', () => {
       controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
     });
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      map: { describeExits: jest.fn(() => ({ '3': 'W2N1' })) } as unknown as GameMap
+      map: { describeExits: jest.fn(() => ({ '3': 'W2N1' })) } as unknown as GameMap,
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
+      }
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
 

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -76,6 +76,71 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('defers seeded adjacent target writes until recording a finalized plan', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits: jest.fn(() => ({ '1': 'W1N2' })) } as unknown as GameMap
+    };
+    const claimersByTargetRoom = new Proxy<Record<string, number>>(
+      {},
+      {
+        get(target, property) {
+          if (property === 'W1N2') {
+            expect(Memory.territory?.targets).toBeUndefined();
+          }
+
+          return typeof property === 'string' ? target[property] : undefined;
+        }
+      }
+    );
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom }, 3, 518)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 518
+      }
+    ]);
+  });
+
+  it('calls describeExits directly when discovering adjacent rooms', () => {
+    const colony = makeSafeColony();
+    const describeExits = jest.fn(() => ({ '3': 'W2N1' }));
+    const callTrap = jest.fn(() => {
+      throw new Error('describeExits.call should not be used');
+    });
+    Object.defineProperty(describeExits, 'call', { value: callTrap });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 519)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(callTrap).not.toHaveBeenCalled();
+  });
+
   it('does not overwrite an existing configured target when adjacent rooms are discoverable', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -185,6 +185,41 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
+  it('does not seed visible reserved adjacent rooms', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits: jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' })) } as unknown as GameMap,
+      rooms: {
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 4_000 }
+          } as StructureController
+        } as Room,
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false } as StructureController
+        } as Room
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 520)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve'
+      }
+    ]);
+  });
+
   it('does not throw when map exit APIs are absent', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -100,6 +100,66 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
+  it('does not seed an adjacent reserve target when the colony has only suppressed configured targets', () => {
+    const colony = makeSafeColony();
+    const suppressedTarget: TerritoryTargetMemory = {
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      action: 'reserve'
+    };
+    const suppressedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: 520
+    };
+    const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [suppressedTarget],
+        intents: [suppressedIntent]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 522)).toBeNull();
+    expect(describeExits).not.toHaveBeenCalled();
+    expect(Memory.territory?.targets).toEqual([suppressedTarget]);
+    expect(Memory.territory?.intents).toEqual([suppressedIntent]);
+  });
+
+  it('does not seed an adjacent reserve target when the colony has only visible unavailable configured targets', () => {
+    const colony = makeSafeColony();
+    const unavailableTarget: TerritoryTargetMemory = {
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      action: 'reserve'
+    };
+    const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false, owner: { username: 'enemy' } } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [unavailableTarget]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 523)).toBeNull();
+    expect(describeExits).not.toHaveBeenCalled();
+    expect(Memory.territory?.targets).toEqual([unavailableTarget]);
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
   it('defers seeded adjacent target writes until recording a finalized plan', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -207,6 +267,37 @@ describe('planTerritoryIntent', () => {
 
     expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 516)).toBeNull();
     expect(Memory.territory).toBeUndefined();
+  });
+
+  it('does not seed visible adjacent rooms without controllers', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits: jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' })) } as unknown as GameMap,
+      rooms: {
+        W1N2: {
+          name: 'W1N2'
+        } as Room,
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false } as StructureController
+        } as Room
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 524)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve'
+      }
+    ]);
   });
 
   it('does not seed visible reserved adjacent rooms', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -79,16 +79,37 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('does not seed unseen adjacent reserve targets', () => {
+  it('seeds an unseen adjacent reserve target when no configured targets exist', () => {
     const colony = makeSafeColony();
     const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       map: { describeExits } as unknown as GameMap
     };
 
-    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 525)).toBeNull();
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 525)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve'
+    });
     expect(describeExits).toHaveBeenCalledWith('W1N1');
-    expect(Memory.territory).toBeUndefined();
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 525
+      }
+    ]);
   });
 
   it('does not seed an adjacent reserve target when the colony has only disabled configured targets', () => {
@@ -290,7 +311,7 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
-  it('does not seed visible adjacent rooms without controllers', () => {
+  it('skips visible adjacent rooms without controllers', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       map: { describeExits: jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' })) } as unknown as GameMap,
@@ -319,6 +340,20 @@ describe('planTerritoryIntent', () => {
         action: 'reserve'
       }
     ]);
+  });
+
+  it('does not seed when every visible adjacent room lacks a controller', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits: jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' })) } as unknown as GameMap,
+      rooms: {
+        W1N2: { name: 'W1N2' } as Room,
+        W2N1: { name: 'W2N1' } as Room
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 526)).toBeNull();
+    expect(Memory.territory).toBeUndefined();
   });
 
   it('does not seed visible reserved adjacent rooms', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -43,6 +43,97 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('seeds an adjacent reserve target when no configured targets exist', () => {
+    const colony = makeSafeColony();
+    const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 514)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 514
+      }
+    ]);
+  });
+
+  it('does not overwrite an existing configured target when adjacent rooms are discoverable', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const describeExits = jest.fn(() => ({ '1': 'W1N2' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 515)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve'
+    });
+    expect(describeExits).not.toHaveBeenCalled();
+    expect(Memory.territory?.targets).toEqual([configuredTarget]);
+  });
+
+  it('does not seed visible hostile-owned or self-owned adjacent rooms', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits: jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' })) } as unknown as GameMap,
+      rooms: {
+        W1N2: {
+          name: 'W1N2',
+          controller: { my: false, owner: { username: 'enemy' } } as StructureController
+        } as Room,
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: true, owner: { username: 'me' } } as StructureController
+        } as Room
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 516)).toBeNull();
+    expect(Memory.territory).toBeUndefined();
+  });
+
+  it('does not throw when map exit APIs are absent', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {} as unknown as GameMap
+    };
+    let intent: ReturnType<typeof planTerritoryIntent>;
+
+    expect(() => {
+      intent = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 517);
+    }).not.toThrow();
+    expect(intent!).toBeNull();
+    expect(Memory.territory).toBeUndefined();
+  });
+
   it('ignores malformed territory memory without throwing', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -47,7 +47,10 @@ describe('planTerritoryIntent', () => {
     const colony = makeSafeColony();
     const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      map: { describeExits } as unknown as GameMap
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N2: { name: 'W1N2', controller: { my: false } as StructureController } as Room
+      }
     };
 
     expect(
@@ -74,6 +77,18 @@ describe('planTerritoryIntent', () => {
         updatedAt: 514
       }
     ]);
+  });
+
+  it('does not seed unseen adjacent reserve targets', () => {
+    const colony = makeSafeColony();
+    const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 525)).toBeNull();
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory).toBeUndefined();
   });
 
   it('does not seed an adjacent reserve target when the colony has only disabled configured targets', () => {
@@ -163,7 +178,10 @@ describe('planTerritoryIntent', () => {
   it('defers seeded adjacent target writes until recording a finalized plan', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      map: { describeExits: jest.fn(() => ({ '1': 'W1N2' })) } as unknown as GameMap
+      map: { describeExits: jest.fn(() => ({ '1': 'W1N2' })) } as unknown as GameMap,
+      rooms: {
+        W1N2: { name: 'W1N2', controller: { my: false } as StructureController } as Room
+      }
     };
     const claimersByTargetRoom = new Proxy<Record<string, number>>(
       {},
@@ -211,7 +229,10 @@ describe('planTerritoryIntent', () => {
     });
     Object.defineProperty(describeExits, 'call', { value: callTrap });
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      map: { describeExits } as unknown as GameMap
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
+      }
     };
 
     expect(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -76,6 +76,30 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('does not seed an adjacent reserve target when the colony has only disabled configured targets', () => {
+    const colony = makeSafeColony();
+    const disabledTarget: TerritoryTargetMemory = {
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      action: 'reserve',
+      enabled: false
+    };
+    const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [disabledTarget]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 521)).toBeNull();
+    expect(describeExits).not.toHaveBeenCalled();
+    expect(Memory.territory?.targets).toEqual([disabledTarget]);
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
   it('defers seeded adjacent target writes until recording a finalized plan', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {


### PR DESCRIPTION
## Summary
- Seeds adjacent territory targets deterministically when no explicit expansion targets exist.
- Keeps territory planning safe by avoiding self-targeting and preserving existing territory target behavior.
- Adds spawn/territory planner coverage and regenerates the Screeps bundle.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand -- territoryPlanner.test.ts spawnPlanner.test.ts`
- [x] `cd prod && npm test -- --runInBand`
- [x] `cd prod && npm run build`

Closes #126

No secrets.