### PR TITLE
feat: add early road planner

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -270,7 +270,7 @@ function isPathFinderAvailable() {
 }
 function hasRequiredRoomApis(room) {
   const partialRoom = room;
-  return typeof partialRoom.find === "function" && typeof partialRoom.lookForAtArea === "function" && typeof partialRoom.createConstructionSite === "function";
+  return typeof partialRoom.find === "function" && typeof partialRoom.createConstructionSite === "function";
 }
 function selectRoadAnchor(colony) {
   const [primarySpawn] = colony.spawns.filter((spawn) => spawn.pos).sort((left, right) => left.name.localeCompare(right.name));
@@ -304,7 +304,7 @@ function countPendingRoadConstructionSites(room) {
   }).length;
 }
 function createRoadPlannerLookups(room) {
-  if (typeof LOOK_STRUCTURES !== "string" || typeof LOOK_CONSTRUCTION_SITES !== "string") {
+  if (typeof FIND_STRUCTURES !== "number" || typeof FIND_CONSTRUCTION_SITES !== "number") {
     return null;
   }
   const terrain = getRoomTerrain(room);
@@ -340,13 +340,13 @@ function blockRoomEdges(lookups) {
   }
 }
 function cacheRoomStructures(room, lookups) {
-  for (const result of room.lookForAtArea(LOOK_STRUCTURES, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MAX, ROOM_COORDINATE_MAX, true)) {
-    if (!result.structure) {
+  for (const structure of room.find(FIND_STRUCTURES)) {
+    const position = structure.pos;
+    if (!position || !isSameRoomPosition(position, room.name)) {
       continue;
     }
-    const position = { x: result.x, y: result.y };
     const key = getPositionKey2(position);
-    if (isRoadStructure(result.structure)) {
+    if (isRoadStructure(structure)) {
       lookups.existingRoadPositions.add(key);
       setRoadPathCostIfOpen(lookups, position);
       continue;
@@ -356,13 +356,13 @@ function cacheRoomStructures(room, lookups) {
   }
 }
 function cacheRoomConstructionSites(room, lookups) {
-  for (const result of room.lookForAtArea(LOOK_CONSTRUCTION_SITES, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MAX, ROOM_COORDINATE_MAX, true)) {
-    if (!result.constructionSite) {
+  for (const constructionSite of room.find(FIND_CONSTRUCTION_SITES)) {
+    const position = constructionSite.pos;
+    if (!position || !isSameRoomPosition(position, room.name)) {
       continue;
     }
-    const position = { x: result.x, y: result.y };
     const key = getPositionKey2(position);
-    if (isRoadConstructionSite(result.constructionSite)) {
+    if (isRoadConstructionSite(constructionSite)) {
       lookups.pendingRoadSitePositions.add(key);
       setRoadPathCostIfOpen(lookups, position);
       continue;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -194,6 +194,280 @@ function getTerrainWallMask() {
   return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK;
 }
 
+// src/construction/roadPlanner.ts
+var DEFAULT_MAX_ROAD_SITES_PER_TICK = 1;
+var DEFAULT_MAX_PENDING_ROAD_SITES = 3;
+var DEFAULT_MAX_ROAD_TARGETS_PER_TICK = 3;
+var DEFAULT_MAX_PATH_OPS_PER_TARGET = 1e3;
+var MIN_CONTROLLER_LEVEL_FOR_ROADS = 2;
+var ROOM_EDGE_MIN2 = 1;
+var ROOM_EDGE_MAX2 = 48;
+var ROOM_COORDINATE_MIN = 0;
+var ROOM_COORDINATE_MAX = 49;
+var DEFAULT_TERRAIN_WALL_MASK2 = 1;
+var PATH_BLOCKED_COST = 255;
+var ROAD_PATH_COST = 1;
+var PLAIN_PATH_COST = 2;
+var SWAMP_PATH_COST = 10;
+function planEarlyRoadConstruction(colony, options = {}) {
+  var _a, _b;
+  const limits = resolveRoadPlannerLimits(options);
+  if (limits.maxSitesPerTick <= 0 || limits.maxPendingRoadSites <= 0 || ((_b = (_a = colony.room.controller) == null ? void 0 : _a.level) != null ? _b : 0) < MIN_CONTROLLER_LEVEL_FOR_ROADS || !isPathFinderAvailable() || !hasRequiredRoomApis(colony.room)) {
+    return [];
+  }
+  const anchor = selectRoadAnchor(colony);
+  if (!anchor) {
+    return [];
+  }
+  const pendingRoadSites = countPendingRoadConstructionSites(colony.room);
+  const remainingSiteBudget = Math.min(limits.maxSitesPerTick, limits.maxPendingRoadSites - pendingRoadSites);
+  if (remainingSiteBudget <= 0) {
+    return [];
+  }
+  const targets = selectRoadTargets(colony.room, limits.maxTargetsPerTick);
+  if (targets.length === 0) {
+    return [];
+  }
+  const lookups = createRoadPlannerLookups(colony.room);
+  if (!lookups) {
+    return [];
+  }
+  const candidates = selectRoadCandidates(colony.room.name, anchor.pos, targets, lookups, limits);
+  const results = [];
+  for (const candidate of candidates) {
+    if (results.length >= remainingSiteBudget) {
+      break;
+    }
+    if (!canPlaceRoad(lookups, candidate)) {
+      continue;
+    }
+    const result = colony.room.createConstructionSite(candidate.x, candidate.y, getRoadStructureType());
+    results.push(result);
+    if (result !== getOkCode()) {
+      break;
+    }
+    lookups.pendingRoadSitePositions.add(candidate.key);
+    lookups.costMatrix.set(candidate.x, candidate.y, ROAD_PATH_COST);
+  }
+  return results;
+}
+function resolveRoadPlannerLimits(options) {
+  return {
+    maxSitesPerTick: resolveNonNegativeInteger(options.maxSitesPerTick, DEFAULT_MAX_ROAD_SITES_PER_TICK),
+    maxPendingRoadSites: resolveNonNegativeInteger(options.maxPendingRoadSites, DEFAULT_MAX_PENDING_ROAD_SITES),
+    maxTargetsPerTick: resolveNonNegativeInteger(options.maxTargetsPerTick, DEFAULT_MAX_ROAD_TARGETS_PER_TICK),
+    maxPathOpsPerTarget: resolveNonNegativeInteger(options.maxPathOpsPerTarget, DEFAULT_MAX_PATH_OPS_PER_TARGET)
+  };
+}
+function resolveNonNegativeInteger(value, fallback) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(0, Math.floor(value));
+}
+function isPathFinderAvailable() {
+  return typeof PathFinder !== "undefined" && typeof PathFinder.search === "function" && typeof PathFinder.CostMatrix === "function";
+}
+function hasRequiredRoomApis(room) {
+  const partialRoom = room;
+  return typeof partialRoom.find === "function" && typeof partialRoom.lookForAtArea === "function" && typeof partialRoom.createConstructionSite === "function";
+}
+function selectRoadAnchor(colony) {
+  const [primarySpawn] = colony.spawns.filter((spawn) => spawn.pos).sort((left, right) => left.name.localeCompare(right.name));
+  return primarySpawn != null ? primarySpawn : null;
+}
+function selectRoadTargets(room, maxTargets) {
+  var _a;
+  if (maxTargets <= 0) {
+    return [];
+  }
+  const targets = getSortedSources(room).map((source) => ({
+    pos: source.pos
+  }));
+  if (((_a = room.controller) == null ? void 0 : _a.pos) && isSameRoomPosition(room.controller.pos, room.name)) {
+    targets.push({ pos: room.controller.pos });
+  }
+  return targets.filter((target) => isSameRoomPosition(target.pos, room.name)).slice(0, maxTargets);
+}
+function getSortedSources(room) {
+  if (typeof FIND_SOURCES !== "number") {
+    return [];
+  }
+  return room.find(FIND_SOURCES).filter((source) => source.pos && isSameRoomPosition(source.pos, room.name)).sort((left, right) => String(left.id).localeCompare(String(right.id)));
+}
+function countPendingRoadConstructionSites(room) {
+  if (typeof FIND_MY_CONSTRUCTION_SITES !== "number") {
+    return 0;
+  }
+  return room.find(FIND_MY_CONSTRUCTION_SITES, {
+    filter: isRoadConstructionSite
+  }).length;
+}
+function createRoadPlannerLookups(room) {
+  if (typeof LOOK_STRUCTURES !== "string" || typeof LOOK_CONSTRUCTION_SITES !== "string") {
+    return null;
+  }
+  const terrain = getRoomTerrain(room);
+  if (!terrain) {
+    return null;
+  }
+  const lookups = {
+    terrain,
+    costMatrix: new PathFinder.CostMatrix(),
+    blockingPositions: /* @__PURE__ */ new Set(),
+    existingRoadPositions: /* @__PURE__ */ new Set(),
+    pendingRoadSitePositions: /* @__PURE__ */ new Set(),
+    pathBlockedPositions: /* @__PURE__ */ new Set()
+  };
+  blockRoomEdges(lookups);
+  cacheRoomStructures(room, lookups);
+  cacheRoomConstructionSites(room, lookups);
+  return lookups;
+}
+function getRoomTerrain(room) {
+  const game = globalThis.Game;
+  if (!(game == null ? void 0 : game.map) || typeof game.map.getRoomTerrain !== "function") {
+    return null;
+  }
+  return game.map.getRoomTerrain(room.name);
+}
+function blockRoomEdges(lookups) {
+  for (let coordinate = ROOM_COORDINATE_MIN; coordinate <= ROOM_COORDINATE_MAX; coordinate += 1) {
+    blockPathPosition(lookups, { x: ROOM_COORDINATE_MIN, y: coordinate });
+    blockPathPosition(lookups, { x: ROOM_COORDINATE_MAX, y: coordinate });
+    blockPathPosition(lookups, { x: coordinate, y: ROOM_COORDINATE_MIN });
+    blockPathPosition(lookups, { x: coordinate, y: ROOM_COORDINATE_MAX });
+  }
+}
+function cacheRoomStructures(room, lookups) {
+  for (const result of room.lookForAtArea(LOOK_STRUCTURES, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MAX, ROOM_COORDINATE_MAX, true)) {
+    if (!result.structure) {
+      continue;
+    }
+    const position = { x: result.x, y: result.y };
+    const key = getPositionKey2(position);
+    if (isRoadStructure(result.structure)) {
+      lookups.existingRoadPositions.add(key);
+      setRoadPathCostIfOpen(lookups, position);
+      continue;
+    }
+    lookups.blockingPositions.add(key);
+    blockPathPosition(lookups, position);
+  }
+}
+function cacheRoomConstructionSites(room, lookups) {
+  for (const result of room.lookForAtArea(LOOK_CONSTRUCTION_SITES, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MAX, ROOM_COORDINATE_MAX, true)) {
+    if (!result.constructionSite) {
+      continue;
+    }
+    const position = { x: result.x, y: result.y };
+    const key = getPositionKey2(position);
+    if (isRoadConstructionSite(result.constructionSite)) {
+      lookups.pendingRoadSitePositions.add(key);
+      setRoadPathCostIfOpen(lookups, position);
+      continue;
+    }
+    lookups.blockingPositions.add(key);
+    blockPathPosition(lookups, position);
+  }
+}
+function selectRoadCandidates(roomName, origin, targets, lookups, limits) {
+  const candidates = /* @__PURE__ */ new Map();
+  targets.forEach((target, targetIndex) => {
+    const path = findRoadPath(roomName, origin, target, lookups, limits);
+    const seenInRoute = /* @__PURE__ */ new Set();
+    path.forEach((position, pathIndex) => {
+      if (!isSameRoomPosition(position, roomName) || !canPlaceRoad(lookups, position)) {
+        return;
+      }
+      const key = getPositionKey2(position);
+      if (seenInRoute.has(key)) {
+        return;
+      }
+      seenInRoute.add(key);
+      const existingCandidate = candidates.get(key);
+      if (existingCandidate) {
+        existingCandidate.routeCount += 1;
+        existingCandidate.minPathIndex = Math.min(existingCandidate.minPathIndex, pathIndex);
+        existingCandidate.minTargetIndex = Math.min(existingCandidate.minTargetIndex, targetIndex);
+        return;
+      }
+      candidates.set(key, {
+        x: position.x,
+        y: position.y,
+        key,
+        routeCount: 1,
+        minPathIndex: pathIndex,
+        minTargetIndex: targetIndex
+      });
+    });
+  });
+  return [...candidates.values()].sort(compareRoadCandidates);
+}
+function findRoadPath(roomName, origin, target, lookups, limits) {
+  const result = PathFinder.search(origin, { pos: target.pos, range: 1 }, {
+    maxRooms: 1,
+    maxOps: limits.maxPathOpsPerTarget,
+    plainCost: PLAIN_PATH_COST,
+    swampCost: SWAMP_PATH_COST,
+    roomCallback: (callbackRoomName) => callbackRoomName === roomName ? lookups.costMatrix : false
+  });
+  return result.incomplete ? [] : result.path;
+}
+function compareRoadCandidates(left, right) {
+  return right.routeCount - left.routeCount || left.minPathIndex - right.minPathIndex || left.minTargetIndex - right.minTargetIndex || left.y - right.y || left.x - right.x;
+}
+function canPlaceRoad(lookups, position) {
+  if (!isWithinBuildableRoomBounds(position) || isTerrainWall2(lookups.terrain, position)) {
+    return false;
+  }
+  const key = getPositionKey2(position);
+  return !lookups.blockingPositions.has(key) && !lookups.existingRoadPositions.has(key) && !lookups.pendingRoadSitePositions.has(key);
+}
+function blockPathPosition(lookups, position) {
+  lookups.pathBlockedPositions.add(getPositionKey2(position));
+  lookups.costMatrix.set(position.x, position.y, PATH_BLOCKED_COST);
+}
+function setRoadPathCostIfOpen(lookups, position) {
+  if (!lookups.pathBlockedPositions.has(getPositionKey2(position))) {
+    lookups.costMatrix.set(position.x, position.y, ROAD_PATH_COST);
+  }
+}
+function isWithinBuildableRoomBounds(position) {
+  return position.x >= ROOM_EDGE_MIN2 && position.x <= ROOM_EDGE_MAX2 && position.y >= ROOM_EDGE_MIN2 && position.y <= ROOM_EDGE_MAX2;
+}
+function isSameRoomPosition(position, roomName) {
+  return !position.roomName || position.roomName === roomName;
+}
+function isTerrainWall2(terrain, position) {
+  return (terrain.get(position.x, position.y) & getTerrainWallMask2()) !== 0;
+}
+function isRoadStructure(structure) {
+  return matchesStructureType(structure.structureType, "STRUCTURE_ROAD", "road");
+}
+function isRoadConstructionSite(site) {
+  return matchesStructureType(site.structureType, "STRUCTURE_ROAD", "road");
+}
+function matchesStructureType(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+function getRoadStructureType() {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants.STRUCTURE_ROAD) != null ? _a : "road";
+}
+function getPositionKey2(position) {
+  return `${position.x},${position.y}`;
+}
+function getTerrainWallMask2() {
+  return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK2;
+}
+function getOkCode() {
+  return typeof OK === "number" ? OK : 0;
+}
+
 // src/creeps/roleCounts.ts
 var WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
 function countCreepsByRole(creeps, colonyName) {
@@ -282,15 +556,15 @@ function selectWorkerTask(creep) {
   return null;
 }
 function isFillableEnergySink(structure) {
-  return (matchesStructureType(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure && structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
+  return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure && structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
 }
 function isSpawnConstructionSite(site) {
-  return matchesStructureType(site.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType2(site.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isExtensionConstructionSite(site) {
-  return matchesStructureType(site.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType2(site.structureType, "STRUCTURE_EXTENSION", "extension");
 }
-function matchesStructureType(actual, globalName, fallback) {
+function matchesStructureType2(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -316,16 +590,16 @@ function isSafeRepairTarget(structure) {
   if (isWorkerRepairTargetComplete(structure)) {
     return false;
   }
-  if (matchesStructureType(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
     return true;
   }
-  return matchesStructureType(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+  return matchesStructureType2(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
 }
 function isWorkerRepairTargetComplete(structure) {
   return structure.hits >= getWorkerRepairHitsCeiling(structure);
 }
 function getWorkerRepairHitsCeiling(structure) {
-  if (matchesStructureType(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
+  if (matchesStructureType2(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
     return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING);
   }
   return structure.hitsMax;
@@ -337,10 +611,10 @@ function compareRepairTargets(left, right) {
   return getRepairPriority(left) - getRepairPriority(right) || getHitsRatio(left) - getHitsRatio(right) || left.hits - right.hits || String(left.id).localeCompare(String(right.id));
 }
 function getRepairPriority(structure) {
-  if (matchesStructureType(structure.structureType, "STRUCTURE_ROAD", "road")) {
+  if (matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road")) {
     return 0;
   }
-  if (matchesStructureType(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
     return 1;
   }
   return 2;
@@ -1254,7 +1528,10 @@ function runEconomy() {
   const colonies = getOwnedColonies();
   const telemetryEvents = [];
   for (const colony of colonies) {
-    planExtensionConstruction(colony);
+    const extensionResult = planExtensionConstruction(colony);
+    if (extensionResult === null) {
+      planEarlyRoadConstruction(colony);
+    }
     const roleCounts = countCreepsByRole(creeps, colony.room.name);
     const spawnRequest = planSpawn(colony, roleCounts, Game.time);
     if (spawnRequest) {

--- a/prod/src/construction/roadPlanner.ts
+++ b/prod/src/construction/roadPlanner.ts
@@ -145,7 +145,6 @@ function hasRequiredRoomApis(room: Room): boolean {
   const partialRoom = room as Partial<Room>;
   return (
     typeof partialRoom.find === 'function' &&
-    typeof partialRoom.lookForAtArea === 'function' &&
     typeof partialRoom.createConstructionSite === 'function'
   );
 }
@@ -196,7 +195,7 @@ function countPendingRoadConstructionSites(room: Room): number {
 }
 
 function createRoadPlannerLookups(room: Room): RoadPlannerLookups | null {
-  if (typeof LOOK_STRUCTURES !== 'string' || typeof LOOK_CONSTRUCTION_SITES !== 'string') {
+  if (typeof FIND_STRUCTURES !== 'number' || typeof FIND_CONSTRUCTION_SITES !== 'number') {
     return null;
   }
 
@@ -240,14 +239,14 @@ function blockRoomEdges(lookups: RoadPlannerLookups): void {
 }
 
 function cacheRoomStructures(room: Room, lookups: RoadPlannerLookups): void {
-  for (const result of room.lookForAtArea(LOOK_STRUCTURES, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MAX, ROOM_COORDINATE_MAX, true)) {
-    if (!result.structure) {
+  for (const structure of room.find(FIND_STRUCTURES)) {
+    const position = structure.pos;
+    if (!position || !isSameRoomPosition(position, room.name)) {
       continue;
     }
 
-    const position = { x: result.x, y: result.y };
     const key = getPositionKey(position);
-    if (isRoadStructure(result.structure)) {
+    if (isRoadStructure(structure)) {
       lookups.existingRoadPositions.add(key);
       setRoadPathCostIfOpen(lookups, position);
       continue;
@@ -259,14 +258,14 @@ function cacheRoomStructures(room: Room, lookups: RoadPlannerLookups): void {
 }
 
 function cacheRoomConstructionSites(room: Room, lookups: RoadPlannerLookups): void {
-  for (const result of room.lookForAtArea(LOOK_CONSTRUCTION_SITES, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MAX, ROOM_COORDINATE_MAX, true)) {
-    if (!result.constructionSite) {
+  for (const constructionSite of room.find(FIND_CONSTRUCTION_SITES)) {
+    const position = constructionSite.pos;
+    if (!position || !isSameRoomPosition(position, room.name)) {
       continue;
     }
 
-    const position = { x: result.x, y: result.y };
     const key = getPositionKey(position);
-    if (isRoadConstructionSite(result.constructionSite)) {
+    if (isRoadConstructionSite(constructionSite)) {
       lookups.pendingRoadSitePositions.add(key);
       setRoadPathCostIfOpen(lookups, position);
       continue;

--- a/prod/src/construction/roadPlanner.ts
+++ b/prod/src/construction/roadPlanner.ts
@@ -1,0 +1,418 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+
+const DEFAULT_MAX_ROAD_SITES_PER_TICK = 1;
+const DEFAULT_MAX_PENDING_ROAD_SITES = 3;
+const DEFAULT_MAX_ROAD_TARGETS_PER_TICK = 3;
+const DEFAULT_MAX_PATH_OPS_PER_TARGET = 1_000;
+const MIN_CONTROLLER_LEVEL_FOR_ROADS = 2;
+const ROOM_EDGE_MIN = 1;
+const ROOM_EDGE_MAX = 48;
+const ROOM_COORDINATE_MIN = 0;
+const ROOM_COORDINATE_MAX = 49;
+const DEFAULT_TERRAIN_WALL_MASK = 1;
+const PATH_BLOCKED_COST = 0xff;
+const ROAD_PATH_COST = 1;
+const PLAIN_PATH_COST = 2;
+const SWAMP_PATH_COST = 10;
+
+export interface EarlyRoadPlannerOptions {
+  maxSitesPerTick?: number;
+  maxPendingRoadSites?: number;
+  maxTargetsPerTick?: number;
+  maxPathOpsPerTarget?: number;
+}
+
+interface RoadPlannerLimits {
+  maxSitesPerTick: number;
+  maxPendingRoadSites: number;
+  maxTargetsPerTick: number;
+  maxPathOpsPerTarget: number;
+}
+
+interface RoadTarget {
+  pos: RoomPosition;
+}
+
+interface RoadPlannerLookups {
+  terrain: RoomTerrain;
+  costMatrix: CostMatrix;
+  blockingPositions: Set<string>;
+  existingRoadPositions: Set<string>;
+  pendingRoadSitePositions: Set<string>;
+  pathBlockedPositions: Set<string>;
+}
+
+interface RoadCandidate {
+  x: number;
+  y: number;
+  key: string;
+  routeCount: number;
+  minPathIndex: number;
+  minTargetIndex: number;
+}
+
+interface Positioned {
+  x: number;
+  y: number;
+  roomName?: string;
+}
+
+type StructureConstantGlobal = 'STRUCTURE_ROAD';
+
+export function planEarlyRoadConstruction(
+  colony: ColonySnapshot,
+  options: EarlyRoadPlannerOptions = {}
+): ScreepsReturnCode[] {
+  const limits = resolveRoadPlannerLimits(options);
+  if (
+    limits.maxSitesPerTick <= 0 ||
+    limits.maxPendingRoadSites <= 0 ||
+    (colony.room.controller?.level ?? 0) < MIN_CONTROLLER_LEVEL_FOR_ROADS ||
+    !isPathFinderAvailable() ||
+    !hasRequiredRoomApis(colony.room)
+  ) {
+    return [];
+  }
+
+  const anchor = selectRoadAnchor(colony);
+  if (!anchor) {
+    return [];
+  }
+
+  const pendingRoadSites = countPendingRoadConstructionSites(colony.room);
+  const remainingSiteBudget = Math.min(limits.maxSitesPerTick, limits.maxPendingRoadSites - pendingRoadSites);
+  if (remainingSiteBudget <= 0) {
+    return [];
+  }
+
+  const targets = selectRoadTargets(colony.room, limits.maxTargetsPerTick);
+  if (targets.length === 0) {
+    return [];
+  }
+
+  const lookups = createRoadPlannerLookups(colony.room);
+  if (!lookups) {
+    return [];
+  }
+
+  const candidates = selectRoadCandidates(colony.room.name, anchor.pos, targets, lookups, limits);
+  const results: ScreepsReturnCode[] = [];
+  for (const candidate of candidates) {
+    if (results.length >= remainingSiteBudget) {
+      break;
+    }
+
+    if (!canPlaceRoad(lookups, candidate)) {
+      continue;
+    }
+
+    const result = colony.room.createConstructionSite(candidate.x, candidate.y, getRoadStructureType());
+    results.push(result);
+
+    if (result !== getOkCode()) {
+      break;
+    }
+
+    lookups.pendingRoadSitePositions.add(candidate.key);
+    lookups.costMatrix.set(candidate.x, candidate.y, ROAD_PATH_COST);
+  }
+
+  return results;
+}
+
+function resolveRoadPlannerLimits(options: EarlyRoadPlannerOptions): RoadPlannerLimits {
+  return {
+    maxSitesPerTick: resolveNonNegativeInteger(options.maxSitesPerTick, DEFAULT_MAX_ROAD_SITES_PER_TICK),
+    maxPendingRoadSites: resolveNonNegativeInteger(options.maxPendingRoadSites, DEFAULT_MAX_PENDING_ROAD_SITES),
+    maxTargetsPerTick: resolveNonNegativeInteger(options.maxTargetsPerTick, DEFAULT_MAX_ROAD_TARGETS_PER_TICK),
+    maxPathOpsPerTarget: resolveNonNegativeInteger(options.maxPathOpsPerTarget, DEFAULT_MAX_PATH_OPS_PER_TARGET)
+  };
+}
+
+function resolveNonNegativeInteger(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(0, Math.floor(value));
+}
+
+function isPathFinderAvailable(): boolean {
+  return typeof PathFinder !== 'undefined' && typeof PathFinder.search === 'function' && typeof PathFinder.CostMatrix === 'function';
+}
+
+function hasRequiredRoomApis(room: Room): boolean {
+  const partialRoom = room as Partial<Room>;
+  return (
+    typeof partialRoom.find === 'function' &&
+    typeof partialRoom.lookForAtArea === 'function' &&
+    typeof partialRoom.createConstructionSite === 'function'
+  );
+}
+
+function selectRoadAnchor(colony: ColonySnapshot): StructureSpawn | null {
+  const [primarySpawn] = colony.spawns
+    .filter((spawn) => spawn.pos)
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  return primarySpawn ?? null;
+}
+
+function selectRoadTargets(room: Room, maxTargets: number): RoadTarget[] {
+  if (maxTargets <= 0) {
+    return [];
+  }
+
+  const targets: RoadTarget[] = getSortedSources(room).map((source) => ({
+    pos: source.pos
+  }));
+
+  if (room.controller?.pos && isSameRoomPosition(room.controller.pos, room.name)) {
+    targets.push({ pos: room.controller.pos });
+  }
+
+  return targets.filter((target) => isSameRoomPosition(target.pos, room.name)).slice(0, maxTargets);
+}
+
+function getSortedSources(room: Room): Source[] {
+  if (typeof FIND_SOURCES !== 'number') {
+    return [];
+  }
+
+  return room
+    .find(FIND_SOURCES)
+    .filter((source) => source.pos && isSameRoomPosition(source.pos, room.name))
+    .sort((left, right) => String(left.id).localeCompare(String(right.id)));
+}
+
+function countPendingRoadConstructionSites(room: Room): number {
+  if (typeof FIND_MY_CONSTRUCTION_SITES !== 'number') {
+    return 0;
+  }
+
+  return room.find(FIND_MY_CONSTRUCTION_SITES, {
+    filter: isRoadConstructionSite
+  }).length;
+}
+
+function createRoadPlannerLookups(room: Room): RoadPlannerLookups | null {
+  if (typeof LOOK_STRUCTURES !== 'string' || typeof LOOK_CONSTRUCTION_SITES !== 'string') {
+    return null;
+  }
+
+  const terrain = getRoomTerrain(room);
+  if (!terrain) {
+    return null;
+  }
+
+  const lookups: RoadPlannerLookups = {
+    terrain,
+    costMatrix: new PathFinder.CostMatrix(),
+    blockingPositions: new Set<string>(),
+    existingRoadPositions: new Set<string>(),
+    pendingRoadSitePositions: new Set<string>(),
+    pathBlockedPositions: new Set<string>()
+  };
+
+  blockRoomEdges(lookups);
+  cacheRoomStructures(room, lookups);
+  cacheRoomConstructionSites(room, lookups);
+
+  return lookups;
+}
+
+function getRoomTerrain(room: Room): RoomTerrain | null {
+  const game = (globalThis as unknown as { Game?: Partial<Game> }).Game;
+  if (!game?.map || typeof game.map.getRoomTerrain !== 'function') {
+    return null;
+  }
+
+  return game.map.getRoomTerrain(room.name);
+}
+
+function blockRoomEdges(lookups: RoadPlannerLookups): void {
+  for (let coordinate = ROOM_COORDINATE_MIN; coordinate <= ROOM_COORDINATE_MAX; coordinate += 1) {
+    blockPathPosition(lookups, { x: ROOM_COORDINATE_MIN, y: coordinate });
+    blockPathPosition(lookups, { x: ROOM_COORDINATE_MAX, y: coordinate });
+    blockPathPosition(lookups, { x: coordinate, y: ROOM_COORDINATE_MIN });
+    blockPathPosition(lookups, { x: coordinate, y: ROOM_COORDINATE_MAX });
+  }
+}
+
+function cacheRoomStructures(room: Room, lookups: RoadPlannerLookups): void {
+  for (const result of room.lookForAtArea(LOOK_STRUCTURES, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MAX, ROOM_COORDINATE_MAX, true)) {
+    if (!result.structure) {
+      continue;
+    }
+
+    const position = { x: result.x, y: result.y };
+    const key = getPositionKey(position);
+    if (isRoadStructure(result.structure)) {
+      lookups.existingRoadPositions.add(key);
+      setRoadPathCostIfOpen(lookups, position);
+      continue;
+    }
+
+    lookups.blockingPositions.add(key);
+    blockPathPosition(lookups, position);
+  }
+}
+
+function cacheRoomConstructionSites(room: Room, lookups: RoadPlannerLookups): void {
+  for (const result of room.lookForAtArea(LOOK_CONSTRUCTION_SITES, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MIN, ROOM_COORDINATE_MAX, ROOM_COORDINATE_MAX, true)) {
+    if (!result.constructionSite) {
+      continue;
+    }
+
+    const position = { x: result.x, y: result.y };
+    const key = getPositionKey(position);
+    if (isRoadConstructionSite(result.constructionSite)) {
+      lookups.pendingRoadSitePositions.add(key);
+      setRoadPathCostIfOpen(lookups, position);
+      continue;
+    }
+
+    lookups.blockingPositions.add(key);
+    blockPathPosition(lookups, position);
+  }
+}
+
+function selectRoadCandidates(
+  roomName: string,
+  origin: RoomPosition,
+  targets: RoadTarget[],
+  lookups: RoadPlannerLookups,
+  limits: RoadPlannerLimits
+): RoadCandidate[] {
+  const candidates = new Map<string, RoadCandidate>();
+
+  targets.forEach((target, targetIndex) => {
+    const path = findRoadPath(roomName, origin, target, lookups, limits);
+    const seenInRoute = new Set<string>();
+
+    path.forEach((position, pathIndex) => {
+      if (!isSameRoomPosition(position, roomName) || !canPlaceRoad(lookups, position)) {
+        return;
+      }
+
+      const key = getPositionKey(position);
+      if (seenInRoute.has(key)) {
+        return;
+      }
+
+      seenInRoute.add(key);
+      const existingCandidate = candidates.get(key);
+      if (existingCandidate) {
+        existingCandidate.routeCount += 1;
+        existingCandidate.minPathIndex = Math.min(existingCandidate.minPathIndex, pathIndex);
+        existingCandidate.minTargetIndex = Math.min(existingCandidate.minTargetIndex, targetIndex);
+        return;
+      }
+
+      candidates.set(key, {
+        x: position.x,
+        y: position.y,
+        key,
+        routeCount: 1,
+        minPathIndex: pathIndex,
+        minTargetIndex: targetIndex
+      });
+    });
+  });
+
+  return [...candidates.values()].sort(compareRoadCandidates);
+}
+
+function findRoadPath(
+  roomName: string,
+  origin: RoomPosition,
+  target: RoadTarget,
+  lookups: RoadPlannerLookups,
+  limits: RoadPlannerLimits
+): RoomPosition[] {
+  const result = PathFinder.search(origin, { pos: target.pos, range: 1 }, {
+    maxRooms: 1,
+    maxOps: limits.maxPathOpsPerTarget,
+    plainCost: PLAIN_PATH_COST,
+    swampCost: SWAMP_PATH_COST,
+    roomCallback: (callbackRoomName) => (callbackRoomName === roomName ? lookups.costMatrix : false)
+  });
+
+  return result.incomplete ? [] : result.path;
+}
+
+function compareRoadCandidates(left: RoadCandidate, right: RoadCandidate): number {
+  return (
+    right.routeCount - left.routeCount ||
+    left.minPathIndex - right.minPathIndex ||
+    left.minTargetIndex - right.minTargetIndex ||
+    left.y - right.y ||
+    left.x - right.x
+  );
+}
+
+function canPlaceRoad(lookups: RoadPlannerLookups, position: Positioned): boolean {
+  if (!isWithinBuildableRoomBounds(position) || isTerrainWall(lookups.terrain, position)) {
+    return false;
+  }
+
+  const key = getPositionKey(position);
+  return (
+    !lookups.blockingPositions.has(key) &&
+    !lookups.existingRoadPositions.has(key) &&
+    !lookups.pendingRoadSitePositions.has(key)
+  );
+}
+
+function blockPathPosition(lookups: RoadPlannerLookups, position: Positioned): void {
+  lookups.pathBlockedPositions.add(getPositionKey(position));
+  lookups.costMatrix.set(position.x, position.y, PATH_BLOCKED_COST);
+}
+
+function setRoadPathCostIfOpen(lookups: RoadPlannerLookups, position: Positioned): void {
+  if (!lookups.pathBlockedPositions.has(getPositionKey(position))) {
+    lookups.costMatrix.set(position.x, position.y, ROAD_PATH_COST);
+  }
+}
+
+function isWithinBuildableRoomBounds(position: Positioned): boolean {
+  return position.x >= ROOM_EDGE_MIN && position.x <= ROOM_EDGE_MAX && position.y >= ROOM_EDGE_MIN && position.y <= ROOM_EDGE_MAX;
+}
+
+function isSameRoomPosition(position: Positioned, roomName: string): boolean {
+  return !position.roomName || position.roomName === roomName;
+}
+
+function isTerrainWall(terrain: RoomTerrain, position: Positioned): boolean {
+  return (terrain.get(position.x, position.y) & getTerrainWallMask()) !== 0;
+}
+
+function isRoadStructure(structure: Structure): boolean {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road');
+}
+
+function isRoadConstructionSite(site: ConstructionSite): boolean {
+  return matchesStructureType(site.structureType, 'STRUCTURE_ROAD', 'road');
+}
+
+function matchesStructureType(actual: string | undefined, globalName: StructureConstantGlobal, fallback: string): boolean {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, string>>;
+  return actual === (constants[globalName] ?? fallback);
+}
+
+function getRoadStructureType(): BuildableStructureConstant {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, BuildableStructureConstant>>;
+  return constants.STRUCTURE_ROAD ?? ('road' as BuildableStructureConstant);
+}
+
+function getPositionKey(position: Positioned): string {
+  return `${position.x},${position.y}`;
+}
+
+function getTerrainWallMask(): number {
+  return typeof TERRAIN_MASK_WALL === 'number' ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK;
+}
+
+function getOkCode(): ScreepsReturnCode {
+  return (typeof OK === 'number' ? OK : 0) as ScreepsReturnCode;
+}

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -1,5 +1,6 @@
 import { getOwnedColonies } from '../colony/colonyRegistry';
 import { planExtensionConstruction } from '../construction/extensionPlanner';
+import { planEarlyRoadConstruction } from '../construction/roadPlanner';
 import { countCreepsByRole } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
 import { planSpawn, type SpawnRequest } from '../spawn/spawnPlanner';
@@ -15,7 +16,10 @@ export function runEconomy(): void {
   const telemetryEvents: RuntimeTelemetryEvent[] = [];
 
   for (const colony of colonies) {
-    planExtensionConstruction(colony);
+    const extensionResult = planExtensionConstruction(colony);
+    if (extensionResult === null) {
+      planEarlyRoadConstruction(colony);
+    }
 
     const roleCounts = countCreepsByRole(creeps, colony.room.name);
     const spawnRequest = planSpawn(colony, roleCounts, Game.time);

--- a/prod/test/roadPlanner.test.ts
+++ b/prod/test/roadPlanner.test.ts
@@ -6,11 +6,11 @@ const OK_CODE = 0 as ScreepsReturnCode;
 const TEST_GLOBALS = {
   FIND_SOURCES: 1,
   FIND_MY_CONSTRUCTION_SITES: 2,
+  FIND_CONSTRUCTION_SITES: 3,
+  FIND_STRUCTURES: 4,
   STRUCTURE_ROAD: 'road',
   STRUCTURE_EXTENSION: 'extension',
   TERRAIN_MASK_WALL: 1,
-  LOOK_STRUCTURES: 'structure',
-  LOOK_CONSTRUCTION_SITES: 'constructionSite',
   OK: OK_CODE
 } as const;
 
@@ -92,6 +92,9 @@ describe('early road planner', () => {
 
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
     expect(room.createConstructionSite).toHaveBeenCalledWith(16, 10, STRUCTURE_ROAD);
+    expect(room.lookForAtArea).not.toHaveBeenCalled();
+    expect(room.find).toHaveBeenCalledWith(FIND_STRUCTURES);
+    expect(room.find).toHaveBeenCalledWith(FIND_CONSTRUCTION_SITES);
   });
 
   it('caps created sites by per-tick and pending road budgets', () => {
@@ -183,26 +186,22 @@ function makeColony(options: MakeColonyOptions): { room: MockRoom; colony: Colon
     controller,
     energyAvailable: 300,
     energyCapacityAvailable: 300,
-    find: jest.fn((findType: number, findOptions?: { filter?: (target: Source | ConstructionSite) => boolean }) => {
+    find: jest.fn((findType: number, findOptions?: { filter?: (target: Source | Structure | ConstructionSite) => boolean }) => {
       const targets =
         findType === TEST_GLOBALS.FIND_SOURCES
           ? options.sources
           : findType === TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES
             ? constructionSites
-            : [];
+            : findType === TEST_GLOBALS.FIND_CONSTRUCTION_SITES
+              ? constructionSites
+              : findType === TEST_GLOBALS.FIND_STRUCTURES
+                ? structures
+                : [];
 
       return findOptions?.filter ? targets.filter(findOptions.filter) : targets;
     }),
-    lookForAtArea: jest.fn((lookType: string, top: number, left: number, bottom: number, right: number) => {
-      if (lookType === TEST_GLOBALS.LOOK_STRUCTURES) {
-        return getStructureLookResults(structures, top, left, bottom, right);
-      }
-
-      if (lookType === TEST_GLOBALS.LOOK_CONSTRUCTION_SITES) {
-        return getConstructionSiteLookResults(constructionSites, top, left, bottom, right);
-      }
-
-      return [];
+    lookForAtArea: jest.fn(() => {
+      throw new Error('road planner should use room.find for room-wide lookups');
     }),
     createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
       constructionSites.push(makeConstructionSite(`site-${x}-${y}`, structureType, { x, y }));
@@ -270,34 +269,6 @@ function makeConstructionSite(id: string, structureType: StructureConstant, posi
 
 function makeRoomPosition(position: TestPosition, roomName: string): RoomPosition {
   return { ...position, roomName } as RoomPosition;
-}
-
-function getStructureLookResults(structures: Structure[], top: number, left: number, bottom: number, right: number): LookAtResultWithPos[] {
-  return structures.flatMap((structure) => {
-    const position = (structure as { pos?: RoomPosition }).pos;
-    return position && isWithinBounds(position, top, left, bottom, right)
-      ? [{ x: position.x, y: position.y, structure } as LookAtResultWithPos]
-      : [];
-  });
-}
-
-function getConstructionSiteLookResults(
-  constructionSites: ConstructionSite[],
-  top: number,
-  left: number,
-  bottom: number,
-  right: number
-): LookAtResultWithPos[] {
-  return constructionSites.flatMap((constructionSite) => {
-    const position = (constructionSite as { pos?: RoomPosition }).pos;
-    return position && isWithinBounds(position, top, left, bottom, right)
-      ? [{ x: position.x, y: position.y, constructionSite } as LookAtResultWithPos]
-      : [];
-  });
-}
-
-function isWithinBounds(position: TestPosition, top: number, left: number, bottom: number, right: number): boolean {
-  return position.x >= left && position.x <= right && position.y >= top && position.y <= bottom;
 }
 
 function getPositionKey(position: TestPosition): string {

--- a/prod/test/roadPlanner.test.ts
+++ b/prod/test/roadPlanner.test.ts
@@ -1,0 +1,310 @@
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import { planEarlyRoadConstruction } from '../src/construction/roadPlanner';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+const TEST_GLOBALS = {
+  FIND_SOURCES: 1,
+  FIND_MY_CONSTRUCTION_SITES: 2,
+  STRUCTURE_ROAD: 'road',
+  STRUCTURE_EXTENSION: 'extension',
+  TERRAIN_MASK_WALL: 1,
+  LOOK_STRUCTURES: 'structure',
+  LOOK_CONSTRUCTION_SITES: 'constructionSite',
+  OK: OK_CODE
+} as const;
+
+describe('early road planner', () => {
+  beforeEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const [key, value] of Object.entries(TEST_GLOBALS)) {
+      globals[key] = value;
+    }
+  });
+
+  afterEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const key of Object.keys(TEST_GLOBALS)) {
+      delete globals[key];
+    }
+
+    delete globals.Game;
+    delete globals.PathFinder;
+  });
+
+  it('places the shared route segment first in deterministic target order', () => {
+    const { room, colony, pathFinderSearch } = makeColony({
+      sources: [
+        makeSource('source-b', { x: 20, y: 11 }),
+        makeSource('source-a', { x: 20, y: 10 })
+      ],
+      controllerPosition: { x: 10, y: 20 },
+      pathsByTarget: {
+        '20,10': [
+          { x: 11, y: 10 },
+          { x: 12, y: 10 },
+          { x: 13, y: 10 }
+        ],
+        '20,11': [
+          { x: 11, y: 10 },
+          { x: 12, y: 10 },
+          { x: 12, y: 11 }
+        ],
+        '10,20': [
+          { x: 10, y: 11 },
+          { x: 10, y: 12 }
+        ]
+      }
+    });
+
+    expect(planEarlyRoadConstruction(colony)).toEqual([OK_CODE]);
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(11, 10, STRUCTURE_ROAD);
+    expect(pathFinderSearch.mock.calls.map(([, goal]) => getGoalPositionKey(goal))).toEqual(['20,10', '20,11', '10,20']);
+  });
+
+  it('skips walls, occupied structures, existing roads, and construction sites', () => {
+    const { room, colony } = makeColony({
+      sources: [makeSource('source-a', { x: 20, y: 10 })],
+      structures: [
+        makeStructure('existing-road', TEST_GLOBALS.STRUCTURE_ROAD, { x: 11, y: 10 }),
+        makeStructure('occupied-extension', TEST_GLOBALS.STRUCTURE_EXTENSION, { x: 14, y: 10 })
+      ],
+      constructionSites: [
+        makeConstructionSite('pending-road', TEST_GLOBALS.STRUCTURE_ROAD, { x: 12, y: 10 }),
+        makeConstructionSite('pending-extension', TEST_GLOBALS.STRUCTURE_EXTENSION, { x: 13, y: 10 })
+      ],
+      wallPositions: new Set(['15,10']),
+      pathsByTarget: {
+        '20,10': [
+          { x: 11, y: 10 },
+          { x: 12, y: 10 },
+          { x: 13, y: 10 },
+          { x: 14, y: 10 },
+          { x: 15, y: 10 },
+          { x: 16, y: 10 }
+        ]
+      }
+    });
+
+    expect(planEarlyRoadConstruction(colony)).toEqual([OK_CODE]);
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(16, 10, STRUCTURE_ROAD);
+  });
+
+  it('caps created sites by per-tick and pending road budgets', () => {
+    const { room, colony, pathFinderSearch } = makeColony({
+      sources: [makeSource('source-a', { x: 20, y: 10 })],
+      pathsByTarget: {
+        '20,10': [
+          { x: 11, y: 10 },
+          { x: 12, y: 10 },
+          { x: 13, y: 10 },
+          { x: 14, y: 10 }
+        ]
+      }
+    });
+
+    expect(planEarlyRoadConstruction(colony, { maxSitesPerTick: 5, maxPendingRoadSites: 2 })).toEqual([
+      OK_CODE,
+      OK_CODE
+    ]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(2);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 11, 10, STRUCTURE_ROAD);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(2, 12, 10, STRUCTURE_ROAD);
+
+    pathFinderSearch.mockClear();
+    expect(planEarlyRoadConstruction(colony, { maxSitesPerTick: 5, maxPendingRoadSites: 2 })).toEqual([]);
+    expect(pathFinderSearch).not.toHaveBeenCalled();
+  });
+});
+
+interface MockRoom extends Room {
+  find: jest.Mock;
+  createConstructionSite: jest.Mock;
+  lookForAtArea: jest.Mock;
+}
+
+interface TestPosition {
+  x: number;
+  y: number;
+}
+
+interface MakeColonyOptions {
+  sources: Source[];
+  controllerPosition?: TestPosition;
+  structures?: Structure[];
+  constructionSites?: ConstructionSite[];
+  wallPositions?: Set<string>;
+  pathsByTarget: Record<string, TestPosition[]>;
+}
+
+class MockCostMatrix {
+  private readonly costs = new Map<string, number>();
+
+  set(x: number, y: number, cost: number): void {
+    this.costs.set(`${x},${y}`, cost);
+  }
+
+  get(x: number, y: number): number {
+    return this.costs.get(`${x},${y}`) ?? 0;
+  }
+
+  clone(): CostMatrix {
+    const clone = new MockCostMatrix();
+    for (const [key, cost] of this.costs.entries()) {
+      const [x, y] = key.split(',').map(Number);
+      clone.set(x, y, cost);
+    }
+
+    return clone as unknown as CostMatrix;
+  }
+
+  serialize(): number[] {
+    return [];
+  }
+}
+
+function makeColony(options: MakeColonyOptions): { room: MockRoom; colony: ColonySnapshot; pathFinderSearch: jest.Mock } {
+  const structures = options.structures ?? [];
+  const constructionSites = [...(options.constructionSites ?? [])];
+  const wallPositions = options.wallPositions ?? new Set<string>();
+  const roomName = 'W1N1';
+  const controller = {
+    id: 'controller1',
+    my: true,
+    level: 2,
+    pos: makeRoomPosition(options.controllerPosition ?? { x: 25, y: 25 }, roomName)
+  } as unknown as StructureController;
+  const room = {
+    name: roomName,
+    controller,
+    energyAvailable: 300,
+    energyCapacityAvailable: 300,
+    find: jest.fn((findType: number, findOptions?: { filter?: (target: Source | ConstructionSite) => boolean }) => {
+      const targets =
+        findType === TEST_GLOBALS.FIND_SOURCES
+          ? options.sources
+          : findType === TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES
+            ? constructionSites
+            : [];
+
+      return findOptions?.filter ? targets.filter(findOptions.filter) : targets;
+    }),
+    lookForAtArea: jest.fn((lookType: string, top: number, left: number, bottom: number, right: number) => {
+      if (lookType === TEST_GLOBALS.LOOK_STRUCTURES) {
+        return getStructureLookResults(structures, top, left, bottom, right);
+      }
+
+      if (lookType === TEST_GLOBALS.LOOK_CONSTRUCTION_SITES) {
+        return getConstructionSiteLookResults(constructionSites, top, left, bottom, right);
+      }
+
+      return [];
+    }),
+    createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+      constructionSites.push(makeConstructionSite(`site-${x}-${y}`, structureType, { x, y }));
+      return OK_CODE;
+    })
+  } as unknown as MockRoom;
+  const spawn = {
+    name: 'Spawn1',
+    room,
+    pos: makeRoomPosition({ x: 10, y: 10 }, roomName)
+  } as unknown as StructureSpawn;
+  const pathFinderSearch = jest.fn((_origin: RoomPosition, goal: { pos: RoomPosition }) => ({
+    path: (options.pathsByTarget[getPositionKey(goal.pos)] ?? []).map((position) => makeRoomPosition(position, roomName)),
+    ops: 1,
+    cost: 1,
+    incomplete: false
+  }));
+
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    map: {
+      getRoomTerrain: jest.fn().mockReturnValue({
+        get: (x: number, y: number) => (wallPositions.has(`${x},${y}`) ? TEST_GLOBALS.TERRAIN_MASK_WALL : 0)
+      })
+    } as unknown as Game['map']
+  };
+  (globalThis as unknown as { PathFinder: Partial<PathFinder> }).PathFinder = {
+    CostMatrix: MockCostMatrix as unknown as CostMatrix,
+    search: pathFinderSearch as unknown as PathFinder['search']
+  };
+
+  return {
+    room,
+    colony: {
+      room,
+      spawns: [spawn],
+      energyAvailable: room.energyAvailable,
+      energyCapacityAvailable: room.energyCapacityAvailable
+    },
+    pathFinderSearch
+  };
+}
+
+function makeSource(id: string, position: TestPosition): Source {
+  return {
+    id,
+    pos: makeRoomPosition(position, 'W1N1')
+  } as unknown as Source;
+}
+
+function makeStructure(id: string, structureType: StructureConstant, position: TestPosition): Structure {
+  return {
+    id,
+    structureType,
+    pos: makeRoomPosition(position, 'W1N1')
+  } as unknown as Structure;
+}
+
+function makeConstructionSite(id: string, structureType: StructureConstant, position: TestPosition): ConstructionSite {
+  return {
+    id,
+    structureType,
+    pos: makeRoomPosition(position, 'W1N1')
+  } as unknown as ConstructionSite;
+}
+
+function makeRoomPosition(position: TestPosition, roomName: string): RoomPosition {
+  return { ...position, roomName } as RoomPosition;
+}
+
+function getStructureLookResults(structures: Structure[], top: number, left: number, bottom: number, right: number): LookAtResultWithPos[] {
+  return structures.flatMap((structure) => {
+    const position = (structure as { pos?: RoomPosition }).pos;
+    return position && isWithinBounds(position, top, left, bottom, right)
+      ? [{ x: position.x, y: position.y, structure } as LookAtResultWithPos]
+      : [];
+  });
+}
+
+function getConstructionSiteLookResults(
+  constructionSites: ConstructionSite[],
+  top: number,
+  left: number,
+  bottom: number,
+  right: number
+): LookAtResultWithPos[] {
+  return constructionSites.flatMap((constructionSite) => {
+    const position = (constructionSite as { pos?: RoomPosition }).pos;
+    return position && isWithinBounds(position, top, left, bottom, right)
+      ? [{ x: position.x, y: position.y, constructionSite } as LookAtResultWithPos]
+      : [];
+  });
+}
+
+function isWithinBounds(position: TestPosition, top: number, left: number, bottom: number, right: number): boolean {
+  return position.x >= left && position.x <= right && position.y >= top && position.y <= bottom;
+}
+
+function getPositionKey(position: TestPosition): string {
+  return `${position.x},${position.y}`;
+}
+
+function getGoalPositionKey(goal: unknown): string {
+  const pathGoal = goal as { pos: TestPosition };
+  return getPositionKey(pathGoal.pos);
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic early road planner for spawn-to-source/controller routes.
- Integrates road planning into the economy loop only when extension planning does not create a site, keeping construction conservative.
- Adds road planner coverage for placement order, blocked/duplicate avoidance, and per-tick/pending-site caps.
- Regenerates `prod/dist/main.js` through the build.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand -- roadPlanner.test.ts`
- [x] `cd prod && npm test -- --runInBand` (16 suites, 166 tests)
- [x] `cd prod && npm run build`

No secrets were touched.

Closes #121
