### PR TITLE
feat: route energy to nearest fillable sink

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -518,9 +518,7 @@ function selectWorkerTask(creep) {
     const source = selectHarvestSource(creep);
     return source ? { type: "harvest", targetId: source.id } : null;
   }
-  const [energySink] = creep.room.find(FIND_MY_STRUCTURES, {
-    filter: isFillableEnergySink
-  });
+  const energySink = selectFillableEnergySink(creep);
   if (energySink) {
     return { type: "transfer", targetId: energySink.id };
   }
@@ -557,6 +555,16 @@ function selectWorkerTask(creep) {
 }
 function isFillableEnergySink(structure) {
   return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure && structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
+}
+function selectFillableEnergySink(creep) {
+  const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
+    filter: isFillableEnergySink
+  });
+  if (energySinks.length === 0) {
+    return null;
+  }
+  const closestEnergySink = findClosestByRange(creep, energySinks);
+  return closestEnergySink != null ? closestEnergySink : energySinks[0];
 }
 function isSpawnConstructionSite(site) {
   return matchesStructureType2(site.structureType, "STRUCTURE_SPAWN", "spawn");
@@ -683,10 +691,20 @@ function findDroppedResources(room) {
 function isUsefulDroppedEnergy(resource) {
   return resource.resourceType === RESOURCE_ENERGY && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
 }
-function findClosestByRange(creep, resources) {
-  var _a, _b;
+function findClosestByRange(creep, objects) {
+  if (objects.length === 0) {
+    return null;
+  }
   const position = creep.pos;
-  return (_b = (_a = position == null ? void 0 : position.findClosestByRange) == null ? void 0 : _a.call(position, resources)) != null ? _b : null;
+  if (typeof (position == null ? void 0 : position.getRangeTo) === "function") {
+    return objects.reduce((closest, candidate) => {
+      var _a, _b, _c, _d;
+      const closestRange = (_b = (_a = position.getRangeTo) == null ? void 0 : _a.call(position, closest)) != null ? _b : Infinity;
+      const candidateRange = (_d = (_c = position.getRangeTo) == null ? void 0 : _c.call(position, candidate)) != null ? _d : Infinity;
+      return candidateRange < closestRange ? candidate : closest;
+    });
+  }
+  return typeof (position == null ? void 0 : position.findClosestByRange) === "function" ? position.findClosestByRange(objects) : null;
 }
 function selectHarvestSource(creep) {
   var _a, _b;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -21,9 +21,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return source ? { type: 'harvest', targetId: source.id } : null;
   }
 
-  const [energySink] = creep.room.find(FIND_MY_STRUCTURES, {
-    filter: isFillableEnergySink
-  });
+  const energySink = selectFillableEnergySink(creep);
   if (energySink) {
     return { type: 'transfer', targetId: energySink.id as Id<AnyStoreStructure> };
   }
@@ -75,6 +73,19 @@ function isFillableEnergySink(structure: AnyOwnedStructure): structure is Struct
     'store' in structure &&
     structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0
   );
+}
+
+function selectFillableEnergySink(creep: Creep): StructureSpawn | StructureExtension | null {
+  const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
+    filter: isFillableEnergySink
+  });
+
+  if (energySinks.length === 0) {
+    return null;
+  }
+
+  const closestEnergySink = findClosestByRange(creep, energySinks);
+  return closestEnergySink ?? energySinks[0];
 }
 
 function isSpawnConstructionSite(site: ConstructionSite): boolean {
@@ -255,14 +266,27 @@ function isUsefulDroppedEnergy(resource: Resource): resource is Resource<RESOURC
   return resource.resourceType === RESOURCE_ENERGY && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
 }
 
-function findClosestByRange(creep: Creep, resources: Resource<RESOURCE_ENERGY>[]): Resource<RESOURCE_ENERGY> | null {
+function findClosestByRange<T extends RoomObject>(creep: Creep, objects: T[]): T | null {
+  if (objects.length === 0) {
+    return null;
+  }
+
   const position = (creep as Creep & {
     pos?: {
-      findClosestByRange?: (objects: Resource<RESOURCE_ENERGY>[]) => Resource<RESOURCE_ENERGY> | null;
+      findClosestByRange?: (objects: T[]) => T | null;
+      getRangeTo?: (target: T) => number;
     };
   }).pos;
 
-  return position?.findClosestByRange?.(resources) ?? null;
+  if (typeof position?.getRangeTo === 'function') {
+    return objects.reduce((closest, candidate) => {
+      const closestRange = position.getRangeTo?.(closest) ?? Infinity;
+      const candidateRange = position.getRangeTo?.(candidate) ?? Infinity;
+      return candidateRange < closestRange ? candidate : closest;
+    });
+  }
+
+  return typeof position?.findClosestByRange === 'function' ? position.findClosestByRange(objects) : null;
 }
 
 function selectHarvestSource(creep: Creep): Source | null {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -26,6 +26,18 @@ function makeStructure(
   return { id, structureType, hits, hitsMax, ...extra } as unknown as AnyStructure;
 }
 
+function makeEnergySink(
+  id: string,
+  structureType: StructureConstant,
+  freeCapacity: number
+): StructureSpawn | StructureExtension {
+  return {
+    id,
+    structureType,
+    store: { getFreeCapacity: jest.fn().mockReturnValue(freeCapacity) }
+  } as unknown as StructureSpawn | StructureExtension;
+}
+
 describe('selectWorkerTask', () => {
   beforeEach(() => {
     (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).FIND_SOURCES = 1;
@@ -240,6 +252,84 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
+  });
+
+  it('selects the nearest fillable energy sink when worker position range helpers are available', () => {
+    const farSpawn = makeEnergySink('spawn-far', 'spawn' as StructureConstant, 300);
+    const fullExtension = makeEnergySink('extension-full', 'extension' as StructureConstant, 0);
+    const nearExtension = makeEnergySink('extension-near', 'extension' as StructureConstant, 50);
+    const structures = [farSpawn, fullExtension, nearExtension];
+    const getRangeTo = jest.fn((target: StructureSpawn | StructureExtension) => {
+      const ranges: Record<string, number> = {
+        'extension-full': 1,
+        'extension-near': 2,
+        'spawn-far': 8
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-near' });
+    expect(getRangeTo).not.toHaveBeenCalledWith(fullExtension);
+  });
+
+  it('keeps room.find order as the stable energy sink fallback when position helpers are unavailable', () => {
+    const firstExtension = makeEnergySink('extension-first', 'extension' as StructureConstant, 50);
+    const secondSpawn = makeEnergySink('spawn-second', 'spawn' as StructureConstant, 300);
+    const structures = [firstExtension, secondSpawn];
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-first' });
+  });
+
+  it('preserves no-sink fallback behavior when all energy sinks are full', () => {
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const fullExtension = makeEnergySink('extension-full', 'extension' as StructureConstant, 0);
+    const site = { id: 'site1' } as ConstructionSite;
+    const structures = [fullSpawn, fullExtension];
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            return type === FIND_CONSTRUCTION_SITES ? [site] : [];
+          }
+        )
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
   });
 
   it('selects build when worker has energy and construction sites exist', () => {


### PR DESCRIPTION
## Summary
- Routes loaded workers to the nearest fillable spawn/extension when range helpers are available.
- Preserves stable room.find fallback order when range helpers are absent.
- Keeps full-structure/no-sink fallback behavior and existing transfer/build/repair/upgrade priorities.
- Regenerates `prod/dist/main.js` via `npm run build`.

## Linked issue
Closes #129

## Roadmap category
Gameplay Evolution / resources-economy

## Served vision layer
Resources/economy: reduces worker travel waste while filling spawn/extension energy sinks, improving early-room throughput after extension and road planner improvements.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand -- workerTasks.test.ts` (40 tests)
- [x] `cd prod && npm test -- --runInBand` (16 suites / 169 tests)
- [x] `cd prod && npm run build`
- [x] `git diff --check`

## Notes
- Codex-authored commit: `a1dc213 lanyusea's bot <lanyusea@gmail.com> feat: route energy to nearest fillable sink`
- No secrets included.
- Requires independent QA PASS, green checks/reviews, no active review threads, current Project fields, and >=15 minute elapsed review gate before merge.
