### PR TITLE
feat: withdraw stored energy before harvesting

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -582,8 +582,13 @@ function matchesStructureType2(actual, globalName, fallback) {
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 function selectStoredEnergySource(creep) {
+  const context = {
+    creepOwnerUsername: getCreepOwnerUsername(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
   const storedEnergySources = findVisibleRoomStructures(creep.room).filter(
-    (structure) => isSafeStoredEnergySource(structure, creep.room)
+    (structure) => isSafeStoredEnergySource(structure, context)
   );
   if (storedEnergySources.length === 0) {
     return null;
@@ -591,8 +596,8 @@ function selectStoredEnergySource(creep) {
   const closestStoredEnergy = findClosestByRange(creep, storedEnergySources);
   return closestStoredEnergy != null ? closestStoredEnergy : storedEnergySources[0];
 }
-function isSafeStoredEnergySource(structure, room) {
-  return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, room);
+function isSafeStoredEnergySource(structure, context) {
+  return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, context);
 }
 function isStoredWorkerEnergySource(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType2(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType2(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
@@ -601,13 +606,48 @@ function hasStoredEnergy(structure) {
   var _a;
   return ((_a = structure.store.getUsedCapacity(RESOURCE_ENERGY)) != null ? _a : 0) > 0;
 }
-function isFriendlyStoredEnergySource(structure, room) {
+function isFriendlyStoredEnergySource(structure, context) {
   var _a;
   const ownership = structure.my;
   if (typeof ownership === "boolean") {
     return ownership;
   }
-  return ((_a = room.controller) == null ? void 0 : _a.my) === true;
+  if (((_a = context.room.controller) == null ? void 0 : _a.my) === true) {
+    return true;
+  }
+  return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
+}
+function isRoomSafeForUnownedContainerWithdrawal(context) {
+  var _a;
+  if (context.hasHostilePresence) {
+    return false;
+  }
+  const controller = context.room.controller;
+  if (!controller) {
+    return true;
+  }
+  if (controller.owner != null) {
+    return false;
+  }
+  const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
+  if (reservationUsername == null) {
+    return true;
+  }
+  return reservationUsername === context.creepOwnerUsername;
+}
+function getCreepOwnerUsername(creep) {
+  var _a;
+  const username = (_a = creep.owner) == null ? void 0 : _a.username;
+  return typeof username === "string" && username.length > 0 ? username : null;
+}
+function hasVisibleHostilePresence(room) {
+  return findHostileCreeps(room).length > 0 || findHostileStructures(room).length > 0;
+}
+function findHostileCreeps(room) {
+  return typeof FIND_HOSTILE_CREEPS === "number" ? room.find(FIND_HOSTILE_CREEPS) : [];
+}
+function findHostileStructures(room) {
+  return typeof FIND_HOSTILE_STRUCTURES === "number" ? room.find(FIND_HOSTILE_STRUCTURES) : [];
 }
 function selectRepairTarget(creep) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -514,6 +514,10 @@ function selectWorkerTask(creep) {
       if (droppedEnergy) {
         return { type: "pickup", targetId: droppedEnergy.id };
       }
+      const storedEnergy = selectStoredEnergySource(creep);
+      if (storedEnergy) {
+        return { type: "withdraw", targetId: storedEnergy.id };
+      }
     }
     const source = selectHarvestSource(creep);
     return source ? { type: "harvest", targetId: source.id } : null;
@@ -576,6 +580,34 @@ function matchesStructureType2(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+function selectStoredEnergySource(creep) {
+  const storedEnergySources = findVisibleRoomStructures(creep.room).filter(
+    (structure) => isSafeStoredEnergySource(structure, creep.room)
+  );
+  if (storedEnergySources.length === 0) {
+    return null;
+  }
+  const closestStoredEnergy = findClosestByRange(creep, storedEnergySources);
+  return closestStoredEnergy != null ? closestStoredEnergy : storedEnergySources[0];
+}
+function isSafeStoredEnergySource(structure, room) {
+  return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, room);
+}
+function isStoredWorkerEnergySource(structure) {
+  return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType2(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType2(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
+}
+function hasStoredEnergy(structure) {
+  var _a;
+  return ((_a = structure.store.getUsedCapacity(RESOURCE_ENERGY)) != null ? _a : 0) > 0;
+}
+function isFriendlyStoredEnergySource(structure, room) {
+  var _a;
+  const ownership = structure.my;
+  if (typeof ownership === "boolean") {
+    return ownership;
+  }
+  return ((_a = room.controller) == null ? void 0 : _a.my) === true;
 }
 function selectRepairTarget(creep) {
   var _a;
@@ -807,7 +839,7 @@ function shouldReplaceTask(creep, task) {
   }
   const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
   const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
-  if (task.type === "harvest" || task.type === "pickup") {
+  if (task.type === "harvest" || task.type === "pickup" || task.type === "withdraw") {
     return freeEnergyCapacity === 0;
   }
   return usedEnergy === 0;
@@ -828,7 +860,11 @@ function shouldPreemptUpgradeTask(creep, task) {
   return true;
 }
 function shouldReplaceTarget(task, target) {
+  var _a;
   if (task.type === "transfer" && "store" in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
+    return true;
+  }
+  if (task.type === "withdraw" && "store" in target && ((_a = target.store.getUsedCapacity(RESOURCE_ENERGY)) != null ? _a : 0) === 0) {
     return true;
   }
   return task.type === "repair" && "hits" in target && isWorkerRepairTargetComplete(target);
@@ -839,6 +875,8 @@ function executeTask(creep, task, target) {
       return creep.harvest(target);
     case "pickup":
       return creep.pickup(target);
+    case "withdraw":
+      return creep.withdraw(target, RESOURCE_ENERGY);
     case "transfer":
       return creep.transfer(target, RESOURCE_ENERGY);
     case "build":

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -59,7 +59,7 @@ function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
   const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
   const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
 
-  if (task.type === 'harvest' || task.type === 'pickup') {
+  if (task.type === 'harvest' || task.type === 'pickup' || task.type === 'withdraw') {
     return freeEnergyCapacity === 0;
   }
 
@@ -92,6 +92,10 @@ function shouldReplaceTarget(
     return true;
   }
 
+  if (task.type === 'withdraw' && 'store' in target && (target.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0) === 0) {
+    return true;
+  }
+
   return task.type === 'repair' && 'hits' in target && isWorkerRepairTargetComplete(target);
 }
 
@@ -105,6 +109,8 @@ function executeTask(
       return creep.harvest(target as Source);
     case 'pickup':
       return creep.pickup(target as Resource<ResourceConstant>);
+    case 'withdraw':
+      return creep.withdraw(target as AnyStoreStructure, RESOURCE_ENERGY);
     case 'transfer':
       return creep.transfer(target as AnyStoreStructure, RESOURCE_ENERGY);
     case 'build':

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -7,6 +7,12 @@ const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal;
 
+interface StoredEnergySourceContext {
+  creepOwnerUsername: string | null;
+  hasHostilePresence: boolean;
+  room: Room;
+}
+
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
 
@@ -117,8 +123,13 @@ function matchesStructureType(actual: string | undefined, globalName: StructureC
 }
 
 function selectStoredEnergySource(creep: Creep): StoredWorkerEnergySource | null {
+  const context: StoredEnergySourceContext = {
+    creepOwnerUsername: getCreepOwnerUsername(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
   const storedEnergySources = findVisibleRoomStructures(creep.room).filter((structure): structure is StoredWorkerEnergySource =>
-    isSafeStoredEnergySource(structure, creep.room)
+    isSafeStoredEnergySource(structure, context)
   );
 
   if (storedEnergySources.length === 0) {
@@ -129,8 +140,11 @@ function selectStoredEnergySource(creep: Creep): StoredWorkerEnergySource | null
   return closestStoredEnergy ?? storedEnergySources[0];
 }
 
-function isSafeStoredEnergySource(structure: AnyStructure, room: Room): structure is StoredWorkerEnergySource {
-  return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, room);
+function isSafeStoredEnergySource(
+  structure: AnyStructure,
+  context: StoredEnergySourceContext
+): structure is StoredWorkerEnergySource {
+  return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, context);
 }
 
 function isStoredWorkerEnergySource(structure: AnyStructure): structure is StoredWorkerEnergySource {
@@ -145,13 +159,59 @@ function hasStoredEnergy(structure: StoredWorkerEnergySource): boolean {
   return (structure.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0) > 0;
 }
 
-function isFriendlyStoredEnergySource(structure: StoredWorkerEnergySource, room: Room): boolean {
+function isFriendlyStoredEnergySource(structure: StoredWorkerEnergySource, context: StoredEnergySourceContext): boolean {
   const ownership = (structure as StoredWorkerEnergySource & { my?: boolean }).my;
   if (typeof ownership === 'boolean') {
     return ownership;
   }
 
-  return room.controller?.my === true;
+  if (context.room.controller?.my === true) {
+    return true;
+  }
+
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container') &&
+    isRoomSafeForUnownedContainerWithdrawal(context)
+  );
+}
+
+function isRoomSafeForUnownedContainerWithdrawal(context: StoredEnergySourceContext): boolean {
+  if (context.hasHostilePresence) {
+    return false;
+  }
+
+  const controller = context.room.controller;
+  if (!controller) {
+    return true;
+  }
+
+  if (controller.owner != null) {
+    return false;
+  }
+
+  const reservationUsername = controller.reservation?.username;
+  if (reservationUsername == null) {
+    return true;
+  }
+
+  return reservationUsername === context.creepOwnerUsername;
+}
+
+function getCreepOwnerUsername(creep: Creep): string | null {
+  const username = (creep as Creep & { owner?: { username?: string } }).owner?.username;
+  return typeof username === 'string' && username.length > 0 ? username : null;
+}
+
+function hasVisibleHostilePresence(room: Room): boolean {
+  return findHostileCreeps(room).length > 0 || findHostileStructures(room).length > 0;
+}
+
+function findHostileCreeps(room: Room): Creep[] {
+  return typeof FIND_HOSTILE_CREEPS === 'number' ? room.find(FIND_HOSTILE_CREEPS) : [];
+}
+
+function findHostileStructures(room: Room): AnyStructure[] {
+  return typeof FIND_HOSTILE_STRUCTURES === 'number' ? room.find(FIND_HOSTILE_STRUCTURES) : [];
 }
 
 function selectRepairTarget(creep: Creep): RepairableWorkerStructure | null {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -5,6 +5,7 @@ const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
+type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal;
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
@@ -14,6 +15,11 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
       const droppedEnergy = selectDroppedEnergy(creep);
       if (droppedEnergy) {
         return { type: 'pickup', targetId: droppedEnergy.id };
+      }
+
+      const storedEnergy = selectStoredEnergySource(creep);
+      if (storedEnergy) {
+        return { type: 'withdraw', targetId: storedEnergy.id as Id<AnyStoreStructure> };
       }
     }
 
@@ -101,11 +107,51 @@ type StructureConstantGlobal =
   | 'STRUCTURE_EXTENSION'
   | 'STRUCTURE_ROAD'
   | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_STORAGE'
+  | 'STRUCTURE_TERMINAL'
   | 'STRUCTURE_RAMPART';
 
 function matchesStructureType(actual: string | undefined, globalName: StructureConstantGlobal, fallback: string): boolean {
   const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, string>>;
   return actual === (constants[globalName] ?? fallback);
+}
+
+function selectStoredEnergySource(creep: Creep): StoredWorkerEnergySource | null {
+  const storedEnergySources = findVisibleRoomStructures(creep.room).filter((structure): structure is StoredWorkerEnergySource =>
+    isSafeStoredEnergySource(structure, creep.room)
+  );
+
+  if (storedEnergySources.length === 0) {
+    return null;
+  }
+
+  const closestStoredEnergy = findClosestByRange(creep, storedEnergySources);
+  return closestStoredEnergy ?? storedEnergySources[0];
+}
+
+function isSafeStoredEnergySource(structure: AnyStructure, room: Room): structure is StoredWorkerEnergySource {
+  return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, room);
+}
+
+function isStoredWorkerEnergySource(structure: AnyStructure): structure is StoredWorkerEnergySource {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_TERMINAL', 'terminal')
+  );
+}
+
+function hasStoredEnergy(structure: StoredWorkerEnergySource): boolean {
+  return (structure.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0) > 0;
+}
+
+function isFriendlyStoredEnergySource(structure: StoredWorkerEnergySource, room: Room): boolean {
+  const ownership = (structure as StoredWorkerEnergySource & { my?: boolean }).my;
+  if (typeof ownership === 'boolean') {
+    return ownership;
+  }
+
+  return room.controller?.my === true;
 }
 
 function selectRepairTarget(creep: Creep): RepairableWorkerStructure | null {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -48,6 +48,7 @@ declare global {
   type CreepTaskMemory =
     | { type: 'harvest'; targetId: Id<Source> }
     | { type: 'pickup'; targetId: Id<Resource<ResourceConstant>> }
+    | { type: 'withdraw'; targetId: Id<AnyStoreStructure> }
     | { type: 'transfer'; targetId: Id<AnyStoreStructure> }
     | { type: 'build'; targetId: Id<ConstructionSite> }
     | { type: 'repair'; targetId: Id<Structure> }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -3,7 +3,7 @@ import { CONTROLLER_DOWNGRADE_GUARD_TICKS, IDLE_RAMPART_REPAIR_HITS_CEILING } fr
 
 describe('runWorker', () => {
   beforeEach(() => {
-    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).ERR_NOT_IN_RANGE = -9;
+    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).ERR_NOT_IN_RANGE = -9;
     (globalThis as unknown as { ERR_FULL: number }).ERR_FULL = -8;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
@@ -15,6 +15,8 @@ describe('runWorker', () => {
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
     (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
     (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
+    (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
     (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
   });
 
@@ -138,6 +140,27 @@ describe('runWorker', () => {
 
     expect(creep.transfer).toHaveBeenCalledWith(spawn, 'energy');
     expect(creep.moveTo).toHaveBeenCalledWith(spawn);
+  });
+
+  it('withdraws energy from a withdraw target and moves when not in range', () => {
+    const container = { id: 'container1' } as StructureContainer;
+    const creep = {
+      memory: { task: { type: 'withdraw', targetId: 'container1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      withdraw: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(container)
+    };
+
+    runWorker(creep);
+
+    expect(creep.withdraw).toHaveBeenCalledWith(container, 'energy');
+    expect(creep.moveTo).toHaveBeenCalledWith(container);
   });
 
   it('builds an existing build target and moves when not in range', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -38,9 +38,23 @@ function makeEnergySink(
   } as unknown as StructureSpawn | StructureExtension;
 }
 
+function makeStoredEnergyStructure(
+  id: string,
+  structureType: StructureConstant,
+  energy: number,
+  extra: Record<string, unknown> = {}
+): StructureContainer | StructureStorage | StructureTerminal {
+  return {
+    id,
+    structureType,
+    store: { getUsedCapacity: jest.fn().mockReturnValue(energy) },
+    ...extra
+  } as unknown as StructureContainer | StructureStorage | StructureTerminal;
+}
+
 describe('selectWorkerTask', () => {
   beforeEach(() => {
-    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
     (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
@@ -50,6 +64,8 @@ describe('selectWorkerTask', () => {
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
     (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
     (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
+    (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
     (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
     (globalThis as unknown as { Game?: Partial<Game> }).Game = { creeps: {} };
   });
@@ -88,6 +104,147 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
     expect(findClosestByRange).toHaveBeenCalledWith([farDroppedEnergy, nearDroppedEnergy]);
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('selects withdraw from safe stored energy before harvesting', () => {
+    const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 100);
+    const storage = makeStoredEnergyStructure('storage1', 'storage' as StructureConstant, 200, { my: true });
+    const source = { id: 'source1' } as Source;
+    const findClosestByRange = jest.fn().mockReturnValue(storage);
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [container, storage];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { findClosestByRange },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage1' });
+    expect(findClosestByRange).toHaveBeenCalledWith([container, storage]);
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('keeps dropped energy priority over stored energy withdraw', () => {
+    const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
+    const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 100);
+    const source = { id: 'source1' } as Source;
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [droppedEnergy];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [container];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop1' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_STRUCTURES);
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('does not drain spawn, extension, hostile, or unowned structures for energy', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(200),
+        getFreeCapacity: jest.fn().mockReturnValue(100)
+      }
+    } as unknown as StructureSpawn;
+    const extension = {
+      id: 'extension1',
+      structureType: 'extension',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(25),
+        getFreeCapacity: jest.fn().mockReturnValue(25)
+      }
+    } as unknown as StructureExtension;
+    const hostileStorage = makeStoredEnergyStructure('hostile-storage', 'storage' as StructureConstant, 1_000, {
+      my: false
+    });
+    const unownedContainer = makeStoredEnergyStructure('unowned-container', 'container' as StructureConstant, 100);
+    const source = { id: 'source1' } as Source;
+    const room = {
+      controller: { my: false },
+      find: jest.fn((type: number) => {
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [spawn, extension, hostileStorage, unownedContainer];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      })
+    } as unknown as Room;
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('falls back to balanced harvesting when stored energy is unavailable', () => {
+    const emptyContainer = makeStoredEnergyStructure('container-empty', 'container' as StructureConstant, 0);
+    const source1 = { id: 'source1' } as Source;
+    const source2 = { id: 'source2' } as Source;
+    const room = {
+      name: 'W1N1',
+      controller: { my: true },
+      find: jest.fn((type: number) => {
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [emptyContainer];
+        }
+
+        return type === FIND_SOURCES ? [source1, source2] : [];
+      })
+    } as unknown as Room;
+    setGameCreeps({
+      Assigned: {
+        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+        room
+      } as unknown as Creep
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
   it('ignores non-energy and trivial dropped resources before falling back to balanced harvesting', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -54,11 +54,13 @@ function makeStoredEnergyStructure(
 
 describe('selectWorkerTask', () => {
   beforeEach(() => {
-    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; FIND_HOSTILE_CREEPS: number; FIND_HOSTILE_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
     (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
@@ -136,6 +138,62 @@ describe('selectWorkerTask', () => {
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
+  it('selects withdraw from a reserved remote container before harvesting', () => {
+    const container = makeStoredEnergyStructure('remote-container', 'container' as StructureConstant, 100);
+    const source = { id: 'source1' } as Source;
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [container];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      owner: { username: 'me' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: {
+        controller: { my: false, reservation: { username: 'me' } },
+        find: roomFind
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'remote-container' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('selects withdraw from a neutral non-hostile container before harvesting', () => {
+    const container = makeStoredEnergyStructure('neutral-container', 'container' as StructureConstant, 100);
+    const source = { id: 'source1' } as Source;
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [container];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { controller: { my: false }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'neutral-container' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
   it('keeps dropped energy priority over stored energy withdraw', () => {
     const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
     const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 100);
@@ -164,7 +222,7 @@ describe('selectWorkerTask', () => {
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
-  it('does not drain spawn, extension, hostile, or unowned structures for energy', () => {
+  it('does not drain spawn, extension, hostile, or enemy-room structures for energy', () => {
     const spawn = {
       id: 'spawn1',
       structureType: 'spawn',
@@ -187,9 +245,9 @@ describe('selectWorkerTask', () => {
     const unownedContainer = makeStoredEnergyStructure('unowned-container', 'container' as StructureConstant, 100);
     const source = { id: 'source1' } as Source;
     const room = {
-      controller: { my: false },
+      controller: { my: false, owner: { username: 'enemy' } },
       find: jest.fn((type: number) => {
-        if (type === FIND_DROPPED_RESOURCES) {
+        if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
           return [];
         }
 
@@ -209,6 +267,49 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('does not withdraw from containers in foreign-reserved or hostile rooms', () => {
+    const source = { id: 'source1' } as Source;
+    const hostileCreep = { id: 'hostile1' } as Creep;
+
+    for (const room of [
+      {
+        controller: { my: false, reservation: { username: 'enemy' } },
+        hostiles: []
+      },
+      {
+        controller: { my: false },
+        hostiles: [hostileCreep]
+      }
+    ]) {
+      const container = makeStoredEnergyStructure('remote-container', 'container' as StructureConstant, 100);
+      const roomFind = jest.fn((type: number) => {
+        if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_STRUCTURES) {
+          return [];
+        }
+
+        if (type === FIND_HOSTILE_CREEPS) {
+          return room.hostiles;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [container];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      });
+      const creep = {
+        owner: { username: 'me' },
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(0),
+          getFreeCapacity: jest.fn().mockReturnValue(50)
+        },
+        room: { controller: room.controller, find: roomFind }
+      } as unknown as Creep;
+
+      expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    }
   });
 
   it('falls back to balanced harvesting when stored energy is unavailable', () => {


### PR DESCRIPTION
## Summary
- Makes workers withdraw stored energy from containers/storage-like structures before falling back to harvesting.
- Adds runner support for withdraw tasks and memory typing.
- Extends deterministic worker task/runner coverage and regenerates `prod/dist/main.js`.

## Linked issue
Closes #131

## Roadmap category
Gameplay Evolution / resources-economy

## Served vision layer
Resources/economy: improves energy throughput by consuming stored room energy before spending worker ticks harvesting.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (16 suites, 174 tests)
- [x] `cd prod && npm run build`
- [x] `git diff --check`

## Notes
- Codex-authored commit: `5b6d018 lanyusea's bot <lanyusea@gmail.com> feat: withdraw stored energy before harvesting`
- No secrets included.
- Requires independent QA PASS, green checks/reviews, no active review threads, current Project fields, and >=15 minute elapsed review gate before merge.
