### PR TITLE
feat: scout unknown territory before reserving

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1616,7 +1616,6 @@ function runTerritoryControllerCreep(creep) {
     return;
   }
   if (assignment.action === "scout") {
-    delete creep.memory.territory;
     return;
   }
   const controller = selectTargetController(creep, assignment);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -473,7 +473,7 @@ var WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
 function countCreepsByRole(creeps, colonyName) {
   return creeps.reduce(
     (counts, creep) => {
-      var _a, _b, _c, _d;
+      var _a, _b, _c, _d, _e, _f, _g, _h;
       if (isColonyWorker(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
         counts.worker += 1;
       }
@@ -486,6 +486,15 @@ function countCreepsByRole(creeps, colonyName) {
           counts.claimersByTargetRoom = claimersByTargetRoom;
         }
       }
+      if (isColonyScout(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
+        counts.scout = ((_e = counts.scout) != null ? _e : 0) + 1;
+        const targetRoom = (_f = creep.memory.territory) == null ? void 0 : _f.targetRoom;
+        if (targetRoom) {
+          const scoutsByTargetRoom = (_g = counts.scoutsByTargetRoom) != null ? _g : {};
+          scoutsByTargetRoom[targetRoom] = ((_h = scoutsByTargetRoom[targetRoom]) != null ? _h : 0) + 1;
+          counts.scoutsByTargetRoom = scoutsByTargetRoom;
+        }
+      }
       return counts;
     },
     { worker: 0, claimer: 0, claimersByTargetRoom: {} }
@@ -496,6 +505,9 @@ function isColonyWorker(creep, colonyName) {
 }
 function isColonyClaimer(creep, colonyName) {
   return creep.memory.colony === colonyName && creep.memory.role === "claimer";
+}
+function isColonyScout(creep, colonyName) {
+  return creep.memory.colony === colonyName && creep.memory.role === "scout";
 }
 function canSatisfyRoleCapacity(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
@@ -894,6 +906,7 @@ function getBodyCost(body) {
 
 // src/territory/territoryPlanner.ts
 var TERRITORY_CLAIMER_ROLE = "claimer";
+var TERRITORY_SCOUT_ROLE = "scout";
 var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
 var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
@@ -908,25 +921,28 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   const plan = {
     colony: colony.room.name,
     targetRoom: target.roomName,
-    action: target.action,
+    action: selection.intentAction,
     ...target.controllerId ? { controllerId: target.controllerId } : {}
   };
-  const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) > 0 ? "active" : "planned";
-  recordTerritoryIntent(plan, status, gameTime, selection.seeded ? target : null);
+  const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? "active" : "planned";
+  recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
   return plan;
 }
 function shouldSpawnTerritoryControllerCreep(plan, roleCounts) {
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action)) {
     return false;
   }
+  if (plan.action === "scout" && isVisibleRoomKnown(plan.targetRoom)) {
+    return false;
+  }
   if (isVisibleTerritoryTargetUnavailable(plan.targetRoom, plan.controllerId)) {
     return false;
   }
-  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) === 0;
+  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) === 0;
 }
 function buildTerritoryCreepMemory(plan) {
   return {
-    role: TERRITORY_CLAIMER_ROLE,
+    role: plan.action === "scout" ? TERRITORY_SCOUT_ROLE : TERRITORY_CLAIMER_ROLE,
     colony: plan.colony,
     territory: {
       targetRoom: plan.targetRoom,
@@ -936,7 +952,7 @@ function buildTerritoryCreepMemory(plan) {
   };
 }
 function suppressTerritoryIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || !isTerritoryAction(assignment.action)) {
+  if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || !isTerritoryIntentAction(assignment.action)) {
     return;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord();
@@ -973,13 +989,12 @@ function selectTerritoryTarget(colonyName) {
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
   const configuredTarget = selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents);
   if (configuredTarget) {
-    return { target: configuredTarget, seeded: false };
+    return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
   }
   if (hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName)) {
     return null;
   }
-  const seededTarget = seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
-  return seededTarget ? { target: seededTarget, seeded: true } : null;
+  return selectAdjacentReserveTarget(colonyName, territoryMemory, intents);
 }
 function selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -996,7 +1011,7 @@ function selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents) {
 function hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName) {
   return getConfiguredTargetRoomsForColony(territoryMemory, colonyName).size > 0;
 }
-function seedAdjacentReserveTarget(colonyName, territoryMemory, intents) {
+function selectAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   const adjacentRooms = getAdjacentRoomNames(colonyName);
   if (adjacentRooms.length === 0) {
     return null;
@@ -1004,21 +1019,27 @@ function seedAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   for (const roomName of adjacentRooms) {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && isAdjacentReserveTargetSeedable(roomName)) {
-      return target;
+    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && !isTerritoryIntentForActionSuppressed(colonyName, roomName, "scout")) {
+      const candidateState = getAdjacentReserveCandidateState(roomName);
+      if (candidateState === "safe") {
+        return { target, intentAction: "reserve", commitTarget: true };
+      }
+      if (candidateState === "unknown") {
+        return { target, intentAction: "scout", commitTarget: false };
+      }
     }
   }
   return null;
 }
-function isAdjacentReserveTargetSeedable(targetRoom) {
+function getAdjacentReserveCandidateState(targetRoom) {
   if (isVisibleRoomMissingController(targetRoom)) {
-    return false;
+    return "unavailable";
   }
   const controller = getVisibleController(targetRoom);
   if (!controller) {
-    return true;
+    return "unknown";
   }
-  return !isControllerOwned(controller) && controller.reservation == null;
+  return !isControllerOwned(controller) && controller.reservation == null ? "safe" : "unavailable";
 }
 function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -1056,7 +1077,7 @@ function normalizeTerritoryTarget(rawTarget) {
   if (!isRecord(rawTarget)) {
     return null;
   }
-  if (!isNonEmptyString(rawTarget.colony) || !isNonEmptyString(rawTarget.roomName) || !isTerritoryAction(rawTarget.action)) {
+  if (!isNonEmptyString(rawTarget.colony) || !isNonEmptyString(rawTarget.roomName) || !isTerritoryControlAction(rawTarget.action)) {
     return null;
   }
   return {
@@ -1107,7 +1128,7 @@ function normalizeTerritoryIntent(rawIntent) {
   if (!isRecord(rawIntent)) {
     return null;
   }
-  if (!isNonEmptyString(rawIntent.colony) || !isNonEmptyString(rawIntent.targetRoom) || !isTerritoryAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
+  if (!isNonEmptyString(rawIntent.colony) || !isNonEmptyString(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
     return null;
   }
   return {
@@ -1119,9 +1140,12 @@ function normalizeTerritoryIntent(rawIntent) {
     ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {}
   };
 }
-function getTerritoryCreepCountForTarget(roleCounts, targetRoom) {
-  var _a, _b;
-  return (_b = (_a = roleCounts.claimersByTargetRoom) == null ? void 0 : _a[targetRoom]) != null ? _b : 0;
+function getTerritoryCreepCountForTarget(roleCounts, targetRoom, action) {
+  var _a, _b, _c, _d;
+  if (action === "scout") {
+    return (_b = (_a = roleCounts.scoutsByTargetRoom) == null ? void 0 : _a[targetRoom]) != null ? _b : 0;
+  }
+  return (_d = (_c = roleCounts.claimersByTargetRoom) == null ? void 0 : _c[targetRoom]) != null ? _d : 0;
 }
 function isTerritoryTargetSuppressed(target, intents) {
   return intents.some(
@@ -1129,6 +1153,15 @@ function isTerritoryTargetSuppressed(target, intents) {
   );
 }
 function isTerritoryIntentSuppressed(colony, targetRoom, action) {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return false;
+  }
+  return normalizeTerritoryIntents(territoryMemory.intents).some(
+    (intent) => intent.status === "suppressed" && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
+  );
+}
+function isTerritoryIntentForActionSuppressed(colony, targetRoom, action) {
   const territoryMemory = getTerritoryMemoryRecord();
   if (!territoryMemory) {
     return false;
@@ -1146,6 +1179,11 @@ function isVisibleTerritoryTargetUnavailable(targetRoom, controllerId) {
     return false;
   }
   return isControllerOwned(controller);
+}
+function isVisibleRoomKnown(targetRoom) {
+  var _a;
+  const game = globalThis.Game;
+  return ((_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom]) != null;
 }
 function isVisibleRoomMissingController(targetRoom) {
   var _a;
@@ -1190,8 +1228,11 @@ function getMemoryRecord() {
   const memory = globalThis.Memory;
   return memory != null ? memory : null;
 }
-function isTerritoryAction(action) {
+function isTerritoryControlAction(action) {
   return action === "claim" || action === "reserve";
+}
+function isTerritoryIntentAction(action) {
+  return isTerritoryControlAction(action) || action === "scout";
 }
 function isTerritoryIntentStatus(status) {
   return status === "planned" || status === "active" || status === "suppressed";
@@ -1206,6 +1247,8 @@ function isRecord(value) {
 // src/spawn/spawnPlanner.ts
 var MIN_WORKER_TARGET = 3;
 var WORKERS_PER_SOURCE = 2;
+var TERRITORY_SCOUT_BODY = ["move"];
+var TERRITORY_SCOUT_BODY_COST = 50;
 var MAX_WORKER_TARGET = 6;
 var sourceCountByRoomName = /* @__PURE__ */ new Map();
 function planSpawn(colony, roleCounts, gameTime) {
@@ -1221,14 +1264,15 @@ function planSpawn(colony, roleCounts, gameTime) {
   if (!spawn) {
     return null;
   }
-  const body = buildTerritoryControllerBody(colony.energyAvailable);
+  const body = buildTerritorySpawnBody(colony.energyAvailable, territoryIntent.action);
   if (body.length === 0) {
     return null;
   }
+  const roleName = territoryIntent.action === "scout" ? "scout" : "claimer";
   return {
     spawn,
     body,
-    name: `claimer-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`,
+    name: `${roleName}-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`,
     memory: buildTerritoryCreepMemory(territoryIntent)
   };
 }
@@ -1260,6 +1304,12 @@ function selectWorkerBody(colony, roleCounts) {
 }
 function canAffordBody(body, energyAvailable) {
   return body.length > 0 && getBodyCost(body) <= energyAvailable;
+}
+function buildTerritorySpawnBody(energyAvailable, action) {
+  if (action === "scout") {
+    return energyAvailable >= TERRITORY_SCOUT_BODY_COST ? [...TERRITORY_SCOUT_BODY] : [];
+  }
+  return buildTerritoryControllerBody(energyAvailable);
 }
 function getWorkerTarget(colony) {
   const sourceCount = getSourceCount(colony.room);
@@ -1565,6 +1615,10 @@ function runTerritoryControllerCreep(creep) {
     moveTowardTargetRoom(creep, assignment.targetRoom);
     return;
   }
+  if (assignment.action === "scout") {
+    delete creep.memory.territory;
+    return;
+  }
   const controller = selectTargetController(creep, assignment);
   if (!controller) {
     suppressTerritoryAssignment(creep, assignment);
@@ -1623,7 +1677,7 @@ function getGameTime2() {
   return typeof gameTime === "number" ? gameTime : 0;
 }
 function isTerritoryAssignment(assignment) {
-  return typeof (assignment == null ? void 0 : assignment.targetRoom) === "string" && assignment.targetRoom.length > 0 && (assignment.action === "claim" || assignment.action === "reserve");
+  return typeof (assignment == null ? void 0 : assignment.targetRoom) === "string" && assignment.targetRoom.length > 0 && (assignment.action === "claim" || assignment.action === "reserve" || assignment.action === "scout");
 }
 
 // src/economy/economyLoop.ts
@@ -1651,7 +1705,7 @@ function runEconomy() {
   for (const creep of creeps) {
     if (creep.memory.role === "worker") {
       runWorker(creep);
-    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE) {
+    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE || creep.memory.role === TERRITORY_SCOUT_ROLE) {
       runTerritoryControllerCreep(creep);
     }
   }

--- a/prod/src/creeps/roleCounts.ts
+++ b/prod/src/creeps/roleCounts.ts
@@ -2,6 +2,8 @@ export interface RoleCounts {
   worker: number;
   claimer?: number;
   claimersByTargetRoom?: Record<string, number>;
+  scout?: number;
+  scoutsByTargetRoom?: Record<string, number>;
 }
 
 export const WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
@@ -21,6 +23,15 @@ export function countCreepsByRole(creeps: Creep[], colonyName: string): RoleCoun
           counts.claimersByTargetRoom = claimersByTargetRoom;
         }
       }
+      if (isColonyScout(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
+        counts.scout = (counts.scout ?? 0) + 1;
+        const targetRoom = creep.memory.territory?.targetRoom;
+        if (targetRoom) {
+          const scoutsByTargetRoom = counts.scoutsByTargetRoom ?? {};
+          scoutsByTargetRoom[targetRoom] = (scoutsByTargetRoom[targetRoom] ?? 0) + 1;
+          counts.scoutsByTargetRoom = scoutsByTargetRoom;
+        }
+      }
       return counts;
     },
     { worker: 0, claimer: 0, claimersByTargetRoom: {} }
@@ -33,6 +44,10 @@ function isColonyWorker(creep: Creep, colonyName: string): boolean {
 
 function isColonyClaimer(creep: Creep, colonyName: string): boolean {
   return creep.memory.colony === colonyName && creep.memory.role === 'claimer';
+}
+
+function isColonyScout(creep: Creep, colonyName: string): boolean {
+  return creep.memory.colony === colonyName && creep.memory.role === 'scout';
 }
 
 function canSatisfyRoleCapacity(creep: Creep): boolean {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -5,7 +5,7 @@ import { countCreepsByRole } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
 import { planSpawn, type SpawnRequest } from '../spawn/spawnPlanner';
 import { emitRuntimeSummary, type RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
-import { TERRITORY_CLAIMER_ROLE } from '../territory/territoryPlanner';
+import { TERRITORY_CLAIMER_ROLE, TERRITORY_SCOUT_ROLE } from '../territory/territoryPlanner';
 import { runTerritoryControllerCreep } from '../territory/territoryRunner';
 
 const ERR_BUSY_CODE = -4 as ScreepsReturnCode;
@@ -37,7 +37,7 @@ export function runEconomy(): void {
   for (const creep of creeps) {
     if (creep.memory.role === 'worker') {
       runWorker(creep);
-    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE) {
+    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE || creep.memory.role === TERRITORY_SCOUT_ROLE) {
       runTerritoryControllerCreep(creep);
     }
   }

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -21,6 +21,8 @@ export interface SpawnRequest {
 
 const MIN_WORKER_TARGET = 3;
 const WORKERS_PER_SOURCE = 2;
+const TERRITORY_SCOUT_BODY: BodyPartConstant[] = ['move'];
+const TERRITORY_SCOUT_BODY_COST = 50;
 // Keep source-aware scaling bounded so unusual source data cannot create runaway early-room spawn pressure.
 const MAX_WORKER_TARGET = 6;
 const sourceCountByRoomName = new Map<string, number>();
@@ -41,15 +43,16 @@ export function planSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTi
     return null;
   }
 
-  const body = buildTerritoryControllerBody(colony.energyAvailable);
+  const body = buildTerritorySpawnBody(colony.energyAvailable, territoryIntent.action);
   if (body.length === 0) {
     return null;
   }
 
+  const roleName = territoryIntent.action === 'scout' ? 'scout' : 'claimer';
   return {
     spawn,
     body,
-    name: `claimer-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`,
+    name: `${roleName}-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`,
     memory: buildTerritoryCreepMemory(territoryIntent)
   };
 }
@@ -88,6 +91,14 @@ function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyP
 
 function canAffordBody(body: BodyPartConstant[], energyAvailable: number): boolean {
   return body.length > 0 && getBodyCost(body) <= energyAvailable;
+}
+
+function buildTerritorySpawnBody(energyAvailable: number, action: TerritoryIntentAction): BodyPartConstant[] {
+  if (action === 'scout') {
+    return energyAvailable >= TERRITORY_SCOUT_BODY_COST ? [...TERRITORY_SCOUT_BODY] : [];
+  }
+
+  return buildTerritoryControllerBody(energyAvailable);
 }
 
 function getWorkerTarget(colony: ColonySnapshot): number {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -3,6 +3,7 @@ import type { RoleCounts } from '../creeps/roleCounts';
 import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
+export const TERRITORY_SCOUT_ROLE = 'scout';
 export const TERRITORY_DOWNGRADE_GUARD_TICKS = 5_000;
 
 const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
@@ -10,7 +11,7 @@ const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
 export interface TerritoryIntentPlan {
   colony: string;
   targetRoom: string;
-  action: TerritoryControlAction;
+  action: TerritoryIntentAction;
   controllerId?: Id<StructureController>;
 }
 
@@ -20,7 +21,8 @@ interface MemoryRecord {
 
 interface SelectedTerritoryTarget {
   target: TerritoryTargetMemory;
-  seeded: boolean;
+  intentAction: TerritoryIntentAction;
+  commitTarget: boolean;
 }
 
 export function planTerritoryIntent(
@@ -42,11 +44,11 @@ export function planTerritoryIntent(
   const plan: TerritoryIntentPlan = {
     colony: colony.room.name,
     targetRoom: target.roomName,
-    action: target.action,
+    action: selection.intentAction,
     ...(target.controllerId ? { controllerId: target.controllerId } : {})
   };
-  const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) > 0 ? 'active' : 'planned';
-  recordTerritoryIntent(plan, status, gameTime, selection.seeded ? target : null);
+  const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? 'active' : 'planned';
+  recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
 
   return plan;
 }
@@ -56,16 +58,20 @@ export function shouldSpawnTerritoryControllerCreep(plan: TerritoryIntentPlan, r
     return false;
   }
 
+  if (plan.action === 'scout' && isVisibleRoomKnown(plan.targetRoom)) {
+    return false;
+  }
+
   if (isVisibleTerritoryTargetUnavailable(plan.targetRoom, plan.controllerId)) {
     return false;
   }
 
-  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom) === 0;
+  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) === 0;
 }
 
 export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemory {
   return {
-    role: TERRITORY_CLAIMER_ROLE,
+    role: plan.action === 'scout' ? TERRITORY_SCOUT_ROLE : TERRITORY_CLAIMER_ROLE,
     colony: plan.colony,
     territory: {
       targetRoom: plan.targetRoom,
@@ -83,7 +89,7 @@ export function suppressTerritoryIntent(
   if (
     !isNonEmptyString(colony) ||
     !isNonEmptyString(assignment.targetRoom) ||
-    !isTerritoryAction(assignment.action)
+    !isTerritoryIntentAction(assignment.action)
   ) {
     return;
   }
@@ -132,15 +138,14 @@ function selectTerritoryTarget(colonyName: string): SelectedTerritoryTarget | nu
   const intents = normalizeTerritoryIntents(territoryMemory?.intents);
   const configuredTarget = selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents);
   if (configuredTarget) {
-    return { target: configuredTarget, seeded: false };
+    return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
   }
 
   if (hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName)) {
     return null;
   }
 
-  const seededTarget = seedAdjacentReserveTarget(colonyName, territoryMemory, intents);
-  return seededTarget ? { target: seededTarget, seeded: true } : null;
+  return selectAdjacentReserveTarget(colonyName, territoryMemory, intents);
 }
 
 function selectConfiguredTerritoryTarget(
@@ -176,11 +181,11 @@ function hasConfiguredTerritoryTargetForColony(
   return getConfiguredTargetRoomsForColony(territoryMemory, colonyName).size > 0;
 }
 
-function seedAdjacentReserveTarget(
+function selectAdjacentReserveTarget(
   colonyName: string,
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[]
-): TerritoryTargetMemory | null {
+): SelectedTerritoryTarget | null {
   const adjacentRooms = getAdjacentRoomNames(colonyName);
   if (adjacentRooms.length === 0) {
     return null;
@@ -193,26 +198,33 @@ function seedAdjacentReserveTarget(
       roomName !== colonyName &&
       !existingTargetRooms.has(roomName) &&
       !isTerritoryTargetSuppressed(target, intents) &&
-      isAdjacentReserveTargetSeedable(roomName)
+      !isTerritoryIntentForActionSuppressed(colonyName, roomName, 'scout')
     ) {
-      return target;
+      const candidateState = getAdjacentReserveCandidateState(roomName);
+      if (candidateState === 'safe') {
+        return { target, intentAction: 'reserve', commitTarget: true };
+      }
+
+      if (candidateState === 'unknown') {
+        return { target, intentAction: 'scout', commitTarget: false };
+      }
     }
   }
 
   return null;
 }
 
-function isAdjacentReserveTargetSeedable(targetRoom: string): boolean {
+function getAdjacentReserveCandidateState(targetRoom: string): 'safe' | 'unknown' | 'unavailable' {
   if (isVisibleRoomMissingController(targetRoom)) {
-    return false;
+    return 'unavailable';
   }
 
   const controller = getVisibleController(targetRoom);
   if (!controller) {
-    return true;
+    return 'unknown';
   }
 
-  return !isControllerOwned(controller) && controller.reservation == null;
+  return !isControllerOwned(controller) && controller.reservation == null ? 'safe' : 'unavailable';
 }
 
 function getConfiguredTargetRoomsForColony(
@@ -265,7 +277,7 @@ function normalizeTerritoryTarget(rawTarget: unknown): TerritoryTargetMemory | n
   if (
     !isNonEmptyString(rawTarget.colony) ||
     !isNonEmptyString(rawTarget.roomName) ||
-    !isTerritoryAction(rawTarget.action)
+    !isTerritoryControlAction(rawTarget.action)
   ) {
     return null;
   }
@@ -343,7 +355,7 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
   if (
     !isNonEmptyString(rawIntent.colony) ||
     !isNonEmptyString(rawIntent.targetRoom) ||
-    !isTerritoryAction(rawIntent.action) ||
+    !isTerritoryIntentAction(rawIntent.action) ||
     !isTerritoryIntentStatus(rawIntent.status) ||
     typeof rawIntent.updatedAt !== 'number'
   ) {
@@ -362,7 +374,15 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
   };
 }
 
-function getTerritoryCreepCountForTarget(roleCounts: RoleCounts, targetRoom: string): number {
+function getTerritoryCreepCountForTarget(
+  roleCounts: RoleCounts,
+  targetRoom: string,
+  action: TerritoryIntentAction
+): number {
+  if (action === 'scout') {
+    return roleCounts.scoutsByTargetRoom?.[targetRoom] ?? 0;
+  }
+
   return roleCounts.claimersByTargetRoom?.[targetRoom] ?? 0;
 }
 
@@ -379,7 +399,26 @@ function isTerritoryTargetSuppressed(target: TerritoryTargetMemory, intents: Ter
 function isTerritoryIntentSuppressed(
   colony: string,
   targetRoom: string,
-  action: TerritoryControlAction
+  action: TerritoryIntentAction
+): boolean {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return false;
+  }
+
+  return normalizeTerritoryIntents(territoryMemory.intents).some(
+    (intent) =>
+      intent.status === 'suppressed' &&
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      intent.action === action
+  );
+}
+
+function isTerritoryIntentForActionSuppressed(
+  colony: string,
+  targetRoom: string,
+  action: TerritoryIntentAction
 ): boolean {
   const territoryMemory = getTerritoryMemoryRecord();
   if (!territoryMemory) {
@@ -409,6 +448,11 @@ function isVisibleTerritoryTargetUnavailable(
   }
 
   return isControllerOwned(controller);
+}
+
+function isVisibleRoomKnown(targetRoom: string): boolean {
+  const game = (globalThis as { Game?: Partial<Game> }).Game;
+  return game?.rooms?.[targetRoom] != null;
 }
 
 function isVisibleRoomMissingController(targetRoom: string): boolean {
@@ -463,8 +507,12 @@ function getMemoryRecord(): MemoryRecord | null {
   return memory ?? null;
 }
 
-function isTerritoryAction(action: unknown): action is TerritoryControlAction {
+function isTerritoryControlAction(action: unknown): action is TerritoryControlAction {
   return action === 'claim' || action === 'reserve';
+}
+
+function isTerritoryIntentAction(action: unknown): action is TerritoryIntentAction {
+  return isTerritoryControlAction(action) || action === 'scout';
 }
 
 function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -23,6 +23,11 @@ export function runTerritoryControllerCreep(creep: Creep): void {
     return;
   }
 
+  if (assignment.action === 'scout') {
+    delete creep.memory.territory;
+    return;
+  }
+
   const controller = selectTargetController(creep, assignment);
   if (!controller) {
     suppressTerritoryAssignment(creep, assignment);
@@ -105,6 +110,6 @@ function isTerritoryAssignment(assignment: CreepTerritoryMemory | undefined): as
   return (
     typeof assignment?.targetRoom === 'string' &&
     assignment.targetRoom.length > 0 &&
-    (assignment.action === 'claim' || assignment.action === 'reserve')
+    (assignment.action === 'claim' || assignment.action === 'reserve' || assignment.action === 'scout')
   );
 }

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -24,7 +24,6 @@ export function runTerritoryControllerCreep(creep: Creep): void {
   }
 
   if (assignment.action === 'scout') {
-    delete creep.memory.territory;
     return;
   }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -16,6 +16,7 @@ declare global {
   }
 
   type TerritoryControlAction = 'claim' | 'reserve';
+  type TerritoryIntentAction = TerritoryControlAction | 'scout';
 
   interface TerritoryMemory {
     targets?: TerritoryTargetMemory[];
@@ -33,7 +34,7 @@ declare global {
   interface TerritoryIntentMemory {
     colony: string;
     targetRoom: string;
-    action: TerritoryControlAction;
+    action: TerritoryIntentAction;
     status: 'planned' | 'active' | 'suppressed';
     updatedAt: number;
     controllerId?: Id<StructureController>;
@@ -41,7 +42,7 @@ declare global {
 
   interface CreepTerritoryMemory {
     targetRoom: string;
-    action: TerritoryControlAction;
+    action: TerritoryIntentAction;
     controllerId?: Id<StructureController>;
   }
 

--- a/prod/test/roleCounts.test.ts
+++ b/prod/test/roleCounts.test.ts
@@ -6,13 +6,18 @@ describe('countCreepsByRole', () => {
     const claimer = {
       memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'reserve' } }
     } as Creep;
+    const scout = {
+      memory: { role: 'scout', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'scout' } }
+    } as Creep;
     const otherColonyWorker = { memory: { role: 'worker', colony: 'W2N2' } } as Creep;
     const unassigned = { memory: {} } as Creep;
 
-    expect(countCreepsByRole([worker, claimer, otherColonyWorker, unassigned], 'W1N1')).toEqual({
+    expect(countCreepsByRole([worker, claimer, scout, otherColonyWorker, unassigned], 'W1N1')).toEqual({
       worker: 1,
       claimer: 1,
-      claimersByTargetRoom: { W2N1: 1 }
+      claimersByTargetRoom: { W2N1: 1 },
+      scout: 1,
+      scoutsByTargetRoom: { W1N2: 1 }
     });
   });
 

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -163,6 +163,39 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('plans a cheap scout for an unseen adjacent reserve candidate before reserving it', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 50,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits: jest.fn(() => ({ '3': 'W2N1' })) } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 144)).toEqual({
+      spawn,
+      body: ['move'],
+      name: 'scout-W1N1-W2N1-144',
+      memory: {
+        role: 'scout',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'scout' }
+      }
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 144
+      }
+    ]);
+  });
+
   it('records territory intent while waiting for claim body energy', () => {
     const { colony } = makeColony({
       energyAvailable: 600,

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -79,7 +79,7 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('seeds an unseen adjacent reserve target when no configured targets exist', () => {
+  it('creates a scout intent for an unseen adjacent reserve candidate when no configured targets exist', () => {
     const colony = makeSafeColony();
     const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -91,9 +91,55 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W1N2',
-      action: 'reserve'
+      action: 'scout'
     });
     expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 525
+      }
+    ]);
+  });
+
+  it('commits a seeded reserve target after scout visibility confirms a safe controller', () => {
+    const colony = makeSafeColony();
+    const describeExits = jest.fn(() => ({ '1': 'W1N2' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 527)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'scout'
+    });
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N2: { name: 'W1N2', controller: { my: false } as StructureController } as Room
+      }
+    };
+
+    expect(
+      planTerritoryIntent(
+        colony,
+        { worker: 3, claimer: 0, claimersByTargetRoom: {}, scout: 1, scoutsByTargetRoom: { W1N2: 1 } },
+        3,
+        528
+      )
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve'
+    });
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
@@ -105,9 +151,16 @@ describe('planTerritoryIntent', () => {
       {
         colony: 'W1N1',
         targetRoom: 'W1N2',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 527
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
         action: 'reserve',
         status: 'planned',
-        updatedAt: 525
+        updatedAt: 528
       }
     ]);
   });

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -26,6 +26,20 @@ describe('runTerritoryControllerCreep', () => {
     expect(creep.reserveController).not.toHaveBeenCalled();
   });
 
+  it('finishes a scout assignment after entering the target room', () => {
+    const creep = {
+      memory: { role: 'scout', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'scout' } },
+      room: { name: 'W1N2' },
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory).toBeUndefined();
+  });
+
   it('reserves the target room controller and moves into range when needed', () => {
     const controller = { id: 'controller1', my: false } as StructureController;
     const creep = {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -26,7 +26,7 @@ describe('runTerritoryControllerCreep', () => {
     expect(creep.reserveController).not.toHaveBeenCalled();
   });
 
-  it('finishes a scout assignment after entering the target room', () => {
+  it('keeps scout target attribution after entering the target room', () => {
     const creep = {
       memory: { role: 'scout', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'scout' } },
       room: { name: 'W1N2' },
@@ -36,7 +36,7 @@ describe('runTerritoryControllerCreep', () => {
     runTerritoryControllerCreep(creep);
 
     expect(creep.moveTo).not.toHaveBeenCalled();
-    expect(creep.memory.territory).toBeUndefined();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'scout' });
     expect(Memory.territory).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- Adds a deterministic scouting/intel step before reserving unknown adjacent territory candidates.
- Introduces scout role/count planning so the bot can gather room intel instead of blindly committing reserve/claim behavior.
- Preserves configured targets, home-safety gates, disabled/suppressed target behavior, and no-map/no-exit safeguards.
- Regenerates `prod/dist/main.js` through the build.

## Linked issue
Closes #133

## Roadmap category
Gameplay Evolution / territory-control

## Served vision layer
Territory/control: advances autonomous expansion by validating adjacent candidates before reservation/claim commitment.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (16 suites / 186 tests)
- [x] `cd prod && npm run build`
- [x] final `git diff --check`

## Notes
- Codex-authored commit: `626c3f8 lanyusea's bot <lanyusea@gmail.com> feat: scout unknown territory before reserving`
- No secrets touched.
- Requires independent QA PASS, green checks/reviews, no active review threads, current Project fields, and >=15 minute elapsed review gate before merge.
