### PR TITLE
feat: repair critical roads and containers before generic construction

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -515,6 +515,7 @@ function canSatisfyRoleCapacity(creep) {
 
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
+var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
@@ -556,6 +557,10 @@ function selectWorkerTask(creep) {
   }
   if (controller && shouldSustainControllerProgress(creep, controller)) {
     return { type: "upgrade", targetId: controller.id };
+  }
+  const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
+  if (criticalRepairTarget) {
+    return { type: "repair", targetId: criticalRepairTarget.id };
   }
   if (constructionSites[0]) {
     return { type: "build", targetId: constructionSites[0].id };
@@ -672,6 +677,17 @@ function selectRepairTarget(creep) {
   }
   return repairTargets.sort(compareRepairTargets)[0];
 }
+function selectCriticalInfrastructureRepairTarget(creep) {
+  var _a;
+  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
+    return null;
+  }
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(isCriticalInfrastructureRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+  return repairTargets.sort(compareRepairTargets)[0];
+}
 function findVisibleRoomStructures(room) {
   if (typeof FIND_STRUCTURES !== "number") {
     return [];
@@ -682,10 +698,16 @@ function isSafeRepairTarget(structure) {
   if (isWorkerRepairTargetComplete(structure)) {
     return false;
   }
-  if (matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (isRoadOrContainerRepairTarget(structure)) {
     return true;
   }
   return matchesStructureType2(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+}
+function isCriticalInfrastructureRepairTarget(structure) {
+  return isSafeRepairTarget(structure) && isRoadOrContainerRepairTarget(structure) && getHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO;
+}
+function isRoadOrContainerRepairTarget(structure) {
+  return matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isWorkerRepairTargetComplete(structure) {
   return structure.hits >= getWorkerRepairHitsCeiling(structure);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1,10 +1,12 @@
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
+export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
+type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
 type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal;
 
 interface StoredEnergySourceContext {
@@ -60,6 +62,11 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
 
   if (controller && shouldSustainControllerProgress(creep, controller)) {
     return { type: 'upgrade', targetId: controller.id };
+  }
+
+  const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
+  if (criticalRepairTarget) {
+    return { type: 'repair', targetId: criticalRepairTarget.id as Id<Structure> };
   }
 
   if (constructionSites[0]) {
@@ -227,6 +234,19 @@ function selectRepairTarget(creep: Creep): RepairableWorkerStructure | null {
   return repairTargets.sort(compareRepairTargets)[0];
 }
 
+function selectCriticalInfrastructureRepairTarget(creep: Creep): CriticalInfrastructureRepairTarget | null {
+  if (creep.room.controller?.my !== true) {
+    return null;
+  }
+
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(isCriticalInfrastructureRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+
 function findVisibleRoomStructures(room: Room): AnyStructure[] {
   if (typeof FIND_STRUCTURES !== 'number') {
     return [];
@@ -240,14 +260,26 @@ function isSafeRepairTarget(structure: AnyStructure): structure is RepairableWor
     return false;
   }
 
-  if (
-    matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road') ||
-    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')
-  ) {
+  if (isRoadOrContainerRepairTarget(structure)) {
     return true;
   }
 
   return matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') && isOwnedRampart(structure);
+}
+
+function isCriticalInfrastructureRepairTarget(structure: AnyStructure): structure is CriticalInfrastructureRepairTarget {
+  return (
+    isSafeRepairTarget(structure) &&
+    isRoadOrContainerRepairTarget(structure) &&
+    getHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO
+  );
+}
+
+function isRoadOrContainerRepairTarget(structure: AnyStructure): structure is StructureRoad | StructureContainer {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')
+  );
 }
 
 export function isWorkerRepairTargetComplete(structure: Structure): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1,5 +1,6 @@
 import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
+  CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
@@ -50,6 +51,38 @@ function makeStoredEnergyStructure(
     store: { getUsedCapacity: jest.fn().mockReturnValue(energy) },
     ...extra
   } as unknown as StructureContainer | StructureStorage | StructureTerminal;
+}
+
+function makeWorkerTaskRoom({
+  constructionSites = [],
+  controller = { id: 'controller1', my: true, level: 3 } as StructureController,
+  myStructures = [],
+  structures = []
+}: {
+  constructionSites?: ConstructionSite[];
+  controller?: StructureController;
+  myStructures?: AnyOwnedStructure[];
+  structures?: AnyStructure[];
+} = {}): Room {
+  return {
+    name: 'W1N1',
+    controller,
+    find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+      if (type === FIND_MY_STRUCTURES) {
+        return options?.filter ? myStructures.filter(options.filter) : myStructures;
+      }
+
+      if (type === FIND_CONSTRUCTION_SITES) {
+        return constructionSites;
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return structures;
+      }
+
+      return [];
+    })
+  } as unknown as Room;
 }
 
 describe('selectWorkerTask', () => {
@@ -598,6 +631,137 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it.each([
+    ['road', 5_000],
+    ['container', 2_000]
+  ])('repairs critical %s damage before generic construction', (structureType, hitsMax) => {
+    const site = { id: 'generic-site1', structureType: 'road' } as ConstructionSite;
+    const repairTarget = makeStructure(
+      `${structureType}-critical`,
+      structureType as StructureConstant,
+      Math.floor(hitsMax * CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO),
+      hitsMax
+    );
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], structures: [repairTarget] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: `${structureType}-critical` });
+  });
+
+  it('keeps non-critical road and container repair behind generic construction', () => {
+    const site = { id: 'generic-site1', structureType: 'road' } as ConstructionSite;
+    const road = makeStructure(
+      'road-non-critical',
+      'road' as StructureConstant,
+      Math.floor(5_000 * CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO) + 1,
+      5_000
+    );
+    const container = makeStructure(
+      'container-non-critical',
+      'container' as StructureConstant,
+      Math.floor(2_000 * CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO) + 1,
+      2_000
+    );
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], structures: [road, container] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'generic-site1' });
+  });
+
+  it.each([
+    ['spawn', 'spawn1'],
+    ['extension', 'extension1']
+  ])('keeps %s refill before critical road repair', (structureType, id) => {
+    const energySink = makeEnergySink(id, structureType as StructureConstant, 300);
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000);
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        myStructures: [energySink as AnyOwnedStructure],
+        structures: [road]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
+  });
+
+  it('keeps controller downgrade guard before critical road repair', () => {
+    const site = { id: 'generic-site1', structureType: 'road' } as ConstructionSite;
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [road] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it.each([
+    ['spawn', 'spawn-site1'],
+    ['extension', 'extension-site1']
+  ])('keeps %s construction before critical container repair', (structureType, id) => {
+    const site = { id, structureType } as ConstructionSite;
+    const container = makeStructure('container-critical', 'container' as StructureConstant, 400, 2_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [container] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: id });
+  });
+
+  it('keeps RCL1 controller rush before critical road repair', () => {
+    const site = { id: 'generic-site1', structureType: 'road' } as ConstructionSite;
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 1,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [road] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps sustained controller progress before critical road repair', () => {
+    const site = { id: 'generic-site1', structureType: 'road' } as ConstructionSite;
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [road] });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Builder: makeLoadedWorker(room) });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('selects RCL1 controller upgrade before non-spawn construction when downgrade is safe', () => {


### PR DESCRIPTION
## Summary
- Repairs critically damaged roads and containers before generic construction in owned rooms.
- Preserves higher-priority spawn/extension filling, controller downgrade guard, spawn/extension construction, RCL1 rush, sustained controller progress, and existing idle repair/upgrade behavior.
- Adds deterministic Jest coverage and regenerates `prod/dist/main.js` via build.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (16 suites, 204 tests)
- [x] `cd prod && npm run build`
- [x] `git diff --check -- prod/src/tasks/workerTasks.ts prod/test/workerTasks.test.ts prod/dist/main.js`

Closes #135

No secrets touched.
