### PR TITLE
fix: allow scout-suppressed rooms to reserve when visible

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1119,12 +1119,12 @@ function selectAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   for (const roomName of adjacentRooms) {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents) && !isTerritoryIntentForActionSuppressed(colonyName, roomName, "scout")) {
+    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents)) {
       const candidateState = getAdjacentReserveCandidateState(roomName);
       if (candidateState === "safe") {
         return { target, intentAction: "reserve", commitTarget: true };
       }
-      if (candidateState === "unknown") {
+      if (candidateState === "unknown" && !isTerritoryIntentForActionSuppressed(colonyName, roomName, "scout")) {
         return { target, intentAction: "scout", commitTarget: false };
       }
     }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -197,15 +197,17 @@ function selectAdjacentReserveTarget(
     if (
       roomName !== colonyName &&
       !existingTargetRooms.has(roomName) &&
-      !isTerritoryTargetSuppressed(target, intents) &&
-      !isTerritoryIntentForActionSuppressed(colonyName, roomName, 'scout')
+      !isTerritoryTargetSuppressed(target, intents)
     ) {
       const candidateState = getAdjacentReserveCandidateState(roomName);
       if (candidateState === 'safe') {
         return { target, intentAction: 'reserve', commitTarget: true };
       }
 
-      if (candidateState === 'unknown') {
+      if (
+        candidateState === 'unknown' &&
+        !isTerritoryIntentForActionSuppressed(colonyName, roomName, 'scout')
+      ) {
         return { target, intentAction: 'scout', commitTarget: false };
       }
     }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -165,6 +165,126 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('commits a safe visible adjacent reserve target after scout suppression', () => {
+    const colony = makeSafeColony();
+    const suppressedScout: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'scout',
+      status: 'suppressed',
+      updatedAt: 529
+    };
+    const describeExits = jest.fn(() => ({ '1': 'W1N2' }));
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [suppressedScout]
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N2: { name: 'W1N2', controller: { my: false } as StructureController } as Room
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 530)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      suppressedScout,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 530
+      }
+    ]);
+  });
+
+  it('does not emit another scout for an unknown adjacent room after scout suppression', () => {
+    const colony = makeSafeColony();
+    const suppressedScout: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'scout',
+      status: 'suppressed',
+      updatedAt: 531
+    };
+    const describeExits = jest.fn(() => ({ '1': 'W1N2' }));
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [suppressedScout]
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 532)
+    ).toBeNull();
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([suppressedScout]);
+  });
+
+  it('skips unavailable, owned, and reserved adjacent rooms before seeding reserve targets', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits: jest.fn(() => ({
+          '1': 'W1N2',
+          '3': 'W2N1',
+          '5': 'W1N0',
+          '7': 'W0N1'
+        }))
+      } as unknown as GameMap,
+      rooms: {
+        W1N2: { name: 'W1N2' } as Room,
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false, owner: { username: 'enemy' } } as StructureController
+        } as Room,
+        W1N0: {
+          name: 'W1N0',
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 4_000 }
+          } as StructureController
+        } as Room,
+        W0N1: { name: 'W0N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 533)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W0N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W0N1',
+        action: 'reserve'
+      }
+    ]);
+  });
+
   it('does not seed an adjacent reserve target when the colony has only disabled configured targets', () => {
     const colony = makeSafeColony();
     const disabledTarget: TerritoryTargetMemory = {


### PR DESCRIPTION
## Summary
- Allows scout-suppressed adjacent rooms to transition to `reserve` once the room is visible and safe.
- Keeps scout suppression active only for unknown-room scout intents.
- Adds deterministic coverage for suppressed scout + visible safe reserve, suppressed scout + unknown room, and unavailable/owned/reserved adjacent-room skips.
- Regenerates `prod/dist/main.js` via `npm run build`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand -- territoryPlanner.test.ts`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

Closes #137
