### PR TITLE
feat: renew adjacent room reservations

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1015,12 +1015,13 @@ function getBodyCost(body) {
 var TERRITORY_CLAIMER_ROLE = "claimer";
 var TERRITORY_SCOUT_ROLE = "scout";
 var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
+var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
 var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
   }
-  const selection = selectTerritoryTarget(colony.room.name);
+  const selection = selectTerritoryTarget(colony);
   if (!selection) {
     return null;
   }
@@ -1042,7 +1043,12 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts) {
   if (plan.action === "scout" && isVisibleRoomKnown(plan.targetRoom)) {
     return false;
   }
-  if (isVisibleTerritoryTargetUnavailable(plan.targetRoom, plan.controllerId)) {
+  if (getVisibleTerritoryTargetState(
+    plan.targetRoom,
+    plan.action,
+    plan.controllerId,
+    getVisibleColonyOwnerUsername(plan.colony)
+  ) !== "available") {
     return false;
   }
   return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) === 0;
@@ -1091,25 +1097,32 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   }
   return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
 }
-function selectTerritoryTarget(colonyName) {
+function selectTerritoryTarget(colony) {
+  const colonyName = colony.room.name;
+  const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
-  const configuredTarget = selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents);
+  const configuredTarget = selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents);
   if (configuredTarget) {
     return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
   }
   if (hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName)) {
     return null;
   }
-  return selectAdjacentReserveTarget(colonyName, territoryMemory, intents);
+  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents);
 }
-function selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents) {
+function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return null;
   }
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
-    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents) && !isVisibleTerritoryTargetUnavailable(target.roomName, target.controllerId)) {
+    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents) && getVisibleTerritoryTargetState(
+      target.roomName,
+      target.action,
+      target.controllerId,
+      colonyOwnerUsername
+    ) === "available") {
       return target;
     }
   }
@@ -1118,7 +1131,7 @@ function selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents) {
 function hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName) {
   return getConfiguredTargetRoomsForColony(territoryMemory, colonyName).size > 0;
 }
-function selectAdjacentReserveTarget(colonyName, territoryMemory, intents) {
+function selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents) {
   const adjacentRooms = getAdjacentRoomNames(colonyName);
   if (adjacentRooms.length === 0) {
     return null;
@@ -1127,7 +1140,7 @@ function selectAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   for (const roomName of adjacentRooms) {
     const target = { colony: colonyName, roomName, action: "reserve" };
     if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents)) {
-      const candidateState = getAdjacentReserveCandidateState(roomName);
+      const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
       if (candidateState === "safe") {
         return { target, intentAction: "reserve", commitTarget: true };
       }
@@ -1138,7 +1151,7 @@ function selectAdjacentReserveTarget(colonyName, territoryMemory, intents) {
   }
   return null;
 }
-function getAdjacentReserveCandidateState(targetRoom) {
+function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
   if (isVisibleRoomMissingController(targetRoom)) {
     return "unavailable";
   }
@@ -1146,7 +1159,8 @@ function getAdjacentReserveCandidateState(targetRoom) {
   if (!controller) {
     return "unknown";
   }
-  return !isControllerOwned(controller) && controller.reservation == null ? "safe" : "unavailable";
+  const targetState = getReserveControllerTargetState(controller, colonyOwnerUsername);
+  return targetState === "available" ? "safe" : "unavailable";
 }
 function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -1277,15 +1291,18 @@ function isTerritoryIntentForActionSuppressed(colony, targetRoom, action) {
     (intent) => intent.status === "suppressed" && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
-function isVisibleTerritoryTargetUnavailable(targetRoom, controllerId) {
+function getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) {
   if (isVisibleRoomMissingController(targetRoom)) {
-    return true;
+    return "unavailable";
   }
   const controller = getVisibleController(targetRoom, controllerId);
   if (!controller) {
-    return false;
+    return "available";
   }
-  return isControllerOwned(controller);
+  if (action === "reserve") {
+    return getReserveControllerTargetState(controller, colonyOwnerUsername != null ? colonyOwnerUsername : null);
+  }
+  return isControllerOwned(controller) ? "unavailable" : "available";
 }
 function isVisibleRoomKnown(targetRoom) {
   var _a;
@@ -1300,6 +1317,28 @@ function isVisibleRoomMissingController(targetRoom) {
 }
 function isControllerOwned(controller) {
   return controller.owner != null || controller.my === true;
+}
+function getReserveControllerTargetState(controller, colonyOwnerUsername) {
+  if (isControllerOwned(controller)) {
+    return "unavailable";
+  }
+  const reservation = controller.reservation;
+  if (!reservation) {
+    return "available";
+  }
+  if (!isNonEmptyString(reservation.username) || reservation.username !== colonyOwnerUsername) {
+    return "unavailable";
+  }
+  return typeof reservation.ticksToEnd === "number" && reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? "available" : "satisfied";
+}
+function getVisibleColonyOwnerUsername(colonyName) {
+  const controller = getVisibleController(colonyName);
+  return getControllerOwnerUsername(controller != null ? controller : void 0);
+}
+function getControllerOwnerUsername(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  return isNonEmptyString(username) ? username : null;
 }
 function getVisibleController(targetRoom, controllerId) {
   var _a, _b;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -5,6 +5,7 @@ import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
 export const TERRITORY_DOWNGRADE_GUARD_TICKS = 5_000;
+export const TERRITORY_RESERVATION_RENEWAL_TICKS = 1_000;
 
 const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
 
@@ -25,6 +26,8 @@ interface SelectedTerritoryTarget {
   commitTarget: boolean;
 }
 
+type TerritoryTargetVisibilityState = 'available' | 'satisfied' | 'unavailable';
+
 export function planTerritoryIntent(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
@@ -35,7 +38,7 @@ export function planTerritoryIntent(
     return null;
   }
 
-  const selection = selectTerritoryTarget(colony.room.name);
+  const selection = selectTerritoryTarget(colony);
   if (!selection) {
     return null;
   }
@@ -62,7 +65,14 @@ export function shouldSpawnTerritoryControllerCreep(plan: TerritoryIntentPlan, r
     return false;
   }
 
-  if (isVisibleTerritoryTargetUnavailable(plan.targetRoom, plan.controllerId)) {
+  if (
+    getVisibleTerritoryTargetState(
+      plan.targetRoom,
+      plan.action,
+      plan.controllerId,
+      getVisibleColonyOwnerUsername(plan.colony)
+    ) !== 'available'
+  ) {
     return false;
   }
 
@@ -133,10 +143,12 @@ export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCoun
   );
 }
 
-function selectTerritoryTarget(colonyName: string): SelectedTerritoryTarget | null {
+function selectTerritoryTarget(colony: ColonySnapshot): SelectedTerritoryTarget | null {
+  const colonyName = colony.room.name;
+  const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   const intents = normalizeTerritoryIntents(territoryMemory?.intents);
-  const configuredTarget = selectConfiguredTerritoryTarget(colonyName, territoryMemory, intents);
+  const configuredTarget = selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents);
   if (configuredTarget) {
     return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
   }
@@ -145,11 +157,12 @@ function selectTerritoryTarget(colonyName: string): SelectedTerritoryTarget | nu
     return null;
   }
 
-  return selectAdjacentReserveTarget(colonyName, territoryMemory, intents);
+  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents);
 }
 
 function selectConfiguredTerritoryTarget(
   colonyName: string,
+  colonyOwnerUsername: string | null,
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[]
 ): TerritoryTargetMemory | null {
@@ -165,7 +178,12 @@ function selectConfiguredTerritoryTarget(
       target.colony === colonyName &&
       target.roomName !== colonyName &&
       !isTerritoryTargetSuppressed(target, intents) &&
-      !isVisibleTerritoryTargetUnavailable(target.roomName, target.controllerId)
+      getVisibleTerritoryTargetState(
+        target.roomName,
+        target.action,
+        target.controllerId,
+        colonyOwnerUsername
+      ) === 'available'
     ) {
       return target;
     }
@@ -183,6 +201,7 @@ function hasConfiguredTerritoryTargetForColony(
 
 function selectAdjacentReserveTarget(
   colonyName: string,
+  colonyOwnerUsername: string | null,
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[]
 ): SelectedTerritoryTarget | null {
@@ -199,7 +218,7 @@ function selectAdjacentReserveTarget(
       !existingTargetRooms.has(roomName) &&
       !isTerritoryTargetSuppressed(target, intents)
     ) {
-      const candidateState = getAdjacentReserveCandidateState(roomName);
+      const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
       if (candidateState === 'safe') {
         return { target, intentAction: 'reserve', commitTarget: true };
       }
@@ -216,7 +235,10 @@ function selectAdjacentReserveTarget(
   return null;
 }
 
-function getAdjacentReserveCandidateState(targetRoom: string): 'safe' | 'unknown' | 'unavailable' {
+function getAdjacentReserveCandidateState(
+  targetRoom: string,
+  colonyOwnerUsername: string | null
+): 'safe' | 'unknown' | 'unavailable' {
   if (isVisibleRoomMissingController(targetRoom)) {
     return 'unavailable';
   }
@@ -226,7 +248,8 @@ function getAdjacentReserveCandidateState(targetRoom: string): 'safe' | 'unknown
     return 'unknown';
   }
 
-  return !isControllerOwned(controller) && controller.reservation == null ? 'safe' : 'unavailable';
+  const targetState = getReserveControllerTargetState(controller, colonyOwnerUsername);
+  return targetState === 'available' ? 'safe' : 'unavailable';
 }
 
 function getConfiguredTargetRoomsForColony(
@@ -436,20 +459,26 @@ function isTerritoryIntentForActionSuppressed(
   );
 }
 
-function isVisibleTerritoryTargetUnavailable(
+function getVisibleTerritoryTargetState(
   targetRoom: string,
-  controllerId?: Id<StructureController>
-): boolean {
+  action: TerritoryIntentAction,
+  controllerId?: Id<StructureController>,
+  colonyOwnerUsername?: string | null
+): TerritoryTargetVisibilityState {
   if (isVisibleRoomMissingController(targetRoom)) {
-    return true;
+    return 'unavailable';
   }
 
   const controller = getVisibleController(targetRoom, controllerId);
   if (!controller) {
-    return false;
+    return 'available';
   }
 
-  return isControllerOwned(controller);
+  if (action === 'reserve') {
+    return getReserveControllerTargetState(controller, colonyOwnerUsername ?? null);
+  }
+
+  return isControllerOwned(controller) ? 'unavailable' : 'available';
 }
 
 function isVisibleRoomKnown(targetRoom: string): boolean {
@@ -465,6 +494,40 @@ function isVisibleRoomMissingController(targetRoom: string): boolean {
 
 function isControllerOwned(controller: StructureController): boolean {
   return controller.owner != null || controller.my === true;
+}
+
+function getReserveControllerTargetState(
+  controller: StructureController,
+  colonyOwnerUsername: string | null
+): TerritoryTargetVisibilityState {
+  if (isControllerOwned(controller)) {
+    return 'unavailable';
+  }
+
+  const reservation = controller.reservation;
+  if (!reservation) {
+    return 'available';
+  }
+
+  if (!isNonEmptyString(reservation.username) || reservation.username !== colonyOwnerUsername) {
+    return 'unavailable';
+  }
+
+  return typeof reservation.ticksToEnd === 'number' &&
+    reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS
+    ? 'available'
+    : 'satisfied';
+}
+
+function getVisibleColonyOwnerUsername(colonyName: string): string | null {
+  const controller = getVisibleController(colonyName);
+  return getControllerOwnerUsername(controller ?? undefined);
+}
+
+function getControllerOwnerUsername(controller: StructureController | undefined): string | null {
+  const username = (controller as (StructureController & { owner?: { username?: string } }) | undefined)?.owner
+    ?.username;
+  return isNonEmptyString(username) ? username : null;
 }
 
 function getVisibleController(targetRoom: string, controllerId?: Id<StructureController>): StructureController | null {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2,7 +2,8 @@ import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   planTerritoryIntent,
   shouldSpawnTerritoryControllerCreep,
-  TERRITORY_DOWNGRADE_GUARD_TICKS
+  TERRITORY_DOWNGRADE_GUARD_TICKS,
+  TERRITORY_RESERVATION_RENEWAL_TICKS
 } from '../src/territory/territoryPlanner';
 
 describe('planTerritoryIntent', () => {
@@ -908,6 +909,155 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('renews an own visible reserve target near expiry', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W1N2', action: 'reserve' }]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 534);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
+    ).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 534
+      }
+    ]);
+  });
+
+  it('does not over-spawn for a healthy own visible reservation', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 1 }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W1N2', action: 'reserve' }]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 535)).toBeNull();
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('skips visible enemy-reserved reserve targets and plans the next eligible target', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: {
+          name: 'W2N1',
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+          } as StructureController
+        } as Room,
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 536);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 536
+      }
+    ]);
+  });
+
+  it('does not renew an explicitly suppressed own reserve target near expiry', () => {
+    const colony = makeSafeColony();
+    const suppressedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: 537
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W1N2', action: 'reserve' }],
+        intents: [suppressedIntent]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 538)).toBeNull();
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toEqual([suppressedIntent]);
+  });
+
   it('still requests claimers for visible unowned reserve targets', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -932,7 +1082,7 @@ describe('planTerritoryIntent', () => {
 
 function makeSafeColony({
   roomName = 'W1N1',
-  controller = { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+  controller = { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 } as StructureController
 }: {
   roomName?: string;
   controller?: StructureController;


### PR DESCRIPTION
## Summary
- Renews visible adjacent reserve targets when our reservation is missing or near expiry.
- Skips hostile-owned, enemy-reserved, disabled, suppressed, self-owned, and healthy long-reservation targets.
- Preserves scout-before-reserve, safe visible reserve handoff, home-safety gates, and no-map/no-exit safeguards.
- Regenerates `prod/dist/main.js` via build.

## Linked issue
Closes #141

## Roadmap category
Gameplay Evolution / territory-control

## Served vision layer
Territory/control: keeps discovered adjacent reservation targets alive instead of allowing territory-control momentum to lapse after the first reserver cycle.

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand -- territoryPlanner.test.ts` (33 tests)
- [x] `cd prod && npm test -- --runInBand` (16 suites / 216 tests)
- [x] `cd prod && npm run build`

## Notes
- Codex-authored commit: `48585fd lanyusea's bot <lanyusea@gmail.com> feat: renew adjacent room reservations`
- No secrets touched.
- Requires independent QA PASS, green checks/reviews, no active review threads, current Project fields, and >=15 minute elapsed review gate before merge.
