### PR TITLE
feat: prefer neutral reserve opportunities

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1106,7 +1106,7 @@ function selectTerritoryTarget(colony) {
   if (configuredTarget) {
     return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
   }
-  if (hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName)) {
+  if (hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents)) {
     return null;
   }
   return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents);
@@ -1128,8 +1128,20 @@ function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territ
   }
   return null;
 }
-function hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName) {
-  return getConfiguredTargetRoomsForColony(territoryMemory, colonyName).size > 0;
+function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return false;
+  }
+  return territoryMemory.targets.some((rawTarget) => {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (!target || target.colony !== colonyName) {
+      return false;
+    }
+    if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents)) {
+      return true;
+    }
+    return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
+  });
 }
 function selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents) {
   const adjacentRooms = getAdjacentRoomNames(colonyName);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -153,7 +153,7 @@ function selectTerritoryTarget(colony: ColonySnapshot): SelectedTerritoryTarget 
     return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
   }
 
-  if (hasConfiguredTerritoryTargetForColony(territoryMemory, colonyName)) {
+  if (hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents)) {
     return null;
   }
 
@@ -192,11 +192,31 @@ function selectConfiguredTerritoryTarget(
   return null;
 }
 
-function hasConfiguredTerritoryTargetForColony(
+function hasBlockingConfiguredTerritoryTargetForColony(
   territoryMemory: Record<string, unknown> | null,
-  colonyName: string
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  intents: TerritoryIntentMemory[]
 ): boolean {
-  return getConfiguredTargetRoomsForColony(territoryMemory, colonyName).size > 0;
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return false;
+  }
+
+  return territoryMemory.targets.some((rawTarget) => {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (!target || target.colony !== colonyName) {
+      return false;
+    }
+
+    if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents)) {
+      return true;
+    }
+
+    return (
+      getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !==
+      'satisfied'
+    );
+  });
 }
 
 function selectAdjacentReserveTarget(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -909,9 +909,141 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('prioritizes a neutral adjacent reserve target over a healthy own configured reservation', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        } as Room,
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 539);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
+    ).toBe(true);
+    expect(Memory.territory?.targets).toEqual([
+      configuredTarget,
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 539
+      }
+    ]);
+  });
+
+  it('skips hostile and suppressed adjacent reserve targets after a satisfied reservation', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const suppressedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: 540
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits: jest.fn(() => ({
+          '1': 'W1N2',
+          '3': 'W2N1',
+          '5': 'W1N0',
+          '7': 'W0N1'
+        }))
+      } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        } as Room,
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room,
+        W1N0: {
+          name: 'W1N0',
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 4_000 }
+          } as StructureController
+        } as Room,
+        W0N1: { name: 'W0N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget],
+        intents: [suppressedIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 541)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W0N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      configuredTarget,
+      {
+        colony: 'W1N1',
+        roomName: 'W0N1',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      suppressedIntent,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W0N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 541
+      }
+    ]);
+  });
+
   it('renews an own visible reserve target near expiry', () => {
     const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const describeExits = jest.fn(() => ({ '3': 'W2N1' }));
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
       rooms: {
         W1N1: colony.room,
         W1N2: {
@@ -920,21 +1052,24 @@ describe('planTerritoryIntent', () => {
             my: false,
             reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
           } as StructureController
-        } as Room
+        } as Room,
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
       }
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
-        targets: [{ colony: 'W1N1', roomName: 'W1N2', action: 'reserve' }]
+        targets: [configuredTarget]
       }
     };
 
     const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 534);
 
     expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' });
+    expect(describeExits).not.toHaveBeenCalled();
     expect(
       shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
     ).toBe(true);
+    expect(Memory.territory?.targets).toEqual([configuredTarget]);
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',


### PR DESCRIPTION
## Summary
- Prefer a neutral adjacent reserve opportunity before treating an already-healthy owned reservation as satisfied.
- Preserve suppression/hostile filters for adjacent reserve candidates.
- Add deterministic territory planner coverage and regenerate `prod/dist/main.js`.

Closes #145

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand territoryPlanner.test.ts`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

## Notes
- No secrets added.
- Codex-authored commit: `bba493b lanyusea's bot <lanyusea@gmail.com> feat: prefer neutral reserve opportunities`.
