### PR TITLE
feat: use surplus energy for controller progress

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -568,7 +568,7 @@ function selectWorkerTask(creep) {
   if (roadOrContainerConstructionSite) {
     return { type: "build", targetId: roadOrContainerConstructionSite.id };
   }
-  if (controller && shouldSustainControllerProgress(creep, controller)) {
+  if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
   if (constructionSites[0]) {
@@ -632,8 +632,8 @@ function isStoredWorkerEnergySource(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType2(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType2(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function hasStoredEnergy(structure) {
-  var _a;
-  return ((_a = structure.store.getUsedCapacity(RESOURCE_ENERGY)) != null ? _a : 0) > 0;
+  var _a, _b, _c;
+  return ((_c = (_b = (_a = structure.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY)) != null ? _c : 0) > 0;
 }
 function isFriendlyStoredEnergySource(structure, context) {
   var _a;
@@ -784,6 +784,15 @@ function shouldSustainControllerProgress(creep, controller) {
   }
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
   return loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS && !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller));
+}
+function shouldUseSurplusForControllerProgress(creep, controller) {
+  if (shouldSustainControllerProgress(creep, controller)) {
+    return true;
+  }
+  return controller.my === true && controller.level >= 2 && hasWithdrawableSurplusEnergy(creep);
+}
+function hasWithdrawableSurplusEnergy(creep) {
+  return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null;
 }
 function getSameRoomLoadedWorkers(creep) {
   const loadedWorkers = getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -77,7 +77,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'build', targetId: roadOrContainerConstructionSite.id };
   }
 
-  if (controller && shouldSustainControllerProgress(creep, controller)) {
+  if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
     return { type: 'upgrade', targetId: controller.id };
   }
 
@@ -182,7 +182,7 @@ function isStoredWorkerEnergySource(structure: AnyStructure): structure is Store
 }
 
 function hasStoredEnergy(structure: StoredWorkerEnergySource): boolean {
-  return (structure.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0) > 0;
+  return (structure.store?.getUsedCapacity?.(RESOURCE_ENERGY) ?? 0) > 0;
 }
 
 function isFriendlyStoredEnergySource(structure: StoredWorkerEnergySource, context: StoredEnergySourceContext): boolean {
@@ -394,6 +394,18 @@ function shouldSustainControllerProgress(creep: Creep, controller: StructureCont
     loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS &&
     !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller))
   );
+}
+
+function shouldUseSurplusForControllerProgress(creep: Creep, controller: StructureController): boolean {
+  if (shouldSustainControllerProgress(creep, controller)) {
+    return true;
+  }
+
+  return controller.my === true && controller.level >= 2 && hasWithdrawableSurplusEnergy(creep);
+}
+
+function hasWithdrawableSurplusEnergy(creep: Creep): boolean {
+  return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null;
 }
 
 function getSameRoomLoadedWorkers(creep: Creep): Creep[] {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1153,6 +1153,140 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
+  it('routes carried energy to controller upgrade before non-critical construction when stored surplus exists', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [storage] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('routes carried energy to controller upgrade before non-critical construction when salvage surplus exists', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const tombstone = makeSalvageEnergySource('tombstone-surplus', 100);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type: number) => {
+        if (
+          type === FIND_MY_STRUCTURES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return [site];
+        }
+
+        return type === FIND_TOMBSTONES ? [tombstone] : [];
+      })
+    } as unknown as Room;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(room.find).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('keeps extension construction before stored-surplus controller upgrading', () => {
+    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [storage] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
+  });
+
+  it('keeps critical repair before stored-surplus controller upgrading', () => {
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ controller, structures: [storage, road] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-critical' });
+  });
+
+  it('keeps road construction before stored-surplus controller upgrading', () => {
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [storage] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('does not treat unsafe stored energy as controller upgrade surplus', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const hostileStorage = makeStoredEnergyStructure('hostile-storage', 'storage' as StructureConstant, 1_000, {
+      my: false
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [hostileStorage] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
+  });
+
   it('selects RCL3 controller upgrade before non-critical construction when another loaded worker can build', () => {
     const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
     const controller = {


### PR DESCRIPTION
## Summary
- routes surplus stored or salvage energy into controller progress when no higher-priority local work is pending
- preserves critical repair, extension, road/container construction, and unsafe-storage safety ordering
- adds worker task coverage for stored/salvage surplus controller upgrading

Fixes #147.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites / 227 tests)
- `cd prod && npm run build`

## Roadmap category
- Bot capability / gameplay: resources/economy controller-progress throughput
