### PR TITLE
feat: prefer high-value dropped resources

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -518,16 +518,12 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
-var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
+var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 function selectWorkerTask(creep) {
-  const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
+  const carriedEnergy = getUsedEnergy(creep);
   if (carriedEnergy === 0) {
     if (getFreeEnergyCapacity(creep) > 0) {
-      const droppedEnergy = selectDroppedEnergy(creep);
-      if (droppedEnergy) {
-        return { type: "pickup", targetId: droppedEnergy.id };
-      }
       const storedEnergy = selectStoredEnergySource(creep);
       if (storedEnergy) {
         return { type: "withdraw", targetId: storedEnergy.id };
@@ -535,6 +531,10 @@ function selectWorkerTask(creep) {
       const salvageEnergy = selectSalvageEnergySource(creep);
       if (salvageEnergy) {
         return { type: "withdraw", targetId: salvageEnergy.id };
+      }
+      const droppedEnergy = selectDroppedEnergy(creep);
+      if (droppedEnergy) {
+        return { type: "pickup", targetId: droppedEnergy.id };
       }
     }
     const source = selectHarvestSource(creep);
@@ -584,7 +584,7 @@ function selectWorkerTask(creep) {
   return null;
 }
 function isFillableEnergySink(structure) {
-  return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure && structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0;
+  return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
 function selectFillableEnergySink(creep) {
   const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
@@ -632,8 +632,7 @@ function isStoredWorkerEnergySource(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType2(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType2(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function hasStoredEnergy(structure) {
-  var _a;
-  return ((_a = structure.store.getUsedCapacity(RESOURCE_ENERGY)) != null ? _a : 0) > 0;
+  return getStoredEnergy(structure) > 0;
 }
 function isFriendlyStoredEnergySource(structure, context) {
   var _a;
@@ -685,8 +684,7 @@ function findRuins(room) {
   return room.find(FIND_RUINS);
 }
 function hasSalvageableEnergy(source) {
-  var _a;
-  return ((_a = source.store.getUsedCapacity(RESOURCE_ENERGY)) != null ? _a : 0) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
+  return getStoredEnergy(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
 }
 function getCreepOwnerUsername(creep) {
   var _a;
@@ -804,12 +802,45 @@ function isInRoom(creep, room) {
   return creep.room === room;
 }
 function getUsedEnergy(creep) {
-  var _a, _b, _c;
-  return (_c = (_b = (_a = creep.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY)) != null ? _c : 0;
+  return getStoredEnergy(creep);
 }
 function getFreeEnergyCapacity(creep) {
-  var _a, _b, _c;
-  return (_c = (_b = (_a = creep.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY)) != null ? _c : 0;
+  return getFreeStoredEnergyCapacity(creep);
+}
+function getStoredEnergy(object) {
+  var _a;
+  const store = getStore(object);
+  if (!store) {
+    return 0;
+  }
+  const usedCapacity = (_a = store.getUsedCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
+  if (typeof usedCapacity === "number") {
+    return usedCapacity;
+  }
+  const storedEnergy = store[getWorkerEnergyResource()];
+  return typeof storedEnergy === "number" ? storedEnergy : 0;
+}
+function getFreeStoredEnergyCapacity(object) {
+  var _a;
+  const store = getStore(object);
+  if (!store) {
+    return 0;
+  }
+  const freeCapacity = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
+  return typeof freeCapacity === "number" ? freeCapacity : 0;
+}
+function getStore(object) {
+  if (!isWorkerTaskRecord(object) || !isWorkerTaskRecord(object.store)) {
+    return null;
+  }
+  return object.store;
+}
+function getWorkerEnergyResource() {
+  const value = globalThis.RESOURCE_ENERGY;
+  return typeof value === "string" ? value : "energy";
+}
+function isWorkerTaskRecord(value) {
+  return typeof value === "object" && value !== null;
 }
 function isUpgradingController(creep, controller) {
   var _a;
@@ -831,7 +862,7 @@ function findDroppedResources(room) {
   return room.find(FIND_DROPPED_RESOURCES);
 }
 function isUsefulDroppedEnergy(resource) {
-  return resource.resourceType === RESOURCE_ENERGY && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
+  return resource.resourceType === getWorkerEnergyResource() && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
 }
 function findClosestByRange(creep, objects) {
   if (objects.length === 0) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3,7 +3,7 @@ export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
-const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 2;
+const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 const MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
@@ -18,15 +18,10 @@ interface StoredEnergySourceContext {
 }
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
-  const carriedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
+  const carriedEnergy = getUsedEnergy(creep);
 
   if (carriedEnergy === 0) {
     if (getFreeEnergyCapacity(creep) > 0) {
-      const droppedEnergy = selectDroppedEnergy(creep);
-      if (droppedEnergy) {
-        return { type: 'pickup', targetId: droppedEnergy.id };
-      }
-
       const storedEnergy = selectStoredEnergySource(creep);
       if (storedEnergy) {
         return { type: 'withdraw', targetId: storedEnergy.id as Id<AnyStoreStructure> };
@@ -35,6 +30,11 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
       const salvageEnergy = selectSalvageEnergySource(creep);
       if (salvageEnergy) {
         return { type: 'withdraw', targetId: salvageEnergy.id as unknown as Id<AnyStoreStructure> };
+      }
+
+      const droppedEnergy = selectDroppedEnergy(creep);
+      if (droppedEnergy) {
+        return { type: 'pickup', targetId: droppedEnergy.id };
       }
     }
 
@@ -102,7 +102,7 @@ function isFillableEnergySink(structure: AnyOwnedStructure): structure is Struct
     (matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') ||
       matchesStructureType(structure.structureType, 'STRUCTURE_EXTENSION', 'extension')) &&
     'store' in structure &&
-    structure.store.getFreeCapacity(RESOURCE_ENERGY) > 0
+    getFreeStoredEnergyCapacity(structure) > 0
   );
 }
 
@@ -182,7 +182,7 @@ function isStoredWorkerEnergySource(structure: AnyStructure): structure is Store
 }
 
 function hasStoredEnergy(structure: StoredWorkerEnergySource): boolean {
-  return (structure.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0) > 0;
+  return getStoredEnergy(structure) > 0;
 }
 
 function isFriendlyStoredEnergySource(structure: StoredWorkerEnergySource, context: StoredEnergySourceContext): boolean {
@@ -250,7 +250,7 @@ function findRuins(room: Room): Ruin[] {
 }
 
 function hasSalvageableEnergy(source: SalvageableWorkerEnergySource): boolean {
-  return (source.store.getUsedCapacity(RESOURCE_ENERGY) ?? 0) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
+  return getStoredEnergy(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
 }
 
 function getCreepOwnerUsername(creep: Creep): string | null {
@@ -419,11 +419,59 @@ function isInRoom(creep: Creep, room: Room): boolean {
 }
 
 function getUsedEnergy(creep: Creep): number {
-  return creep.store?.getUsedCapacity?.(RESOURCE_ENERGY) ?? 0;
+  return getStoredEnergy(creep);
 }
 
 function getFreeEnergyCapacity(creep: Creep): number {
-  return creep.store?.getFreeCapacity?.(RESOURCE_ENERGY) ?? 0;
+  return getFreeStoredEnergyCapacity(creep);
+}
+
+interface StoreLike {
+  getUsedCapacity?: (resource?: ResourceConstant) => number | null;
+  getFreeCapacity?: (resource?: ResourceConstant) => number | null;
+  [resource: string]: unknown;
+}
+
+function getStoredEnergy(object: unknown): number {
+  const store = getStore(object);
+  if (!store) {
+    return 0;
+  }
+
+  const usedCapacity = store.getUsedCapacity?.(getWorkerEnergyResource());
+  if (typeof usedCapacity === 'number') {
+    return usedCapacity;
+  }
+
+  const storedEnergy = store[getWorkerEnergyResource()];
+  return typeof storedEnergy === 'number' ? storedEnergy : 0;
+}
+
+function getFreeStoredEnergyCapacity(object: unknown): number {
+  const store = getStore(object);
+  if (!store) {
+    return 0;
+  }
+
+  const freeCapacity = store.getFreeCapacity?.(getWorkerEnergyResource());
+  return typeof freeCapacity === 'number' ? freeCapacity : 0;
+}
+
+function getStore(object: unknown): StoreLike | null {
+  if (!isWorkerTaskRecord(object) || !isWorkerTaskRecord(object.store)) {
+    return null;
+  }
+
+  return object.store as StoreLike;
+}
+
+function getWorkerEnergyResource(): RESOURCE_ENERGY {
+  const value = (globalThis as unknown as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY;
+  return (typeof value === 'string' ? value : 'energy') as RESOURCE_ENERGY;
+}
+
+function isWorkerTaskRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function isUpgradingController(creep: Creep, controller: StructureController): boolean {
@@ -450,7 +498,7 @@ function findDroppedResources(room: Room): Resource[] {
 }
 
 function isUsefulDroppedEnergy(resource: Resource): resource is Resource<RESOURCE_ENERGY> {
-  return resource.resourceType === RESOURCE_ENERGY && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
+  return resource.resourceType === getWorkerEnergyResource() && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
 }
 
 function findClosestByRange<T extends RoomObject>(creep: Creep, objects: T[]): T | null {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -130,14 +130,15 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
-  it('selects nearby useful dropped energy before harvesting when worker has free capacity', () => {
+  it('selects nearest high-value dropped energy before harvesting when worker has free capacity', () => {
+    const lowValueDroppedEnergy = { id: 'drop-low', resourceType: 'energy', amount: 24 } as Resource<ResourceConstant>;
     const farDroppedEnergy = { id: 'drop-far', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
     const nearDroppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
     const source = { id: 'source1' } as Source;
     const findClosestByRange = jest.fn().mockReturnValue(nearDroppedEnergy);
     const roomFind = jest.fn((type: number) => {
       if (type === FIND_DROPPED_RESOURCES) {
-        return [farDroppedEnergy, nearDroppedEnergy];
+        return [lowValueDroppedEnergy, farDroppedEnergy, nearDroppedEnergy];
       }
 
       return type === FIND_SOURCES ? [source] : [];
@@ -153,6 +154,34 @@ describe('selectWorkerTask', () => {
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
     expect(findClosestByRange).toHaveBeenCalledWith([farDroppedEnergy, nearDroppedEnergy]);
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('keeps dropped energy fallback deterministic when energy globals or stores are partially mocked', () => {
+    delete (globalThis as unknown as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY;
+    const partialContainer = { id: 'container1', structureType: 'container' } as AnyStructure;
+    const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
+    const source = { id: 'source1' } as Source;
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_STRUCTURES) {
+        return [partialContainer];
+      }
+
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [droppedEnergy];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop1' });
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
@@ -325,17 +354,17 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
-  it('keeps dropped energy priority over stored energy withdraw', () => {
+  it('keeps stored energy withdrawal priority over dropped energy pickup', () => {
     const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
     const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 100);
     const source = { id: 'source1' } as Source;
     const roomFind = jest.fn((type: number) => {
-      if (type === FIND_DROPPED_RESOURCES) {
-        return [droppedEnergy];
-      }
-
       if (type === FIND_STRUCTURES) {
         return [container];
+      }
+
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [droppedEnergy];
       }
 
       return type === FIND_SOURCES ? [source] : [];
@@ -348,27 +377,27 @@ describe('selectWorkerTask', () => {
       room: { controller: { my: true }, find: roomFind }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop1' });
-    expect(roomFind).not.toHaveBeenCalledWith(FIND_STRUCTURES);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_DROPPED_RESOURCES);
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
-  it('keeps dropped energy priority over tombstone and ruin salvage', () => {
+  it('keeps tombstone and ruin salvage priority over dropped energy pickup', () => {
     const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
     const tombstone = makeSalvageEnergySource('tombstone1', 25);
     const ruin = makeSalvageEnergySource('ruin1', 25);
     const source = { id: 'source1' } as Source;
     const roomFind = jest.fn((type: number) => {
-      if (type === FIND_DROPPED_RESOURCES) {
-        return [droppedEnergy];
-      }
-
       if (type === FIND_TOMBSTONES) {
         return [tombstone];
       }
 
       if (type === FIND_RUINS) {
         return [ruin];
+      }
+
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [droppedEnergy];
       }
 
       return type === FIND_SOURCES ? [source] : [];
@@ -381,9 +410,8 @@ describe('selectWorkerTask', () => {
       room: { find: roomFind }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop1' });
-    expect(roomFind).not.toHaveBeenCalledWith(FIND_TOMBSTONES);
-    expect(roomFind).not.toHaveBeenCalledWith(FIND_RUINS);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'tombstone1' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_DROPPED_RESOURCES);
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
@@ -551,12 +579,12 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
-  it('ignores non-energy and trivial dropped resources before falling back to balanced harvesting', () => {
+  it('ignores non-energy and below-threshold dropped resources before falling back to balanced harvesting', () => {
     const source1 = { id: 'source1' } as Source;
     const source2 = { id: 'source2' } as Source;
     const droppedMineral = { id: 'drop-mineral', resourceType: 'H' as ResourceConstant, amount: 100 } as Resource<ResourceConstant>;
     const zeroEnergy = { id: 'drop-zero', resourceType: 'energy', amount: 0 } as Resource<ResourceConstant>;
-    const trivialEnergy = { id: 'drop-trivial', resourceType: 'energy', amount: 1 } as Resource<ResourceConstant>;
+    const trivialEnergy = { id: 'drop-trivial', resourceType: 'energy', amount: 24 } as Resource<ResourceConstant>;
     const room = {
       name: 'W1N1',
       find: jest.fn((type: number) => {


### PR DESCRIPTION
## Summary
- prefers safer stored/salvage energy before dropped-energy pickup, then selects high-value dropped resources before harvesting
- raises low-value dropped-energy noise threshold and adds robust energy/store handling for partial mocks/runtime objects
- adds worker task coverage for high-value dropped-resource pickup and deterministic fallback behavior

Fixes #148.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites / 222 tests)
- `cd prod && npm run build`

## Roadmap category
- Bot capability / gameplay: resources/economy worker energy acquisition
