### PR TITLE
feat: renew low-TTL reserve targets

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1184,6 +1184,9 @@ function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territ
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return null;
   }
+  let fallbackTarget = null;
+  let renewalTarget = null;
+  let renewalTicksToEnd = null;
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
     if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents) && getVisibleTerritoryTargetState(
@@ -1192,10 +1195,20 @@ function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territ
       target.controllerId,
       colonyOwnerUsername
     ) === "available") {
-      return target;
+      const targetRenewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername);
+      if (targetRenewalTicksToEnd !== null) {
+        if (renewalTicksToEnd === null || targetRenewalTicksToEnd < renewalTicksToEnd) {
+          renewalTarget = target;
+          renewalTicksToEnd = targetRenewalTicksToEnd;
+        }
+        continue;
+      }
+      if (fallbackTarget === null) {
+        fallbackTarget = target;
+      }
     }
   }
-  return null;
+  return renewalTarget != null ? renewalTarget : fallbackTarget;
 }
 function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -1411,6 +1424,20 @@ function getReserveControllerTargetState(controller, colonyOwnerUsername) {
     return "unavailable";
   }
   return typeof reservation.ticksToEnd === "number" && reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? "available" : "satisfied";
+}
+function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
+  if (target.action !== "reserve" || colonyOwnerUsername === null) {
+    return null;
+  }
+  const controller = getVisibleController(target.roomName, target.controllerId);
+  if (!controller || isControllerOwned(controller)) {
+    return null;
+  }
+  const reservation = controller.reservation;
+  if (!reservation || reservation.username !== colonyOwnerUsername || typeof reservation.ticksToEnd !== "number") {
+    return null;
+  }
+  return reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? reservation.ticksToEnd : null;
 }
 function getVisibleColonyOwnerUsername(colonyName) {
   const controller = getVisibleController(colonyName);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -170,6 +170,10 @@ function selectConfiguredTerritoryTarget(
     return null;
   }
 
+  let fallbackTarget: TerritoryTargetMemory | null = null;
+  let renewalTarget: TerritoryTargetMemory | null = null;
+  let renewalTicksToEnd: number | null = null;
+
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
     if (
@@ -185,11 +189,22 @@ function selectConfiguredTerritoryTarget(
         colonyOwnerUsername
       ) === 'available'
     ) {
-      return target;
+      const targetRenewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername);
+      if (targetRenewalTicksToEnd !== null) {
+        if (renewalTicksToEnd === null || targetRenewalTicksToEnd < renewalTicksToEnd) {
+          renewalTarget = target;
+          renewalTicksToEnd = targetRenewalTicksToEnd;
+        }
+        continue;
+      }
+
+      if (fallbackTarget === null) {
+        fallbackTarget = target;
+      }
     }
   }
 
-  return null;
+  return renewalTarget ?? fallbackTarget;
 }
 
 function hasBlockingConfiguredTerritoryTargetForColony(
@@ -537,6 +552,27 @@ function getReserveControllerTargetState(
     reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS
     ? 'available'
     : 'satisfied';
+}
+
+function getConfiguredReserveRenewalTicksToEnd(
+  target: TerritoryTargetMemory,
+  colonyOwnerUsername: string | null
+): number | null {
+  if (target.action !== 'reserve' || colonyOwnerUsername === null) {
+    return null;
+  }
+
+  const controller = getVisibleController(target.roomName, target.controllerId);
+  if (!controller || isControllerOwned(controller)) {
+    return null;
+  }
+
+  const reservation = controller.reservation;
+  if (!reservation || reservation.username !== colonyOwnerUsername || typeof reservation.ticksToEnd !== 'number') {
+    return null;
+  }
+
+  return reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? reservation.ticksToEnd : null;
 }
 
 function getVisibleColonyOwnerUsername(colonyName: string): string | null {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1081,6 +1081,138 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('renews the lowest-TTL configured reserve before other configured targets', () => {
+    const colony = makeSafeColony();
+    const unreservedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const higherTtlTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const lowerTtlTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W4N1', action: 'reserve' };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room,
+        W3N1: {
+          name: 'W3N1',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS - 100 }
+          } as StructureController
+        } as Room,
+        W4N1: {
+          name: 'W4N1',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS - 700 }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [unreservedTarget, higherTtlTarget, lowerTtlTarget]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 542);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W4N1', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
+    ).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W4N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 542
+      }
+    ]);
+  });
+
+  it('keeps unreserved configured reserve targets eligible when no renewal is urgent', () => {
+    const colony = makeSafeColony();
+    const healthyReservationTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const unreservedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        } as Room,
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [healthyReservationTarget, unreservedTarget]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 543);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
+    ).toBe(true);
+    expect(Memory.territory?.targets).toEqual([healthyReservationTarget, unreservedTarget]);
+  });
+
+  it('does not treat hostile or owned reserve targets as renewal candidates', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS - 900 }
+          } as StructureController
+        } as Room,
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: true, owner: { username: 'me' } } as StructureController
+        } as Room,
+        W3N1: {
+          name: 'W3N1',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS - 100 }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 544);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+      )
+    ).toBe(false);
+  });
+
   it('does not over-spawn for a healthy own visible reservation', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {


### PR DESCRIPTION
## Summary
- Prioritizes low-TTL friendly reserve renewals before fresh configured reserve expansion.
- Keeps unreserved configured reserve targets eligible when no urgent renewal exists.
- Preserves owned/hostile target rejection and adds regression coverage.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

Closes #151
