### PR TITLE
feat: add construction backlog worker throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1474,12 +1474,13 @@ function isRecord(value) {
 // src/spawn/spawnPlanner.ts
 var MIN_WORKER_TARGET = 3;
 var WORKERS_PER_SOURCE = 2;
+var CONSTRUCTION_BACKLOG_WORKER_BONUS = 1;
 var TERRITORY_SCOUT_BODY = ["move"];
 var TERRITORY_SCOUT_BODY_COST = 50;
 var MAX_WORKER_TARGET = 6;
 var sourceCountByRoomName = /* @__PURE__ */ new Map();
 function planSpawn(colony, roleCounts, gameTime) {
-  const workerTarget = getWorkerTarget(colony);
+  const workerTarget = getWorkerTarget(colony, roleCounts);
   if (roleCounts.worker < workerTarget) {
     return planWorkerSpawn(colony, roleCounts, gameTime);
   }
@@ -1538,10 +1539,26 @@ function buildTerritorySpawnBody(energyAvailable, action) {
   }
   return buildTerritoryControllerBody(energyAvailable);
 }
-function getWorkerTarget(colony) {
+function getWorkerTarget(colony, roleCounts) {
   const sourceCount = getSourceCount(colony.room);
   const sourceAwareTarget = sourceCount * WORKERS_PER_SOURCE;
-  return Math.min(MAX_WORKER_TARGET, Math.max(MIN_WORKER_TARGET, sourceAwareTarget));
+  const baseTarget = Math.min(MAX_WORKER_TARGET, Math.max(MIN_WORKER_TARGET, sourceAwareTarget));
+  if (!shouldAddConstructionBacklogWorkerBonus(colony, roleCounts, baseTarget)) {
+    return baseTarget;
+  }
+  return Math.min(MAX_WORKER_TARGET, baseTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
+}
+function shouldAddConstructionBacklogWorkerBonus(colony, roleCounts, baseWorkerTarget) {
+  return roleCounts.worker >= baseWorkerTarget && isConstructionBonusHomeSafe(colony.room.controller) && hasActiveConstructionBacklog(colony.room);
+}
+function isConstructionBonusHomeSafe(controller) {
+  return (controller == null ? void 0 : controller.my) === true && (typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS);
+}
+function hasActiveConstructionBacklog(room) {
+  if (typeof room.find !== "function" || typeof FIND_MY_CONSTRUCTION_SITES !== "number") {
+    return false;
+  }
+  return room.find(FIND_MY_CONSTRUCTION_SITES).length > 0;
 }
 function getSourceCount(room) {
   const roomName = typeof room.name === "string" && room.name.length > 0 ? room.name : void 0;

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -9,7 +9,8 @@ import {
 import {
   buildTerritoryCreepMemory,
   planTerritoryIntent,
-  shouldSpawnTerritoryControllerCreep
+  shouldSpawnTerritoryControllerCreep,
+  TERRITORY_DOWNGRADE_GUARD_TICKS
 } from '../territory/territoryPlanner';
 
 export interface SpawnRequest {
@@ -21,6 +22,7 @@ export interface SpawnRequest {
 
 const MIN_WORKER_TARGET = 3;
 const WORKERS_PER_SOURCE = 2;
+const CONSTRUCTION_BACKLOG_WORKER_BONUS = 1;
 const TERRITORY_SCOUT_BODY: BodyPartConstant[] = ['move'];
 const TERRITORY_SCOUT_BODY_COST = 50;
 // Keep source-aware scaling bounded so unusual source data cannot create runaway early-room spawn pressure.
@@ -28,7 +30,7 @@ const MAX_WORKER_TARGET = 6;
 const sourceCountByRoomName = new Map<string, number>();
 
 export function planSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTime: number): SpawnRequest | null {
-  const workerTarget = getWorkerTarget(colony);
+  const workerTarget = getWorkerTarget(colony, roleCounts);
   if (roleCounts.worker < workerTarget) {
     return planWorkerSpawn(colony, roleCounts, gameTime);
   }
@@ -101,11 +103,44 @@ function buildTerritorySpawnBody(energyAvailable: number, action: TerritoryInten
   return buildTerritoryControllerBody(energyAvailable);
 }
 
-function getWorkerTarget(colony: ColonySnapshot): number {
+function getWorkerTarget(colony: ColonySnapshot, roleCounts: RoleCounts): number {
   const sourceCount = getSourceCount(colony.room);
   const sourceAwareTarget = sourceCount * WORKERS_PER_SOURCE;
+  const baseTarget = Math.min(MAX_WORKER_TARGET, Math.max(MIN_WORKER_TARGET, sourceAwareTarget));
 
-  return Math.min(MAX_WORKER_TARGET, Math.max(MIN_WORKER_TARGET, sourceAwareTarget));
+  if (!shouldAddConstructionBacklogWorkerBonus(colony, roleCounts, baseTarget)) {
+    return baseTarget;
+  }
+
+  return Math.min(MAX_WORKER_TARGET, baseTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
+}
+
+function shouldAddConstructionBacklogWorkerBonus(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  baseWorkerTarget: number
+): boolean {
+  return (
+    roleCounts.worker >= baseWorkerTarget &&
+    isConstructionBonusHomeSafe(colony.room.controller) &&
+    hasActiveConstructionBacklog(colony.room)
+  );
+}
+
+function isConstructionBonusHomeSafe(controller: StructureController | undefined): boolean {
+  return (
+    controller?.my === true &&
+    (typeof controller.ticksToDowngrade !== 'number' ||
+      controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS)
+  );
+}
+
+function hasActiveConstructionBacklog(room: Room): boolean {
+  if (typeof room.find !== 'function' || typeof FIND_MY_CONSTRUCTION_SITES !== 'number') {
+    return false;
+  }
+
+  return room.find(FIND_MY_CONSTRUCTION_SITES).length > 0;
 }
 
 function getSourceCount(room: Room): number {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -4,6 +4,7 @@ import { ColonySnapshot } from '../src/colony/colonyRegistry';
 describe('planSpawn', () => {
   beforeEach(() => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
     delete (globalThis as { Game?: Partial<Game> }).Game;
     delete (globalThis as { Memory?: Partial<Memory> }).Memory;
   });
@@ -13,6 +14,7 @@ describe('planSpawn', () => {
     energyAvailable = 300,
     energyCapacityAvailable = 300,
     roomName = 'W1N1',
+    constructionSiteCount = 0,
     spawning = null,
     controller
   }: {
@@ -20,11 +22,26 @@ describe('planSpawn', () => {
     energyAvailable?: number;
     energyCapacityAvailable?: number;
     roomName?: string;
+    constructionSiteCount?: number;
     spawning?: Spawning | null;
     controller?: StructureController;
-  } = {}): { colony: ColonySnapshot; spawn: StructureSpawn; find: jest.Mock<Source[], [number]> } {
+  } = {}): { colony: ColonySnapshot; spawn: StructureSpawn; find: jest.Mock<unknown[], [number]> } {
     const sources = Array.from({ length: sourceCount }, (_, index) => ({ id: `source${index}` }) as Source);
-    const find = jest.fn((type: number) => (type === FIND_SOURCES ? sources : []));
+    const constructionSites = Array.from(
+      { length: constructionSiteCount },
+      (_, index) => ({ id: `site${index}` }) as ConstructionSite
+    );
+    const find = jest.fn((type: number) => {
+      if (type === FIND_SOURCES) {
+        return sources;
+      }
+
+      if (type === FIND_MY_CONSTRUCTION_SITES) {
+        return constructionSites;
+      }
+
+      return [];
+    });
     const room = {
       name: roomName,
       energyAvailable,
@@ -41,6 +58,10 @@ describe('planSpawn', () => {
     };
 
     return { colony, spawn, find };
+  }
+
+  function makeSafeOwnedController(): StructureController {
+    return { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController;
   }
 
   it('plans a worker when the colony has no workers and an idle spawn', () => {
@@ -88,6 +109,32 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 3 }, 124)).toBeNull();
   });
 
+  it('adds one worker target for active construction backlog after the baseline target is safe', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N8',
+      constructionSiteCount: 1,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 145)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W1N8-145',
+      memory: { role: 'worker', colony: 'W1N8' }
+    });
+    expect(planSpawn(colony, { worker: 4 }, 146)).toBeNull();
+  });
+
+  it('does not spend the construction backlog bonus while the home controller needs downgrade recovery', () => {
+    const { colony } = makeColony({
+      roomName: 'W1N9',
+      constructionSiteCount: 1,
+      controller: { my: true, level: 3, ticksToDowngrade: 5_000 } as StructureController
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 147)).toBeNull();
+  });
+
   it('plans a claimer-role reserver for an explicit memory target when home survival is safe', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,
@@ -117,6 +164,41 @@ describe('planSpawn', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: 139
+      }
+    ]);
+  });
+
+  it('plans territory control once the construction-adjusted worker target is satisfied', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N10',
+      constructionSiteCount: 1,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N10', roomName: 'W2N10', action: 'reserve' }]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 4, claimer: 0, claimersByTargetRoom: {} }, 148)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N10-W2N10-148',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N10',
+        territory: { targetRoom: 'W2N10', action: 'reserve' }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N10',
+        targetRoom: 'W2N10',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 148
       }
     ]);
   });
@@ -278,8 +360,13 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 4 }, 126)).toBeNull();
   });
 
-  it('caps the source-aware worker target', () => {
-    const { colony, spawn } = makeColony({ roomName: 'W1N3', sourceCount: 10 });
+  it('caps the source-aware worker target even with active construction backlog', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N3',
+      sourceCount: 10,
+      constructionSiteCount: 1,
+      controller: makeSafeOwnedController()
+    });
 
     expect(planSpawn(colony, { worker: 5 }, 127)).toEqual({
       spawn,
@@ -339,14 +426,20 @@ describe('planSpawn', () => {
     });
   });
 
-  it('keeps zero-worker recovery on the emergency basic worker body when full body is unavailable', () => {
-    const { colony, spawn } = makeColony({ energyAvailable: 400, energyCapacityAvailable: 600 });
+  it('keeps zero-worker recovery on the emergency basic worker body when construction backlog exists', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N11',
+      constructionSiteCount: 1,
+      energyAvailable: 400,
+      energyCapacityAvailable: 600,
+      controller: makeSafeOwnedController()
+    });
 
     expect(planSpawn(colony, { worker: 0 }, 135)).toEqual({
       spawn,
       body: ['work', 'carry', 'move'],
-      name: 'worker-W1N1-135',
-      memory: { role: 'worker', colony: 'W1N1' }
+      name: 'worker-W1N11-135',
+      memory: { role: 'worker', colony: 'W1N11' }
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a bounded +1 worker target when a safe owned room has active construction backlog.
- Preserves zero-worker emergency affordability and caps total worker pressure.
- Adds spawn planner coverage for construction backlog, controller-safety guard, cap behavior, and territory handoff after the adjusted worker target is met.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

Closes #152
