### PR TITLE
feat: score stored energy sources

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -520,6 +520,7 @@ var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
+var STORED_ENERGY_RANGE_COST = 50;
 function selectWorkerTask(creep) {
   const carriedEnergy = getUsedEnergy(creep);
   if (carriedEnergy === 0) {
@@ -622,8 +623,32 @@ function selectStoredEnergySource(creep) {
   if (storedEnergySources.length === 0) {
     return null;
   }
+  const scoredStoredEnergy = scoreStoredEnergySources(creep, storedEnergySources);
+  if (scoredStoredEnergy.length > 0) {
+    return scoredStoredEnergy.sort(compareStoredEnergySourceScores)[0].source;
+  }
   const closestStoredEnergy = findClosestByRange(creep, storedEnergySources);
   return closestStoredEnergy != null ? closestStoredEnergy : storedEnergySources[0];
+}
+function scoreStoredEnergySources(creep, sources) {
+  const position = creep.pos;
+  if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
+    return [];
+  }
+  return sources.map((source) => {
+    var _a, _b;
+    const energy = getStoredEnergy(source);
+    const range = Math.max(0, (_b = (_a = position.getRangeTo) == null ? void 0 : _a.call(position, source)) != null ? _b : 0);
+    return {
+      energy,
+      range,
+      score: energy - range * STORED_ENERGY_RANGE_COST,
+      source
+    };
+  });
+}
+function compareStoredEnergySourceScores(left, right) {
+  return right.score - left.score || left.range - right.range || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id));
 }
 function isSafeStoredEnergySource(structure, context) {
   return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, context);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -5,6 +5,7 @@ export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 const MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
+const STORED_ENERGY_RANGE_COST = 50;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
@@ -162,8 +163,51 @@ function selectStoredEnergySource(creep: Creep): StoredWorkerEnergySource | null
     return null;
   }
 
+  const scoredStoredEnergy = scoreStoredEnergySources(creep, storedEnergySources);
+  if (scoredStoredEnergy.length > 0) {
+    return scoredStoredEnergy.sort(compareStoredEnergySourceScores)[0].source;
+  }
+
   const closestStoredEnergy = findClosestByRange(creep, storedEnergySources);
   return closestStoredEnergy ?? storedEnergySources[0];
+}
+
+interface StoredEnergySourceScore {
+  energy: number;
+  range: number;
+  score: number;
+  source: StoredWorkerEnergySource;
+}
+
+function scoreStoredEnergySources(
+  creep: Creep,
+  sources: StoredWorkerEnergySource[]
+): StoredEnergySourceScore[] {
+  const position = (creep as Creep & { pos?: { getRangeTo?: (target: StoredWorkerEnergySource) => number } }).pos;
+  if (typeof position?.getRangeTo !== 'function') {
+    return [];
+  }
+
+  return sources.map((source) => {
+    const energy = getStoredEnergy(source);
+    const range = Math.max(0, position.getRangeTo?.(source) ?? 0);
+
+    return {
+      energy,
+      range,
+      score: energy - range * STORED_ENERGY_RANGE_COST,
+      source
+    };
+  });
+}
+
+function compareStoredEnergySourceScores(left: StoredEnergySourceScore, right: StoredEnergySourceScore): number {
+  return (
+    right.score - left.score ||
+    left.range - right.range ||
+    right.energy - left.energy ||
+    String(left.source.id).localeCompare(String(right.source.id))
+  );
 }
 
 function isSafeStoredEnergySource(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -215,6 +215,143 @@ describe('selectWorkerTask', () => {
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
+  it('prefers much richer safe stored energy over nearby tiny stored energy', () => {
+    const nearbyTinyContainer = makeStoredEnergyStructure('container-tiny', 'container' as StructureConstant, 25);
+    const richStorage = makeStoredEnergyStructure('storage-rich', 'storage' as StructureConstant, 1_000, { my: true });
+    const source = { id: 'source1' } as Source;
+    const getRangeTo = jest.fn((target: StructureContainer | StructureStorage) => {
+      const ranges: Record<string, number> = {
+        'container-tiny': 1,
+        'storage-rich': 8
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [nearbyTinyContainer, richStorage];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage-rich' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('keeps closest safe stored energy when stored amounts are comparable', () => {
+    const nearbyContainer = makeStoredEnergyStructure('container-near', 'container' as StructureConstant, 100);
+    const fartherStorage = makeStoredEnergyStructure('storage-far', 'storage' as StructureConstant, 150, { my: true });
+    const source = { id: 'source1' } as Source;
+    const getRangeTo = jest.fn((target: StructureContainer | StructureStorage) => {
+      const ranges: Record<string, number> = {
+        'container-near': 1,
+        'storage-far': 3
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [fartherStorage, nearbyContainer];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-near' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('breaks equal stored energy score ties by id', () => {
+    const secondContainer = makeStoredEnergyStructure('container-b', 'container' as StructureConstant, 100);
+    const firstContainer = makeStoredEnergyStructure('container-a', 'container' as StructureConstant, 100);
+    const source = { id: 'source1' } as Source;
+    const getRangeTo = jest.fn().mockReturnValue(2);
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [secondContainer, firstContainer];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-a' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('ignores hostile-owned stored energy even when it would score higher', () => {
+    const safeContainer = makeStoredEnergyStructure('container-safe', 'container' as StructureConstant, 50);
+    const hostileStorage = makeStoredEnergyStructure('storage-hostile', 'storage' as StructureConstant, 10_000, {
+      my: false
+    });
+    const source = { id: 'source1' } as Source;
+    const getRangeTo = jest.fn((target: StructureContainer | StructureStorage) => {
+      const ranges: Record<string, number> = {
+        'container-safe': 6,
+        'storage-hostile': 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [hostileStorage, safeContainer];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-safe' });
+    expect(getRangeTo).not.toHaveBeenCalledWith(hostileStorage);
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
   it('selects withdraw from a reserved remote container before harvesting', () => {
     const container = makeStoredEnergyStructure('remote-container', 'container' as StructureConstant, 100);
     const source = { id: 'source1' } as Source;


### PR DESCRIPTION
## Summary
- Scores safe stored-energy sources so workers prefer a much richer safe source when the energy advantage outweighs travel distance.
- Preserves closest-source behavior for comparable stores and leaves hostile/ownership safety filtering intact.
- Adds worker task coverage for richer-source selection and hostile-source exclusion.

Closes #156

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (16 suites / 240 tests)
- `npm run build`
- `git diff --exit-code -- prod/dist/main.js` confirmed the bundle diff is the generated output staged with the code changes.

## Orchestration evidence
- Codex implementation process `proc_eb8eab00f835` produced verified dirty changes but exited before committing.
- Narrow Codex commit-only recovery created `5be8675` with author `lanyusea's bot <lanyusea@gmail.com>` and staged only `prod/src/tasks/workerTasks.ts`, `prod/test/workerTasks.test.ts`, and `prod/dist/main.js`.
