### PR TITLE
feat: retry stale territory suppressions

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1085,12 +1085,13 @@ var TERRITORY_CLAIMER_ROLE = "claimer";
 var TERRITORY_SCOUT_ROLE = "scout";
 var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
 var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
+var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
 var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
   }
-  const selection = selectTerritoryTarget(colony);
+  const selection = selectTerritoryTarget(colony, gameTime);
   if (!selection) {
     return null;
   }
@@ -1105,8 +1106,8 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
   return plan;
 }
-function shouldSpawnTerritoryControllerCreep(plan, roleCounts) {
-  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action)) {
+function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime()) {
+  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
     return false;
   }
   if (plan.action === "scout" && isVisibleRoomKnown(plan.targetRoom)) {
@@ -1166,21 +1167,27 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   }
   return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
 }
-function selectTerritoryTarget(colony) {
+function selectTerritoryTarget(colony, gameTime) {
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
-  const configuredTarget = selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents);
+  const configuredTarget = selectConfiguredTerritoryTarget(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime
+  );
   if (configuredTarget) {
     return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
   }
-  if (hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents)) {
+  if (hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime)) {
     return null;
   }
-  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents);
+  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime);
 }
-function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents) {
+function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return null;
   }
@@ -1189,7 +1196,7 @@ function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territ
   let renewalTicksToEnd = null;
   for (const rawTarget of territoryMemory.targets) {
     const target = normalizeTerritoryTarget(rawTarget);
-    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents) && getVisibleTerritoryTargetState(
+    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents, gameTime) && getVisibleTerritoryTargetState(
       target.roomName,
       target.action,
       target.controllerId,
@@ -1210,7 +1217,7 @@ function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territ
   }
   return renewalTarget != null ? renewalTarget : fallbackTarget;
 }
-function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents) {
+function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return false;
   }
@@ -1219,13 +1226,13 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     if (!target || target.colony !== colonyName) {
       return false;
     }
-    if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents)) {
+    if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime)) {
       return true;
     }
     return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
   });
 }
-function selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents) {
+function selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
   const adjacentRooms = getAdjacentRoomNames(colonyName);
   if (adjacentRooms.length === 0) {
     return null;
@@ -1233,12 +1240,12 @@ function selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryM
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   for (const roomName of adjacentRooms) {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents)) {
+    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents, gameTime)) {
       const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
       if (candidateState === "safe") {
         return { target, intentAction: "reserve", commitTarget: true };
       }
-      if (candidateState === "unknown" && !isTerritoryIntentForActionSuppressed(colonyName, roomName, "scout")) {
+      if (candidateState === "unknown" && !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, "scout", gameTime)) {
         return { target, intentAction: "scout", commitTarget: false };
       }
     }
@@ -1362,28 +1369,25 @@ function getTerritoryCreepCountForTarget(roleCounts, targetRoom, action) {
   }
   return (_d = (_c = roleCounts.claimersByTargetRoom) == null ? void 0 : _c[targetRoom]) != null ? _d : 0;
 }
-function isTerritoryTargetSuppressed(target, intents) {
+function isTerritoryTargetSuppressed(target, intents, gameTime) {
+  return isSuppressedTerritoryIntentForAction(intents, target.colony, target.roomName, target.action, gameTime);
+}
+function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, action, gameTime) {
   return intents.some(
-    (intent) => intent.status === "suppressed" && intent.colony === target.colony && intent.targetRoom === target.roomName && intent.action === target.action
+    (intent) => isTerritorySuppressionFresh(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
-function isTerritoryIntentSuppressed(colony, targetRoom, action) {
+function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime) {
   const territoryMemory = getTerritoryMemoryRecord();
   if (!territoryMemory) {
     return false;
   }
   return normalizeTerritoryIntents(territoryMemory.intents).some(
-    (intent) => intent.status === "suppressed" && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
+    (intent) => isTerritorySuppressionFresh(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
-function isTerritoryIntentForActionSuppressed(colony, targetRoom, action) {
-  const territoryMemory = getTerritoryMemoryRecord();
-  if (!territoryMemory) {
-    return false;
-  }
-  return normalizeTerritoryIntents(territoryMemory.intents).some(
-    (intent) => intent.status === "suppressed" && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
-  );
+function isTerritorySuppressionFresh(intent, gameTime) {
+  return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
 }
 function getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) {
   if (isVisibleRoomMissingController(targetRoom)) {
@@ -1461,6 +1465,11 @@ function getVisibleController(targetRoom, controllerId) {
   }
   return null;
 }
+function getGameTime() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" ? gameTime : 0;
+}
 function getWritableTerritoryMemoryRecord() {
   const memory = getMemoryRecord();
   if (!memory) {
@@ -1512,7 +1521,7 @@ function planSpawn(colony, roleCounts, gameTime) {
     return planWorkerSpawn(colony, roleCounts, gameTime);
   }
   const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
-  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts)) {
+  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
     return null;
   }
   const spawn = colony.spawns.find((candidate) => !candidate.spawning);
@@ -1617,7 +1626,7 @@ function emitRuntimeSummary(colonies, creeps, events = []) {
   if (colonies.length === 0 && events.length === 0) {
     return;
   }
-  const tick = getGameTime();
+  const tick = getGameTime2();
   if (!shouldEmitRuntimeSummary(tick, events)) {
     return;
   }
@@ -1862,7 +1871,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime() {
+function getGameTime2() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -1910,7 +1919,7 @@ function runTerritoryControllerCreep(creep) {
   }
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime2());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime3());
   delete creep.memory.territory;
 }
 function selectTargetController(creep, assignment) {
@@ -1941,7 +1950,7 @@ function moveTowardTargetRoom(creep, targetRoom) {
   }
   creep.moveTo(new RoomPositionCtor(25, 25, targetRoom));
 }
-function getGameTime2() {
+function getGameTime3() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -36,7 +36,7 @@ export function planSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTi
   }
 
   const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
-  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts)) {
+  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
     return null;
   }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -6,6 +6,7 @@ export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
 export const TERRITORY_DOWNGRADE_GUARD_TICKS = 5_000;
 export const TERRITORY_RESERVATION_RENEWAL_TICKS = 1_000;
+export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 
 const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
 
@@ -38,7 +39,7 @@ export function planTerritoryIntent(
     return null;
   }
 
-  const selection = selectTerritoryTarget(colony);
+  const selection = selectTerritoryTarget(colony, gameTime);
   if (!selection) {
     return null;
   }
@@ -56,8 +57,12 @@ export function planTerritoryIntent(
   return plan;
 }
 
-export function shouldSpawnTerritoryControllerCreep(plan: TerritoryIntentPlan, roleCounts: RoleCounts): boolean {
-  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action)) {
+export function shouldSpawnTerritoryControllerCreep(
+  plan: TerritoryIntentPlan,
+  roleCounts: RoleCounts,
+  gameTime = getGameTime()
+): boolean {
+  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
     return false;
   }
 
@@ -143,28 +148,37 @@ export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCoun
   );
 }
 
-function selectTerritoryTarget(colony: ColonySnapshot): SelectedTerritoryTarget | null {
+function selectTerritoryTarget(colony: ColonySnapshot, gameTime: number): SelectedTerritoryTarget | null {
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   const intents = normalizeTerritoryIntents(territoryMemory?.intents);
-  const configuredTarget = selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents);
+  const configuredTarget = selectConfiguredTerritoryTarget(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime
+  );
   if (configuredTarget) {
     return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
   }
 
-  if (hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents)) {
+  if (
+    hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime)
+  ) {
     return null;
   }
 
-  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents);
+  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime);
 }
 
 function selectConfiguredTerritoryTarget(
   colonyName: string,
   colonyOwnerUsername: string | null,
   territoryMemory: Record<string, unknown> | null,
-  intents: TerritoryIntentMemory[]
+  intents: TerritoryIntentMemory[],
+  gameTime: number
 ): TerritoryTargetMemory | null {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return null;
@@ -181,7 +195,7 @@ function selectConfiguredTerritoryTarget(
       target.enabled !== false &&
       target.colony === colonyName &&
       target.roomName !== colonyName &&
-      !isTerritoryTargetSuppressed(target, intents) &&
+      !isTerritoryTargetSuppressed(target, intents, gameTime) &&
       getVisibleTerritoryTargetState(
         target.roomName,
         target.action,
@@ -211,7 +225,8 @@ function hasBlockingConfiguredTerritoryTargetForColony(
   territoryMemory: Record<string, unknown> | null,
   colonyName: string,
   colonyOwnerUsername: string | null,
-  intents: TerritoryIntentMemory[]
+  intents: TerritoryIntentMemory[],
+  gameTime: number
 ): boolean {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return false;
@@ -223,7 +238,11 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       return false;
     }
 
-    if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents)) {
+    if (
+      target.enabled === false ||
+      target.roomName === colonyName ||
+      isTerritoryTargetSuppressed(target, intents, gameTime)
+    ) {
       return true;
     }
 
@@ -238,7 +257,8 @@ function selectAdjacentReserveTarget(
   colonyName: string,
   colonyOwnerUsername: string | null,
   territoryMemory: Record<string, unknown> | null,
-  intents: TerritoryIntentMemory[]
+  intents: TerritoryIntentMemory[],
+  gameTime: number
 ): SelectedTerritoryTarget | null {
   const adjacentRooms = getAdjacentRoomNames(colonyName);
   if (adjacentRooms.length === 0) {
@@ -251,7 +271,7 @@ function selectAdjacentReserveTarget(
     if (
       roomName !== colonyName &&
       !existingTargetRooms.has(roomName) &&
-      !isTerritoryTargetSuppressed(target, intents)
+      !isTerritoryTargetSuppressed(target, intents, gameTime)
     ) {
       const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
       if (candidateState === 'safe') {
@@ -260,7 +280,7 @@ function selectAdjacentReserveTarget(
 
       if (
         candidateState === 'unknown' &&
-        !isTerritoryIntentForActionSuppressed(colonyName, roomName, 'scout')
+        !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, 'scout', gameTime)
       ) {
         return { target, intentAction: 'scout', commitTarget: false };
       }
@@ -446,20 +466,35 @@ function getTerritoryCreepCountForTarget(
   return roleCounts.claimersByTargetRoom?.[targetRoom] ?? 0;
 }
 
-function isTerritoryTargetSuppressed(target: TerritoryTargetMemory, intents: TerritoryIntentMemory[]): boolean {
+function isTerritoryTargetSuppressed(
+  target: TerritoryTargetMemory,
+  intents: TerritoryIntentMemory[],
+  gameTime: number
+): boolean {
+  return isSuppressedTerritoryIntentForAction(intents, target.colony, target.roomName, target.action, gameTime);
+}
+
+function isSuppressedTerritoryIntentForAction(
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  targetRoom: string,
+  action: TerritoryIntentAction,
+  gameTime: number
+): boolean {
   return intents.some(
     (intent) =>
-      intent.status === 'suppressed' &&
-      intent.colony === target.colony &&
-      intent.targetRoom === target.roomName &&
-      intent.action === target.action
+      isTerritorySuppressionFresh(intent, gameTime) &&
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      intent.action === action
   );
 }
 
 function isTerritoryIntentSuppressed(
   colony: string,
   targetRoom: string,
-  action: TerritoryIntentAction
+  action: TerritoryIntentAction,
+  gameTime: number
 ): boolean {
   const territoryMemory = getTerritoryMemoryRecord();
   if (!territoryMemory) {
@@ -468,30 +503,15 @@ function isTerritoryIntentSuppressed(
 
   return normalizeTerritoryIntents(territoryMemory.intents).some(
     (intent) =>
-      intent.status === 'suppressed' &&
+      isTerritorySuppressionFresh(intent, gameTime) &&
       intent.colony === colony &&
       intent.targetRoom === targetRoom &&
       intent.action === action
   );
 }
 
-function isTerritoryIntentForActionSuppressed(
-  colony: string,
-  targetRoom: string,
-  action: TerritoryIntentAction
-): boolean {
-  const territoryMemory = getTerritoryMemoryRecord();
-  if (!territoryMemory) {
-    return false;
-  }
-
-  return normalizeTerritoryIntents(territoryMemory.intents).some(
-    (intent) =>
-      intent.status === 'suppressed' &&
-      intent.colony === colony &&
-      intent.targetRoom === targetRoom &&
-      intent.action === action
-  );
+function isTerritorySuppressionFresh(intent: TerritoryIntentMemory, gameTime: number): boolean {
+  return intent.status === 'suppressed' && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
 }
 
 function getVisibleTerritoryTargetState(
@@ -599,6 +619,11 @@ function getVisibleController(targetRoom: string, controllerId?: Id<StructureCon
   }
 
   return null;
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof gameTime === 'number' ? gameTime : 0;
 }
 
 function getWritableTerritoryMemoryRecord(): TerritoryMemory | null {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3,7 +3,8 @@ import {
   planTerritoryIntent,
   shouldSpawnTerritoryControllerCreep,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
-  TERRITORY_RESERVATION_RENEWAL_TICKS
+  TERRITORY_RESERVATION_RENEWAL_TICKS,
+  TERRITORY_SUPPRESSION_RETRY_TICKS
 } from '../src/territory/territoryPlanner';
 
 describe('planTerritoryIntent', () => {
@@ -240,6 +241,47 @@ describe('planTerritoryIntent', () => {
     expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(Memory.territory?.targets).toBeUndefined();
     expect(Memory.territory?.intents).toEqual([suppressedScout]);
+  });
+
+  it('retries stale scout suppression for an unknown adjacent room', () => {
+    const colony = makeSafeColony();
+    const suppressionTime = 531;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const describeExits = jest.fn(() => ({ '1': 'W1N2' }));
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'scout',
+            status: 'suppressed',
+            updatedAt: suppressionTime
+          }
+        ]
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'scout'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: retryTime
+      }
+    ]);
   });
 
   it('skips unavailable, owned, and reserved adjacent rooms before seeding reserve targets', () => {
@@ -669,7 +711,8 @@ describe('planTerritoryIntent', () => {
     expect(
       shouldSpawnTerritoryControllerCreep(
         { colony: 'W1N1', targetRoom: 'W2N1', action: 'claim' },
-        { worker: 3, claimer: 0, claimersByTargetRoom: {} }
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+        511
       )
     ).toBe(false);
     expect(Memory.territory?.intents).toEqual([
@@ -679,6 +722,40 @@ describe('planTerritoryIntent', () => {
         action: 'claim',
         status: 'suppressed',
         updatedAt: 510
+      }
+    ]);
+  });
+
+  it('retries stale suppressed claim targets', () => {
+    const colony = makeSafeColony();
+    const suppressionTime = 510;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const roleCounts = { worker: 3, claimer: 0, claimersByTargetRoom: {} };
+    const plan = { colony: 'W1N1', targetRoom: 'W2N1', action: 'claim' } as const;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'suppressed',
+            updatedAt: suppressionTime
+          }
+        ]
+      }
+    };
+
+    expect(shouldSpawnTerritoryControllerCreep(plan, roleCounts, retryTime)).toBe(true);
+    expect(planTerritoryIntent(colony, roleCounts, 3, retryTime)).toEqual(plan);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: retryTime
       }
     ]);
   });
@@ -1323,6 +1400,59 @@ describe('planTerritoryIntent', () => {
       )
     ).toBe(false);
     expect(Memory.territory?.intents).toEqual([suppressedIntent]);
+  });
+
+  it('renews a stale suppressed own reserve target near expiry', () => {
+    const colony = makeSafeColony();
+    const suppressionTime = 537;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W1N2', action: 'reserve' }],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'suppressed',
+            updatedAt: suppressionTime
+          }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(
+      colony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      retryTime
+    );
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, retryTime)
+    ).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: retryTime
+      }
+    ]);
   });
 
   it('still requests claimers for visible unowned reserve targets', () => {


### PR DESCRIPTION
## Summary
- Adds a bounded retry window for suppressed territory intents so transient scout/reserve/claim failures do not permanently block territory control.
- Threads the current game time through territory selection/spawn checks so fresh suppressions still prevent duplicate attempts while stale suppressions expire.
- Adds territory planner coverage for fresh suppression blocking and stale suppression retrying.

Closes #155

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (16 suites / 239 tests)
- `npm run build`
- `git diff --exit-code -- prod/dist/main.js` confirmed the bundle diff is the generated output staged with the code changes.

## Orchestration evidence
- Codex implementation process `proc_e9b417637893` produced verified dirty changes but exited before committing.
- Narrow Codex commit-only recovery created `d046706` with author `lanyusea's bot <lanyusea@gmail.com>` and staged only the intended production/test/bundle files.
