### PR TITLE
feat: rank worker energy acquisition candidates

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -520,22 +520,14 @@ var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
-var STORED_ENERGY_RANGE_COST = 50;
+var ENERGY_ACQUISITION_RANGE_COST = 50;
 function selectWorkerTask(creep) {
   const carriedEnergy = getUsedEnergy(creep);
   if (carriedEnergy === 0) {
     if (getFreeEnergyCapacity(creep) > 0) {
-      const storedEnergy = selectStoredEnergySource(creep);
-      if (storedEnergy) {
-        return { type: "withdraw", targetId: storedEnergy.id };
-      }
-      const salvageEnergy = selectSalvageEnergySource(creep);
-      if (salvageEnergy) {
-        return { type: "withdraw", targetId: salvageEnergy.id };
-      }
-      const droppedEnergy = selectDroppedEnergy(creep);
-      if (droppedEnergy) {
-        return { type: "pickup", targetId: droppedEnergy.id };
+      const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
+      if (energyAcquisitionTask) {
+        return energyAcquisitionTask;
       }
     }
     const source = selectHarvestSource(creep);
@@ -642,7 +634,7 @@ function scoreStoredEnergySources(creep, sources) {
     return {
       energy,
       range,
-      score: energy - range * STORED_ENERGY_RANGE_COST,
+      score: energy - range * ENERGY_ACQUISITION_RANGE_COST,
       source
     };
   });
@@ -687,6 +679,72 @@ function isRoomSafeForUnownedContainerWithdrawal(context) {
     return true;
   }
   return reservationUsername === context.creepOwnerUsername;
+}
+function selectWorkerEnergyAcquisitionTask(creep) {
+  const candidates = findWorkerEnergyAcquisitionCandidates(creep);
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+function findWorkerEnergyAcquisitionCandidates(creep) {
+  const context = {
+    creepOwnerUsername: getCreepOwnerUsername(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).map(
+    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+      type: "withdraw",
+      targetId: source.id
+    })
+  );
+  const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).map(
+    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+      type: "withdraw",
+      targetId: source.id
+    })
+  );
+  const droppedEnergyCandidates = findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).map(
+    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
+      type: "pickup",
+      targetId: source.id
+    })
+  );
+  return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
+}
+function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
+  const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
+  return {
+    energy,
+    range,
+    score: range === null ? energy : energy - range * ENERGY_ACQUISITION_RANGE_COST,
+    source,
+    task
+  };
+}
+function getRangeToWorkerEnergyAcquisitionSource(creep, source) {
+  const position = creep.pos;
+  if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
+    return null;
+  }
+  const range = position.getRangeTo(source);
+  return Number.isFinite(range) ? Math.max(0, range) : null;
+}
+function compareWorkerEnergyAcquisitionCandidates(left, right) {
+  return right.score - left.score || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
+}
+function compareOptionalRanges(left, right) {
+  if (left !== null && right !== null) {
+    return left - right;
+  }
+  if (left !== null) {
+    return -1;
+  }
+  if (right !== null) {
+    return 1;
+  }
+  return 0;
 }
 function selectSalvageEnergySource(creep) {
   const salvageEnergySources = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy);
@@ -880,14 +938,6 @@ function isUpgradingController(creep, controller) {
   var _a;
   const task = (_a = creep.memory) == null ? void 0 : _a.task;
   return (task == null ? void 0 : task.type) === "upgrade" && task.targetId === controller.id;
-}
-function selectDroppedEnergy(creep) {
-  const droppedEnergy = findDroppedResources(creep.room).filter(isUsefulDroppedEnergy);
-  if (droppedEnergy.length === 0) {
-    return null;
-  }
-  const closestDroppedEnergy = findClosestByRange(creep, droppedEnergy);
-  return closestDroppedEnergy != null ? closestDroppedEnergy : droppedEnergy[0];
 }
 function findDroppedResources(room) {
   if (typeof FIND_DROPPED_RESOURCES !== "number") {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -5,12 +5,17 @@ export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 const MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
-const STORED_ENERGY_RANGE_COST = 50;
+const ENERGY_ACQUISITION_RANGE_COST = 50;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
 type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal;
 type SalvageableWorkerEnergySource = Tombstone | Ruin;
+type WorkerEnergyAcquisitionSource =
+  | StoredWorkerEnergySource
+  | SalvageableWorkerEnergySource
+  | Resource<ResourceConstant>;
+type WorkerEnergyAcquisitionTask = Extract<CreepTaskMemory, { type: 'pickup' | 'withdraw' }>;
 
 interface StoredEnergySourceContext {
   creepOwnerUsername: string | null;
@@ -23,19 +28,9 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
 
   if (carriedEnergy === 0) {
     if (getFreeEnergyCapacity(creep) > 0) {
-      const storedEnergy = selectStoredEnergySource(creep);
-      if (storedEnergy) {
-        return { type: 'withdraw', targetId: storedEnergy.id as Id<AnyStoreStructure> };
-      }
-
-      const salvageEnergy = selectSalvageEnergySource(creep);
-      if (salvageEnergy) {
-        return { type: 'withdraw', targetId: salvageEnergy.id as unknown as Id<AnyStoreStructure> };
-      }
-
-      const droppedEnergy = selectDroppedEnergy(creep);
-      if (droppedEnergy) {
-        return { type: 'pickup', targetId: droppedEnergy.id };
+      const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
+      if (energyAcquisitionTask) {
+        return energyAcquisitionTask;
       }
     }
 
@@ -195,7 +190,7 @@ function scoreStoredEnergySources(
     return {
       energy,
       range,
-      score: energy - range * STORED_ENERGY_RANGE_COST,
+      score: energy - range * ENERGY_ACQUISITION_RANGE_COST,
       source
     };
   });
@@ -265,6 +260,120 @@ function isRoomSafeForUnownedContainerWithdrawal(context: StoredEnergySourceCont
   }
 
   return reservationUsername === context.creepOwnerUsername;
+}
+
+interface WorkerEnergyAcquisitionCandidate {
+  energy: number;
+  range: number | null;
+  score: number;
+  source: WorkerEnergyAcquisitionSource;
+  task: WorkerEnergyAcquisitionTask;
+}
+
+function selectWorkerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitionTask | null {
+  const candidates = findWorkerEnergyAcquisitionCandidates(creep);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+
+function findWorkerEnergyAcquisitionCandidates(creep: Creep): WorkerEnergyAcquisitionCandidate[] {
+  const context: StoredEnergySourceContext = {
+    creepOwnerUsername: getCreepOwnerUsername(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const storedEnergyCandidates = findVisibleRoomStructures(creep.room)
+    .filter((structure): structure is StoredWorkerEnergySource => isSafeStoredEnergySource(structure, context))
+    .map((source) =>
+      createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+        type: 'withdraw',
+        targetId: source.id as Id<AnyStoreStructure>
+      })
+    );
+  const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)]
+    .filter(hasSalvageableEnergy)
+    .map((source) =>
+      createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+        type: 'withdraw',
+        targetId: source.id as unknown as Id<AnyStoreStructure>
+      })
+    );
+  const droppedEnergyCandidates = findDroppedResources(creep.room)
+    .filter(isUsefulDroppedEnergy)
+    .map((source) =>
+      createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
+        type: 'pickup',
+        targetId: source.id
+      })
+    );
+
+  return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
+}
+
+function createWorkerEnergyAcquisitionCandidate(
+  creep: Creep,
+  source: WorkerEnergyAcquisitionSource,
+  energy: number,
+  task: WorkerEnergyAcquisitionTask
+): WorkerEnergyAcquisitionCandidate {
+  const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
+
+  return {
+    energy,
+    range,
+    score: range === null ? energy : energy - range * ENERGY_ACQUISITION_RANGE_COST,
+    source,
+    task
+  };
+}
+
+function getRangeToWorkerEnergyAcquisitionSource(
+  creep: Creep,
+  source: WorkerEnergyAcquisitionSource
+): number | null {
+  const position = (creep as Creep & {
+    pos?: {
+      getRangeTo?: (target: WorkerEnergyAcquisitionSource) => number;
+    };
+  }).pos;
+  if (typeof position?.getRangeTo !== 'function') {
+    return null;
+  }
+
+  const range = position.getRangeTo(source);
+  return Number.isFinite(range) ? Math.max(0, range) : null;
+}
+
+function compareWorkerEnergyAcquisitionCandidates(
+  left: WorkerEnergyAcquisitionCandidate,
+  right: WorkerEnergyAcquisitionCandidate
+): number {
+  return (
+    right.score - left.score ||
+    compareOptionalRanges(left.range, right.range) ||
+    right.energy - left.energy ||
+    String(left.source.id).localeCompare(String(right.source.id)) ||
+    left.task.type.localeCompare(right.task.type)
+  );
+}
+
+function compareOptionalRanges(left: number | null, right: number | null): number {
+  if (left !== null && right !== null) {
+    return left - right;
+  }
+
+  if (left !== null) {
+    return -1;
+  }
+
+  if (right !== null) {
+    return 1;
+  }
+
+  return 0;
 }
 
 function selectSalvageEnergySource(creep: Creep): SalvageableWorkerEnergySource | null {
@@ -533,16 +642,6 @@ function isWorkerTaskRecord(value: unknown): value is Record<string, unknown> {
 function isUpgradingController(creep: Creep, controller: StructureController): boolean {
   const task = creep.memory?.task as Partial<CreepTaskMemory> | undefined;
   return task?.type === 'upgrade' && task.targetId === controller.id;
-}
-
-function selectDroppedEnergy(creep: Creep): Resource<ResourceConstant> | null {
-  const droppedEnergy = findDroppedResources(creep.room).filter(isUsefulDroppedEnergy);
-  if (droppedEnergy.length === 0) {
-    return null;
-  }
-
-  const closestDroppedEnergy = findClosestByRange(creep, droppedEnergy);
-  return closestDroppedEnergy ?? droppedEnergy[0];
 }
 
 function findDroppedResources(room: Room): Resource[] {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -130,12 +130,18 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
-  it('selects nearest high-value dropped energy before harvesting when worker has free capacity', () => {
+  it('selects the best range-aware dropped energy before harvesting when worker has free capacity', () => {
     const lowValueDroppedEnergy = { id: 'drop-low', resourceType: 'energy', amount: 24 } as Resource<ResourceConstant>;
     const farDroppedEnergy = { id: 'drop-far', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
     const nearDroppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
     const source = { id: 'source1' } as Source;
-    const findClosestByRange = jest.fn().mockReturnValue(nearDroppedEnergy);
+    const getRangeTo = jest.fn((target: Resource<ResourceConstant>) => {
+      const ranges: Record<string, number> = {
+        'drop-far': 10,
+        'drop-near': 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
     const roomFind = jest.fn((type: number) => {
       if (type === FIND_DROPPED_RESOURCES) {
         return [lowValueDroppedEnergy, farDroppedEnergy, nearDroppedEnergy];
@@ -148,12 +154,12 @@ describe('selectWorkerTask', () => {
         getUsedCapacity: jest.fn().mockReturnValue(0),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
-      pos: { findClosestByRange },
+      pos: { getRangeTo },
       room: { find: roomFind }
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
-    expect(findClosestByRange).toHaveBeenCalledWith([farDroppedEnergy, nearDroppedEnergy]);
+    expect(getRangeTo).not.toHaveBeenCalledWith(lowValueDroppedEnergy);
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
@@ -189,7 +195,6 @@ describe('selectWorkerTask', () => {
     const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 100);
     const storage = makeStoredEnergyStructure('storage1', 'storage' as StructureConstant, 200, { my: true });
     const source = { id: 'source1' } as Source;
-    const findClosestByRange = jest.fn().mockReturnValue(storage);
     const roomFind = jest.fn((type: number) => {
       if (type === FIND_DROPPED_RESOURCES) {
         return [];
@@ -206,12 +211,10 @@ describe('selectWorkerTask', () => {
         getUsedCapacity: jest.fn().mockReturnValue(0),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
-      pos: { findClosestByRange },
       room: { controller: { my: true }, find: roomFind }
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage1' });
-    expect(findClosestByRange).toHaveBeenCalledWith([container, storage]);
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
@@ -411,7 +414,6 @@ describe('selectWorkerTask', () => {
   it.each(['tombstone', 'ruin'] as const)('selects withdraw from %s energy before harvesting', (sourceKind) => {
     const salvageEnergy = makeSalvageEnergySource(`${sourceKind}1`, 25);
     const source = { id: 'source1' } as Source;
-    const findClosestByRange = jest.fn().mockReturnValue(salvageEnergy);
     const salvageFindType = sourceKind === 'tombstone' ? FIND_TOMBSTONES : FIND_RUINS;
     const otherSalvageFindType = sourceKind === 'tombstone' ? FIND_RUINS : FIND_TOMBSTONES;
     const roomFind = jest.fn((type: number) => {
@@ -436,12 +438,10 @@ describe('selectWorkerTask', () => {
         getUsedCapacity: jest.fn().mockReturnValue(0),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
-      pos: { findClosestByRange },
       room: { find: roomFind }
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: `${sourceKind}1` });
-    expect(findClosestByRange).toHaveBeenCalledWith([salvageEnergy]);
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
@@ -491,17 +491,40 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
-  it('keeps stored energy withdrawal priority over dropped energy pickup', () => {
-    const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
-    const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 100);
+  it('ranks stored, salvage, and dropped energy by range-aware score', () => {
+    const droppedEnergy = { id: 'drop-best', resourceType: 'energy', amount: 300 } as Resource<ResourceConstant>;
+    const container = makeStoredEnergyStructure('container-near', 'container' as StructureConstant, 75);
+    const tombstone = makeSalvageEnergySource('tombstone-mid', 350);
+    const ruin = makeSalvageEnergySource('ruin-far', 500);
     const source = { id: 'source1' } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'container-near': 1,
+        'drop-best': 2,
+        'ruin-far': 8,
+        'tombstone-mid': 4
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
     const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [droppedEnergy];
+      }
+
+      if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_RUINS) {
+        return [ruin];
+      }
+
       if (type === FIND_STRUCTURES) {
         return [container];
       }
 
-      if (type === FIND_DROPPED_RESOURCES) {
-        return [droppedEnergy];
+      if (type === FIND_TOMBSTONES) {
+        return [tombstone];
       }
 
       return type === FIND_SOURCES ? [source] : [];
@@ -511,20 +534,42 @@ describe('selectWorkerTask', () => {
         getUsedCapacity: jest.fn().mockReturnValue(0),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
+      pos: { getRangeTo },
       room: { controller: { my: true }, find: roomFind }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
-    expect(roomFind).not.toHaveBeenCalledWith(FIND_DROPPED_RESOURCES);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-best' });
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
-  it('keeps tombstone and ruin salvage priority over dropped energy pickup', () => {
-    const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
-    const tombstone = makeSalvageEnergySource('tombstone1', 25);
-    const ruin = makeSalvageEnergySource('ruin1', 25);
+  it('can prefer salvage over stored and dropped energy when salvage scores highest', () => {
+    const droppedEnergy = { id: 'drop-far', resourceType: 'energy', amount: 500 } as Resource<ResourceConstant>;
+    const container = makeStoredEnergyStructure('container-far', 'container' as StructureConstant, 400);
+    const tombstone = makeSalvageEnergySource('tombstone-near', 260);
+    const ruin = makeSalvageEnergySource('ruin-near', 100);
     const source = { id: 'source1' } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'container-far': 8,
+        'drop-far': 10,
+        'ruin-near': 1,
+        'tombstone-near': 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
     const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [droppedEnergy];
+      }
+
+      if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [container];
+      }
+
       if (type === FIND_TOMBSTONES) {
         return [tombstone];
       }
@@ -533,10 +578,6 @@ describe('selectWorkerTask', () => {
         return [ruin];
       }
 
-      if (type === FIND_DROPPED_RESOURCES) {
-        return [droppedEnergy];
-      }
-
       return type === FIND_SOURCES ? [source] : [];
     });
     const creep = {
@@ -544,21 +585,26 @@ describe('selectWorkerTask', () => {
         getUsedCapacity: jest.fn().mockReturnValue(0),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
-      room: { find: roomFind }
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'tombstone1' });
-    expect(roomFind).not.toHaveBeenCalledWith(FIND_DROPPED_RESOURCES);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'tombstone-near' });
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
-  it('keeps stored structure withdrawal priority over tombstone and ruin salvage', () => {
-    const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 100);
-    const tombstone = makeSalvageEnergySource('tombstone1', 25);
-    const ruin = makeSalvageEnergySource('ruin1', 25);
+  it('uses stable amount and id fallback when range helpers are unavailable', () => {
+    const droppedEnergy = { id: 'm-drop', resourceType: 'energy', amount: 100 } as Resource<ResourceConstant>;
+    const container = makeStoredEnergyStructure('z-container', 'container' as StructureConstant, 100);
+    const tombstone = makeSalvageEnergySource('a-tombstone', 100);
+    const ruin = makeSalvageEnergySource('r-ruin', 100);
     const source = { id: 'source1' } as Source;
     const roomFind = jest.fn((type: number) => {
-      if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [droppedEnergy];
+      }
+
+      if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
         return [];
       }
 
@@ -584,9 +630,7 @@ describe('selectWorkerTask', () => {
       room: { controller: { my: true }, find: roomFind }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
-    expect(roomFind).not.toHaveBeenCalledWith(FIND_TOMBSTONES);
-    expect(roomFind).not.toHaveBeenCalledWith(FIND_RUINS);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'a-tombstone' });
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 


### PR DESCRIPTION
## Summary
- ranks empty-worker energy acquisition candidates across stored structures, tombstones/ruins, and dropped resources using energy-vs-range scoring
- preserves safety filters for hostile-owned structures, unsafe unowned containers, and low-value dropped/salvage targets
- adds Jest coverage for cross-category ranking, range-aware decisions, deterministic fallback/ties, and safety preservation
- synchronizes `prod/dist/main.js`

Closes #159.

## Verification
Controller verified from `/root/screeps-worktrees/energy-acquisition-ranking-159`:
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites, 243 tests)
- `cd prod && npm run build`

Codex-authored commit: `44dae77 lanyusea's bot <lanyusea@gmail.com> feat: rank worker energy acquisition candidates`

## Notes
- `prod/node_modules` is untracked worktree infrastructure and was not staged.
- No secrets.