### PR TITLE
feat: prioritize visible territory controller work

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -513,6 +513,663 @@ function canSatisfyRoleCapacity(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
 
+// src/spawn/bodyBuilder.ts
+var WORKER_PATTERN = ["work", "carry", "move"];
+var WORKER_PATTERN_COST = 200;
+var TERRITORY_CONTROLLER_BODY = ["claim", "move"];
+var TERRITORY_CONTROLLER_BODY_COST = 650;
+var MAX_CREEP_PARTS = 50;
+var MAX_WORKER_PATTERN_COUNT = 4;
+var BODY_PART_COSTS = {
+  move: 50,
+  work: 100,
+  carry: 50,
+  attack: 80,
+  ranged_attack: 150,
+  heal: 250,
+  claim: 600,
+  tough: 10
+};
+function buildWorkerBody(energyAvailable) {
+  if (energyAvailable < WORKER_PATTERN_COST) {
+    return [];
+  }
+  const maxPatternCountByEnergy = Math.floor(energyAvailable / WORKER_PATTERN_COST);
+  const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS / WORKER_PATTERN.length);
+  const patternCount = Math.min(maxPatternCountByEnergy, maxPatternCountBySize, MAX_WORKER_PATTERN_COUNT);
+  return Array.from({ length: patternCount }).flatMap(() => WORKER_PATTERN);
+}
+function buildEmergencyWorkerBody(energyAvailable) {
+  if (energyAvailable < WORKER_PATTERN_COST) {
+    return [];
+  }
+  return [...WORKER_PATTERN];
+}
+function buildTerritoryControllerBody(energyAvailable) {
+  if (energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return [];
+  }
+  return [...TERRITORY_CONTROLLER_BODY];
+}
+function getBodyCost(body) {
+  return body.reduce((cost, part) => cost + BODY_PART_COSTS[part], 0);
+}
+
+// src/territory/territoryPlanner.ts
+var TERRITORY_CLAIMER_ROLE = "claimer";
+var TERRITORY_SCOUT_ROLE = "scout";
+var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
+var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
+var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
+var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
+function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
+  if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
+    return null;
+  }
+  const selection = selectTerritoryTarget(colony, gameTime);
+  if (!selection) {
+    return null;
+  }
+  const target = selection.target;
+  const plan = {
+    colony: colony.room.name,
+    targetRoom: target.roomName,
+    action: selection.intentAction,
+    ...target.controllerId ? { controllerId: target.controllerId } : {}
+  };
+  const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? "active" : "planned";
+  recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
+  return plan;
+}
+function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime()) {
+  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
+    return false;
+  }
+  if (plan.action === "scout" && isVisibleRoomKnown(plan.targetRoom)) {
+    return false;
+  }
+  if (getVisibleTerritoryTargetState(
+    plan.targetRoom,
+    plan.action,
+    plan.controllerId,
+    getVisibleColonyOwnerUsername(plan.colony)
+  ) !== "available") {
+    return false;
+  }
+  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) === 0;
+}
+function buildTerritoryCreepMemory(plan) {
+  return {
+    role: plan.action === "scout" ? TERRITORY_SCOUT_ROLE : TERRITORY_CLAIMER_ROLE,
+    colony: plan.colony,
+    territory: {
+      targetRoom: plan.targetRoom,
+      action: plan.action,
+      ...plan.controllerId ? { controllerId: plan.controllerId } : {}
+    }
+  };
+}
+function selectVisibleTerritoryControllerTask(creep) {
+  const intent = selectVisibleTerritoryControllerIntent(creep);
+  if (!intent) {
+    return null;
+  }
+  const controller = selectCreepRoomController(creep, intent.controllerId);
+  if (!controller) {
+    return null;
+  }
+  if (intent.action === "reserve") {
+    return canUseControllerClaimPart(creep) ? { type: "reserve", targetId: controller.id } : null;
+  }
+  if (controller.my === true) {
+    return getStoredEnergy(creep) > 0 ? { type: "upgrade", targetId: controller.id } : null;
+  }
+  return canUseControllerClaimPart(creep) ? { type: "claim", targetId: controller.id } : null;
+}
+function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
+  var _a;
+  if (!isNonEmptyString(assignment.targetRoom)) {
+    return false;
+  }
+  if (isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
+    return false;
+  }
+  if (assignment.action === "scout") {
+    return true;
+  }
+  if (!isTerritoryControlAction(assignment.action)) {
+    return false;
+  }
+  if (isNonEmptyString(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
+    return false;
+  }
+  const controller = ((_a = creep == null ? void 0 : creep.room) == null ? void 0 : _a.name) === assignment.targetRoom ? selectCreepRoomController(creep, assignment.controllerId) : getVisibleController(assignment.targetRoom, assignment.controllerId);
+  if (!controller) {
+    return !isVisibleRoomMissingController(assignment.targetRoom);
+  }
+  if (assignment.action === "claim" && controller.my === true) {
+    return true;
+  }
+  const actorUsername = getTerritoryActorUsername(creep, colony);
+  return getTerritoryControllerTargetState(controller, assignment.action, actorUsername) === "available";
+}
+function suppressTerritoryIntent(colony, assignment, gameTime) {
+  if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || !isTerritoryIntentAction(assignment.action)) {
+    return;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const suppressedIntent = {
+    colony,
+    targetRoom: assignment.targetRoom,
+    action: assignment.action,
+    status: "suppressed",
+    updatedAt: gameTime,
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
+  };
+  upsertTerritoryIntent(intents, suppressedIntent);
+}
+function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
+  if (roleCounts.worker < workerTarget) {
+    return false;
+  }
+  if (colony.energyCapacityAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return false;
+  }
+  const controller = colony.room.controller;
+  if ((controller == null ? void 0 : controller.my) !== true || typeof controller.level !== "number" || controller.level < 2) {
+    return false;
+  }
+  return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
+}
+function selectTerritoryTarget(colony, gameTime) {
+  const colonyName = colony.room.name;
+  const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
+  const territoryMemory = getTerritoryMemoryRecord();
+  const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
+  const configuredTarget = selectConfiguredTerritoryTarget(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime
+  );
+  if (configuredTarget) {
+    return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
+  }
+  if (hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime)) {
+    return null;
+  }
+  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime);
+}
+function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return null;
+  }
+  let fallbackTarget = null;
+  let renewalTarget = null;
+  let renewalTicksToEnd = null;
+  for (const rawTarget of territoryMemory.targets) {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents, gameTime) && getVisibleTerritoryTargetState(
+      target.roomName,
+      target.action,
+      target.controllerId,
+      colonyOwnerUsername
+    ) === "available") {
+      const targetRenewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername);
+      if (targetRenewalTicksToEnd !== null) {
+        if (renewalTicksToEnd === null || targetRenewalTicksToEnd < renewalTicksToEnd) {
+          renewalTarget = target;
+          renewalTicksToEnd = targetRenewalTicksToEnd;
+        }
+        continue;
+      }
+      if (fallbackTarget === null) {
+        fallbackTarget = target;
+      }
+    }
+  }
+  return renewalTarget != null ? renewalTarget : fallbackTarget;
+}
+function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return false;
+  }
+  return territoryMemory.targets.some((rawTarget) => {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (!target || target.colony !== colonyName) {
+      return false;
+    }
+    if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime)) {
+      return true;
+    }
+    return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
+  });
+}
+function selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
+  const adjacentRooms = getAdjacentRoomNames(colonyName);
+  if (adjacentRooms.length === 0) {
+    return null;
+  }
+  const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
+  for (const roomName of adjacentRooms) {
+    const target = { colony: colonyName, roomName, action: "reserve" };
+    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents, gameTime)) {
+      const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
+      if (candidateState === "safe") {
+        return { target, intentAction: "reserve", commitTarget: true };
+      }
+      if (candidateState === "unknown" && !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, "scout", gameTime)) {
+        return { target, intentAction: "scout", commitTarget: false };
+      }
+    }
+  }
+  return null;
+}
+function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
+  if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
+    return "unavailable";
+  }
+  if (isVisibleRoomMissingController(targetRoom)) {
+    return "unavailable";
+  }
+  const controller = getVisibleController(targetRoom);
+  if (!controller) {
+    return "unknown";
+  }
+  const targetState = getReserveControllerTargetState(controller, colonyOwnerUsername);
+  return targetState === "available" ? "safe" : "unavailable";
+}
+function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return /* @__PURE__ */ new Set();
+  }
+  return new Set(
+    territoryMemory.targets.flatMap((rawTarget) => {
+      const target = normalizeTerritoryTarget(rawTarget);
+      return (target == null ? void 0 : target.colony) === colonyName ? [target.roomName] : [];
+    })
+  );
+}
+function appendTerritoryTarget(territoryMemory, target) {
+  if (!Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = [];
+  }
+  territoryMemory.targets.push(target);
+}
+function getAdjacentRoomNames(roomName) {
+  const game = globalThis.Game;
+  const gameMap = game == null ? void 0 : game.map;
+  if (!gameMap || typeof gameMap.describeExits !== "function") {
+    return [];
+  }
+  const exits = gameMap.describeExits(roomName);
+  if (!isRecord(exits)) {
+    return [];
+  }
+  return EXIT_DIRECTION_ORDER.flatMap((direction) => {
+    const exitRoom = exits[direction];
+    return isNonEmptyString(exitRoom) ? [exitRoom] : [];
+  });
+}
+function normalizeTerritoryTarget(rawTarget) {
+  if (!isRecord(rawTarget)) {
+    return null;
+  }
+  if (!isNonEmptyString(rawTarget.colony) || !isNonEmptyString(rawTarget.roomName) || !isTerritoryControlAction(rawTarget.action)) {
+    return null;
+  }
+  return {
+    colony: rawTarget.colony,
+    roomName: rawTarget.roomName,
+    action: rawTarget.action,
+    ...typeof rawTarget.controllerId === "string" ? { controllerId: rawTarget.controllerId } : {},
+    ...rawTarget.enabled === false ? { enabled: false } : {}
+  };
+}
+function recordTerritoryIntent(plan, status, gameTime, seededTarget = null) {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+  if (seededTarget) {
+    appendTerritoryTarget(territoryMemory, seededTarget);
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const nextIntent = {
+    colony: plan.colony,
+    targetRoom: plan.targetRoom,
+    action: plan.action,
+    status,
+    updatedAt: gameTime,
+    ...plan.controllerId ? { controllerId: plan.controllerId } : {}
+  };
+  upsertTerritoryIntent(intents, nextIntent);
+}
+function normalizeTerritoryIntents(rawIntents) {
+  return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
+    const normalizedIntent = normalizeTerritoryIntent(intent);
+    return normalizedIntent ? [normalizedIntent] : [];
+  }) : [];
+}
+function upsertTerritoryIntent(intents, nextIntent) {
+  const existingIndex = intents.findIndex(
+    (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action
+  );
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+  intents.push(nextIntent);
+}
+function normalizeTerritoryIntent(rawIntent) {
+  if (!isRecord(rawIntent)) {
+    return null;
+  }
+  if (!isNonEmptyString(rawIntent.colony) || !isNonEmptyString(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
+    return null;
+  }
+  return {
+    colony: rawIntent.colony,
+    targetRoom: rawIntent.targetRoom,
+    action: rawIntent.action,
+    status: rawIntent.status,
+    updatedAt: rawIntent.updatedAt,
+    ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {}
+  };
+}
+function getTerritoryCreepCountForTarget(roleCounts, targetRoom, action) {
+  var _a, _b, _c, _d;
+  if (action === "scout") {
+    return (_b = (_a = roleCounts.scoutsByTargetRoom) == null ? void 0 : _a[targetRoom]) != null ? _b : 0;
+  }
+  return (_d = (_c = roleCounts.claimersByTargetRoom) == null ? void 0 : _c[targetRoom]) != null ? _d : 0;
+}
+function isTerritoryTargetSuppressed(target, intents, gameTime) {
+  return isSuppressedTerritoryIntentForAction(intents, target.colony, target.roomName, target.action, gameTime);
+}
+function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, action, gameTime) {
+  return intents.some(
+    (intent) => isTerritorySuppressionFresh(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
+  );
+}
+function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime()) {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return false;
+  }
+  return normalizeTerritoryIntents(territoryMemory.intents).some(
+    (intent) => isTerritorySuppressionFresh(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
+  );
+}
+function isTerritorySuppressionFresh(intent, gameTime) {
+  return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
+}
+function selectVisibleTerritoryControllerIntent(creep) {
+  var _a, _b, _c;
+  const roomName = (_a = creep.room) == null ? void 0 : _a.name;
+  if (!isNonEmptyString(roomName) || isVisibleRoomUnsafe(creep.room)) {
+    return null;
+  }
+  const assignmentIntent = normalizeCreepTerritoryIntent(creep, roomName);
+  if (assignmentIntent && isCreepVisibleTerritoryIntentActionable(creep, assignmentIntent)) {
+    return assignmentIntent;
+  }
+  const territoryMemory = getTerritoryMemoryRecord();
+  const colony = (_b = creep.memory) == null ? void 0 : _b.colony;
+  const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents).filter((intent) => isActiveVisibleControllerIntentForCreep(intent, roomName, colony)).sort(compareVisibleControllerIntents);
+  return (_c = intents.find((intent) => isCreepVisibleTerritoryIntentActionable(creep, intent))) != null ? _c : null;
+}
+function normalizeCreepTerritoryIntent(creep, roomName) {
+  var _a, _b, _c, _d;
+  const assignment = (_a = creep.memory) == null ? void 0 : _a.territory;
+  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction(assignment.action) || isNonEmptyString((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
+    return null;
+  }
+  return {
+    colony: (_d = (_c = creep.memory) == null ? void 0 : _c.colony) != null ? _d : "",
+    targetRoom: assignment.targetRoom,
+    action: assignment.action,
+    status: "active",
+    updatedAt: getGameTime(),
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
+  };
+}
+function isActiveVisibleControllerIntentForCreep(intent, roomName, creepColony) {
+  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString(creepColony) || intent.colony === creepColony);
+}
+function compareVisibleControllerIntents(left, right) {
+  return getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) || getIntentActionPriority(left.action) - getIntentActionPriority(right.action) || right.updatedAt - left.updatedAt || left.colony.localeCompare(right.colony);
+}
+function getIntentStatusPriority(status) {
+  return status === "active" ? 0 : 1;
+}
+function getIntentActionPriority(action) {
+  return action === "claim" ? 0 : 1;
+}
+function isCreepVisibleTerritoryIntentActionable(creep, intent) {
+  if (!isTerritoryControlAction(intent.action)) {
+    return false;
+  }
+  const controller = selectCreepRoomController(creep, intent.controllerId);
+  if (!controller) {
+    return false;
+  }
+  if (!isVisibleRoomSafe(creep.room)) {
+    return false;
+  }
+  if (intent.action === "claim" && controller.my === true) {
+    return true;
+  }
+  return getTerritoryControllerTargetState(controller, intent.action, getTerritoryActorUsername(creep, intent.colony)) === "available";
+}
+function selectCreepRoomController(creep, controllerId) {
+  var _a;
+  const roomController = (_a = creep.room) == null ? void 0 : _a.controller;
+  if (!controllerId) {
+    return roomController != null ? roomController : null;
+  }
+  if ((roomController == null ? void 0 : roomController.id) === controllerId) {
+    return roomController;
+  }
+  const game = globalThis.Game;
+  const getObjectById = game == null ? void 0 : game.getObjectById;
+  if (typeof getObjectById !== "function") {
+    return null;
+  }
+  return getObjectById.call(game, controllerId);
+}
+function getTerritoryControllerTargetState(controller, action, colonyOwnerUsername) {
+  if (action === "reserve") {
+    return getReserveControllerTargetState(controller, colonyOwnerUsername);
+  }
+  return isControllerOwned(controller) ? "unavailable" : "available";
+}
+function getTerritoryActorUsername(creep, colony) {
+  var _a;
+  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString(colony) ? getVisibleColonyOwnerUsername(colony) : null;
+}
+function getCreepOwnerUsername(creep) {
+  var _a;
+  const username = (_a = creep == null ? void 0 : creep.owner) == null ? void 0 : _a.username;
+  return isNonEmptyString(username) ? username : null;
+}
+function canUseControllerClaimPart(creep) {
+  var _a;
+  const claimPart = getBodyPartConstant("CLAIM", "claim");
+  const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
+  if (typeof activeClaimParts === "number") {
+    return activeClaimParts > 0;
+  }
+  return Array.isArray(creep.body) && creep.body.some((part) => part.type === claimPart && part.hits > 0);
+}
+function getBodyPartConstant(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function getStoredEnergy(object) {
+  var _a;
+  const store = object == null ? void 0 : object.store;
+  const energyResource = getEnergyResource();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, energyResource);
+  if (typeof usedCapacity === "number") {
+    return usedCapacity;
+  }
+  const storedEnergy = store == null ? void 0 : store[energyResource];
+  return typeof storedEnergy === "number" ? storedEnergy : 0;
+}
+function getEnergyResource() {
+  const resource = globalThis.RESOURCE_ENERGY;
+  return typeof resource === "string" ? resource : "energy";
+}
+function isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom) {
+  var _a, _b;
+  const room = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[targetRoom];
+  return room ? isVisibleRoomUnsafe(room) : false;
+}
+function isVisibleRoomSafe(room) {
+  return !isVisibleRoomUnsafe(room);
+}
+function isVisibleRoomUnsafe(room) {
+  return findVisibleHostileCreeps(room).length > 0 || findVisibleHostileStructures(room).length > 0;
+}
+function findVisibleHostileCreeps(room) {
+  return typeof FIND_HOSTILE_CREEPS === "number" && typeof room.find === "function" ? room.find(FIND_HOSTILE_CREEPS) : [];
+}
+function findVisibleHostileStructures(room) {
+  return typeof FIND_HOSTILE_STRUCTURES === "number" && typeof room.find === "function" ? room.find(FIND_HOSTILE_STRUCTURES) : [];
+}
+function getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) {
+  if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
+    return "unavailable";
+  }
+  if (isVisibleRoomMissingController(targetRoom)) {
+    return "unavailable";
+  }
+  if (action === "scout") {
+    return isVisibleRoomKnown(targetRoom) ? "unavailable" : "available";
+  }
+  const controller = getVisibleController(targetRoom, controllerId);
+  if (!controller) {
+    return "available";
+  }
+  if (action === "reserve") {
+    return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername != null ? colonyOwnerUsername : null);
+  }
+  return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername != null ? colonyOwnerUsername : null);
+}
+function isVisibleRoomKnown(targetRoom) {
+  var _a;
+  const game = globalThis.Game;
+  return ((_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom]) != null;
+}
+function isVisibleRoomMissingController(targetRoom) {
+  var _a;
+  const game = globalThis.Game;
+  const room = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom];
+  return room != null && room.controller == null;
+}
+function isControllerOwned(controller) {
+  return controller.owner != null || controller.my === true;
+}
+function getReserveControllerTargetState(controller, colonyOwnerUsername) {
+  if (isControllerOwned(controller)) {
+    return "unavailable";
+  }
+  const reservation = controller.reservation;
+  if (!reservation) {
+    return "available";
+  }
+  if (!isNonEmptyString(reservation.username) || reservation.username !== colonyOwnerUsername) {
+    return "unavailable";
+  }
+  return typeof reservation.ticksToEnd === "number" && reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? "available" : "satisfied";
+}
+function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
+  if (target.action !== "reserve" || colonyOwnerUsername === null) {
+    return null;
+  }
+  const controller = getVisibleController(target.roomName, target.controllerId);
+  if (!controller || isControllerOwned(controller)) {
+    return null;
+  }
+  const reservation = controller.reservation;
+  if (!reservation || reservation.username !== colonyOwnerUsername || typeof reservation.ticksToEnd !== "number") {
+    return null;
+  }
+  return reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? reservation.ticksToEnd : null;
+}
+function getVisibleColonyOwnerUsername(colonyName) {
+  const controller = getVisibleController(colonyName);
+  return getControllerOwnerUsername(controller != null ? controller : void 0);
+}
+function getControllerOwnerUsername(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  return isNonEmptyString(username) ? username : null;
+}
+function getVisibleController(targetRoom, controllerId) {
+  var _a, _b;
+  const game = globalThis.Game;
+  const roomController = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom]) == null ? void 0 : _b.controller;
+  if (roomController) {
+    return roomController;
+  }
+  const getObjectById = game == null ? void 0 : game.getObjectById;
+  if (controllerId && typeof getObjectById === "function") {
+    return getObjectById.call(game, controllerId);
+  }
+  return null;
+}
+function getGameTime() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" ? gameTime : 0;
+}
+function getWritableTerritoryMemoryRecord() {
+  const memory = getMemoryRecord();
+  if (!memory) {
+    return null;
+  }
+  if (!isRecord(memory.territory)) {
+    memory.territory = {};
+  }
+  return memory.territory;
+}
+function getTerritoryMemoryRecord() {
+  const memory = getMemoryRecord();
+  if (!memory || !isRecord(memory.territory)) {
+    return null;
+  }
+  return memory.territory;
+}
+function getMemoryRecord() {
+  const memory = globalThis.Memory;
+  return memory != null ? memory : null;
+}
+function isTerritoryControlAction(action) {
+  return action === "claim" || action === "reserve";
+}
+function isTerritoryIntentAction(action) {
+  return isTerritoryControlAction(action) || action === "scout";
+}
+function isTerritoryIntentStatus(status) {
+  return status === "planned" || status === "active" || status === "suppressed";
+}
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
@@ -523,7 +1180,11 @@ var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 var STORED_ENERGY_RANGE_COST = 50;
 function selectWorkerTask(creep) {
   const carriedEnergy = getUsedEnergy(creep);
+  const territoryControllerTask = selectVisibleTerritoryControllerTask(creep);
   if (carriedEnergy === 0) {
+    if (isTerritoryControlTask(territoryControllerTask)) {
+      return territoryControllerTask;
+    }
     if (getFreeEnergyCapacity(creep) > 0) {
       const storedEnergy = selectStoredEnergySource(creep);
       if (storedEnergy) {
@@ -548,6 +1209,9 @@ function selectWorkerTask(creep) {
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: "upgrade", targetId: controller.id };
+  }
+  if (territoryControllerTask) {
+    return territoryControllerTask;
   }
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
   const spawnConstructionSite = constructionSites.find(isSpawnConstructionSite);
@@ -584,6 +1248,9 @@ function selectWorkerTask(creep) {
   }
   return null;
 }
+function isTerritoryControlTask(task) {
+  return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
+}
 function isFillableEnergySink(structure) {
   return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
@@ -613,7 +1280,7 @@ function matchesStructureType2(actual, globalName, fallback) {
 }
 function selectStoredEnergySource(creep) {
   const context = {
-    creepOwnerUsername: getCreepOwnerUsername(creep),
+    creepOwnerUsername: getCreepOwnerUsername2(creep),
     hasHostilePresence: hasVisibleHostilePresence(creep.room),
     room: creep.room
   };
@@ -637,7 +1304,7 @@ function scoreStoredEnergySources(creep, sources) {
   }
   return sources.map((source) => {
     var _a, _b;
-    const energy = getStoredEnergy(source);
+    const energy = getStoredEnergy2(source);
     const range = Math.max(0, (_b = (_a = position.getRangeTo) == null ? void 0 : _a.call(position, source)) != null ? _b : 0);
     return {
       energy,
@@ -657,7 +1324,7 @@ function isStoredWorkerEnergySource(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType2(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType2(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function hasStoredEnergy(structure) {
-  return getStoredEnergy(structure) > 0;
+  return getStoredEnergy2(structure) > 0;
 }
 function isFriendlyStoredEnergySource(structure, context) {
   var _a;
@@ -709,9 +1376,9 @@ function findRuins(room) {
   return room.find(FIND_RUINS);
 }
 function hasSalvageableEnergy(source) {
-  return getStoredEnergy(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
+  return getStoredEnergy2(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
 }
-function getCreepOwnerUsername(creep) {
+function getCreepOwnerUsername2(creep) {
   var _a;
   const username = (_a = creep.owner) == null ? void 0 : _a.username;
   return typeof username === "string" && username.length > 0 ? username : null;
@@ -836,12 +1503,12 @@ function isInRoom(creep, room) {
   return creep.room === room;
 }
 function getUsedEnergy(creep) {
-  return getStoredEnergy(creep);
+  return getStoredEnergy2(creep);
 }
 function getFreeEnergyCapacity(creep) {
   return getFreeStoredEnergyCapacity(creep);
 }
-function getStoredEnergy(object) {
+function getStoredEnergy2(object) {
   var _a;
   const store = getStore(object);
   if (!store) {
@@ -974,6 +1641,11 @@ function runWorker(creep) {
     assignNextTask(creep);
     return;
   }
+  if (shouldPreemptForVisibleTerritoryControllerTask(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
   if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
@@ -1009,6 +1681,9 @@ function assignNextTask(creep) {
 }
 function shouldReplaceTask(creep, task) {
   var _a, _b;
+  if (isTerritoryControlTask2(task)) {
+    return false;
+  }
   if (!((_a = creep.store) == null ? void 0 : _a.getUsedCapacity) || !((_b = creep.store) == null ? void 0 : _b.getFreeCapacity)) {
     return false;
   }
@@ -1018,6 +1693,17 @@ function shouldReplaceTask(creep, task) {
     return freeEnergyCapacity === 0;
   }
   return usedEnergy === 0;
+}
+function shouldPreemptForVisibleTerritoryControllerTask(creep, task) {
+  const controllerTask = selectVisibleTerritoryControllerTask(creep);
+  if (!controllerTask) {
+    return isTerritoryControlTask2(task);
+  }
+  const selectedTask = selectWorkerTask(creep);
+  if (!selectedTask || !isSameTask(selectedTask, controllerTask)) {
+    return false;
+  }
+  return !isSameTask(task, controllerTask);
 }
 function shouldPreemptUpgradeTask(creep, task) {
   var _a;
@@ -1033,6 +1719,12 @@ function shouldPreemptUpgradeTask(creep, task) {
     return false;
   }
   return true;
+}
+function isSameTask(left, right) {
+  return left.type === right.type && left.targetId === right.targetId;
+}
+function isTerritoryControlTask2(task) {
+  return task.type === "claim" || task.type === "reserve";
 }
 function shouldReplaceTarget(task, target) {
   var _a;
@@ -1058,478 +1750,13 @@ function executeTask(creep, task, target) {
       return creep.build(target);
     case "repair":
       return creep.repair(target);
+    case "claim":
+      return creep.claimController(target);
+    case "reserve":
+      return creep.reserveController(target);
     case "upgrade":
       return creep.upgradeController(target);
   }
-}
-
-// src/spawn/bodyBuilder.ts
-var WORKER_PATTERN = ["work", "carry", "move"];
-var WORKER_PATTERN_COST = 200;
-var TERRITORY_CONTROLLER_BODY = ["claim", "move"];
-var TERRITORY_CONTROLLER_BODY_COST = 650;
-var MAX_CREEP_PARTS = 50;
-var MAX_WORKER_PATTERN_COUNT = 4;
-var BODY_PART_COSTS = {
-  move: 50,
-  work: 100,
-  carry: 50,
-  attack: 80,
-  ranged_attack: 150,
-  heal: 250,
-  claim: 600,
-  tough: 10
-};
-function buildWorkerBody(energyAvailable) {
-  if (energyAvailable < WORKER_PATTERN_COST) {
-    return [];
-  }
-  const maxPatternCountByEnergy = Math.floor(energyAvailable / WORKER_PATTERN_COST);
-  const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS / WORKER_PATTERN.length);
-  const patternCount = Math.min(maxPatternCountByEnergy, maxPatternCountBySize, MAX_WORKER_PATTERN_COUNT);
-  return Array.from({ length: patternCount }).flatMap(() => WORKER_PATTERN);
-}
-function buildEmergencyWorkerBody(energyAvailable) {
-  if (energyAvailable < WORKER_PATTERN_COST) {
-    return [];
-  }
-  return [...WORKER_PATTERN];
-}
-function buildTerritoryControllerBody(energyAvailable) {
-  if (energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
-    return [];
-  }
-  return [...TERRITORY_CONTROLLER_BODY];
-}
-function getBodyCost(body) {
-  return body.reduce((cost, part) => cost + BODY_PART_COSTS[part], 0);
-}
-
-// src/territory/territoryPlanner.ts
-var TERRITORY_CLAIMER_ROLE = "claimer";
-var TERRITORY_SCOUT_ROLE = "scout";
-var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
-var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
-var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
-var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
-function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
-  if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
-    return null;
-  }
-  const selection = selectTerritoryTarget(colony, gameTime);
-  if (!selection) {
-    return null;
-  }
-  const target = selection.target;
-  const plan = {
-    colony: colony.room.name,
-    targetRoom: target.roomName,
-    action: selection.intentAction,
-    ...target.controllerId ? { controllerId: target.controllerId } : {}
-  };
-  const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? "active" : "planned";
-  recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
-  return plan;
-}
-function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime()) {
-  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
-    return false;
-  }
-  if (plan.action === "scout" && isVisibleRoomKnown(plan.targetRoom)) {
-    return false;
-  }
-  if (getVisibleTerritoryTargetState(
-    plan.targetRoom,
-    plan.action,
-    plan.controllerId,
-    getVisibleColonyOwnerUsername(plan.colony)
-  ) !== "available") {
-    return false;
-  }
-  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) === 0;
-}
-function buildTerritoryCreepMemory(plan) {
-  return {
-    role: plan.action === "scout" ? TERRITORY_SCOUT_ROLE : TERRITORY_CLAIMER_ROLE,
-    colony: plan.colony,
-    territory: {
-      targetRoom: plan.targetRoom,
-      action: plan.action,
-      ...plan.controllerId ? { controllerId: plan.controllerId } : {}
-    }
-  };
-}
-function suppressTerritoryIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || !isTerritoryIntentAction(assignment.action)) {
-    return;
-  }
-  const territoryMemory = getWritableTerritoryMemoryRecord();
-  if (!territoryMemory) {
-    return;
-  }
-  const intents = normalizeTerritoryIntents(territoryMemory.intents);
-  territoryMemory.intents = intents;
-  const suppressedIntent = {
-    colony,
-    targetRoom: assignment.targetRoom,
-    action: assignment.action,
-    status: "suppressed",
-    updatedAt: gameTime,
-    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
-  };
-  upsertTerritoryIntent(intents, suppressedIntent);
-}
-function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
-  if (roleCounts.worker < workerTarget) {
-    return false;
-  }
-  if (colony.energyCapacityAvailable < TERRITORY_CONTROLLER_BODY_COST) {
-    return false;
-  }
-  const controller = colony.room.controller;
-  if ((controller == null ? void 0 : controller.my) !== true || typeof controller.level !== "number" || controller.level < 2) {
-    return false;
-  }
-  return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
-}
-function selectTerritoryTarget(colony, gameTime) {
-  const colonyName = colony.room.name;
-  const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
-  const territoryMemory = getTerritoryMemoryRecord();
-  const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
-  const configuredTarget = selectConfiguredTerritoryTarget(
-    colonyName,
-    colonyOwnerUsername,
-    territoryMemory,
-    intents,
-    gameTime
-  );
-  if (configuredTarget) {
-    return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
-  }
-  if (hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime)) {
-    return null;
-  }
-  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime);
-}
-function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
-  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
-    return null;
-  }
-  let fallbackTarget = null;
-  let renewalTarget = null;
-  let renewalTicksToEnd = null;
-  for (const rawTarget of territoryMemory.targets) {
-    const target = normalizeTerritoryTarget(rawTarget);
-    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents, gameTime) && getVisibleTerritoryTargetState(
-      target.roomName,
-      target.action,
-      target.controllerId,
-      colonyOwnerUsername
-    ) === "available") {
-      const targetRenewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername);
-      if (targetRenewalTicksToEnd !== null) {
-        if (renewalTicksToEnd === null || targetRenewalTicksToEnd < renewalTicksToEnd) {
-          renewalTarget = target;
-          renewalTicksToEnd = targetRenewalTicksToEnd;
-        }
-        continue;
-      }
-      if (fallbackTarget === null) {
-        fallbackTarget = target;
-      }
-    }
-  }
-  return renewalTarget != null ? renewalTarget : fallbackTarget;
-}
-function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime) {
-  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
-    return false;
-  }
-  return territoryMemory.targets.some((rawTarget) => {
-    const target = normalizeTerritoryTarget(rawTarget);
-    if (!target || target.colony !== colonyName) {
-      return false;
-    }
-    if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime)) {
-      return true;
-    }
-    return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
-  });
-}
-function selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
-  const adjacentRooms = getAdjacentRoomNames(colonyName);
-  if (adjacentRooms.length === 0) {
-    return null;
-  }
-  const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
-  for (const roomName of adjacentRooms) {
-    const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents, gameTime)) {
-      const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
-      if (candidateState === "safe") {
-        return { target, intentAction: "reserve", commitTarget: true };
-      }
-      if (candidateState === "unknown" && !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, "scout", gameTime)) {
-        return { target, intentAction: "scout", commitTarget: false };
-      }
-    }
-  }
-  return null;
-}
-function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
-  if (isVisibleRoomMissingController(targetRoom)) {
-    return "unavailable";
-  }
-  const controller = getVisibleController(targetRoom);
-  if (!controller) {
-    return "unknown";
-  }
-  const targetState = getReserveControllerTargetState(controller, colonyOwnerUsername);
-  return targetState === "available" ? "safe" : "unavailable";
-}
-function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
-  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
-    return /* @__PURE__ */ new Set();
-  }
-  return new Set(
-    territoryMemory.targets.flatMap((rawTarget) => {
-      const target = normalizeTerritoryTarget(rawTarget);
-      return (target == null ? void 0 : target.colony) === colonyName ? [target.roomName] : [];
-    })
-  );
-}
-function appendTerritoryTarget(territoryMemory, target) {
-  if (!Array.isArray(territoryMemory.targets)) {
-    territoryMemory.targets = [];
-  }
-  territoryMemory.targets.push(target);
-}
-function getAdjacentRoomNames(roomName) {
-  const game = globalThis.Game;
-  const gameMap = game == null ? void 0 : game.map;
-  if (!gameMap || typeof gameMap.describeExits !== "function") {
-    return [];
-  }
-  const exits = gameMap.describeExits(roomName);
-  if (!isRecord(exits)) {
-    return [];
-  }
-  return EXIT_DIRECTION_ORDER.flatMap((direction) => {
-    const exitRoom = exits[direction];
-    return isNonEmptyString(exitRoom) ? [exitRoom] : [];
-  });
-}
-function normalizeTerritoryTarget(rawTarget) {
-  if (!isRecord(rawTarget)) {
-    return null;
-  }
-  if (!isNonEmptyString(rawTarget.colony) || !isNonEmptyString(rawTarget.roomName) || !isTerritoryControlAction(rawTarget.action)) {
-    return null;
-  }
-  return {
-    colony: rawTarget.colony,
-    roomName: rawTarget.roomName,
-    action: rawTarget.action,
-    ...typeof rawTarget.controllerId === "string" ? { controllerId: rawTarget.controllerId } : {},
-    ...rawTarget.enabled === false ? { enabled: false } : {}
-  };
-}
-function recordTerritoryIntent(plan, status, gameTime, seededTarget = null) {
-  const territoryMemory = getWritableTerritoryMemoryRecord();
-  if (!territoryMemory) {
-    return;
-  }
-  if (seededTarget) {
-    appendTerritoryTarget(territoryMemory, seededTarget);
-  }
-  const intents = normalizeTerritoryIntents(territoryMemory.intents);
-  territoryMemory.intents = intents;
-  const nextIntent = {
-    colony: plan.colony,
-    targetRoom: plan.targetRoom,
-    action: plan.action,
-    status,
-    updatedAt: gameTime,
-    ...plan.controllerId ? { controllerId: plan.controllerId } : {}
-  };
-  upsertTerritoryIntent(intents, nextIntent);
-}
-function normalizeTerritoryIntents(rawIntents) {
-  return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
-    const normalizedIntent = normalizeTerritoryIntent(intent);
-    return normalizedIntent ? [normalizedIntent] : [];
-  }) : [];
-}
-function upsertTerritoryIntent(intents, nextIntent) {
-  const existingIndex = intents.findIndex(
-    (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action
-  );
-  if (existingIndex >= 0) {
-    intents[existingIndex] = nextIntent;
-    return;
-  }
-  intents.push(nextIntent);
-}
-function normalizeTerritoryIntent(rawIntent) {
-  if (!isRecord(rawIntent)) {
-    return null;
-  }
-  if (!isNonEmptyString(rawIntent.colony) || !isNonEmptyString(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
-    return null;
-  }
-  return {
-    colony: rawIntent.colony,
-    targetRoom: rawIntent.targetRoom,
-    action: rawIntent.action,
-    status: rawIntent.status,
-    updatedAt: rawIntent.updatedAt,
-    ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {}
-  };
-}
-function getTerritoryCreepCountForTarget(roleCounts, targetRoom, action) {
-  var _a, _b, _c, _d;
-  if (action === "scout") {
-    return (_b = (_a = roleCounts.scoutsByTargetRoom) == null ? void 0 : _a[targetRoom]) != null ? _b : 0;
-  }
-  return (_d = (_c = roleCounts.claimersByTargetRoom) == null ? void 0 : _c[targetRoom]) != null ? _d : 0;
-}
-function isTerritoryTargetSuppressed(target, intents, gameTime) {
-  return isSuppressedTerritoryIntentForAction(intents, target.colony, target.roomName, target.action, gameTime);
-}
-function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, action, gameTime) {
-  return intents.some(
-    (intent) => isTerritorySuppressionFresh(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
-  );
-}
-function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime) {
-  const territoryMemory = getTerritoryMemoryRecord();
-  if (!territoryMemory) {
-    return false;
-  }
-  return normalizeTerritoryIntents(territoryMemory.intents).some(
-    (intent) => isTerritorySuppressionFresh(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
-  );
-}
-function isTerritorySuppressionFresh(intent, gameTime) {
-  return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
-}
-function getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) {
-  if (isVisibleRoomMissingController(targetRoom)) {
-    return "unavailable";
-  }
-  const controller = getVisibleController(targetRoom, controllerId);
-  if (!controller) {
-    return "available";
-  }
-  if (action === "reserve") {
-    return getReserveControllerTargetState(controller, colonyOwnerUsername != null ? colonyOwnerUsername : null);
-  }
-  return isControllerOwned(controller) ? "unavailable" : "available";
-}
-function isVisibleRoomKnown(targetRoom) {
-  var _a;
-  const game = globalThis.Game;
-  return ((_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom]) != null;
-}
-function isVisibleRoomMissingController(targetRoom) {
-  var _a;
-  const game = globalThis.Game;
-  const room = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom];
-  return room != null && room.controller == null;
-}
-function isControllerOwned(controller) {
-  return controller.owner != null || controller.my === true;
-}
-function getReserveControllerTargetState(controller, colonyOwnerUsername) {
-  if (isControllerOwned(controller)) {
-    return "unavailable";
-  }
-  const reservation = controller.reservation;
-  if (!reservation) {
-    return "available";
-  }
-  if (!isNonEmptyString(reservation.username) || reservation.username !== colonyOwnerUsername) {
-    return "unavailable";
-  }
-  return typeof reservation.ticksToEnd === "number" && reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? "available" : "satisfied";
-}
-function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
-  if (target.action !== "reserve" || colonyOwnerUsername === null) {
-    return null;
-  }
-  const controller = getVisibleController(target.roomName, target.controllerId);
-  if (!controller || isControllerOwned(controller)) {
-    return null;
-  }
-  const reservation = controller.reservation;
-  if (!reservation || reservation.username !== colonyOwnerUsername || typeof reservation.ticksToEnd !== "number") {
-    return null;
-  }
-  return reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? reservation.ticksToEnd : null;
-}
-function getVisibleColonyOwnerUsername(colonyName) {
-  const controller = getVisibleController(colonyName);
-  return getControllerOwnerUsername(controller != null ? controller : void 0);
-}
-function getControllerOwnerUsername(controller) {
-  var _a;
-  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString(username) ? username : null;
-}
-function getVisibleController(targetRoom, controllerId) {
-  var _a, _b;
-  const game = globalThis.Game;
-  const roomController = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom]) == null ? void 0 : _b.controller;
-  if (roomController) {
-    return roomController;
-  }
-  const getObjectById = game == null ? void 0 : game.getObjectById;
-  if (controllerId && typeof getObjectById === "function") {
-    return getObjectById.call(game, controllerId);
-  }
-  return null;
-}
-function getGameTime() {
-  var _a;
-  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
-  return typeof gameTime === "number" ? gameTime : 0;
-}
-function getWritableTerritoryMemoryRecord() {
-  const memory = getMemoryRecord();
-  if (!memory) {
-    return null;
-  }
-  if (!isRecord(memory.territory)) {
-    memory.territory = {};
-  }
-  return memory.territory;
-}
-function getTerritoryMemoryRecord() {
-  const memory = getMemoryRecord();
-  if (!memory || !isRecord(memory.territory)) {
-    return null;
-  }
-  return memory.territory;
-}
-function getMemoryRecord() {
-  const memory = globalThis.Memory;
-  return memory != null ? memory : null;
-}
-function isTerritoryControlAction(action) {
-  return action === "claim" || action === "reserve";
-}
-function isTerritoryIntentAction(action) {
-  return isTerritoryControlAction(action) || action === "scout";
-}
-function isTerritoryIntentStatus(status) {
-  return status === "planned" || status === "active" || status === "suppressed";
-}
-function isNonEmptyString(value) {
-  return typeof value === "string" && value.length > 0;
-}
-function isRecord(value) {
-  return typeof value === "object" && value !== null;
 }
 
 // src/spawn/spawnPlanner.ts
@@ -1848,14 +2075,14 @@ function getEnergyInStore(object) {
   }
   const getUsedCapacity = object.store.getUsedCapacity;
   if (typeof getUsedCapacity === "function") {
-    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource());
+    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource2());
     return typeof usedCapacity === "number" ? usedCapacity : 0;
   }
-  const storedEnergy = object.store[getEnergyResource()];
+  const storedEnergy = object.store[getEnergyResource2()];
   return typeof storedEnergy === "number" ? storedEnergy : 0;
 }
 function sumDroppedEnergy(droppedResources) {
-  const energyResource = getEnergyResource();
+  const energyResource = getEnergyResource2();
   return droppedResources.reduce((total, droppedResource) => {
     if (!isRecord2(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
@@ -1864,7 +2091,7 @@ function sumDroppedEnergy(droppedResources) {
   }, 0);
 }
 function isEnergyEventData(data) {
-  return data.resourceType === void 0 || data.resourceType === getEnergyResource();
+  return data.resourceType === void 0 || data.resourceType === getEnergyResource2();
 }
 function getNumericEventData(data, key) {
   const value = data[key];
@@ -1874,7 +2101,7 @@ function getGlobalNumber(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getEnergyResource() {
+function getEnergyResource2() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
@@ -1914,6 +2141,10 @@ function runTerritoryControllerCreep(creep) {
   var _a;
   const assignment = creep.memory.territory;
   if (!isTerritoryAssignment(assignment)) {
+    return;
+  }
+  if (!isVisibleTerritoryAssignmentSafe(assignment, creep.memory.colony, creep)) {
+    suppressTerritoryAssignment(creep, assignment);
     return;
   }
   if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -513,635 +513,6 @@ function canSatisfyRoleCapacity(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
 
-// src/tasks/workerTasks.ts
-var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
-var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
-var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
-var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
-var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
-var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
-var ENERGY_ACQUISITION_RANGE_COST = 50;
-function selectWorkerTask(creep) {
-  const carriedEnergy = getUsedEnergy(creep);
-  if (carriedEnergy === 0) {
-    if (getFreeEnergyCapacity(creep) > 0) {
-      const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
-      if (energyAcquisitionTask) {
-        return energyAcquisitionTask;
-      }
-    }
-    const source = selectHarvestSource(creep);
-    return source ? { type: "harvest", targetId: source.id } : null;
-  }
-  const energySink = selectFillableEnergySink(creep);
-  if (energySink) {
-    return { type: "transfer", targetId: energySink.id };
-  }
-  const controller = creep.room.controller;
-  if (controller && shouldGuardControllerDowngrade(controller)) {
-    return { type: "upgrade", targetId: controller.id };
-  }
-  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
-  const spawnConstructionSite = constructionSites.find(isSpawnConstructionSite);
-  if (spawnConstructionSite) {
-    return { type: "build", targetId: spawnConstructionSite.id };
-  }
-  if (controller && shouldRushRcl1Controller(controller)) {
-    return { type: "upgrade", targetId: controller.id };
-  }
-  const extensionConstructionSite = constructionSites.find(isExtensionConstructionSite);
-  if (extensionConstructionSite) {
-    return { type: "build", targetId: extensionConstructionSite.id };
-  }
-  const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
-  if (criticalRepairTarget) {
-    return { type: "repair", targetId: criticalRepairTarget.id };
-  }
-  const roadOrContainerConstructionSite = constructionSites.find(isRoadOrContainerConstructionSite);
-  if (roadOrContainerConstructionSite) {
-    return { type: "build", targetId: roadOrContainerConstructionSite.id };
-  }
-  if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
-    return { type: "upgrade", targetId: controller.id };
-  }
-  if (constructionSites[0]) {
-    return { type: "build", targetId: constructionSites[0].id };
-  }
-  const repairTarget = selectRepairTarget(creep);
-  if (repairTarget) {
-    return { type: "repair", targetId: repairTarget.id };
-  }
-  if (controller == null ? void 0 : controller.my) {
-    return { type: "upgrade", targetId: controller.id };
-  }
-  return null;
-}
-function isFillableEnergySink(structure) {
-  return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
-}
-function selectFillableEnergySink(creep) {
-  const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
-    filter: isFillableEnergySink
-  });
-  const spawn = selectClosestEnergySink(creep, energySinks.filter(isSpawnEnergySink));
-  if (spawn) {
-    return spawn;
-  }
-  return selectClosestEnergySink(creep, energySinks.filter(isExtensionEnergySink));
-}
-function isSpawnEnergySink(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn");
-}
-function isExtensionEnergySink(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension");
-}
-function selectClosestEnergySink(creep, energySinks) {
-  var _a;
-  if (energySinks.length === 0) {
-    return null;
-  }
-  const energySinksByStableId = [...energySinks].sort(compareEnergySinkId);
-  const position = creep.pos;
-  if (typeof (position == null ? void 0 : position.getRangeTo) === "function") {
-    return energySinksByStableId.reduce((closest, candidate) => {
-      var _a2, _b, _c, _d;
-      const closestRange = (_b = (_a2 = position.getRangeTo) == null ? void 0 : _a2.call(position, closest)) != null ? _b : Infinity;
-      const candidateRange = (_d = (_c = position.getRangeTo) == null ? void 0 : _c.call(position, candidate)) != null ? _d : Infinity;
-      return candidateRange < closestRange || candidateRange === closestRange && compareEnergySinkId(candidate, closest) < 0 ? candidate : closest;
-    });
-  }
-  if (typeof (position == null ? void 0 : position.findClosestByRange) === "function") {
-    return (_a = position.findClosestByRange(energySinksByStableId)) != null ? _a : energySinksByStableId[0];
-  }
-  return energySinksByStableId[0];
-}
-function compareEnergySinkId(left, right) {
-  return String(left.id).localeCompare(String(right.id));
-}
-function isSpawnConstructionSite(site) {
-  return matchesStructureType2(site.structureType, "STRUCTURE_SPAWN", "spawn");
-}
-function isExtensionConstructionSite(site) {
-  return matchesStructureType2(site.structureType, "STRUCTURE_EXTENSION", "extension");
-}
-function isRoadOrContainerConstructionSite(site) {
-  return matchesStructureType2(site.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType2(site.structureType, "STRUCTURE_CONTAINER", "container");
-}
-function matchesStructureType2(actual, globalName, fallback) {
-  var _a;
-  const constants = globalThis;
-  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
-}
-function selectStoredEnergySource(creep) {
-  const context = {
-    creepOwnerUsername: getCreepOwnerUsername(creep),
-    hasHostilePresence: hasVisibleHostilePresence(creep.room),
-    room: creep.room
-  };
-  const storedEnergySources = findVisibleRoomStructures(creep.room).filter(
-    (structure) => isSafeStoredEnergySource(structure, context)
-  );
-  if (storedEnergySources.length === 0) {
-    return null;
-  }
-  const scoredStoredEnergy = scoreStoredEnergySources(creep, storedEnergySources);
-  if (scoredStoredEnergy.length > 0) {
-    return scoredStoredEnergy.sort(compareStoredEnergySourceScores)[0].source;
-  }
-  const closestStoredEnergy = findClosestByRange(creep, storedEnergySources);
-  return closestStoredEnergy != null ? closestStoredEnergy : storedEnergySources[0];
-}
-function scoreStoredEnergySources(creep, sources) {
-  const position = creep.pos;
-  if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
-    return [];
-  }
-  return sources.map((source) => {
-    var _a, _b;
-    const energy = getStoredEnergy(source);
-    const range = Math.max(0, (_b = (_a = position.getRangeTo) == null ? void 0 : _a.call(position, source)) != null ? _b : 0);
-    return {
-      energy,
-      range,
-      score: energy - range * ENERGY_ACQUISITION_RANGE_COST,
-      source
-    };
-  });
-}
-function compareStoredEnergySourceScores(left, right) {
-  return right.score - left.score || left.range - right.range || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id));
-}
-function isSafeStoredEnergySource(structure, context) {
-  return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, context);
-}
-function isStoredWorkerEnergySource(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType2(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType2(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
-}
-function hasStoredEnergy(structure) {
-  return getStoredEnergy(structure) > 0;
-}
-function isFriendlyStoredEnergySource(structure, context) {
-  var _a;
-  const ownership = structure.my;
-  if (typeof ownership === "boolean") {
-    return ownership;
-  }
-  if (((_a = context.room.controller) == null ? void 0 : _a.my) === true) {
-    return true;
-  }
-  return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
-}
-function isRoomSafeForUnownedContainerWithdrawal(context) {
-  var _a;
-  if (context.hasHostilePresence) {
-    return false;
-  }
-  const controller = context.room.controller;
-  if (!controller) {
-    return true;
-  }
-  if (controller.owner != null) {
-    return false;
-  }
-  const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  if (reservationUsername == null) {
-    return true;
-  }
-  return reservationUsername === context.creepOwnerUsername;
-}
-function selectWorkerEnergyAcquisitionTask(creep) {
-  const candidates = findWorkerEnergyAcquisitionCandidates(creep);
-  if (candidates.length === 0) {
-    return null;
-  }
-  return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
-}
-function findWorkerEnergyAcquisitionCandidates(creep) {
-  const context = {
-    creepOwnerUsername: getCreepOwnerUsername(creep),
-    hasHostilePresence: hasVisibleHostilePresence(creep.room),
-    room: creep.room
-  };
-  const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).map(
-    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
-      type: "withdraw",
-      targetId: source.id
-    })
-  );
-  const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).map(
-    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
-      type: "withdraw",
-      targetId: source.id
-    })
-  );
-  const droppedEnergyCandidates = findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).map(
-    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
-      type: "pickup",
-      targetId: source.id
-    })
-  );
-  return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
-}
-function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
-  const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
-  return {
-    energy,
-    range,
-    score: range === null ? energy : energy - range * ENERGY_ACQUISITION_RANGE_COST,
-    source,
-    task
-  };
-}
-function getRangeToWorkerEnergyAcquisitionSource(creep, source) {
-  const position = creep.pos;
-  if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
-    return null;
-  }
-  const range = position.getRangeTo(source);
-  return Number.isFinite(range) ? Math.max(0, range) : null;
-}
-function compareWorkerEnergyAcquisitionCandidates(left, right) {
-  return right.score - left.score || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
-}
-function compareOptionalRanges(left, right) {
-  if (left !== null && right !== null) {
-    return left - right;
-  }
-  if (left !== null) {
-    return -1;
-  }
-  if (right !== null) {
-    return 1;
-  }
-  return 0;
-}
-function selectSalvageEnergySource(creep) {
-  const salvageEnergySources = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy);
-  if (salvageEnergySources.length === 0) {
-    return null;
-  }
-  const closestSalvageEnergy = findClosestByRange(creep, salvageEnergySources);
-  return closestSalvageEnergy != null ? closestSalvageEnergy : salvageEnergySources[0];
-}
-function findTombstones(room) {
-  if (typeof FIND_TOMBSTONES !== "number") {
-    return [];
-  }
-  return room.find(FIND_TOMBSTONES);
-}
-function findRuins(room) {
-  if (typeof FIND_RUINS !== "number") {
-    return [];
-  }
-  return room.find(FIND_RUINS);
-}
-function hasSalvageableEnergy(source) {
-  return getStoredEnergy(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
-}
-function getCreepOwnerUsername(creep) {
-  var _a;
-  const username = (_a = creep.owner) == null ? void 0 : _a.username;
-  return typeof username === "string" && username.length > 0 ? username : null;
-}
-function hasVisibleHostilePresence(room) {
-  return findHostileCreeps(room).length > 0 || findHostileStructures(room).length > 0;
-}
-function findHostileCreeps(room) {
-  return typeof FIND_HOSTILE_CREEPS === "number" ? room.find(FIND_HOSTILE_CREEPS) : [];
-}
-function findHostileStructures(room) {
-  return typeof FIND_HOSTILE_STRUCTURES === "number" ? room.find(FIND_HOSTILE_STRUCTURES) : [];
-}
-function selectRepairTarget(creep) {
-  var _a;
-  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
-    return null;
-  }
-  const repairTargets = findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget);
-  if (repairTargets.length === 0) {
-    return null;
-  }
-  return repairTargets.sort(compareRepairTargets)[0];
-}
-function selectCriticalInfrastructureRepairTarget(creep) {
-  var _a;
-  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
-    return null;
-  }
-  const repairTargets = findVisibleRoomStructures(creep.room).filter(isCriticalInfrastructureRepairTarget);
-  if (repairTargets.length === 0) {
-    return null;
-  }
-  return repairTargets.sort(compareRepairTargets)[0];
-}
-function findVisibleRoomStructures(room) {
-  if (typeof FIND_STRUCTURES !== "number") {
-    return [];
-  }
-  return room.find(FIND_STRUCTURES);
-}
-function isSafeRepairTarget(structure) {
-  if (isWorkerRepairTargetComplete(structure)) {
-    return false;
-  }
-  if (isRoadOrContainerRepairTarget(structure)) {
-    return true;
-  }
-  return matchesStructureType2(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
-}
-function isCriticalInfrastructureRepairTarget(structure) {
-  return isSafeRepairTarget(structure) && isRoadOrContainerRepairTarget(structure) && getHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO;
-}
-function isRoadOrContainerRepairTarget(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container");
-}
-function isWorkerRepairTargetComplete(structure) {
-  return structure.hits >= getWorkerRepairHitsCeiling(structure);
-}
-function getWorkerRepairHitsCeiling(structure) {
-  if (matchesStructureType2(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
-    return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING);
-  }
-  return structure.hitsMax;
-}
-function isOwnedRampart(structure) {
-  return structure.my === true;
-}
-function compareRepairTargets(left, right) {
-  return getRepairPriority(left) - getRepairPriority(right) || getHitsRatio(left) - getHitsRatio(right) || left.hits - right.hits || String(left.id).localeCompare(String(right.id));
-}
-function getRepairPriority(structure) {
-  if (matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road")) {
-    return 0;
-  }
-  if (matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
-    return 1;
-  }
-  return 2;
-}
-function getHitsRatio(structure) {
-  return structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
-}
-function shouldGuardControllerDowngrade(controller) {
-  return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
-}
-function shouldRushRcl1Controller(controller) {
-  return controller.my === true && controller.level === 1;
-}
-function shouldSustainControllerProgress(creep, controller) {
-  if (controller.my !== true || controller.level < 2) {
-    return false;
-  }
-  const loadedWorkers = getSameRoomLoadedWorkers(creep);
-  return loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS && !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller));
-}
-function shouldUseSurplusForControllerProgress(creep, controller) {
-  if (shouldSustainControllerProgress(creep, controller)) {
-    return true;
-  }
-  return controller.my === true && controller.level >= 2 && hasWithdrawableSurplusEnergy(creep);
-}
-function hasWithdrawableSurplusEnergy(creep) {
-  return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null;
-}
-function getSameRoomLoadedWorkers(creep) {
-  const loadedWorkers = getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
-  if (!loadedWorkers.includes(creep) && getUsedEnergy(creep) > 0) {
-    loadedWorkers.push(creep);
-  }
-  return loadedWorkers;
-}
-function isSameRoomWorkerWithEnergy(creep, room) {
-  var _a;
-  return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom(creep, room) && getUsedEnergy(creep) > 0;
-}
-function isInRoom(creep, room) {
-  var _a;
-  if (typeof room.name === "string" && room.name.length > 0) {
-    return ((_a = creep.room) == null ? void 0 : _a.name) === room.name;
-  }
-  return creep.room === room;
-}
-function getUsedEnergy(creep) {
-  return getStoredEnergy(creep);
-}
-function getFreeEnergyCapacity(creep) {
-  return getFreeStoredEnergyCapacity(creep);
-}
-function getStoredEnergy(object) {
-  var _a;
-  const store = getStore(object);
-  if (!store) {
-    return 0;
-  }
-  const usedCapacity = (_a = store.getUsedCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
-  if (typeof usedCapacity === "number") {
-    return usedCapacity;
-  }
-  const storedEnergy = store[getWorkerEnergyResource()];
-  return typeof storedEnergy === "number" ? storedEnergy : 0;
-}
-function getFreeStoredEnergyCapacity(object) {
-  var _a;
-  const store = getStore(object);
-  if (!store) {
-    return 0;
-  }
-  const freeCapacity = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
-  return typeof freeCapacity === "number" ? freeCapacity : 0;
-}
-function getStore(object) {
-  if (!isWorkerTaskRecord(object) || !isWorkerTaskRecord(object.store)) {
-    return null;
-  }
-  return object.store;
-}
-function getWorkerEnergyResource() {
-  const value = globalThis.RESOURCE_ENERGY;
-  return typeof value === "string" ? value : "energy";
-}
-function isWorkerTaskRecord(value) {
-  return typeof value === "object" && value !== null;
-}
-function isUpgradingController(creep, controller) {
-  var _a;
-  const task = (_a = creep.memory) == null ? void 0 : _a.task;
-  return (task == null ? void 0 : task.type) === "upgrade" && task.targetId === controller.id;
-}
-function findDroppedResources(room) {
-  if (typeof FIND_DROPPED_RESOURCES !== "number") {
-    return [];
-  }
-  return room.find(FIND_DROPPED_RESOURCES);
-}
-function isUsefulDroppedEnergy(resource) {
-  return resource.resourceType === getWorkerEnergyResource() && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
-}
-function findClosestByRange(creep, objects) {
-  if (objects.length === 0) {
-    return null;
-  }
-  const position = creep.pos;
-  if (typeof (position == null ? void 0 : position.getRangeTo) === "function") {
-    return objects.reduce((closest, candidate) => {
-      var _a, _b, _c, _d;
-      const closestRange = (_b = (_a = position.getRangeTo) == null ? void 0 : _a.call(position, closest)) != null ? _b : Infinity;
-      const candidateRange = (_d = (_c = position.getRangeTo) == null ? void 0 : _c.call(position, candidate)) != null ? _d : Infinity;
-      return candidateRange < closestRange ? candidate : closest;
-    });
-  }
-  return typeof (position == null ? void 0 : position.findClosestByRange) === "function" ? position.findClosestByRange(objects) : null;
-}
-function selectHarvestSource(creep) {
-  var _a, _b;
-  const sources = creep.room.find(FIND_SOURCES);
-  if (sources.length === 0) {
-    return null;
-  }
-  const viableSources = selectViableHarvestSources(sources);
-  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
-  let selectedSource = viableSources[0];
-  let selectedCount = (_a = assignmentCounts.get(selectedSource.id)) != null ? _a : 0;
-  for (const source of viableSources.slice(1)) {
-    const count = (_b = assignmentCounts.get(source.id)) != null ? _b : 0;
-    if (count < selectedCount) {
-      selectedSource = source;
-      selectedCount = count;
-    }
-  }
-  return selectedSource;
-}
-function selectViableHarvestSources(sources) {
-  const sourcesWithEnergy = sources.filter((source) => typeof source.energy === "number" && source.energy > 0);
-  return sourcesWithEnergy.length > 0 ? sourcesWithEnergy : sources;
-}
-function countSameRoomWorkerHarvestAssignments(roomName, sources) {
-  var _a, _b, _c, _d;
-  const assignmentCounts = /* @__PURE__ */ new Map();
-  for (const source of sources) {
-    assignmentCounts.set(source.id, 0);
-  }
-  if (!roomName) {
-    return assignmentCounts;
-  }
-  const sourceIds = new Set(sources.map((source) => source.id));
-  for (const assignedCreep of getGameCreeps()) {
-    const task = (_a = assignedCreep.memory) == null ? void 0 : _a.task;
-    const targetId = typeof (task == null ? void 0 : task.targetId) === "string" ? task.targetId : void 0;
-    if (((_b = assignedCreep.memory) == null ? void 0 : _b.role) !== "worker" || ((_c = assignedCreep.room) == null ? void 0 : _c.name) !== roomName || (task == null ? void 0 : task.type) !== "harvest" || !targetId || !sourceIds.has(targetId)) {
-      continue;
-    }
-    const sourceId = targetId;
-    assignmentCounts.set(sourceId, ((_d = assignmentCounts.get(sourceId)) != null ? _d : 0) + 1);
-  }
-  return assignmentCounts;
-}
-function getGameCreeps() {
-  var _a;
-  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  return creeps ? Object.values(creeps) : [];
-}
-
-// src/creeps/workerRunner.ts
-function runWorker(creep) {
-  if (!creep.memory.task) {
-    assignNextTask(creep);
-    return;
-  }
-  if (shouldReplaceTask(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  const task = creep.memory.task;
-  const target = Game.getObjectById(task.targetId);
-  if (!target) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  if (shouldReplaceTarget(task, target)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  const result = executeTask(creep, task, target);
-  if (task.type === "transfer" && result === ERR_FULL) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  if (result === ERR_NOT_IN_RANGE) {
-    creep.moveTo(target);
-  }
-}
-function assignNextTask(creep) {
-  const task = selectWorkerTask(creep);
-  if (task) {
-    creep.memory.task = task;
-  }
-}
-function shouldReplaceTask(creep, task) {
-  var _a, _b;
-  if (!((_a = creep.store) == null ? void 0 : _a.getUsedCapacity) || !((_b = creep.store) == null ? void 0 : _b.getFreeCapacity)) {
-    return false;
-  }
-  const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
-  const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
-  if (task.type === "harvest" || task.type === "pickup" || task.type === "withdraw") {
-    return freeEnergyCapacity === 0;
-  }
-  return usedEnergy === 0;
-}
-function shouldPreemptUpgradeTask(creep, task) {
-  var _a;
-  if (task.type !== "upgrade") {
-    return false;
-  }
-  const controller = (_a = creep.room) == null ? void 0 : _a.controller;
-  if ((controller == null ? void 0 : controller.my) !== true) {
-    return false;
-  }
-  const nextTask = selectWorkerTask(creep);
-  if (nextTask === null || nextTask.type === task.type && nextTask.targetId === task.targetId) {
-    return false;
-  }
-  return true;
-}
-function shouldReplaceTarget(task, target) {
-  var _a;
-  if (task.type === "transfer" && "store" in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
-    return true;
-  }
-  if (task.type === "withdraw" && "store" in target && ((_a = target.store.getUsedCapacity(RESOURCE_ENERGY)) != null ? _a : 0) === 0) {
-    return true;
-  }
-  return task.type === "repair" && "hits" in target && isWorkerRepairTargetComplete(target);
-}
-function executeTask(creep, task, target) {
-  switch (task.type) {
-    case "harvest":
-      return creep.harvest(target);
-    case "pickup":
-      return creep.pickup(target);
-    case "withdraw":
-      return creep.withdraw(target, RESOURCE_ENERGY);
-    case "transfer":
-      return creep.transfer(target, RESOURCE_ENERGY);
-    case "build":
-      return creep.build(target);
-    case "repair":
-      return creep.repair(target);
-    case "upgrade":
-      return creep.upgradeController(target);
-  }
-}
-
 // src/spawn/bodyBuilder.ts
 var WORKER_PATTERN = ["work", "carry", "move"];
 var WORKER_PATTERN_COST = 200;
@@ -1237,6 +608,57 @@ function buildTerritoryCreepMemory(plan) {
       ...plan.controllerId ? { controllerId: plan.controllerId } : {}
     }
   };
+}
+function selectVisibleTerritoryControllerTask(creep) {
+  const intent = selectVisibleTerritoryControllerIntent(creep);
+  if (!intent) {
+    return null;
+  }
+  const controller = selectCreepRoomController(creep, intent.controllerId);
+  if (!controller) {
+    return null;
+  }
+  if (intent.action === "reserve") {
+    return canUseControllerClaimPart(creep) ? { type: "reserve", targetId: controller.id } : null;
+  }
+  if (controller.my === true) {
+    return getStoredEnergy(creep) > 0 ? { type: "upgrade", targetId: controller.id } : null;
+  }
+  return canUseControllerClaimPart(creep) ? { type: "claim", targetId: controller.id } : null;
+}
+function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
+  if (!isNonEmptyString(assignment.targetRoom)) {
+    return false;
+  }
+  if (isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
+    return false;
+  }
+  if (assignment.action === "scout") {
+    return true;
+  }
+  if (!isTerritoryControlAction(assignment.action)) {
+    return false;
+  }
+  if (isNonEmptyString(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
+    return false;
+  }
+  const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
+  if (!controller) {
+    return !isVisibleRoomMissingController(assignment.targetRoom);
+  }
+  if (assignment.action === "claim" && controller.my === true) {
+    return false;
+  }
+  const actorUsername = getTerritoryActorUsername(creep, colony);
+  const targetState = getTerritoryControllerTargetState(controller, assignment.action, actorUsername);
+  return targetState === "available" || assignment.action === "reserve" && targetState === "satisfied";
+}
+function isVisibleTerritoryAssignmentComplete(assignment, creep) {
+  if (assignment.action !== "claim" || !isNonEmptyString(assignment.targetRoom)) {
+    return false;
+  }
+  const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
+  return (controller == null ? void 0 : controller.my) === true;
 }
 function suppressTerritoryIntent(colony, assignment, gameTime) {
   if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || !isTerritoryIntentAction(assignment.action)) {
@@ -1357,6 +779,9 @@ function selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryM
   return null;
 }
 function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
+  if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
+    return "unavailable";
+  }
   if (isVisibleRoomMissingController(targetRoom)) {
     return "unavailable";
   }
@@ -1481,7 +906,7 @@ function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, actio
     (intent) => isTerritorySuppressionFresh(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
-function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime) {
+function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime()) {
   const territoryMemory = getTerritoryMemoryRecord();
   if (!territoryMemory) {
     return false;
@@ -1493,18 +918,163 @@ function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime) {
 function isTerritorySuppressionFresh(intent, gameTime) {
   return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
 }
+function selectVisibleTerritoryControllerIntent(creep) {
+  var _a, _b, _c;
+  const roomName = (_a = creep.room) == null ? void 0 : _a.name;
+  if (!isNonEmptyString(roomName) || isVisibleRoomUnsafe(creep.room)) {
+    return null;
+  }
+  const assignmentIntent = normalizeCreepTerritoryIntent(creep, roomName);
+  if (assignmentIntent && isCreepVisibleTerritoryIntentActionable(creep, assignmentIntent)) {
+    return assignmentIntent;
+  }
+  const territoryMemory = getTerritoryMemoryRecord();
+  const colony = (_b = creep.memory) == null ? void 0 : _b.colony;
+  const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents).filter((intent) => isActiveVisibleControllerIntentForCreep(intent, roomName, colony)).sort(compareVisibleControllerIntents);
+  return (_c = intents.find((intent) => isCreepVisibleTerritoryIntentActionable(creep, intent))) != null ? _c : null;
+}
+function normalizeCreepTerritoryIntent(creep, roomName) {
+  var _a, _b, _c, _d;
+  const assignment = (_a = creep.memory) == null ? void 0 : _a.territory;
+  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction(assignment.action) || isNonEmptyString((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
+    return null;
+  }
+  return {
+    colony: (_d = (_c = creep.memory) == null ? void 0 : _c.colony) != null ? _d : "",
+    targetRoom: assignment.targetRoom,
+    action: assignment.action,
+    status: "active",
+    updatedAt: getGameTime(),
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
+  };
+}
+function isActiveVisibleControllerIntentForCreep(intent, roomName, creepColony) {
+  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString(creepColony) || intent.colony === creepColony);
+}
+function compareVisibleControllerIntents(left, right) {
+  return getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) || getIntentActionPriority(left.action) - getIntentActionPriority(right.action) || right.updatedAt - left.updatedAt || left.colony.localeCompare(right.colony);
+}
+function getIntentStatusPriority(status) {
+  return status === "active" ? 0 : 1;
+}
+function getIntentActionPriority(action) {
+  return action === "claim" ? 0 : 1;
+}
+function isCreepVisibleTerritoryIntentActionable(creep, intent) {
+  if (!isTerritoryControlAction(intent.action)) {
+    return false;
+  }
+  const controller = selectCreepRoomController(creep, intent.controllerId);
+  if (!controller) {
+    return false;
+  }
+  if (!isVisibleRoomSafe(creep.room)) {
+    return false;
+  }
+  if (intent.action === "claim" && controller.my === true) {
+    return true;
+  }
+  return getTerritoryControllerTargetState(controller, intent.action, getTerritoryActorUsername(creep, intent.colony)) === "available";
+}
+function selectVisibleTerritoryAssignmentController(assignment, creep) {
+  var _a;
+  return ((_a = creep == null ? void 0 : creep.room) == null ? void 0 : _a.name) === assignment.targetRoom ? selectCreepRoomController(creep, assignment.controllerId) : getVisibleController(assignment.targetRoom, assignment.controllerId);
+}
+function selectCreepRoomController(creep, controllerId) {
+  var _a;
+  const roomController = (_a = creep.room) == null ? void 0 : _a.controller;
+  if (!controllerId) {
+    return roomController != null ? roomController : null;
+  }
+  if ((roomController == null ? void 0 : roomController.id) === controllerId) {
+    return roomController;
+  }
+  const game = globalThis.Game;
+  const getObjectById = game == null ? void 0 : game.getObjectById;
+  if (typeof getObjectById !== "function") {
+    return null;
+  }
+  return getObjectById.call(game, controllerId);
+}
+function getTerritoryControllerTargetState(controller, action, colonyOwnerUsername) {
+  if (action === "reserve") {
+    return getReserveControllerTargetState(controller, colonyOwnerUsername);
+  }
+  return isControllerOwned(controller) ? "unavailable" : "available";
+}
+function getTerritoryActorUsername(creep, colony) {
+  var _a;
+  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString(colony) ? getVisibleColonyOwnerUsername(colony) : null;
+}
+function getCreepOwnerUsername(creep) {
+  var _a;
+  const username = (_a = creep == null ? void 0 : creep.owner) == null ? void 0 : _a.username;
+  return isNonEmptyString(username) ? username : null;
+}
+function canUseControllerClaimPart(creep) {
+  var _a;
+  const claimPart = getBodyPartConstant("CLAIM", "claim");
+  const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
+  if (typeof activeClaimParts === "number") {
+    return activeClaimParts > 0;
+  }
+  return Array.isArray(creep.body) && creep.body.some((part) => part.type === claimPart && part.hits > 0);
+}
+function getBodyPartConstant(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function getStoredEnergy(object) {
+  var _a;
+  const store = object == null ? void 0 : object.store;
+  const energyResource = getEnergyResource();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, energyResource);
+  if (typeof usedCapacity === "number") {
+    return usedCapacity;
+  }
+  const storedEnergy = store == null ? void 0 : store[energyResource];
+  return typeof storedEnergy === "number" ? storedEnergy : 0;
+}
+function getEnergyResource() {
+  const resource = globalThis.RESOURCE_ENERGY;
+  return typeof resource === "string" ? resource : "energy";
+}
+function isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom) {
+  var _a, _b;
+  const room = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[targetRoom];
+  return room ? isVisibleRoomUnsafe(room) : false;
+}
+function isVisibleRoomSafe(room) {
+  return !isVisibleRoomUnsafe(room);
+}
+function isVisibleRoomUnsafe(room) {
+  return findVisibleHostileCreeps(room).length > 0 || findVisibleHostileStructures(room).length > 0;
+}
+function findVisibleHostileCreeps(room) {
+  return typeof FIND_HOSTILE_CREEPS === "number" && typeof room.find === "function" ? room.find(FIND_HOSTILE_CREEPS) : [];
+}
+function findVisibleHostileStructures(room) {
+  return typeof FIND_HOSTILE_STRUCTURES === "number" && typeof room.find === "function" ? room.find(FIND_HOSTILE_STRUCTURES) : [];
+}
 function getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) {
+  if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
+    return "unavailable";
+  }
   if (isVisibleRoomMissingController(targetRoom)) {
     return "unavailable";
+  }
+  if (action === "scout") {
+    return isVisibleRoomKnown(targetRoom) ? "unavailable" : "available";
   }
   const controller = getVisibleController(targetRoom, controllerId);
   if (!controller) {
     return "available";
   }
   if (action === "reserve") {
-    return getReserveControllerTargetState(controller, colonyOwnerUsername != null ? colonyOwnerUsername : null);
+    return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername != null ? colonyOwnerUsername : null);
   }
-  return isControllerOwned(controller) ? "unavailable" : "available";
+  return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername != null ? colonyOwnerUsername : null);
 }
 function isVisibleRoomKnown(targetRoom) {
   var _a;
@@ -1609,6 +1179,674 @@ function isNonEmptyString(value) {
 }
 function isRecord(value) {
   return typeof value === "object" && value !== null;
+}
+
+// src/tasks/workerTasks.ts
+var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
+var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
+var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
+var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
+var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
+var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
+var ENERGY_ACQUISITION_RANGE_COST = 50;
+function selectWorkerTask(creep) {
+  const carriedEnergy = getUsedEnergy(creep);
+  const territoryControllerTask = selectVisibleTerritoryControllerTask(creep);
+  if (carriedEnergy === 0) {
+    if (isTerritoryControlTask(territoryControllerTask)) {
+      return territoryControllerTask;
+    }
+    if (getFreeEnergyCapacity(creep) > 0) {
+      const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
+      if (energyAcquisitionTask) {
+        return energyAcquisitionTask;
+      }
+    }
+    const source = selectHarvestSource(creep);
+    return source ? { type: "harvest", targetId: source.id } : null;
+  }
+  const energySink = selectFillableEnergySink(creep);
+  if (energySink) {
+    return { type: "transfer", targetId: energySink.id };
+  }
+  const controller = creep.room.controller;
+  if (controller && shouldGuardControllerDowngrade(controller)) {
+    return { type: "upgrade", targetId: controller.id };
+  }
+  if (territoryControllerTask) {
+    return territoryControllerTask;
+  }
+  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
+  const spawnConstructionSite = constructionSites.find(isSpawnConstructionSite);
+  if (spawnConstructionSite) {
+    return { type: "build", targetId: spawnConstructionSite.id };
+  }
+  if (controller && shouldRushRcl1Controller(controller)) {
+    return { type: "upgrade", targetId: controller.id };
+  }
+  const extensionConstructionSite = constructionSites.find(isExtensionConstructionSite);
+  if (extensionConstructionSite) {
+    return { type: "build", targetId: extensionConstructionSite.id };
+  }
+  const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
+  if (criticalRepairTarget) {
+    return { type: "repair", targetId: criticalRepairTarget.id };
+  }
+  const roadOrContainerConstructionSite = constructionSites.find(isRoadOrContainerConstructionSite);
+  if (roadOrContainerConstructionSite) {
+    return { type: "build", targetId: roadOrContainerConstructionSite.id };
+  }
+  if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
+    return { type: "upgrade", targetId: controller.id };
+  }
+  if (constructionSites[0]) {
+    return { type: "build", targetId: constructionSites[0].id };
+  }
+  const repairTarget = selectRepairTarget(creep);
+  if (repairTarget) {
+    return { type: "repair", targetId: repairTarget.id };
+  }
+  if (controller == null ? void 0 : controller.my) {
+    return { type: "upgrade", targetId: controller.id };
+  }
+  return null;
+}
+function isTerritoryControlTask(task) {
+  return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
+}
+function isFillableEnergySink(structure) {
+  return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
+}
+function selectFillableEnergySink(creep) {
+  const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
+    filter: isFillableEnergySink
+  });
+  const spawn = selectClosestEnergySink(creep, energySinks.filter(isSpawnEnergySink));
+  if (spawn) {
+    return spawn;
+  }
+  return selectClosestEnergySink(creep, energySinks.filter(isExtensionEnergySink));
+}
+function isSpawnEnergySink(structure) {
+  return matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+}
+function isExtensionEnergySink(structure) {
+  return matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension");
+}
+function selectClosestEnergySink(creep, energySinks) {
+  var _a;
+  if (energySinks.length === 0) {
+    return null;
+  }
+  const energySinksByStableId = [...energySinks].sort(compareEnergySinkId);
+  const position = creep.pos;
+  if (typeof (position == null ? void 0 : position.getRangeTo) === "function") {
+    return energySinksByStableId.reduce((closest, candidate) => {
+      var _a2, _b, _c, _d;
+      const closestRange = (_b = (_a2 = position.getRangeTo) == null ? void 0 : _a2.call(position, closest)) != null ? _b : Infinity;
+      const candidateRange = (_d = (_c = position.getRangeTo) == null ? void 0 : _c.call(position, candidate)) != null ? _d : Infinity;
+      return candidateRange < closestRange || candidateRange === closestRange && compareEnergySinkId(candidate, closest) < 0 ? candidate : closest;
+    });
+  }
+  if (typeof (position == null ? void 0 : position.findClosestByRange) === "function") {
+    return (_a = position.findClosestByRange(energySinksByStableId)) != null ? _a : energySinksByStableId[0];
+  }
+  return energySinksByStableId[0];
+}
+function compareEnergySinkId(left, right) {
+  return String(left.id).localeCompare(String(right.id));
+}
+function isSpawnConstructionSite(site) {
+  return matchesStructureType2(site.structureType, "STRUCTURE_SPAWN", "spawn");
+}
+function isExtensionConstructionSite(site) {
+  return matchesStructureType2(site.structureType, "STRUCTURE_EXTENSION", "extension");
+}
+function isRoadOrContainerConstructionSite(site) {
+  return matchesStructureType2(site.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType2(site.structureType, "STRUCTURE_CONTAINER", "container");
+}
+function matchesStructureType2(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+function selectStoredEnergySource(creep) {
+  const context = {
+    creepOwnerUsername: getCreepOwnerUsername2(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const storedEnergySources = findVisibleRoomStructures(creep.room).filter(
+    (structure) => isSafeStoredEnergySource(structure, context)
+  );
+  if (storedEnergySources.length === 0) {
+    return null;
+  }
+  const scoredStoredEnergy = scoreStoredEnergySources(creep, storedEnergySources);
+  if (scoredStoredEnergy.length > 0) {
+    return scoredStoredEnergy.sort(compareStoredEnergySourceScores)[0].source;
+  }
+  const closestStoredEnergy = findClosestByRange(creep, storedEnergySources);
+  return closestStoredEnergy != null ? closestStoredEnergy : storedEnergySources[0];
+}
+function scoreStoredEnergySources(creep, sources) {
+  const position = creep.pos;
+  if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
+    return [];
+  }
+  return sources.map((source) => {
+    var _a, _b;
+    const energy = getStoredEnergy2(source);
+    const range = Math.max(0, (_b = (_a = position.getRangeTo) == null ? void 0 : _a.call(position, source)) != null ? _b : 0);
+    return {
+      energy,
+      range,
+      score: energy - range * ENERGY_ACQUISITION_RANGE_COST,
+      source
+    };
+  });
+}
+function compareStoredEnergySourceScores(left, right) {
+  return right.score - left.score || left.range - right.range || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id));
+}
+function isSafeStoredEnergySource(structure, context) {
+  return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, context);
+}
+function isStoredWorkerEnergySource(structure) {
+  return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType2(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType2(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
+}
+function hasStoredEnergy(structure) {
+  return getStoredEnergy2(structure) > 0;
+}
+function isFriendlyStoredEnergySource(structure, context) {
+  var _a;
+  const ownership = structure.my;
+  if (typeof ownership === "boolean") {
+    return ownership;
+  }
+  if (((_a = context.room.controller) == null ? void 0 : _a.my) === true) {
+    return true;
+  }
+  return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
+}
+function isRoomSafeForUnownedContainerWithdrawal(context) {
+  var _a;
+  if (context.hasHostilePresence) {
+    return false;
+  }
+  const controller = context.room.controller;
+  if (!controller) {
+    return true;
+  }
+  if (controller.owner != null) {
+    return false;
+  }
+  const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
+  if (reservationUsername == null) {
+    return true;
+  }
+  return reservationUsername === context.creepOwnerUsername;
+}
+function selectWorkerEnergyAcquisitionTask(creep) {
+  const candidates = findWorkerEnergyAcquisitionCandidates(creep);
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+function findWorkerEnergyAcquisitionCandidates(creep) {
+  const context = {
+    creepOwnerUsername: getCreepOwnerUsername2(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).map(
+    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
+      type: "withdraw",
+      targetId: source.id
+    })
+  );
+  const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).map(
+    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
+      type: "withdraw",
+      targetId: source.id
+    })
+  );
+  const droppedEnergyCandidates = findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).map(
+    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
+      type: "pickup",
+      targetId: source.id
+    })
+  );
+  return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
+}
+function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
+  const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
+  return {
+    energy,
+    range,
+    score: range === null ? energy : energy - range * ENERGY_ACQUISITION_RANGE_COST,
+    source,
+    task
+  };
+}
+function getRangeToWorkerEnergyAcquisitionSource(creep, source) {
+  const position = creep.pos;
+  if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
+    return null;
+  }
+  const range = position.getRangeTo(source);
+  return Number.isFinite(range) ? Math.max(0, range) : null;
+}
+function compareWorkerEnergyAcquisitionCandidates(left, right) {
+  return right.score - left.score || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
+}
+function compareOptionalRanges(left, right) {
+  if (left !== null && right !== null) {
+    return left - right;
+  }
+  if (left !== null) {
+    return -1;
+  }
+  if (right !== null) {
+    return 1;
+  }
+  return 0;
+}
+function selectSalvageEnergySource(creep) {
+  const salvageEnergySources = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy);
+  if (salvageEnergySources.length === 0) {
+    return null;
+  }
+  const closestSalvageEnergy = findClosestByRange(creep, salvageEnergySources);
+  return closestSalvageEnergy != null ? closestSalvageEnergy : salvageEnergySources[0];
+}
+function findTombstones(room) {
+  if (typeof FIND_TOMBSTONES !== "number") {
+    return [];
+  }
+  return room.find(FIND_TOMBSTONES);
+}
+function findRuins(room) {
+  if (typeof FIND_RUINS !== "number") {
+    return [];
+  }
+  return room.find(FIND_RUINS);
+}
+function hasSalvageableEnergy(source) {
+  return getStoredEnergy2(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
+}
+function getCreepOwnerUsername2(creep) {
+  var _a;
+  const username = (_a = creep.owner) == null ? void 0 : _a.username;
+  return typeof username === "string" && username.length > 0 ? username : null;
+}
+function hasVisibleHostilePresence(room) {
+  return findHostileCreeps(room).length > 0 || findHostileStructures(room).length > 0;
+}
+function findHostileCreeps(room) {
+  return typeof FIND_HOSTILE_CREEPS === "number" ? room.find(FIND_HOSTILE_CREEPS) : [];
+}
+function findHostileStructures(room) {
+  return typeof FIND_HOSTILE_STRUCTURES === "number" ? room.find(FIND_HOSTILE_STRUCTURES) : [];
+}
+function selectRepairTarget(creep) {
+  var _a;
+  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
+    return null;
+  }
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+function selectCriticalInfrastructureRepairTarget(creep) {
+  var _a;
+  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
+    return null;
+  }
+  const repairTargets = findVisibleRoomStructures(creep.room).filter(isCriticalInfrastructureRepairTarget);
+  if (repairTargets.length === 0) {
+    return null;
+  }
+  return repairTargets.sort(compareRepairTargets)[0];
+}
+function findVisibleRoomStructures(room) {
+  if (typeof FIND_STRUCTURES !== "number") {
+    return [];
+  }
+  return room.find(FIND_STRUCTURES);
+}
+function isSafeRepairTarget(structure) {
+  if (isWorkerRepairTargetComplete(structure)) {
+    return false;
+  }
+  if (isRoadOrContainerRepairTarget(structure)) {
+    return true;
+  }
+  return matchesStructureType2(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+}
+function isCriticalInfrastructureRepairTarget(structure) {
+  return isSafeRepairTarget(structure) && isRoadOrContainerRepairTarget(structure) && getHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO;
+}
+function isRoadOrContainerRepairTarget(structure) {
+  return matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container");
+}
+function isWorkerRepairTargetComplete(structure) {
+  return structure.hits >= getWorkerRepairHitsCeiling(structure);
+}
+function getWorkerRepairHitsCeiling(structure) {
+  if (matchesStructureType2(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
+    return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING);
+  }
+  return structure.hitsMax;
+}
+function isOwnedRampart(structure) {
+  return structure.my === true;
+}
+function compareRepairTargets(left, right) {
+  return getRepairPriority(left) - getRepairPriority(right) || getHitsRatio(left) - getHitsRatio(right) || left.hits - right.hits || String(left.id).localeCompare(String(right.id));
+}
+function getRepairPriority(structure) {
+  if (matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road")) {
+    return 0;
+  }
+  if (matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+    return 1;
+  }
+  return 2;
+}
+function getHitsRatio(structure) {
+  return structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
+}
+function shouldGuardControllerDowngrade(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
+}
+function shouldRushRcl1Controller(controller) {
+  return controller.my === true && controller.level === 1;
+}
+function shouldSustainControllerProgress(creep, controller) {
+  if (controller.my !== true || controller.level < 2) {
+    return false;
+  }
+  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  return loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS && !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller));
+}
+function shouldUseSurplusForControllerProgress(creep, controller) {
+  if (shouldSustainControllerProgress(creep, controller)) {
+    return true;
+  }
+  return controller.my === true && controller.level >= 2 && hasWithdrawableSurplusEnergy(creep);
+}
+function hasWithdrawableSurplusEnergy(creep) {
+  return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null;
+}
+function getSameRoomLoadedWorkers(creep) {
+  const loadedWorkers = getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
+  if (!loadedWorkers.includes(creep) && getUsedEnergy(creep) > 0) {
+    loadedWorkers.push(creep);
+  }
+  return loadedWorkers;
+}
+function isSameRoomWorkerWithEnergy(creep, room) {
+  var _a;
+  return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom(creep, room) && getUsedEnergy(creep) > 0;
+}
+function isInRoom(creep, room) {
+  var _a;
+  if (typeof room.name === "string" && room.name.length > 0) {
+    return ((_a = creep.room) == null ? void 0 : _a.name) === room.name;
+  }
+  return creep.room === room;
+}
+function getUsedEnergy(creep) {
+  return getStoredEnergy2(creep);
+}
+function getFreeEnergyCapacity(creep) {
+  return getFreeStoredEnergyCapacity(creep);
+}
+function getStoredEnergy2(object) {
+  var _a;
+  const store = getStore(object);
+  if (!store) {
+    return 0;
+  }
+  const usedCapacity = (_a = store.getUsedCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
+  if (typeof usedCapacity === "number") {
+    return usedCapacity;
+  }
+  const storedEnergy = store[getWorkerEnergyResource()];
+  return typeof storedEnergy === "number" ? storedEnergy : 0;
+}
+function getFreeStoredEnergyCapacity(object) {
+  var _a;
+  const store = getStore(object);
+  if (!store) {
+    return 0;
+  }
+  const freeCapacity = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
+  return typeof freeCapacity === "number" ? freeCapacity : 0;
+}
+function getStore(object) {
+  if (!isWorkerTaskRecord(object) || !isWorkerTaskRecord(object.store)) {
+    return null;
+  }
+  return object.store;
+}
+function getWorkerEnergyResource() {
+  const value = globalThis.RESOURCE_ENERGY;
+  return typeof value === "string" ? value : "energy";
+}
+function isWorkerTaskRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+function isUpgradingController(creep, controller) {
+  var _a;
+  const task = (_a = creep.memory) == null ? void 0 : _a.task;
+  return (task == null ? void 0 : task.type) === "upgrade" && task.targetId === controller.id;
+}
+function findDroppedResources(room) {
+  if (typeof FIND_DROPPED_RESOURCES !== "number") {
+    return [];
+  }
+  return room.find(FIND_DROPPED_RESOURCES);
+}
+function isUsefulDroppedEnergy(resource) {
+  return resource.resourceType === getWorkerEnergyResource() && resource.amount >= MIN_DROPPED_ENERGY_PICKUP_AMOUNT;
+}
+function findClosestByRange(creep, objects) {
+  if (objects.length === 0) {
+    return null;
+  }
+  const position = creep.pos;
+  if (typeof (position == null ? void 0 : position.getRangeTo) === "function") {
+    return objects.reduce((closest, candidate) => {
+      var _a, _b, _c, _d;
+      const closestRange = (_b = (_a = position.getRangeTo) == null ? void 0 : _a.call(position, closest)) != null ? _b : Infinity;
+      const candidateRange = (_d = (_c = position.getRangeTo) == null ? void 0 : _c.call(position, candidate)) != null ? _d : Infinity;
+      return candidateRange < closestRange ? candidate : closest;
+    });
+  }
+  return typeof (position == null ? void 0 : position.findClosestByRange) === "function" ? position.findClosestByRange(objects) : null;
+}
+function selectHarvestSource(creep) {
+  var _a, _b;
+  const sources = creep.room.find(FIND_SOURCES);
+  if (sources.length === 0) {
+    return null;
+  }
+  const viableSources = selectViableHarvestSources(sources);
+  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
+  let selectedSource = viableSources[0];
+  let selectedCount = (_a = assignmentCounts.get(selectedSource.id)) != null ? _a : 0;
+  for (const source of viableSources.slice(1)) {
+    const count = (_b = assignmentCounts.get(source.id)) != null ? _b : 0;
+    if (count < selectedCount) {
+      selectedSource = source;
+      selectedCount = count;
+    }
+  }
+  return selectedSource;
+}
+function selectViableHarvestSources(sources) {
+  const sourcesWithEnergy = sources.filter((source) => typeof source.energy === "number" && source.energy > 0);
+  return sourcesWithEnergy.length > 0 ? sourcesWithEnergy : sources;
+}
+function countSameRoomWorkerHarvestAssignments(roomName, sources) {
+  var _a, _b, _c, _d;
+  const assignmentCounts = /* @__PURE__ */ new Map();
+  for (const source of sources) {
+    assignmentCounts.set(source.id, 0);
+  }
+  if (!roomName) {
+    return assignmentCounts;
+  }
+  const sourceIds = new Set(sources.map((source) => source.id));
+  for (const assignedCreep of getGameCreeps()) {
+    const task = (_a = assignedCreep.memory) == null ? void 0 : _a.task;
+    const targetId = typeof (task == null ? void 0 : task.targetId) === "string" ? task.targetId : void 0;
+    if (((_b = assignedCreep.memory) == null ? void 0 : _b.role) !== "worker" || ((_c = assignedCreep.room) == null ? void 0 : _c.name) !== roomName || (task == null ? void 0 : task.type) !== "harvest" || !targetId || !sourceIds.has(targetId)) {
+      continue;
+    }
+    const sourceId = targetId;
+    assignmentCounts.set(sourceId, ((_d = assignmentCounts.get(sourceId)) != null ? _d : 0) + 1);
+  }
+  return assignmentCounts;
+}
+function getGameCreeps() {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  return creeps ? Object.values(creeps) : [];
+}
+
+// src/creeps/workerRunner.ts
+function runWorker(creep) {
+  if (!creep.memory.task) {
+    assignNextTask(creep);
+    return;
+  }
+  if (shouldReplaceTask(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+  if (shouldPreemptForVisibleTerritoryControllerTask(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+  if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+  const task = creep.memory.task;
+  const target = Game.getObjectById(task.targetId);
+  if (!target) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+  if (shouldReplaceTarget(task, target)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+  const result = executeTask(creep, task, target);
+  if (task.type === "transfer" && result === ERR_FULL) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+  if (result === ERR_NOT_IN_RANGE) {
+    creep.moveTo(target);
+  }
+}
+function assignNextTask(creep) {
+  const task = selectWorkerTask(creep);
+  if (task) {
+    creep.memory.task = task;
+  }
+}
+function shouldReplaceTask(creep, task) {
+  var _a, _b;
+  if (isTerritoryControlTask2(task)) {
+    return false;
+  }
+  if (!((_a = creep.store) == null ? void 0 : _a.getUsedCapacity) || !((_b = creep.store) == null ? void 0 : _b.getFreeCapacity)) {
+    return false;
+  }
+  const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
+  const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
+  if (task.type === "harvest" || task.type === "pickup" || task.type === "withdraw") {
+    return freeEnergyCapacity === 0;
+  }
+  return usedEnergy === 0;
+}
+function shouldPreemptForVisibleTerritoryControllerTask(creep, task) {
+  const controllerTask = selectVisibleTerritoryControllerTask(creep);
+  if (!controllerTask) {
+    return isTerritoryControlTask2(task);
+  }
+  const selectedTask = selectWorkerTask(creep);
+  if (!selectedTask || !isSameTask(selectedTask, controllerTask)) {
+    return false;
+  }
+  return !isSameTask(task, controllerTask);
+}
+function shouldPreemptUpgradeTask(creep, task) {
+  var _a;
+  if (task.type !== "upgrade") {
+    return false;
+  }
+  const controller = (_a = creep.room) == null ? void 0 : _a.controller;
+  if ((controller == null ? void 0 : controller.my) !== true) {
+    return false;
+  }
+  const nextTask = selectWorkerTask(creep);
+  if (nextTask === null || nextTask.type === task.type && nextTask.targetId === task.targetId) {
+    return false;
+  }
+  return true;
+}
+function isSameTask(left, right) {
+  return left.type === right.type && left.targetId === right.targetId;
+}
+function isTerritoryControlTask2(task) {
+  return task.type === "claim" || task.type === "reserve";
+}
+function shouldReplaceTarget(task, target) {
+  var _a;
+  if (task.type === "transfer" && "store" in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
+    return true;
+  }
+  if (task.type === "withdraw" && "store" in target && ((_a = target.store.getUsedCapacity(RESOURCE_ENERGY)) != null ? _a : 0) === 0) {
+    return true;
+  }
+  return task.type === "repair" && "hits" in target && isWorkerRepairTargetComplete(target);
+}
+function executeTask(creep, task, target) {
+  switch (task.type) {
+    case "harvest":
+      return creep.harvest(target);
+    case "pickup":
+      return creep.pickup(target);
+    case "withdraw":
+      return creep.withdraw(target, RESOURCE_ENERGY);
+    case "transfer":
+      return creep.transfer(target, RESOURCE_ENERGY);
+    case "build":
+      return creep.build(target);
+    case "repair":
+      return creep.repair(target);
+    case "claim":
+      return creep.claimController(target);
+    case "reserve":
+      return creep.reserveController(target);
+    case "upgrade":
+      return creep.upgradeController(target);
+  }
 }
 
 // src/spawn/spawnPlanner.ts
@@ -1927,14 +2165,14 @@ function getEnergyInStore(object) {
   }
   const getUsedCapacity = object.store.getUsedCapacity;
   if (typeof getUsedCapacity === "function") {
-    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource());
+    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource2());
     return typeof usedCapacity === "number" ? usedCapacity : 0;
   }
-  const storedEnergy = object.store[getEnergyResource()];
+  const storedEnergy = object.store[getEnergyResource2()];
   return typeof storedEnergy === "number" ? storedEnergy : 0;
 }
 function sumDroppedEnergy(droppedResources) {
-  const energyResource = getEnergyResource();
+  const energyResource = getEnergyResource2();
   return droppedResources.reduce((total, droppedResource) => {
     if (!isRecord2(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
@@ -1943,7 +2181,7 @@ function sumDroppedEnergy(droppedResources) {
   }, 0);
 }
 function isEnergyEventData(data) {
-  return data.resourceType === void 0 || data.resourceType === getEnergyResource();
+  return data.resourceType === void 0 || data.resourceType === getEnergyResource2();
 }
 function getNumericEventData(data, key) {
   const value = data[key];
@@ -1953,7 +2191,7 @@ function getGlobalNumber(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getEnergyResource() {
+function getEnergyResource2() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
@@ -1995,6 +2233,14 @@ function runTerritoryControllerCreep(creep) {
   if (!isTerritoryAssignment(assignment)) {
     return;
   }
+  if (isVisibleTerritoryAssignmentComplete(assignment, creep)) {
+    completeTerritoryAssignment(creep);
+    return;
+  }
+  if (!isVisibleTerritoryAssignmentSafe(assignment, creep.memory.colony, creep)) {
+    suppressTerritoryAssignment(creep, assignment);
+    return;
+  }
   if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
     moveTowardTargetRoom(creep, assignment.targetRoom);
     return;
@@ -2010,6 +2256,8 @@ function runTerritoryControllerCreep(creep) {
   if (controller.my === true) {
     if (assignment.action === "reserve") {
       suppressTerritoryAssignment(creep, assignment);
+    } else {
+      completeTerritoryAssignment(creep);
     }
     return;
   }
@@ -2024,6 +2272,9 @@ function runTerritoryControllerCreep(creep) {
 }
 function suppressTerritoryAssignment(creep, assignment) {
   suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime3());
+  completeTerritoryAssignment(creep);
+}
+function completeTerritoryAssignment(creep) {
   delete creep.memory.territory;
 }
 function selectTargetController(creep, assignment) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -627,7 +627,6 @@ function selectVisibleTerritoryControllerTask(creep) {
   return canUseControllerClaimPart(creep) ? { type: "claim", targetId: controller.id } : null;
 }
 function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
-  var _a;
   if (!isNonEmptyString(assignment.targetRoom)) {
     return false;
   }
@@ -643,15 +642,22 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   if (isNonEmptyString(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
     return false;
   }
-  const controller = ((_a = creep == null ? void 0 : creep.room) == null ? void 0 : _a.name) === assignment.targetRoom ? selectCreepRoomController(creep, assignment.controllerId) : getVisibleController(assignment.targetRoom, assignment.controllerId);
+  const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
   if (!controller) {
     return !isVisibleRoomMissingController(assignment.targetRoom);
   }
   if (assignment.action === "claim" && controller.my === true) {
-    return true;
+    return false;
   }
   const actorUsername = getTerritoryActorUsername(creep, colony);
   return getTerritoryControllerTargetState(controller, assignment.action, actorUsername) === "available";
+}
+function isVisibleTerritoryAssignmentComplete(assignment, creep) {
+  if (assignment.action !== "claim" || !isNonEmptyString(assignment.targetRoom)) {
+    return false;
+  }
+  const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
+  return (controller == null ? void 0 : controller.my) === true;
 }
 function suppressTerritoryIntent(colony, assignment, gameTime) {
   if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || !isTerritoryIntentAction(assignment.action)) {
@@ -968,6 +974,10 @@ function isCreepVisibleTerritoryIntentActionable(creep, intent) {
     return true;
   }
   return getTerritoryControllerTargetState(controller, intent.action, getTerritoryActorUsername(creep, intent.colony)) === "available";
+}
+function selectVisibleTerritoryAssignmentController(assignment, creep) {
+  var _a;
+  return ((_a = creep == null ? void 0 : creep.room) == null ? void 0 : _a.name) === assignment.targetRoom ? selectCreepRoomController(creep, assignment.controllerId) : getVisibleController(assignment.targetRoom, assignment.controllerId);
 }
 function selectCreepRoomController(creep, controllerId) {
   var _a;
@@ -1356,18 +1366,18 @@ function selectWorkerEnergyAcquisitionTask(creep) {
 }
 function findWorkerEnergyAcquisitionCandidates(creep) {
   const context = {
-    creepOwnerUsername: getCreepOwnerUsername(creep),
+    creepOwnerUsername: getCreepOwnerUsername2(creep),
     hasHostilePresence: hasVisibleHostilePresence(creep.room),
     room: creep.room
   };
   const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).map(
-    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
       type: "withdraw",
       targetId: source.id
     })
   );
   const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).map(
-    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
       type: "withdraw",
       targetId: source.id
     })
@@ -2193,6 +2203,10 @@ function runTerritoryControllerCreep(creep) {
   if (!isTerritoryAssignment(assignment)) {
     return;
   }
+  if (isVisibleTerritoryAssignmentComplete(assignment, creep)) {
+    completeTerritoryAssignment(creep);
+    return;
+  }
   if (!isVisibleTerritoryAssignmentSafe(assignment, creep.memory.colony, creep)) {
     suppressTerritoryAssignment(creep, assignment);
     return;
@@ -2212,6 +2226,8 @@ function runTerritoryControllerCreep(creep) {
   if (controller.my === true) {
     if (assignment.action === "reserve") {
       suppressTerritoryAssignment(creep, assignment);
+    } else {
+      completeTerritoryAssignment(creep);
     }
     return;
   }
@@ -2226,6 +2242,9 @@ function runTerritoryControllerCreep(creep) {
 }
 function suppressTerritoryAssignment(creep, assignment) {
   suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime3());
+  completeTerritoryAssignment(creep);
+}
+function completeTerritoryAssignment(creep) {
   delete creep.memory.territory;
 }
 function selectTargetController(creep, assignment) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1,4 +1,5 @@
 import { isWorkerRepairTargetComplete, selectWorkerTask } from '../tasks/workerTasks';
+import { selectVisibleTerritoryControllerTask } from '../territory/territoryPlanner';
 
 export function runWorker(creep: Creep): void {
   if (!creep.memory.task) {
@@ -7,6 +8,12 @@ export function runWorker(creep: Creep): void {
   }
 
   if (shouldReplaceTask(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+
+  if (shouldPreemptForVisibleTerritoryControllerTask(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
     return;
@@ -52,6 +59,10 @@ function assignNextTask(creep: Creep): void {
 }
 
 function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
+  if (isTerritoryControlTask(task)) {
+    return false;
+  }
+
   if (!creep.store?.getUsedCapacity || !creep.store?.getFreeCapacity) {
     return false;
   }
@@ -64,6 +75,20 @@ function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
   }
 
   return usedEnergy === 0;
+}
+
+function shouldPreemptForVisibleTerritoryControllerTask(creep: Creep, task: CreepTaskMemory): boolean {
+  const controllerTask = selectVisibleTerritoryControllerTask(creep);
+  if (!controllerTask) {
+    return isTerritoryControlTask(task);
+  }
+
+  const selectedTask = selectWorkerTask(creep);
+  if (!selectedTask || !isSameTask(selectedTask, controllerTask)) {
+    return false;
+  }
+
+  return !isSameTask(task, controllerTask);
 }
 
 function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean {
@@ -82,6 +107,14 @@ function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean 
   }
 
   return true;
+}
+
+function isSameTask(left: CreepTaskMemory, right: CreepTaskMemory): boolean {
+  return left.type === right.type && left.targetId === right.targetId;
+}
+
+function isTerritoryControlTask(task: CreepTaskMemory): task is Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }> {
+  return task.type === 'claim' || task.type === 'reserve';
 }
 
 function shouldReplaceTarget(
@@ -117,6 +150,10 @@ function executeTask(
       return creep.build(target as ConstructionSite);
     case 'repair':
       return creep.repair(target as Structure);
+    case 'claim':
+      return creep.claimController(target as StructureController);
+    case 'reserve':
+      return creep.reserveController(target as StructureController);
     case 'upgrade':
       return creep.upgradeController(target as StructureController);
   }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1,3 +1,5 @@
+import { selectVisibleTerritoryControllerTask } from '../territory/territoryPlanner';
+
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
@@ -20,8 +22,13 @@ interface StoredEnergySourceContext {
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = getUsedEnergy(creep);
+  const territoryControllerTask = selectVisibleTerritoryControllerTask(creep);
 
   if (carriedEnergy === 0) {
+    if (isTerritoryControlTask(territoryControllerTask)) {
+      return territoryControllerTask;
+    }
+
     if (getFreeEnergyCapacity(creep) > 0) {
       const storedEnergy = selectStoredEnergySource(creep);
       if (storedEnergy) {
@@ -51,6 +58,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: 'upgrade', targetId: controller.id };
+  }
+
+  if (territoryControllerTask) {
+    return territoryControllerTask;
   }
 
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
@@ -96,6 +107,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   return null;
+}
+
+function isTerritoryControlTask(task: CreepTaskMemory | null): task is Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }> {
+  return task?.type === 'claim' || task?.type === 'reserve';
 }
 
 function isFillableEnergySink(structure: AnyOwnedStructure): structure is StructureSpawn | StructureExtension {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1,3 +1,5 @@
+import { selectVisibleTerritoryControllerTask } from '../territory/territoryPlanner';
+
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
@@ -26,8 +28,13 @@ interface StoredEnergySourceContext {
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = getUsedEnergy(creep);
+  const territoryControllerTask = selectVisibleTerritoryControllerTask(creep);
 
   if (carriedEnergy === 0) {
+    if (isTerritoryControlTask(territoryControllerTask)) {
+      return territoryControllerTask;
+    }
+
     if (getFreeEnergyCapacity(creep) > 0) {
       const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
       if (energyAcquisitionTask) {
@@ -47,6 +54,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: 'upgrade', targetId: controller.id };
+  }
+
+  if (territoryControllerTask) {
+    return territoryControllerTask;
   }
 
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
@@ -92,6 +103,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   return null;
+}
+
+function isTerritoryControlTask(task: CreepTaskMemory | null): task is Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }> {
+  return task?.type === 'claim' || task?.type === 'reserve';
 }
 
 function isFillableEnergySink(structure: AnyOwnedStructure): structure is FillableEnergySink {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -153,7 +153,8 @@ export function isVisibleTerritoryAssignmentSafe(
   }
 
   const actorUsername = getTerritoryActorUsername(creep, colony);
-  return getTerritoryControllerTargetState(controller, assignment.action, actorUsername) === 'available';
+  const targetState = getTerritoryControllerTargetState(controller, assignment.action, actorUsername);
+  return targetState === 'available' || (assignment.action === 'reserve' && targetState === 'satisfied');
 }
 
 export function isVisibleTerritoryAssignmentComplete(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -143,19 +143,29 @@ export function isVisibleTerritoryAssignmentSafe(
     return false;
   }
 
-  const controller = creep?.room?.name === assignment.targetRoom
-    ? selectCreepRoomController(creep, assignment.controllerId)
-    : getVisibleController(assignment.targetRoom, assignment.controllerId);
+  const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
   if (!controller) {
     return !isVisibleRoomMissingController(assignment.targetRoom);
   }
 
   if (assignment.action === 'claim' && controller.my === true) {
-    return true;
+    return false;
   }
 
   const actorUsername = getTerritoryActorUsername(creep, colony);
   return getTerritoryControllerTargetState(controller, assignment.action, actorUsername) === 'available';
+}
+
+export function isVisibleTerritoryAssignmentComplete(
+  assignment: CreepTerritoryMemory,
+  creep?: Creep
+): boolean {
+  if (assignment.action !== 'claim' || !isNonEmptyString(assignment.targetRoom)) {
+    return false;
+  }
+
+  const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
+  return controller?.my === true;
 }
 
 export function suppressTerritoryIntent(
@@ -675,6 +685,15 @@ function isCreepVisibleTerritoryIntentActionable(creep: Creep, intent: Territory
     getTerritoryControllerTargetState(controller, intent.action, getTerritoryActorUsername(creep, intent.colony)) ===
     'available'
   );
+}
+
+function selectVisibleTerritoryAssignmentController(
+  assignment: CreepTerritoryMemory,
+  creep?: Creep
+): StructureController | null {
+  return creep?.room?.name === assignment.targetRoom
+    ? selectCreepRoomController(creep, assignment.controllerId)
+    : getVisibleController(assignment.targetRoom, assignment.controllerId);
 }
 
 function selectCreepRoomController(creep: Creep, controllerId?: Id<StructureController>): StructureController | null {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -96,6 +96,68 @@ export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemor
   };
 }
 
+export function selectVisibleTerritoryControllerTask(creep: Creep): CreepTaskMemory | null {
+  const intent = selectVisibleTerritoryControllerIntent(creep);
+  if (!intent) {
+    return null;
+  }
+
+  const controller = selectCreepRoomController(creep, intent.controllerId);
+  if (!controller) {
+    return null;
+  }
+
+  if (intent.action === 'reserve') {
+    return canUseControllerClaimPart(creep) ? { type: 'reserve', targetId: controller.id } : null;
+  }
+
+  if (controller.my === true) {
+    return getStoredEnergy(creep) > 0 ? { type: 'upgrade', targetId: controller.id } : null;
+  }
+
+  return canUseControllerClaimPart(creep) ? { type: 'claim', targetId: controller.id } : null;
+}
+
+export function isVisibleTerritoryAssignmentSafe(
+  assignment: CreepTerritoryMemory,
+  colony: string | undefined,
+  creep?: Creep
+): boolean {
+  if (!isNonEmptyString(assignment.targetRoom)) {
+    return false;
+  }
+
+  if (isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
+    return false;
+  }
+
+  if (assignment.action === 'scout') {
+    return true;
+  }
+
+  if (!isTerritoryControlAction(assignment.action)) {
+    return false;
+  }
+
+  if (isNonEmptyString(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
+    return false;
+  }
+
+  const controller = creep?.room?.name === assignment.targetRoom
+    ? selectCreepRoomController(creep, assignment.controllerId)
+    : getVisibleController(assignment.targetRoom, assignment.controllerId);
+  if (!controller) {
+    return !isVisibleRoomMissingController(assignment.targetRoom);
+  }
+
+  if (assignment.action === 'claim' && controller.my === true) {
+    return true;
+  }
+
+  const actorUsername = getTerritoryActorUsername(creep, colony);
+  return getTerritoryControllerTargetState(controller, assignment.action, actorUsername) === 'available';
+}
+
 export function suppressTerritoryIntent(
   colony: string | undefined,
   assignment: CreepTerritoryMemory,
@@ -294,6 +356,10 @@ function getAdjacentReserveCandidateState(
   targetRoom: string,
   colonyOwnerUsername: string | null
 ): 'safe' | 'unknown' | 'unavailable' {
+  if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
+    return 'unavailable';
+  }
+
   if (isVisibleRoomMissingController(targetRoom)) {
     return 'unavailable';
   }
@@ -494,7 +560,7 @@ function isTerritoryIntentSuppressed(
   colony: string,
   targetRoom: string,
   action: TerritoryIntentAction,
-  gameTime: number
+  gameTime = getGameTime()
 ): boolean {
   const territoryMemory = getTerritoryMemoryRecord();
   if (!territoryMemory) {
@@ -514,14 +580,217 @@ function isTerritorySuppressionFresh(intent: TerritoryIntentMemory, gameTime: nu
   return intent.status === 'suppressed' && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
 }
 
+function selectVisibleTerritoryControllerIntent(creep: Creep): TerritoryIntentMemory | null {
+  const roomName = creep.room?.name;
+  if (!isNonEmptyString(roomName) || isVisibleRoomUnsafe(creep.room)) {
+    return null;
+  }
+
+  const assignmentIntent = normalizeCreepTerritoryIntent(creep, roomName);
+  if (assignmentIntent && isCreepVisibleTerritoryIntentActionable(creep, assignmentIntent)) {
+    return assignmentIntent;
+  }
+
+  const territoryMemory = getTerritoryMemoryRecord();
+  const colony = creep.memory?.colony;
+  const intents = normalizeTerritoryIntents(territoryMemory?.intents)
+    .filter((intent) => isActiveVisibleControllerIntentForCreep(intent, roomName, colony))
+    .sort(compareVisibleControllerIntents);
+
+  return intents.find((intent) => isCreepVisibleTerritoryIntentActionable(creep, intent)) ?? null;
+}
+
+function normalizeCreepTerritoryIntent(creep: Creep, roomName: string): TerritoryIntentMemory | null {
+  const assignment = creep.memory?.territory;
+  if (
+    !assignment ||
+    assignment.targetRoom !== roomName ||
+    !isTerritoryControlAction(assignment.action) ||
+    (isNonEmptyString(creep.memory?.colony) &&
+      isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action))
+  ) {
+    return null;
+  }
+
+  return {
+    colony: creep.memory?.colony ?? '',
+    targetRoom: assignment.targetRoom,
+    action: assignment.action,
+    status: 'active',
+    updatedAt: getGameTime(),
+    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {})
+  };
+}
+
+function isActiveVisibleControllerIntentForCreep(
+  intent: TerritoryIntentMemory,
+  roomName: string,
+  creepColony: string | undefined
+): boolean {
+  return (
+    intent.targetRoom === roomName &&
+    intent.targetRoom !== intent.colony &&
+    isTerritoryControlAction(intent.action) &&
+    (intent.status === 'planned' || intent.status === 'active') &&
+    (!isNonEmptyString(creepColony) || intent.colony === creepColony)
+  );
+}
+
+function compareVisibleControllerIntents(left: TerritoryIntentMemory, right: TerritoryIntentMemory): number {
+  return (
+    getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) ||
+    getIntentActionPriority(left.action) - getIntentActionPriority(right.action) ||
+    right.updatedAt - left.updatedAt ||
+    left.colony.localeCompare(right.colony)
+  );
+}
+
+function getIntentStatusPriority(status: TerritoryIntentMemory['status']): number {
+  return status === 'active' ? 0 : 1;
+}
+
+function getIntentActionPriority(action: TerritoryIntentAction): number {
+  return action === 'claim' ? 0 : 1;
+}
+
+function isCreepVisibleTerritoryIntentActionable(creep: Creep, intent: TerritoryIntentMemory): boolean {
+  if (!isTerritoryControlAction(intent.action)) {
+    return false;
+  }
+
+  const controller = selectCreepRoomController(creep, intent.controllerId);
+  if (!controller) {
+    return false;
+  }
+
+  if (!isVisibleRoomSafe(creep.room)) {
+    return false;
+  }
+
+  if (intent.action === 'claim' && controller.my === true) {
+    return true;
+  }
+
+  return (
+    getTerritoryControllerTargetState(controller, intent.action, getTerritoryActorUsername(creep, intent.colony)) ===
+    'available'
+  );
+}
+
+function selectCreepRoomController(creep: Creep, controllerId?: Id<StructureController>): StructureController | null {
+  const roomController = creep.room?.controller;
+  if (!controllerId) {
+    return roomController ?? null;
+  }
+
+  if (roomController?.id === controllerId) {
+    return roomController;
+  }
+
+  const game = (globalThis as { Game?: Partial<Game> }).Game;
+  const getObjectById = game?.getObjectById;
+  if (typeof getObjectById !== 'function') {
+    return null;
+  }
+
+  return getObjectById.call(game, controllerId) as StructureController | null;
+}
+
+function getTerritoryControllerTargetState(
+  controller: StructureController,
+  action: TerritoryControlAction,
+  colonyOwnerUsername: string | null
+): TerritoryTargetVisibilityState {
+  if (action === 'reserve') {
+    return getReserveControllerTargetState(controller, colonyOwnerUsername);
+  }
+
+  return isControllerOwned(controller) ? 'unavailable' : 'available';
+}
+
+function getTerritoryActorUsername(creep: Creep | undefined, colony: string | undefined): string | null {
+  return getCreepOwnerUsername(creep) ?? (isNonEmptyString(colony) ? getVisibleColonyOwnerUsername(colony) : null);
+}
+
+function getCreepOwnerUsername(creep: Creep | undefined): string | null {
+  const username = (creep as (Creep & { owner?: { username?: string } }) | undefined)?.owner?.username;
+  return isNonEmptyString(username) ? username : null;
+}
+
+function canUseControllerClaimPart(creep: Creep): boolean {
+  const claimPart = getBodyPartConstant('CLAIM', 'claim');
+  const activeClaimParts = creep.getActiveBodyparts?.(claimPart);
+  if (typeof activeClaimParts === 'number') {
+    return activeClaimParts > 0;
+  }
+
+  return Array.isArray(creep.body) && creep.body.some((part) => part.type === claimPart && part.hits > 0);
+}
+
+function getBodyPartConstant(globalName: 'CLAIM', fallback: BodyPartConstant): BodyPartConstant {
+  const constants = globalThis as unknown as Partial<Record<'CLAIM', BodyPartConstant>>;
+  return constants[globalName] ?? fallback;
+}
+
+function getStoredEnergy(object: unknown): number {
+  const store = (object as { store?: { getUsedCapacity?: (resource?: ResourceConstant) => number | null } } | null)
+    ?.store;
+  const energyResource = getEnergyResource();
+  const usedCapacity = store?.getUsedCapacity?.(energyResource);
+  if (typeof usedCapacity === 'number') {
+    return usedCapacity;
+  }
+
+  const storedEnergy = (store as Record<string, unknown> | undefined)?.[energyResource];
+  return typeof storedEnergy === 'number' ? storedEnergy : 0;
+}
+
+function getEnergyResource(): ResourceConstant {
+  const resource = (globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY;
+  return (typeof resource === 'string' ? resource : 'energy') as ResourceConstant;
+}
+
+function isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom: string): boolean {
+  const room = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[targetRoom];
+  return room ? isVisibleRoomUnsafe(room) : false;
+}
+
+function isVisibleRoomSafe(room: Room): boolean {
+  return !isVisibleRoomUnsafe(room);
+}
+
+function isVisibleRoomUnsafe(room: Room): boolean {
+  return findVisibleHostileCreeps(room).length > 0 || findVisibleHostileStructures(room).length > 0;
+}
+
+function findVisibleHostileCreeps(room: Room): Creep[] {
+  return typeof FIND_HOSTILE_CREEPS === 'number' && typeof room.find === 'function'
+    ? room.find(FIND_HOSTILE_CREEPS)
+    : [];
+}
+
+function findVisibleHostileStructures(room: Room): AnyStructure[] {
+  return typeof FIND_HOSTILE_STRUCTURES === 'number' && typeof room.find === 'function'
+    ? room.find(FIND_HOSTILE_STRUCTURES)
+    : [];
+}
+
 function getVisibleTerritoryTargetState(
   targetRoom: string,
   action: TerritoryIntentAction,
   controllerId?: Id<StructureController>,
   colonyOwnerUsername?: string | null
 ): TerritoryTargetVisibilityState {
+  if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
+    return 'unavailable';
+  }
+
   if (isVisibleRoomMissingController(targetRoom)) {
     return 'unavailable';
+  }
+
+  if (action === 'scout') {
+    return isVisibleRoomKnown(targetRoom) ? 'unavailable' : 'available';
   }
 
   const controller = getVisibleController(targetRoom, controllerId);
@@ -530,10 +799,10 @@ function getVisibleTerritoryTargetState(
   }
 
   if (action === 'reserve') {
-    return getReserveControllerTargetState(controller, colonyOwnerUsername ?? null);
+    return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername ?? null);
   }
 
-  return isControllerOwned(controller) ? 'unavailable' : 'available';
+  return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername ?? null);
 }
 
 function isVisibleRoomKnown(targetRoom: string): boolean {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -1,4 +1,8 @@
-import { isVisibleTerritoryAssignmentSafe, suppressTerritoryIntent } from './territoryPlanner';
+import {
+  isVisibleTerritoryAssignmentComplete,
+  isVisibleTerritoryAssignmentSafe,
+  suppressTerritoryIntent
+} from './territoryPlanner';
 
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
@@ -15,6 +19,11 @@ type RoomPositionConstructor = new (x: number, y: number, roomName: string) => R
 export function runTerritoryControllerCreep(creep: Creep): void {
   const assignment = creep.memory.territory;
   if (!isTerritoryAssignment(assignment)) {
+    return;
+  }
+
+  if (isVisibleTerritoryAssignmentComplete(assignment, creep)) {
+    completeTerritoryAssignment(creep);
     return;
   }
 
@@ -41,6 +50,8 @@ export function runTerritoryControllerCreep(creep: Creep): void {
   if (controller.my === true) {
     if (assignment.action === 'reserve') {
       suppressTerritoryAssignment(creep, assignment);
+    } else {
+      completeTerritoryAssignment(creep);
     }
     return;
   }
@@ -65,6 +76,10 @@ export function runTerritoryControllerCreep(creep: Creep): void {
 
 function suppressTerritoryAssignment(creep: Creep, assignment: CreepTerritoryMemory): void {
   suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime());
+  completeTerritoryAssignment(creep);
+}
+
+function completeTerritoryAssignment(creep: Creep): void {
   delete creep.memory.territory;
 }
 

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -1,4 +1,4 @@
-import { suppressTerritoryIntent } from './territoryPlanner';
+import { isVisibleTerritoryAssignmentSafe, suppressTerritoryIntent } from './territoryPlanner';
 
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
@@ -15,6 +15,11 @@ type RoomPositionConstructor = new (x: number, y: number, roomName: string) => R
 export function runTerritoryControllerCreep(creep: Creep): void {
   const assignment = creep.memory.territory;
   if (!isTerritoryAssignment(assignment)) {
+    return;
+  }
+
+  if (!isVisibleTerritoryAssignmentSafe(assignment, creep.memory.colony, creep)) {
+    suppressTerritoryAssignment(creep, assignment);
     return;
   }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -53,5 +53,7 @@ declare global {
     | { type: 'transfer'; targetId: Id<AnyStoreStructure> }
     | { type: 'build'; targetId: Id<ConstructionSite> }
     | { type: 'repair'; targetId: Id<Structure> }
+    | { type: 'claim'; targetId: Id<StructureController> }
+    | { type: 'reserve'; targetId: Id<StructureController> }
     | { type: 'upgrade'; targetId: Id<StructureController> };
 }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -9,6 +9,8 @@ import {
 
 describe('planTerritoryIntent', () => {
   beforeEach(() => {
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     delete (globalThis as { Game?: Partial<Game> }).Game;
   });
@@ -525,6 +527,41 @@ describe('planTerritoryIntent', () => {
 
     expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 516)).toBeNull();
     expect(Memory.territory).toBeUndefined();
+  });
+
+  it('does not seed visible adjacent rooms with hostile presence', () => {
+    const colony = makeSafeColony();
+    const hostile = { id: 'enemy1' } as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits: jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' })) } as unknown as GameMap,
+      rooms: {
+        W1N2: {
+          name: 'W1N2',
+          controller: { my: false } as StructureController,
+          find: jest.fn((type: number) => (type === FIND_HOSTILE_CREEPS ? [hostile] : []))
+        } as unknown as Room,
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false } as StructureController,
+          find: jest.fn().mockReturnValue([])
+        } as unknown as Room
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 517)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve'
+      }
+    ]);
   });
 
   it('skips visible adjacent rooms without controllers', () => {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -90,6 +90,51 @@ describe('runTerritoryControllerCreep', () => {
 
     expect(creep.reserveController).toHaveBeenCalledWith(controller);
     expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve' });
+    expect(Memory.territory).toBeUndefined();
+  });
+
+  it('keeps a visible healthy own reservation active without suppressing it', () => {
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: 4_000 }
+    } as StructureController;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 500
+          }
+        ]
+      }
+    };
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      reserveController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve' });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 500
+      }
+    ]);
   });
 
   it('claims a configured controller id when claim action is requested', () => {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -2,6 +2,8 @@ import { runTerritoryControllerCreep } from '../src/territory/territoryRunner';
 
 describe('runTerritoryControllerCreep', () => {
   beforeEach(() => {
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
     (globalThis as unknown as { RoomPosition: typeof RoomPosition }).RoomPosition = jest.fn(
       (x: number, y: number, roomName: string) => ({ x, y, roomName }) as RoomPosition
     ) as unknown as typeof RoomPosition;
@@ -24,6 +26,41 @@ describe('runTerritoryControllerCreep', () => {
 
     expect(creep.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W1N2' });
     expect(creep.reserveController).not.toHaveBeenCalled();
+  });
+
+  it('suppresses and does not move toward a visible hostile target room', () => {
+    const hostile = { id: 'enemy1' } as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 501,
+      rooms: {
+        W1N2: {
+          name: 'W1N2',
+          controller: { id: 'controller1', my: false } as StructureController,
+          find: jest.fn((type: number) => (type === FIND_HOSTILE_CREEPS ? [hostile] : []))
+        } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve', status: 'active', updatedAt: 500 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N1' },
+      moveTo: jest.fn(),
+      reserveController: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      { colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve', status: 'suppressed', updatedAt: 501 }
+    ]);
   });
 
   it('keeps scout target attribution after entering the target room', () => {
@@ -221,7 +258,7 @@ describe('runTerritoryControllerCreep', () => {
     ]);
   });
 
-  it('suppresses a reserve target and stops the creep assignment when reserve is impossible', () => {
+  it('suppresses an enemy-owned reserve target without issuing the impossible reserve call', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 504,
       getObjectById: jest.fn().mockReturnValue(null)
@@ -249,7 +286,7 @@ describe('runTerritoryControllerCreep', () => {
 
     runTerritoryControllerCreep(creep);
 
-    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.reserveController).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
     expect(creep.memory.territory).toBeUndefined();
     expect(Memory.territory?.intents).toEqual([

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -131,6 +131,36 @@ describe('runTerritoryControllerCreep', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
+  it('clears completed claim assignments without suppressing shared upgrade intent', () => {
+    const sharedIntents: TerritoryIntentMemory[] = [
+      { colony: 'W1N1', targetRoom: 'W1N2', action: 'claim', status: 'active', updatedAt: 508 }
+    ];
+    const controller = { id: 'controller1', my: true, owner: { username: 'me' } } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 509,
+      rooms: {
+        W1N2: { name: 'W1N2', controller } as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: { intents: sharedIntents }
+    };
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim' } },
+      room: { name: 'W1N1' },
+      claimController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual(sharedIntents);
+  });
+
   it('suppresses a claim assignment when the target room has no controller', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 506,

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -11,6 +11,8 @@ describe('runWorker', () => {
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
     (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
     (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
@@ -18,6 +20,9 @@ describe('runWorker', () => {
     (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
     (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
     (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
+    (globalThis as unknown as { CLAIM: BodyPartConstant }).CLAIM = 'claim';
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {} };
   });
 
   it('assigns a task when the creep has none', () => {
@@ -452,6 +457,43 @@ describe('runWorker', () => {
     expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller2' });
     expect(upgradeController).not.toHaveBeenCalled();
     expect(moveTo).not.toHaveBeenCalled();
+  });
+
+  it('preempts local construction when a claimed territory target needs upgrade support', () => {
+    const controller = { id: 'controller2', my: true, level: 1 } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 200 }]
+      }
+    };
+    const room = {
+      name: 'W2N1',
+      controller,
+      find: jest.fn((type: number) => (type === FIND_CONSTRUCTION_SITES ? [site] : []))
+    } as unknown as Room;
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1', task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const getObjectById = jest.fn().mockReturnValue(site);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller2' });
+    expect(creep.build).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
   it('clears completed repair targets and reassigns without repairing the stale target', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -117,6 +117,8 @@ describe('selectWorkerTask', () => {
     (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
     (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
     (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
+    (globalThis as unknown as { CLAIM: BodyPartConstant }).CLAIM = 'claim';
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     (globalThis as unknown as { Game?: Partial<Game> }).Game = { creeps: {} };
   });
 
@@ -956,6 +958,120 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('reserves a safe visible territory target before local resource collection', () => {
+    const controller = { id: 'controller2', my: false } as StructureController;
+    const source = { id: 'source1' } as Source;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 100 }]
+      }
+    };
+    const room = {
+      name: 'W2N1',
+      controller,
+      find: jest.fn((type: number) => (type === FIND_SOURCES ? [source] : []))
+    } as unknown as Room;
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
+    expect(room.find).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('claims a safe visible territory target before local construction', () => {
+    const controller = { id: 'controller2', my: false } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 101 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'claim', targetId: 'controller2' });
+  });
+
+  it('upgrades a claimed territory target before unrelated construction support', () => {
+    const controller = { id: 'controller2', my: true, level: 1 } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 102 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller2' });
+  });
+
+  it('does not prioritize a freshly suppressed visible territory target', () => {
+    const controller = { id: 'controller2', my: false } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'suppressed', updatedAt: 103 }]
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 104 };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('keeps spawn refill before claimed territory upgrade support', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const controller = { id: 'controller2', my: true, level: 2 } as StructureController;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 105 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
   it('selects build when worker has energy and construction sites exist', () => {


### PR DESCRIPTION
## Summary
- prioritizes visible safe territory-controller work for creeps in target rooms
- preserves hostile/suppression safety and home-room emergency precedence
- adds runner/planner test coverage for visible target-room claim/reserve/upgrade paths and suppression handling
- synchronizes `prod/dist/main.js`

Closes #160.

## Verification
Controller verified from `/root/screeps-worktrees/visible-territory-controller-160` after Codex fix:
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites, 251 tests)
- `cd prod && npm run build`

Codex-authored commit: `39f20ab lanyusea's bot <lanyusea@gmail.com> feat: prioritize visible territory controller work`

## Notes
- `prod/node_modules` is untracked worktree infrastructure and was not staged.
- No secrets.