### PR TITLE
feat: prefer spawn refill before extension top-off

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -583,11 +583,40 @@ function selectFillableEnergySink(creep) {
   const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
     filter: isFillableEnergySink
   });
+  const spawn = selectClosestEnergySink(creep, energySinks.filter(isSpawnEnergySink));
+  if (spawn) {
+    return spawn;
+  }
+  return selectClosestEnergySink(creep, energySinks.filter(isExtensionEnergySink));
+}
+function isSpawnEnergySink(structure) {
+  return matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+}
+function isExtensionEnergySink(structure) {
+  return matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension");
+}
+function selectClosestEnergySink(creep, energySinks) {
+  var _a;
   if (energySinks.length === 0) {
     return null;
   }
-  const closestEnergySink = findClosestByRange(creep, energySinks);
-  return closestEnergySink != null ? closestEnergySink : energySinks[0];
+  const energySinksByStableId = [...energySinks].sort(compareEnergySinkId);
+  const position = creep.pos;
+  if (typeof (position == null ? void 0 : position.getRangeTo) === "function") {
+    return energySinksByStableId.reduce((closest, candidate) => {
+      var _a2, _b, _c, _d;
+      const closestRange = (_b = (_a2 = position.getRangeTo) == null ? void 0 : _a2.call(position, closest)) != null ? _b : Infinity;
+      const candidateRange = (_d = (_c = position.getRangeTo) == null ? void 0 : _c.call(position, candidate)) != null ? _d : Infinity;
+      return candidateRange < closestRange || candidateRange === closestRange && compareEnergySinkId(candidate, closest) < 0 ? candidate : closest;
+    });
+  }
+  if (typeof (position == null ? void 0 : position.findClosestByRange) === "function") {
+    return (_a = position.findClosestByRange(energySinksByStableId)) != null ? _a : energySinksByStableId[0];
+  }
+  return energySinksByStableId[0];
+}
+function compareEnergySinkId(left, right) {
+  return String(left.id).localeCompare(String(right.id));
 }
 function isSpawnConstructionSite(site) {
   return matchesStructureType2(site.structureType, "STRUCTURE_SPAWN", "spawn");

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -11,6 +11,7 @@ type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureR
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
 type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal;
 type SalvageableWorkerEnergySource = Tombstone | Ruin;
+type FillableEnergySink = StructureSpawn | StructureExtension;
 type WorkerEnergyAcquisitionSource =
   | StoredWorkerEnergySource
   | SalvageableWorkerEnergySource
@@ -93,7 +94,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   return null;
 }
 
-function isFillableEnergySink(structure: AnyOwnedStructure): structure is StructureSpawn | StructureExtension {
+function isFillableEnergySink(structure: AnyOwnedStructure): structure is FillableEnergySink {
   return (
     (matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') ||
       matchesStructureType(structure.structureType, 'STRUCTURE_EXTENSION', 'extension')) &&
@@ -102,17 +103,60 @@ function isFillableEnergySink(structure: AnyOwnedStructure): structure is Struct
   );
 }
 
-function selectFillableEnergySink(creep: Creep): StructureSpawn | StructureExtension | null {
+function selectFillableEnergySink(creep: Creep): FillableEnergySink | null {
   const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
     filter: isFillableEnergySink
   });
 
+  const spawn = selectClosestEnergySink(creep, energySinks.filter(isSpawnEnergySink));
+  if (spawn) {
+    return spawn;
+  }
+
+  return selectClosestEnergySink(creep, energySinks.filter(isExtensionEnergySink));
+}
+
+function isSpawnEnergySink(structure: FillableEnergySink): structure is StructureSpawn {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn');
+}
+
+function isExtensionEnergySink(structure: FillableEnergySink): structure is StructureExtension {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_EXTENSION', 'extension');
+}
+
+function selectClosestEnergySink<T extends FillableEnergySink>(creep: Creep, energySinks: T[]): T | null {
   if (energySinks.length === 0) {
     return null;
   }
 
-  const closestEnergySink = findClosestByRange(creep, energySinks);
-  return closestEnergySink ?? energySinks[0];
+  const energySinksByStableId = [...energySinks].sort(compareEnergySinkId);
+  const position = (creep as Creep & {
+    pos?: {
+      findClosestByRange?: (objects: T[]) => T | null;
+      getRangeTo?: (target: T) => number;
+    };
+  }).pos;
+
+  if (typeof position?.getRangeTo === 'function') {
+    return energySinksByStableId.reduce((closest, candidate) => {
+      const closestRange = position.getRangeTo?.(closest) ?? Infinity;
+      const candidateRange = position.getRangeTo?.(candidate) ?? Infinity;
+      return candidateRange < closestRange ||
+        (candidateRange === closestRange && compareEnergySinkId(candidate, closest) < 0)
+        ? candidate
+        : closest;
+    });
+  }
+
+  if (typeof position?.findClosestByRange === 'function') {
+    return position.findClosestByRange(energySinksByStableId) ?? energySinksByStableId[0];
+  }
+
+  return energySinksByStableId[0];
+}
+
+function compareEnergySinkId(left: FillableEnergySink, right: FillableEnergySink): number {
+  return String(left.id).localeCompare(String(right.id));
 }
 
 function isSpawnConstructionSite(site: ConstructionSite): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -924,7 +924,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
   });
 
-  it('selects the nearest fillable energy sink when worker position range helpers are available', () => {
+  it('prefers a fillable spawn over a nearer fillable extension', () => {
     const farSpawn = makeEnergySink('spawn-far', 'spawn' as StructureConstant, 300);
     const fullExtension = makeEnergySink('extension-full', 'extension' as StructureConstant, 0);
     const nearExtension = makeEnergySink('extension-near', 'extension' as StructureConstant, 50);
@@ -953,14 +953,73 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-near' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-far' });
     expect(getRangeTo).not.toHaveBeenCalledWith(fullExtension);
+    expect(getRangeTo).not.toHaveBeenCalledWith(nearExtension);
   });
 
-  it('keeps room.find order as the stable energy sink fallback when position helpers are unavailable', () => {
-    const firstExtension = makeEnergySink('extension-first', 'extension' as StructureConstant, 50);
-    const secondSpawn = makeEnergySink('spawn-second', 'spawn' as StructureConstant, 300);
-    const structures = [firstExtension, secondSpawn];
+  it('selects the closest fillable spawn before considering fillable extensions', () => {
+    const farSpawn = makeEnergySink('spawn-far', 'spawn' as StructureConstant, 300);
+    const nearSpawn = makeEnergySink('spawn-near', 'spawn' as StructureConstant, 100);
+    const closerExtension = makeEnergySink('extension-closer', 'extension' as StructureConstant, 50);
+    const structures = [farSpawn, closerExtension, nearSpawn];
+    const getRangeTo = jest.fn((target: StructureSpawn | StructureExtension) => {
+      const ranges: Record<string, number> = {
+        'extension-closer': 1,
+        'spawn-far': 8,
+        'spawn-near': 3
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-near' });
+    expect(getRangeTo).not.toHaveBeenCalledWith(closerExtension);
+  });
+
+  it('breaks same-class fillable energy sink range ties by id', () => {
+    const laterSpawn = makeEnergySink('spawn-b', 'spawn' as StructureConstant, 300);
+    const firstSpawn = makeEnergySink('spawn-a', 'spawn' as StructureConstant, 300);
+    const structures = [laterSpawn, firstSpawn];
+    const getRangeTo = jest.fn().mockReturnValue(4);
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-a' });
+  });
+
+  it('keeps id order as the stable energy sink fallback when position helpers are unavailable', () => {
+    const extension = makeEnergySink('extension-first', 'extension' as StructureConstant, 50);
+    const laterSpawn = makeEnergySink('spawn-z', 'spawn' as StructureConstant, 300);
+    const firstSpawn = makeEnergySink('spawn-a', 'spawn' as StructureConstant, 300);
+    const structures = [extension, laterSpawn, firstSpawn];
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
       room: {
@@ -976,7 +1035,7 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-first' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-a' });
   });
 
   it('preserves no-sink fallback behavior when all energy sinks are full', () => {


### PR DESCRIPTION
Closes #165

## Summary
- prioritize fillable spawns before extension top-off when workers choose transfer sinks
- keep same-class sink choice deterministic by range/id fallback
- sync generated Screeps bundle

## Verification
- git diff --check
- cd prod && npm run typecheck
- cd prod && npm test -- --runInBand
- cd prod && npm run build
- git diff --exit-code -- prod/dist/main.js

Notes: prod/node_modules is untracked local dependency infrastructure and is not staged.