### PR TITLE
feat: pre-spawn expiring worker replacements

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -471,34 +471,45 @@ function getOkCode() {
 // src/creeps/roleCounts.ts
 var WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
 function countCreepsByRole(creeps, colonyName) {
-  return creeps.reduce(
-    (counts, creep) => {
-      var _a, _b, _c, _d, _e, _f, _g, _h;
-      if (isColonyWorker(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
-        counts.worker += 1;
+  const counts = creeps.reduce(
+    (counts2, creep) => {
+      var _a, _b, _c, _d, _e, _f, _g, _h, _i;
+      if (isColonyWorker(creep, colonyName)) {
+        counts2.worker += 1;
+        if (canSatisfyRoleCapacity(creep)) {
+          counts2.workerCapacity = ((_a = counts2.workerCapacity) != null ? _a : 0) + 1;
+        }
       }
       if (isColonyClaimer(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
-        counts.claimer = ((_a = counts.claimer) != null ? _a : 0) + 1;
-        const targetRoom = (_b = creep.memory.territory) == null ? void 0 : _b.targetRoom;
+        counts2.claimer = ((_b = counts2.claimer) != null ? _b : 0) + 1;
+        const targetRoom = (_c = creep.memory.territory) == null ? void 0 : _c.targetRoom;
         if (targetRoom) {
-          const claimersByTargetRoom = (_c = counts.claimersByTargetRoom) != null ? _c : {};
-          claimersByTargetRoom[targetRoom] = ((_d = claimersByTargetRoom[targetRoom]) != null ? _d : 0) + 1;
-          counts.claimersByTargetRoom = claimersByTargetRoom;
+          const claimersByTargetRoom = (_d = counts2.claimersByTargetRoom) != null ? _d : {};
+          claimersByTargetRoom[targetRoom] = ((_e = claimersByTargetRoom[targetRoom]) != null ? _e : 0) + 1;
+          counts2.claimersByTargetRoom = claimersByTargetRoom;
         }
       }
       if (isColonyScout(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
-        counts.scout = ((_e = counts.scout) != null ? _e : 0) + 1;
-        const targetRoom = (_f = creep.memory.territory) == null ? void 0 : _f.targetRoom;
+        counts2.scout = ((_f = counts2.scout) != null ? _f : 0) + 1;
+        const targetRoom = (_g = creep.memory.territory) == null ? void 0 : _g.targetRoom;
         if (targetRoom) {
-          const scoutsByTargetRoom = (_g = counts.scoutsByTargetRoom) != null ? _g : {};
-          scoutsByTargetRoom[targetRoom] = ((_h = scoutsByTargetRoom[targetRoom]) != null ? _h : 0) + 1;
-          counts.scoutsByTargetRoom = scoutsByTargetRoom;
+          const scoutsByTargetRoom = (_h = counts2.scoutsByTargetRoom) != null ? _h : {};
+          scoutsByTargetRoom[targetRoom] = ((_i = scoutsByTargetRoom[targetRoom]) != null ? _i : 0) + 1;
+          counts2.scoutsByTargetRoom = scoutsByTargetRoom;
         }
       }
-      return counts;
+      return counts2;
     },
-    { worker: 0, claimer: 0, claimersByTargetRoom: {} }
+    { worker: 0, workerCapacity: 0, claimer: 0, claimersByTargetRoom: {} }
   );
+  if (counts.workerCapacity === counts.worker) {
+    delete counts.workerCapacity;
+  }
+  return counts;
+}
+function getWorkerCapacity(roleCounts) {
+  var _a;
+  return (_a = roleCounts.workerCapacity) != null ? _a : roleCounts.worker;
 }
 function isColonyWorker(creep, colonyName) {
   return creep.memory.colony === colonyName && creep.memory.role === "worker";
@@ -681,7 +692,7 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
   upsertTerritoryIntent(intents, suppressedIntent);
 }
 function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
-  if (roleCounts.worker < workerTarget) {
+  if (getWorkerCapacity(roleCounts) < workerTarget) {
     return false;
   }
   if (colony.energyCapacityAvailable < TERRITORY_CONTROLLER_BODY_COST) {
@@ -1859,7 +1870,7 @@ var MAX_WORKER_TARGET = 6;
 var sourceCountByRoomName = /* @__PURE__ */ new Map();
 function planSpawn(colony, roleCounts, gameTime) {
   const workerTarget = getWorkerTarget(colony, roleCounts);
-  if (roleCounts.worker < workerTarget) {
+  if (getWorkerCapacity(roleCounts) < workerTarget) {
     return planWorkerSpawn(colony, roleCounts, gameTime);
   }
   const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
@@ -1906,7 +1917,7 @@ function selectWorkerBody(colony, roleCounts) {
   if (roleCounts.worker === 0) {
     return buildEmergencyWorkerBody(colony.energyAvailable);
   }
-  return roleCounts.worker < MIN_WORKER_TARGET ? buildWorkerBody(colony.energyAvailable) : [];
+  return getWorkerCapacity(roleCounts) < MIN_WORKER_TARGET ? buildWorkerBody(colony.energyAvailable) : [];
 }
 function canAffordBody(body, energyAvailable) {
   return body.length > 0 && getBodyCost(body) <= energyAvailable;
@@ -1927,7 +1938,7 @@ function getWorkerTarget(colony, roleCounts) {
   return Math.min(MAX_WORKER_TARGET, baseTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
 }
 function shouldAddConstructionBacklogWorkerBonus(colony, roleCounts, baseWorkerTarget) {
-  return roleCounts.worker >= baseWorkerTarget && isConstructionBonusHomeSafe(colony.room.controller) && hasActiveConstructionBacklog(colony.room);
+  return getWorkerCapacity(roleCounts) >= baseWorkerTarget && isConstructionBonusHomeSafe(colony.room.controller) && hasActiveConstructionBacklog(colony.room);
 }
 function isConstructionBonusHomeSafe(controller) {
   return (controller == null ? void 0 : controller.my) === true && (typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS);

--- a/prod/src/creeps/roleCounts.ts
+++ b/prod/src/creeps/roleCounts.ts
@@ -1,18 +1,25 @@
 export interface RoleCounts {
   worker: number;
+  workerCapacity?: number;
   claimer?: number;
   claimersByTargetRoom?: Record<string, number>;
   scout?: number;
   scoutsByTargetRoom?: Record<string, number>;
 }
 
+// Conservative worker pre-spawn window. A three-part worker takes 9 ticks to
+// spawn, so 100 ticks leaves scheduling and travel buffer while only retiring
+// the final small slice of a 1500 tick lifetime from steady-state capacity.
 export const WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
 
 export function countCreepsByRole(creeps: Creep[], colonyName: string): RoleCounts {
-  return creeps.reduce<RoleCounts>(
+  const counts = creeps.reduce<RoleCounts>(
     (counts, creep) => {
-      if (isColonyWorker(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
+      if (isColonyWorker(creep, colonyName)) {
         counts.worker += 1;
+        if (canSatisfyRoleCapacity(creep)) {
+          counts.workerCapacity = (counts.workerCapacity ?? 0) + 1;
+        }
       }
       if (isColonyClaimer(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
         counts.claimer = (counts.claimer ?? 0) + 1;
@@ -34,8 +41,18 @@ export function countCreepsByRole(creeps: Creep[], colonyName: string): RoleCoun
       }
       return counts;
     },
-    { worker: 0, claimer: 0, claimersByTargetRoom: {} }
+    { worker: 0, workerCapacity: 0, claimer: 0, claimersByTargetRoom: {} }
   );
+
+  if (counts.workerCapacity === counts.worker) {
+    delete counts.workerCapacity;
+  }
+
+  return counts;
+}
+
+export function getWorkerCapacity(roleCounts: RoleCounts): number {
+  return roleCounts.workerCapacity ?? roleCounts.worker;
 }
 
 function isColonyWorker(creep: Creep, colonyName: string): boolean {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -1,5 +1,5 @@
 import { ColonySnapshot } from '../colony/colonyRegistry';
-import type { RoleCounts } from '../creeps/roleCounts';
+import { getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import {
   buildEmergencyWorkerBody,
   buildTerritoryControllerBody,
@@ -31,7 +31,7 @@ const sourceCountByRoomName = new Map<string, number>();
 
 export function planSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTime: number): SpawnRequest | null {
   const workerTarget = getWorkerTarget(colony, roleCounts);
-  if (roleCounts.worker < workerTarget) {
+  if (getWorkerCapacity(roleCounts) < workerTarget) {
     return planWorkerSpawn(colony, roleCounts, gameTime);
   }
 
@@ -88,7 +88,7 @@ function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyP
     return buildEmergencyWorkerBody(colony.energyAvailable);
   }
 
-  return roleCounts.worker < MIN_WORKER_TARGET ? buildWorkerBody(colony.energyAvailable) : [];
+  return getWorkerCapacity(roleCounts) < MIN_WORKER_TARGET ? buildWorkerBody(colony.energyAvailable) : [];
 }
 
 function canAffordBody(body: BodyPartConstant[], energyAvailable: number): boolean {
@@ -121,7 +121,7 @@ function shouldAddConstructionBacklogWorkerBonus(
   baseWorkerTarget: number
 ): boolean {
   return (
-    roleCounts.worker >= baseWorkerTarget &&
+    getWorkerCapacity(roleCounts) >= baseWorkerTarget &&
     isConstructionBonusHomeSafe(colony.room.controller) &&
     hasActiveConstructionBacklog(colony.room)
   );

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1,5 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
-import type { RoleCounts } from '../creeps/roleCounts';
+import { getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
@@ -202,7 +202,7 @@ export function suppressTerritoryIntent(
 }
 
 export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {
-  if (roleCounts.worker < workerTarget) {
+  if (getWorkerCapacity(roleCounts) < workerTarget) {
     return false;
   }
 

--- a/prod/test/mvpEconomyLifecycle.test.ts
+++ b/prod/test/mvpEconomyLifecycle.test.ts
@@ -183,8 +183,8 @@ describe('MVP economy lifecycle', () => {
   it('plans a replacement before a colony worker expires without counting unrelated workers', () => {
     const room = {
       name: 'W1N1',
-      energyAvailable: 300,
-      energyCapacityAvailable: 300,
+      energyAvailable: 600,
+      energyCapacityAvailable: 800,
       controller: { my: true, id: 'controller1' } as StructureController,
       find: jest.fn().mockReturnValue([])
     } as unknown as Room;
@@ -226,8 +226,61 @@ describe('MVP economy lifecycle', () => {
 
     runEconomy();
 
-    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-10', {
-      memory: { role: 'worker', colony: 'W1N1' }
-    });
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(
+      ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      'worker-W1N1-10',
+      {
+        memory: { role: 'worker', colony: 'W1N1' }
+      }
+    );
+  });
+
+  it('does not plan a replacement when healthy, lifetime-unknown, and spawning workers satisfy target', () => {
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controller: { my: true, id: 'controller1' } as StructureController,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const spawn = {
+      id: 'spawn1',
+      name: 'Spawn1',
+      room,
+      structureType: 'spawn',
+      spawning: null,
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) },
+      spawnCreep: jest.fn().mockReturnValue(0)
+    } as unknown as StructureSpawn;
+    const makeWorker = (memory: CreepMemory, options: Partial<Creep> = {}): Creep =>
+      ({
+        memory,
+        store: {
+          getUsedCapacity: jest.fn().mockReturnValue(0),
+          getFreeCapacity: jest.fn().mockReturnValue(50)
+        },
+        room: {
+          ...room,
+          find: jest.fn().mockReturnValue([])
+        },
+        ...options
+      }) as unknown as Creep;
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 11,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        Healthy: makeWorker({ role: 'worker', colony: 'W1N1' }, {
+          ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1
+        }),
+        LifetimeUnknown: makeWorker({ role: 'worker', colony: 'W1N1' }),
+        Spawning: makeWorker({ role: 'worker', colony: 'W1N1' }, { spawning: true })
+      }
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).not.toHaveBeenCalled();
   });
 });

--- a/prod/test/roleCounts.test.ts
+++ b/prod/test/roleCounts.test.ts
@@ -21,12 +21,16 @@ describe('countCreepsByRole', () => {
     });
   });
 
-  it('excludes colony workers at replacement age from steady-state capacity', () => {
+  it('tracks replacement-aware worker capacity at the deterministic TTL threshold', () => {
     const healthyWorker = {
       memory: { role: 'worker', colony: 'W1N1' },
       ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1
     } as Creep;
     const mockWorkerWithoutLifetime = { memory: { role: 'worker', colony: 'W1N1' } } as Creep;
+    const spawningWorker = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      spawning: true
+    } as Creep;
     const expiringWorker = {
       memory: { role: 'worker', colony: 'W1N1' },
       ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE
@@ -42,11 +46,19 @@ describe('countCreepsByRole', () => {
 
     expect(
       countCreepsByRole(
-        [healthyWorker, mockWorkerWithoutLifetime, expiringWorker, otherColonyWorker, unassignedWorker],
+        [
+          healthyWorker,
+          mockWorkerWithoutLifetime,
+          spawningWorker,
+          expiringWorker,
+          otherColonyWorker,
+          unassignedWorker
+        ],
         'W1N1'
       )
     ).toEqual({
-      worker: 2,
+      worker: 4,
+      workerCapacity: 3,
       claimer: 0,
       claimersByTargetRoom: {}
     });

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -92,6 +92,17 @@ describe('planSpawn', () => {
     });
   });
 
+  it('plans a replacement when low-TTL workers leave steady-state capacity below target', () => {
+    const { colony, spawn } = makeColony();
+
+    expect(planSpawn(colony, { worker: 3, workerCapacity: 2 }, 125)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W1N1-125',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
   it('plans the full capacity worker body when currently affordable', () => {
     const { colony, spawn } = makeColony({ energyAvailable: 400, energyCapacityAvailable: 400 });
 
@@ -106,7 +117,29 @@ describe('planSpawn', () => {
   it('does not overbuild when replacement-aware worker capacity is at target', () => {
     const { colony } = makeColony();
 
-    expect(planSpawn(colony, { worker: 3 }, 124)).toBeNull();
+    expect(planSpawn(colony, { worker: 3, workerCapacity: 3 }, 124)).toBeNull();
+  });
+
+  it('keeps normal replacement body selection when only expiring workers remain', () => {
+    const { colony, spawn } = makeColony({ energyAvailable: 600, energyCapacityAvailable: 800 });
+
+    expect(planSpawn(colony, { worker: 3, workerCapacity: 0 }, 135)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      name: 'worker-W1N1-135',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
+  it('keeps the emergency worker body for true zero-creep recovery', () => {
+    const { colony, spawn } = makeColony({ energyAvailable: 600, energyCapacityAvailable: 800 });
+
+    expect(planSpawn(colony, { worker: 0, workerCapacity: 0 }, 136)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W1N1-136',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
   });
 
   it('adds one worker target for active construction backlog after the baseline target is safe', () => {


### PR DESCRIPTION
## Summary
- Pre-spawns replacement workers before low-TTL workers expire.
- Keeps healthy worker counts from over-spawning while preserving emergency/zero-creep behavior.
- Adds Jest coverage for healthy, low-TTL, spawning, and missing-ttl worker planning cases.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites, 259 tests)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #167
