### PR TITLE
feat: prioritize urgent reservation renewals

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -571,8 +571,10 @@ var TERRITORY_CLAIMER_ROLE = "claimer";
 var TERRITORY_SCOUT_ROLE = "scout";
 var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
 var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
+var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
 var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
+var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
@@ -630,7 +632,18 @@ function selectVisibleTerritoryControllerTask(creep) {
     return null;
   }
   if (intent.action === "reserve") {
-    return canUseControllerClaimPart(creep) ? { type: "reserve", targetId: controller.id } : null;
+    const activeClaimParts = getActiveControllerClaimPartCount(creep);
+    if (activeClaimParts <= 0) {
+      return null;
+    }
+    const reservationTicksToEnd = getUrgentOwnReservationTicksToEnd(
+      controller,
+      getTerritoryActorUsername(creep, intent.colony)
+    );
+    if (reservationTicksToEnd !== null && !canRenewReservation(activeClaimParts, reservationTicksToEnd)) {
+      return null;
+    }
+    return { type: "reserve", targetId: controller.id };
   }
   if (controller.my === true) {
     return getStoredEnergy(creep) > 0 ? { type: "upgrade", targetId: controller.id } : null;
@@ -639,11 +652,22 @@ function selectVisibleTerritoryControllerTask(creep) {
 }
 function selectUrgentVisibleReservationRenewalTask(creep) {
   const intent = selectVisibleTerritoryControllerIntent(creep);
-  if (!intent || intent.action !== "reserve" || !canUseControllerClaimPart(creep)) {
+  if (!intent || intent.action !== "reserve") {
+    return null;
+  }
+  const activeClaimParts = getActiveControllerClaimPartCount(creep);
+  if (activeClaimParts <= 0) {
     return null;
   }
   const controller = selectCreepRoomController(creep, intent.controllerId);
-  if (!controller || getUrgentOwnReservationTicksToEnd(controller, getTerritoryActorUsername(creep, intent.colony)) === null) {
+  if (!controller) {
+    return null;
+  }
+  const reservationTicksToEnd = getUrgentOwnReservationTicksToEnd(
+    controller,
+    getTerritoryActorUsername(creep, intent.colony)
+  );
+  if (reservationTicksToEnd === null || !canRenewReservation(activeClaimParts, reservationTicksToEnd)) {
     return null;
   }
   return { type: "reserve", targetId: controller.id };
@@ -1034,13 +1058,19 @@ function getCreepOwnerUsername(creep) {
   return isNonEmptyString(username) ? username : null;
 }
 function canUseControllerClaimPart(creep) {
+  return getActiveControllerClaimPartCount(creep) > 0;
+}
+function canRenewReservation(activeClaimParts, reservationTicksToEnd) {
+  return activeClaimParts >= MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS || reservationTicksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
+}
+function getActiveControllerClaimPartCount(creep) {
   var _a;
   const claimPart = getBodyPartConstant("CLAIM", "claim");
   const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
   if (typeof activeClaimParts === "number") {
-    return activeClaimParts > 0;
+    return activeClaimParts;
   }
-  return Array.isArray(creep.body) && creep.body.some((part) => part.type === claimPart && part.hits > 0);
+  return Array.isArray(creep.body) ? creep.body.filter((part) => part.type === claimPart && part.hits > 0).length : 0;
 }
 function getBodyPartConstant(globalName, fallback) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -626,6 +626,17 @@ function selectVisibleTerritoryControllerTask(creep) {
   }
   return canUseControllerClaimPart(creep) ? { type: "claim", targetId: controller.id } : null;
 }
+function selectUrgentVisibleReservationRenewalTask(creep) {
+  const intent = selectVisibleTerritoryControllerIntent(creep);
+  if (!intent || intent.action !== "reserve" || !canUseControllerClaimPart(creep)) {
+    return null;
+  }
+  const controller = selectCreepRoomController(creep, intent.controllerId);
+  if (!controller || getUrgentOwnReservationTicksToEnd(controller, getTerritoryActorUsername(creep, intent.colony)) === null) {
+    return null;
+  }
+  return { type: "reserve", targetId: controller.id };
+}
 function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   if (!isNonEmptyString(assignment.targetRoom)) {
     return false;
@@ -1101,7 +1112,7 @@ function getReserveControllerTargetState(controller, colonyOwnerUsername) {
   if (!isNonEmptyString(reservation.username) || reservation.username !== colonyOwnerUsername) {
     return "unavailable";
   }
-  return typeof reservation.ticksToEnd === "number" && reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? "available" : "satisfied";
+  return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) === null ? "satisfied" : "available";
 }
 function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
   if (target.action !== "reserve" || colonyOwnerUsername === null) {
@@ -1111,11 +1122,17 @@ function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
   if (!controller || isControllerOwned(controller)) {
     return null;
   }
-  const reservation = controller.reservation;
-  if (!reservation || reservation.username !== colonyOwnerUsername || typeof reservation.ticksToEnd !== "number") {
+  return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+}
+function getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
+  if (isControllerOwned(controller) || !isNonEmptyString(colonyOwnerUsername)) {
     return null;
   }
-  return reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? reservation.ticksToEnd : null;
+  const reservation = controller.reservation;
+  if (!reservation || reservation.username !== colonyOwnerUsername || typeof reservation.ticksToEnd !== "number" || reservation.ticksToEnd > TERRITORY_RESERVATION_RENEWAL_TICKS) {
+    return null;
+  }
+  return reservation.ticksToEnd;
 }
 function getVisibleColonyOwnerUsername(colonyName) {
   const controller = getVisibleController(colonyName);
@@ -1191,8 +1208,12 @@ var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 var ENERGY_ACQUISITION_RANGE_COST = 50;
 function selectWorkerTask(creep) {
   const carriedEnergy = getUsedEnergy(creep);
+  const urgentReservationRenewalTask = selectUrgentVisibleReservationRenewalTask(creep);
   const territoryControllerTask = selectVisibleTerritoryControllerTask(creep);
   if (carriedEnergy === 0) {
+    if (urgentReservationRenewalTask) {
+      return urgentReservationRenewalTask;
+    }
     if (isTerritoryControlTask(territoryControllerTask)) {
       return territoryControllerTask;
     }
@@ -1212,6 +1233,9 @@ function selectWorkerTask(creep) {
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: "upgrade", targetId: controller.id };
+  }
+  if (urgentReservationRenewalTask) {
+    return urgentReservationRenewalTask;
   }
   if (territoryControllerTask) {
     return territoryControllerTask;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1,4 +1,7 @@
-import { selectVisibleTerritoryControllerTask } from '../territory/territoryPlanner';
+import {
+  selectUrgentVisibleReservationRenewalTask,
+  selectVisibleTerritoryControllerTask
+} from '../territory/territoryPlanner';
 
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
@@ -28,9 +31,14 @@ interface StoredEnergySourceContext {
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = getUsedEnergy(creep);
+  const urgentReservationRenewalTask = selectUrgentVisibleReservationRenewalTask(creep);
   const territoryControllerTask = selectVisibleTerritoryControllerTask(creep);
 
   if (carriedEnergy === 0) {
+    if (urgentReservationRenewalTask) {
+      return urgentReservationRenewalTask;
+    }
+
     if (isTerritoryControlTask(territoryControllerTask)) {
       return territoryControllerTask;
     }
@@ -54,6 +62,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: 'upgrade', targetId: controller.id };
+  }
+
+  if (urgentReservationRenewalTask) {
+    return urgentReservationRenewalTask;
   }
 
   if (territoryControllerTask) {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -118,6 +118,23 @@ export function selectVisibleTerritoryControllerTask(creep: Creep): CreepTaskMem
   return canUseControllerClaimPart(creep) ? { type: 'claim', targetId: controller.id } : null;
 }
 
+export function selectUrgentVisibleReservationRenewalTask(creep: Creep): CreepTaskMemory | null {
+  const intent = selectVisibleTerritoryControllerIntent(creep);
+  if (!intent || intent.action !== 'reserve' || !canUseControllerClaimPart(creep)) {
+    return null;
+  }
+
+  const controller = selectCreepRoomController(creep, intent.controllerId);
+  if (
+    !controller ||
+    getUrgentOwnReservationTicksToEnd(controller, getTerritoryActorUsername(creep, intent.colony)) === null
+  ) {
+    return null;
+  }
+
+  return { type: 'reserve', targetId: controller.id };
+}
+
 export function isVisibleTerritoryAssignmentSafe(
   assignment: CreepTerritoryMemory,
   colony: string | undefined,
@@ -857,10 +874,7 @@ function getReserveControllerTargetState(
     return 'unavailable';
   }
 
-  return typeof reservation.ticksToEnd === 'number' &&
-    reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS
-    ? 'available'
-    : 'satisfied';
+  return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) === null ? 'satisfied' : 'available';
 }
 
 function getConfiguredReserveRenewalTicksToEnd(
@@ -876,12 +890,28 @@ function getConfiguredReserveRenewalTicksToEnd(
     return null;
   }
 
-  const reservation = controller.reservation;
-  if (!reservation || reservation.username !== colonyOwnerUsername || typeof reservation.ticksToEnd !== 'number') {
+  return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+}
+
+function getUrgentOwnReservationTicksToEnd(
+  controller: StructureController,
+  colonyOwnerUsername: string | null
+): number | null {
+  if (isControllerOwned(controller) || !isNonEmptyString(colonyOwnerUsername)) {
     return null;
   }
 
-  return reservation.ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? reservation.ticksToEnd : null;
+  const reservation = controller.reservation;
+  if (
+    !reservation ||
+    reservation.username !== colonyOwnerUsername ||
+    typeof reservation.ticksToEnd !== 'number' ||
+    reservation.ticksToEnd > TERRITORY_RESERVATION_RENEWAL_TICKS
+  ) {
+    return null;
+  }
+
+  return reservation.ticksToEnd;
 }
 
 function getVisibleColonyOwnerUsername(colonyName: string): string | null {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -6,9 +6,11 @@ export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
 export const TERRITORY_DOWNGRADE_GUARD_TICKS = 5_000;
 export const TERRITORY_RESERVATION_RENEWAL_TICKS = 1_000;
+export const TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 
 const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
+const MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -108,7 +110,20 @@ export function selectVisibleTerritoryControllerTask(creep: Creep): CreepTaskMem
   }
 
   if (intent.action === 'reserve') {
-    return canUseControllerClaimPart(creep) ? { type: 'reserve', targetId: controller.id } : null;
+    const activeClaimParts = getActiveControllerClaimPartCount(creep);
+    if (activeClaimParts <= 0) {
+      return null;
+    }
+
+    const reservationTicksToEnd = getUrgentOwnReservationTicksToEnd(
+      controller,
+      getTerritoryActorUsername(creep, intent.colony)
+    );
+    if (reservationTicksToEnd !== null && !canRenewReservation(activeClaimParts, reservationTicksToEnd)) {
+      return null;
+    }
+
+    return { type: 'reserve', targetId: controller.id };
   }
 
   if (controller.my === true) {
@@ -120,15 +135,25 @@ export function selectVisibleTerritoryControllerTask(creep: Creep): CreepTaskMem
 
 export function selectUrgentVisibleReservationRenewalTask(creep: Creep): CreepTaskMemory | null {
   const intent = selectVisibleTerritoryControllerIntent(creep);
-  if (!intent || intent.action !== 'reserve' || !canUseControllerClaimPart(creep)) {
+  if (!intent || intent.action !== 'reserve') {
+    return null;
+  }
+
+  const activeClaimParts = getActiveControllerClaimPartCount(creep);
+  if (activeClaimParts <= 0) {
     return null;
   }
 
   const controller = selectCreepRoomController(creep, intent.controllerId);
-  if (
-    !controller ||
-    getUrgentOwnReservationTicksToEnd(controller, getTerritoryActorUsername(creep, intent.colony)) === null
-  ) {
+  if (!controller) {
+    return null;
+  }
+
+  const reservationTicksToEnd = getUrgentOwnReservationTicksToEnd(
+    controller,
+    getTerritoryActorUsername(creep, intent.colony)
+  );
+  if (reservationTicksToEnd === null || !canRenewReservation(activeClaimParts, reservationTicksToEnd)) {
     return null;
   }
 
@@ -755,13 +780,24 @@ function getCreepOwnerUsername(creep: Creep | undefined): string | null {
 }
 
 function canUseControllerClaimPart(creep: Creep): boolean {
+  return getActiveControllerClaimPartCount(creep) > 0;
+}
+
+function canRenewReservation(activeClaimParts: number, reservationTicksToEnd: number): boolean {
+  return (
+    activeClaimParts >= MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS ||
+    reservationTicksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS
+  );
+}
+
+function getActiveControllerClaimPartCount(creep: Creep): number {
   const claimPart = getBodyPartConstant('CLAIM', 'claim');
   const activeClaimParts = creep.getActiveBodyparts?.(claimPart);
   if (typeof activeClaimParts === 'number') {
-    return activeClaimParts > 0;
+    return activeClaimParts;
   }
 
-  return Array.isArray(creep.body) && creep.body.some((part) => part.type === claimPart && part.hits > 0);
+  return Array.isArray(creep.body) ? creep.body.filter((part) => part.type === claimPart && part.hits > 0).length : 0;
 }
 
 function getBodyPartConstant(globalName: 'CLAIM', fallback: BodyPartConstant): BodyPartConstant {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1,5 +1,6 @@
 import { runWorker } from '../src/creeps/workerRunner';
 import { CONTROLLER_DOWNGRADE_GUARD_TICKS, IDLE_RAMPART_REPAIR_HITS_CEILING } from '../src/tasks/workerTasks';
+import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
 
 describe('runWorker', () => {
   beforeEach(() => {
@@ -493,6 +494,53 @@ describe('runWorker', () => {
     expect(getObjectById).not.toHaveBeenCalled();
     expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller2' });
     expect(creep.build).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('clears a normal-threshold reservation task for a one-CLAIM worker before executing it', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 201 }]
+      }
+    };
+    const room = {
+      name: 'W2N1',
+      controller,
+      find: jest.fn((type: number) => (type === FIND_CONSTRUCTION_SITES ? [site] : []))
+    } as unknown as Room;
+    const creep = {
+      owner: { username: 'me' },
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'reserve', targetId: 'controller2' as Id<StructureController> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      reserveController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const getObjectById = jest.fn().mockReturnValue(controller);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(creep.reserveController).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4,6 +4,7 @@ import {
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
+import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
 
 function makeLoadedWorker(room: Room, task?: CreepTaskMemory): Creep {
   return {
@@ -1090,6 +1091,60 @@ describe('selectWorkerTask', () => {
     expect(room.find).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
+  it('renews an urgent own visible reservation before local construction', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 106 }]
+      }
+    };
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
+  });
+
+  it('keeps local construction before a comfortable own visible reservation', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 1 }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 107 }]
+      }
+    };
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
   it('claims a safe visible territory target before local construction', () => {
     const controller = { id: 'controller2', my: false } as StructureController;
     const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
@@ -1133,8 +1188,12 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller2' });
   });
 
-  it('does not prioritize a freshly suppressed visible territory target', () => {
-    const controller = { id: 'controller2', my: false } as StructureController;
+  it('does not prioritize a freshly suppressed urgent reservation renewal', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+    } as StructureController;
     const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
@@ -1143,6 +1202,7 @@ describe('selectWorkerTask', () => {
     };
     (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 104 };
     const creep = {
+      owner: { username: 'me' },
       memory: { role: 'worker', colony: 'W1N1' },
       getActiveBodyparts: jest.fn().mockReturnValue(1),
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
@@ -1150,6 +1210,43 @@ describe('selectWorkerTask', () => {
         constructionSites: [site],
         controller
       })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('does not prioritize an unsafe urgent reservation renewal', () => {
+    const hostile = { id: 'hostile1' } as Creep;
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 108 }]
+      }
+    };
+    const room = makeWorkerTaskRoom({ constructionSites: [site], controller });
+    const baseFind = room.find.bind(room) as (
+      type: number,
+      options?: { filter?: (structure: AnyOwnedStructure) => boolean }
+    ) => unknown[];
+    room.find = jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+      if (type === FIND_HOSTILE_CREEPS) {
+        return [hostile];
+      }
+
+      return baseFind(type, options);
+    }) as unknown as Room['find'];
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
     } as unknown as Creep;
     (creep.room as Room & { name: string }).name = 'W2N1';
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4,7 +4,10 @@ import {
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
-import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
+import {
+  TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
+  TERRITORY_RESERVATION_RENEWAL_TICKS
+} from '../src/territory/territoryPlanner';
 
 function makeLoadedWorker(room: Room, task?: CreepTaskMemory): Creep {
   return {
@@ -1091,7 +1094,34 @@ describe('selectWorkerTask', () => {
     expect(room.find).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
-  it('renews an urgent own visible reservation before local construction', () => {
+  it('renews an urgent own visible reservation before local construction with enough CLAIM parts', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 106 }]
+      }
+    };
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(2),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
+  });
+
+  it('keeps local construction before a normal-threshold own reservation renewal with one CLAIM part', () => {
     const controller = {
       id: 'controller2',
       my: false,
@@ -1115,7 +1145,61 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
     (creep.room as Room & { name: string }).name = 'W2N1';
 
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('renews an emergency own visible reservation before local construction with one CLAIM part', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 106 }]
+      }
+    };
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
     expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
+  });
+
+  it('keeps local construction before a non-emergency own reservation renewal with one CLAIM part', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS + 1 }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 106 }]
+      }
+    };
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
   });
 
   it('keeps local construction before a comfortable own visible reservation', () => {


### PR DESCRIPTION
## Summary
- Prefer urgent visible own reservation renewals before local non-urgent work when a worker has CLAIM capability and the reservation is at/below the renewal threshold.
- Keep comfortable reservations, suppressed territory targets, and hostile/unsafe rooms from preempting local work.
- Add Jest coverage for urgent renewal preference, comfortable non-preemption, suppression, and hostile safety; synchronize `prod/dist/main.js`.

Closes #169.

## Verification
- Controller pre-commit: `git diff --check`
- Controller pre-commit: `npm run typecheck`
- Controller pre-commit: `npm test -- --runInBand` (16 suites, 258 tests before PR #168 merge)
- Controller pre-commit: `npm run build`
- Controller after merging current `origin/main` / PR #168: `git diff --check`
- Controller after merging current `origin/main` / PR #168: `npm run typecheck`
- Controller after merging current `origin/main` / PR #168: `npm test -- --runInBand` (16 suites, 262 tests)
- Controller after merging current `origin/main` / PR #168: `npm run build`
- Controller after merging current `origin/main` / PR #168: `git diff --exit-code -- prod/dist/main.js`

## Scheduler notes
- Worktree: `/root/screeps-worktrees/urgent-reservation-renewal-169`
- Branch contains current `origin/main` (`059ceac`, PR #168) as an ancestor.
- Remaining untracked `prod/node_modules` is dependency infrastructure and is intentionally not staged.
