### PR TITLE
feat: preempt worker spending for spawn energy pressure

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1747,6 +1747,11 @@ function runWorker(creep) {
     assignNextTask(creep);
     return;
   }
+  if (shouldPreemptSpendingTaskForEnergySink(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
   if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
@@ -1806,6 +1811,16 @@ function shouldPreemptForVisibleTerritoryControllerTask(creep, task) {
   }
   return !isSameTask(task, controllerTask);
 }
+function shouldPreemptSpendingTaskForEnergySink(creep, task) {
+  if (!isEnergySpendingTask(task)) {
+    return false;
+  }
+  if (!creep.room) {
+    return false;
+  }
+  const nextTask = selectWorkerTask(creep);
+  return (nextTask == null ? void 0 : nextTask.type) === "transfer" && !isSameTask(task, nextTask);
+}
 function shouldPreemptUpgradeTask(creep, task) {
   var _a;
   if (task.type !== "upgrade") {
@@ -1823,6 +1838,9 @@ function shouldPreemptUpgradeTask(creep, task) {
 }
 function isSameTask(left, right) {
   return left.type === right.type && left.targetId === right.targetId;
+}
+function isEnergySpendingTask(task) {
+  return task.type === "build" || task.type === "repair" || task.type === "upgrade";
 }
 function isTerritoryControlTask2(task) {
   return task.type === "claim" || task.type === "reserve";

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -19,6 +19,12 @@ export function runWorker(creep: Creep): void {
     return;
   }
 
+  if (shouldPreemptSpendingTaskForEnergySink(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+
   if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
@@ -91,6 +97,19 @@ function shouldPreemptForVisibleTerritoryControllerTask(creep: Creep, task: Cree
   return !isSameTask(task, controllerTask);
 }
 
+function shouldPreemptSpendingTaskForEnergySink(creep: Creep, task: CreepTaskMemory): boolean {
+  if (!isEnergySpendingTask(task)) {
+    return false;
+  }
+
+  if (!creep.room) {
+    return false;
+  }
+
+  const nextTask = selectWorkerTask(creep);
+  return nextTask?.type === 'transfer' && !isSameTask(task, nextTask);
+}
+
 function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean {
   if (task.type !== 'upgrade') {
     return false;
@@ -111,6 +130,13 @@ function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean 
 
 function isSameTask(left: CreepTaskMemory, right: CreepTaskMemory): boolean {
   return left.type === right.type && left.targetId === right.targetId;
+}
+
+function isEnergySpendingTask(task: CreepTaskMemory): task is Extract<
+  CreepTaskMemory,
+  { type: 'build' | 'repair' | 'upgrade' }
+> {
+  return task.type === 'build' || task.type === 'repair' || task.type === 'upgrade';
 }
 
 function isTerritoryControlTask(task: CreepTaskMemory): task is Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }> {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -405,6 +405,142 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['spawn', 'spawn1'],
+    ['extension', 'extension1']
+  ])('preempts construction for fillable %s energy under spawn pressure', (structureType, id) => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const energySink = {
+      id,
+      structureType,
+      store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
+    } as unknown as StructureSpawn | StructureExtension;
+    const creep = {
+      memory: { task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [energySink];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            return type === FIND_CONSTRUCTION_SITES ? [site] : [];
+          }
+        )
+      },
+      build: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(site)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: id });
+    expect(Game.getObjectById).not.toHaveBeenCalled();
+    expect(creep.build).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps construction work when spawn and extension energy is full', () => {
+    const site = { id: 'site1' } as ConstructionSite;
+    const fullSpawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const fullExtension = {
+      id: 'extension1',
+      structureType: 'extension',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureExtension;
+    const build = jest.fn().mockReturnValue(0);
+    const creep = {
+      memory: { task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [fullSpawn, fullExtension];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            return type === FIND_CONSTRUCTION_SITES ? [site] : [];
+          }
+        )
+      },
+      build,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(site)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(Game.getObjectById).toHaveBeenCalledWith('site1');
+    expect(build).toHaveBeenCalledWith(site);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps controller upgrade work when spawn and extension energy is full', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const fullSpawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const fullExtension = {
+      id: 'extension1',
+      structureType: 'extension',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureExtension;
+    const upgradeController = jest.fn().mockReturnValue(0);
+    const creep = {
+      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        controller,
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [fullSpawn, fullExtension];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            return [];
+          }
+        )
+      },
+      upgradeController,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(Game.getObjectById).toHaveBeenCalledWith('controller1');
+    expect(upgradeController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('clears missing build targets and reassigns without building the stale target', () => {
     const site = { id: 'site2' } as ConstructionSite;
     const build = jest.fn();


### PR DESCRIPTION
Closes #171.

## Summary
- preempts stale build/repair/upgrade work when a loaded worker can refill a spawn or extension under pressure
- keeps existing spending tasks when spawn/extension sinks are full
- adds worker-runner coverage and refreshes the Screeps bundle

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites, 263 tests)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Scheduler notes: Codex-authored commit `c6f612f`; untracked `prod/node_modules` was not staged.