### PR TITLE
feat: keep territory renewals active until safe

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -572,6 +572,7 @@ var TERRITORY_SCOUT_ROLE = "scout";
 var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
 var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
 var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
+var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
 var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
@@ -632,23 +633,31 @@ function selectVisibleTerritoryControllerTask(creep) {
     return null;
   }
   if (intent.action === "reserve") {
-    const activeClaimParts = getActiveControllerClaimPartCount(creep);
-    if (activeClaimParts <= 0) {
-      return null;
-    }
-    const reservationTicksToEnd = getUrgentOwnReservationTicksToEnd(
-      controller,
-      getTerritoryActorUsername(creep, intent.colony)
-    );
-    if (reservationTicksToEnd !== null && !canRenewReservation(activeClaimParts, reservationTicksToEnd)) {
-      return null;
-    }
-    return { type: "reserve", targetId: controller.id };
+    return canCreepReserveTerritoryController(creep, controller, intent.colony) ? { type: "reserve", targetId: controller.id } : null;
   }
   if (controller.my === true) {
     return getStoredEnergy(creep) > 0 ? { type: "upgrade", targetId: controller.id } : null;
   }
   return canUseControllerClaimPart(creep) ? { type: "claim", targetId: controller.id } : null;
+}
+function canCreepReserveTerritoryController(creep, controller, colony) {
+  const activeClaimParts = getActiveControllerClaimPartCount(creep);
+  if (activeClaimParts <= 0) {
+    return false;
+  }
+  if (isControllerOwned(controller)) {
+    return false;
+  }
+  const reservation = controller.reservation;
+  if (!reservation) {
+    return true;
+  }
+  const actorUsername = getTerritoryActorUsername(creep, colony);
+  if (!isNonEmptyString(actorUsername) || !isNonEmptyString(reservation.username) || reservation.username !== actorUsername || typeof reservation.ticksToEnd !== "number") {
+    return false;
+  }
+  const reservationTicksToEnd = reservation.ticksToEnd;
+  return reservationTicksToEnd <= TERRITORY_RESERVATION_COMFORT_TICKS && canRenewReservation(activeClaimParts, reservationTicksToEnd);
 }
 function selectUrgentVisibleReservationRenewalTask(creep) {
   const intent = selectVisibleTerritoryControllerIntent(creep);
@@ -1020,6 +1029,9 @@ function isCreepVisibleTerritoryIntentActionable(creep, intent) {
   if (intent.action === "claim" && controller.my === true) {
     return true;
   }
+  if (intent.action === "reserve") {
+    return canCreepReserveTerritoryController(creep, controller, intent.colony);
+  }
   return getTerritoryControllerTargetState(controller, intent.action, getTerritoryActorUsername(creep, intent.colony)) === "available";
 }
 function selectVisibleTerritoryAssignmentController(assignment, creep) {
@@ -1166,11 +1178,15 @@ function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername);
 }
 function getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
+  const ticksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+  return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? ticksToEnd : null;
+}
+function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   if (isControllerOwned(controller) || !isNonEmptyString(colonyOwnerUsername)) {
     return null;
   }
   const reservation = controller.reservation;
-  if (!reservation || reservation.username !== colonyOwnerUsername || typeof reservation.ticksToEnd !== "number" || reservation.ticksToEnd > TERRITORY_RESERVATION_RENEWAL_TICKS) {
+  if (!reservation || reservation.username !== colonyOwnerUsername || typeof reservation.ticksToEnd !== "number") {
     return null;
   }
   return reservation.ticksToEnd;
@@ -2342,6 +2358,9 @@ function runTerritoryControllerCreep(creep) {
     } else {
       completeTerritoryAssignment(creep);
     }
+    return;
+  }
+  if (assignment.action === "reserve" && !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return;
   }
   const result = assignment.action === "claim" ? executeControllerAction(creep, controller, "claimController") : executeControllerAction(creep, controller, "reserveController");

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1073,7 +1073,7 @@ function canUseControllerClaimPart(creep) {
   return getActiveControllerClaimPartCount(creep) > 0;
 }
 function canRenewReservation(activeClaimParts, reservationTicksToEnd) {
-  return activeClaimParts >= MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS || reservationTicksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
+  return reservationTicksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS || reservationTicksToEnd <= TERRITORY_RESERVATION_COMFORT_TICKS && activeClaimParts >= MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS;
 }
 function getActiveControllerClaimPartCount(creep) {
   var _a;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -7,6 +7,7 @@ export const TERRITORY_SCOUT_ROLE = 'scout';
 export const TERRITORY_DOWNGRADE_GUARD_TICKS = 5_000;
 export const TERRITORY_RESERVATION_RENEWAL_TICKS = 1_000;
 export const TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
+export const TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 
 const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
@@ -110,20 +111,9 @@ export function selectVisibleTerritoryControllerTask(creep: Creep): CreepTaskMem
   }
 
   if (intent.action === 'reserve') {
-    const activeClaimParts = getActiveControllerClaimPartCount(creep);
-    if (activeClaimParts <= 0) {
-      return null;
-    }
-
-    const reservationTicksToEnd = getUrgentOwnReservationTicksToEnd(
-      controller,
-      getTerritoryActorUsername(creep, intent.colony)
-    );
-    if (reservationTicksToEnd !== null && !canRenewReservation(activeClaimParts, reservationTicksToEnd)) {
-      return null;
-    }
-
-    return { type: 'reserve', targetId: controller.id };
+    return canCreepReserveTerritoryController(creep, controller, intent.colony)
+      ? { type: 'reserve', targetId: controller.id }
+      : null;
   }
 
   if (controller.my === true) {
@@ -131,6 +121,42 @@ export function selectVisibleTerritoryControllerTask(creep: Creep): CreepTaskMem
   }
 
   return canUseControllerClaimPart(creep) ? { type: 'claim', targetId: controller.id } : null;
+}
+
+export function canCreepReserveTerritoryController(
+  creep: Creep,
+  controller: StructureController,
+  colony: string | undefined
+): boolean {
+  const activeClaimParts = getActiveControllerClaimPartCount(creep);
+  if (activeClaimParts <= 0) {
+    return false;
+  }
+
+  if (isControllerOwned(controller)) {
+    return false;
+  }
+
+  const reservation = controller.reservation;
+  if (!reservation) {
+    return true;
+  }
+
+  const actorUsername = getTerritoryActorUsername(creep, colony);
+  if (
+    !isNonEmptyString(actorUsername) ||
+    !isNonEmptyString(reservation.username) ||
+    reservation.username !== actorUsername ||
+    typeof reservation.ticksToEnd !== 'number'
+  ) {
+    return false;
+  }
+
+  const reservationTicksToEnd = reservation.ticksToEnd;
+  return (
+    reservationTicksToEnd <= TERRITORY_RESERVATION_COMFORT_TICKS &&
+    canRenewReservation(activeClaimParts, reservationTicksToEnd)
+  );
 }
 
 export function selectUrgentVisibleReservationRenewalTask(creep: Creep): CreepTaskMemory | null {
@@ -724,6 +750,10 @@ function isCreepVisibleTerritoryIntentActionable(creep: Creep, intent: Territory
     return true;
   }
 
+  if (intent.action === 'reserve') {
+    return canCreepReserveTerritoryController(creep, controller, intent.colony);
+  }
+
   return (
     getTerritoryControllerTargetState(controller, intent.action, getTerritoryActorUsername(creep, intent.colony)) ===
     'available'
@@ -933,6 +963,14 @@ function getUrgentOwnReservationTicksToEnd(
   controller: StructureController,
   colonyOwnerUsername: string | null
 ): number | null {
+  const ticksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+  return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? ticksToEnd : null;
+}
+
+function getOwnReservationTicksToEnd(
+  controller: StructureController,
+  colonyOwnerUsername: string | null
+): number | null {
   if (isControllerOwned(controller) || !isNonEmptyString(colonyOwnerUsername)) {
     return null;
   }
@@ -941,8 +979,7 @@ function getUrgentOwnReservationTicksToEnd(
   if (
     !reservation ||
     reservation.username !== colonyOwnerUsername ||
-    typeof reservation.ticksToEnd !== 'number' ||
-    reservation.ticksToEnd > TERRITORY_RESERVATION_RENEWAL_TICKS
+    typeof reservation.ticksToEnd !== 'number'
   ) {
     return null;
   }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -815,8 +815,9 @@ function canUseControllerClaimPart(creep: Creep): boolean {
 
 function canRenewReservation(activeClaimParts: number, reservationTicksToEnd: number): boolean {
   return (
-    activeClaimParts >= MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS ||
-    reservationTicksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS
+    reservationTicksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ||
+    (reservationTicksToEnd <= TERRITORY_RESERVATION_COMFORT_TICKS &&
+      activeClaimParts >= MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS)
   );
 }
 

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -1,4 +1,5 @@
 import {
+  canCreepReserveTerritoryController,
   isVisibleTerritoryAssignmentComplete,
   isVisibleTerritoryAssignmentSafe,
   suppressTerritoryIntent
@@ -53,6 +54,13 @@ export function runTerritoryControllerCreep(creep: Creep): void {
     } else {
       completeTerritoryAssignment(creep);
     }
+    return;
+  }
+
+  if (
+    assignment.action === 'reserve' &&
+    !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)
+  ) {
     return;
   }
 

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -383,6 +383,7 @@ describe('runEconomy', () => {
     const creep = {
       memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
       room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
       reserveController: jest.fn().mockReturnValue(0),
       moveTo: jest.fn()
     } as unknown as Creep;

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -122,7 +122,7 @@ describe('runTerritoryControllerCreep', () => {
     expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve' });
   });
 
-  it('idles a one-CLAIM reserver at the normal renewal threshold until emergency', () => {
+  it('lets a one-CLAIM reserver renew at the normal renewal threshold', () => {
     const controller = {
       id: 'controller1',
       my: false,
@@ -139,7 +139,7 @@ describe('runTerritoryControllerCreep', () => {
 
     runTerritoryControllerCreep(creep);
 
-    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
     expect(creep.moveTo).not.toHaveBeenCalled();
     expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve' });
   });

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -1,3 +1,8 @@
+import {
+  TERRITORY_RESERVATION_COMFORT_TICKS,
+  TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
+  TERRITORY_RESERVATION_RENEWAL_TICKS
+} from '../src/territory/territoryPlanner';
 import { runTerritoryControllerCreep } from '../src/territory/territoryRunner';
 
 describe('runTerritoryControllerCreep', () => {
@@ -82,6 +87,7 @@ describe('runTerritoryControllerCreep', () => {
     const creep = {
       memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
       room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
       reserveController: jest.fn().mockReturnValue(-9),
       moveTo: jest.fn()
     } as unknown as Creep;
@@ -94,11 +100,77 @@ describe('runTerritoryControllerCreep', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
-  it('keeps a visible healthy own reservation active without suppressing it', () => {
+  it('continues a visible own reservation above the normal renewal threshold with enough CLAIM parts', () => {
     const controller = {
       id: 'controller1',
       my: false,
-      reservation: { username: 'me', ticksToEnd: 4_000 }
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 1 }
+    } as StructureController;
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(2),
+      reserveController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve' });
+  });
+
+  it('idles a one-CLAIM reserver at the normal renewal threshold until emergency', () => {
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+    } as StructureController;
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      reserveController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve' });
+  });
+
+  it('lets a one-CLAIM reserver renew at the emergency threshold', () => {
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS }
+    } as StructureController;
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      reserveController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve' });
+  });
+
+  it('keeps a visible comfortably safe own reservation active without working it or suppressing it', () => {
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_COMFORT_TICKS + 1 }
     } as StructureController;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
@@ -117,13 +189,14 @@ describe('runTerritoryControllerCreep', () => {
       owner: { username: 'me' },
       memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
       room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(2),
       reserveController: jest.fn().mockReturnValue(0),
       moveTo: jest.fn()
     } as unknown as Creep;
 
     runTerritoryControllerCreep(creep);
 
-    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.reserveController).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
     expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve' });
     expect(Memory.territory?.intents).toEqual([

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -633,7 +633,7 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
-  it('clears a normal-threshold reservation task for a one-CLAIM worker before executing it', () => {
+  it('executes a normal-threshold reservation task for a one-CLAIM worker', () => {
     const controller = {
       id: 'controller2',
       my: false,
@@ -674,9 +674,9 @@ describe('runWorker', () => {
 
     runWorker(creep);
 
-    expect(getObjectById).not.toHaveBeenCalled();
-    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
-    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(getObjectById).toHaveBeenCalledWith('controller2');
+    expect(creep.memory.task).toEqual({ type: 'reserve', targetId: 'controller2' });
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1122,7 +1122,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
   });
 
-  it('keeps local construction before a normal-threshold own reservation renewal with one CLAIM part', () => {
+  it('renews a normal-threshold own visible reservation before local construction with one CLAIM part', () => {
     const controller = {
       id: 'controller2',
       my: false,
@@ -1146,7 +1146,7 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
     (creep.room as Room & { name: string }).name = 'W2N1';
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
   });
 
   it('renews an emergency own visible reservation before local construction with one CLAIM part', () => {
@@ -1176,11 +1176,11 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
   });
 
-  it('keeps local construction before a non-emergency own reservation renewal with one CLAIM part', () => {
+  it('keeps local construction before an above-normal own reservation renewal with one CLAIM part', () => {
     const controller = {
       id: 'controller2',
       my: false,
-      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS + 1 }
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 1 }
     } as StructureController;
     const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -5,6 +5,7 @@ import {
   selectWorkerTask
 } from '../src/tasks/workerTasks';
 import {
+  TERRITORY_RESERVATION_COMFORT_TICKS,
   TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
   TERRITORY_RESERVATION_RENEWAL_TICKS
 } from '../src/territory/territoryPlanner';
@@ -1229,6 +1230,60 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
   });
 
+  it('continues a visible own reservation above the normal renewal threshold with enough CLAIM parts', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 1 }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 107 }]
+      }
+    };
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(2),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
+  });
+
+  it('stops continuing a visible own reservation once it is comfortably safe', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_COMFORT_TICKS + 1 }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 107 }]
+      }
+    };
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(2),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
   it('claims a safe visible territory target before local construction', () => {
     const controller = { id: 'controller2', my: false } as StructureController;
     const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
@@ -1300,6 +1355,34 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
   });
 
+  it('does not continue a freshly suppressed reservation inside the comfort buffer', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 1 }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'suppressed', updatedAt: 103 }]
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 104 };
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(2),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
   it('does not prioritize an unsafe urgent reservation renewal', () => {
     const hostile = { id: 'hostile1' } as Creep;
     const controller = {
@@ -1329,6 +1412,43 @@ describe('selectWorkerTask', () => {
       owner: { username: 'me' },
       memory: { role: 'worker', colony: 'W1N1' },
       getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('does not continue a reservation inside the comfort buffer in an unsafe room', () => {
+    const hostile = { id: 'hostile1' } as Creep;
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 1 }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'active', updatedAt: 108 }]
+      }
+    };
+    const room = makeWorkerTaskRoom({ constructionSites: [site], controller });
+    const baseFind = room.find.bind(room) as (
+      type: number,
+      options?: { filter?: (structure: AnyOwnedStructure) => boolean }
+    ) => unknown[];
+    room.find = jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+      if (type === FIND_HOSTILE_CREEPS) {
+        return [hostile];
+      }
+
+      return baseFind(type, options);
+    }) as unknown as Room['find'];
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1' },
+      getActiveBodyparts: jest.fn().mockReturnValue(2),
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
       room
     } as unknown as Creep;


### PR DESCRIPTION
Closes #173.

## Summary
- Keep territory reservation renewals active until a safer reservation buffer is reached.
- Preserve emergency/hostile/suppression and one-CLAIM guard behavior.
- Add deterministic Jest coverage for reservation continuation and guard cases.
- Synchronize `prod/dist/main.js` through the build.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites / 277 tests)
- `cd prod && npm run build`
- `cd prod && git diff --exit-code -- prod/dist/main.js`

## Notes
- Recovered from Codex worktree after prior process ended without a real commit; final commit is Codex-authored (`lanyusea's bot <lanyusea@gmail.com>`).
- `prod/node_modules` remains untracked dependency infrastructure and is not part of this PR.
