### PR TITLE
feat: keep workers focused on spawn energy recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1263,6 +1263,8 @@ var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 var ENERGY_ACQUISITION_RANGE_COST = 50;
+var ENERGY_ACQUISITION_ACTION_TICKS = 1;
+var HARVEST_ENERGY_PER_WORK_PART = 2;
 function selectWorkerTask(creep) {
   const carriedEnergy = getUsedEnergy(creep);
   const urgentReservationRenewalTask = selectUrgentVisibleReservationRenewalTask(creep);
@@ -1275,9 +1277,17 @@ function selectWorkerTask(creep) {
       return territoryControllerTask;
     }
     if (getFreeEnergyCapacity(creep) > 0) {
-      const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
-      if (energyAcquisitionTask) {
-        return energyAcquisitionTask;
+      const spawnRecoveryEnergySink = selectFillableEnergySink(creep);
+      if (spawnRecoveryEnergySink) {
+        const spawnRecoveryTask = selectSpawnRecoveryEnergyAcquisitionTask(creep, spawnRecoveryEnergySink);
+        if (spawnRecoveryTask) {
+          return spawnRecoveryTask;
+        }
+      } else {
+        const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
+        if (energyAcquisitionTask) {
+          return energyAcquisitionTask;
+        }
       }
     }
     const source = selectHarvestSource(creep);
@@ -1475,6 +1485,14 @@ function selectWorkerEnergyAcquisitionTask(creep) {
   }
   return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
 }
+function selectSpawnRecoveryEnergyAcquisitionTask(creep, energySink) {
+  const harvestEta = estimateHarvestDeliveryEta(creep, energySink);
+  const candidates = findWorkerEnergyAcquisitionCandidates(creep).map((candidate) => createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink)).filter((candidate) => candidate !== null).filter((candidate) => harvestEta === null || candidate.deliveryEta < harvestEta);
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(compareSpawnRecoveryEnergyAcquisitionCandidates)[0].task;
+}
 function findWorkerEnergyAcquisitionCandidates(creep) {
   const context = {
     creepOwnerUsername: getCreepOwnerUsername2(creep),
@@ -1511,6 +1529,52 @@ function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
     task
   };
 }
+function createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink) {
+  if (candidate.range === null) {
+    return null;
+  }
+  const sourceToSinkRange = getRangeBetweenRoomObjects(candidate.source, energySink);
+  if (sourceToSinkRange === null) {
+    return null;
+  }
+  return {
+    ...candidate,
+    deliveryEta: candidate.range + ENERGY_ACQUISITION_ACTION_TICKS + sourceToSinkRange
+  };
+}
+function estimateHarvestDeliveryEta(creep, energySink) {
+  const source = selectHarvestSource(creep);
+  if (!source) {
+    return null;
+  }
+  const creepToSourceRange = getRangeBetweenRoomObjects(creep, source);
+  const sourceToSinkRange = getRangeBetweenRoomObjects(source, energySink);
+  if (creepToSourceRange === null || sourceToSinkRange === null) {
+    return null;
+  }
+  return creepToSourceRange + estimateHarvestTicks(creep, energySink) + sourceToSinkRange;
+}
+function estimateHarvestTicks(creep, energySink) {
+  const energyNeeded = Math.max(1, Math.min(getFreeEnergyCapacity(creep), getFreeStoredEnergyCapacity(energySink)));
+  const workParts = getActiveWorkParts(creep);
+  return Math.ceil(energyNeeded / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
+}
+function getActiveWorkParts(creep) {
+  const workPart = globalThis.WORK;
+  if (typeof workPart !== "string" || typeof creep.getActiveBodyparts !== "function") {
+    return 1;
+  }
+  const activeWorkParts = creep.getActiveBodyparts(workPart);
+  return Number.isFinite(activeWorkParts) && activeWorkParts > 0 ? activeWorkParts : 1;
+}
+function getRangeBetweenRoomObjects(left, right) {
+  const position = left.pos;
+  if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
+    return null;
+  }
+  const range = position.getRangeTo(right);
+  return Number.isFinite(range) ? Math.max(0, range) : null;
+}
 function getRangeToWorkerEnergyAcquisitionSource(creep, source) {
   const position = creep.pos;
   if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
@@ -1521,6 +1585,9 @@ function getRangeToWorkerEnergyAcquisitionSource(creep, source) {
 }
 function compareWorkerEnergyAcquisitionCandidates(left, right) {
   return right.score - left.score || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
+}
+function compareSpawnRecoveryEnergyAcquisitionCandidates(left, right) {
+  return left.deliveryEta - right.deliveryEta || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
 }
 function compareOptionalRanges(left, right) {
   if (left !== null && right !== null) {
@@ -1817,6 +1884,11 @@ function runWorker(creep) {
     assignNextTask(creep);
     return;
   }
+  if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
   if (shouldPreemptSpendingTaskForEnergySink(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
@@ -1891,6 +1963,25 @@ function shouldPreemptSpendingTaskForEnergySink(creep, task) {
   const nextTask = selectWorkerTask(creep);
   return (nextTask == null ? void 0 : nextTask.type) === "transfer" && !isSameTask(task, nextTask);
 }
+function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task) {
+  var _a, _b, _c;
+  if (!isEnergyAcquisitionTask(task)) {
+    return false;
+  }
+  if (!((_a = creep.store) == null ? void 0 : _a.getUsedCapacity) || !((_b = creep.store) == null ? void 0 : _b.getFreeCapacity)) {
+    return false;
+  }
+  if (typeof ((_c = creep.room) == null ? void 0 : _c.find) !== "function") {
+    return false;
+  }
+  const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
+  const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
+  if (usedEnergy !== 0 || freeEnergyCapacity <= 0) {
+    return false;
+  }
+  const nextTask = selectWorkerTask(creep);
+  return isRecoverableEnergyTask(nextTask) && !isSameTask(task, nextTask);
+}
 function shouldPreemptUpgradeTask(creep, task) {
   var _a;
   if (task.type !== "upgrade") {
@@ -1911,6 +2002,12 @@ function isSameTask(left, right) {
 }
 function isEnergySpendingTask(task) {
   return task.type === "build" || task.type === "repair" || task.type === "upgrade";
+}
+function isEnergyAcquisitionTask(task) {
+  return task.type === "harvest" || task.type === "pickup" || task.type === "withdraw";
+}
+function isRecoverableEnergyTask(task) {
+  return (task == null ? void 0 : task.type) === "pickup" || (task == null ? void 0 : task.type) === "withdraw";
 }
 function isTerritoryControlTask2(task) {
   return task.type === "claim" || task.type === "reserve";

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1547,17 +1547,31 @@ function estimateHarvestDeliveryEta(creep, energySink) {
   if (!source) {
     return null;
   }
+  const sourceAvailabilityDelay = estimateHarvestSourceAvailabilityDelay(source);
+  if (sourceAvailabilityDelay === null) {
+    return null;
+  }
   const creepToSourceRange = getRangeBetweenRoomObjects(creep, source);
   const sourceToSinkRange = getRangeBetweenRoomObjects(source, energySink);
   if (creepToSourceRange === null || sourceToSinkRange === null) {
     return null;
   }
-  return creepToSourceRange + estimateHarvestTicks(creep, energySink) + sourceToSinkRange;
+  return creepToSourceRange + sourceAvailabilityDelay + estimateHarvestTicks(creep, energySink) + sourceToSinkRange;
 }
 function estimateHarvestTicks(creep, energySink) {
   const energyNeeded = Math.max(1, Math.min(getFreeEnergyCapacity(creep), getFreeStoredEnergyCapacity(energySink)));
   const workParts = getActiveWorkParts(creep);
   return Math.ceil(energyNeeded / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
+}
+function estimateHarvestSourceAvailabilityDelay(source) {
+  if (typeof source.energy !== "number") {
+    return 0;
+  }
+  if (source.energy > 0) {
+    return 0;
+  }
+  const ticksToRegeneration = source.ticksToRegeneration;
+  return Number.isFinite(ticksToRegeneration) && ticksToRegeneration > 0 ? Math.ceil(ticksToRegeneration) : null;
 }
 function getActiveWorkParts(creep) {
   const workPart = globalThis.WORK;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1561,6 +1561,9 @@ function estimateHarvestDeliveryEta(creep, energySink) {
 function estimateHarvestTicks(creep, energySink) {
   const energyNeeded = Math.max(1, Math.min(getFreeEnergyCapacity(creep), getFreeStoredEnergyCapacity(energySink)));
   const workParts = getActiveWorkParts(creep);
+  if (workParts === 0) {
+    return Number.POSITIVE_INFINITY;
+  }
   return Math.ceil(energyNeeded / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
 }
 function estimateHarvestSourceAvailabilityDelay(source) {
@@ -1579,6 +1582,9 @@ function getActiveWorkParts(creep) {
     return 1;
   }
   const activeWorkParts = creep.getActiveBodyparts(workPart);
+  if (activeWorkParts === 0) {
+    return 0;
+  }
   return Number.isFinite(activeWorkParts) && activeWorkParts > 0 ? activeWorkParts : 1;
 }
 function getRangeBetweenRoomObjects(left, right) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -19,6 +19,12 @@ export function runWorker(creep: Creep): void {
     return;
   }
 
+  if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+
   if (shouldPreemptSpendingTaskForEnergySink(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
@@ -110,6 +116,29 @@ function shouldPreemptSpendingTaskForEnergySink(creep: Creep, task: CreepTaskMem
   return nextTask?.type === 'transfer' && !isSameTask(task, nextTask);
 }
 
+function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep: Creep, task: CreepTaskMemory): boolean {
+  if (!isEnergyAcquisitionTask(task)) {
+    return false;
+  }
+
+  if (!creep.store?.getUsedCapacity || !creep.store?.getFreeCapacity) {
+    return false;
+  }
+
+  if (typeof creep.room?.find !== 'function') {
+    return false;
+  }
+
+  const usedEnergy = creep.store.getUsedCapacity(RESOURCE_ENERGY);
+  const freeEnergyCapacity = creep.store.getFreeCapacity(RESOURCE_ENERGY);
+  if (usedEnergy !== 0 || freeEnergyCapacity <= 0) {
+    return false;
+  }
+
+  const nextTask = selectWorkerTask(creep);
+  return isRecoverableEnergyTask(nextTask) && !isSameTask(task, nextTask);
+}
+
 function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean {
   if (task.type !== 'upgrade') {
     return false;
@@ -137,6 +166,19 @@ function isEnergySpendingTask(task: CreepTaskMemory): task is Extract<
   { type: 'build' | 'repair' | 'upgrade' }
 > {
   return task.type === 'build' || task.type === 'repair' || task.type === 'upgrade';
+}
+
+function isEnergyAcquisitionTask(task: CreepTaskMemory): task is Extract<
+  CreepTaskMemory,
+  { type: 'harvest' | 'pickup' | 'withdraw' }
+> {
+  return task.type === 'harvest' || task.type === 'pickup' || task.type === 'withdraw';
+}
+
+function isRecoverableEnergyTask(
+  task: CreepTaskMemory | null
+): task is Extract<CreepTaskMemory, { type: 'pickup' | 'withdraw' }> {
+  return task?.type === 'pickup' || task?.type === 'withdraw';
 }
 
 function isTerritoryControlTask(task: CreepTaskMemory): task is Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }> {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -457,19 +457,37 @@ function estimateHarvestDeliveryEta(creep: Creep, energySink: FillableEnergySink
     return null;
   }
 
+  const sourceAvailabilityDelay = estimateHarvestSourceAvailabilityDelay(source);
+  if (sourceAvailabilityDelay === null) {
+    return null;
+  }
+
   const creepToSourceRange = getRangeBetweenRoomObjects(creep, source);
   const sourceToSinkRange = getRangeBetweenRoomObjects(source, energySink);
   if (creepToSourceRange === null || sourceToSinkRange === null) {
     return null;
   }
 
-  return creepToSourceRange + estimateHarvestTicks(creep, energySink) + sourceToSinkRange;
+  return creepToSourceRange + sourceAvailabilityDelay + estimateHarvestTicks(creep, energySink) + sourceToSinkRange;
 }
 
 function estimateHarvestTicks(creep: Creep, energySink: FillableEnergySink): number {
   const energyNeeded = Math.max(1, Math.min(getFreeEnergyCapacity(creep), getFreeStoredEnergyCapacity(energySink)));
   const workParts = getActiveWorkParts(creep);
   return Math.ceil(energyNeeded / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
+}
+
+function estimateHarvestSourceAvailabilityDelay(source: Source): number | null {
+  if (typeof source.energy !== 'number') {
+    return 0;
+  }
+
+  if (source.energy > 0) {
+    return 0;
+  }
+
+  const ticksToRegeneration = source.ticksToRegeneration;
+  return Number.isFinite(ticksToRegeneration) && ticksToRegeneration > 0 ? Math.ceil(ticksToRegeneration) : null;
 }
 
 function getActiveWorkParts(creep: Creep): number {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -474,6 +474,10 @@ function estimateHarvestDeliveryEta(creep: Creep, energySink: FillableEnergySink
 function estimateHarvestTicks(creep: Creep, energySink: FillableEnergySink): number {
   const energyNeeded = Math.max(1, Math.min(getFreeEnergyCapacity(creep), getFreeStoredEnergyCapacity(energySink)));
   const workParts = getActiveWorkParts(creep);
+  if (workParts === 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+
   return Math.ceil(energyNeeded / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
 }
 
@@ -497,6 +501,10 @@ function getActiveWorkParts(creep: Creep): number {
   }
 
   const activeWorkParts = creep.getActiveBodyparts(workPart);
+  if (activeWorkParts === 0) {
+    return 0;
+  }
+
   return Number.isFinite(activeWorkParts) && activeWorkParts > 0 ? activeWorkParts : 1;
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -11,6 +11,8 @@ const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 const MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 const ENERGY_ACQUISITION_RANGE_COST = 50;
+const ENERGY_ACQUISITION_ACTION_TICKS = 1;
+const HARVEST_ENERGY_PER_WORK_PART = 2;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
@@ -44,9 +46,17 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     }
 
     if (getFreeEnergyCapacity(creep) > 0) {
-      const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
-      if (energyAcquisitionTask) {
-        return energyAcquisitionTask;
+      const spawnRecoveryEnergySink = selectFillableEnergySink(creep);
+      if (spawnRecoveryEnergySink) {
+        const spawnRecoveryTask = selectSpawnRecoveryEnergyAcquisitionTask(creep, spawnRecoveryEnergySink);
+        if (spawnRecoveryTask) {
+          return spawnRecoveryTask;
+        }
+      } else {
+        const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
+        if (energyAcquisitionTask) {
+          return energyAcquisitionTask;
+        }
       }
     }
 
@@ -341,6 +351,10 @@ interface WorkerEnergyAcquisitionCandidate {
   task: WorkerEnergyAcquisitionTask;
 }
 
+interface SpawnRecoveryEnergyAcquisitionCandidate extends WorkerEnergyAcquisitionCandidate {
+  deliveryEta: number;
+}
+
 function selectWorkerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitionTask | null {
   const candidates = findWorkerEnergyAcquisitionCandidates(creep);
   if (candidates.length === 0) {
@@ -348,6 +362,23 @@ function selectWorkerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitio
   }
 
   return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+
+function selectSpawnRecoveryEnergyAcquisitionTask(
+  creep: Creep,
+  energySink: FillableEnergySink
+): WorkerEnergyAcquisitionTask | null {
+  const harvestEta = estimateHarvestDeliveryEta(creep, energySink);
+  const candidates = findWorkerEnergyAcquisitionCandidates(creep)
+    .map((candidate) => createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink))
+    .filter((candidate): candidate is SpawnRecoveryEnergyAcquisitionCandidate => candidate !== null)
+    .filter((candidate) => harvestEta === null || candidate.deliveryEta < harvestEta);
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.sort(compareSpawnRecoveryEnergyAcquisitionCandidates)[0].task;
 }
 
 function findWorkerEnergyAcquisitionCandidates(creep: Creep): WorkerEnergyAcquisitionCandidate[] {
@@ -401,6 +432,70 @@ function createWorkerEnergyAcquisitionCandidate(
   };
 }
 
+function createSpawnRecoveryEnergyAcquisitionCandidate(
+  candidate: WorkerEnergyAcquisitionCandidate,
+  energySink: FillableEnergySink
+): SpawnRecoveryEnergyAcquisitionCandidate | null {
+  if (candidate.range === null) {
+    return null;
+  }
+
+  const sourceToSinkRange = getRangeBetweenRoomObjects(candidate.source, energySink);
+  if (sourceToSinkRange === null) {
+    return null;
+  }
+
+  return {
+    ...candidate,
+    deliveryEta: candidate.range + ENERGY_ACQUISITION_ACTION_TICKS + sourceToSinkRange
+  };
+}
+
+function estimateHarvestDeliveryEta(creep: Creep, energySink: FillableEnergySink): number | null {
+  const source = selectHarvestSource(creep);
+  if (!source) {
+    return null;
+  }
+
+  const creepToSourceRange = getRangeBetweenRoomObjects(creep, source);
+  const sourceToSinkRange = getRangeBetweenRoomObjects(source, energySink);
+  if (creepToSourceRange === null || sourceToSinkRange === null) {
+    return null;
+  }
+
+  return creepToSourceRange + estimateHarvestTicks(creep, energySink) + sourceToSinkRange;
+}
+
+function estimateHarvestTicks(creep: Creep, energySink: FillableEnergySink): number {
+  const energyNeeded = Math.max(1, Math.min(getFreeEnergyCapacity(creep), getFreeStoredEnergyCapacity(energySink)));
+  const workParts = getActiveWorkParts(creep);
+  return Math.ceil(energyNeeded / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
+}
+
+function getActiveWorkParts(creep: Creep): number {
+  const workPart = (globalThis as unknown as { WORK?: BodyPartConstant }).WORK;
+  if (typeof workPart !== 'string' || typeof creep.getActiveBodyparts !== 'function') {
+    return 1;
+  }
+
+  const activeWorkParts = creep.getActiveBodyparts(workPart);
+  return Number.isFinite(activeWorkParts) && activeWorkParts > 0 ? activeWorkParts : 1;
+}
+
+function getRangeBetweenRoomObjects(left: RoomObject, right: RoomObject): number | null {
+  const position = (left as RoomObject & {
+    pos?: {
+      getRangeTo?: (target: RoomObject) => number;
+    };
+  }).pos;
+  if (typeof position?.getRangeTo !== 'function') {
+    return null;
+  }
+
+  const range = position.getRangeTo(right);
+  return Number.isFinite(range) ? Math.max(0, range) : null;
+}
+
 function getRangeToWorkerEnergyAcquisitionSource(
   creep: Creep,
   source: WorkerEnergyAcquisitionSource
@@ -424,6 +519,19 @@ function compareWorkerEnergyAcquisitionCandidates(
 ): number {
   return (
     right.score - left.score ||
+    compareOptionalRanges(left.range, right.range) ||
+    right.energy - left.energy ||
+    String(left.source.id).localeCompare(String(right.source.id)) ||
+    left.task.type.localeCompare(right.task.type)
+  );
+}
+
+function compareSpawnRecoveryEnergyAcquisitionCandidates(
+  left: SpawnRecoveryEnergyAcquisitionCandidate,
+  right: SpawnRecoveryEnergyAcquisitionCandidate
+): number {
+  return (
+    left.deliveryEta - right.deliveryEta ||
     compareOptionalRanges(left.range, right.range) ||
     right.energy - left.energy ||
     String(left.source.id).localeCompare(String(right.source.id)) ||

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -2,6 +2,15 @@ import { runWorker } from '../src/creeps/workerRunner';
 import { CONTROLLER_DOWNGRADE_GUARD_TICKS, IDLE_RAMPART_REPAIR_HITS_CEILING } from '../src/tasks/workerTasks';
 import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
 
+function withRangeTo<T extends { id: string }>(object: T, rangesByTargetId: Record<string, number>): T {
+  return {
+    ...object,
+    pos: {
+      getRangeTo: jest.fn((target: RoomObject) => rangesByTargetId[String((target as { id?: string }).id)] ?? 99)
+    }
+  };
+}
+
 describe('runWorker', () => {
   beforeEach(() => {
     (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).ERR_NOT_IN_RANGE = -9;
@@ -823,6 +832,67 @@ describe('runWorker', () => {
     runWorker(creep);
 
     expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('preempts an empty harvest trip for faster local spawn recovery energy', () => {
+    const source = withRangeTo({ id: 'source1', energy: 300 } as Source, { spawn1: 5 });
+    const droppedEnergy = withRangeTo(
+      { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>,
+      { spawn1: 1 }
+    );
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'drop-near': 1,
+        source1: 2,
+        spawn1: 3
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      memory: { task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [spawn];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            if (type === FIND_DROPPED_RESOURCES) {
+              return [droppedEnergy];
+            }
+
+            if (type === FIND_STRUCTURES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+              return [];
+            }
+
+            return type === FIND_SOURCES ? [source] : [];
+          }
+        )
+      },
+      harvest: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(source)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'pickup', targetId: 'drop-near' });
+    expect(Game.getObjectById).not.toHaveBeenCalled();
+    expect(creep.harvest).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
   it('switches from spending tasks when creep is empty', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -44,6 +44,15 @@ function makeEnergySink(
   } as unknown as StructureSpawn | StructureExtension;
 }
 
+function withRangeTo<T extends { id: string }>(object: T, rangesByTargetId: Record<string, number>): T {
+  return {
+    ...object,
+    pos: {
+      getRangeTo: jest.fn((target: RoomObject) => rangesByTargetId[String((target as { id?: string }).id)] ?? 99)
+    }
+  };
+}
+
 function makeStoredEnergyStructure(
   id: string,
   structureType: StructureConstant,
@@ -196,6 +205,99 @@ describe('selectWorkerTask', () => {
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop1' });
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('uses the fastest local recoverable energy path under spawn pressure', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const droppedEnergy = withRangeTo(
+      { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>,
+      { spawn1: 1 }
+    );
+    const richStorage = withRangeTo(
+      makeStoredEnergyStructure('storage-rich', 'storage' as StructureConstant, 1_000, { my: true }),
+      { spawn1: 8 }
+    );
+    const source = withRangeTo({ id: 'source1', energy: 300 } as Source, { spawn1: 5 });
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'drop-near': 1,
+        source1: 2,
+        'storage-rich': 8
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+          return type === FIND_DROPPED_RESOURCES ? [droppedEnergy] : [];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [richStorage];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
+  });
+
+  it('falls back to harvesting under spawn pressure when recoverable energy cannot beat a harvest trip', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const farStorage = withRangeTo(
+      makeStoredEnergyStructure('storage-far', 'storage' as StructureConstant, 1_000, { my: true }),
+      { spawn1: 100 }
+    );
+    const source = withRangeTo({ id: 'source1', energy: 300 } as Source, { spawn1: 1 });
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        source1: 1,
+        'storage-far': 100
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+          return [];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [farStorage];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
   it('selects withdraw from safe stored energy before harvesting', () => {
@@ -1068,8 +1170,10 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
   });
 
-  it('reserves a safe visible territory target before local resource collection', () => {
+  it('reserves a safe visible territory target before spawn recovery resource collection', () => {
     const controller = { id: 'controller2', my: false } as StructureController;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
     const source = { id: 'source1' } as Source;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
@@ -1079,7 +1183,18 @@ describe('selectWorkerTask', () => {
     const room = {
       name: 'W2N1',
       controller,
-      find: jest.fn((type: number) => (type === FIND_SOURCES ? [source] : []))
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [droppedEnergy];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      })
     } as unknown as Room;
     const creep = {
       memory: { role: 'worker', colony: 'W1N1' },
@@ -1092,6 +1207,8 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
+    expect(room.find).not.toHaveBeenCalledWith(FIND_MY_STRUCTURES, expect.anything());
+    expect(room.find).not.toHaveBeenCalledWith(FIND_DROPPED_RESOURCES);
     expect(room.find).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -132,6 +132,7 @@ describe('selectWorkerTask', () => {
     (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
     (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
     (globalThis as unknown as { CLAIM: BodyPartConstant }).CLAIM = 'claim';
+    (globalThis as unknown as { WORK: BodyPartConstant }).WORK = 'work';
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     (globalThis as unknown as { Game?: Partial<Game> }).Game = { creeps: {} };
   });
@@ -254,6 +255,112 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
+  });
+
+  it('uses recoverable dropped energy under spawn pressure when the creep has no active work parts', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const droppedEnergy = withRangeTo(
+      { id: 'drop-recoverable', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>,
+      { spawn1: 1 }
+    );
+    const source = withRangeTo({ id: 'source1', energy: 300 } as Source, { spawn1: 1 });
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'drop-recoverable': 30,
+        source1: 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const getActiveBodyparts = jest.fn().mockReturnValue(0);
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [droppedEnergy];
+        }
+
+        if (
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      getActiveBodyparts,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-recoverable' });
+    expect(getActiveBodyparts).toHaveBeenCalledWith('work');
+  });
+
+  it('uses recoverable stored energy under spawn pressure when the creep has no active work parts', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const storedEnergy = withRangeTo(
+      makeStoredEnergyStructure('storage-recoverable', 'storage' as StructureConstant, 1_000, { my: true }),
+      { spawn1: 1 }
+    );
+    const source = withRangeTo({ id: 'source1', energy: 300 } as Source, { spawn1: 1 });
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'storage-recoverable': 30,
+        source1: 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const getActiveBodyparts = jest.fn().mockReturnValue(0);
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [storedEnergy];
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      getActiveBodyparts,
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage-recoverable' });
+    expect(getActiveBodyparts).toHaveBeenCalledWith('work');
   });
 
   it('keeps dropped energy recoverable under spawn pressure when harvest sources are empty', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -256,6 +256,100 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
   });
 
+  it('keeps dropped energy recoverable under spawn pressure when harvest sources are empty', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const droppedEnergy = withRangeTo(
+      { id: 'drop-recoverable', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>,
+      { spawn1: 15 }
+    );
+    const emptySource = withRangeTo(
+      { id: 'source-empty', energy: 0, ticksToRegeneration: 100 } as Source,
+      { spawn1: 1 }
+    );
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'drop-recoverable': 15,
+        'source-empty': 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [droppedEnergy];
+        }
+
+        if (type === FIND_STRUCTURES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [emptySource] : [];
+      }
+    );
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-recoverable' });
+  });
+
+  it('keeps stored energy recoverable under spawn pressure when harvest sources are empty', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const storedEnergy = withRangeTo(
+      makeStoredEnergyStructure('storage-recoverable', 'storage' as StructureConstant, 1_000, { my: true }),
+      { spawn1: 15 }
+    );
+    const emptySource = withRangeTo(
+      { id: 'source-empty', energy: 0, ticksToRegeneration: 100 } as Source,
+      { spawn1: 1 }
+    );
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'source-empty': 1,
+        'storage-recoverable': 15
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+          return [];
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [storedEnergy];
+        }
+
+        return type === FIND_SOURCES ? [emptySource] : [];
+      }
+    );
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage-recoverable' });
+  });
+
   it('falls back to harvesting under spawn pressure when recoverable energy cannot beat a harvest trip', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const farStorage = withRangeTo(
@@ -298,6 +392,49 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('falls back to harvesting under spawn pressure when empty sources have no recoverable energy', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const emptySource = withRangeTo(
+      { id: 'source-empty', energy: 0, ticksToRegeneration: 100 } as Source,
+      { spawn1: 1 }
+    );
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'source-empty': 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [emptySource] : [];
+      }
+    );
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-empty' });
   });
 
   it('selects withdraw from safe stored energy before harvesting', () => {


### PR DESCRIPTION
## Summary
- Keeps worker task selection focused on spawn energy recovery before lower-priority energy sinks.
- Prioritizes refill/harvest behavior while spawn energy remains below recovery targets.
- Adds regression coverage for worker runner and worker task selection paths, with bundle output synchronized.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites / 280 tests)
- `cd prod && npm run build`
- `git diff --check`

Closes #175
