### PR TITLE
feat: isolate territory controller work from spawn recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1283,6 +1283,12 @@ function selectWorkerTask(creep) {
     const source = selectHarvestSource(creep);
     return source ? { type: "harvest", targetId: source.id } : null;
   }
+  if (urgentReservationRenewalTask) {
+    return urgentReservationRenewalTask;
+  }
+  if (isTerritoryControlTask(territoryControllerTask)) {
+    return territoryControllerTask;
+  }
   const energySink = selectFillableEnergySink(creep);
   if (energySink) {
     return { type: "transfer", targetId: energySink.id };
@@ -1290,9 +1296,6 @@ function selectWorkerTask(creep) {
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: "upgrade", targetId: controller.id };
-  }
-  if (urgentReservationRenewalTask) {
-    return urgentReservationRenewalTask;
   }
   if (territoryControllerTask) {
     return territoryControllerTask;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -54,6 +54,14 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return source ? { type: 'harvest', targetId: source.id } : null;
   }
 
+  if (urgentReservationRenewalTask) {
+    return urgentReservationRenewalTask;
+  }
+
+  if (isTerritoryControlTask(territoryControllerTask)) {
+    return territoryControllerTask;
+  }
+
   const energySink = selectFillableEnergySink(creep);
   if (energySink) {
     return { type: 'transfer', targetId: energySink.id as Id<AnyStoreStructure> };
@@ -62,10 +70,6 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: 'upgrade', targetId: controller.id };
-  }
-
-  if (urgentReservationRenewalTask) {
-    return urgentReservationRenewalTask;
   }
 
   if (territoryControllerTask) {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -449,6 +449,61 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts construction for an assigned visible reserve target before spawn refill pressure', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const controller = { id: 'controller2', my: false } as StructureController;
+    const site = { id: 'site1' } as ConstructionSite;
+    const creep = {
+      owner: { username: 'me' },
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve' },
+        task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        name: 'W2N1',
+        controller,
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [spawn];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            if (type === FIND_CONSTRUCTION_SITES) {
+              return [site];
+            }
+
+            return [];
+          }
+        )
+      },
+      build: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById: jest.fn().mockReturnValue(site)
+    };
+
+    runWorker(creep);
+
+    expect(Game.getObjectById).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'reserve', targetId: 'controller2' });
+    expect(creep.build).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('keeps construction work when spawn and extension energy is full', () => {
     const site = { id: 'site1' } as ConstructionSite;
     const fullSpawn = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1095,6 +1095,25 @@ describe('selectWorkerTask', () => {
     expect(room.find).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
+  it('keeps a visible reserve target before spawn refill under concurrent energy pressure', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const controller = { id: 'controller2', my: false } as StructureController;
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'worker', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'reserve' } },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'reserve', targetId: 'controller2' });
+    expect(spawn.store.getFreeCapacity).not.toHaveBeenCalled();
+  });
+
   it('renews an urgent own visible reservation before local construction with enough CLAIM parts', () => {
     const controller = {
       id: 'controller2',


### PR DESCRIPTION
## Summary
- Keeps assigned territory reserve/claim/sign controller work ahead of generic spawn-recovery energy refill when the creep is on a territory-control task.
- Preserves normal worker spawn recovery and claimed-room upgrade/refill priority behavior.
- Adds deterministic coverage for visible territory controller work under concurrent spawn-energy pressure.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites / 279 tests)
- `cd prod && npm run build`
- `git diff --check`

Refs #177
