### PR TITLE
feat: keep controller pressure active after recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1260,6 +1260,7 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
+var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 var ENERGY_ACQUISITION_RANGE_COST = 50;
@@ -1737,21 +1738,48 @@ function shouldGuardControllerDowngrade(controller) {
 function shouldRushRcl1Controller(controller) {
   return controller.my === true && controller.level === 1;
 }
-function shouldSustainControllerProgress(creep, controller) {
+function shouldApplyControllerPressureLane(creep, controller) {
   if (controller.my !== true || controller.level < 2) {
     return false;
   }
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
-  return loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS && !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller));
+  return (loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS || loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasActiveTerritoryPressure(creep)) && !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller));
 }
 function shouldUseSurplusForControllerProgress(creep, controller) {
-  if (shouldSustainControllerProgress(creep, controller)) {
+  if (shouldApplyControllerPressureLane(creep, controller)) {
     return true;
   }
   return controller.my === true && controller.level >= 2 && hasWithdrawableSurplusEnergy(creep);
 }
 function hasWithdrawableSurplusEnergy(creep) {
   return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null;
+}
+function hasActiveTerritoryPressure(creep) {
+  var _a;
+  const colonyName = getCreepColonyName(creep);
+  if (!colonyName) {
+    return false;
+  }
+  const territoryMemory = (_a = globalThis.Memory) == null ? void 0 : _a.territory;
+  if (!territoryMemory || !Array.isArray(territoryMemory.intents)) {
+    return false;
+  }
+  return territoryMemory.intents.some((intent) => isActiveTerritoryPressureIntent(intent, colonyName));
+}
+function getCreepColonyName(creep) {
+  var _a, _b;
+  const colony = (_a = creep.memory) == null ? void 0 : _a.colony;
+  if (typeof colony === "string" && colony.length > 0) {
+    return colony;
+  }
+  const roomName = (_b = creep.room) == null ? void 0 : _b.name;
+  return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
+}
+function isActiveTerritoryPressureIntent(intent, colonyName) {
+  if (!isWorkerTaskRecord(intent)) {
+    return false;
+  }
+  return intent.colony === colonyName && intent.targetRoom !== colonyName && (intent.status === "planned" || intent.status === "active") && (intent.action === "claim" || intent.action === "reserve" || intent.action === "scout");
 }
 function getSameRoomLoadedWorkers(creep) {
   const loadedWorkers = getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
@@ -1917,6 +1945,11 @@ function runWorker(creep) {
     assignNextTask(creep);
     return;
   }
+  if (shouldPreemptSpendingTaskForControllerPressure(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
   if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
@@ -2005,6 +2038,17 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task) {
   const nextTask = selectWorkerTask(creep);
   return isRecoverableEnergyTask(nextTask) && !isSameTask(task, nextTask);
 }
+function shouldPreemptSpendingTaskForControllerPressure(creep, task) {
+  var _a;
+  if (!isEnergySpendingTask(task) || task.type === "upgrade") {
+    return false;
+  }
+  if (typeof ((_a = creep.room) == null ? void 0 : _a.find) !== "function") {
+    return false;
+  }
+  const nextTask = selectWorkerTask(creep);
+  return isOwnedControllerUpgradeTask(creep, nextTask) && !isSameTask(task, nextTask);
+}
 function shouldPreemptUpgradeTask(creep, task) {
   var _a;
   if (task.type !== "upgrade") {
@@ -2019,6 +2063,10 @@ function shouldPreemptUpgradeTask(creep, task) {
     return false;
   }
   return true;
+}
+function isOwnedControllerUpgradeTask(creep, task) {
+  var _a, _b;
+  return (task == null ? void 0 : task.type) === "upgrade" && ((_b = (_a = creep.room) == null ? void 0 : _a.controller) == null ? void 0 : _b.my) === true && task.targetId === creep.room.controller.id;
 }
 function isSameTask(left, right) {
   return left.type === right.type && left.targetId === right.targetId;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1767,13 +1767,12 @@ function hasActiveTerritoryPressure(creep) {
   return territoryMemory.intents.some((intent) => isActiveTerritoryPressureIntent(intent, colonyName));
 }
 function getCreepColonyName(creep) {
-  var _a, _b;
+  var _a;
   const colony = (_a = creep.memory) == null ? void 0 : _a.colony;
   if (typeof colony === "string" && colony.length > 0) {
     return colony;
   }
-  const roomName = (_b = creep.room) == null ? void 0 : _b.name;
-  return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
+  return null;
 }
 function isActiveTerritoryPressureIntent(intent, colonyName) {
   if (!isWorkerTaskRecord(intent)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -31,6 +31,12 @@ export function runWorker(creep: Creep): void {
     return;
   }
 
+  if (shouldPreemptSpendingTaskForControllerPressure(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+
   if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
@@ -139,6 +145,19 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep: Creep, task: 
   return isRecoverableEnergyTask(nextTask) && !isSameTask(task, nextTask);
 }
 
+function shouldPreemptSpendingTaskForControllerPressure(creep: Creep, task: CreepTaskMemory): boolean {
+  if (!isEnergySpendingTask(task) || task.type === 'upgrade') {
+    return false;
+  }
+
+  if (typeof creep.room?.find !== 'function') {
+    return false;
+  }
+
+  const nextTask = selectWorkerTask(creep);
+  return isOwnedControllerUpgradeTask(creep, nextTask) && !isSameTask(task, nextTask);
+}
+
 function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean {
   if (task.type !== 'upgrade') {
     return false;
@@ -155,6 +174,17 @@ function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean 
   }
 
   return true;
+}
+
+function isOwnedControllerUpgradeTask(
+  creep: Creep,
+  task: CreepTaskMemory | null
+): task is Extract<CreepTaskMemory, { type: 'upgrade' }> {
+  return (
+    task?.type === 'upgrade' &&
+    creep.room?.controller?.my === true &&
+    task.targetId === creep.room.controller.id
+  );
 }
 
 function isSameTask(left: CreepTaskMemory, right: CreepTaskMemory): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -8,6 +8,7 @@ export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
+const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 const MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 const ENERGY_ACQUISITION_RANGE_COST = 50;
@@ -746,20 +747,21 @@ function shouldRushRcl1Controller(controller: StructureController): boolean {
   return controller.my === true && controller.level === 1;
 }
 
-function shouldSustainControllerProgress(creep: Creep, controller: StructureController): boolean {
+function shouldApplyControllerPressureLane(creep: Creep, controller: StructureController): boolean {
   if (controller.my !== true || controller.level < 2) {
     return false;
   }
 
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
   return (
-    loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS &&
+    (loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS ||
+      (loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasActiveTerritoryPressure(creep))) &&
     !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller))
   );
 }
 
 function shouldUseSurplusForControllerProgress(creep: Creep, controller: StructureController): boolean {
-  if (shouldSustainControllerProgress(creep, controller)) {
+  if (shouldApplyControllerPressureLane(creep, controller)) {
     return true;
   }
 
@@ -768,6 +770,43 @@ function shouldUseSurplusForControllerProgress(creep: Creep, controller: Structu
 
 function hasWithdrawableSurplusEnergy(creep: Creep): boolean {
   return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null;
+}
+
+function hasActiveTerritoryPressure(creep: Creep): boolean {
+  const colonyName = getCreepColonyName(creep);
+  if (!colonyName) {
+    return false;
+  }
+
+  const territoryMemory = (globalThis as unknown as { Memory?: Partial<Memory> }).Memory?.territory;
+  if (!territoryMemory || !Array.isArray(territoryMemory.intents)) {
+    return false;
+  }
+
+  return territoryMemory.intents.some((intent) => isActiveTerritoryPressureIntent(intent, colonyName));
+}
+
+function getCreepColonyName(creep: Creep): string | null {
+  const colony = creep.memory?.colony;
+  if (typeof colony === 'string' && colony.length > 0) {
+    return colony;
+  }
+
+  const roomName = creep.room?.name;
+  return typeof roomName === 'string' && roomName.length > 0 ? roomName : null;
+}
+
+function isActiveTerritoryPressureIntent(intent: unknown, colonyName: string): boolean {
+  if (!isWorkerTaskRecord(intent)) {
+    return false;
+  }
+
+  return (
+    intent.colony === colonyName &&
+    intent.targetRoom !== colonyName &&
+    (intent.status === 'planned' || intent.status === 'active') &&
+    (intent.action === 'claim' || intent.action === 'reserve' || intent.action === 'scout')
+  );
 }
 
 function getSameRoomLoadedWorkers(creep: Creep): Creep[] {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -792,8 +792,7 @@ function getCreepColonyName(creep: Creep): string | null {
     return colony;
   }
 
-  const roomName = creep.room?.name;
-  return typeof roomName === 'string' && roomName.length > 0 ? roomName : null;
+  return null;
 }
 
 function isActiveTerritoryPressureIntent(intent: unknown, colonyName: string): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -697,6 +697,112 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts non-critical construction for controller pressure once spawn recovery is safe', () => {
+    const fullSpawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const controller = { id: 'controller1', my: true, level: 3 } as StructureController;
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 200 }]
+      }
+    };
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [fullSpawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return type === FIND_CONSTRUCTION_SITES ? [site] : [];
+      })
+    } as unknown as Room;
+    const creep = {
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'build', targetId: 'tower-site1' as Id<ConstructionSite> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const getObjectById = jest.fn().mockReturnValue(site);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(creep.build).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps spawn recovery transfer ahead of controller pressure preemption', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const controller = { id: 'controller1', my: true, level: 3 } as StructureController;
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 200 }]
+      }
+    };
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return type === FIND_CONSTRUCTION_SITES ? [site] : [];
+      })
+    } as unknown as Room;
+    const creep = {
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'build', targetId: 'tower-site1' as Id<ConstructionSite> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      build: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const getObjectById = jest.fn().mockReturnValue(site);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.build).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('executes a normal-threshold reservation task for a one-CLAIM worker', () => {
     const controller = {
       id: 'controller2',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2245,6 +2245,36 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it.each([
+    ['missing', { role: 'worker' }],
+    ['empty', { role: 'worker', colony: '' }]
+  ])('ignores territory pressure when worker colony memory is %s', (_caseName, memory) => {
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 200 }]
+      }
+    };
+    const creep = {
+      memory,
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
+  });
+
   it('routes carried energy to controller upgrade before non-critical construction when stored surplus exists', () => {
     const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2218,6 +2218,33 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
+  it('routes carried energy to controller upgrade before non-critical construction once spawn recovery is safe', () => {
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 200 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it('routes carried energy to controller upgrade before non-critical construction when stored surplus exists', () => {
     const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
@@ -2444,6 +2471,44 @@ describe('selectWorkerTask', () => {
           }
 
           return type === 2 ? [site] : [];
+        })
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('keeps spawn refill priority over the controller pressure lane', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 200 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: {
+        name: 'W1N1',
+        controller,
+        find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          return type === FIND_CONSTRUCTION_SITES ? [site] : [];
         })
       }
     } as unknown as Creep;


### PR DESCRIPTION
## Summary
- Keeps controller-upgrade pressure available after emergency spawn recovery has eased.
- Adds worker assignment coverage for controller pressure while preserving spawn energy protection.
- Regenerates the Screeps bundle.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #179
