### PR TITLE
feat: improve post-recovery energy throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1326,9 +1326,13 @@ function selectWorkerTask(creep) {
   if (criticalRepairTarget) {
     return { type: "repair", targetId: criticalRepairTarget.id };
   }
-  const roadOrContainerConstructionSite = constructionSites.find(isRoadOrContainerConstructionSite);
-  if (roadOrContainerConstructionSite) {
-    return { type: "build", targetId: roadOrContainerConstructionSite.id };
+  const containerConstructionSite = constructionSites.find(isContainerConstructionSite);
+  if (containerConstructionSite) {
+    return { type: "build", targetId: containerConstructionSite.id };
+  }
+  const roadConstructionSite = constructionSites.find(isRoadConstructionSite2);
+  if (roadConstructionSite) {
+    return { type: "build", targetId: roadConstructionSite.id };
   }
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
     return { type: "upgrade", targetId: controller.id };
@@ -1396,8 +1400,11 @@ function isSpawnConstructionSite(site) {
 function isExtensionConstructionSite(site) {
   return matchesStructureType2(site.structureType, "STRUCTURE_EXTENSION", "extension");
 }
-function isRoadOrContainerConstructionSite(site) {
-  return matchesStructureType2(site.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType2(site.structureType, "STRUCTURE_CONTAINER", "container");
+function isContainerConstructionSite(site) {
+  return matchesStructureType2(site.structureType, "STRUCTURE_CONTAINER", "container");
+}
+function isRoadConstructionSite2(site) {
+  return matchesStructureType2(site.structureType, "STRUCTURE_ROAD", "road");
 }
 function matchesStructureType2(actual, globalName, fallback) {
   var _a;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -106,9 +106,14 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'repair', targetId: criticalRepairTarget.id as Id<Structure> };
   }
 
-  const roadOrContainerConstructionSite = constructionSites.find(isRoadOrContainerConstructionSite);
-  if (roadOrContainerConstructionSite) {
-    return { type: 'build', targetId: roadOrContainerConstructionSite.id };
+  const containerConstructionSite = constructionSites.find(isContainerConstructionSite);
+  if (containerConstructionSite) {
+    return { type: 'build', targetId: containerConstructionSite.id };
+  }
+
+  const roadConstructionSite = constructionSites.find(isRoadConstructionSite);
+  if (roadConstructionSite) {
+    return { type: 'build', targetId: roadConstructionSite.id };
   }
 
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
@@ -208,11 +213,12 @@ function isExtensionConstructionSite(site: ConstructionSite): boolean {
   return matchesStructureType(site.structureType, 'STRUCTURE_EXTENSION', 'extension');
 }
 
-function isRoadOrContainerConstructionSite(site: ConstructionSite): boolean {
-  return (
-    matchesStructureType(site.structureType, 'STRUCTURE_ROAD', 'road') ||
-    matchesStructureType(site.structureType, 'STRUCTURE_CONTAINER', 'container')
-  );
+function isContainerConstructionSite(site: ConstructionSite): boolean {
+  return matchesStructureType(site.structureType, 'STRUCTURE_CONTAINER', 'container');
+}
+
+function isRoadConstructionSite(site: ConstructionSite): boolean {
+  return matchesStructureType(site.structureType, 'STRUCTURE_ROAD', 'road');
 }
 
 type StructureConstantGlobal =

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2175,6 +2175,50 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
   });
 
+  it('builds container construction before road construction after spawn refill is satisfied', () => {
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [roadSite, containerSite],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'container-site1' });
+  });
+
+  it('keeps spawn refill before container-first construction throughput', () => {
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [roadSite, containerSite],
+        controller,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
   it('builds RCL2 extension construction before controller progress guard when STRUCTURE_EXTENSION is missing', () => {
     delete (globalThis as unknown as { STRUCTURE_EXTENSION?: StructureConstant }).STRUCTURE_EXTENSION;
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;


### PR DESCRIPTION
## Summary
- Improves post-recovery energy throughput by preferring higher-value energy acquisition after spawn recovery pressure eases.
- Adds worker-task ranking tests for the post-recovery behavior.
- Regenerates the Screeps bundle.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #180
