### PR TITLE
feat: improve territory intent reliability

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -473,7 +473,7 @@ var WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
 function countCreepsByRole(creeps, colonyName) {
   const counts = creeps.reduce(
     (counts2, creep) => {
-      var _a, _b, _c, _d, _e, _f, _g, _h, _i;
+      var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j;
       if (isColonyWorker(creep, colonyName)) {
         counts2.worker += 1;
         if (canSatisfyRoleCapacity(creep)) {
@@ -487,14 +487,15 @@ function countCreepsByRole(creeps, colonyName) {
           const claimersByTargetRoom = (_d = counts2.claimersByTargetRoom) != null ? _d : {};
           claimersByTargetRoom[targetRoom] = ((_e = claimersByTargetRoom[targetRoom]) != null ? _e : 0) + 1;
           counts2.claimersByTargetRoom = claimersByTargetRoom;
+          incrementTargetRoomActionCount(counts2, (_f = creep.memory.territory) == null ? void 0 : _f.action, targetRoom);
         }
       }
       if (isColonyScout(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
-        counts2.scout = ((_f = counts2.scout) != null ? _f : 0) + 1;
-        const targetRoom = (_g = creep.memory.territory) == null ? void 0 : _g.targetRoom;
+        counts2.scout = ((_g = counts2.scout) != null ? _g : 0) + 1;
+        const targetRoom = (_h = creep.memory.territory) == null ? void 0 : _h.targetRoom;
         if (targetRoom) {
-          const scoutsByTargetRoom = (_h = counts2.scoutsByTargetRoom) != null ? _h : {};
-          scoutsByTargetRoom[targetRoom] = ((_i = scoutsByTargetRoom[targetRoom]) != null ? _i : 0) + 1;
+          const scoutsByTargetRoom = (_i = counts2.scoutsByTargetRoom) != null ? _i : {};
+          scoutsByTargetRoom[targetRoom] = ((_j = scoutsByTargetRoom[targetRoom]) != null ? _j : 0) + 1;
           counts2.scoutsByTargetRoom = scoutsByTargetRoom;
         }
       }
@@ -510,6 +511,17 @@ function countCreepsByRole(creeps, colonyName) {
 function getWorkerCapacity(roleCounts) {
   var _a;
   return (_a = roleCounts.workerCapacity) != null ? _a : roleCounts.worker;
+}
+function incrementTargetRoomActionCount(counts, action, targetRoom) {
+  var _a, _b, _c;
+  if (action !== "claim" && action !== "reserve") {
+    return;
+  }
+  const claimersByTargetRoomAction = (_a = counts.claimersByTargetRoomAction) != null ? _a : {};
+  const claimersForAction = (_b = claimersByTargetRoomAction[action]) != null ? _b : {};
+  claimersForAction[targetRoom] = ((_c = claimersForAction[targetRoom]) != null ? _c : 0) + 1;
+  claimersByTargetRoomAction[action] = claimersForAction;
+  counts.claimersByTargetRoomAction = claimersByTargetRoomAction;
 }
 function isColonyWorker(creep, colonyName) {
   return creep.memory.colony === colonyName && creep.memory.role === "worker";
@@ -947,11 +959,14 @@ function normalizeTerritoryIntent(rawIntent) {
   };
 }
 function getTerritoryCreepCountForTarget(roleCounts, targetRoom, action) {
-  var _a, _b, _c, _d;
+  var _a, _b, _c, _d, _e, _f;
   if (action === "scout") {
     return (_b = (_a = roleCounts.scoutsByTargetRoom) == null ? void 0 : _a[targetRoom]) != null ? _b : 0;
   }
-  return (_d = (_c = roleCounts.claimersByTargetRoom) == null ? void 0 : _c[targetRoom]) != null ? _d : 0;
+  if (roleCounts.claimersByTargetRoomAction) {
+    return (_d = (_c = roleCounts.claimersByTargetRoomAction[action]) == null ? void 0 : _c[targetRoom]) != null ? _d : 0;
+  }
+  return (_f = (_e = roleCounts.claimersByTargetRoom) == null ? void 0 : _e[targetRoom]) != null ? _f : 0;
 }
 function isTerritoryTargetSuppressed(target, intents, gameTime) {
   return isSuppressedTerritoryIntentForAction(intents, target.colony, target.roomName, target.action, gameTime);

--- a/prod/src/creeps/roleCounts.ts
+++ b/prod/src/creeps/roleCounts.ts
@@ -3,6 +3,7 @@ export interface RoleCounts {
   workerCapacity?: number;
   claimer?: number;
   claimersByTargetRoom?: Record<string, number>;
+  claimersByTargetRoomAction?: Partial<Record<TerritoryControlAction, Record<string, number>>>;
   scout?: number;
   scoutsByTargetRoom?: Record<string, number>;
 }
@@ -28,6 +29,7 @@ export function countCreepsByRole(creeps: Creep[], colonyName: string): RoleCoun
           const claimersByTargetRoom = counts.claimersByTargetRoom ?? {};
           claimersByTargetRoom[targetRoom] = (claimersByTargetRoom[targetRoom] ?? 0) + 1;
           counts.claimersByTargetRoom = claimersByTargetRoom;
+          incrementTargetRoomActionCount(counts, creep.memory.territory?.action, targetRoom);
         }
       }
       if (isColonyScout(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
@@ -53,6 +55,22 @@ export function countCreepsByRole(creeps: Creep[], colonyName: string): RoleCoun
 
 export function getWorkerCapacity(roleCounts: RoleCounts): number {
   return roleCounts.workerCapacity ?? roleCounts.worker;
+}
+
+function incrementTargetRoomActionCount(
+  counts: RoleCounts,
+  action: TerritoryIntentAction | undefined,
+  targetRoom: string
+): void {
+  if (action !== 'claim' && action !== 'reserve') {
+    return;
+  }
+
+  const claimersByTargetRoomAction = counts.claimersByTargetRoomAction ?? {};
+  const claimersForAction = claimersByTargetRoomAction[action] ?? {};
+  claimersForAction[targetRoom] = (claimersForAction[targetRoom] ?? 0) + 1;
+  claimersByTargetRoomAction[action] = claimersForAction;
+  counts.claimersByTargetRoomAction = claimersByTargetRoomAction;
 }
 
 function isColonyWorker(creep: Creep, colonyName: string): boolean {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -608,6 +608,10 @@ function getTerritoryCreepCountForTarget(
     return roleCounts.scoutsByTargetRoom?.[targetRoom] ?? 0;
   }
 
+  if (roleCounts.claimersByTargetRoomAction) {
+    return roleCounts.claimersByTargetRoomAction[action]?.[targetRoom] ?? 0;
+  }
+
   return roleCounts.claimersByTargetRoom?.[targetRoom] ?? 0;
 }
 

--- a/prod/test/roleCounts.test.ts
+++ b/prod/test/roleCounts.test.ts
@@ -16,6 +16,7 @@ describe('countCreepsByRole', () => {
       worker: 1,
       claimer: 1,
       claimersByTargetRoom: { W2N1: 1 },
+      claimersByTargetRoomAction: { reserve: { W2N1: 1 } },
       scout: 1,
       scoutsByTargetRoom: { W1N2: 1 }
     });
@@ -81,7 +82,8 @@ describe('countCreepsByRole', () => {
     expect(countCreepsByRole([healthyClaimer, expiringClaimer, foreignClaimer], 'W1N1')).toEqual({
       worker: 0,
       claimer: 1,
-      claimersByTargetRoom: { W2N1: 1 }
+      claimersByTargetRoom: { W2N1: 1 },
+      claimersByTargetRoomAction: { claim: { W2N1: 1 } }
     });
   });
 });

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -336,6 +336,50 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('plans a claim creep when only reserve capacity exists for the recovered target room', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }]
+      }
+    };
+
+    expect(
+      planSpawn(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W2N1: 1 },
+          claimersByTargetRoomAction: { reserve: { W2N1: 1 } }
+        },
+        149
+      )
+    ).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N1-149',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim' }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 149
+      }
+    ]);
+  });
+
   it('keeps territory control absent when the home worker floor is unsafe', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,


### PR DESCRIPTION
## Summary
- Counts claim/reserve territory creeps separately per target action so a reservation claimer does not satisfy a claim intent for the same room.
- Keeps spawn recovery priority intact while making territory-control intent reliability more precise.
- Updates Jest coverage and regenerates `prod/dist/main.js`.

Closes #185

## Verification
Controller-side recovery/verification before commit:
- `git diff --check` PASS
- `cd prod && npm run typecheck` PASS
- `cd prod && npm test -- --runInBand` PASS (16 suites, 296 tests)
- `cd prod && npm run build` PASS
- `prod/dist/main.js` included as regenerated artifact

## Scheduler evidence
Recovered useful dirty Codex-authored edits from `/root/screeps-worktrees/territory-intent-reliability-185` after the referenced background process was no longer active. Commit authored by `lanyusea's bot <lanyusea@gmail.com>`: `ee99624`.
