### PR TITLE
feat: improve post-recovery resource spending efficiency

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1312,14 +1312,14 @@ function selectWorkerTask(creep) {
     return territoryControllerTask;
   }
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
-  const spawnConstructionSite = constructionSites.find(isSpawnConstructionSite);
+  const spawnConstructionSite = selectConstructionSite(creep, constructionSites, isSpawnConstructionSite);
   if (spawnConstructionSite) {
     return { type: "build", targetId: spawnConstructionSite.id };
   }
   if (controller && shouldRushRcl1Controller(controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
-  const extensionConstructionSite = constructionSites.find(isExtensionConstructionSite);
+  const extensionConstructionSite = selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
   if (extensionConstructionSite) {
     return { type: "build", targetId: extensionConstructionSite.id };
   }
@@ -1327,19 +1327,20 @@ function selectWorkerTask(creep) {
   if (criticalRepairTarget) {
     return { type: "repair", targetId: criticalRepairTarget.id };
   }
-  const containerConstructionSite = constructionSites.find(isContainerConstructionSite);
+  const containerConstructionSite = selectConstructionSite(creep, constructionSites, isContainerConstructionSite);
   if (containerConstructionSite) {
     return { type: "build", targetId: containerConstructionSite.id };
   }
-  const roadConstructionSite = constructionSites.find(isRoadConstructionSite2);
+  const roadConstructionSite = selectConstructionSite(creep, constructionSites, isRoadConstructionSite2);
   if (roadConstructionSite) {
     return { type: "build", targetId: roadConstructionSite.id };
   }
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
-  if (constructionSites[0]) {
-    return { type: "build", targetId: constructionSites[0].id };
+  const constructionSite = selectConstructionSite(creep, constructionSites);
+  if (constructionSite) {
+    return { type: "build", targetId: constructionSite.id };
   }
   const repairTarget = selectRepairTarget(creep);
   if (repairTarget) {
@@ -1393,6 +1394,30 @@ function selectClosestEnergySink(creep, energySinks) {
   return energySinksByStableId[0];
 }
 function compareEnergySinkId(left, right) {
+  return String(left.id).localeCompare(String(right.id));
+}
+function selectConstructionSite(creep, constructionSites, predicate = () => true) {
+  var _a;
+  const candidates = constructionSites.filter(predicate);
+  if (candidates.length === 0) {
+    return null;
+  }
+  const position = creep.pos;
+  if (typeof (position == null ? void 0 : position.getRangeTo) === "function") {
+    return [...candidates].sort(compareConstructionSiteId).reduce((closest, candidate) => {
+      var _a2, _b, _c, _d;
+      const closestRange = (_b = (_a2 = position.getRangeTo) == null ? void 0 : _a2.call(position, closest)) != null ? _b : Infinity;
+      const candidateRange = (_d = (_c = position.getRangeTo) == null ? void 0 : _c.call(position, candidate)) != null ? _d : Infinity;
+      return candidateRange < closestRange || candidateRange === closestRange && compareConstructionSiteId(candidate, closest) < 0 ? candidate : closest;
+    });
+  }
+  if (typeof (position == null ? void 0 : position.findClosestByRange) === "function") {
+    const candidatesByStableId = [...candidates].sort(compareConstructionSiteId);
+    return (_a = position.findClosestByRange(candidatesByStableId)) != null ? _a : candidatesByStableId[0];
+  }
+  return candidates[0];
+}
+function compareConstructionSiteId(left, right) {
   return String(left.id).localeCompare(String(right.id));
 }
 function isSpawnConstructionSite(site) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -88,7 +88,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
-  const spawnConstructionSite = constructionSites.find(isSpawnConstructionSite);
+  const spawnConstructionSite = selectConstructionSite(creep, constructionSites, isSpawnConstructionSite);
   if (spawnConstructionSite) {
     return { type: 'build', targetId: spawnConstructionSite.id };
   }
@@ -97,7 +97,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'upgrade', targetId: controller.id };
   }
 
-  const extensionConstructionSite = constructionSites.find(isExtensionConstructionSite);
+  const extensionConstructionSite = selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
   if (extensionConstructionSite) {
     return { type: 'build', targetId: extensionConstructionSite.id };
   }
@@ -107,12 +107,12 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'repair', targetId: criticalRepairTarget.id as Id<Structure> };
   }
 
-  const containerConstructionSite = constructionSites.find(isContainerConstructionSite);
+  const containerConstructionSite = selectConstructionSite(creep, constructionSites, isContainerConstructionSite);
   if (containerConstructionSite) {
     return { type: 'build', targetId: containerConstructionSite.id };
   }
 
-  const roadConstructionSite = constructionSites.find(isRoadConstructionSite);
+  const roadConstructionSite = selectConstructionSite(creep, constructionSites, isRoadConstructionSite);
   if (roadConstructionSite) {
     return { type: 'build', targetId: roadConstructionSite.id };
   }
@@ -121,8 +121,9 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'upgrade', targetId: controller.id };
   }
 
-  if (constructionSites[0]) {
-    return { type: 'build', targetId: constructionSites[0].id };
+  const constructionSite = selectConstructionSite(creep, constructionSites);
+  if (constructionSite) {
+    return { type: 'build', targetId: constructionSite.id };
   }
 
   const repairTarget = selectRepairTarget(creep);
@@ -203,6 +204,46 @@ function selectClosestEnergySink<T extends FillableEnergySink>(creep: Creep, ene
 }
 
 function compareEnergySinkId(left: FillableEnergySink, right: FillableEnergySink): number {
+  return String(left.id).localeCompare(String(right.id));
+}
+
+function selectConstructionSite(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  predicate: (site: ConstructionSite) => boolean = () => true
+): ConstructionSite | null {
+  const candidates = constructionSites.filter(predicate);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const position = (creep as Creep & {
+    pos?: {
+      findClosestByRange?: (objects: ConstructionSite[]) => ConstructionSite | null;
+      getRangeTo?: (target: ConstructionSite) => number;
+    };
+  }).pos;
+
+  if (typeof position?.getRangeTo === 'function') {
+    return [...candidates].sort(compareConstructionSiteId).reduce((closest, candidate) => {
+      const closestRange = position.getRangeTo?.(closest) ?? Infinity;
+      const candidateRange = position.getRangeTo?.(candidate) ?? Infinity;
+      return candidateRange < closestRange ||
+        (candidateRange === closestRange && compareConstructionSiteId(candidate, closest) < 0)
+        ? candidate
+        : closest;
+    });
+  }
+
+  if (typeof position?.findClosestByRange === 'function') {
+    const candidatesByStableId = [...candidates].sort(compareConstructionSiteId);
+    return position.findClosestByRange(candidatesByStableId) ?? candidatesByStableId[0];
+  }
+
+  return candidates[0];
+}
+
+function compareConstructionSiteId(left: ConstructionSite, right: ConstructionSite): number {
   return String(left.id).localeCompare(String(right.id));
 }
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2197,6 +2197,57 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'container-site1' });
   });
 
+  it('builds the closest same-priority construction site after spawn refill is satisfied', () => {
+    const farRoadSite = { id: 'road-far', structureType: 'road' } as ConstructionSite;
+    const nearRoadSite = { id: 'road-near', structureType: 'road' } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const getRangeTo = jest.fn((target: ConstructionSite) => {
+      const ranges: Record<string, number> = {
+        'road-far': 9,
+        'road-near': 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: makeWorkerTaskRoom({
+        constructionSites: [farRoadSite, nearRoadSite],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-near' });
+  });
+
+  it('breaks same-priority construction site range ties by id', () => {
+    const secondRoadSite = { id: 'road-b', structureType: 'road' } as ConstructionSite;
+    const firstRoadSite = { id: 'road-a', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo: jest.fn().mockReturnValue(4) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [secondRoadSite, firstRoadSite],
+        controller
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-a' });
+  });
+
   it('keeps spawn refill before container-first construction throughput', () => {
     const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
     const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;


### PR DESCRIPTION
## Summary
- Chooses closer construction work within existing worker priority bands to spend recovered energy more efficiently.
- Preserves emergency spawn/refill and existing priority ordering before lower-priority construction selection.
- Updates Jest coverage and regenerates `prod/dist/main.js`.

Closes #186

## Verification
Controller-side recovery/verification before commit:
- `git diff --check` PASS
- `cd prod && npm run typecheck` PASS
- `cd prod && npm test -- --runInBand` PASS (16 suites, 297 tests)
- `cd prod && npm run build` PASS
- `prod/dist/main.js` included as regenerated artifact

## Scheduler evidence
Recovered useful dirty Codex-authored edits from `/root/screeps-worktrees/resource-spending-efficiency-186` after the referenced background process was no longer active. Commit authored by `lanyusea's bot <lanyusea@gmail.com>`: `41a0357`.
