### PR TITLE
feat: improve claim target scoring

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -596,6 +596,7 @@ var TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM = 3;
 var TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE = 4;
 var TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
 var MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
+var TERRITORY_ROUTE_DISTANCE_SEPARATOR = ">";
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
@@ -932,15 +933,43 @@ function getKnownRouteLength(fromRoom, targetRoom) {
   if (fromRoom === targetRoom) {
     return 0;
   }
+  const cache = getTerritoryRouteDistanceCache();
+  const cacheKey = getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom);
+  const cachedRouteLength = cache == null ? void 0 : cache[cacheKey];
+  if (typeof cachedRouteLength === "number" || cachedRouteLength === null) {
+    return cachedRouteLength;
+  }
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
     return void 0;
   }
   const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom);
   if (route === getNoPathResultCode()) {
+    if (cache) {
+      cache[cacheKey] = null;
+    }
     return null;
   }
-  return Array.isArray(route) ? route.length : void 0;
+  if (!Array.isArray(route)) {
+    return void 0;
+  }
+  if (cache) {
+    cache[cacheKey] = route.length;
+  }
+  return route.length;
+}
+function getTerritoryRouteDistanceCache() {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return void 0;
+  }
+  if (!isRecord(territoryMemory.routeDistances)) {
+    territoryMemory.routeDistances = {};
+  }
+  return territoryMemory.routeDistances;
+}
+function getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom) {
+  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`;
 }
 function getNoPathResultCode() {
   const noPathCode = globalThis.ERR_NO_PATH;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -774,19 +774,22 @@ function selectTerritoryTarget(colony, gameTime) {
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
+  const routeDistanceLookupContext = createRouteDistanceLookupContext();
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     territoryMemory,
     colonyName,
     colonyOwnerUsername,
     intents,
-    gameTime
+    gameTime,
+    routeDistanceLookupContext
   );
   const configuredCandidates = getConfiguredTerritoryCandidates(
     colonyName,
     colonyOwnerUsername,
     territoryMemory,
     intents,
-    gameTime
+    gameTime,
+    routeDistanceLookupContext
   );
   const bestConfiguredCandidate = selectBestScoredTerritoryCandidate(configuredCandidates);
   if (bestConfiguredCandidate && bestConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
@@ -801,7 +804,8 @@ function selectTerritoryTarget(colony, gameTime) {
         territoryMemory,
         intents,
         gameTime,
-        !hasBlockingConfiguredTarget
+        !hasBlockingConfiguredTarget,
+        routeDistanceLookupContext
       )
     ])
   );
@@ -822,7 +826,7 @@ function toSelectedTerritoryTarget(candidate) {
     commitTarget: candidate.commitTarget
   } : null;
 }
-function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
+function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return [];
   }
@@ -836,12 +840,13 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
       "configured",
       order,
       colonyName,
-      colonyOwnerUsername
+      colonyOwnerUsername,
+      routeDistanceLookupContext
     );
     return candidate ? [candidate] : [];
   });
 }
-function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime) {
+function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return false;
   }
@@ -850,7 +855,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     if (!target || target.colony !== colonyName) {
       return false;
     }
-    if (hasKnownNoRoute(colonyName, target.roomName)) {
+    if (hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext)) {
       return false;
     }
     if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime)) {
@@ -859,7 +864,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
   });
 }
-function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates) {
+function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, routeDistanceLookupContext) {
   const adjacentRooms = getAdjacentRoomNames(colonyName);
   if (adjacentRooms.length === 0) {
     return [];
@@ -877,7 +882,8 @@ function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territory
         "adjacent",
         order,
         colonyName,
-        colonyOwnerUsername
+        colonyOwnerUsername,
+        routeDistanceLookupContext
       );
       return candidate ? [candidate] : [];
     }
@@ -887,15 +893,16 @@ function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territory
         "adjacent",
         order,
         colonyName,
-        colonyOwnerUsername
+        colonyOwnerUsername,
+        routeDistanceLookupContext
       );
       return candidate ? [candidate] : [];
     }
     return [];
   });
 }
-function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwnerUsername) {
-  if (hasKnownNoRoute(colonyName, selection.target.roomName)) {
+function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwnerUsername, routeDistanceLookupContext) {
+  if (hasKnownNoRoute(colonyName, selection.target.roomName, routeDistanceLookupContext)) {
     return null;
   }
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
@@ -931,10 +938,13 @@ function getTerritoryCandidateSourcePriority(source) {
 function isTerritoryTargetVisible(target) {
   return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;
 }
-function hasKnownNoRoute(fromRoom, targetRoom) {
-  return getKnownRouteLength(fromRoom, targetRoom) === null;
+function createRouteDistanceLookupContext() {
+  return { revalidatedNoRouteCacheKeys: /* @__PURE__ */ new Set() };
 }
-function getKnownRouteLength(fromRoom, targetRoom) {
+function hasKnownNoRoute(fromRoom, targetRoom, routeDistanceLookupContext) {
+  return getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) === null;
+}
+function getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) {
   var _a;
   if (fromRoom === targetRoom) {
     return 0;
@@ -942,8 +952,11 @@ function getKnownRouteLength(fromRoom, targetRoom) {
   const cache = getTerritoryRouteDistanceCache();
   const cacheKey = getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom);
   const cachedRouteLength = cache == null ? void 0 : cache[cacheKey];
-  if (typeof cachedRouteLength === "number" || cachedRouteLength === null) {
+  if (typeof cachedRouteLength === "number") {
     return cachedRouteLength;
+  }
+  if (cachedRouteLength === null && routeDistanceLookupContext.revalidatedNoRouteCacheKeys.has(cacheKey)) {
+    return null;
   }
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
@@ -954,6 +967,7 @@ function getKnownRouteLength(fromRoom, targetRoom) {
     if (cache) {
       cache[cacheKey] = null;
     }
+    routeDistanceLookupContext.revalidatedNoRouteCacheKeys.add(cacheKey);
     return null;
   }
   if (!Array.isArray(route)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -850,6 +850,9 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     if (!target || target.colony !== colonyName) {
       return false;
     }
+    if (hasKnownNoRoute(colonyName, target.roomName)) {
+      return false;
+    }
     if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime)) {
       return true;
     }
@@ -892,7 +895,7 @@ function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territory
   });
 }
 function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwnerUsername) {
-  if (getKnownRouteLength(colonyName, selection.target.roomName) === null) {
+  if (hasKnownNoRoute(colonyName, selection.target.roomName)) {
     return null;
   }
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
@@ -927,6 +930,9 @@ function getTerritoryCandidateSourcePriority(source) {
 }
 function isTerritoryTargetVisible(target) {
   return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;
+}
+function hasKnownNoRoute(fromRoom, targetRoom) {
+  return getKnownRouteLength(fromRoom, targetRoom) === null;
 }
 function getKnownRouteLength(fromRoom, targetRoom) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -588,6 +588,14 @@ var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 
 var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
 var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
+var ERR_NO_PATH_CODE = -2;
+var TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL = 0;
+var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM = 1;
+var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE = 2;
+var TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM = 3;
+var TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE = 4;
+var TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
+var MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
@@ -765,50 +773,72 @@ function selectTerritoryTarget(colony, gameTime) {
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
-  const configuredTarget = selectConfiguredTerritoryTarget(
+  const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
+    territoryMemory,
+    colonyName,
+    colonyOwnerUsername,
+    intents,
+    gameTime
+  );
+  const configuredCandidates = getConfiguredTerritoryCandidates(
     colonyName,
     colonyOwnerUsername,
     territoryMemory,
     intents,
     gameTime
   );
-  if (configuredTarget) {
-    return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
+  const bestConfiguredCandidate = selectBestScoredTerritoryCandidate(configuredCandidates);
+  if (bestConfiguredCandidate && bestConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
+    return toSelectedTerritoryTarget(bestConfiguredCandidate);
   }
-  if (hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime)) {
-    return null;
-  }
-  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime);
+  return toSelectedTerritoryTarget(
+    selectBestScoredTerritoryCandidate([
+      ...configuredCandidates,
+      ...getAdjacentReserveCandidates(
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        !hasBlockingConfiguredTarget
+      )
+    ])
+  );
 }
-function selectConfiguredTerritoryTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
-  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
-    return null;
-  }
-  let fallbackTarget = null;
-  let renewalTarget = null;
-  let renewalTicksToEnd = null;
-  for (const rawTarget of territoryMemory.targets) {
-    const target = normalizeTerritoryTarget(rawTarget);
-    if (target && target.enabled !== false && target.colony === colonyName && target.roomName !== colonyName && !isTerritoryTargetSuppressed(target, intents, gameTime) && getVisibleTerritoryTargetState(
-      target.roomName,
-      target.action,
-      target.controllerId,
-      colonyOwnerUsername
-    ) === "available") {
-      const targetRenewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername);
-      if (targetRenewalTicksToEnd !== null) {
-        if (renewalTicksToEnd === null || targetRenewalTicksToEnd < renewalTicksToEnd) {
-          renewalTarget = target;
-          renewalTicksToEnd = targetRenewalTicksToEnd;
-        }
-        continue;
-      }
-      if (fallbackTarget === null) {
-        fallbackTarget = target;
-      }
+function selectBestScoredTerritoryCandidate(candidates) {
+  let bestCandidate = null;
+  for (const candidate of candidates) {
+    if (!bestCandidate || compareTerritoryCandidates(candidate, bestCandidate) < 0) {
+      bestCandidate = candidate;
     }
   }
-  return renewalTarget != null ? renewalTarget : fallbackTarget;
+  return bestCandidate;
+}
+function toSelectedTerritoryTarget(candidate) {
+  return candidate ? {
+    target: candidate.target,
+    intentAction: candidate.intentAction,
+    commitTarget: candidate.commitTarget
+  } : null;
+}
+function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return [];
+  }
+  return territoryMemory.targets.flatMap((rawTarget, order) => {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
+      return [];
+    }
+    const candidate = scoreTerritoryCandidate(
+      { target, intentAction: target.action, commitTarget: false },
+      "configured",
+      order,
+      colonyName,
+      colonyOwnerUsername
+    );
+    return candidate ? [candidate] : [];
+  });
 }
 function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -825,25 +855,96 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
   });
 }
-function selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime) {
+function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates) {
   const adjacentRooms = getAdjacentRoomNames(colonyName);
   if (adjacentRooms.length === 0) {
-    return null;
+    return [];
   }
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
-  for (const roomName of adjacentRooms) {
+  return adjacentRooms.flatMap((roomName, order) => {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName !== colonyName && !existingTargetRooms.has(roomName) && !isTerritoryTargetSuppressed(target, intents, gameTime)) {
-      const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
-      if (candidateState === "safe") {
-        return { target, intentAction: "reserve", commitTarget: true };
-      }
-      if (candidateState === "unknown" && !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, "scout", gameTime)) {
-        return { target, intentAction: "scout", commitTarget: false };
-      }
+    if (roomName === colonyName || existingTargetRooms.has(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime)) {
+      return [];
     }
+    const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
+    if (candidateState === "safe") {
+      const candidate = scoreTerritoryCandidate(
+        { target, intentAction: "reserve", commitTarget: true },
+        "adjacent",
+        order,
+        colonyName,
+        colonyOwnerUsername
+      );
+      return candidate ? [candidate] : [];
+    }
+    if (candidateState === "unknown" && includeScoutCandidates && !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, "scout", gameTime)) {
+      const candidate = scoreTerritoryCandidate(
+        { target, intentAction: "scout", commitTarget: false },
+        "adjacent",
+        order,
+        colonyName,
+        colonyOwnerUsername
+      );
+      return candidate ? [candidate] : [];
+    }
+    return [];
+  });
+}
+function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwnerUsername) {
+  if (getKnownRouteLength(colonyName, selection.target.roomName) === null) {
+    return null;
   }
-  return null;
+  const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
+  return {
+    ...selection,
+    source,
+    order,
+    priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
+    ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
+  };
+}
+function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
+  if (renewalTicksToEnd !== null) {
+    return TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL;
+  }
+  if (selection.intentAction === "scout") {
+    return TERRITORY_CANDIDATE_PRIORITY_SCOUT;
+  }
+  if (isTerritoryTargetVisible(selection.target)) {
+    return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM : TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
+  }
+  return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
+}
+function compareTerritoryCandidates(left, right) {
+  return left.priority - right.priority || compareOptionalNumbers(left.renewalTicksToEnd, right.renewalTicksToEnd) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+}
+function compareOptionalNumbers(left, right) {
+  return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
+}
+function getTerritoryCandidateSourcePriority(source) {
+  return source === "configured" ? 0 : 1;
+}
+function isTerritoryTargetVisible(target) {
+  return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;
+}
+function getKnownRouteLength(fromRoom, targetRoom) {
+  var _a;
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
+    return void 0;
+  }
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom);
+  if (route === getNoPathResultCode()) {
+    return null;
+  }
+  return Array.isArray(route) ? route.length : void 0;
+}
+function getNoPathResultCode() {
+  const noPathCode = globalThis.ERR_NO_PATH;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE;
 }
 function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
   if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -50,6 +50,10 @@ interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
 
 type TerritoryTargetVisibilityState = 'available' | 'satisfied' | 'unavailable';
 
+interface RouteDistanceLookupContext {
+  revalidatedNoRouteCacheKeys: Set<string>;
+}
+
 export function planTerritoryIntent(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
@@ -312,19 +316,22 @@ function selectTerritoryTarget(colony: ColonySnapshot, gameTime: number): Select
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   const intents = normalizeTerritoryIntents(territoryMemory?.intents);
+  const routeDistanceLookupContext = createRouteDistanceLookupContext();
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     territoryMemory,
     colonyName,
     colonyOwnerUsername,
     intents,
-    gameTime
+    gameTime,
+    routeDistanceLookupContext
   );
   const configuredCandidates = getConfiguredTerritoryCandidates(
     colonyName,
     colonyOwnerUsername,
     territoryMemory,
     intents,
-    gameTime
+    gameTime,
+    routeDistanceLookupContext
   );
   const bestConfiguredCandidate = selectBestScoredTerritoryCandidate(configuredCandidates);
   if (bestConfiguredCandidate && bestConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
@@ -340,7 +347,8 @@ function selectTerritoryTarget(colony: ColonySnapshot, gameTime: number): Select
         territoryMemory,
         intents,
         gameTime,
-        !hasBlockingConfiguredTarget
+        !hasBlockingConfiguredTarget,
+        routeDistanceLookupContext
       )
     ])
   );
@@ -372,7 +380,8 @@ function getConfiguredTerritoryCandidates(
   colonyOwnerUsername: string | null,
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[],
-  gameTime: number
+  gameTime: number,
+  routeDistanceLookupContext: RouteDistanceLookupContext
 ): ScoredTerritoryTarget[] {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return [];
@@ -397,7 +406,8 @@ function getConfiguredTerritoryCandidates(
       'configured',
       order,
       colonyName,
-      colonyOwnerUsername
+      colonyOwnerUsername,
+      routeDistanceLookupContext
     );
     return candidate ? [candidate] : [];
   });
@@ -408,7 +418,8 @@ function hasBlockingConfiguredTerritoryTargetForColony(
   colonyName: string,
   colonyOwnerUsername: string | null,
   intents: TerritoryIntentMemory[],
-  gameTime: number
+  gameTime: number,
+  routeDistanceLookupContext: RouteDistanceLookupContext
 ): boolean {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return false;
@@ -420,7 +431,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       return false;
     }
 
-    if (hasKnownNoRoute(colonyName, target.roomName)) {
+    if (hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext)) {
       return false;
     }
 
@@ -445,7 +456,8 @@ function getAdjacentReserveCandidates(
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[],
   gameTime: number,
-  includeScoutCandidates: boolean
+  includeScoutCandidates: boolean,
+  routeDistanceLookupContext: RouteDistanceLookupContext
 ): ScoredTerritoryTarget[] {
   const adjacentRooms = getAdjacentRoomNames(colonyName);
   if (adjacentRooms.length === 0) {
@@ -470,7 +482,8 @@ function getAdjacentReserveCandidates(
         'adjacent',
         order,
         colonyName,
-        colonyOwnerUsername
+        colonyOwnerUsername,
+        routeDistanceLookupContext
       );
       return candidate ? [candidate] : [];
     }
@@ -485,7 +498,8 @@ function getAdjacentReserveCandidates(
         'adjacent',
         order,
         colonyName,
-        colonyOwnerUsername
+        colonyOwnerUsername,
+        routeDistanceLookupContext
       );
       return candidate ? [candidate] : [];
     }
@@ -499,9 +513,10 @@ function scoreTerritoryCandidate(
   source: TerritoryCandidateSource,
   order: number,
   colonyName: string,
-  colonyOwnerUsername: string | null
+  colonyOwnerUsername: string | null,
+  routeDistanceLookupContext: RouteDistanceLookupContext
 ): ScoredTerritoryTarget | null {
-  if (hasKnownNoRoute(colonyName, selection.target.roomName)) {
+  if (hasKnownNoRoute(colonyName, selection.target.roomName, routeDistanceLookupContext)) {
     return null;
   }
 
@@ -561,11 +576,23 @@ function isTerritoryTargetVisible(target: TerritoryTargetMemory): boolean {
   return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;
 }
 
-function hasKnownNoRoute(fromRoom: string, targetRoom: string): boolean {
-  return getKnownRouteLength(fromRoom, targetRoom) === null;
+function createRouteDistanceLookupContext(): RouteDistanceLookupContext {
+  return { revalidatedNoRouteCacheKeys: new Set() };
 }
 
-function getKnownRouteLength(fromRoom: string, targetRoom: string): number | null | undefined {
+function hasKnownNoRoute(
+  fromRoom: string,
+  targetRoom: string,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): boolean {
+  return getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) === null;
+}
+
+function getKnownRouteLength(
+  fromRoom: string,
+  targetRoom: string,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): number | null | undefined {
   if (fromRoom === targetRoom) {
     return 0;
   }
@@ -573,8 +600,12 @@ function getKnownRouteLength(fromRoom: string, targetRoom: string): number | nul
   const cache = getTerritoryRouteDistanceCache();
   const cacheKey = getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom);
   const cachedRouteLength = cache?.[cacheKey];
-  if (typeof cachedRouteLength === 'number' || cachedRouteLength === null) {
+  if (typeof cachedRouteLength === 'number') {
     return cachedRouteLength;
+  }
+
+  if (cachedRouteLength === null && routeDistanceLookupContext.revalidatedNoRouteCacheKeys.has(cacheKey)) {
+    return null;
   }
 
   const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map as
@@ -591,6 +622,7 @@ function getKnownRouteLength(fromRoom: string, targetRoom: string): number | nul
     if (cache) {
       cache[cacheKey] = null;
     }
+    routeDistanceLookupContext.revalidatedNoRouteCacheKeys.add(cacheKey);
     return null;
   }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -12,6 +12,14 @@ export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 
 const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
 const MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+const TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL = 0;
+const TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM = 1;
+const TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE = 2;
+const TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM = 3;
+const TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE = 4;
+const TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
+const MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -28,6 +36,15 @@ interface SelectedTerritoryTarget {
   target: TerritoryTargetMemory;
   intentAction: TerritoryIntentAction;
   commitTarget: boolean;
+}
+
+type TerritoryCandidateSource = 'configured' | 'adjacent';
+
+interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
+  order: number;
+  priority: number;
+  source: TerritoryCandidateSource;
+  renewalTicksToEnd?: number;
 }
 
 type TerritoryTargetVisibilityState = 'available' | 'satisfied' | 'unavailable';
@@ -294,72 +311,95 @@ function selectTerritoryTarget(colony: ColonySnapshot, gameTime: number): Select
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   const intents = normalizeTerritoryIntents(territoryMemory?.intents);
-  const configuredTarget = selectConfiguredTerritoryTarget(
+  const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
+    territoryMemory,
+    colonyName,
+    colonyOwnerUsername,
+    intents,
+    gameTime
+  );
+  const configuredCandidates = getConfiguredTerritoryCandidates(
     colonyName,
     colonyOwnerUsername,
     territoryMemory,
     intents,
     gameTime
   );
-  if (configuredTarget) {
-    return { target: configuredTarget, intentAction: configuredTarget.action, commitTarget: false };
+  const bestConfiguredCandidate = selectBestScoredTerritoryCandidate(configuredCandidates);
+  if (bestConfiguredCandidate && bestConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
+    return toSelectedTerritoryTarget(bestConfiguredCandidate);
   }
 
-  if (
-    hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime)
-  ) {
-    return null;
-  }
-
-  return selectAdjacentReserveTarget(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime);
+  return toSelectedTerritoryTarget(
+    selectBestScoredTerritoryCandidate([
+      ...configuredCandidates,
+      ...getAdjacentReserveCandidates(
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        !hasBlockingConfiguredTarget
+      )
+    ])
+  );
 }
 
-function selectConfiguredTerritoryTarget(
+function selectBestScoredTerritoryCandidate(candidates: ScoredTerritoryTarget[]): ScoredTerritoryTarget | null {
+  let bestCandidate: ScoredTerritoryTarget | null = null;
+  for (const candidate of candidates) {
+    if (!bestCandidate || compareTerritoryCandidates(candidate, bestCandidate) < 0) {
+      bestCandidate = candidate;
+    }
+  }
+
+  return bestCandidate;
+}
+
+function toSelectedTerritoryTarget(candidate: ScoredTerritoryTarget | null): SelectedTerritoryTarget | null {
+  return candidate
+    ? {
+        target: candidate.target,
+        intentAction: candidate.intentAction,
+        commitTarget: candidate.commitTarget
+      }
+    : null;
+}
+
+function getConfiguredTerritoryCandidates(
   colonyName: string,
   colonyOwnerUsername: string | null,
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[],
   gameTime: number
-): TerritoryTargetMemory | null {
+): ScoredTerritoryTarget[] {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
-    return null;
+    return [];
   }
 
-  let fallbackTarget: TerritoryTargetMemory | null = null;
-  let renewalTarget: TerritoryTargetMemory | null = null;
-  let renewalTicksToEnd: number | null = null;
-
-  for (const rawTarget of territoryMemory.targets) {
+  return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget(rawTarget);
     if (
-      target &&
-      target.enabled !== false &&
-      target.colony === colonyName &&
-      target.roomName !== colonyName &&
-      !isTerritoryTargetSuppressed(target, intents, gameTime) &&
-      getVisibleTerritoryTargetState(
-        target.roomName,
-        target.action,
-        target.controllerId,
-        colonyOwnerUsername
-      ) === 'available'
+      !target ||
+      target.enabled === false ||
+      target.colony !== colonyName ||
+      target.roomName === colonyName ||
+      isTerritoryTargetSuppressed(target, intents, gameTime) ||
+      getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !==
+        'available'
     ) {
-      const targetRenewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername);
-      if (targetRenewalTicksToEnd !== null) {
-        if (renewalTicksToEnd === null || targetRenewalTicksToEnd < renewalTicksToEnd) {
-          renewalTarget = target;
-          renewalTicksToEnd = targetRenewalTicksToEnd;
-        }
-        continue;
-      }
-
-      if (fallbackTarget === null) {
-        fallbackTarget = target;
-      }
+      return [];
     }
-  }
 
-  return renewalTarget ?? fallbackTarget;
+    const candidate = scoreTerritoryCandidate(
+      { target, intentAction: target.action, commitTarget: false },
+      'configured',
+      order,
+      colonyName,
+      colonyOwnerUsername
+    );
+    return candidate ? [candidate] : [];
+  });
 }
 
 function hasBlockingConfiguredTerritoryTargetForColony(
@@ -394,41 +434,153 @@ function hasBlockingConfiguredTerritoryTargetForColony(
   });
 }
 
-function selectAdjacentReserveTarget(
+function getAdjacentReserveCandidates(
   colonyName: string,
   colonyOwnerUsername: string | null,
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[],
-  gameTime: number
-): SelectedTerritoryTarget | null {
+  gameTime: number,
+  includeScoutCandidates: boolean
+): ScoredTerritoryTarget[] {
   const adjacentRooms = getAdjacentRoomNames(colonyName);
   if (adjacentRooms.length === 0) {
-    return null;
+    return [];
   }
 
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
-  for (const roomName of adjacentRooms) {
+  return adjacentRooms.flatMap((roomName, order) => {
     const target: TerritoryTargetMemory = { colony: colonyName, roomName, action: 'reserve' };
     if (
-      roomName !== colonyName &&
-      !existingTargetRooms.has(roomName) &&
-      !isTerritoryTargetSuppressed(target, intents, gameTime)
+      roomName === colonyName ||
+      existingTargetRooms.has(roomName) ||
+      isTerritoryTargetSuppressed(target, intents, gameTime)
     ) {
-      const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
-      if (candidateState === 'safe') {
-        return { target, intentAction: 'reserve', commitTarget: true };
-      }
-
-      if (
-        candidateState === 'unknown' &&
-        !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, 'scout', gameTime)
-      ) {
-        return { target, intentAction: 'scout', commitTarget: false };
-      }
+      return [];
     }
+
+    const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
+    if (candidateState === 'safe') {
+      const candidate = scoreTerritoryCandidate(
+        { target, intentAction: 'reserve', commitTarget: true },
+        'adjacent',
+        order,
+        colonyName,
+        colonyOwnerUsername
+      );
+      return candidate ? [candidate] : [];
+    }
+
+    if (
+      candidateState === 'unknown' &&
+      includeScoutCandidates &&
+      !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, 'scout', gameTime)
+    ) {
+      const candidate = scoreTerritoryCandidate(
+        { target, intentAction: 'scout', commitTarget: false },
+        'adjacent',
+        order,
+        colonyName,
+        colonyOwnerUsername
+      );
+      return candidate ? [candidate] : [];
+    }
+
+    return [];
+  });
+}
+
+function scoreTerritoryCandidate(
+  selection: SelectedTerritoryTarget,
+  source: TerritoryCandidateSource,
+  order: number,
+  colonyName: string,
+  colonyOwnerUsername: string | null
+): ScoredTerritoryTarget | null {
+  if (getKnownRouteLength(colonyName, selection.target.roomName) === null) {
+    return null;
   }
 
-  return null;
+  const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
+  return {
+    ...selection,
+    source,
+    order,
+    priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
+    ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
+  };
+}
+
+function getTerritoryCandidatePriority(
+  selection: SelectedTerritoryTarget,
+  renewalTicksToEnd: number | null
+): number {
+  if (renewalTicksToEnd !== null) {
+    return TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL;
+  }
+
+  if (selection.intentAction === 'scout') {
+    return TERRITORY_CANDIDATE_PRIORITY_SCOUT;
+  }
+
+  if (isTerritoryTargetVisible(selection.target)) {
+    return selection.target.action === 'claim'
+      ? TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM
+      : TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
+  }
+
+  return selection.target.action === 'claim'
+    ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM
+    : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
+}
+
+function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTerritoryTarget): number {
+  return (
+    left.priority - right.priority ||
+    compareOptionalNumbers(left.renewalTicksToEnd, right.renewalTicksToEnd) ||
+    getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) ||
+    left.order - right.order ||
+    left.target.roomName.localeCompare(right.target.roomName) ||
+    left.intentAction.localeCompare(right.intentAction)
+  );
+}
+
+function compareOptionalNumbers(left: number | undefined, right: number | undefined): number {
+  return (left ?? Number.POSITIVE_INFINITY) - (right ?? Number.POSITIVE_INFINITY);
+}
+
+function getTerritoryCandidateSourcePriority(source: TerritoryCandidateSource): number {
+  return source === 'configured' ? 0 : 1;
+}
+
+function isTerritoryTargetVisible(target: TerritoryTargetMemory): boolean {
+  return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;
+}
+
+function getKnownRouteLength(fromRoom: string, targetRoom: string): number | null | undefined {
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map as
+    | (Partial<GameMap> & {
+        findRoute?: (fromRoom: string, toRoom: string) => unknown;
+      })
+    | undefined;
+  if (typeof gameMap?.findRoute !== 'function') {
+    return undefined;
+  }
+
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom);
+  if (route === getNoPathResultCode()) {
+    return null;
+  }
+
+  return Array.isArray(route) ? route.length : undefined;
+}
+
+function getNoPathResultCode(): ScreepsReturnCode {
+  const noPathCode = (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
+  return typeof noPathCode === 'number' ? noPathCode : ERR_NO_PATH_CODE;
 }
 
 function getAdjacentReserveCandidateState(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -20,6 +20,7 @@ const TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM = 3;
 const TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE = 4;
 const TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
 const MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
+const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -561,6 +562,13 @@ function getKnownRouteLength(fromRoom: string, targetRoom: string): number | nul
     return 0;
   }
 
+  const cache = getTerritoryRouteDistanceCache();
+  const cacheKey = getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom);
+  const cachedRouteLength = cache?.[cacheKey];
+  if (typeof cachedRouteLength === 'number' || cachedRouteLength === null) {
+    return cachedRouteLength;
+  }
+
   const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map as
     | (Partial<GameMap> & {
         findRoute?: (fromRoom: string, toRoom: string) => unknown;
@@ -572,10 +580,37 @@ function getKnownRouteLength(fromRoom: string, targetRoom: string): number | nul
 
   const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom);
   if (route === getNoPathResultCode()) {
+    if (cache) {
+      cache[cacheKey] = null;
+    }
     return null;
   }
 
-  return Array.isArray(route) ? route.length : undefined;
+  if (!Array.isArray(route)) {
+    return undefined;
+  }
+
+  if (cache) {
+    cache[cacheKey] = route.length;
+  }
+  return route.length;
+}
+
+function getTerritoryRouteDistanceCache(): TerritoryMemory['routeDistances'] | undefined {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return undefined;
+  }
+
+  if (!isRecord(territoryMemory.routeDistances)) {
+    territoryMemory.routeDistances = {};
+  }
+
+  return territoryMemory.routeDistances as TerritoryMemory['routeDistances'];
+}
+
+function getTerritoryRouteDistanceCacheKey(fromRoom: string, targetRoom: string): string {
+  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`;
 }
 
 function getNoPathResultCode(): ScreepsReturnCode {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -420,6 +420,10 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       return false;
     }
 
+    if (hasKnownNoRoute(colonyName, target.roomName)) {
+      return false;
+    }
+
     if (
       target.enabled === false ||
       target.roomName === colonyName ||
@@ -497,7 +501,7 @@ function scoreTerritoryCandidate(
   colonyName: string,
   colonyOwnerUsername: string | null
 ): ScoredTerritoryTarget | null {
-  if (getKnownRouteLength(colonyName, selection.target.roomName) === null) {
+  if (hasKnownNoRoute(colonyName, selection.target.roomName)) {
     return null;
   }
 
@@ -555,6 +559,10 @@ function getTerritoryCandidateSourcePriority(source: TerritoryCandidateSource): 
 
 function isTerritoryTargetVisible(target: TerritoryTargetMemory): boolean {
   return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;
+}
+
+function hasKnownNoRoute(fromRoom: string, targetRoom: string): boolean {
+  return getKnownRouteLength(fromRoom, targetRoom) === null;
 }
 
 function getKnownRouteLength(fromRoom: string, targetRoom: string): number | null | undefined {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -21,6 +21,7 @@ declare global {
   interface TerritoryMemory {
     targets?: TerritoryTargetMemory[];
     intents?: TerritoryIntentMemory[];
+    routeDistances?: Record<string, number | null>;
   }
 
   interface TerritoryTargetMemory {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -110,6 +110,42 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('prefers a visible adjacent reserve target before scouting an unknown exit', () => {
+    const colony = makeSafeColony();
+    const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 529)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 529
+      }
+    ]);
+  });
+
   it('commits a seeded reserve target after scout visibility confirms a safe controller', () => {
     const colony = makeSafeColony();
     const describeExits = jest.fn(() => ({ '1': 'W1N2' }));
@@ -349,7 +385,7 @@ describe('planTerritoryIntent', () => {
     };
 
     expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 521)).toBeNull();
-    expect(describeExits).not.toHaveBeenCalled();
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(Memory.territory?.targets).toEqual([disabledTarget]);
     expect(Memory.territory?.intents).toBeUndefined();
   });
@@ -380,7 +416,7 @@ describe('planTerritoryIntent', () => {
     };
 
     expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 522)).toBeNull();
-    expect(describeExits).not.toHaveBeenCalled();
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(Memory.territory?.targets).toEqual([suppressedTarget]);
     expect(Memory.territory?.intents).toEqual([suppressedIntent]);
   });
@@ -409,9 +445,79 @@ describe('planTerritoryIntent', () => {
     };
 
     expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 523)).toBeNull();
-    expect(describeExits).not.toHaveBeenCalled();
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(Memory.territory?.targets).toEqual([unavailableTarget]);
     expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('uses a visible adjacent reserve target instead of blocked configured targets', () => {
+    const colony = makeSafeColony();
+    const disabledTarget: TerritoryTargetMemory = {
+      colony: 'W1N1',
+      roomName: 'W1N2',
+      action: 'reserve',
+      enabled: false
+    };
+    const suppressedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const unavailableTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N0', action: 'reserve' };
+    const suppressedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: 545
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits: jest.fn(() => ({
+          '1': 'W1N2',
+          '3': 'W2N1',
+          '5': 'W1N0',
+          '7': 'W0N1'
+        }))
+      } as unknown as GameMap,
+      rooms: {
+        W1N0: {
+          name: 'W1N0',
+          controller: { my: false, owner: { username: 'enemy' } } as StructureController
+        } as Room,
+        W0N1: { name: 'W0N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [disabledTarget, suppressedTarget, unavailableTarget],
+        intents: [suppressedIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 546)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W0N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      disabledTarget,
+      suppressedTarget,
+      unavailableTarget,
+      {
+        colony: 'W1N1',
+        roomName: 'W0N1',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      suppressedIntent,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W0N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 546
+      }
+    ]);
   });
 
   it('defers seeded adjacent target writes until recording a finalized plan', () => {
@@ -505,8 +611,51 @@ describe('planTerritoryIntent', () => {
       targetRoom: 'W3N1',
       action: 'reserve'
     });
-    expect(describeExits).not.toHaveBeenCalled();
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(Memory.territory?.targets).toEqual([configuredTarget]);
+  });
+
+  it('prefers a visible adjacent reserve target over an unknown configured target', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const describeExits = jest.fn(() => ({ '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 547)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toEqual([
+      configuredTarget,
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 547
+      }
+    ]);
   });
 
   it('does not seed visible hostile-owned or self-owned adjacent rooms', () => {
@@ -924,6 +1073,37 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('prefers visible claim targets over visible reserve targets', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room,
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'claim' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 548);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'claim' });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 548
+      }
+    ]);
+  });
+
   it('still requests claimers for visible unowned claim targets', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -1019,6 +1199,44 @@ describe('planTerritoryIntent', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: 506
+      }
+    ]);
+  });
+
+  it('skips configured targets when route lookup reports no path', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;
+    const findRoute = jest.fn((fromRoom: string, toRoom: string) =>
+      fromRoom === 'W1N1' && toRoom === 'W2N1' ? -2 : [{ exit: 3, room: toRoom }]
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room,
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 549);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W2N1');
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W3N1');
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 549
       }
     ]);
   });

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1230,6 +1230,10 @@ describe('planTerritoryIntent', () => {
     expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
     expect(findRoute).toHaveBeenCalledWith('W1N1', 'W2N1');
     expect(findRoute).toHaveBeenCalledWith('W1N1', 'W3N1');
+    expect(Memory.territory?.routeDistances).toEqual({
+      'W1N1>W2N1': null,
+      'W1N1>W3N1': 1
+    });
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
@@ -1239,6 +1243,43 @@ describe('planTerritoryIntent', () => {
         updatedAt: 549
       }
     ]);
+  });
+
+  it('reuses cached route lengths while scoring repeated configured targets', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;
+    const findRoute = jest.fn((fromRoom: string, toRoom: string) =>
+      fromRoom === 'W1N1' && toRoom === 'W2N1' ? -2 : [{ exit: 3, room: toRoom }]
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room,
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 550);
+    const nextPlan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 551);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
+    expect(nextPlan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
+    expect(findRoute).toHaveBeenCalledTimes(2);
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W2N1');
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W3N1');
+    expect(Memory.territory?.routeDistances).toEqual({
+      'W1N1>W2N1': null,
+      'W1N1>W3N1': 1
+    });
   });
 
   it('prioritizes a neutral adjacent reserve target over a healthy own configured reservation', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1245,6 +1245,44 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('plans an adjacent scout when configured targets have no known route', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;
+    const describeExits = jest.fn(() => ({ '1': 'W1N2' }));
+    const findRoute = jest.fn((fromRoom: string, toRoom: string) =>
+      fromRoom === 'W1N1' && toRoom === 'W3N1' ? -2 : [{ exit: 1, room: toRoom }]
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits, findRoute } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 552);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W1N2', action: 'scout' });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W3N1');
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W1N2');
+    expect(Memory.territory?.routeDistances).toEqual({
+      'W1N1>W3N1': null,
+      'W1N1>W1N2': 1
+    });
+    expect(Memory.territory?.targets).toEqual([{ colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 552
+      }
+    ]);
+  });
+
   it('reuses cached route lengths while scoring repeated configured targets', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1283,7 +1283,50 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('reuses cached route lengths while scoring repeated configured targets', () => {
+  it('revalidates cached no-route entries before suppressing configured targets', () => {
+    const colony = makeSafeColony();
+    const findRoute = jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 3, room: toRoom }]);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room,
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ],
+        routeDistances: {
+          'W1N1>W2N1': null,
+          'W1N1>W3N1': 1
+        }
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 553);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(findRoute).toHaveBeenCalledTimes(1);
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W2N1');
+    expect(Memory.territory?.routeDistances).toEqual({
+      'W1N1>W2N1': 1,
+      'W1N1>W3N1': 1
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 553
+      }
+    ]);
+  });
+
+  it('reuses cached route lengths while rechecking cached no-route targets in later planning passes', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;
     const findRoute = jest.fn((fromRoom: string, toRoom: string) =>
@@ -1311,9 +1354,10 @@ describe('planTerritoryIntent', () => {
 
     expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
     expect(nextPlan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
-    expect(findRoute).toHaveBeenCalledTimes(2);
-    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W2N1');
-    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W3N1');
+    expect(findRoute).toHaveBeenCalledTimes(3);
+    expect(findRoute).toHaveBeenNthCalledWith(1, 'W1N1', 'W2N1');
+    expect(findRoute).toHaveBeenNthCalledWith(2, 'W1N1', 'W3N1');
+    expect(findRoute).toHaveBeenNthCalledWith(3, 'W1N1', 'W2N1');
     expect(Memory.territory?.routeDistances).toEqual({
       'W1N1>W2N1': null,
       'W1N1>W3N1': 1


### PR DESCRIPTION
Closes #189.

## Summary
- improve claim/reserve target scoring after recovery
- add territory planner coverage for target selection and recovery guard behavior
- regenerate `prod/dist/main.js`

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (303 tests)
- `cd prod && npm run build`
- `git diff --check`

## Scheduler evidence
Recovered useful dirty Codex edits after the implementation process exited, controller-verified them, and used Codex commit-only recovery to preserve `lanyusea's bot <lanyusea@gmail.com>` authorship.
