### PR TITLE
feat: improve territory recovery handoff

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1223,6 +1223,9 @@ function getTerritoryControllerTargetState(controller, action, colonyOwnerUserna
   if (action === "reserve") {
     return getReserveControllerTargetState(controller, colonyOwnerUsername);
   }
+  if (isControllerOwnedByColony(controller, colonyOwnerUsername)) {
+    return "satisfied";
+  }
   return isControllerOwned(controller) ? "unavailable" : "available";
 }
 function getTerritoryActorUsername(creep, colony) {
@@ -1318,6 +1321,10 @@ function isVisibleRoomMissingController(targetRoom) {
 }
 function isControllerOwned(controller) {
   return controller.owner != null || controller.my === true;
+}
+function isControllerOwnedByColony(controller, colonyOwnerUsername) {
+  const ownerUsername = getControllerOwnerUsername(controller);
+  return controller.my === true || isNonEmptyString(ownerUsername) && ownerUsername === colonyOwnerUsername;
 }
 function getReserveControllerTargetState(controller, colonyOwnerUsername) {
   if (isControllerOwned(controller)) {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1028,6 +1028,10 @@ function getTerritoryControllerTargetState(
     return getReserveControllerTargetState(controller, colonyOwnerUsername);
   }
 
+  if (isControllerOwnedByColony(controller, colonyOwnerUsername)) {
+    return 'satisfied';
+  }
+
   return isControllerOwned(controller) ? 'unavailable' : 'available';
 }
 
@@ -1153,6 +1157,11 @@ function isVisibleRoomMissingController(targetRoom: string): boolean {
 
 function isControllerOwned(controller: StructureController): boolean {
   return controller.owner != null || controller.my === true;
+}
+
+function isControllerOwnedByColony(controller: StructureController, colonyOwnerUsername: string | null): boolean {
+  const ownerUsername = getControllerOwnerUsername(controller);
+  return controller.my === true || (isNonEmptyString(ownerUsername) && ownerUsername === colonyOwnerUsername);
 }
 
 function getReserveControllerTargetState(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1030,6 +1030,45 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
+  it('scouts adjacent rooms after a configured claim target is owned by the colony account', () => {
+    const colony = makeSafeColony();
+    const claimedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'claim' };
+    const describeExits = jest.fn(() => ({ '3': 'W3N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false, owner: { username: 'me' } } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [claimedTarget]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 554)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'scout'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toEqual([claimedTarget]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 554
+      }
+    ]);
+  });
+
   it('skips visible hostile-owned claim targets and plans the next eligible target', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {


### PR DESCRIPTION
## Summary
- Improves territory/control handoff after recovery by preserving/renewing territory intent when recovery work resumes.
- Adds territory planner test coverage for the recovery-handoff behavior.
- Regenerates `prod/dist/main.js` from the build.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #198
