### PR TITLE
feat: improve post-recovery resource throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2330,10 +2330,13 @@ var TERRITORY_SCOUT_BODY = ["move"];
 var TERRITORY_SCOUT_BODY_COST = 50;
 var MAX_WORKER_TARGET = 6;
 var sourceCountByRoomName = /* @__PURE__ */ new Map();
-function planSpawn(colony, roleCounts, gameTime) {
+function planSpawn(colony, roleCounts, gameTime, options = {}) {
   const workerTarget = getWorkerTarget(colony, roleCounts);
   if (getWorkerCapacity(roleCounts) < workerTarget) {
-    return planWorkerSpawn(colony, roleCounts, gameTime);
+    return planWorkerSpawn(colony, roleCounts, gameTime, options);
+  }
+  if (options.workersOnly) {
+    return null;
   }
   const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
   if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
@@ -2351,11 +2354,11 @@ function planSpawn(colony, roleCounts, gameTime) {
   return {
     spawn,
     body,
-    name: `${roleName}-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`,
+    name: appendSpawnNameSuffix(`${roleName}-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`, options),
     memory: buildTerritoryCreepMemory(territoryIntent)
   };
 }
-function planWorkerSpawn(colony, roleCounts, gameTime) {
+function planWorkerSpawn(colony, roleCounts, gameTime, options) {
   const spawn = colony.spawns.find((candidate) => !candidate.spawning);
   if (!spawn) {
     return null;
@@ -2367,9 +2370,12 @@ function planWorkerSpawn(colony, roleCounts, gameTime) {
   return {
     spawn,
     body,
-    name: `worker-${colony.room.name}-${gameTime}`,
+    name: appendSpawnNameSuffix(`worker-${colony.room.name}-${gameTime}`, options),
     memory: { role: "worker", colony: colony.room.name }
   };
+}
+function appendSpawnNameSuffix(baseName, options) {
+  return options.nameSuffix ? `${baseName}-${options.nameSuffix}` : baseName;
 }
 function selectWorkerBody(colony, roleCounts) {
   const normalBody = buildWorkerBody(colony.energyCapacityAvailable);
@@ -2792,6 +2798,7 @@ function isTerritoryAssignment(assignment) {
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
+var OK_CODE2 = 0;
 function runEconomy() {
   const creeps = Object.values(Game.creeps);
   const colonies = getOwnedColonies();
@@ -2801,15 +2808,40 @@ function runEconomy() {
     if (extensionResult === null) {
       planEarlyRoadConstruction(colony);
     }
-    const roleCounts = countCreepsByRole(creeps, colony.room.name);
-    const spawnRequest = planSpawn(colony, roleCounts, Game.time);
-    if (spawnRequest) {
-      for (const spawn of getSpawnAttemptOrder(spawnRequest, colony.spawns)) {
-        const result = attemptSpawn({ ...spawnRequest, spawn }, colony.room.name, telemetryEvents);
-        if (result !== ERR_BUSY_CODE) {
-          break;
-        }
+    let roleCounts = countCreepsByRole(creeps, colony.room.name);
+    let availableEnergy = colony.energyAvailable;
+    let successfulSpawnCount = 0;
+    const usedSpawns = /* @__PURE__ */ new Set();
+    while (true) {
+      const planningColony = createSpawnPlanningColony(colony, availableEnergy, usedSpawns);
+      const spawnRequest = planSpawn(
+        planningColony,
+        roleCounts,
+        Game.time,
+        getSpawnPlanningOptions(successfulSpawnCount)
+      );
+      if (!spawnRequest) {
+        break;
       }
+      if (successfulSpawnCount > 0 && spawnRequest.memory.role !== "worker") {
+        break;
+      }
+      const outcome = attemptSpawnRequest(
+        spawnRequest,
+        colony.room.name,
+        telemetryEvents,
+        planningColony.spawns
+      );
+      if (!outcome || outcome.result !== OK_CODE2) {
+        break;
+      }
+      usedSpawns.add(outcome.spawn);
+      availableEnergy = Math.max(0, availableEnergy - getBodyCost(spawnRequest.body));
+      successfulSpawnCount += 1;
+      if (spawnRequest.memory.role !== "worker") {
+        break;
+      }
+      roleCounts = addPlannedWorker(roleCounts);
     }
   }
   for (const creep of creeps) {
@@ -2820,6 +2852,40 @@ function runEconomy() {
     }
   }
   emitRuntimeSummary(colonies, creeps, telemetryEvents);
+}
+function createSpawnPlanningColony(colony, energyAvailable, usedSpawns) {
+  return {
+    ...colony,
+    energyAvailable,
+    spawns: colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
+  };
+}
+function getSpawnPlanningOptions(successfulSpawnCount) {
+  return successfulSpawnCount > 0 ? { nameSuffix: String(successfulSpawnCount + 1), workersOnly: true } : {};
+}
+function attemptSpawnRequest(spawnRequest, roomName, telemetryEvents, spawns) {
+  let lastOutcome = null;
+  for (const spawn of getSpawnAttemptOrder(spawnRequest, spawns)) {
+    const result = attemptSpawn({ ...spawnRequest, spawn }, roomName, telemetryEvents);
+    lastOutcome = { spawn, result };
+    if (result !== ERR_BUSY_CODE) {
+      return lastOutcome;
+    }
+  }
+  return lastOutcome;
+}
+function addPlannedWorker(roleCounts) {
+  const nextRoleCounts = {
+    ...roleCounts,
+    worker: roleCounts.worker + 1
+  };
+  const workerCapacity = getWorkerCapacity(roleCounts) + 1;
+  if (workerCapacity === nextRoleCounts.worker) {
+    delete nextRoleCounts.workerCapacity;
+  } else {
+    nextRoleCounts.workerCapacity = workerCapacity;
+  }
+  return nextRoleCounts;
 }
 function getSpawnAttemptOrder(spawnRequest, spawns) {
   return [spawnRequest.spawn, ...spawns.filter((spawn) => spawn !== spawnRequest.spawn && !spawn.spawning)];

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -1,14 +1,21 @@
-import { getOwnedColonies } from '../colony/colonyRegistry';
+import { getOwnedColonies, type ColonySnapshot } from '../colony/colonyRegistry';
 import { planExtensionConstruction } from '../construction/extensionPlanner';
 import { planEarlyRoadConstruction } from '../construction/roadPlanner';
-import { countCreepsByRole } from '../creeps/roleCounts';
+import { countCreepsByRole, getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
-import { planSpawn, type SpawnRequest } from '../spawn/spawnPlanner';
+import { getBodyCost } from '../spawn/bodyBuilder';
+import { planSpawn, type SpawnPlanningOptions, type SpawnRequest } from '../spawn/spawnPlanner';
 import { emitRuntimeSummary, type RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 import { TERRITORY_CLAIMER_ROLE, TERRITORY_SCOUT_ROLE } from '../territory/territoryPlanner';
 import { runTerritoryControllerCreep } from '../territory/territoryRunner';
 
 const ERR_BUSY_CODE = -4 as ScreepsReturnCode;
+const OK_CODE = 0 as ScreepsReturnCode;
+
+interface SpawnAttemptOutcome {
+  spawn: StructureSpawn;
+  result: ScreepsReturnCode;
+}
 
 export function runEconomy(): void {
   const creeps = Object.values(Game.creeps);
@@ -21,16 +28,46 @@ export function runEconomy(): void {
       planEarlyRoadConstruction(colony);
     }
 
-    const roleCounts = countCreepsByRole(creeps, colony.room.name);
-    const spawnRequest = planSpawn(colony, roleCounts, Game.time);
+    let roleCounts = countCreepsByRole(creeps, colony.room.name);
+    let availableEnergy = colony.energyAvailable;
+    let successfulSpawnCount = 0;
+    const usedSpawns = new Set<StructureSpawn>();
 
-    if (spawnRequest) {
-      for (const spawn of getSpawnAttemptOrder(spawnRequest, colony.spawns)) {
-        const result = attemptSpawn({ ...spawnRequest, spawn }, colony.room.name, telemetryEvents);
-        if (result !== ERR_BUSY_CODE) {
-          break;
-        }
+    while (true) {
+      const planningColony = createSpawnPlanningColony(colony, availableEnergy, usedSpawns);
+      const spawnRequest = planSpawn(
+        planningColony,
+        roleCounts,
+        Game.time,
+        getSpawnPlanningOptions(successfulSpawnCount)
+      );
+      if (!spawnRequest) {
+        break;
       }
+
+      if (successfulSpawnCount > 0 && spawnRequest.memory.role !== 'worker') {
+        break;
+      }
+
+      const outcome = attemptSpawnRequest(
+        spawnRequest,
+        colony.room.name,
+        telemetryEvents,
+        planningColony.spawns
+      );
+      if (!outcome || outcome.result !== OK_CODE) {
+        break;
+      }
+
+      usedSpawns.add(outcome.spawn);
+      availableEnergy = Math.max(0, availableEnergy - getBodyCost(spawnRequest.body));
+      successfulSpawnCount += 1;
+
+      if (spawnRequest.memory.role !== 'worker') {
+        break;
+      }
+
+      roleCounts = addPlannedWorker(roleCounts);
     }
   }
 
@@ -43,6 +80,56 @@ export function runEconomy(): void {
   }
 
   emitRuntimeSummary(colonies, creeps, telemetryEvents);
+}
+
+function createSpawnPlanningColony(
+  colony: ColonySnapshot,
+  energyAvailable: number,
+  usedSpawns: Set<StructureSpawn>
+): ColonySnapshot {
+  return {
+    ...colony,
+    energyAvailable,
+    spawns: colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
+  };
+}
+
+function getSpawnPlanningOptions(successfulSpawnCount: number): SpawnPlanningOptions {
+  return successfulSpawnCount > 0 ? { nameSuffix: String(successfulSpawnCount + 1), workersOnly: true } : {};
+}
+
+function attemptSpawnRequest(
+  spawnRequest: SpawnRequest,
+  roomName: string,
+  telemetryEvents: RuntimeTelemetryEvent[],
+  spawns: StructureSpawn[]
+): SpawnAttemptOutcome | null {
+  let lastOutcome: SpawnAttemptOutcome | null = null;
+  for (const spawn of getSpawnAttemptOrder(spawnRequest, spawns)) {
+    const result = attemptSpawn({ ...spawnRequest, spawn }, roomName, telemetryEvents);
+    lastOutcome = { spawn, result };
+    if (result !== ERR_BUSY_CODE) {
+      return lastOutcome;
+    }
+  }
+
+  return lastOutcome;
+}
+
+function addPlannedWorker(roleCounts: RoleCounts): RoleCounts {
+  const nextRoleCounts: RoleCounts = {
+    ...roleCounts,
+    worker: roleCounts.worker + 1
+  };
+  const workerCapacity = getWorkerCapacity(roleCounts) + 1;
+
+  if (workerCapacity === nextRoleCounts.worker) {
+    delete nextRoleCounts.workerCapacity;
+  } else {
+    nextRoleCounts.workerCapacity = workerCapacity;
+  }
+
+  return nextRoleCounts;
 }
 
 function getSpawnAttemptOrder(spawnRequest: SpawnRequest, spawns: StructureSpawn[]): StructureSpawn[] {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -20,6 +20,11 @@ export interface SpawnRequest {
   memory: CreepMemory;
 }
 
+export interface SpawnPlanningOptions {
+  nameSuffix?: string;
+  workersOnly?: boolean;
+}
+
 const MIN_WORKER_TARGET = 3;
 const WORKERS_PER_SOURCE = 2;
 const CONSTRUCTION_BACKLOG_WORKER_BONUS = 1;
@@ -29,10 +34,19 @@ const TERRITORY_SCOUT_BODY_COST = 50;
 const MAX_WORKER_TARGET = 6;
 const sourceCountByRoomName = new Map<string, number>();
 
-export function planSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTime: number): SpawnRequest | null {
+export function planSpawn(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  gameTime: number,
+  options: SpawnPlanningOptions = {}
+): SpawnRequest | null {
   const workerTarget = getWorkerTarget(colony, roleCounts);
   if (getWorkerCapacity(roleCounts) < workerTarget) {
-    return planWorkerSpawn(colony, roleCounts, gameTime);
+    return planWorkerSpawn(colony, roleCounts, gameTime, options);
+  }
+
+  if (options.workersOnly) {
+    return null;
   }
 
   const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
@@ -54,12 +68,17 @@ export function planSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTi
   return {
     spawn,
     body,
-    name: `${roleName}-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`,
+    name: appendSpawnNameSuffix(`${roleName}-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`, options),
     memory: buildTerritoryCreepMemory(territoryIntent)
   };
 }
 
-function planWorkerSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTime: number): SpawnRequest | null {
+function planWorkerSpawn(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  gameTime: number,
+  options: SpawnPlanningOptions
+): SpawnRequest | null {
   const spawn = colony.spawns.find((candidate) => !candidate.spawning);
   if (!spawn) {
     return null;
@@ -73,9 +92,13 @@ function planWorkerSpawn(colony: ColonySnapshot, roleCounts: RoleCounts, gameTim
   return {
     spawn,
     body,
-    name: `worker-${colony.room.name}-${gameTime}`,
+    name: appendSpawnNameSuffix(`worker-${colony.room.name}-${gameTime}`, options),
     memory: { role: 'worker', colony: colony.room.name }
   };
+}
+
+function appendSpawnNameSuffix(baseName: string, options: SpawnPlanningOptions): string {
+  return options.nameSuffix ? `${baseName}-${options.nameSuffix}` : baseName;
 }
 
 function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyPartConstant[] {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -67,6 +67,78 @@ describe('runEconomy', () => {
     });
   });
 
+  it('uses multiple idle spawns in one tick when worker recovery has enough room energy', () => {
+    (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 4;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const ownedStructures: AnyOwnedStructure[] = [];
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 1200,
+      energyCapacityAvailable: 1200,
+      controller: { my: true } as StructureController,
+      find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          return options?.filter ? ownedStructures.filter(options.filter) : ownedStructures;
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const spawn1 = {
+      id: 'spawn1',
+      name: 'Spawn1',
+      room,
+      structureType: 'spawn',
+      spawning: null,
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) },
+      spawnCreep: jest.fn().mockReturnValue(0)
+    } as unknown as StructureSpawn;
+    const spawn2 = {
+      id: 'spawn2',
+      name: 'Spawn2',
+      room,
+      structureType: 'spawn',
+      spawning: null,
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) },
+      spawnCreep: jest.fn().mockReturnValue(0)
+    } as unknown as StructureSpawn;
+    ownedStructures.push(spawn1 as unknown as AnyOwnedStructure, spawn2 as unknown as AnyOwnedStructure);
+    const existingWorker = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 126,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn1, Spawn2: spawn2 },
+      creeps: { ExistingWorker: existingWorker }
+    };
+
+    runEconomy();
+
+    expect(spawn1.spawnCreep).toHaveBeenCalledTimes(1);
+    expect(spawn2.spawnCreep).toHaveBeenCalledTimes(1);
+    expect(spawn1.spawnCreep).toHaveBeenCalledWith(
+      ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      'worker-W1N1-126',
+      {
+        memory: { role: 'worker', colony: 'W1N1' }
+      }
+    );
+    expect(spawn2.spawnCreep).toHaveBeenCalledWith(
+      ['work', 'carry', 'move', 'work', 'carry', 'move'],
+      'worker-W1N1-126-2',
+      {
+        memory: { role: 'worker', colony: 'W1N1' }
+      }
+    );
+  });
+
   it('waits through critical energy without invalid spawn attempts and recovers when an emergency body is affordable', () => {
     const room = {
       name: 'W1N1',


### PR DESCRIPTION
## Summary
- Improves post-recovery resource throughput by ranking/acquiring higher-value resource work after low-energy recovery.
- Adjusts spawn/economy behavior and adds economy-loop test coverage.
- Regenerates `prod/dist/main.js` from the build.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #199
