### PR TITLE
feat: refresh territory claim targets after satisfaction

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -800,6 +800,18 @@ function selectTerritoryTarget(colony, gameTime) {
       ...configuredCandidates,
       ...getAdjacentReserveCandidates(
         colonyName,
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        !hasBlockingConfiguredTarget,
+        "adjacent",
+        0,
+        routeDistanceLookupContext
+      ),
+      ...getSatisfiedClaimAdjacentReserveCandidates(
+        colonyName,
         colonyOwnerUsername,
         territoryMemory,
         intents,
@@ -864,8 +876,8 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
   });
 }
-function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, routeDistanceLookupContext) {
-  const adjacentRooms = getAdjacentRoomNames(colonyName);
+function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, source, orderOffset, routeDistanceLookupContext) {
+  const adjacentRooms = getAdjacentRoomNames(originRoomName);
   if (adjacentRooms.length === 0) {
     return [];
   }
@@ -879,8 +891,8 @@ function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territory
     if (candidateState === "safe") {
       const candidate = scoreTerritoryCandidate(
         { target, intentAction: "reserve", commitTarget: true },
-        "adjacent",
-        order,
+        source,
+        orderOffset + order,
         colonyName,
         colonyOwnerUsername,
         routeDistanceLookupContext
@@ -890,8 +902,8 @@ function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territory
     if (candidateState === "unknown" && includeScoutCandidates && !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, "scout", gameTime)) {
       const candidate = scoreTerritoryCandidate(
         { target, intentAction: "scout", commitTarget: false },
-        "adjacent",
-        order,
+        source,
+        orderOffset + order,
         colonyName,
         colonyOwnerUsername,
         routeDistanceLookupContext
@@ -899,6 +911,41 @@ function getAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territory
       return candidate ? [candidate] : [];
     }
     return [];
+  });
+}
+function getSatisfiedClaimAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, routeDistanceLookupContext) {
+  return getSatisfiedConfiguredClaimTargets(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    routeDistanceLookupContext
+  ).flatMap(
+    ({ target, order }) => getAdjacentReserveCandidates(
+      colonyName,
+      target.roomName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      "satisfiedClaimAdjacent",
+      (order + 1) * EXIT_DIRECTION_ORDER.length,
+      routeDistanceLookupContext
+    )
+  );
+}
+function getSatisfiedConfiguredClaimTargets(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return [];
+  }
+  return territoryMemory.targets.flatMap((rawTarget, order) => {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "claim" || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
+      return [];
+    }
+    return [{ target, order }];
   });
 }
 function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwnerUsername, routeDistanceLookupContext) {
@@ -933,7 +980,10 @@ function compareOptionalNumbers(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 function getTerritoryCandidateSourcePriority(source) {
-  return source === "configured" ? 0 : 1;
+  if (source === "configured") {
+    return 0;
+  }
+  return source === "satisfiedClaimAdjacent" ? 1 : 2;
 }
 function isTerritoryTargetVisible(target) {
   return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -39,7 +39,7 @@ interface SelectedTerritoryTarget {
   commitTarget: boolean;
 }
 
-type TerritoryCandidateSource = 'configured' | 'adjacent';
+type TerritoryCandidateSource = 'configured' | 'satisfiedClaimAdjacent' | 'adjacent';
 
 interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   order: number;
@@ -343,6 +343,18 @@ function selectTerritoryTarget(colony: ColonySnapshot, gameTime: number): Select
       ...configuredCandidates,
       ...getAdjacentReserveCandidates(
         colonyName,
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        !hasBlockingConfiguredTarget,
+        'adjacent',
+        0,
+        routeDistanceLookupContext
+      ),
+      ...getSatisfiedClaimAdjacentReserveCandidates(
+        colonyName,
         colonyOwnerUsername,
         territoryMemory,
         intents,
@@ -452,14 +464,17 @@ function hasBlockingConfiguredTerritoryTargetForColony(
 
 function getAdjacentReserveCandidates(
   colonyName: string,
+  originRoomName: string,
   colonyOwnerUsername: string | null,
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[],
   gameTime: number,
   includeScoutCandidates: boolean,
+  source: TerritoryCandidateSource,
+  orderOffset: number,
   routeDistanceLookupContext: RouteDistanceLookupContext
 ): ScoredTerritoryTarget[] {
-  const adjacentRooms = getAdjacentRoomNames(colonyName);
+  const adjacentRooms = getAdjacentRoomNames(originRoomName);
   if (adjacentRooms.length === 0) {
     return [];
   }
@@ -479,8 +494,8 @@ function getAdjacentReserveCandidates(
     if (candidateState === 'safe') {
       const candidate = scoreTerritoryCandidate(
         { target, intentAction: 'reserve', commitTarget: true },
-        'adjacent',
-        order,
+        source,
+        orderOffset + order,
         colonyName,
         colonyOwnerUsername,
         routeDistanceLookupContext
@@ -495,8 +510,8 @@ function getAdjacentReserveCandidates(
     ) {
       const candidate = scoreTerritoryCandidate(
         { target, intentAction: 'scout', commitTarget: false },
-        'adjacent',
-        order,
+        source,
+        orderOffset + order,
         colonyName,
         colonyOwnerUsername,
         routeDistanceLookupContext
@@ -505,6 +520,70 @@ function getAdjacentReserveCandidates(
     }
 
     return [];
+  });
+}
+
+function getSatisfiedClaimAdjacentReserveCandidates(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  includeScoutCandidates: boolean,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): ScoredTerritoryTarget[] {
+  return getSatisfiedConfiguredClaimTargets(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    routeDistanceLookupContext
+  ).flatMap(({ target, order }) =>
+    getAdjacentReserveCandidates(
+      colonyName,
+      target.roomName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      'satisfiedClaimAdjacent',
+      (order + 1) * EXIT_DIRECTION_ORDER.length,
+      routeDistanceLookupContext
+    )
+  );
+}
+
+function getSatisfiedConfiguredClaimTargets(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): Array<{ target: TerritoryTargetMemory; order: number }> {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return [];
+  }
+
+  return territoryMemory.targets.flatMap((rawTarget, order) => {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (
+      !target ||
+      target.enabled === false ||
+      target.colony !== colonyName ||
+      target.action !== 'claim' ||
+      target.roomName === colonyName ||
+      isTerritoryTargetSuppressed(target, intents, gameTime) ||
+      hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) ||
+      getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !==
+        'satisfied'
+    ) {
+      return [];
+    }
+
+    return [{ target, order }];
   });
 }
 
@@ -569,7 +648,11 @@ function compareOptionalNumbers(left: number | undefined, right: number | undefi
 }
 
 function getTerritoryCandidateSourcePriority(source: TerritoryCandidateSource): number {
-  return source === 'configured' ? 0 : 1;
+  if (source === 'configured') {
+    return 0;
+  }
+
+  return source === 'satisfiedClaimAdjacent' ? 1 : 2;
 }
 
 function isTerritoryTargetVisible(target: TerritoryTargetMemory): boolean {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1069,6 +1069,48 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('prefers the satisfied claim target as the next adjacent scout origin', () => {
+    const colony = makeSafeColony();
+    const claimedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'claim' };
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === 'W2N1' ? { '3': 'W3N1' } : { '1': 'W1N2' }
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false, owner: { username: 'me' } } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [claimedTarget]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 555)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'scout'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(describeExits).toHaveBeenCalledWith('W2N1');
+    expect(Memory.territory?.targets).toEqual([claimedTarget]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 555
+      }
+    ]);
+  });
+
   it('skips visible hostile-owned claim targets and plans the next eligible target', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {


### PR DESCRIPTION
## Summary
- Refreshes territory claim-target planning after a satisfied claim target so the bot can continue scanning for useful claim/reserve opportunities.
- Adds regression coverage for satisfied-target refresh behavior.
- Updates the bundled Screeps artifact via `npm run build`.

Closes #202.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `cd prod && git diff --exit-code -- prod/dist/main.js`

## Scheduler evidence
- Recovered useful Codex-authored edits from stale/missing session noted on #202.
- Commit: `8aaf13c` by `lanyusea's bot <lanyusea@gmail.com>`.
- Untracked `prod/node_modules` was left unstaged as dependency infrastructure.
