### PR TITLE
feat: improve worker energy spending after recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1431,6 +1431,7 @@ function isRecord(value) {
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
+var TOWER_REFILL_ENERGY_FLOOR = 500;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -1544,7 +1545,7 @@ function selectFillableEnergySink(creep) {
   if (extension) {
     return extension;
   }
-  return selectClosestEnergySink(creep, energySinks.filter(isTowerEnergySink));
+  return selectClosestEnergySink(creep, energySinks.filter(isPriorityTowerEnergySink));
 }
 function isSpawnEnergySink(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn");
@@ -1554,6 +1555,9 @@ function isExtensionEnergySink(structure) {
 }
 function isTowerEnergySink(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_TOWER", "tower");
+}
+function isPriorityTowerEnergySink(structure) {
+  return isTowerEnergySink(structure) && getStoredEnergy2(structure) < TOWER_REFILL_ENERGY_FLOOR;
 }
 function selectClosestEnergySink(creep, energySinks) {
   var _a;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -7,6 +7,7 @@ import {
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
+export const TOWER_REFILL_ENERGY_FLOOR = 500;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -171,7 +172,7 @@ function selectFillableEnergySink(creep: Creep): FillableEnergySink | null {
     return extension;
   }
 
-  return selectClosestEnergySink(creep, energySinks.filter(isTowerEnergySink));
+  return selectClosestEnergySink(creep, energySinks.filter(isPriorityTowerEnergySink));
 }
 
 function isSpawnEnergySink(structure: FillableEnergySink): structure is StructureSpawn {
@@ -184,6 +185,10 @@ function isExtensionEnergySink(structure: FillableEnergySink): structure is Stru
 
 function isTowerEnergySink(structure: FillableEnergySink): structure is StructureTower {
   return matchesStructureType(structure.structureType, 'STRUCTURE_TOWER', 'tower');
+}
+
+function isPriorityTowerEnergySink(structure: FillableEnergySink): structure is StructureTower {
+  return isTowerEnergySink(structure) && getStoredEnergy(structure) < TOWER_REFILL_ENERGY_FLOOR;
 }
 
 function selectClosestEnergySink<T extends FillableEnergySink>(creep: Creep, energySinks: T[]): T | null {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2,6 +2,7 @@ import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
   CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
+  TOWER_REFILL_ENERGY_FLOOR,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
 import {
@@ -44,6 +45,17 @@ function makeEnergySink(
     structureType,
     store: { getFreeCapacity: jest.fn().mockReturnValue(freeCapacity) }
   } as unknown as TestEnergySink;
+}
+
+function makeTowerEnergySink(id: string, usedEnergy: number, freeCapacity: number): StructureTower {
+  return {
+    id,
+    structureType: 'tower',
+    store: {
+      getUsedCapacity: jest.fn().mockReturnValue(usedEnergy),
+      getFreeCapacity: jest.fn().mockReturnValue(freeCapacity)
+    }
+  } as unknown as StructureTower;
 }
 
 function withRangeTo<T extends { id: string }>(object: T, rangesByTargetId: Record<string, number>): T {
@@ -1378,6 +1390,53 @@ describe('selectWorkerTask', () => {
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-far' });
     expect(getRangeTo).not.toHaveBeenCalledWith(nearTower);
+  });
+
+  it('spends carried energy on construction instead of topping off a healthy tower after recovery', () => {
+    const healthyTower = makeTowerEnergySink('tower-healthy', TOWER_REFILL_ENERGY_FLOOR, 500);
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        myStructures: [healthyTower as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('spends carried energy on controller progress instead of topping off a healthy tower when no construction remains', () => {
+    const healthyTower = makeTowerEnergySink('tower-healthy', TOWER_REFILL_ENERGY_FLOOR + 1, 499);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        myStructures: [healthyTower as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps low tower refill before construction progress', () => {
+    const lowTower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        myStructures: [lowTower as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
   });
 
   it('breaks same-class fillable energy sink range ties by id', () => {


### PR DESCRIPTION
## Summary
- Improves worker energy-spending decisions after recovery so carried energy is routed into productive sinks instead of staying idle.
- Adds regression coverage for recovery/spending behavior.
- Updates the bundled Screeps artifact via `npm run build`.

Closes #203.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `cd prod && git diff --exit-code -- prod/dist/main.js`

## Scheduler evidence
- Recovered useful Codex-authored edits from stale/missing session noted on #203.
- Commit: `3e1ea56` by `lanyusea's bot <lanyusea@gmail.com>`.
- Untracked `prod/node_modules` was left unstaged as dependency infrastructure.
