### PR TITLE
feat: maintain territory pressure after refreshed claims

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -601,7 +601,7 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
   }
-  const selection = selectTerritoryTarget(colony, gameTime);
+  const selection = selectTerritoryTarget(colony, roleCounts, gameTime);
   if (!selection) {
     return null;
   }
@@ -769,7 +769,8 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   }
   return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
 }
-function selectTerritoryTarget(colony, gameTime) {
+function selectTerritoryTarget(colony, roleCounts, gameTime) {
+  var _a;
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
@@ -781,6 +782,7 @@ function selectTerritoryTarget(colony, gameTime) {
     colonyOwnerUsername,
     intents,
     gameTime,
+    roleCounts,
     routeDistanceLookupContext
   );
   const configuredCandidates = getConfiguredTerritoryCandidates(
@@ -791,35 +793,38 @@ function selectTerritoryTarget(colony, gameTime) {
     gameTime,
     routeDistanceLookupContext
   );
-  const bestConfiguredCandidate = selectBestScoredTerritoryCandidate(configuredCandidates);
-  if (bestConfiguredCandidate && bestConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
-    return toSelectedTerritoryTarget(bestConfiguredCandidate);
+  const bestSpawnableConfiguredCandidate = selectBestScoredTerritoryCandidate(
+    getSpawnableTerritoryCandidates(configuredCandidates, roleCounts)
+  );
+  if (bestSpawnableConfiguredCandidate && bestSpawnableConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
+    return toSelectedTerritoryTarget(bestSpawnableConfiguredCandidate);
   }
+  const adjacentCandidates = [
+    ...getAdjacentReserveCandidates(
+      colonyName,
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      !hasBlockingConfiguredTarget,
+      "adjacent",
+      0,
+      routeDistanceLookupContext
+    ),
+    ...getSatisfiedClaimAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      !hasBlockingConfiguredTarget,
+      routeDistanceLookupContext
+    )
+  ];
+  const candidates = [...configuredCandidates, ...adjacentCandidates];
   return toSelectedTerritoryTarget(
-    selectBestScoredTerritoryCandidate([
-      ...configuredCandidates,
-      ...getAdjacentReserveCandidates(
-        colonyName,
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        !hasBlockingConfiguredTarget,
-        "adjacent",
-        0,
-        routeDistanceLookupContext
-      ),
-      ...getSatisfiedClaimAdjacentReserveCandidates(
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        !hasBlockingConfiguredTarget,
-        routeDistanceLookupContext
-      )
-    ])
+    (_a = selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts))) != null ? _a : selectBestScoredTerritoryCandidate(candidates)
   );
 }
 function selectBestScoredTerritoryCandidate(candidates) {
@@ -837,6 +842,11 @@ function toSelectedTerritoryTarget(candidate) {
     intentAction: candidate.intentAction,
     commitTarget: candidate.commitTarget
   } : null;
+}
+function getSpawnableTerritoryCandidates(candidates, roleCounts) {
+  return candidates.filter(
+    (candidate) => getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.intentAction) === 0
+  );
 }
 function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -858,7 +868,7 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
     return candidate ? [candidate] : [];
   });
 }
-function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime, routeDistanceLookupContext) {
+function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime, roleCounts, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return false;
   }
@@ -872,6 +882,9 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     }
     if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime)) {
       return true;
+    }
+    if (getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) > 0) {
+      return false;
     }
     return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
   });

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -64,7 +64,7 @@ export function planTerritoryIntent(
     return null;
   }
 
-  const selection = selectTerritoryTarget(colony, gameTime);
+  const selection = selectTerritoryTarget(colony, roleCounts, gameTime);
   if (!selection) {
     return null;
   }
@@ -311,7 +311,11 @@ export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCoun
   );
 }
 
-function selectTerritoryTarget(colony: ColonySnapshot, gameTime: number): SelectedTerritoryTarget | null {
+function selectTerritoryTarget(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  gameTime: number
+): SelectedTerritoryTarget | null {
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
@@ -323,6 +327,7 @@ function selectTerritoryTarget(colony: ColonySnapshot, gameTime: number): Select
     colonyOwnerUsername,
     intents,
     gameTime,
+    roleCounts,
     routeDistanceLookupContext
   );
   const configuredCandidates = getConfiguredTerritoryCandidates(
@@ -333,36 +338,44 @@ function selectTerritoryTarget(colony: ColonySnapshot, gameTime: number): Select
     gameTime,
     routeDistanceLookupContext
   );
-  const bestConfiguredCandidate = selectBestScoredTerritoryCandidate(configuredCandidates);
-  if (bestConfiguredCandidate && bestConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
-    return toSelectedTerritoryTarget(bestConfiguredCandidate);
+  const bestSpawnableConfiguredCandidate = selectBestScoredTerritoryCandidate(
+    getSpawnableTerritoryCandidates(configuredCandidates, roleCounts)
+  );
+  if (
+    bestSpawnableConfiguredCandidate &&
+    bestSpawnableConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY
+  ) {
+    return toSelectedTerritoryTarget(bestSpawnableConfiguredCandidate);
   }
 
+  const adjacentCandidates = [
+    ...getAdjacentReserveCandidates(
+      colonyName,
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      !hasBlockingConfiguredTarget,
+      'adjacent',
+      0,
+      routeDistanceLookupContext
+    ),
+    ...getSatisfiedClaimAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      !hasBlockingConfiguredTarget,
+      routeDistanceLookupContext
+    )
+  ];
+  const candidates = [...configuredCandidates, ...adjacentCandidates];
+
   return toSelectedTerritoryTarget(
-    selectBestScoredTerritoryCandidate([
-      ...configuredCandidates,
-      ...getAdjacentReserveCandidates(
-        colonyName,
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        !hasBlockingConfiguredTarget,
-        'adjacent',
-        0,
-        routeDistanceLookupContext
-      ),
-      ...getSatisfiedClaimAdjacentReserveCandidates(
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        !hasBlockingConfiguredTarget,
-        routeDistanceLookupContext
-      )
-    ])
+    selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts)) ??
+      selectBestScoredTerritoryCandidate(candidates)
   );
 }
 
@@ -385,6 +398,16 @@ function toSelectedTerritoryTarget(candidate: ScoredTerritoryTarget | null): Sel
         commitTarget: candidate.commitTarget
       }
     : null;
+}
+
+function getSpawnableTerritoryCandidates(
+  candidates: ScoredTerritoryTarget[],
+  roleCounts: RoleCounts
+): ScoredTerritoryTarget[] {
+  return candidates.filter(
+    (candidate) =>
+      getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.intentAction) === 0
+  );
 }
 
 function getConfiguredTerritoryCandidates(
@@ -431,6 +454,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(
   colonyOwnerUsername: string | null,
   intents: TerritoryIntentMemory[],
   gameTime: number,
+  roleCounts: RoleCounts,
   routeDistanceLookupContext: RouteDistanceLookupContext
 ): boolean {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -453,6 +477,10 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       isTerritoryTargetSuppressed(target, intents, gameTime)
     ) {
       return true;
+    }
+
+    if (getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) > 0) {
+      return false;
     }
 
     return (

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -425,6 +425,68 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('plans the next territory controller target while another target has active capacity', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    const activeReserveIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'active',
+      updatedAt: 143
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room,
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ],
+        intents: [activeReserveIntent]
+      }
+    };
+
+    expect(
+      planSpawn(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W2N1: 1 },
+          claimersByTargetRoomAction: { reserve: { W2N1: 1 } }
+        },
+        150
+      )
+    ).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W3N1-150',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W3N1', action: 'reserve' }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      activeReserveIntent,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 150
+      }
+    ]);
+  });
+
   it('targets a fourth worker for two-source rooms', () => {
     const { colony, spawn } = makeColony({ roomName: 'W1N2', sourceCount: 2 });
 

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1111,6 +1111,57 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('scouts an adjacent room while a configured claim target already has active coverage', () => {
+    const colony = makeSafeColony();
+    const activeClaimIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      status: 'active',
+      updatedAt: 555
+    };
+    const describeExits = jest.fn(() => ({ '1': 'W1N2' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }],
+        intents: [activeClaimIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W2N1: 1 },
+          claimersByTargetRoomAction: { claim: { W2N1: 1 } }
+        },
+        3,
+        556
+      )
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'scout'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toEqual([{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }]);
+    expect(Memory.territory?.intents).toEqual([
+      activeClaimIntent,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 556
+      }
+    ]);
+  });
+
   it('skips visible hostile-owned claim targets and plans the next eligible target', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {


### PR DESCRIPTION
## Summary
- Maintains territory/control pressure after refreshed claims with a narrow planner behavior slice.
- Adds focused Jest coverage and updates the generated Screeps bundle.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites / 319 tests passed)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #206
