### PR TITLE
feat: sustain territory pressure after active coverage

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -597,6 +597,7 @@ var TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE = 4;
 var TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
 var MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR = ">";
+var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
@@ -631,7 +632,8 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
   ) !== "available") {
     return false;
   }
-  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) === 0;
+  const activeCoverageCount = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action);
+  return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount);
 }
 function buildTerritoryCreepMemory(plan) {
   return {
@@ -844,9 +846,17 @@ function toSelectedTerritoryTarget(candidate) {
   } : null;
 }
 function getSpawnableTerritoryCandidates(candidates, roleCounts) {
-  return candidates.filter(
-    (candidate) => getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.intentAction) === 0
-  );
+  return candidates.filter((candidate) => {
+    const activeCoverageCount = getTerritoryCreepCountForTarget(
+      roleCounts,
+      candidate.target.roomName,
+      candidate.intentAction
+    );
+    return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount);
+  });
+}
+function shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount) {
+  return activeCoverageCount < TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET && candidate.intentAction === "reserve" && typeof candidate.renewalTicksToEnd === "number" && candidate.renewalTicksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
 }
 function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -1411,6 +1421,18 @@ function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
     return null;
   }
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+}
+function shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount) {
+  if (activeCoverageCount >= TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET || plan.action !== "reserve") {
+    return false;
+  }
+  const controller = getVisibleController(plan.targetRoom, plan.controllerId);
+  if (!controller || isControllerOwned(controller)) {
+    return false;
+  }
+  const colonyOwnerUsername = getVisibleColonyOwnerUsername(plan.colony);
+  const ticksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+  return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
 }
 function getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   const ticksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -21,6 +21,7 @@ const TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE = 4;
 const TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
 const MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
 const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
+const TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -106,7 +107,10 @@ export function shouldSpawnTerritoryControllerCreep(
     return false;
   }
 
-  return getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) === 0;
+  const activeCoverageCount = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action);
+  return (
+    activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount)
+  );
 }
 
 export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemory {
@@ -404,9 +408,28 @@ function getSpawnableTerritoryCandidates(
   candidates: ScoredTerritoryTarget[],
   roleCounts: RoleCounts
 ): ScoredTerritoryTarget[] {
-  return candidates.filter(
-    (candidate) =>
-      getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.intentAction) === 0
+  return candidates.filter((candidate) => {
+    const activeCoverageCount = getTerritoryCreepCountForTarget(
+      roleCounts,
+      candidate.target.roomName,
+      candidate.intentAction
+    );
+    return (
+      activeCoverageCount === 0 ||
+      shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount)
+    );
+  });
+}
+
+function shouldSpawnEmergencyReservationRenewalCandidate(
+  candidate: ScoredTerritoryTarget,
+  activeCoverageCount: number
+): boolean {
+  return (
+    activeCoverageCount < TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET &&
+    candidate.intentAction === 'reserve' &&
+    typeof candidate.renewalTicksToEnd === 'number' &&
+    candidate.renewalTicksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS
   );
 }
 
@@ -1309,6 +1332,27 @@ function getConfiguredReserveRenewalTicksToEnd(
   }
 
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+}
+
+function shouldSpawnEmergencyReservationRenewal(
+  plan: TerritoryIntentPlan,
+  activeCoverageCount: number
+): boolean {
+  if (
+    activeCoverageCount >= TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET ||
+    plan.action !== 'reserve'
+  ) {
+    return false;
+  }
+
+  const controller = getVisibleController(plan.targetRoom, plan.controllerId);
+  if (!controller || isControllerOwned(controller)) {
+    return false;
+  }
+
+  const colonyOwnerUsername = getVisibleColonyOwnerUsername(plan.colony);
+  const ticksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+  return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
 }
 
 function getUrgentOwnReservationTicksToEnd(

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1,5 +1,6 @@
 import { planSpawn } from '../src/spawn/spawnPlanner';
 import { ColonySnapshot } from '../src/colony/colonyRegistry';
+import { TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
 
 describe('planSpawn', () => {
   beforeEach(() => {
@@ -421,6 +422,62 @@ describe('planSpawn', () => {
         action: 'reserve',
         status: 'active',
         updatedAt: 143
+      }
+    ]);
+  });
+
+  it('plans a backup reserver when an active own reservation reaches emergency renewal', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: {
+          name: 'W2N1',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    expect(
+      planSpawn(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W2N1: 1 },
+          claimersByTargetRoomAction: { reserve: { W2N1: 1 } }
+        },
+        151
+      )
+    ).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N1-151',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve' }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 151
       }
     ]);
   });

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3,6 +3,7 @@ import {
   planTerritoryIntent,
   shouldSpawnTerritoryControllerCreep,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
+  TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
   TERRITORY_RESERVATION_RENEWAL_TICKS,
   TERRITORY_SUPPRESSION_RETRY_TICKS
 } from '../src/territory/territoryPlanner';
@@ -1664,6 +1665,99 @@ describe('planTerritoryIntent', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: 534
+      }
+    ]);
+  });
+
+  it('spawns one backup reserver for an emergency own reservation despite active coverage', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const roleCounts = {
+      worker: 3,
+      claimer: 1,
+      claimersByTargetRoom: { W1N2: 1 },
+      claimersByTargetRoomAction: { reserve: { W1N2: 1 } }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 559
+          }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, roleCounts, 3, 560);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' });
+    expect(shouldSpawnTerritoryControllerCreep(plan!, roleCounts, 560)).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 560
+      }
+    ]);
+  });
+
+  it('does not spawn a third reserver for an emergency own reservation', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const roleCounts = {
+      worker: 3,
+      claimer: 2,
+      claimersByTargetRoom: { W1N2: 2 },
+      claimersByTargetRoomAction: { reserve: { W1N2: 2 } }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, roleCounts, 3, 561);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' });
+    expect(shouldSpawnTerritoryControllerCreep(plan!, roleCounts, 561)).toBe(false);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 561
       }
     ]);
   });


### PR DESCRIPTION
Closes #211.

## Summary
- sustains territory/control pressure after active-coverage filtering by preserving fallback intent for temporarily covered/stale targets
- adds focused territory/spawn planner coverage for the new behavior
- regenerates `prod/dist/main.js`

## Controller verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `npm test -- --runInBand` (16 suites / 324 tests passed after merging current main)
- `npm run build`
- final `git diff --check`
- `git diff --exit-code -- prod/dist/main.js`

## Notes
- No secrets touched or printed.
- `prod/node_modules` is untracked local dependency infrastructure and was not staged.
