### PR TITLE
feat: improve resource economy flow after worker throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2252,6 +2252,11 @@ function runWorker(creep) {
     assignNextTask(creep);
     return;
   }
+  if (shouldPreemptTransferTaskForBetterEnergySink(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
   if (shouldPreemptSpendingTaskForEnergySink(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
@@ -2349,6 +2354,23 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task) {
   }
   const nextTask = selectWorkerTask(creep);
   return isRecoverableEnergyTask(nextTask) && !isSameTask(task, nextTask);
+}
+function shouldPreemptTransferTaskForBetterEnergySink(creep, task) {
+  var _a, _b;
+  if (task.type !== "transfer") {
+    return false;
+  }
+  if (!((_a = creep.store) == null ? void 0 : _a.getUsedCapacity)) {
+    return false;
+  }
+  if (typeof ((_b = creep.room) == null ? void 0 : _b.find) !== "function") {
+    return false;
+  }
+  if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+    return false;
+  }
+  const nextTask = selectWorkerTask(creep);
+  return (nextTask == null ? void 0 : nextTask.type) === "transfer" && !isSameTask(task, nextTask);
 }
 function shouldPreemptSpendingTaskForControllerPressure(creep, task) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2233,56 +2233,55 @@ function getGameCreeps() {
 
 // src/creeps/workerRunner.ts
 function runWorker(creep) {
-  if (!creep.memory.task) {
-    assignNextTask(creep);
+  const selectedTask = selectWorkerTask(creep);
+  const currentTask = creep.memory.task;
+  if (!currentTask) {
+    assignSelectedTask(creep, selectedTask);
+  } else if (shouldReplaceTask(creep, currentTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptForVisibleTerritoryControllerTask(currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptSpendingTaskForEnergySink(currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptSpendingTaskForControllerPressure(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptUpgradeTask(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  }
+  executeAssignedTask(creep, selectedTask);
+}
+function executeAssignedTask(creep, selectedTask) {
+  let task = creep.memory.task;
+  if (!task || !canExecuteTask(creep, task)) {
     return;
   }
-  if (shouldReplaceTask(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  if (shouldPreemptForVisibleTerritoryControllerTask(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  if (shouldPreemptTransferTaskForBetterEnergySink(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  if (shouldPreemptSpendingTaskForEnergySink(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  if (shouldPreemptSpendingTaskForControllerPressure(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-  const task = creep.memory.task;
-  const target = Game.getObjectById(task.targetId);
+  let target = Game.getObjectById(task.targetId);
   if (!target) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
+    if (selectedTask && isSameTask(task, selectedTask)) {
+      return;
+    }
+    task = assignSelectedTask(creep, selectedTask, task);
+    if (!task || !canExecuteTask(creep, task)) {
+      return;
+    }
+    target = Game.getObjectById(task.targetId);
+    if (!target) {
+      return;
+    }
   }
   if (shouldReplaceTarget(task, target)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
+    task = assignSelectedTask(creep, selectedTask, task);
+    if (!task || !canExecuteTask(creep, task)) {
+      return;
+    }
+    target = Game.getObjectById(task.targetId);
+    if (!target || shouldReplaceTarget(task, target)) {
+      return;
+    }
   }
   const result = executeTask(creep, task, target);
   if (task.type === "transfer" && result === ERR_FULL) {
@@ -2292,6 +2291,36 @@ function runWorker(creep) {
   }
   if (result === ERR_NOT_IN_RANGE) {
     creep.moveTo(target);
+  }
+}
+function assignSelectedTask(creep, selectedTask, previousTask) {
+  if (!selectedTask || previousTask && isSameTask(previousTask, selectedTask)) {
+    delete creep.memory.task;
+    return null;
+  }
+  creep.memory.task = selectedTask;
+  return selectedTask;
+}
+function canExecuteTask(creep, task) {
+  switch (task.type) {
+    case "harvest":
+      return typeof creep.harvest === "function";
+    case "pickup":
+      return typeof creep.pickup === "function";
+    case "withdraw":
+      return typeof creep.withdraw === "function";
+    case "transfer":
+      return typeof creep.transfer === "function";
+    case "build":
+      return typeof creep.build === "function";
+    case "repair":
+      return typeof creep.repair === "function";
+    case "claim":
+      return typeof creep.claimController === "function";
+    case "reserve":
+      return typeof creep.reserveController === "function";
+    case "upgrade":
+      return typeof creep.upgradeController === "function";
   }
 }
 function assignNextTask(creep) {
@@ -2315,28 +2344,19 @@ function shouldReplaceTask(creep, task) {
   }
   return usedEnergy === 0;
 }
-function shouldPreemptForVisibleTerritoryControllerTask(creep, task) {
-  const controllerTask = selectVisibleTerritoryControllerTask(creep);
-  if (!controllerTask) {
-    return isTerritoryControlTask2(task);
+function shouldPreemptForVisibleTerritoryControllerTask(task, selectedTask) {
+  if (isTerritoryControlTask2(task)) {
+    return !selectedTask || !isSameTask(task, selectedTask);
   }
-  const selectedTask = selectWorkerTask(creep);
-  if (!selectedTask || !isSameTask(selectedTask, controllerTask)) {
-    return false;
-  }
-  return !isSameTask(task, controllerTask);
+  return isTerritoryControlTask2(selectedTask);
 }
-function shouldPreemptSpendingTaskForEnergySink(creep, task) {
+function shouldPreemptSpendingTaskForEnergySink(task, selectedTask) {
   if (!isEnergySpendingTask(task)) {
     return false;
   }
-  if (!creep.room) {
-    return false;
-  }
-  const nextTask = selectWorkerTask(creep);
-  return (nextTask == null ? void 0 : nextTask.type) === "transfer" && !isSameTask(task, nextTask);
+  return (selectedTask == null ? void 0 : selectedTask.type) === "transfer" && !isSameTask(task, selectedTask);
 }
-function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task) {
+function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task, selectedTask) {
   var _a, _b, _c;
   if (!isEnergyAcquisitionTask(task)) {
     return false;
@@ -2352,12 +2372,14 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task) {
   if (usedEnergy !== 0 || freeEnergyCapacity <= 0) {
     return false;
   }
-  const nextTask = selectWorkerTask(creep);
-  return isRecoverableEnergyTask(nextTask) && !isSameTask(task, nextTask);
+  return isRecoverableEnergyTask(selectedTask) && !isSameTask(task, selectedTask);
 }
-function shouldPreemptTransferTaskForBetterEnergySink(creep, task) {
+function shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectedTask) {
   var _a, _b;
   if (task.type !== "transfer") {
+    return false;
+  }
+  if ((selectedTask == null ? void 0 : selectedTask.type) !== "transfer" || isSameTask(task, selectedTask)) {
     return false;
   }
   if (!((_a = creep.store) == null ? void 0 : _a.getUsedCapacity)) {
@@ -2369,10 +2391,14 @@ function shouldPreemptTransferTaskForBetterEnergySink(creep, task) {
   if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
     return false;
   }
-  const nextTask = selectWorkerTask(creep);
-  return (nextTask == null ? void 0 : nextTask.type) === "transfer" && !isSameTask(task, nextTask);
+  const currentTarget = Game.getObjectById(task.targetId);
+  if (!isValidTransferTarget(currentTarget)) {
+    return true;
+  }
+  const selectedTarget = Game.getObjectById(selectedTask.targetId);
+  return getTransferSinkPriority(selectedTarget) > getTransferSinkPriority(currentTarget);
 }
-function shouldPreemptSpendingTaskForControllerPressure(creep, task) {
+function shouldPreemptSpendingTaskForControllerPressure(creep, task, selectedTask) {
   var _a;
   if (!isEnergySpendingTask(task) || task.type === "upgrade") {
     return false;
@@ -2380,10 +2406,9 @@ function shouldPreemptSpendingTaskForControllerPressure(creep, task) {
   if (typeof ((_a = creep.room) == null ? void 0 : _a.find) !== "function") {
     return false;
   }
-  const nextTask = selectWorkerTask(creep);
-  return isOwnedControllerUpgradeTask(creep, nextTask) && !isSameTask(task, nextTask);
+  return isOwnedControllerUpgradeTask(creep, selectedTask) && !isSameTask(task, selectedTask);
 }
-function shouldPreemptUpgradeTask(creep, task) {
+function shouldPreemptUpgradeTask(creep, task, selectedTask) {
   var _a;
   if (task.type !== "upgrade") {
     return false;
@@ -2392,8 +2417,7 @@ function shouldPreemptUpgradeTask(creep, task) {
   if ((controller == null ? void 0 : controller.my) !== true) {
     return false;
   }
-  const nextTask = selectWorkerTask(creep);
-  if (nextTask === null || nextTask.type === task.type && nextTask.targetId === task.targetId) {
+  if (selectedTask === null || isSameTask(task, selectedTask)) {
     return false;
   }
   return true;
@@ -2415,7 +2439,34 @@ function isRecoverableEnergyTask(task) {
   return (task == null ? void 0 : task.type) === "pickup" || (task == null ? void 0 : task.type) === "withdraw";
 }
 function isTerritoryControlTask2(task) {
-  return task.type === "claim" || task.type === "reserve";
+  return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
+}
+function isValidTransferTarget(target) {
+  return getFreeTransferEnergyCapacity(target) > 0;
+}
+function getFreeTransferEnergyCapacity(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, RESOURCE_ENERGY);
+  return typeof freeCapacity === "number" ? freeCapacity : 0;
+}
+function getTransferSinkPriority(target) {
+  const structureType = target == null ? void 0 : target.structureType;
+  if (typeof structureType !== "string") {
+    return 0;
+  }
+  if (matchesTransferSinkStructureType(structureType, "STRUCTURE_SPAWN", "spawn")) {
+    return 3;
+  }
+  if (matchesTransferSinkStructureType(structureType, "STRUCTURE_EXTENSION", "extension")) {
+    return 2;
+  }
+  return matchesTransferSinkStructureType(structureType, "STRUCTURE_TOWER", "tower") ? 1 : 0;
+}
+function matchesTransferSinkStructureType(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 function shouldReplaceTarget(task, target) {
   var _a;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -25,6 +25,12 @@ export function runWorker(creep: Creep): void {
     return;
   }
 
+  if (shouldPreemptTransferTaskForBetterEnergySink(creep, creep.memory.task)) {
+    delete creep.memory.task;
+    assignNextTask(creep);
+    return;
+  }
+
   if (shouldPreemptSpendingTaskForEnergySink(creep, creep.memory.task)) {
     delete creep.memory.task;
     assignNextTask(creep);
@@ -143,6 +149,27 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep: Creep, task: 
 
   const nextTask = selectWorkerTask(creep);
   return isRecoverableEnergyTask(nextTask) && !isSameTask(task, nextTask);
+}
+
+function shouldPreemptTransferTaskForBetterEnergySink(creep: Creep, task: CreepTaskMemory): boolean {
+  if (task.type !== 'transfer') {
+    return false;
+  }
+
+  if (!creep.store?.getUsedCapacity) {
+    return false;
+  }
+
+  if (typeof creep.room?.find !== 'function') {
+    return false;
+  }
+
+  if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+    return false;
+  }
+
+  const nextTask = selectWorkerTask(creep);
+  return nextTask?.type === 'transfer' && !isSameTask(task, nextTask);
 }
 
 function shouldPreemptSpendingTaskForControllerPressure(creep: Creep, task: CreepTaskMemory): boolean {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1,66 +1,65 @@
 import { isWorkerRepairTargetComplete, selectWorkerTask } from '../tasks/workerTasks';
-import { selectVisibleTerritoryControllerTask } from '../territory/territoryPlanner';
+
+type TransferSinkStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION' | 'STRUCTURE_TOWER';
 
 export function runWorker(creep: Creep): void {
-  if (!creep.memory.task) {
-    assignNextTask(creep);
+  const selectedTask = selectWorkerTask(creep);
+  const currentTask = creep.memory.task;
+
+  if (!currentTask) {
+    assignSelectedTask(creep, selectedTask);
+  } else if (shouldReplaceTask(creep, currentTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptForVisibleTerritoryControllerTask(currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptSpendingTaskForEnergySink(currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptSpendingTaskForControllerPressure(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptUpgradeTask(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  }
+
+  executeAssignedTask(creep, selectedTask);
+}
+
+function executeAssignedTask(creep: Creep, selectedTask: CreepTaskMemory | null): void {
+  let task: CreepTaskMemory | null | undefined = creep.memory.task;
+  if (!task || !canExecuteTask(creep, task)) {
     return;
   }
 
-  if (shouldReplaceTask(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-
-  if (shouldPreemptForVisibleTerritoryControllerTask(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-
-  if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-
-  if (shouldPreemptTransferTaskForBetterEnergySink(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-
-  if (shouldPreemptSpendingTaskForEnergySink(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-
-  if (shouldPreemptSpendingTaskForControllerPressure(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-
-  if (shouldPreemptUpgradeTask(creep, creep.memory.task)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
-  }
-
-  const task = creep.memory.task;
-  const target = Game.getObjectById(task.targetId);
+  let target = Game.getObjectById(task.targetId);
   if (!target) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
+    if (selectedTask && isSameTask(task, selectedTask)) {
+      return;
+    }
+
+    task = assignSelectedTask(creep, selectedTask, task);
+    if (!task || !canExecuteTask(creep, task)) {
+      return;
+    }
+
+    target = Game.getObjectById(task.targetId);
+    if (!target) {
+      return;
+    }
   }
 
   if (shouldReplaceTarget(task, target)) {
-    delete creep.memory.task;
-    assignNextTask(creep);
-    return;
+    task = assignSelectedTask(creep, selectedTask, task);
+    if (!task || !canExecuteTask(creep, task)) {
+      return;
+    }
+
+    target = Game.getObjectById(task.targetId);
+    if (!target || shouldReplaceTarget(task, target)) {
+      return;
+    }
   }
 
   const result = executeTask(creep, task, target);
@@ -72,6 +71,43 @@ export function runWorker(creep: Creep): void {
 
   if (result === ERR_NOT_IN_RANGE) {
     creep.moveTo(target as RoomObject);
+  }
+}
+
+function assignSelectedTask(
+  creep: Creep,
+  selectedTask: CreepTaskMemory | null,
+  previousTask?: CreepTaskMemory
+): CreepTaskMemory | null {
+  if (!selectedTask || (previousTask && isSameTask(previousTask, selectedTask))) {
+    delete creep.memory.task;
+    return null;
+  }
+
+  creep.memory.task = selectedTask;
+  return selectedTask;
+}
+
+function canExecuteTask(creep: Creep, task: CreepTaskMemory): boolean {
+  switch (task.type) {
+    case 'harvest':
+      return typeof creep.harvest === 'function';
+    case 'pickup':
+      return typeof creep.pickup === 'function';
+    case 'withdraw':
+      return typeof creep.withdraw === 'function';
+    case 'transfer':
+      return typeof creep.transfer === 'function';
+    case 'build':
+      return typeof creep.build === 'function';
+    case 'repair':
+      return typeof creep.repair === 'function';
+    case 'claim':
+      return typeof creep.claimController === 'function';
+    case 'reserve':
+      return typeof creep.reserveController === 'function';
+    case 'upgrade':
+      return typeof creep.upgradeController === 'function';
   }
 }
 
@@ -101,34 +137,33 @@ function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {
   return usedEnergy === 0;
 }
 
-function shouldPreemptForVisibleTerritoryControllerTask(creep: Creep, task: CreepTaskMemory): boolean {
-  const controllerTask = selectVisibleTerritoryControllerTask(creep);
-  if (!controllerTask) {
-    return isTerritoryControlTask(task);
+function shouldPreemptForVisibleTerritoryControllerTask(
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (isTerritoryControlTask(task)) {
+    return !selectedTask || !isSameTask(task, selectedTask);
   }
 
-  const selectedTask = selectWorkerTask(creep);
-  if (!selectedTask || !isSameTask(selectedTask, controllerTask)) {
-    return false;
-  }
-
-  return !isSameTask(task, controllerTask);
+  return isTerritoryControlTask(selectedTask);
 }
 
-function shouldPreemptSpendingTaskForEnergySink(creep: Creep, task: CreepTaskMemory): boolean {
+function shouldPreemptSpendingTaskForEnergySink(
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
   if (!isEnergySpendingTask(task)) {
     return false;
   }
 
-  if (!creep.room) {
-    return false;
-  }
-
-  const nextTask = selectWorkerTask(creep);
-  return nextTask?.type === 'transfer' && !isSameTask(task, nextTask);
+  return selectedTask?.type === 'transfer' && !isSameTask(task, selectedTask);
 }
 
-function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep: Creep, task: CreepTaskMemory): boolean {
+function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
   if (!isEnergyAcquisitionTask(task)) {
     return false;
   }
@@ -147,12 +182,19 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep: Creep, task: 
     return false;
   }
 
-  const nextTask = selectWorkerTask(creep);
-  return isRecoverableEnergyTask(nextTask) && !isSameTask(task, nextTask);
+  return isRecoverableEnergyTask(selectedTask) && !isSameTask(task, selectedTask);
 }
 
-function shouldPreemptTransferTaskForBetterEnergySink(creep: Creep, task: CreepTaskMemory): boolean {
+function shouldPreemptTransferTaskForBetterEnergySink(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
   if (task.type !== 'transfer') {
+    return false;
+  }
+
+  if (selectedTask?.type !== 'transfer' || isSameTask(task, selectedTask)) {
     return false;
   }
 
@@ -168,11 +210,20 @@ function shouldPreemptTransferTaskForBetterEnergySink(creep: Creep, task: CreepT
     return false;
   }
 
-  const nextTask = selectWorkerTask(creep);
-  return nextTask?.type === 'transfer' && !isSameTask(task, nextTask);
+  const currentTarget = Game.getObjectById(task.targetId);
+  if (!isValidTransferTarget(currentTarget)) {
+    return true;
+  }
+
+  const selectedTarget = Game.getObjectById(selectedTask.targetId);
+  return getTransferSinkPriority(selectedTarget) > getTransferSinkPriority(currentTarget);
 }
 
-function shouldPreemptSpendingTaskForControllerPressure(creep: Creep, task: CreepTaskMemory): boolean {
+function shouldPreemptSpendingTaskForControllerPressure(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
   if (!isEnergySpendingTask(task) || task.type === 'upgrade') {
     return false;
   }
@@ -181,11 +232,14 @@ function shouldPreemptSpendingTaskForControllerPressure(creep: Creep, task: Cree
     return false;
   }
 
-  const nextTask = selectWorkerTask(creep);
-  return isOwnedControllerUpgradeTask(creep, nextTask) && !isSameTask(task, nextTask);
+  return isOwnedControllerUpgradeTask(creep, selectedTask) && !isSameTask(task, selectedTask);
 }
 
-function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean {
+function shouldPreemptUpgradeTask(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
   if (task.type !== 'upgrade') {
     return false;
   }
@@ -195,8 +249,7 @@ function shouldPreemptUpgradeTask(creep: Creep, task: CreepTaskMemory): boolean 
     return false;
   }
 
-  const nextTask = selectWorkerTask(creep);
-  if (nextTask === null || (nextTask.type === task.type && nextTask.targetId === task.targetId)) {
+  if (selectedTask === null || isSameTask(task, selectedTask)) {
     return false;
   }
 
@@ -238,8 +291,47 @@ function isRecoverableEnergyTask(
   return task?.type === 'pickup' || task?.type === 'withdraw';
 }
 
-function isTerritoryControlTask(task: CreepTaskMemory): task is Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }> {
-  return task.type === 'claim' || task.type === 'reserve';
+function isTerritoryControlTask(
+  task: CreepTaskMemory | null
+): task is Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }> {
+  return task?.type === 'claim' || task?.type === 'reserve';
+}
+
+function isValidTransferTarget(target: unknown): target is AnyStoreStructure {
+  return getFreeTransferEnergyCapacity(target) > 0;
+}
+
+function getFreeTransferEnergyCapacity(target: unknown): number {
+  const store = (target as { store?: { getFreeCapacity?: (resource?: ResourceConstant) => number | null } } | null)
+    ?.store;
+  const freeCapacity = store?.getFreeCapacity?.(RESOURCE_ENERGY);
+  return typeof freeCapacity === 'number' ? freeCapacity : 0;
+}
+
+function getTransferSinkPriority(target: unknown): number {
+  const structureType = (target as { structureType?: unknown } | null)?.structureType;
+  if (typeof structureType !== 'string') {
+    return 0;
+  }
+
+  if (matchesTransferSinkStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn')) {
+    return 3;
+  }
+
+  if (matchesTransferSinkStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')) {
+    return 2;
+  }
+
+  return matchesTransferSinkStructureType(structureType, 'STRUCTURE_TOWER', 'tower') ? 1 : 0;
+}
+
+function matchesTransferSinkStructureType(
+  actual: string,
+  globalName: TransferSinkStructureConstantGlobal,
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<Record<TransferSinkStructureConstantGlobal, string>>;
+  return actual === (constants[globalName] ?? fallback);
 }
 
 function shouldReplaceTarget(

--- a/prod/test/mvpEconomyLifecycle.test.ts
+++ b/prod/test/mvpEconomyLifecycle.test.ts
@@ -152,13 +152,14 @@ describe('MVP economy lifecycle', () => {
       rooms: {},
       spawns: {},
       creeps: { Worker1: worker },
-      getObjectById: jest.fn().mockReturnValue(fullSpawn)
+      getObjectById: jest.fn((id: string) => (id === 'site1' ? site : fullSpawn))
     };
 
     runEconomy();
 
     expect(worker.memory.task).toEqual({ type: 'build', targetId: 'site1' });
     expect((worker as unknown as { transfer: jest.Mock }).transfer).not.toHaveBeenCalled();
+    expect((worker as unknown as { build: jest.Mock }).build).toHaveBeenCalledWith(site);
 
     (worker as unknown as { room: Room }).room = {
       name: 'W1N1',
@@ -172,12 +173,14 @@ describe('MVP economy lifecycle', () => {
         return [];
       })
     } as unknown as Room;
-    (Game.getObjectById as jest.Mock).mockReturnValue(null);
+    (worker as unknown as { build: jest.Mock }).build.mockClear();
+    (Game.getObjectById as jest.Mock).mockImplementation((id: string) => (id === 'controller1' ? controller : null));
 
     runEconomy();
 
     expect(worker.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
     expect((worker as unknown as { build: jest.Mock }).build).not.toHaveBeenCalled();
+    expect((worker as unknown as { upgradeController: jest.Mock }).upgradeController).toHaveBeenCalledWith(controller);
   });
 
   it('plans a replacement before a colony worker expires without counting unrelated workers', () => {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -48,6 +48,26 @@ describe('runWorker', () => {
     expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('executes a newly assigned task in the same tick when the target is available', () => {
+    const source = { id: 'source1' } as Source;
+    const creep = {
+      memory: {},
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      room: { find: jest.fn().mockReturnValue([source]) },
+      harvest: jest.fn().mockReturnValue(ERR_NOT_IN_RANGE),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(source)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.harvest).toHaveBeenCalledWith(source);
+    expect(creep.moveTo).toHaveBeenCalledWith(source);
+  });
+
   it('splits empty workers across sources as harvest assignments change', () => {
     const source1 = { id: 'source1' } as Source;
     const source2 = { id: 'source2' } as Source;
@@ -106,6 +126,7 @@ describe('runWorker', () => {
     const source = { id: 'source1' } as Source;
     const creep = {
       memory: { task: { type: 'harvest', targetId: 'source1' } },
+      room: { find: jest.fn().mockReturnValue([]) },
       harvest: jest.fn().mockReturnValue(-9),
       moveTo: jest.fn()
     } as unknown as Creep;
@@ -127,6 +148,7 @@ describe('runWorker', () => {
         getUsedCapacity: jest.fn().mockReturnValue(0),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
+      room: { find: jest.fn().mockReturnValue([]) },
       pickup: jest.fn().mockReturnValue(-9),
       moveTo: jest.fn()
     } as unknown as Creep;
@@ -144,6 +166,7 @@ describe('runWorker', () => {
     const spawn = { id: 'spawn1' } as StructureSpawn;
     const creep = {
       memory: { task: { type: 'transfer', targetId: 'spawn1' } },
+      room: { find: jest.fn().mockReturnValue([]) },
       transfer: jest.fn().mockReturnValue(-9),
       moveTo: jest.fn()
     } as unknown as Creep;
@@ -165,6 +188,7 @@ describe('runWorker', () => {
         getUsedCapacity: jest.fn().mockReturnValue(0),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
+      room: { find: jest.fn().mockReturnValue([]) },
       withdraw: jest.fn().mockReturnValue(-9),
       moveTo: jest.fn()
     } as unknown as Creep;
@@ -189,6 +213,7 @@ describe('runWorker', () => {
         getUsedCapacity: jest.fn().mockReturnValue(50),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
+      room: { find: jest.fn().mockReturnValue([]) },
       build,
       moveTo
     } as unknown as Creep;
@@ -214,6 +239,7 @@ describe('runWorker', () => {
         getUsedCapacity: jest.fn().mockReturnValue(50),
         getFreeCapacity: jest.fn().mockReturnValue(0)
       },
+      room: { find: jest.fn().mockReturnValue([]) },
       repair,
       moveTo
     } as unknown as Creep;
@@ -239,6 +265,7 @@ describe('runWorker', () => {
         getUsedCapacity: jest.fn().mockReturnValue(50),
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
+      room: { find: jest.fn().mockReturnValue([]) },
       upgradeController,
       moveTo
     } as unknown as Creep;
@@ -654,7 +681,7 @@ describe('runWorker', () => {
 
     runWorker(creep);
 
-    expect(getObjectById).not.toHaveBeenCalled();
+    expect(getObjectById).toHaveBeenCalledWith('controller2');
     expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller2' });
     expect(upgradeController).not.toHaveBeenCalled();
     expect(moveTo).not.toHaveBeenCalled();
@@ -922,7 +949,8 @@ describe('runWorker', () => {
     const creep = {
       memory: { task: { type: 'build', targetId: 'missing' as Id<ConstructionSite> } },
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: { find: jest.fn().mockReturnValue([]) }
+      room: { find: jest.fn().mockReturnValue([]) },
+      build: jest.fn()
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       getObjectById: jest.fn().mockReturnValue(null)
@@ -1080,6 +1108,7 @@ describe('runWorker', () => {
         getUsedCapacity: jest.fn().mockReturnValue(50),
         getFreeCapacity: jest.fn().mockReturnValue(0)
       },
+      room: { find: jest.fn().mockReturnValue([]) },
       transfer: jest.fn().mockReturnValue(0),
       moveTo: jest.fn()
     } as unknown as Creep;
@@ -1093,7 +1122,7 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
-  it('retargets transfer work to the closest same-priority fillable energy sink before walking', () => {
+  it('keeps same-priority transfer work stable instead of chasing a closer fillable sink', () => {
     const farExtension = {
       id: 'extension-far',
       structureType: 'extension',
@@ -1139,9 +1168,94 @@ describe('runWorker', () => {
 
     runWorker(creep);
 
-    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'extension-near' });
-    expect(Game.getObjectById).not.toHaveBeenCalled();
-    expect(creep.transfer).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'extension-far' });
+    expect(creep.transfer).toHaveBeenCalledWith(farExtension, 'energy');
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('preempts transfer work for a higher-priority fillable energy sink and executes it immediately', () => {
+    const extension = {
+      id: 'extension1',
+      structureType: 'extension',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
+    } as unknown as StructureExtension;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const creep = {
+      memory: { task: { type: 'transfer', targetId: 'extension1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            const structures = [extension, spawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      },
+      transfer: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : extension))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.transfer).toHaveBeenCalledWith(spawn, 'energy');
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('reselects and executes a same-priority transfer when the current sink is full', () => {
+    const fullExtension = {
+      id: 'extension-full',
+      structureType: 'extension',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureExtension;
+    const fillableExtension = {
+      id: 'extension-fillable',
+      structureType: 'extension',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
+    } as unknown as StructureExtension;
+    const creep = {
+      memory: { task: { type: 'transfer', targetId: 'extension-full' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureExtension) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            const structures = [fullExtension, fillableExtension];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      },
+      transfer: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn((id: string) => (id === 'extension-fillable' ? fillableExtension : fullExtension))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'extension-fillable' });
+    expect(creep.transfer).toHaveBeenCalledWith(fillableExtension, 'energy');
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1093,12 +1093,64 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('retargets transfer work to the closest same-priority fillable energy sink before walking', () => {
+    const farExtension = {
+      id: 'extension-far',
+      structureType: 'extension',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
+    } as unknown as StructureExtension;
+    const nearExtension = {
+      id: 'extension-near',
+      structureType: 'extension',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
+    } as unknown as StructureExtension;
+    const getRangeTo = jest.fn((target: StructureExtension) => {
+      const ranges: Record<string, number> = {
+        'extension-far': 8,
+        'extension-near': 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      memory: { task: { type: 'transfer', targetId: 'extension-far' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      pos: { getRangeTo },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureExtension) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            const structures = [farExtension, nearExtension];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      },
+      transfer: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(farExtension)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'extension-near' });
+    expect(Game.getObjectById).not.toHaveBeenCalled();
+    expect(creep.transfer).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('reselects a worker task without moving when transfer returns ERR_FULL', () => {
     const site = { id: 'site1' } as ConstructionSite;
     const spawn = {
       id: 'spawn1',
       structureType: 'spawn',
-      store: { getFreeCapacity: jest.fn().mockReturnValueOnce(1).mockReturnValue(0) }
+      store: { getFreeCapacity: jest.fn().mockReturnValueOnce(1).mockReturnValueOnce(1).mockReturnValue(0) }
     } as unknown as StructureSpawn;
     const creep = {
       memory: { task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> } },


### PR DESCRIPTION
Closes #213.

## Summary
- improve worker resource/economy flow by allowing loaded workers to preempt stale transfer tasks when a better energy sink appears
- add worker runner regression coverage
- update generated `prod/dist/main.js`

## Controller verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (16 suites / 325 tests)
- `npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Codex-authored commit: d31e0cc (`lanyusea's bot <lanyusea@gmail.com>`).
