### PR TITLE
feat: extend territory pressure after reservation renewal

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -832,6 +832,15 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       gameTime,
       !hasBlockingConfiguredTarget,
       routeDistanceLookupContext
+    ),
+    ...getSatisfiedReserveAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      !hasBlockingConfiguredTarget,
+      routeDistanceLookupContext
     )
   ];
   const candidates = [...configuredCandidates, ...adjacentCandidates];
@@ -969,13 +978,48 @@ function getSatisfiedClaimAdjacentReserveCandidates(colonyName, colonyOwnerUsern
     )
   );
 }
+function getSatisfiedReserveAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, routeDistanceLookupContext) {
+  return getSatisfiedConfiguredTargets(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    "reserve",
+    routeDistanceLookupContext
+  ).flatMap(
+    ({ target, order }) => getAdjacentReserveCandidates(
+      colonyName,
+      target.roomName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      "satisfiedReserveAdjacent",
+      (order + 1) * EXIT_DIRECTION_ORDER.length,
+      routeDistanceLookupContext
+    )
+  );
+}
 function getSatisfiedConfiguredClaimTargets(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
+  return getSatisfiedConfiguredTargets(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    "claim",
+    routeDistanceLookupContext
+  );
+}
+function getSatisfiedConfiguredTargets(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, action, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "claim" || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== action || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
       return [];
     }
     return [{ target, order }];
@@ -1016,7 +1060,10 @@ function getTerritoryCandidateSourcePriority(source) {
   if (source === "configured") {
     return 0;
   }
-  return source === "satisfiedClaimAdjacent" ? 1 : 2;
+  if (source === "satisfiedClaimAdjacent") {
+    return 1;
+  }
+  return source === "satisfiedReserveAdjacent" ? 2 : 3;
 }
 function isTerritoryTargetVisible(target) {
   return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -40,7 +40,7 @@ interface SelectedTerritoryTarget {
   commitTarget: boolean;
 }
 
-type TerritoryCandidateSource = 'configured' | 'satisfiedClaimAdjacent' | 'adjacent';
+type TerritoryCandidateSource = 'configured' | 'satisfiedClaimAdjacent' | 'satisfiedReserveAdjacent' | 'adjacent';
 
 interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   order: number;
@@ -373,6 +373,15 @@ function selectTerritoryTarget(
       gameTime,
       !hasBlockingConfiguredTarget,
       routeDistanceLookupContext
+    ),
+    ...getSatisfiedReserveAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      !hasBlockingConfiguredTarget,
+      routeDistanceLookupContext
     )
   ];
   const candidates = [...configuredCandidates, ...adjacentCandidates];
@@ -606,12 +615,65 @@ function getSatisfiedClaimAdjacentReserveCandidates(
   );
 }
 
+function getSatisfiedReserveAdjacentReserveCandidates(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  includeScoutCandidates: boolean,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): ScoredTerritoryTarget[] {
+  return getSatisfiedConfiguredTargets(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    'reserve',
+    routeDistanceLookupContext
+  ).flatMap(({ target, order }) =>
+    getAdjacentReserveCandidates(
+      colonyName,
+      target.roomName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      'satisfiedReserveAdjacent',
+      (order + 1) * EXIT_DIRECTION_ORDER.length,
+      routeDistanceLookupContext
+    )
+  );
+}
+
 function getSatisfiedConfiguredClaimTargets(
   colonyName: string,
   colonyOwnerUsername: string | null,
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[],
   gameTime: number,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): Array<{ target: TerritoryTargetMemory; order: number }> {
+  return getSatisfiedConfiguredTargets(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    'claim',
+    routeDistanceLookupContext
+  );
+}
+
+function getSatisfiedConfiguredTargets(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  action: TerritoryControlAction,
   routeDistanceLookupContext: RouteDistanceLookupContext
 ): Array<{ target: TerritoryTargetMemory; order: number }> {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -624,7 +686,7 @@ function getSatisfiedConfiguredClaimTargets(
       !target ||
       target.enabled === false ||
       target.colony !== colonyName ||
-      target.action !== 'claim' ||
+      target.action !== action ||
       target.roomName === colonyName ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
       hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) ||
@@ -703,7 +765,11 @@ function getTerritoryCandidateSourcePriority(source: TerritoryCandidateSource): 
     return 0;
   }
 
-  return source === 'satisfiedClaimAdjacent' ? 1 : 2;
+  if (source === 'satisfiedClaimAdjacent') {
+    return 1;
+  }
+
+  return source === 'satisfiedReserveAdjacent' ? 2 : 3;
 }
 
 function isTerritoryTargetVisible(target: TerritoryTargetMemory): boolean {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1553,6 +1553,57 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('extends from a satisfied configured reservation before home-adjacent reserve pressure', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === 'W1N2' ? { '3': 'W2N2' } : { '3': 'W2N1' }
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        } as Room,
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room,
+        W2N2: { name: 'W2N2', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 562);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N2', action: 'reserve' });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(describeExits).toHaveBeenCalledWith('W1N2');
+    expect(Memory.territory?.targets).toEqual([
+      configuredTarget,
+      {
+        colony: 'W1N1',
+        roomName: 'W2N2',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 562
+      }
+    ]);
+  });
+
   it('skips hostile and suppressed adjacent reserve targets after a satisfied reservation', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };


### PR DESCRIPTION
## Summary
- Extends the territory/control lane after reservation renewal by letting satisfied reserve targets seed adjacent reserve pressure.
- Keeps configured claim pressure precedence while adding deterministic ordering for satisfied-reserve adjacent candidates.
- Regenerates `prod/dist/main.js` from the build.

Closes #215

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites / 325 tests)
- `cd prod && npm run build`

## Commit
- `22191a7 lanyusea's bot <lanyusea@gmail.com> feat: extend territory pressure after reservation renewal`
