### PR TITLE
feat: extend territory control opportunities

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -841,6 +841,16 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       gameTime,
       !hasBlockingConfiguredTarget,
       routeDistanceLookupContext
+    ),
+    ...getActiveReserveAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      roleCounts,
+      !hasBlockingConfiguredTarget,
+      routeDistanceLookupContext
     )
   ];
   const candidates = [...configuredCandidates, ...adjacentCandidates];
@@ -1002,6 +1012,42 @@ function getSatisfiedReserveAdjacentReserveCandidates(colonyName, colonyOwnerUse
     )
   );
 }
+function getActiveReserveAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, roleCounts, includeScoutCandidates, routeDistanceLookupContext) {
+  return getActiveCoveredConfiguredReserveTargets(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    roleCounts,
+    routeDistanceLookupContext
+  ).flatMap(
+    ({ target, order }) => getAdjacentReserveCandidates(
+      colonyName,
+      target.roomName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      "activeReserveAdjacent",
+      (order + 1) * EXIT_DIRECTION_ORDER.length,
+      routeDistanceLookupContext
+    )
+  );
+}
+function getActiveCoveredConfiguredReserveTargets(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, roleCounts, routeDistanceLookupContext) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return [];
+  }
+  return territoryMemory.targets.flatMap((rawTarget, order) => {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || !isVisibleRoomKnown(target.roomName) || getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
+      return [];
+    }
+    return [{ target, order }];
+  });
+}
 function getSatisfiedConfiguredClaimTargets(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
   return getSatisfiedConfiguredTargets(
     colonyName,
@@ -1063,7 +1109,10 @@ function getTerritoryCandidateSourcePriority(source) {
   if (source === "satisfiedClaimAdjacent") {
     return 1;
   }
-  return source === "satisfiedReserveAdjacent" ? 2 : 3;
+  if (source === "satisfiedReserveAdjacent") {
+    return 2;
+  }
+  return source === "activeReserveAdjacent" ? 3 : 4;
 }
 function isTerritoryTargetVisible(target) {
   return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -40,7 +40,12 @@ interface SelectedTerritoryTarget {
   commitTarget: boolean;
 }
 
-type TerritoryCandidateSource = 'configured' | 'satisfiedClaimAdjacent' | 'satisfiedReserveAdjacent' | 'adjacent';
+type TerritoryCandidateSource =
+  | 'configured'
+  | 'satisfiedClaimAdjacent'
+  | 'satisfiedReserveAdjacent'
+  | 'activeReserveAdjacent'
+  | 'adjacent';
 
 interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   order: number;
@@ -382,6 +387,16 @@ function selectTerritoryTarget(
       gameTime,
       !hasBlockingConfiguredTarget,
       routeDistanceLookupContext
+    ),
+    ...getActiveReserveAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      roleCounts,
+      !hasBlockingConfiguredTarget,
+      routeDistanceLookupContext
     )
   ];
   const candidates = [...configuredCandidates, ...adjacentCandidates];
@@ -648,6 +663,75 @@ function getSatisfiedReserveAdjacentReserveCandidates(
   );
 }
 
+function getActiveReserveAdjacentReserveCandidates(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  roleCounts: RoleCounts,
+  includeScoutCandidates: boolean,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): ScoredTerritoryTarget[] {
+  return getActiveCoveredConfiguredReserveTargets(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    roleCounts,
+    routeDistanceLookupContext
+  ).flatMap(({ target, order }) =>
+    getAdjacentReserveCandidates(
+      colonyName,
+      target.roomName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      'activeReserveAdjacent',
+      (order + 1) * EXIT_DIRECTION_ORDER.length,
+      routeDistanceLookupContext
+    )
+  );
+}
+
+function getActiveCoveredConfiguredReserveTargets(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  roleCounts: RoleCounts,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): Array<{ target: TerritoryTargetMemory; order: number }> {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return [];
+  }
+
+  return territoryMemory.targets.flatMap((rawTarget, order) => {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (
+      !target ||
+      target.enabled === false ||
+      target.colony !== colonyName ||
+      target.action !== 'reserve' ||
+      target.roomName === colonyName ||
+      isTerritoryTargetSuppressed(target, intents, gameTime) ||
+      hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) ||
+      !isVisibleRoomKnown(target.roomName) ||
+      getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 ||
+      getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !==
+        'available'
+    ) {
+      return [];
+    }
+
+    return [{ target, order }];
+  });
+}
+
 function getSatisfiedConfiguredClaimTargets(
   colonyName: string,
   colonyOwnerUsername: string | null,
@@ -769,7 +853,11 @@ function getTerritoryCandidateSourcePriority(source: TerritoryCandidateSource): 
     return 1;
   }
 
-  return source === 'satisfiedReserveAdjacent' ? 2 : 3;
+  if (source === 'satisfiedReserveAdjacent') {
+    return 2;
+  }
+
+  return source === 'activeReserveAdjacent' ? 3 : 4;
 }
 
 function isTerritoryTargetVisible(target: TerritoryTargetMemory): boolean {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1604,6 +1604,110 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('extends from an actively covered visible reservation before home-adjacent reserve pressure', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === 'W1N2' ? { '3': 'W2N2' } : { '1': 'W1N2', '3': 'W2N1' }
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: { name: 'W1N2', controller: { my: false } as StructureController } as Room,
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room,
+        W2N2: { name: 'W2N2', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    const plan = planTerritoryIntent(
+      colony,
+      {
+        worker: 3,
+        claimer: 1,
+        claimersByTargetRoom: { W1N2: 1 },
+        claimersByTargetRoomAction: { reserve: { W1N2: 1 } }
+      },
+      3,
+      563
+    );
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N2', action: 'reserve' });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(describeExits).toHaveBeenCalledWith('W1N2');
+    expect(Memory.territory?.targets).toEqual([
+      configuredTarget,
+      {
+        colony: 'W1N1',
+        roomName: 'W2N2',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 563
+      }
+    ]);
+  });
+
+  it('keeps emergency renewal ahead of active-reserve frontier expansion', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === 'W1N2' ? { '3': 'W2N2' } : { '1': 'W1N2' }
+    );
+    const roleCounts = {
+      worker: 3,
+      claimer: 1,
+      claimersByTargetRoom: { W1N2: 1 },
+      claimersByTargetRoomAction: { reserve: { W1N2: 1 } }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS }
+          } as StructureController
+        } as Room,
+        W2N2: { name: 'W2N2', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, roleCounts, 3, 564);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' });
+    expect(describeExits).not.toHaveBeenCalled();
+    expect(shouldSpawnTerritoryControllerCreep(plan!, roleCounts, 564)).toBe(true);
+    expect(Memory.territory?.targets).toEqual([configuredTarget]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 564
+      }
+    ]);
+  });
+
   it('skips hostile and suppressed adjacent reserve targets after a satisfied reservation', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };


### PR DESCRIPTION
## Summary
- Extends territory expansion from actively covered visible reserve targets into adjacent reserve opportunities.
- Preserves emergency reservation renewal priority ahead of frontier expansion.
- Adds deterministic territory planner coverage and regenerates `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (16 suites, 331 tests passed)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #223
