### PR TITLE
feat: improve resource economy after spawn recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1728,18 +1728,17 @@ function selectFillableEnergySink(creep) {
   const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
     filter: isFillableEnergySink
   });
-  const spawn = selectClosestEnergySink(creep, energySinks.filter(isSpawnEnergySink));
-  if (spawn) {
-    return spawn;
-  }
-  const extension = selectClosestEnergySink(creep, energySinks.filter(isExtensionEnergySink));
-  if (extension) {
-    return extension;
+  const spawnOrExtension = selectClosestEnergySink(creep, energySinks.filter(isSpawnOrExtensionEnergySink));
+  if (spawnOrExtension) {
+    return spawnOrExtension;
   }
   return selectClosestEnergySink(creep, energySinks.filter(isPriorityTowerEnergySink));
 }
 function isSpawnEnergySink(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+}
+function isSpawnOrExtensionEnergySink(structure) {
+  return isSpawnEnergySink(structure) || isExtensionEnergySink(structure);
 }
 function isExtensionEnergySink(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension");
@@ -2551,10 +2550,7 @@ function getTransferSinkPriority(target) {
   if (typeof structureType !== "string") {
     return 0;
   }
-  if (matchesTransferSinkStructureType(structureType, "STRUCTURE_SPAWN", "spawn")) {
-    return 3;
-  }
-  if (matchesTransferSinkStructureType(structureType, "STRUCTURE_EXTENSION", "extension")) {
+  if (matchesTransferSinkStructureType(structureType, "STRUCTURE_SPAWN", "spawn") || matchesTransferSinkStructureType(structureType, "STRUCTURE_EXTENSION", "extension")) {
     return 2;
   }
   return matchesTransferSinkStructureType(structureType, "STRUCTURE_TOWER", "tower") ? 1 : 0;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -314,11 +314,10 @@ function getTransferSinkPriority(target: unknown): number {
     return 0;
   }
 
-  if (matchesTransferSinkStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn')) {
-    return 3;
-  }
-
-  if (matchesTransferSinkStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')) {
+  if (
+    matchesTransferSinkStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+    matchesTransferSinkStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')
+  ) {
     return 2;
   }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -162,14 +162,9 @@ function selectFillableEnergySink(creep: Creep): FillableEnergySink | null {
     filter: isFillableEnergySink
   });
 
-  const spawn = selectClosestEnergySink(creep, energySinks.filter(isSpawnEnergySink));
-  if (spawn) {
-    return spawn;
-  }
-
-  const extension = selectClosestEnergySink(creep, energySinks.filter(isExtensionEnergySink));
-  if (extension) {
-    return extension;
+  const spawnOrExtension = selectClosestEnergySink(creep, energySinks.filter(isSpawnOrExtensionEnergySink));
+  if (spawnOrExtension) {
+    return spawnOrExtension;
   }
 
   return selectClosestEnergySink(creep, energySinks.filter(isPriorityTowerEnergySink));
@@ -177,6 +172,10 @@ function selectFillableEnergySink(creep: Creep): FillableEnergySink | null {
 
 function isSpawnEnergySink(structure: FillableEnergySink): structure is StructureSpawn {
   return matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn');
+}
+
+function isSpawnOrExtensionEnergySink(structure: FillableEnergySink): structure is StructureSpawn | StructureExtension {
+  return isSpawnEnergySink(structure) || isExtensionEnergySink(structure);
 }
 
 function isExtensionEnergySink(structure: FillableEnergySink): structure is StructureExtension {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1122,21 +1122,21 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
-  it('keeps same-priority transfer work stable instead of chasing a closer fillable sink', () => {
+  it('keeps primary transfer work stable instead of chasing a closer fillable sink', () => {
     const farExtension = {
       id: 'extension-far',
       structureType: 'extension',
       store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
     } as unknown as StructureExtension;
-    const nearExtension = {
-      id: 'extension-near',
-      structureType: 'extension',
+    const nearSpawn = {
+      id: 'spawn-near',
+      structureType: 'spawn',
       store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
-    } as unknown as StructureExtension;
-    const getRangeTo = jest.fn((target: StructureExtension) => {
+    } as unknown as StructureSpawn;
+    const getRangeTo = jest.fn((target: StructureExtension | StructureSpawn) => {
       const ranges: Record<string, number> = {
         'extension-far': 8,
-        'extension-near': 1
+        'spawn-near': 1
       };
       return ranges[String(target.id)] ?? 99;
     });
@@ -1149,12 +1149,12 @@ describe('runWorker', () => {
       pos: { getRangeTo },
       room: {
         find: jest.fn(
-          (type: number, options?: { filter?: (structure: StructureExtension) => boolean }) => {
+          (type: number, options?: { filter?: (structure: StructureExtension | StructureSpawn) => boolean }) => {
             if (type !== FIND_MY_STRUCTURES) {
               return [];
             }
 
-            const structures = [farExtension, nearExtension];
+            const structures = [farExtension, nearSpawn];
             return options?.filter ? structures.filter(options.filter) : structures;
           }
         )
@@ -1163,7 +1163,7 @@ describe('runWorker', () => {
       moveTo: jest.fn()
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      getObjectById: jest.fn().mockReturnValue(farExtension)
+      getObjectById: jest.fn((id: string) => (id === 'spawn-near' ? nearSpawn : farExtension))
     };
 
     runWorker(creep);
@@ -1173,31 +1173,31 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
-  it('preempts transfer work for a higher-priority fillable energy sink and executes it immediately', () => {
+  it('preempts tower transfer work for a primary fillable energy sink and executes it immediately', () => {
     const extension = {
       id: 'extension1',
       structureType: 'extension',
       store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
     } as unknown as StructureExtension;
-    const spawn = {
-      id: 'spawn1',
-      structureType: 'spawn',
+    const tower = {
+      id: 'tower1',
+      structureType: 'tower',
       store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
-    } as unknown as StructureSpawn;
+    } as unknown as StructureTower;
     const creep = {
-      memory: { task: { type: 'transfer', targetId: 'extension1' as Id<AnyStoreStructure> } },
+      memory: { task: { type: 'transfer', targetId: 'tower1' as Id<AnyStoreStructure> } },
       store: {
         getUsedCapacity: jest.fn().mockReturnValue(50),
         getFreeCapacity: jest.fn().mockReturnValue(0)
       },
       room: {
         find: jest.fn(
-          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+          (type: number, options?: { filter?: (structure: StructureExtension | StructureTower) => boolean }) => {
             if (type !== FIND_MY_STRUCTURES) {
               return [];
             }
 
-            const structures = [extension, spawn];
+            const structures = [extension, tower];
             return options?.filter ? structures.filter(options.filter) : structures;
           }
         )
@@ -1206,13 +1206,13 @@ describe('runWorker', () => {
       moveTo: jest.fn()
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : extension))
+      getObjectById: jest.fn((id: string) => (id === 'tower1' ? tower : extension))
     };
 
     runWorker(creep);
 
-    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
-    expect(creep.transfer).toHaveBeenCalledWith(spawn, 'energy');
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'extension1' });
+    expect(creep.transfer).toHaveBeenCalledWith(extension, 'energy');
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1413,7 +1413,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
   });
 
-  it('prefers a fillable spawn over nearer fillable extension and tower targets', () => {
+  it('selects the closest spawn or extension before fillable towers', () => {
     const farSpawn = makeEnergySink('spawn-far', 'spawn' as StructureConstant, 300);
     const fullExtension = makeEnergySink('extension-full', 'extension' as StructureConstant, 0);
     const nearExtension = makeEnergySink('extension-near', 'extension' as StructureConstant, 50);
@@ -1444,13 +1444,12 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-far' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-near' });
     expect(getRangeTo).not.toHaveBeenCalledWith(fullExtension);
-    expect(getRangeTo).not.toHaveBeenCalledWith(nearExtension);
     expect(getRangeTo).not.toHaveBeenCalledWith(nearTower);
   });
 
-  it('selects the closest fillable spawn before considering fillable extensions', () => {
+  it('selects the closest fillable spawn or extension', () => {
     const farSpawn = makeEnergySink('spawn-far', 'spawn' as StructureConstant, 300);
     const nearSpawn = makeEnergySink('spawn-near', 'spawn' as StructureConstant, 100);
     const closerExtension = makeEnergySink('extension-closer', 'extension' as StructureConstant, 50);
@@ -1479,8 +1478,7 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-near' });
-    expect(getRangeTo).not.toHaveBeenCalledWith(closerExtension);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-closer' });
   });
 
   it('selects fillable extensions before fillable towers', () => {
@@ -1583,7 +1581,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-a' });
   });
 
-  it('keeps id order as the stable energy sink fallback when position helpers are unavailable', () => {
+  it('keeps id order across primary energy sinks when position helpers are unavailable', () => {
     const extension = makeEnergySink('extension-first', 'extension' as StructureConstant, 50);
     const laterSpawn = makeEnergySink('spawn-z', 'spawn' as StructureConstant, 300);
     const firstSpawn = makeEnergySink('spawn-a', 'spawn' as StructureConstant, 300);
@@ -1603,7 +1601,7 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-a' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-first' });
   });
 
   it('preserves no-sink fallback behavior when all energy sinks are full', () => {


### PR DESCRIPTION
Closes #225

## Summary
- Improve worker resource-economy behavior after spawn recovery is deployed.
- Update worker task/runner behavior and deterministic tests.
- Rebuild `prod/dist/main.js` from source.

## Controller verification
- `git diff --check` passed after rebasing/merging current `origin/main`.
- `cd prod && npm run typecheck` passed.
- `cd prod && npm test -- --runInBand` passed (16 suites, 334 tests).
- `cd prod && npm run build` passed.

## Notes
- Production/test/build changes are Codex-authored in commit `9b2c06f` by `lanyusea's bot <lanyusea@gmail.com>`.
- Untracked `prod/node_modules` in the worktree is dependency infrastructure and was not staged.