### PR TITLE
docs: add strategy self-evolution vision

### DIFF
--- a/docs/ops/gameplay-evolution-roadmap.md
+++ b/docs/ops/gameplay-evolution-roadmap.md
@@ -2,7 +2,7 @@
 
 > This is the专项 plan for turning the project vision into a recurring game-result → postmortem analysis → roadmap/task-update loop.
 
-Date: 2026-04-27
+Date: 2026-04-29
 
 ## Problem statement
 
@@ -27,8 +27,10 @@ Without this loop, the bot can keep improving peripheral systems while not measu
 5. **Main Hermes agent remains the authority.** Gameplay-review agents provide evidence and recommendations; the main agent accepts/rejects and updates GitHub.
 6. **GitHub is the source of truth.** Any accepted work item must become or update a GitHub Issue, Milestone, and Project `screeps` item.
 7. **Codex owns production code.** Any `prod/` code change must be delegated to Codex and verified with typecheck/test/build.
-8. **Scheduled reviews and tactical emergencies are separate paths.** The 12-hour loop must not delay an urgent response to attacks or collapse.
+8. **Scheduled reviews and tactical emergencies are separate paths.** The 8-hour loop must not delay an urgent response to attacks or collapse.
 9. **Release is a gameplay decision, not just a build artifact.** A release candidate must have expected KPI movement and observation requirements.
+10. **The strategy model itself must evolve.** The review loop must judge whether the current scoring model, decision rules, and task-generation contract remain valid. If not, it should propose model changes, research tasks, or controlled experiments.
+11. **RL is the long-term self-evolution path, not an immediate production shortcut.** Reinforcement-learning-driven strategy iteration requires autoresearch, a formal paper, offline/private-server evaluation, and explicit safety gates before influencing official MMO behavior.
 
 ## Reporting weight contract
 
@@ -52,9 +54,9 @@ Responsibilities:
 - Fan out concise summaries to Discord typed channels.
 - Run or request QA/acceptance before accepting completion.
 
-### Gameplay Evolution Agent — 12-hour strategic reviewer
+### Gameplay Evolution Agent — 8-hour strategic reviewer
 
-Cadence: every 12 hours, plus manual invocation after major releases or major incidents.
+Cadence: every 8 hours, plus manual invocation after major releases or major incidents.
 
 Inputs:
 
@@ -190,6 +192,46 @@ Returns only `PASS` or `REQUEST_CHANGES` with evidence. It verifies:
 - Discord/reporting requirements are met;
 - release/incident gates are not skipped.
 
+## Strategy model self-evolution
+
+The 8-hour review must evaluate three levels of strategy state:
+
+1. **Parameter tuning** — numeric thresholds, weights, and urgency cutoffs inside an accepted model.
+2. **Model revision** — adding/removing features or changing the scoring formula when evidence shows the current model misses important Screeps outcomes.
+3. **Research-driven evolution** — opening formal research/paper tasks when the required model change is not obvious or may require reinforcement learning, offline evaluation, or private-server experimentation.
+
+A strategy-model change may be accepted only when it states:
+
+- the gameplay failure or opportunity it addresses;
+- the affected vision layer: territory, resources, kills, or reliability prerequisite;
+- the current model behavior and why it is insufficient;
+- the proposed model change or research question;
+- expected KPI movement and safety/rollback conditions;
+- whether it is a heuristic update, experiment, autoresearch task, or RL-roadmap item.
+
+### Expansion recommendation model
+
+Each review must score visible/current candidate rooms and name the next room to occupy, reserve, or scout when evidence is sufficient. A 0-100 score should include controller state, distance and route safety, source/mineral/economic value, owner/reservation/hostile risk, logistics and construction cost, current-room ability to support expansion, and contribution to territory before resources before kills. If evidence is insufficient, the review must name the next observation/scout task instead of guessing.
+
+### Construction priority model
+
+Construction scoring is intentionally broader than a fixed checklist. The review should combine good Screeps practice with current evidence and optimize for winning game outcomes. A 0-100 construction priority score should consider:
+
+- survival and recovery urgency: spawn availability, worker recovery, controller downgrade, tower/rampart/repair threats;
+- energy throughput: extensions, containers, links, roads, dropped-resource salvage, spawn refill latency, harvest/haul bottlenecks;
+- expansion enablement: roads to exits/remotes, remote containers, reserver/claimer logistics, forward defense, room-claim prerequisites;
+- RCL progression and unlock timing: when a build accelerates extensions, towers, storage, terminal, labs, observer, power spawn, or nuker readiness;
+- defense and loss avoidance: towers, ramparts, walls, safe-mode readiness, repair triage, hostile path exposure;
+- CPU/pathing efficiency: whether a build reduces repeated movement, search, repair churn, or creep body inefficiency;
+- opportunity cost: energy locked in construction vs upgrading/spawning/repairing, build time, worker travel, and risk of abandoned construction sites;
+- strategic layer served: territory first, resources second, kills third, with reliability as a prerequisite guardrail.
+
+The output must name the next primary construction item when evidence supports one. If not, it must name the missing instrumentation or scout/monitor task.
+
+### RL self-evolution research track
+
+Issue #232 tracks the formal autoresearch paper required before RL implementation. The first paper must define Screeps state/action/reward choices, offline/private-server evaluation, safety gates, and a staged roadmap from heuristic scoring to shadow evaluation to reinforcement-learning-assisted strategy iteration. RL reward functions must remain subordinate to the project vision: territory > resources > enemy kills.
+
 ## KPI and evidence schema
 
 ### North-star outcome KPIs
@@ -197,7 +239,7 @@ Returns only `PASS` or `REQUEST_CHANGES` with evidence. It verifies:
 | Vision layer | KPI | First implementation target |
 | --- | --- | --- |
 | Territory | owned rooms, reserved/remote rooms, room gain/loss, RCL progress | external monitor + in-game telemetry summary fields |
-| Resources | total stored energy/resources, harvest/collection deltas, GCL/RCL deltas, spawn utilization | in-game counters plus 12h window reducer |
+| Resources | total stored energy/resources, harvest/collection deltas, GCL/RCL deltas, spawn utilization | in-game counters plus 8h window reducer |
 | Enemy kills | hostile creeps/structures destroyed, own losses, net combat value | `Room.getEventLog()` where visible plus monitor hostiles/damage observations |
 
 ### Guardrails
@@ -223,7 +265,7 @@ A gameplay finding may become a development task only if it states:
 
 ### Track 1 — Vision KPI telemetry and reducer
 
-Goal: make the bot and monitor emit enough cumulative data for a 12-hour review.
+Goal: make the bot and monitor emit enough cumulative data for an 8-hour review.
 
 Initial tasks:
 
@@ -237,7 +279,7 @@ Acceptance:
 - Review report can list territory/resource/combat/reliability deltas without manual guessing.
 - Missing fields are explicitly marked `not instrumented`, not silently omitted.
 
-### Track 2 — 12-hour gameplay review worker
+### Track 2 — 8-hour gameplay review worker
 
 Goal: schedule a recurring analysis loop that recommends roadmap changes.
 
@@ -246,7 +288,7 @@ Initial tasks:
 1. Create a self-contained cron prompt for `Screeps Gameplay Evolution Review`.
 2. Run one manual dry run against current evidence.
 3. Main agent accepts/rejects the dry-run output.
-4. Enable every-12-hour cadence after dry-run success.
+4. Enable every-8-hour cadence after dry-run success.
 
 Acceptance:
 
@@ -274,7 +316,7 @@ Acceptance:
 
 ### Track 4 — Tactical emergency response
 
-Goal: avoid waiting 12 hours when an attack or collapse requires immediate action.
+Goal: avoid waiting 8 hours when an attack or collapse requires immediate action.
 
 Initial tasks:
 
@@ -294,9 +336,9 @@ Goal: ensure release decisions are based on gameplay risk and expected outcomes.
 
 Normal releases:
 
-- Prefer at most one meaningful gameplay release per 12-hour review cycle.
+- Prefer at most one meaningful gameplay release per 8-hour review cycle.
 - Require accepted roadmap issue, Codex implementation, typecheck/test/build, PR gate, QA `PASS`, and risk-appropriate runtime/private validation.
-- Require the next 12-hour review to evaluate expected KPI movement.
+- Require the next 8-hour review to evaluate expected KPI movement.
 
 Emergency hotfixes:
 
@@ -316,7 +358,7 @@ This专项 is tracked by GitHub issues instead of local-only TODOs:
    - Domain: Docs/process
    - Kind: ops
    - Status: In progress
-2. **#60 — P1: Phase C: 12h gameplay evolution review loop is not automated**
+2. **#60 — P1: Phase C: 8h gameplay evolution review loop is not automated**
    - Domain: Agent OS
    - Kind: ops
 3. **#61 — P1: Phase B: gameplay findings do not yet bridge into Codex task pipeline**
@@ -336,17 +378,20 @@ Existing issue **#29** remains the immediate KPI telemetry bridge; it is cross-l
 1. Land this docs/ops/research plan and GitHub issue setup.
 2. Update or create GitHub issues and Project fields.
 3. Run a manual gameplay-review dry run using current evidence.
-4. Enable a 12-hour review job only after dry-run output is useful.
+4. Enable an 8-hour review job only after dry-run output is useful.
 5. Dispatch Codex for KPI telemetry implementation under `prod/`.
-6. Add reducer/reporting automation.
-7. Wire tactical emergency response from runtime-alert outputs.
-8. Update release gate docs and enforce via Project status / release checklist.
+6. Complete #232 autoresearch and formal paper before any RL implementation task.
+7. Add reducer/reporting automation.
+8. Wire tactical emergency response from runtime-alert outputs.
+9. Update release gate docs and enforce via Project status / release checklist.
 
 ## Definition of done for the专项
 
 - [ ] KPI framework exists and is source-backed.
+- [ ] Strategy-model self-evolution requirements are in the 8-hour review contract.
+- [ ] RL-driven self-evolution has a formal autoresearch paper before implementation.
 - [ ] Runtime telemetry/monitor can provide territory/resource/combat/reliability deltas.
-- [ ] 12-hour gameplay review job runs and produces an accepted report.
+- [ ] 8-hour gameplay review job runs and produces an accepted report.
 - [ ] Accepted findings update GitHub Issues/Milestones/Project before implementation.
 - [ ] Codex receives concrete production-code tasks with acceptance criteria.
 - [ ] Tactical emergency path handles attacks/collapse without waiting for cadence.

--- a/docs/ops/project-vision.md
+++ b/docs/ops/project-vision.md
@@ -1,6 +1,6 @@
 # Screeps Project Vision
 
-Last updated: 2026-04-26T06:03:38Z
+Last updated: 2026-04-29T02:00:00+08:00
 
 This document is the durable counterpart to the Discord `#project-vision` channel. It is the north star for roadmap decomposition, priority evaluation, and trade-off decisions.
 
@@ -11,8 +11,9 @@ In Screeps competition-map play, build a bot that achieves, in strict priority o
 1. **Enough large territory** — claim, hold, defend, and operate a large footprint of rooms.
 2. **Enough resources across categories** — convert territory into durable energy, minerals, commodities, infrastructure, and logistical throughput.
 3. **Enough enemy kills** — develop combat capability that removes threats and wins fights, but only after the bot can expand and sustain itself.
+4. **Self-evolving strategy capability** — continuously evaluate whether the current strategy model, scoring functions, and task-generation rules are still improving the first three objectives; evolve the model through evidence-backed research, controlled experiments, and eventually reinforcement-learning-driven iteration without violating the territory → resources → kills priority order.
 
-The priority order is intentional: territory comes before resource volume, and resource volume comes before kill count. Combat matters, but it should serve expansion, defense, and economic control rather than become an isolated optimization target.
+The priority order is intentional: territory comes before resource volume, and resource volume comes before kill count. Combat matters, but it should serve expansion, defense, and economic control rather than become an isolated optimization target. Strategy self-evolution is a capability layer, not a separate victory condition: learned policies, scoring-model changes, and experiments are accepted only when they improve or protect the ordered gameplay vision.
 
 ## Roadmap evaluation contract
 
@@ -21,6 +22,7 @@ Every roadmap item must answer how it advances at least one layer of the vision:
 - **Territory:** Does this help us safely claim, reserve, scout, path through, defend, or coordinate more rooms?
 - **Resources:** Does this improve energy/mineral extraction, logistics, storage, market readiness, build/repair throughput, or CPU efficiency that scales with room count?
 - **Kills:** Does this improve threat detection, tower/rampart defense, squad control, target selection, or post-economy offensive capability?
+- **Strategy evolution:** Does this improve how the bot chooses between territory/resource/combat strategies over time, with measurable evidence and a rollback-safe experiment path?
 
 When two tasks compete for priority, prefer the task that unlocks the earliest bottleneck in this chain:
 
@@ -35,9 +37,12 @@ survive reliably → expand territory → scale resources → defend/attack effe
 - Resource systems should be designed as territory multipliers: hauling, storage, roads, repairs, remote mining, minerals, and market behavior should be ranked by how much they increase sustainable controlled footprint.
 - Military work should start with defense and threat telemetry, then progress to coordinated combat only when the economy can replace losses and support sustained operations.
 - Roadmap snapshots should show each domain's contribution to territory/resources/kills, plus next-point completion percentage, so progress remains tied to the final objective rather than local implementation churn.
+- The Gameplay Evolution loop must evaluate the strategy model itself, not only tune numeric thresholds. When evidence shows a scoring model is stale, misweighted, or missing a decision class, the loop should create a research or implementation task to revise the model.
+- The long-term strategy-evolution target is reinforcement-learning-assisted iteration, but only after autoresearch and formal paper review define a safe offline/private-server evaluation pipeline. Unvalidated learned policies must not directly control the official MMO bot.
 
 ## Non-goals
 
 - Do not optimize for elegant architecture unless it accelerates the territory/resources/kills chain.
 - Do not chase kill count before expansion and resource foundations can sustain combat losses.
 - Do not treat private-server or CI infrastructure as the final goal; they are release gates that protect progress toward the gameplay vision.
+- Do not treat reinforcement learning as a shortcut around evidence. RL work must begin as research and offline evaluation, then pass controlled validation before any official MMO influence.

--- a/docs/research/2026-04-29-screeps-rl-self-evolving-strategy-paper.md
+++ b/docs/research/2026-04-29-screeps-rl-self-evolving-strategy-paper.md
@@ -1,0 +1,72 @@
+# Toward Reinforcement-Learning-Assisted Self-Evolving Strategy for Hermes Screeps
+
+Status: research paper task scaffold; full autoresearch tracked by GitHub issue #232.
+Date: 2026-04-29
+
+## Abstract
+
+Hermes Screeps currently uses evidence-backed heuristic strategy reviews to pursue the ordered project vision: territory first, resources second, enemy kills third. The next strategic capability is not to replace that vision, but to make the strategy model itself evolvable. This paper will research how to move from hand-tuned scoring models toward reinforcement-learning-assisted strategy iteration using offline artifacts, private-server scenarios, and strict safety gates before any official MMO influence.
+
+## Research questions
+
+1. How should Screeps strategic state be represented under partial observability, limited CPU, persistent world memory, and non-stationary opponents?
+2. Which decisions are appropriate for learned policies first: scoring weights, construction priorities, expansion target ranking, resource routing, defense posture, or full tick-level control?
+3. What reward design best preserves the vision chain: survive reliably → expand territory → scale resources → defend/attack effectively → optimize kills?
+4. What offline/private-server evaluation is sufficient before a learned or auto-tuned policy can affect official MMO code?
+5. How should the 8-hour Evolution cron decide whether to tune parameters, revise a model, request more evidence, or open an RL research/implementation task?
+
+## Initial method space to verify
+
+- Heuristic scoring with versioned weights and evidence-backed changes.
+- Contextual bandits for bounded strategy knobs such as construction weighting or expansion candidate ranking.
+- Offline reinforcement learning from runtime summaries, event logs, Memory snapshots, and private-server traces.
+- Imitation learning from known-good bot behavior or curated Hermes runs.
+- Curriculum/self-play in private-server scenarios for expansion, economy, and defense tasks.
+- Population-based training for strategy parameters after safe simulation harnesses exist.
+- Hierarchical reinforcement learning where high-level strategy picks goals and existing deterministic bot code executes safe actions.
+
+## Required related-work search
+
+The full paper must verify and cite sources for at least these areas:
+
+- RTS reinforcement learning and self-play, including StarCraft/AlphaStar-style lessons for long-horizon partial-observation games.
+- MicroRTS or lightweight RTS benchmarks for reproducible strategy-learning experiments.
+- Offline RL surveys and safety constraints for learning from historical traces.
+- Population-based training and curriculum learning for strategy parameter evolution.
+- Screeps community bot architecture patterns and operational constraints.
+
+The first attempt to query public paper APIs from the controller hit transient arXiv timeout and Semantic Scholar rate limiting; the research worker should retry with bounded rate limits and record exact URLs/versions for all citations.
+
+## Proposed safe landing architecture
+
+1. **Strategy registry:** version expansion/construction/combat scoring models and record why each version changed.
+2. **Shadow evaluator:** run candidate scoring models against saved observations without affecting the live bot.
+3. **Private-server scenario suite:** evaluate candidate policies in repeatable room/economy/hostile scenarios.
+4. **Bandit/weight tuning:** begin with bounded parameter recommendations, not direct tick-level learned control.
+5. **Hierarchical RL:** only after evaluator maturity, let learned policy choose high-level goals while deterministic code handles safety-critical execution.
+6. **Official MMO gate:** learned-policy influence requires paper acceptance, issue/PR/Project tracking, private validation, deployment evidence, and post-deploy observation.
+
+## Reward contract
+
+Reward functions must be subordinate to the durable project vision. A candidate reward may not optimize kills, CPU, or short-term energy if doing so damages earlier layers of the chain. Suggested reward components to research:
+
+- survival/reliability floor: no loop exceptions, spawn recovery, controller downgrade avoidance;
+- territory: owned/reserved room count, stable remote access, successful claim/reserve actions;
+- resources: net harvested energy/minerals, storage growth, spawn utilization, RCL/GCL progress;
+- defense/combat: hostile damage avoided, hostile creeps destroyed, own losses minimized;
+- cost penalties: CPU, creep deaths, abandoned construction, unsafe expansion, failed deploy/rollback.
+
+## Roadmap decomposition
+
+- #232: complete this paper through autoresearch and accepted recommendations.
+- Follow-up issue: implement strategy registry and shadow evaluator.
+- Follow-up issue: add private-server scenario suite for expansion/construction strategy evaluation.
+- Follow-up issue: test contextual-bandit or offline weight-tuning for construction/expansion scores.
+- Follow-up issue: only after evidence, evaluate hierarchical RL for high-level strategic goal selection.
+
+## Acceptance criteria for the completed paper
+
+- Every related-work claim has a traceable citation.
+- The paper names at least one near-term non-RL strategy-evolution slice and at least one long-term RL slice.
+- The safety gate prohibits direct official MMO control by unvalidated learned policies.
+- The implementation roadmap produces GitHub issues with verification and rollback criteria.


### PR DESCRIPTION
## Summary
- Add strategy self-evolution as a durable project-vision capability layer subordinate to territory > resources > enemy kills.
- Update Gameplay Evolution roadmap from 12h language to 8h and require model-level strategy evolution, not only threshold tuning.
- Add an RL self-evolution research-paper scaffold and safety-gated roadmap for #232.
- Broaden construction-priority evaluation to cover Screeps best-practice factors and future model revision.

## Linked issues
- Closes #232
- Updates #59
- Updates #231

## Roadmap category
Gameplay Evolution / strategy self-evolution / RL autoresearch

## Verification
- `git diff --check`

## Safety
- No production bot code changed.
- RL remains research/offline/private-server gated; no learned policy is allowed to directly control official MMO behavior from this PR.
