### PR TITLE
feat: score construction priorities

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3199,7 +3199,10 @@ function buildRuntimeConstructionPriorityState(colony, creeps) {
   const hostileCreeps = findRoomObjects(room, "FIND_HOSTILE_CREEPS");
   const hostileStructures = findRoomObjects(room, "FIND_HOSTILE_STRUCTURES");
   const sources = findRoomObjects(room, "FIND_SOURCES");
-  const colonyWorkers = creeps.filter((creep) => creep.memory.role === "worker" && creep.memory.colony === room.name);
+  const colonyWorkers = creeps.filter((creep) => {
+    var _a2, _b2;
+    return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && ((_b2 = creep.memory) == null ? void 0 : _b2.colony) === room.name;
+  });
   const repairSignals = summarizeRepairSignals(visibleStructures);
   const territoryIntentCounts = countTerritoryIntents(room.name);
   return {
@@ -3523,6 +3526,9 @@ function countTerritoryIntents(roomName) {
   }
   return intents.reduce(
     (counts, intent) => {
+      if (!isRecord2(intent)) {
+        return counts;
+      }
       if (intent.colony !== roomName) {
         return counts;
       }
@@ -3535,6 +3541,9 @@ function countTerritoryIntents(roomName) {
     },
     { active: 0, planned: 0 }
   );
+}
+function isRecord2(value) {
+  return typeof value === "object" && value !== null;
 }
 function matchesStructureType3(actual, globalName, fallback) {
   var _a;
@@ -3703,10 +3712,10 @@ function summarizeRoomEventMetrics(room) {
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord2(entry) || typeof entry.event !== "number") {
+    if (!isRecord3(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord2(entry.data) ? entry.data : {};
+    const data = isRecord3(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -3762,7 +3771,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord2(object) || !isRecord2(object.store)) {
+  if (!isRecord3(object) || !isRecord3(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -3776,7 +3785,7 @@ function getEnergyInStore(object) {
 function sumDroppedEnergy(droppedResources) {
   const energyResource = getEnergyResource2();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord2(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord3(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -3797,7 +3806,7 @@ function getEnergyResource2() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord2(value) {
+function isRecord3(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2709,6 +2709,779 @@ function findSourceCount(room) {
   return room.find(FIND_SOURCES).length;
 }
 
+// src/construction/constructionPriority.ts
+var CONTROLLER_DOWNGRADE_CRITICAL_TICKS = 5e3;
+var CONTROLLER_DOWNGRADE_WARNING_TICKS = 1e4;
+var EARLY_ENERGY_CAPACITY_TARGET = 550;
+var MIN_SAFE_WORKERS_FOR_EXPANSION = 3;
+var MAX_SCORE = 100;
+var MAX_URGENCY_POINTS = 35;
+var MAX_ROOM_STATE_POINTS = 20;
+var MAX_EXPANSION_POINTS = 20;
+var MAX_ECONOMIC_POINTS = 20;
+var MAX_VISION_POINTS = 15;
+var MAX_RISK_COST = 25;
+var CRITICAL_REPAIR_HITS_RATIO = 0.5;
+var DECAYING_REPAIR_HITS_RATIO = 0.8;
+var IDLE_RAMPART_REPAIR_HITS_CEILING2 = 1e5;
+var STRUCTURE_BUILD_COSTS = {
+  spawn: 15e3,
+  extension: 3e3,
+  tower: 5e3,
+  rampart: 1,
+  road: 300,
+  container: 5e3,
+  storage: 3e4,
+  "remote-logistics": 5e3,
+  observation: 0
+};
+var EXPOSURE_COST = {
+  none: 0,
+  low: 2,
+  medium: 5,
+  high: 9
+};
+var OBSERVATION_LABELS = {
+  "room-controller": "missing observation: room controller/RCL",
+  "energy-capacity": "missing observation: room energy capacity",
+  "worker-count": "missing observation: available worker count",
+  "spawn-count": "missing observation: spawn count",
+  "construction-sites": "missing observation: construction site backlog",
+  "repair-decay": "missing observation: repair/decay signals",
+  "hostile-presence": "missing observation: hostile pressure",
+  sources: "missing observation: source count",
+  "territory-intents": "missing observation: territory intent state",
+  "remote-paths": "missing observation: remote path/logistics exposure"
+};
+function scoreConstructionPriorities(roomState, candidates) {
+  const scoredCandidates = candidates.map((candidate) => scoreConstructionCandidate(roomState, candidate)).sort(compareConstructionPriorityScores);
+  return {
+    candidates: scoredCandidates,
+    nextPrimary: selectNextPrimaryConstruction(scoredCandidates)
+  };
+}
+function scoreConstructionCandidate(roomState, candidate) {
+  var _a, _b, _c, _d, _e;
+  const missingObservations = getMissingObservations(roomState, candidate);
+  const blockingPreconditions = getBlockingPreconditions(roomState, candidate, missingObservations);
+  const preconditions = [
+    ...(_a = candidate.preconditions) != null ? _a : [],
+    ...missingObservations.map((observation) => OBSERVATION_LABELS[observation]),
+    ...blockingPreconditions
+  ];
+  const blocked = missingObservations.length > 0 || blockingPreconditions.length > 0;
+  if (blocked) {
+    return {
+      buildItem: candidate.buildItem,
+      room: (_b = candidate.roomName) != null ? _b : roomState.roomName,
+      score: 0,
+      urgency: "blocked",
+      preconditions,
+      expectedKpiMovement: candidate.expectedKpiMovement,
+      risk: (_c = candidate.risk) != null ? _c : [],
+      factors: {
+        urgency: 0,
+        roomState: 0,
+        expansionPrerequisites: 0,
+        economicBenefit: 0,
+        visionWeight: 0,
+        riskCost: 0
+      },
+      missingObservations,
+      blocked
+    };
+  }
+  const urgencyMagnitude = getUrgencyMagnitude(roomState, candidate);
+  const factors = {
+    urgency: Math.round(urgencyMagnitude * MAX_URGENCY_POINTS),
+    roomState: scoreRoomState(roomState, candidate),
+    expansionPrerequisites: scoreExpansionPrerequisites(roomState, candidate),
+    economicBenefit: scoreEconomicBenefit(roomState, candidate),
+    visionWeight: scoreVisionWeight(candidate),
+    riskCost: scoreRiskCost(roomState, candidate)
+  };
+  const rawScore = factors.urgency + factors.roomState + factors.expansionPrerequisites + factors.economicBenefit + factors.visionWeight - factors.riskCost;
+  const gatedScore = applySurvivalGate(roomState, candidate, rawScore);
+  const score = clampScore(Math.round(gatedScore));
+  return {
+    buildItem: candidate.buildItem,
+    room: (_d = candidate.roomName) != null ? _d : roomState.roomName,
+    score,
+    urgency: classifyUrgency(score, urgencyMagnitude),
+    preconditions,
+    expectedKpiMovement: candidate.expectedKpiMovement,
+    risk: (_e = candidate.risk) != null ? _e : [],
+    factors,
+    missingObservations,
+    blocked
+  };
+}
+function selectNextPrimaryConstruction(candidates) {
+  var _a;
+  if (candidates.length === 0) {
+    return null;
+  }
+  return (_a = candidates.find((candidate) => !candidate.blocked)) != null ? _a : candidates[0];
+}
+function buildRuntimeConstructionPriorityReport(colony, creeps) {
+  const state = buildRuntimeConstructionPriorityState(colony, creeps);
+  return scoreConstructionPriorities(state, buildRuntimeConstructionCandidates(state));
+}
+function getMissingObservations(roomState, candidate) {
+  var _a;
+  return ((_a = candidate.requiredObservations) != null ? _a : []).filter((observation) => !hasObservation(roomState, observation));
+}
+function hasObservation(roomState, observation) {
+  var _a;
+  const explicitObservation = (_a = roomState.observations) == null ? void 0 : _a[observation];
+  if (typeof explicitObservation === "boolean") {
+    return explicitObservation;
+  }
+  switch (observation) {
+    case "room-controller":
+      return typeof roomState.rcl === "number";
+    case "energy-capacity":
+      return typeof roomState.energyCapacity === "number";
+    case "worker-count":
+      return typeof roomState.workerCount === "number";
+    case "spawn-count":
+      return typeof roomState.spawnCount === "number";
+    case "construction-sites":
+      return typeof roomState.constructionSiteCount === "number";
+    case "repair-decay":
+      return typeof roomState.criticalRepairCount === "number" && typeof roomState.decayingStructureCount === "number";
+    case "hostile-presence":
+      return typeof roomState.hostileCreepCount === "number" && typeof roomState.hostileStructureCount === "number";
+    case "sources":
+      return typeof roomState.sourceCount === "number";
+    case "territory-intents":
+      return typeof roomState.activeTerritoryIntentCount === "number" && typeof roomState.plannedTerritoryIntentCount === "number";
+    case "remote-paths":
+      return roomState.remoteLogisticsReady === true;
+    default:
+      return false;
+  }
+}
+function getBlockingPreconditions(roomState, candidate, missingObservations) {
+  var _a, _b, _c, _d, _e, _f;
+  if (missingObservations.length > 0) {
+    return [];
+  }
+  const preconditions = [];
+  if (typeof candidate.minimumRcl === "number" && ((_a = roomState.rcl) != null ? _a : 0) < candidate.minimumRcl) {
+    preconditions.push(`requires RCL ${candidate.minimumRcl} (current RCL ${(_b = roomState.rcl) != null ? _b : "unknown"})`);
+  }
+  if (typeof candidate.minimumWorkers === "number" && ((_c = roomState.workerCount) != null ? _c : 0) < candidate.minimumWorkers) {
+    preconditions.push(`needs ${candidate.minimumWorkers} available workers (current ${(_d = roomState.workerCount) != null ? _d : "unknown"})`);
+  }
+  if (typeof candidate.minimumEnergyCapacity === "number" && ((_e = roomState.energyCapacity) != null ? _e : 0) < candidate.minimumEnergyCapacity) {
+    preconditions.push(
+      `needs ${candidate.minimumEnergyCapacity} energy capacity (current ${(_f = roomState.energyCapacity) != null ? _f : "unknown"})`
+    );
+  }
+  if (candidate.requiresSafeHome && hasSurvivalPressure(roomState)) {
+    preconditions.push("resolve survival/recovery pressure before expansion construction");
+  }
+  return preconditions;
+}
+function getUrgencyMagnitude(roomState, candidate) {
+  var _a;
+  const signals = (_a = candidate.signals) != null ? _a : {};
+  const recoveryUrgency = Math.max(
+    normalizeSignal(signals.survivalRecovery),
+    isRecoveryCandidate(candidate) ? getWorkerRecoveryPressure(roomState) : 0
+  );
+  const downgradeUrgency = Math.max(
+    normalizeSignal(signals.controllerDowngrade),
+    isControllerProtectionCandidate(candidate) ? getControllerDowngradePressure(roomState) : 0
+  );
+  const defenseUrgency = Math.max(
+    normalizeSignal(signals.defense),
+    isDefenseCandidate(candidate) ? getDefensePressure(roomState) : 0
+  );
+  const energyUrgency = Math.max(
+    normalizeSignal(signals.energyBottleneck),
+    isEnergyCapacityCandidate(candidate) ? getEnergyBottleneckPressure(roomState) : 0
+  );
+  const repairUrgency = Math.max(
+    normalizeSignal(signals.repairDecay),
+    isRepairSupportCandidate(candidate) ? getRepairDecayPressure(roomState) : 0
+  );
+  return Math.max(recoveryUrgency, downgradeUrgency, defenseUrgency, energyUrgency, repairUrgency);
+}
+function scoreRoomState(roomState, candidate) {
+  var _a, _b, _c, _d, _e;
+  let score = 0;
+  if (candidate.status === "existing-site") {
+    score += 4;
+  }
+  if (typeof roomState.rcl === "number" && (!candidate.minimumRcl || roomState.rcl >= candidate.minimumRcl)) {
+    score += Math.min(5, Math.max(1, roomState.rcl));
+  }
+  if (isRecoveryCandidate(candidate)) {
+    score += Math.round(getWorkerRecoveryPressure(roomState) * 7);
+  } else if (((_a = roomState.workerCount) != null ? _a : 0) >= MIN_SAFE_WORKERS_FOR_EXPANSION) {
+    score += 4;
+  }
+  if (isEnergyCapacityCandidate(candidate) && ((_b = roomState.energyCapacity) != null ? _b : EARLY_ENERGY_CAPACITY_TARGET) < EARLY_ENERGY_CAPACITY_TARGET) {
+    score += 4;
+  }
+  if (isRepairSupportCandidate(candidate)) {
+    score += Math.min(4, ((_c = roomState.criticalRepairCount) != null ? _c : 0) * 2 + ((_d = roomState.decayingStructureCount) != null ? _d : 0));
+  }
+  if (isDefenseCandidate(candidate)) {
+    score += Math.round(getDefensePressure(roomState) * 5);
+  }
+  if (((_e = roomState.constructionSiteCount) != null ? _e : 0) > 0 && candidate.status === "existing-site") {
+    score += 2;
+  }
+  return Math.min(MAX_ROOM_STATE_POINTS, score);
+}
+function scoreExpansionPrerequisites(roomState, candidate) {
+  var _a, _b, _c;
+  const signal = normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.expansionPrerequisite);
+  const territoryIntentPressure = Math.min(
+    1,
+    ((_b = roomState.activeTerritoryIntentCount) != null ? _b : 0) * 0.7 + ((_c = roomState.plannedTerritoryIntentCount) != null ? _c : 0) * 0.45
+  );
+  const structureMultiplier = candidate.buildType === "remote-logistics" || candidate.buildType === "road" || candidate.buildType === "container" || candidate.buildType === "tower" || candidate.buildType === "rampart" ? 1 : 0.35;
+  return Math.min(
+    MAX_EXPANSION_POINTS,
+    Math.round(signal * 14 + territoryIntentPressure * structureMultiplier * 6)
+  );
+}
+function scoreEconomicBenefit(roomState, candidate) {
+  var _a;
+  const signals = (_a = candidate.signals) != null ? _a : {};
+  const score = normalizeSignal(signals.harvestThroughput) * 8 + normalizeSignal(signals.spawnUtilization) * 5 + normalizeSignal(signals.rclAcceleration) * 5 + normalizeSignal(signals.storageLogistics) * 4 + normalizeSignal(signals.energyBottleneck) * 4 + getSourceBenefit(roomState, candidate);
+  return Math.min(MAX_ECONOMIC_POINTS, Math.round(score));
+}
+function scoreVisionWeight(candidate) {
+  var _a;
+  const vision = (_a = candidate.vision) != null ? _a : {};
+  const score = normalizeSignal(vision.survival) * 15 + normalizeSignal(vision.territory) * 13 + normalizeSignal(vision.resources) * 9 + normalizeSignal(vision.enemyKills) * 5;
+  return Math.min(MAX_VISION_POINTS, Math.round(score));
+}
+function scoreRiskCost(roomState, candidate) {
+  var _a, _b, _c, _d, _e, _f, _g, _h;
+  const energyCost = (_b = (_a = candidate.estimatedEnergyCost) != null ? _a : STRUCTURE_BUILD_COSTS[candidate.buildType]) != null ? _b : 0;
+  const buildTicks = (_c = candidate.estimatedBuildTicks) != null ? _c : 0;
+  const energyRisk = Math.min(8, energyCost / 4e3);
+  const buildTimeRisk = Math.min(5, buildTicks / 1500);
+  const exposureRisk = EXPOSURE_COST[(_d = candidate.pathExposure) != null ? _d : "none"] + EXPOSURE_COST[(_e = candidate.hostileExposure) != null ? _e : "none"];
+  const backlogRisk = Math.max(0, (((_f = roomState.constructionSiteCount) != null ? _f : 0) - 3) * 1.5);
+  const hostilePressureRisk = ((_g = roomState.hostileCreepCount) != null ? _g : 0) > 0 && !isDefenseCandidate(candidate) ? 4 : 0;
+  const lowWorkerRisk = ((_h = roomState.workerCount) != null ? _h : MIN_SAFE_WORKERS_FOR_EXPANSION) < MIN_SAFE_WORKERS_FOR_EXPANSION && !isSurvivalCandidate(candidate) ? 4 : 0;
+  return Math.min(
+    MAX_RISK_COST,
+    Math.round(energyRisk + buildTimeRisk + exposureRisk + backlogRisk + hostilePressureRisk + lowWorkerRisk)
+  );
+}
+function applySurvivalGate(roomState, candidate, rawScore) {
+  var _a, _b;
+  if (!hasSurvivalPressure(roomState) || isSurvivalCandidate(candidate)) {
+    return rawScore;
+  }
+  const hardRecoveryPressure = ((_a = roomState.workerCount) != null ? _a : MIN_SAFE_WORKERS_FOR_EXPANSION) === 0 || ((_b = roomState.spawnCount) != null ? _b : 1) === 0 || getControllerDowngradePressure(roomState) >= 0.85 || getDefensePressure(roomState) >= 0.9;
+  return Math.min(rawScore, hardRecoveryPressure ? 45 : 60);
+}
+function classifyUrgency(score, urgencyMagnitude) {
+  if (score >= 85 || urgencyMagnitude >= 0.9) {
+    return "critical";
+  }
+  if (score >= 70 || urgencyMagnitude >= 0.7) {
+    return "high";
+  }
+  if (score >= 45 || urgencyMagnitude >= 0.4) {
+    return "medium";
+  }
+  return "low";
+}
+function compareConstructionPriorityScores(left, right) {
+  if (left.blocked !== right.blocked) {
+    return left.blocked ? 1 : -1;
+  }
+  return right.score - left.score || urgencyRank(right.urgency) - urgencyRank(left.urgency) || right.factors.visionWeight - left.factors.visionWeight || left.buildItem.localeCompare(right.buildItem) || left.room.localeCompare(right.room);
+}
+function urgencyRank(urgency) {
+  switch (urgency) {
+    case "critical":
+      return 4;
+    case "high":
+      return 3;
+    case "medium":
+      return 2;
+    case "low":
+      return 1;
+    case "blocked":
+      return 0;
+    default:
+      return 0;
+  }
+}
+function hasSurvivalPressure(roomState) {
+  var _a, _b;
+  return ((_a = roomState.workerCount) != null ? _a : MIN_SAFE_WORKERS_FOR_EXPANSION) === 0 || ((_b = roomState.spawnCount) != null ? _b : 1) === 0 || getControllerDowngradePressure(roomState) >= 0.7 || getDefensePressure(roomState) >= 0.7;
+}
+function isSurvivalCandidate(candidate) {
+  return isRecoveryCandidate(candidate) || isDefenseCandidate(candidate) || isControllerProtectionCandidate(candidate);
+}
+function isRecoveryCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "spawn" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.survivalRecovery) > 0;
+}
+function isControllerProtectionCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "container" || candidate.buildType === "road" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.controllerDowngrade) > 0;
+}
+function isDefenseCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "tower" || candidate.buildType === "rampart" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.defense) > 0;
+}
+function isEnergyCapacityCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "extension" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.energyBottleneck) > 0;
+}
+function isRepairSupportCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "road" || candidate.buildType === "container" || candidate.buildType === "rampart" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.repairDecay) > 0;
+}
+function getWorkerRecoveryPressure(roomState) {
+  if (roomState.spawnCount === 0) {
+    return 1;
+  }
+  const workerCount = roomState.workerCount;
+  if (typeof workerCount !== "number") {
+    return 0;
+  }
+  if (workerCount <= 0) {
+    return 1;
+  }
+  if (workerCount === 1) {
+    return 0.65;
+  }
+  if (workerCount === 2) {
+    return 0.35;
+  }
+  return 0;
+}
+function getControllerDowngradePressure(roomState) {
+  const ticksToDowngrade = roomState.controllerTicksToDowngrade;
+  if (typeof ticksToDowngrade !== "number") {
+    return 0;
+  }
+  if (ticksToDowngrade <= 1e3) {
+    return 1;
+  }
+  if (ticksToDowngrade <= CONTROLLER_DOWNGRADE_CRITICAL_TICKS) {
+    return 0.85;
+  }
+  if (ticksToDowngrade <= CONTROLLER_DOWNGRADE_WARNING_TICKS) {
+    return 0.35;
+  }
+  return 0;
+}
+function getDefensePressure(roomState) {
+  var _a, _b;
+  if (((_a = roomState.hostileCreepCount) != null ? _a : 0) > 0) {
+    return 0.9;
+  }
+  if (((_b = roomState.hostileStructureCount) != null ? _b : 0) > 0) {
+    return 0.55;
+  }
+  return 0;
+}
+function getEnergyBottleneckPressure(roomState) {
+  const energyCapacity = roomState.energyCapacity;
+  if (typeof energyCapacity !== "number") {
+    return 0;
+  }
+  if (energyCapacity < 350) {
+    return 0.85;
+  }
+  if (energyCapacity < EARLY_ENERGY_CAPACITY_TARGET) {
+    return 0.65;
+  }
+  return 0;
+}
+function getRepairDecayPressure(roomState) {
+  var _a, _b;
+  if (((_a = roomState.criticalRepairCount) != null ? _a : 0) > 0) {
+    return 0.7;
+  }
+  if (((_b = roomState.decayingStructureCount) != null ? _b : 0) > 0) {
+    return 0.35;
+  }
+  return 0;
+}
+function getSourceBenefit(roomState, candidate) {
+  var _a;
+  if (candidate.buildType !== "container" && candidate.buildType !== "road" && candidate.buildType !== "remote-logistics") {
+    return 0;
+  }
+  return Math.min(3, (_a = roomState.sourceCount) != null ? _a : 0);
+}
+function normalizeSignal(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+function clampScore(score) {
+  return Math.max(0, Math.min(MAX_SCORE, score));
+}
+function buildRuntimeConstructionPriorityState(colony, creeps) {
+  var _a, _b, _c;
+  const room = colony.room;
+  const ownedConstructionSites = findRoomObjects(room, "FIND_MY_CONSTRUCTION_SITES");
+  const ownedStructures = findRoomObjects(room, "FIND_MY_STRUCTURES");
+  const visibleStructures = findRoomObjects(room, "FIND_STRUCTURES");
+  const hostileCreeps = findRoomObjects(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects(room, "FIND_HOSTILE_STRUCTURES");
+  const sources = findRoomObjects(room, "FIND_SOURCES");
+  const colonyWorkers = creeps.filter((creep) => creep.memory.role === "worker" && creep.memory.colony === room.name);
+  const repairSignals = summarizeRepairSignals(visibleStructures);
+  const territoryIntentCounts = countTerritoryIntents(room.name);
+  return {
+    roomName: room.name,
+    rcl: ((_a = room.controller) == null ? void 0 : _a.my) === true ? room.controller.level : void 0,
+    energyAvailable: colony.energyAvailable,
+    energyCapacity: colony.energyCapacityAvailable,
+    workerCount: colonyWorkers.length,
+    spawnCount: colony.spawns.length,
+    sourceCount: sources == null ? void 0 : sources.length,
+    extensionCount: countStructuresByType(ownedStructures, "STRUCTURE_EXTENSION", "extension"),
+    towerCount: countStructuresByType(ownedStructures, "STRUCTURE_TOWER", "tower"),
+    constructionSiteCount: ownedConstructionSites == null ? void 0 : ownedConstructionSites.length,
+    criticalRepairCount: repairSignals == null ? void 0 : repairSignals.criticalRepairCount,
+    decayingStructureCount: repairSignals == null ? void 0 : repairSignals.decayingStructureCount,
+    controllerTicksToDowngrade: ((_b = room.controller) == null ? void 0 : _b.my) === true ? room.controller.ticksToDowngrade : void 0,
+    hostileCreepCount: hostileCreeps == null ? void 0 : hostileCreeps.length,
+    hostileStructureCount: hostileStructures == null ? void 0 : hostileStructures.length,
+    activeTerritoryIntentCount: territoryIntentCounts.active,
+    plannedTerritoryIntentCount: territoryIntentCounts.planned,
+    remoteLogisticsReady: false,
+    observations: {
+      "room-controller": ((_c = room.controller) == null ? void 0 : _c.my) === true && typeof room.controller.level === "number",
+      "energy-capacity": typeof colony.energyCapacityAvailable === "number",
+      "worker-count": true,
+      "spawn-count": true,
+      "construction-sites": ownedConstructionSites !== null,
+      "repair-decay": visibleStructures !== null,
+      "hostile-presence": hostileCreeps !== null && hostileStructures !== null,
+      sources: sources !== null,
+      "territory-intents": true,
+      "remote-paths": false
+    },
+    ownedConstructionSites,
+    ownedStructures,
+    visibleStructures
+  };
+}
+function buildRuntimeConstructionCandidates(state) {
+  const candidates = [
+    ...buildExistingSiteCandidates(state),
+    ...buildPlannedLocalCandidates(state),
+    ...buildRemoteLogisticsCandidates(state)
+  ];
+  if (candidates.length > 0) {
+    return candidates;
+  }
+  return [
+    {
+      buildItem: "observe construction backlog",
+      buildType: "observation",
+      requiredObservations: ["construction-sites"],
+      expectedKpiMovement: ["construction priority table becomes evidence-backed"],
+      risk: ["no build action should be selected until construction-site observations exist"],
+      vision: { resources: 0.2 }
+    }
+  ];
+}
+function buildExistingSiteCandidates(state) {
+  var _a;
+  return ((_a = state.ownedConstructionSites) != null ? _a : []).map((site) => {
+    const buildType = mapStructureTypeToBuildType(String(site.structureType));
+    return {
+      ...createCandidateForBuildType(buildType, state),
+      buildItem: `finish ${site.structureType} site`,
+      status: "existing-site",
+      estimatedEnergyCost: getConstructionSiteRemainingProgress(site)
+    };
+  });
+}
+function buildPlannedLocalCandidates(state) {
+  var _a, _b, _c, _d, _e;
+  const candidates = [];
+  const rcl = (_a = state.rcl) != null ? _a : 0;
+  const extensionLimit = getExtensionLimitForRcl(state.rcl);
+  if (extensionLimit > 0 && ((_b = state.extensionCount) != null ? _b : 0) < extensionLimit) {
+    candidates.push(createCandidateForBuildType("extension", state));
+  }
+  if (rcl >= 2 && ((_c = state.sourceCount) != null ? _c : 0) > 0) {
+    candidates.push(createCandidateForBuildType("road", state));
+    candidates.push(createCandidateForBuildType("container", state));
+  }
+  if (rcl >= 2 && getDefensePressure(state) > 0) {
+    candidates.push(createCandidateForBuildType("rampart", state));
+  }
+  if (rcl >= 3 && ((_d = state.towerCount) != null ? _d : 0) === 0) {
+    candidates.push(createCandidateForBuildType("tower", state));
+  }
+  if (((_e = state.spawnCount) != null ? _e : 1) === 0) {
+    candidates.push(createCandidateForBuildType("spawn", state));
+  }
+  return candidates;
+}
+function buildRemoteLogisticsCandidates(state) {
+  var _a, _b;
+  const territoryIntentCount = ((_a = state.activeTerritoryIntentCount) != null ? _a : 0) + ((_b = state.plannedTerritoryIntentCount) != null ? _b : 0);
+  if (territoryIntentCount === 0) {
+    return [];
+  }
+  return [createCandidateForBuildType("remote-logistics", state)];
+}
+function createCandidateForBuildType(buildType, state) {
+  var _a, _b;
+  switch (buildType) {
+    case "spawn":
+      return {
+        buildItem: "build spawn recovery",
+        buildType,
+        minimumRcl: 1,
+        requiredObservations: ["spawn-count", "worker-count", "room-controller"],
+        expectedKpiMovement: ["restores worker production and prevents room loss"],
+        risk: ["high energy commitment before economy is recovered"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.spawn,
+        signals: { survivalRecovery: 1, spawnUtilization: 0.8 },
+        vision: { survival: 1, territory: 0.6 }
+      };
+    case "extension":
+      return {
+        buildItem: "build extension capacity",
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ["room-controller", "energy-capacity", "worker-count", "construction-sites"],
+        expectedKpiMovement: ["raises spawn energy capacity", "unlocks larger workers and faster RCL progress"],
+        risk: ["adds build backlog before roads/containers if worker capacity is low"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.extension,
+        signals: {
+          energyBottleneck: getEnergyBottleneckPressure(state),
+          spawnUtilization: 0.8,
+          rclAcceleration: 0.65
+        },
+        vision: { resources: 1, territory: 0.35 }
+      };
+    case "tower":
+      return {
+        buildItem: "build tower defense",
+        buildType,
+        minimumRcl: 3,
+        requiredObservations: ["room-controller", "hostile-presence", "energy-capacity", "worker-count"],
+        expectedKpiMovement: ["improves room hold safety", "adds hostile damage and repair response capacity"],
+        risk: ["requires steady energy income to keep tower effective"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.tower,
+        hostileExposure: "medium",
+        signals: { defense: Math.max(0.75, getDefensePressure(state)), enemyKillPotential: 0.7 },
+        vision: { survival: getDefensePressure(state), territory: 0.9, enemyKills: 0.5 }
+      };
+    case "rampart":
+      return {
+        buildItem: "build rampart defense",
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ["room-controller", "hostile-presence", "repair-decay", "worker-count"],
+        expectedKpiMovement: ["improves spawn/controller survivability under pressure"],
+        risk: ["decays without sustained repair budget"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.rampart,
+        hostileExposure: "medium",
+        signals: { defense: getDefensePressure(state), repairDecay: getRepairDecayPressure(state) },
+        vision: { survival: getDefensePressure(state), territory: 0.8, enemyKills: 0.15 }
+      };
+    case "road":
+      return {
+        buildItem: "build source/controller roads",
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ["room-controller", "sources", "repair-decay", "worker-count"],
+        expectedKpiMovement: ["reduces worker travel time", "improves harvest-to-spawn throughput"],
+        risk: ["road decay creates recurring repair load"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.road,
+        pathExposure: "low",
+        signals: {
+          harvestThroughput: 0.55,
+          rclAcceleration: 0.45,
+          expansionPrerequisite: ((_a = state.activeTerritoryIntentCount) != null ? _a : 0) > 0 ? 0.45 : 0.2,
+          controllerDowngrade: getControllerDowngradePressure(state) >= 0.7 ? 0.55 : 0
+        },
+        vision: { resources: 0.8, territory: 0.45 }
+      };
+    case "container":
+      return {
+        buildItem: "build source containers",
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ["room-controller", "sources", "worker-count"],
+        expectedKpiMovement: ["raises harvest throughput", "reduces dropped-energy waste"],
+        risk: ["large early build cost and decay upkeep"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.container,
+        pathExposure: "low",
+        signals: {
+          harvestThroughput: 0.9,
+          storageLogistics: 0.65,
+          rclAcceleration: 0.35,
+          expansionPrerequisite: ((_b = state.activeTerritoryIntentCount) != null ? _b : 0) > 0 ? 0.4 : 0.15,
+          controllerDowngrade: getControllerDowngradePressure(state) >= 0.7 ? 0.5 : 0
+        },
+        vision: { resources: 1, territory: 0.35 }
+      };
+    case "storage":
+      return {
+        buildItem: "build storage logistics",
+        buildType,
+        minimumRcl: 4,
+        minimumWorkers: MIN_SAFE_WORKERS_FOR_EXPANSION,
+        requiredObservations: ["room-controller", "energy-capacity", "worker-count"],
+        expectedKpiMovement: ["improves durable resource buffering and logistics"],
+        risk: ["very high energy commitment"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.storage,
+        signals: { storageLogistics: 0.95 },
+        vision: { resources: 1, territory: 0.25 }
+      };
+    case "remote-logistics":
+      return {
+        buildItem: "build remote road/container logistics",
+        buildType,
+        minimumRcl: 2,
+        minimumWorkers: MIN_SAFE_WORKERS_FOR_EXPANSION,
+        requiresSafeHome: true,
+        requiredObservations: ["territory-intents", "remote-paths", "worker-count", "hostile-presence"],
+        expectedKpiMovement: ["turns reserved/scouted territory into sustainable income", "improves remote room hold viability"],
+        risk: ["path exposure and hostile pressure can waste builder time"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS["remote-logistics"],
+        pathExposure: "high",
+        hostileExposure: "medium",
+        signals: {
+          expansionPrerequisite: 1,
+          harvestThroughput: 0.75,
+          storageLogistics: 0.5
+        },
+        vision: { territory: 1, resources: 0.6 }
+      };
+    case "observation":
+    default:
+      return {
+        buildItem: "observe construction backlog",
+        buildType: "observation",
+        requiredObservations: ["construction-sites"],
+        expectedKpiMovement: ["construction priority table becomes evidence-backed"],
+        risk: ["no build action should be selected until construction-site observations exist"],
+        signals: {},
+        vision: { resources: 0.2 }
+      };
+  }
+}
+function mapStructureTypeToBuildType(structureType) {
+  if (matchesStructureType3(structureType, "STRUCTURE_SPAWN", "spawn")) {
+    return "spawn";
+  }
+  if (matchesStructureType3(structureType, "STRUCTURE_EXTENSION", "extension")) {
+    return "extension";
+  }
+  if (matchesStructureType3(structureType, "STRUCTURE_TOWER", "tower")) {
+    return "tower";
+  }
+  if (matchesStructureType3(structureType, "STRUCTURE_RAMPART", "rampart")) {
+    return "rampart";
+  }
+  if (matchesStructureType3(structureType, "STRUCTURE_ROAD", "road")) {
+    return "road";
+  }
+  if (matchesStructureType3(structureType, "STRUCTURE_CONTAINER", "container")) {
+    return "container";
+  }
+  if (matchesStructureType3(structureType, "STRUCTURE_STORAGE", "storage")) {
+    return "storage";
+  }
+  return "observation";
+}
+function getConstructionSiteRemainingProgress(site) {
+  var _a;
+  const progressTotal = typeof site.progressTotal === "number" ? site.progressTotal : (_a = STRUCTURE_BUILD_COSTS.observation) != null ? _a : 0;
+  const progress = typeof site.progress === "number" ? site.progress : 0;
+  return Math.max(0, progressTotal - progress);
+}
+function findRoomObjects(room, constantName) {
+  const findConstant = globalThis[constantName];
+  if (typeof findConstant !== "number" || typeof room.find !== "function") {
+    return null;
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return null;
+  }
+}
+function countStructuresByType(structures, globalName, fallback) {
+  return structures == null ? void 0 : structures.filter((structure) => matchesStructureType3(structure.structureType, globalName, fallback)).length;
+}
+function summarizeRepairSignals(structures) {
+  if (structures === null) {
+    return null;
+  }
+  return structures.reduce(
+    (summary, structure) => {
+      if (!isRepairSignalStructure(structure) || !hasHits(structure)) {
+        return summary;
+      }
+      const hitsRatio = structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
+      if (hitsRatio <= CRITICAL_REPAIR_HITS_RATIO) {
+        summary.criticalRepairCount += 1;
+      } else if (hitsRatio <= DECAYING_REPAIR_HITS_RATIO) {
+        summary.decayingStructureCount += 1;
+      }
+      return summary;
+    },
+    { criticalRepairCount: 0, decayingStructureCount: 0 }
+  );
+}
+function isRepairSignalStructure(structure) {
+  if (matchesStructureType3(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType3(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+    return true;
+  }
+  return matchesStructureType3(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true && structure.hits <= IDLE_RAMPART_REPAIR_HITS_CEILING2;
+}
+function hasHits(structure) {
+  return typeof structure.hits === "number" && typeof structure.hitsMax === "number";
+}
+function countTerritoryIntents(roomName) {
+  var _a, _b;
+  const intents = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.intents;
+  if (!Array.isArray(intents)) {
+    return { active: 0, planned: 0 };
+  }
+  return intents.reduce(
+    (counts, intent) => {
+      if (intent.colony !== roomName) {
+        return counts;
+      }
+      if (intent.status === "active") {
+        counts.active += 1;
+      } else if (intent.status === "planned") {
+        counts.planned += 1;
+      }
+      return counts;
+    },
+    { active: 0, planned: 0 }
+  );
+}
+function matchesStructureType3(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+
 // src/telemetry/runtimeSummary.ts
 var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
@@ -2748,7 +3521,8 @@ function summarizeRoom(colony, creeps) {
     taskCounts: countWorkerTasks(colonyWorkers),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
-    combat: summarizeCombat(colony.room, eventMetrics.combat)
+    combat: summarizeCombat(colony.room, eventMetrics.combat),
+    constructionPriority: summarizeConstructionPriority(colony, colonyWorkers)
   };
 }
 function summarizeSpawn(spawn) {
@@ -2808,9 +3582,9 @@ function buildControllerSummary(room) {
 }
 function summarizeResources(colony, colonyWorkers, events) {
   var _a, _b, _c;
-  const roomStructures = (_a = findRoomObjects(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const droppedResources = (_b = findRoomObjects(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _b : [];
-  const sources = (_c = findRoomObjects(colony.room, "FIND_SOURCES")) != null ? _c : [];
+  const roomStructures = (_a = findRoomObjects2(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const droppedResources = (_b = findRoomObjects2(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _b : [];
+  const sources = (_c = findRoomObjects2(colony.room, "FIND_SOURCES")) != null ? _c : [];
   return {
     storedEnergy: sumEnergyInStores(roomStructures),
     workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
@@ -2821,12 +3595,30 @@ function summarizeResources(colony, colonyWorkers, events) {
 }
 function summarizeCombat(room, events) {
   var _a, _b;
-  const hostileCreeps = (_a = findRoomObjects(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
-  const hostileStructures = (_b = findRoomObjects(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
+  const hostileCreeps = (_a = findRoomObjects2(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
+  const hostileStructures = (_b = findRoomObjects2(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
   return {
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
     ...events ? { events } : {}
+  };
+}
+function summarizeConstructionPriority(colony, colonyWorkers) {
+  const report = buildRuntimeConstructionPriorityReport(colony, colonyWorkers);
+  return {
+    candidates: report.candidates.map(toRuntimeConstructionPriorityCandidateSummary),
+    nextPrimary: report.nextPrimary ? toRuntimeConstructionPriorityCandidateSummary(report.nextPrimary) : null
+  };
+}
+function toRuntimeConstructionPriorityCandidateSummary(score) {
+  return {
+    buildItem: score.buildItem,
+    room: score.room,
+    score: score.score,
+    urgency: score.urgency,
+    preconditions: score.preconditions,
+    expectedKpiMovement: score.expectedKpiMovement,
+    risk: score.risk
   };
 }
 function summarizeRoomEventMetrics(room) {
@@ -2881,7 +3673,7 @@ function summarizeRoomEventMetrics(room) {
     ...hasCombatEvents ? { combat: combatEvents } : {}
   };
 }
-function findRoomObjects(room, constantName) {
+function findRoomObjects2(room, constantName) {
   const findConstant = getGlobalNumber(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -715,7 +715,7 @@ function buildRuntimeConstructionPriorityState(
   const hostileCreeps = findRoomObjects(room, 'FIND_HOSTILE_CREEPS') as Creep[] | null;
   const hostileStructures = findRoomObjects(room, 'FIND_HOSTILE_STRUCTURES') as Structure[] | null;
   const sources = findRoomObjects(room, 'FIND_SOURCES') as Source[] | null;
-  const colonyWorkers = creeps.filter((creep) => creep.memory.role === 'worker' && creep.memory.colony === room.name);
+  const colonyWorkers = creeps.filter((creep) => creep.memory?.role === 'worker' && creep.memory?.colony === room.name);
   const repairSignals = summarizeRepairSignals(visibleStructures);
   const territoryIntentCounts = countTerritoryIntents(room.name);
 
@@ -1101,6 +1101,10 @@ function countTerritoryIntents(roomName: string): { active: number; planned: num
 
   return intents.reduce(
     (counts, intent) => {
+      if (!isRecord(intent)) {
+        return counts;
+      }
+
       if (intent.colony !== roomName) {
         return counts;
       }
@@ -1115,6 +1119,10 @@ function countTerritoryIntents(roomName: string): { active: number; planned: num
     },
     { active: 0, planned: 0 }
   );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function matchesStructureType(

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -1,0 +1,1127 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { getExtensionLimitForRcl } from './extensionPlanner';
+
+export type ConstructionVisionLayer = 'survival' | 'territory' | 'resources' | 'enemyKills';
+
+export type ConstructionPriorityObservation =
+  | 'room-controller'
+  | 'energy-capacity'
+  | 'worker-count'
+  | 'spawn-count'
+  | 'construction-sites'
+  | 'repair-decay'
+  | 'hostile-presence'
+  | 'sources'
+  | 'territory-intents'
+  | 'remote-paths';
+
+export type ConstructionPriorityUrgency = 'blocked' | 'critical' | 'high' | 'medium' | 'low';
+
+export type ConstructionPriorityBuildType =
+  | 'spawn'
+  | 'extension'
+  | 'tower'
+  | 'rampart'
+  | 'road'
+  | 'container'
+  | 'storage'
+  | 'remote-logistics'
+  | 'observation';
+
+export type ConstructionPriorityExposure = 'none' | 'low' | 'medium' | 'high';
+
+export interface ConstructionPrioritySignals {
+  survivalRecovery?: number;
+  controllerDowngrade?: number;
+  defense?: number;
+  energyBottleneck?: number;
+  repairDecay?: number;
+  expansionPrerequisite?: number;
+  harvestThroughput?: number;
+  spawnUtilization?: number;
+  rclAcceleration?: number;
+  storageLogistics?: number;
+  enemyKillPotential?: number;
+}
+
+export interface ConstructionPriorityRoomState {
+  roomName: string;
+  rcl?: number;
+  energyAvailable?: number;
+  energyCapacity?: number;
+  workerCount?: number;
+  spawnCount?: number;
+  sourceCount?: number;
+  extensionCount?: number;
+  towerCount?: number;
+  constructionSiteCount?: number;
+  criticalRepairCount?: number;
+  decayingStructureCount?: number;
+  controllerTicksToDowngrade?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  activeTerritoryIntentCount?: number;
+  plannedTerritoryIntentCount?: number;
+  remoteLogisticsReady?: boolean;
+  observations?: Partial<Record<ConstructionPriorityObservation, boolean>>;
+}
+
+export interface ConstructionBuildCandidate {
+  buildItem: string;
+  roomName?: string;
+  buildType: ConstructionPriorityBuildType;
+  status?: 'existing-site' | 'planned';
+  minimumRcl?: number;
+  minimumWorkers?: number;
+  minimumEnergyCapacity?: number;
+  requiresSafeHome?: boolean;
+  requiredObservations?: ConstructionPriorityObservation[];
+  preconditions?: string[];
+  expectedKpiMovement: string[];
+  risk?: string[];
+  estimatedEnergyCost?: number;
+  estimatedBuildTicks?: number;
+  pathExposure?: ConstructionPriorityExposure;
+  hostileExposure?: ConstructionPriorityExposure;
+  signals?: ConstructionPrioritySignals;
+  vision?: Partial<Record<ConstructionVisionLayer, number>>;
+}
+
+export interface ConstructionPriorityFactors {
+  urgency: number;
+  roomState: number;
+  expansionPrerequisites: number;
+  economicBenefit: number;
+  visionWeight: number;
+  riskCost: number;
+}
+
+export interface ConstructionPriorityScore {
+  buildItem: string;
+  room: string;
+  score: number;
+  urgency: ConstructionPriorityUrgency;
+  preconditions: string[];
+  expectedKpiMovement: string[];
+  risk: string[];
+  factors: ConstructionPriorityFactors;
+  missingObservations: ConstructionPriorityObservation[];
+  blocked: boolean;
+}
+
+export interface ConstructionPriorityReport {
+  candidates: ConstructionPriorityScore[];
+  nextPrimary: ConstructionPriorityScore | null;
+}
+
+interface RuntimeConstructionPriorityState extends ConstructionPriorityRoomState {
+  ownedConstructionSites: ConstructionSite[] | null;
+  ownedStructures: AnyOwnedStructure[] | null;
+  visibleStructures: AnyStructure[] | null;
+}
+
+const CONTROLLER_DOWNGRADE_CRITICAL_TICKS = 5_000;
+const CONTROLLER_DOWNGRADE_WARNING_TICKS = 10_000;
+const EARLY_ENERGY_CAPACITY_TARGET = 550;
+const MIN_SAFE_WORKERS_FOR_EXPANSION = 3;
+const MAX_SCORE = 100;
+const MAX_URGENCY_POINTS = 35;
+const MAX_ROOM_STATE_POINTS = 20;
+const MAX_EXPANSION_POINTS = 20;
+const MAX_ECONOMIC_POINTS = 20;
+const MAX_VISION_POINTS = 15;
+const MAX_RISK_COST = 25;
+const CRITICAL_REPAIR_HITS_RATIO = 0.5;
+const DECAYING_REPAIR_HITS_RATIO = 0.8;
+const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
+
+const STRUCTURE_BUILD_COSTS: Partial<Record<ConstructionPriorityBuildType, number>> = {
+  spawn: 15_000,
+  extension: 3_000,
+  tower: 5_000,
+  rampart: 1,
+  road: 300,
+  container: 5_000,
+  storage: 30_000,
+  'remote-logistics': 5_000,
+  observation: 0
+};
+
+const EXPOSURE_COST: Record<ConstructionPriorityExposure, number> = {
+  none: 0,
+  low: 2,
+  medium: 5,
+  high: 9
+};
+
+const OBSERVATION_LABELS: Record<ConstructionPriorityObservation, string> = {
+  'room-controller': 'missing observation: room controller/RCL',
+  'energy-capacity': 'missing observation: room energy capacity',
+  'worker-count': 'missing observation: available worker count',
+  'spawn-count': 'missing observation: spawn count',
+  'construction-sites': 'missing observation: construction site backlog',
+  'repair-decay': 'missing observation: repair/decay signals',
+  'hostile-presence': 'missing observation: hostile pressure',
+  sources: 'missing observation: source count',
+  'territory-intents': 'missing observation: territory intent state',
+  'remote-paths': 'missing observation: remote path/logistics exposure'
+};
+
+export function scoreConstructionPriorities(
+  roomState: ConstructionPriorityRoomState,
+  candidates: ConstructionBuildCandidate[]
+): ConstructionPriorityReport {
+  const scoredCandidates = candidates
+    .map((candidate) => scoreConstructionCandidate(roomState, candidate))
+    .sort(compareConstructionPriorityScores);
+
+  return {
+    candidates: scoredCandidates,
+    nextPrimary: selectNextPrimaryConstruction(scoredCandidates)
+  };
+}
+
+export function scoreConstructionCandidate(
+  roomState: ConstructionPriorityRoomState,
+  candidate: ConstructionBuildCandidate
+): ConstructionPriorityScore {
+  const missingObservations = getMissingObservations(roomState, candidate);
+  const blockingPreconditions = getBlockingPreconditions(roomState, candidate, missingObservations);
+  const preconditions = [
+    ...(candidate.preconditions ?? []),
+    ...missingObservations.map((observation) => OBSERVATION_LABELS[observation]),
+    ...blockingPreconditions
+  ];
+  const blocked = missingObservations.length > 0 || blockingPreconditions.length > 0;
+
+  if (blocked) {
+    return {
+      buildItem: candidate.buildItem,
+      room: candidate.roomName ?? roomState.roomName,
+      score: 0,
+      urgency: 'blocked',
+      preconditions,
+      expectedKpiMovement: candidate.expectedKpiMovement,
+      risk: candidate.risk ?? [],
+      factors: {
+        urgency: 0,
+        roomState: 0,
+        expansionPrerequisites: 0,
+        economicBenefit: 0,
+        visionWeight: 0,
+        riskCost: 0
+      },
+      missingObservations,
+      blocked
+    };
+  }
+
+  const urgencyMagnitude = getUrgencyMagnitude(roomState, candidate);
+  const factors: ConstructionPriorityFactors = {
+    urgency: Math.round(urgencyMagnitude * MAX_URGENCY_POINTS),
+    roomState: scoreRoomState(roomState, candidate),
+    expansionPrerequisites: scoreExpansionPrerequisites(roomState, candidate),
+    economicBenefit: scoreEconomicBenefit(roomState, candidate),
+    visionWeight: scoreVisionWeight(candidate),
+    riskCost: scoreRiskCost(roomState, candidate)
+  };
+  const rawScore =
+    factors.urgency +
+    factors.roomState +
+    factors.expansionPrerequisites +
+    factors.economicBenefit +
+    factors.visionWeight -
+    factors.riskCost;
+  const gatedScore = applySurvivalGate(roomState, candidate, rawScore);
+  const score = clampScore(Math.round(gatedScore));
+
+  return {
+    buildItem: candidate.buildItem,
+    room: candidate.roomName ?? roomState.roomName,
+    score,
+    urgency: classifyUrgency(score, urgencyMagnitude),
+    preconditions,
+    expectedKpiMovement: candidate.expectedKpiMovement,
+    risk: candidate.risk ?? [],
+    factors,
+    missingObservations,
+    blocked
+  };
+}
+
+export function selectNextPrimaryConstruction(
+  candidates: ConstructionPriorityScore[]
+): ConstructionPriorityScore | null {
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.find((candidate) => !candidate.blocked) ?? candidates[0];
+}
+
+export function buildRuntimeConstructionPriorityReport(
+  colony: ColonySnapshot,
+  creeps: Creep[]
+): ConstructionPriorityReport {
+  const state = buildRuntimeConstructionPriorityState(colony, creeps);
+  return scoreConstructionPriorities(state, buildRuntimeConstructionCandidates(state));
+}
+
+function getMissingObservations(
+  roomState: ConstructionPriorityRoomState,
+  candidate: ConstructionBuildCandidate
+): ConstructionPriorityObservation[] {
+  return (candidate.requiredObservations ?? []).filter((observation) => !hasObservation(roomState, observation));
+}
+
+function hasObservation(
+  roomState: ConstructionPriorityRoomState,
+  observation: ConstructionPriorityObservation
+): boolean {
+  const explicitObservation = roomState.observations?.[observation];
+  if (typeof explicitObservation === 'boolean') {
+    return explicitObservation;
+  }
+
+  switch (observation) {
+    case 'room-controller':
+      return typeof roomState.rcl === 'number';
+    case 'energy-capacity':
+      return typeof roomState.energyCapacity === 'number';
+    case 'worker-count':
+      return typeof roomState.workerCount === 'number';
+    case 'spawn-count':
+      return typeof roomState.spawnCount === 'number';
+    case 'construction-sites':
+      return typeof roomState.constructionSiteCount === 'number';
+    case 'repair-decay':
+      return typeof roomState.criticalRepairCount === 'number' && typeof roomState.decayingStructureCount === 'number';
+    case 'hostile-presence':
+      return typeof roomState.hostileCreepCount === 'number' && typeof roomState.hostileStructureCount === 'number';
+    case 'sources':
+      return typeof roomState.sourceCount === 'number';
+    case 'territory-intents':
+      return typeof roomState.activeTerritoryIntentCount === 'number' && typeof roomState.plannedTerritoryIntentCount === 'number';
+    case 'remote-paths':
+      return roomState.remoteLogisticsReady === true;
+    default:
+      return false;
+  }
+}
+
+function getBlockingPreconditions(
+  roomState: ConstructionPriorityRoomState,
+  candidate: ConstructionBuildCandidate,
+  missingObservations: ConstructionPriorityObservation[]
+): string[] {
+  if (missingObservations.length > 0) {
+    return [];
+  }
+
+  const preconditions: string[] = [];
+  if (typeof candidate.minimumRcl === 'number' && (roomState.rcl ?? 0) < candidate.minimumRcl) {
+    preconditions.push(`requires RCL ${candidate.minimumRcl} (current RCL ${roomState.rcl ?? 'unknown'})`);
+  }
+
+  if (typeof candidate.minimumWorkers === 'number' && (roomState.workerCount ?? 0) < candidate.minimumWorkers) {
+    preconditions.push(`needs ${candidate.minimumWorkers} available workers (current ${roomState.workerCount ?? 'unknown'})`);
+  }
+
+  if (
+    typeof candidate.minimumEnergyCapacity === 'number' &&
+    (roomState.energyCapacity ?? 0) < candidate.minimumEnergyCapacity
+  ) {
+    preconditions.push(
+      `needs ${candidate.minimumEnergyCapacity} energy capacity (current ${roomState.energyCapacity ?? 'unknown'})`
+    );
+  }
+
+  if (candidate.requiresSafeHome && hasSurvivalPressure(roomState)) {
+    preconditions.push('resolve survival/recovery pressure before expansion construction');
+  }
+
+  return preconditions;
+}
+
+function getUrgencyMagnitude(
+  roomState: ConstructionPriorityRoomState,
+  candidate: ConstructionBuildCandidate
+): number {
+  const signals = candidate.signals ?? {};
+  const recoveryUrgency = Math.max(
+    normalizeSignal(signals.survivalRecovery),
+    isRecoveryCandidate(candidate) ? getWorkerRecoveryPressure(roomState) : 0
+  );
+  const downgradeUrgency = Math.max(
+    normalizeSignal(signals.controllerDowngrade),
+    isControllerProtectionCandidate(candidate) ? getControllerDowngradePressure(roomState) : 0
+  );
+  const defenseUrgency = Math.max(
+    normalizeSignal(signals.defense),
+    isDefenseCandidate(candidate) ? getDefensePressure(roomState) : 0
+  );
+  const energyUrgency = Math.max(
+    normalizeSignal(signals.energyBottleneck),
+    isEnergyCapacityCandidate(candidate) ? getEnergyBottleneckPressure(roomState) : 0
+  );
+  const repairUrgency = Math.max(
+    normalizeSignal(signals.repairDecay),
+    isRepairSupportCandidate(candidate) ? getRepairDecayPressure(roomState) : 0
+  );
+
+  return Math.max(recoveryUrgency, downgradeUrgency, defenseUrgency, energyUrgency, repairUrgency);
+}
+
+function scoreRoomState(roomState: ConstructionPriorityRoomState, candidate: ConstructionBuildCandidate): number {
+  let score = 0;
+
+  if (candidate.status === 'existing-site') {
+    score += 4;
+  }
+
+  if (typeof roomState.rcl === 'number' && (!candidate.minimumRcl || roomState.rcl >= candidate.minimumRcl)) {
+    score += Math.min(5, Math.max(1, roomState.rcl));
+  }
+
+  if (isRecoveryCandidate(candidate)) {
+    score += Math.round(getWorkerRecoveryPressure(roomState) * 7);
+  } else if ((roomState.workerCount ?? 0) >= MIN_SAFE_WORKERS_FOR_EXPANSION) {
+    score += 4;
+  }
+
+  if (isEnergyCapacityCandidate(candidate) && (roomState.energyCapacity ?? EARLY_ENERGY_CAPACITY_TARGET) < EARLY_ENERGY_CAPACITY_TARGET) {
+    score += 4;
+  }
+
+  if (isRepairSupportCandidate(candidate)) {
+    score += Math.min(4, (roomState.criticalRepairCount ?? 0) * 2 + (roomState.decayingStructureCount ?? 0));
+  }
+
+  if (isDefenseCandidate(candidate)) {
+    score += Math.round(getDefensePressure(roomState) * 5);
+  }
+
+  if ((roomState.constructionSiteCount ?? 0) > 0 && candidate.status === 'existing-site') {
+    score += 2;
+  }
+
+  return Math.min(MAX_ROOM_STATE_POINTS, score);
+}
+
+function scoreExpansionPrerequisites(
+  roomState: ConstructionPriorityRoomState,
+  candidate: ConstructionBuildCandidate
+): number {
+  const signal = normalizeSignal(candidate.signals?.expansionPrerequisite);
+  const territoryIntentPressure = Math.min(
+    1,
+    ((roomState.activeTerritoryIntentCount ?? 0) * 0.7) + ((roomState.plannedTerritoryIntentCount ?? 0) * 0.45)
+  );
+  const structureMultiplier =
+    candidate.buildType === 'remote-logistics' ||
+    candidate.buildType === 'road' ||
+    candidate.buildType === 'container' ||
+    candidate.buildType === 'tower' ||
+    candidate.buildType === 'rampart'
+      ? 1
+      : 0.35;
+
+  return Math.min(
+    MAX_EXPANSION_POINTS,
+    Math.round(signal * 14 + territoryIntentPressure * structureMultiplier * 6)
+  );
+}
+
+function scoreEconomicBenefit(
+  roomState: ConstructionPriorityRoomState,
+  candidate: ConstructionBuildCandidate
+): number {
+  const signals = candidate.signals ?? {};
+  const score =
+    normalizeSignal(signals.harvestThroughput) * 8 +
+    normalizeSignal(signals.spawnUtilization) * 5 +
+    normalizeSignal(signals.rclAcceleration) * 5 +
+    normalizeSignal(signals.storageLogistics) * 4 +
+    normalizeSignal(signals.energyBottleneck) * 4 +
+    getSourceBenefit(roomState, candidate);
+
+  return Math.min(MAX_ECONOMIC_POINTS, Math.round(score));
+}
+
+function scoreVisionWeight(candidate: ConstructionBuildCandidate): number {
+  const vision = candidate.vision ?? {};
+  const score =
+    normalizeSignal(vision.survival) * 15 +
+    normalizeSignal(vision.territory) * 13 +
+    normalizeSignal(vision.resources) * 9 +
+    normalizeSignal(vision.enemyKills) * 5;
+
+  return Math.min(MAX_VISION_POINTS, Math.round(score));
+}
+
+function scoreRiskCost(roomState: ConstructionPriorityRoomState, candidate: ConstructionBuildCandidate): number {
+  const energyCost = candidate.estimatedEnergyCost ?? STRUCTURE_BUILD_COSTS[candidate.buildType] ?? 0;
+  const buildTicks = candidate.estimatedBuildTicks ?? 0;
+  const energyRisk = Math.min(8, energyCost / 4_000);
+  const buildTimeRisk = Math.min(5, buildTicks / 1_500);
+  const exposureRisk =
+    EXPOSURE_COST[candidate.pathExposure ?? 'none'] + EXPOSURE_COST[candidate.hostileExposure ?? 'none'];
+  const backlogRisk = Math.max(0, ((roomState.constructionSiteCount ?? 0) - 3) * 1.5);
+  const hostilePressureRisk = (roomState.hostileCreepCount ?? 0) > 0 && !isDefenseCandidate(candidate) ? 4 : 0;
+  const lowWorkerRisk =
+    (roomState.workerCount ?? MIN_SAFE_WORKERS_FOR_EXPANSION) < MIN_SAFE_WORKERS_FOR_EXPANSION &&
+    !isSurvivalCandidate(candidate)
+      ? 4
+      : 0;
+
+  return Math.min(
+    MAX_RISK_COST,
+    Math.round(energyRisk + buildTimeRisk + exposureRisk + backlogRisk + hostilePressureRisk + lowWorkerRisk)
+  );
+}
+
+function applySurvivalGate(
+  roomState: ConstructionPriorityRoomState,
+  candidate: ConstructionBuildCandidate,
+  rawScore: number
+): number {
+  if (!hasSurvivalPressure(roomState) || isSurvivalCandidate(candidate)) {
+    return rawScore;
+  }
+
+  const hardRecoveryPressure =
+    (roomState.workerCount ?? MIN_SAFE_WORKERS_FOR_EXPANSION) === 0 ||
+    (roomState.spawnCount ?? 1) === 0 ||
+    getControllerDowngradePressure(roomState) >= 0.85 ||
+    getDefensePressure(roomState) >= 0.9;
+
+  return Math.min(rawScore, hardRecoveryPressure ? 45 : 60);
+}
+
+function classifyUrgency(score: number, urgencyMagnitude: number): ConstructionPriorityUrgency {
+  if (score >= 85 || urgencyMagnitude >= 0.9) {
+    return 'critical';
+  }
+
+  if (score >= 70 || urgencyMagnitude >= 0.7) {
+    return 'high';
+  }
+
+  if (score >= 45 || urgencyMagnitude >= 0.4) {
+    return 'medium';
+  }
+
+  return 'low';
+}
+
+function compareConstructionPriorityScores(
+  left: ConstructionPriorityScore,
+  right: ConstructionPriorityScore
+): number {
+  if (left.blocked !== right.blocked) {
+    return left.blocked ? 1 : -1;
+  }
+
+  return (
+    right.score - left.score ||
+    urgencyRank(right.urgency) - urgencyRank(left.urgency) ||
+    right.factors.visionWeight - left.factors.visionWeight ||
+    left.buildItem.localeCompare(right.buildItem) ||
+    left.room.localeCompare(right.room)
+  );
+}
+
+function urgencyRank(urgency: ConstructionPriorityUrgency): number {
+  switch (urgency) {
+    case 'critical':
+      return 4;
+    case 'high':
+      return 3;
+    case 'medium':
+      return 2;
+    case 'low':
+      return 1;
+    case 'blocked':
+      return 0;
+    default:
+      return 0;
+  }
+}
+
+function hasSurvivalPressure(roomState: ConstructionPriorityRoomState): boolean {
+  return (
+    (roomState.workerCount ?? MIN_SAFE_WORKERS_FOR_EXPANSION) === 0 ||
+    (roomState.spawnCount ?? 1) === 0 ||
+    getControllerDowngradePressure(roomState) >= 0.7 ||
+    getDefensePressure(roomState) >= 0.7
+  );
+}
+
+function isSurvivalCandidate(candidate: ConstructionBuildCandidate): boolean {
+  return isRecoveryCandidate(candidate) || isDefenseCandidate(candidate) || isControllerProtectionCandidate(candidate);
+}
+
+function isRecoveryCandidate(candidate: ConstructionBuildCandidate): boolean {
+  return (
+    candidate.buildType === 'spawn' ||
+    normalizeSignal(candidate.signals?.survivalRecovery) > 0
+  );
+}
+
+function isControllerProtectionCandidate(candidate: ConstructionBuildCandidate): boolean {
+  return (
+    candidate.buildType === 'container' ||
+    candidate.buildType === 'road' ||
+    normalizeSignal(candidate.signals?.controllerDowngrade) > 0
+  );
+}
+
+function isDefenseCandidate(candidate: ConstructionBuildCandidate): boolean {
+  return (
+    candidate.buildType === 'tower' ||
+    candidate.buildType === 'rampart' ||
+    normalizeSignal(candidate.signals?.defense) > 0
+  );
+}
+
+function isEnergyCapacityCandidate(candidate: ConstructionBuildCandidate): boolean {
+  return candidate.buildType === 'extension' || normalizeSignal(candidate.signals?.energyBottleneck) > 0;
+}
+
+function isRepairSupportCandidate(candidate: ConstructionBuildCandidate): boolean {
+  return (
+    candidate.buildType === 'road' ||
+    candidate.buildType === 'container' ||
+    candidate.buildType === 'rampart' ||
+    normalizeSignal(candidate.signals?.repairDecay) > 0
+  );
+}
+
+function getWorkerRecoveryPressure(roomState: ConstructionPriorityRoomState): number {
+  if (roomState.spawnCount === 0) {
+    return 1;
+  }
+
+  const workerCount = roomState.workerCount;
+  if (typeof workerCount !== 'number') {
+    return 0;
+  }
+
+  if (workerCount <= 0) {
+    return 1;
+  }
+
+  if (workerCount === 1) {
+    return 0.65;
+  }
+
+  if (workerCount === 2) {
+    return 0.35;
+  }
+
+  return 0;
+}
+
+function getControllerDowngradePressure(roomState: ConstructionPriorityRoomState): number {
+  const ticksToDowngrade = roomState.controllerTicksToDowngrade;
+  if (typeof ticksToDowngrade !== 'number') {
+    return 0;
+  }
+
+  if (ticksToDowngrade <= 1_000) {
+    return 1;
+  }
+
+  if (ticksToDowngrade <= CONTROLLER_DOWNGRADE_CRITICAL_TICKS) {
+    return 0.85;
+  }
+
+  if (ticksToDowngrade <= CONTROLLER_DOWNGRADE_WARNING_TICKS) {
+    return 0.35;
+  }
+
+  return 0;
+}
+
+function getDefensePressure(roomState: ConstructionPriorityRoomState): number {
+  if ((roomState.hostileCreepCount ?? 0) > 0) {
+    return 0.9;
+  }
+
+  if ((roomState.hostileStructureCount ?? 0) > 0) {
+    return 0.55;
+  }
+
+  return 0;
+}
+
+function getEnergyBottleneckPressure(roomState: ConstructionPriorityRoomState): number {
+  const energyCapacity = roomState.energyCapacity;
+  if (typeof energyCapacity !== 'number') {
+    return 0;
+  }
+
+  if (energyCapacity < 350) {
+    return 0.85;
+  }
+
+  if (energyCapacity < EARLY_ENERGY_CAPACITY_TARGET) {
+    return 0.65;
+  }
+
+  return 0;
+}
+
+function getRepairDecayPressure(roomState: ConstructionPriorityRoomState): number {
+  if ((roomState.criticalRepairCount ?? 0) > 0) {
+    return 0.7;
+  }
+
+  if ((roomState.decayingStructureCount ?? 0) > 0) {
+    return 0.35;
+  }
+
+  return 0;
+}
+
+function getSourceBenefit(roomState: ConstructionPriorityRoomState, candidate: ConstructionBuildCandidate): number {
+  if (candidate.buildType !== 'container' && candidate.buildType !== 'road' && candidate.buildType !== 'remote-logistics') {
+    return 0;
+  }
+
+  return Math.min(3, roomState.sourceCount ?? 0);
+}
+
+function normalizeSignal(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(1, value));
+}
+
+function clampScore(score: number): number {
+  return Math.max(0, Math.min(MAX_SCORE, score));
+}
+
+function buildRuntimeConstructionPriorityState(
+  colony: ColonySnapshot,
+  creeps: Creep[]
+): RuntimeConstructionPriorityState {
+  const room = colony.room;
+  const ownedConstructionSites = findRoomObjects(room, 'FIND_MY_CONSTRUCTION_SITES') as ConstructionSite[] | null;
+  const ownedStructures = findRoomObjects(room, 'FIND_MY_STRUCTURES') as AnyOwnedStructure[] | null;
+  const visibleStructures = findRoomObjects(room, 'FIND_STRUCTURES') as AnyStructure[] | null;
+  const hostileCreeps = findRoomObjects(room, 'FIND_HOSTILE_CREEPS') as Creep[] | null;
+  const hostileStructures = findRoomObjects(room, 'FIND_HOSTILE_STRUCTURES') as Structure[] | null;
+  const sources = findRoomObjects(room, 'FIND_SOURCES') as Source[] | null;
+  const colonyWorkers = creeps.filter((creep) => creep.memory.role === 'worker' && creep.memory.colony === room.name);
+  const repairSignals = summarizeRepairSignals(visibleStructures);
+  const territoryIntentCounts = countTerritoryIntents(room.name);
+
+  return {
+    roomName: room.name,
+    rcl: room.controller?.my === true ? room.controller.level : undefined,
+    energyAvailable: colony.energyAvailable,
+    energyCapacity: colony.energyCapacityAvailable,
+    workerCount: colonyWorkers.length,
+    spawnCount: colony.spawns.length,
+    sourceCount: sources?.length,
+    extensionCount: countStructuresByType(ownedStructures, 'STRUCTURE_EXTENSION', 'extension'),
+    towerCount: countStructuresByType(ownedStructures, 'STRUCTURE_TOWER', 'tower'),
+    constructionSiteCount: ownedConstructionSites?.length,
+    criticalRepairCount: repairSignals?.criticalRepairCount,
+    decayingStructureCount: repairSignals?.decayingStructureCount,
+    controllerTicksToDowngrade: room.controller?.my === true ? room.controller.ticksToDowngrade : undefined,
+    hostileCreepCount: hostileCreeps?.length,
+    hostileStructureCount: hostileStructures?.length,
+    activeTerritoryIntentCount: territoryIntentCounts.active,
+    plannedTerritoryIntentCount: territoryIntentCounts.planned,
+    remoteLogisticsReady: false,
+    observations: {
+      'room-controller': room.controller?.my === true && typeof room.controller.level === 'number',
+      'energy-capacity': typeof colony.energyCapacityAvailable === 'number',
+      'worker-count': true,
+      'spawn-count': true,
+      'construction-sites': ownedConstructionSites !== null,
+      'repair-decay': visibleStructures !== null,
+      'hostile-presence': hostileCreeps !== null && hostileStructures !== null,
+      sources: sources !== null,
+      'territory-intents': true,
+      'remote-paths': false
+    },
+    ownedConstructionSites,
+    ownedStructures,
+    visibleStructures
+  };
+}
+
+function buildRuntimeConstructionCandidates(state: RuntimeConstructionPriorityState): ConstructionBuildCandidate[] {
+  const candidates = [
+    ...buildExistingSiteCandidates(state),
+    ...buildPlannedLocalCandidates(state),
+    ...buildRemoteLogisticsCandidates(state)
+  ];
+
+  if (candidates.length > 0) {
+    return candidates;
+  }
+
+  return [
+    {
+      buildItem: 'observe construction backlog',
+      buildType: 'observation',
+      requiredObservations: ['construction-sites'],
+      expectedKpiMovement: ['construction priority table becomes evidence-backed'],
+      risk: ['no build action should be selected until construction-site observations exist'],
+      vision: { resources: 0.2 }
+    }
+  ];
+}
+
+function buildExistingSiteCandidates(state: RuntimeConstructionPriorityState): ConstructionBuildCandidate[] {
+  return (state.ownedConstructionSites ?? []).map((site) => {
+    const buildType = mapStructureTypeToBuildType(String(site.structureType));
+    return {
+      ...createCandidateForBuildType(buildType, state),
+      buildItem: `finish ${site.structureType} site`,
+      status: 'existing-site' as const,
+      estimatedEnergyCost: getConstructionSiteRemainingProgress(site)
+    };
+  });
+}
+
+function buildPlannedLocalCandidates(state: RuntimeConstructionPriorityState): ConstructionBuildCandidate[] {
+  const candidates: ConstructionBuildCandidate[] = [];
+  const rcl = state.rcl ?? 0;
+  const extensionLimit = getExtensionLimitForRcl(state.rcl);
+  if (extensionLimit > 0 && (state.extensionCount ?? 0) < extensionLimit) {
+    candidates.push(createCandidateForBuildType('extension', state));
+  }
+
+  if (rcl >= 2 && (state.sourceCount ?? 0) > 0) {
+    candidates.push(createCandidateForBuildType('road', state));
+    candidates.push(createCandidateForBuildType('container', state));
+  }
+
+  if (rcl >= 2 && getDefensePressure(state) > 0) {
+    candidates.push(createCandidateForBuildType('rampart', state));
+  }
+
+  if (rcl >= 3 && (state.towerCount ?? 0) === 0) {
+    candidates.push(createCandidateForBuildType('tower', state));
+  }
+
+  if ((state.spawnCount ?? 1) === 0) {
+    candidates.push(createCandidateForBuildType('spawn', state));
+  }
+
+  return candidates;
+}
+
+function buildRemoteLogisticsCandidates(state: RuntimeConstructionPriorityState): ConstructionBuildCandidate[] {
+  const territoryIntentCount = (state.activeTerritoryIntentCount ?? 0) + (state.plannedTerritoryIntentCount ?? 0);
+  if (territoryIntentCount === 0) {
+    return [];
+  }
+
+  return [createCandidateForBuildType('remote-logistics', state)];
+}
+
+function createCandidateForBuildType(
+  buildType: ConstructionPriorityBuildType,
+  state: ConstructionPriorityRoomState
+): ConstructionBuildCandidate {
+  switch (buildType) {
+    case 'spawn':
+      return {
+        buildItem: 'build spawn recovery',
+        buildType,
+        minimumRcl: 1,
+        requiredObservations: ['spawn-count', 'worker-count', 'room-controller'],
+        expectedKpiMovement: ['restores worker production and prevents room loss'],
+        risk: ['high energy commitment before economy is recovered'],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.spawn,
+        signals: { survivalRecovery: 1, spawnUtilization: 0.8 },
+        vision: { survival: 1, territory: 0.6 }
+      };
+    case 'extension':
+      return {
+        buildItem: 'build extension capacity',
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ['room-controller', 'energy-capacity', 'worker-count', 'construction-sites'],
+        expectedKpiMovement: ['raises spawn energy capacity', 'unlocks larger workers and faster RCL progress'],
+        risk: ['adds build backlog before roads/containers if worker capacity is low'],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.extension,
+        signals: {
+          energyBottleneck: getEnergyBottleneckPressure(state),
+          spawnUtilization: 0.8,
+          rclAcceleration: 0.65
+        },
+        vision: { resources: 1, territory: 0.35 }
+      };
+    case 'tower':
+      return {
+        buildItem: 'build tower defense',
+        buildType,
+        minimumRcl: 3,
+        requiredObservations: ['room-controller', 'hostile-presence', 'energy-capacity', 'worker-count'],
+        expectedKpiMovement: ['improves room hold safety', 'adds hostile damage and repair response capacity'],
+        risk: ['requires steady energy income to keep tower effective'],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.tower,
+        hostileExposure: 'medium',
+        signals: { defense: Math.max(0.75, getDefensePressure(state)), enemyKillPotential: 0.7 },
+        vision: { survival: getDefensePressure(state), territory: 0.9, enemyKills: 0.5 }
+      };
+    case 'rampart':
+      return {
+        buildItem: 'build rampart defense',
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ['room-controller', 'hostile-presence', 'repair-decay', 'worker-count'],
+        expectedKpiMovement: ['improves spawn/controller survivability under pressure'],
+        risk: ['decays without sustained repair budget'],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.rampart,
+        hostileExposure: 'medium',
+        signals: { defense: getDefensePressure(state), repairDecay: getRepairDecayPressure(state) },
+        vision: { survival: getDefensePressure(state), territory: 0.8, enemyKills: 0.15 }
+      };
+    case 'road':
+      return {
+        buildItem: 'build source/controller roads',
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ['room-controller', 'sources', 'repair-decay', 'worker-count'],
+        expectedKpiMovement: ['reduces worker travel time', 'improves harvest-to-spawn throughput'],
+        risk: ['road decay creates recurring repair load'],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.road,
+        pathExposure: 'low',
+        signals: {
+          harvestThroughput: 0.55,
+          rclAcceleration: 0.45,
+          expansionPrerequisite: (state.activeTerritoryIntentCount ?? 0) > 0 ? 0.45 : 0.2,
+          controllerDowngrade: getControllerDowngradePressure(state) >= 0.7 ? 0.55 : 0
+        },
+        vision: { resources: 0.8, territory: 0.45 }
+      };
+    case 'container':
+      return {
+        buildItem: 'build source containers',
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ['room-controller', 'sources', 'worker-count'],
+        expectedKpiMovement: ['raises harvest throughput', 'reduces dropped-energy waste'],
+        risk: ['large early build cost and decay upkeep'],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.container,
+        pathExposure: 'low',
+        signals: {
+          harvestThroughput: 0.9,
+          storageLogistics: 0.65,
+          rclAcceleration: 0.35,
+          expansionPrerequisite: (state.activeTerritoryIntentCount ?? 0) > 0 ? 0.4 : 0.15,
+          controllerDowngrade: getControllerDowngradePressure(state) >= 0.7 ? 0.5 : 0
+        },
+        vision: { resources: 1, territory: 0.35 }
+      };
+    case 'storage':
+      return {
+        buildItem: 'build storage logistics',
+        buildType,
+        minimumRcl: 4,
+        minimumWorkers: MIN_SAFE_WORKERS_FOR_EXPANSION,
+        requiredObservations: ['room-controller', 'energy-capacity', 'worker-count'],
+        expectedKpiMovement: ['improves durable resource buffering and logistics'],
+        risk: ['very high energy commitment'],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.storage,
+        signals: { storageLogistics: 0.95 },
+        vision: { resources: 1, territory: 0.25 }
+      };
+    case 'remote-logistics':
+      return {
+        buildItem: 'build remote road/container logistics',
+        buildType,
+        minimumRcl: 2,
+        minimumWorkers: MIN_SAFE_WORKERS_FOR_EXPANSION,
+        requiresSafeHome: true,
+        requiredObservations: ['territory-intents', 'remote-paths', 'worker-count', 'hostile-presence'],
+        expectedKpiMovement: ['turns reserved/scouted territory into sustainable income', 'improves remote room hold viability'],
+        risk: ['path exposure and hostile pressure can waste builder time'],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS['remote-logistics'],
+        pathExposure: 'high',
+        hostileExposure: 'medium',
+        signals: {
+          expansionPrerequisite: 1,
+          harvestThroughput: 0.75,
+          storageLogistics: 0.5
+        },
+        vision: { territory: 1, resources: 0.6 }
+      };
+    case 'observation':
+    default:
+      return {
+        buildItem: 'observe construction backlog',
+        buildType: 'observation',
+        requiredObservations: ['construction-sites'],
+        expectedKpiMovement: ['construction priority table becomes evidence-backed'],
+        risk: ['no build action should be selected until construction-site observations exist'],
+        signals: {},
+        vision: { resources: 0.2 }
+      };
+  }
+}
+
+function mapStructureTypeToBuildType(structureType: string): ConstructionPriorityBuildType {
+  if (matchesStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn')) {
+    return 'spawn';
+  }
+
+  if (matchesStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')) {
+    return 'extension';
+  }
+
+  if (matchesStructureType(structureType, 'STRUCTURE_TOWER', 'tower')) {
+    return 'tower';
+  }
+
+  if (matchesStructureType(structureType, 'STRUCTURE_RAMPART', 'rampart')) {
+    return 'rampart';
+  }
+
+  if (matchesStructureType(structureType, 'STRUCTURE_ROAD', 'road')) {
+    return 'road';
+  }
+
+  if (matchesStructureType(structureType, 'STRUCTURE_CONTAINER', 'container')) {
+    return 'container';
+  }
+
+  if (matchesStructureType(structureType, 'STRUCTURE_STORAGE', 'storage')) {
+    return 'storage';
+  }
+
+  return 'observation';
+}
+
+function getConstructionSiteRemainingProgress(site: ConstructionSite): number {
+  const progressTotal = typeof site.progressTotal === 'number' ? site.progressTotal : STRUCTURE_BUILD_COSTS.observation ?? 0;
+  const progress = typeof site.progress === 'number' ? site.progress : 0;
+  return Math.max(0, progressTotal - progress);
+}
+
+function findRoomObjects(room: Room, constantName: FindConstantName): unknown[] | null {
+  const findConstant = (globalThis as unknown as Partial<Record<FindConstantName, number>>)[constantName];
+  if (typeof findConstant !== 'number' || typeof room.find !== 'function') {
+    return null;
+  }
+
+  try {
+    const result = room.find(findConstant as FindConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return null;
+  }
+}
+
+type FindConstantName =
+  | 'FIND_MY_CONSTRUCTION_SITES'
+  | 'FIND_MY_STRUCTURES'
+  | 'FIND_STRUCTURES'
+  | 'FIND_HOSTILE_CREEPS'
+  | 'FIND_HOSTILE_STRUCTURES'
+  | 'FIND_SOURCES';
+
+type StructureConstantName =
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_TOWER'
+  | 'STRUCTURE_RAMPART'
+  | 'STRUCTURE_ROAD'
+  | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_STORAGE';
+
+function countStructuresByType(
+  structures: AnyStructure[] | null,
+  globalName: StructureConstantName,
+  fallback: string
+): number | undefined {
+  return structures?.filter((structure) => matchesStructureType(structure.structureType, globalName, fallback)).length;
+}
+
+function summarizeRepairSignals(
+  structures: AnyStructure[] | null
+): { criticalRepairCount: number; decayingStructureCount: number } | null {
+  if (structures === null) {
+    return null;
+  }
+
+  return structures.reduce(
+    (summary, structure) => {
+      if (!isRepairSignalStructure(structure) || !hasHits(structure)) {
+        return summary;
+      }
+
+      const hitsRatio = structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
+      if (hitsRatio <= CRITICAL_REPAIR_HITS_RATIO) {
+        summary.criticalRepairCount += 1;
+      } else if (hitsRatio <= DECAYING_REPAIR_HITS_RATIO) {
+        summary.decayingStructureCount += 1;
+      }
+
+      return summary;
+    },
+    { criticalRepairCount: 0, decayingStructureCount: 0 }
+  );
+}
+
+function isRepairSignalStructure(structure: AnyStructure): structure is StructureRoad | StructureContainer | StructureRampart {
+  if (
+    matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')
+  ) {
+    return true;
+  }
+
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') &&
+    (structure as StructureRampart).my === true &&
+    (structure as StructureRampart).hits <= IDLE_RAMPART_REPAIR_HITS_CEILING
+  );
+}
+
+function hasHits(structure: AnyStructure): structure is AnyStructure & { hits: number; hitsMax: number } {
+  return typeof structure.hits === 'number' && typeof structure.hitsMax === 'number';
+}
+
+function countTerritoryIntents(roomName: string): { active: number; planned: number } {
+  const intents = (globalThis as unknown as { Memory?: Partial<Memory> }).Memory?.territory?.intents;
+  if (!Array.isArray(intents)) {
+    return { active: 0, planned: 0 };
+  }
+
+  return intents.reduce(
+    (counts, intent) => {
+      if (intent.colony !== roomName) {
+        return counts;
+      }
+
+      if (intent.status === 'active') {
+        counts.active += 1;
+      } else if (intent.status === 'planned') {
+        counts.planned += 1;
+      }
+
+      return counts;
+    },
+    { active: 0, planned: 0 }
+  );
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: StructureConstantName,
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantName, string>>;
+  return actual === (constants[globalName] ?? fallback);
+}

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -1,4 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { buildRuntimeConstructionPriorityReport, type ConstructionPriorityScore } from '../construction/constructionPriority';
 
 export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
@@ -38,6 +39,7 @@ interface RuntimeRoomSummary {
   controller?: RuntimeControllerSummary;
   resources: RuntimeResourceSummary;
   combat: RuntimeCombatSummary;
+  constructionPriority: RuntimeConstructionPrioritySummary;
 }
 
 interface RuntimeControllerSummary {
@@ -71,6 +73,21 @@ interface RuntimeCombatSummary {
   hostileCreepCount: number;
   hostileStructureCount: number;
   events?: RuntimeCombatEventSummary;
+}
+
+interface RuntimeConstructionPrioritySummary {
+  candidates: RuntimeConstructionPriorityCandidateSummary[];
+  nextPrimary: RuntimeConstructionPriorityCandidateSummary | null;
+}
+
+interface RuntimeConstructionPriorityCandidateSummary {
+  buildItem: string;
+  room: string;
+  score: number;
+  urgency: ConstructionPriorityScore['urgency'];
+  preconditions: string[];
+  expectedKpiMovement: string[];
+  risk: string[];
 }
 
 interface RuntimeRoomEventMetrics {
@@ -132,7 +149,8 @@ function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSumm
     taskCounts: countWorkerTasks(colonyWorkers),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
-    combat: summarizeCombat(colony.room, eventMetrics.combat)
+    combat: summarizeCombat(colony.room, eventMetrics.combat),
+    constructionPriority: summarizeConstructionPriority(colony, colonyWorkers)
   };
 }
 
@@ -228,6 +246,32 @@ function summarizeCombat(room: Room, events: RuntimeCombatEventSummary | undefin
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
     ...(events ? { events } : {})
+  };
+}
+
+function summarizeConstructionPriority(
+  colony: ColonySnapshot,
+  colonyWorkers: Creep[]
+): RuntimeConstructionPrioritySummary {
+  const report = buildRuntimeConstructionPriorityReport(colony, colonyWorkers);
+
+  return {
+    candidates: report.candidates.map(toRuntimeConstructionPriorityCandidateSummary),
+    nextPrimary: report.nextPrimary ? toRuntimeConstructionPriorityCandidateSummary(report.nextPrimary) : null
+  };
+}
+
+function toRuntimeConstructionPriorityCandidateSummary(
+  score: ConstructionPriorityScore
+): RuntimeConstructionPriorityCandidateSummary {
+  return {
+    buildItem: score.buildItem,
+    room: score.room,
+    score: score.score,
+    urgency: score.urgency,
+    preconditions: score.preconditions,
+    expectedKpiMovement: score.expectedKpiMovement,
+    risk: score.risk
   };
 }
 

--- a/prod/test/constructionPriority.test.ts
+++ b/prod/test/constructionPriority.test.ts
@@ -1,8 +1,26 @@
 import {
+  buildRuntimeConstructionPriorityReport,
   scoreConstructionPriorities,
   type ConstructionBuildCandidate,
   type ConstructionPriorityRoomState
 } from '../src/construction/constructionPriority';
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+
+const TEST_GLOBALS = {
+  FIND_MY_CONSTRUCTION_SITES: 101,
+  FIND_MY_STRUCTURES: 102,
+  FIND_STRUCTURES: 103,
+  FIND_HOSTILE_CREEPS: 104,
+  FIND_HOSTILE_STRUCTURES: 105,
+  FIND_SOURCES: 106,
+  STRUCTURE_EXTENSION: 'extension',
+  STRUCTURE_SPAWN: 'spawn',
+  STRUCTURE_TOWER: 'tower',
+  STRUCTURE_RAMPART: 'rampart',
+  STRUCTURE_ROAD: 'road',
+  STRUCTURE_CONTAINER: 'container',
+  STRUCTURE_STORAGE: 'storage'
+} as const;
 
 describe('construction priority scoring', () => {
   it('hard-gates survival and worker recovery above normal energy-capacity construction', () => {
@@ -197,6 +215,64 @@ describe('construction priority scoring', () => {
   });
 });
 
+describe('runtime construction priority report', () => {
+  beforeEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const [key, value] of Object.entries(TEST_GLOBALS)) {
+      globals[key] = value;
+    }
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  afterEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const key of Object.keys(TEST_GLOBALS)) {
+      delete globals[key];
+    }
+    delete globals.Memory;
+  });
+
+  it('ignores creeps with missing memory while counting runtime workers', () => {
+    const { colony } = makeRuntimeColony();
+    const report = buildRuntimeConstructionPriorityReport(colony, [
+      {} as unknown as Creep,
+      { memory: { role: 'worker', colony: 'W1N1' } } as Creep
+    ]);
+
+    expect(scoreByName(report.candidates, 'build extension capacity').blocked).toBe(false);
+  });
+
+  it('skips malformed territory intent entries while counting runtime intent pressure', () => {
+    const { colony } = makeRuntimeColony();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          null,
+          undefined,
+          'stale',
+          7,
+          { status: 'active' },
+          makeTerritoryIntent('W1N1', 'W2N1', 'active'),
+          makeTerritoryIntent('W1N1', 'W3N1', 'planned'),
+          makeTerritoryIntent('W2N2', 'W4N1', 'active'),
+          makeTerritoryIntent('W1N1', 'W5N1', 'suppressed')
+        ] as unknown as TerritoryIntentMemory[]
+      }
+    };
+
+    const report = buildRuntimeConstructionPriorityReport(colony, [
+      { memory: { role: 'worker', colony: 'W1N1' } } as Creep,
+      { memory: { role: 'worker', colony: 'W1N1' } } as Creep,
+      { memory: { role: 'worker', colony: 'W1N1' } } as Creep
+    ]);
+
+    expect(scoreByName(report.candidates, 'build remote road/container logistics')).toMatchObject({
+      blocked: true,
+      missingObservations: ['remote-paths']
+    });
+  });
+});
+
 function makeRoomState(overrides: Partial<ConstructionPriorityRoomState> = {}): ConstructionPriorityRoomState {
   return {
     roomName: 'W1N1',
@@ -246,6 +322,52 @@ function makeTowerCandidate(): ConstructionBuildCandidate {
     hostileExposure: 'medium',
     signals: { defense: 0.9, enemyKillPotential: 0.7 },
     vision: { survival: 0.9, territory: 0.9, enemyKills: 0.5 }
+  };
+}
+
+function makeRuntimeColony(): { colony: ColonySnapshot; room: Room } {
+  const room = {
+    name: 'W1N1',
+    controller: { my: true, level: 2, ticksToDowngrade: 20_000 } as StructureController,
+    find: jest.fn((findType: number) => {
+      switch (findType) {
+        case TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES:
+        case TEST_GLOBALS.FIND_MY_STRUCTURES:
+        case TEST_GLOBALS.FIND_STRUCTURES:
+        case TEST_GLOBALS.FIND_HOSTILE_CREEPS:
+        case TEST_GLOBALS.FIND_HOSTILE_STRUCTURES:
+          return [];
+        case TEST_GLOBALS.FIND_SOURCES:
+          return [{ id: 'source1' }, { id: 'source2' }] as Source[];
+        default:
+          return [];
+      }
+    })
+  } as unknown as Room;
+  const spawn = { structureType: TEST_GLOBALS.STRUCTURE_SPAWN, room } as unknown as StructureSpawn;
+
+  return {
+    room,
+    colony: {
+      room,
+      spawns: [spawn],
+      energyAvailable: 300,
+      energyCapacityAvailable: 550
+    }
+  };
+}
+
+function makeTerritoryIntent(
+  colony: string,
+  targetRoom: string,
+  status: TerritoryIntentMemory['status']
+): TerritoryIntentMemory {
+  return {
+    colony,
+    targetRoom,
+    action: 'reserve',
+    status,
+    updatedAt: 1
   };
 }
 

--- a/prod/test/constructionPriority.test.ts
+++ b/prod/test/constructionPriority.test.ts
@@ -1,0 +1,263 @@
+import {
+  scoreConstructionPriorities,
+  type ConstructionBuildCandidate,
+  type ConstructionPriorityRoomState
+} from '../src/construction/constructionPriority';
+
+describe('construction priority scoring', () => {
+  it('hard-gates survival and worker recovery above normal energy-capacity construction', () => {
+    const state = makeRoomState({
+      workerCount: 0,
+      energyCapacity: 300
+    });
+
+    const report = scoreConstructionPriorities(state, [
+      {
+        buildItem: 'build extension capacity',
+        buildType: 'extension',
+        minimumRcl: 2,
+        requiredObservations: ['room-controller', 'energy-capacity', 'worker-count'],
+        expectedKpiMovement: ['raises spawn energy capacity'],
+        risk: ['adds construction backlog while recovery is unstable'],
+        estimatedEnergyCost: 3_000,
+        signals: { energyBottleneck: 0.9, spawnUtilization: 0.8 },
+        vision: { resources: 1 }
+      },
+      {
+        buildItem: 'build spawn recovery',
+        buildType: 'spawn',
+        minimumRcl: 1,
+        requiredObservations: ['room-controller', 'spawn-count', 'worker-count'],
+        expectedKpiMovement: ['restores worker production'],
+        risk: ['large energy commitment'],
+        estimatedEnergyCost: 15_000,
+        signals: { survivalRecovery: 1 },
+        vision: { survival: 1, territory: 0.5 }
+      }
+    ]);
+
+    expect(report.nextPrimary?.buildItem).toBe('build spawn recovery');
+    expect(scoreFor(report.candidates, 'build spawn recovery')).toBeGreaterThan(
+      scoreFor(report.candidates, 'build extension capacity')
+    );
+    expect(report.nextPrimary).toMatchObject({
+      room: 'W1N1',
+      urgency: 'critical',
+      expectedKpiMovement: ['restores worker production'],
+      risk: ['large energy commitment']
+    });
+  });
+
+  it('prioritizes defense construction when hostile pressure is visible', () => {
+    const state = makeRoomState({
+      rcl: 3,
+      workerCount: 4,
+      energyCapacity: 800,
+      hostileCreepCount: 1
+    });
+
+    const report = scoreConstructionPriorities(state, [
+      makeTowerCandidate(),
+      {
+        buildItem: 'build extension capacity',
+        buildType: 'extension',
+        minimumRcl: 2,
+        requiredObservations: ['room-controller', 'energy-capacity', 'hostile-presence'],
+        expectedKpiMovement: ['raises spawn energy capacity'],
+        risk: ['does not directly answer hostile pressure'],
+        estimatedEnergyCost: 3_000,
+        signals: { spawnUtilization: 0.75 },
+        vision: { resources: 1 }
+      }
+    ]);
+
+    expect(report.nextPrimary?.buildItem).toBe('build tower defense');
+    expect(report.nextPrimary?.urgency).toBe('critical');
+    expect(scoreFor(report.candidates, 'build tower defense')).toBeGreaterThan(
+      scoreFor(report.candidates, 'build extension capacity')
+    );
+  });
+
+  it('weights expansion prerequisites ahead of lower-chain resource storage when home state is safe', () => {
+    const state = makeRoomState({
+      rcl: 4,
+      workerCount: 5,
+      energyCapacity: 1_300,
+      activeTerritoryIntentCount: 1,
+      remoteLogisticsReady: true
+    });
+
+    const report = scoreConstructionPriorities(state, [
+      {
+        buildItem: 'build remote road/container logistics',
+        buildType: 'remote-logistics',
+        minimumRcl: 2,
+        minimumWorkers: 3,
+        requiresSafeHome: true,
+        requiredObservations: ['territory-intents', 'remote-paths', 'worker-count', 'hostile-presence'],
+        expectedKpiMovement: ['turns territory intent into sustainable income'],
+        risk: ['remote path exposure'],
+        estimatedEnergyCost: 2_000,
+        pathExposure: 'low',
+        signals: { expansionPrerequisite: 1, harvestThroughput: 0.75, storageLogistics: 0.5 },
+        vision: { territory: 1, resources: 0.6 }
+      },
+      {
+        buildItem: 'build storage logistics',
+        buildType: 'storage',
+        minimumRcl: 4,
+        minimumWorkers: 3,
+        requiredObservations: ['room-controller', 'energy-capacity', 'worker-count'],
+        expectedKpiMovement: ['improves local resource buffering'],
+        risk: ['very high energy commitment'],
+        estimatedEnergyCost: 30_000,
+        signals: { storageLogistics: 0.95 },
+        vision: { resources: 1 }
+      }
+    ]);
+
+    expect(report.nextPrimary?.buildItem).toBe('build remote road/container logistics');
+    expect(report.nextPrimary?.factors.expansionPrerequisites).toBeGreaterThan(
+      scoreByName(report.candidates, 'build storage logistics').factors.expansionPrerequisites
+    );
+  });
+
+  it('orders economic throughput construction above low-impact combat infrastructure without hostile pressure', () => {
+    const state = makeRoomState({
+      rcl: 3,
+      workerCount: 4,
+      energyCapacity: 800,
+      sourceCount: 2
+    });
+
+    const report = scoreConstructionPriorities(state, [
+      {
+        buildItem: 'build source containers',
+        buildType: 'container',
+        minimumRcl: 2,
+        requiredObservations: ['room-controller', 'sources', 'worker-count'],
+        expectedKpiMovement: ['raises harvest throughput', 'reduces dropped-energy waste'],
+        risk: ['container decay upkeep'],
+        estimatedEnergyCost: 5_000,
+        pathExposure: 'low',
+        signals: { harvestThroughput: 0.95, storageLogistics: 0.65, rclAcceleration: 0.35 },
+        vision: { resources: 1, territory: 0.35 }
+      },
+      {
+        buildItem: 'build idle rampart layer',
+        buildType: 'rampart',
+        minimumRcl: 2,
+        requiredObservations: ['room-controller', 'hostile-presence', 'repair-decay'],
+        expectedKpiMovement: ['adds future defensive surface'],
+        risk: ['creates recurring repair load before a threat exists'],
+        estimatedEnergyCost: 1_000,
+        signals: { defense: 0.1, enemyKillPotential: 0.15 },
+        vision: { enemyKills: 0.4, territory: 0.2 }
+      }
+    ]);
+
+    expect(report.nextPrimary?.buildItem).toBe('build source containers');
+    expect(scoreByName(report.candidates, 'build source containers').factors.economicBenefit).toBeGreaterThan(
+      scoreByName(report.candidates, 'build idle rampart layer').factors.economicBenefit
+    );
+  });
+
+  it('returns a missing-observation precondition instead of scoring unsupported remote certainty', () => {
+    const state = makeRoomState({
+      activeTerritoryIntentCount: 1,
+      remoteLogisticsReady: false,
+      observations: {
+        'remote-paths': false
+      }
+    });
+
+    const report = scoreConstructionPriorities(state, [
+      {
+        buildItem: 'build remote road/container logistics',
+        buildType: 'remote-logistics',
+        minimumRcl: 2,
+        minimumWorkers: 3,
+        requiresSafeHome: true,
+        requiredObservations: ['territory-intents', 'remote-paths', 'worker-count', 'hostile-presence'],
+        expectedKpiMovement: ['turns territory intent into sustainable income'],
+        risk: ['remote path exposure'],
+        signals: { expansionPrerequisite: 1, harvestThroughput: 0.75 },
+        vision: { territory: 1, resources: 0.6 }
+      }
+    ]);
+
+    expect(report.nextPrimary).toMatchObject({
+      buildItem: 'build remote road/container logistics',
+      score: 0,
+      urgency: 'blocked',
+      blocked: true,
+      missingObservations: ['remote-paths']
+    });
+    expect(report.nextPrimary?.preconditions).toContain('missing observation: remote path/logistics exposure');
+  });
+});
+
+function makeRoomState(overrides: Partial<ConstructionPriorityRoomState> = {}): ConstructionPriorityRoomState {
+  return {
+    roomName: 'W1N1',
+    rcl: 2,
+    energyAvailable: 300,
+    energyCapacity: 550,
+    workerCount: 3,
+    spawnCount: 1,
+    sourceCount: 2,
+    extensionCount: 5,
+    towerCount: 0,
+    constructionSiteCount: 0,
+    criticalRepairCount: 0,
+    decayingStructureCount: 0,
+    controllerTicksToDowngrade: 20_000,
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    activeTerritoryIntentCount: 0,
+    plannedTerritoryIntentCount: 0,
+    remoteLogisticsReady: true,
+    observations: {
+      'room-controller': true,
+      'energy-capacity': true,
+      'worker-count': true,
+      'spawn-count': true,
+      'construction-sites': true,
+      'repair-decay': true,
+      'hostile-presence': true,
+      sources: true,
+      'territory-intents': true,
+      'remote-paths': true,
+      ...overrides.observations
+    },
+    ...overrides
+  };
+}
+
+function makeTowerCandidate(): ConstructionBuildCandidate {
+  return {
+    buildItem: 'build tower defense',
+    buildType: 'tower',
+    minimumRcl: 3,
+    requiredObservations: ['room-controller', 'hostile-presence', 'worker-count'],
+    expectedKpiMovement: ['improves room hold safety', 'adds hostile damage capacity'],
+    risk: ['requires steady energy income'],
+    estimatedEnergyCost: 5_000,
+    hostileExposure: 'medium',
+    signals: { defense: 0.9, enemyKillPotential: 0.7 },
+    vision: { survival: 0.9, territory: 0.9, enemyKills: 0.5 }
+  };
+}
+
+function scoreFor(candidates: { buildItem: string; score: number }[], buildItem: string): number {
+  return scoreByName(candidates, buildItem).score;
+}
+
+function scoreByName<T extends { buildItem: string }>(candidates: T[], buildItem: string): T {
+  const candidate = candidates.find((entry) => entry.buildItem === buildItem);
+  if (!candidate) {
+    throw new Error(`missing scored candidate ${buildItem}`);
+  }
+
+  return candidate;
+}

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -13,11 +13,19 @@ const TEST_GLOBALS = {
   FIND_SOURCES: 103,
   FIND_HOSTILE_CREEPS: 104,
   FIND_HOSTILE_STRUCTURES: 105,
+  FIND_MY_STRUCTURES: 106,
+  FIND_MY_CONSTRUCTION_SITES: 107,
   EVENT_HARVEST: 201,
   EVENT_TRANSFER: 202,
   EVENT_ATTACK: 203,
   EVENT_OBJECT_DESTROYED: 204,
-  RESOURCE_ENERGY: 'energy'
+  RESOURCE_ENERGY: 'energy',
+  STRUCTURE_EXTENSION: 'extension',
+  STRUCTURE_TOWER: 'tower',
+  STRUCTURE_RAMPART: 'rampart',
+  STRUCTURE_ROAD: 'road',
+  STRUCTURE_CONTAINER: 'container',
+  STRUCTURE_STORAGE: 'storage'
 } as const;
 
 const RUNTIME_GLOBAL_KEYS = Object.keys(TEST_GLOBALS);
@@ -100,6 +108,58 @@ describe('runtime telemetry summaries', () => {
               attackDamage: 30,
               objectDestroyedCount: 1,
               creepDestroyedCount: 1
+            }
+          },
+          constructionPriority: {
+            candidates: [
+              {
+                buildItem: 'build rampart defense',
+                room: 'W1N1',
+                score: 49,
+                urgency: 'critical',
+                preconditions: [],
+                expectedKpiMovement: ['improves spawn/controller survivability under pressure'],
+                risk: ['decays without sustained repair budget']
+              },
+              {
+                buildItem: 'build extension capacity',
+                room: 'W1N1',
+                score: 45,
+                urgency: 'high',
+                preconditions: [],
+                expectedKpiMovement: [
+                  'raises spawn energy capacity',
+                  'unlocks larger workers and faster RCL progress'
+                ],
+                risk: ['adds build backlog before roads/containers if worker capacity is low']
+              },
+              {
+                buildItem: 'build source containers',
+                room: 'W1N1',
+                score: 25,
+                urgency: 'low',
+                preconditions: [],
+                expectedKpiMovement: ['raises harvest throughput', 'reduces dropped-energy waste'],
+                risk: ['large early build cost and decay upkeep']
+              },
+              {
+                buildItem: 'build source/controller roads',
+                room: 'W1N1',
+                score: 21,
+                urgency: 'low',
+                preconditions: [],
+                expectedKpiMovement: ['reduces worker travel time', 'improves harvest-to-spawn throughput'],
+                risk: ['road decay creates recurring repair load']
+              }
+            ],
+            nextPrimary: {
+              buildItem: 'build rampart defense',
+              room: 'W1N1',
+              score: 49,
+              urgency: 'critical',
+              preconditions: [],
+              expectedKpiMovement: ['improves spawn/controller survivability under pressure'],
+              risk: ['decays without sustained repair budget']
             }
           }
         }
@@ -261,6 +321,10 @@ function makeColony(options: {
       switch (findType) {
         case TEST_GLOBALS.FIND_STRUCTURES:
           return structures;
+        case TEST_GLOBALS.FIND_MY_STRUCTURES:
+          return structures;
+        case TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES:
+          return [];
         case TEST_GLOBALS.FIND_DROPPED_RESOURCES:
           return [
             { resourceType: TEST_GLOBALS.RESOURCE_ENERGY, amount: 25 },


### PR DESCRIPTION
Closes #231.

## Summary
- Adds construction priority scoring for recovery, defense, expansion, economy, RCL timing, CPU/pathing, opportunity cost, and vision-chain alignment.
- Adds runtime summary construction-priority evidence so the strategy loop can name the next primary build item with score/urgency/preconditions/KPI/risk context.
- Adds deterministic Jest coverage for scoring and summary behavior, and regenerates the bundled Screeps artifact.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (17 suites, 339 tests)
- `cd prod && npm run build`
- `cd prod && git diff --exit-code -- prod/dist/main.js`

## Safety
- Production code authored by Codex as `lanyusea's bot <lanyusea@gmail.com>`.
- `prod/node_modules` is an untracked local dependency symlink/infrastructure and is not staged.
