### PR TITLE
feat: sign occupied controllers

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2389,6 +2389,7 @@ function getGameCreeps() {
 // src/territory/controllerSigning.ts
 var OCCUPIED_CONTROLLER_SIGN_TEXT = "by Hermes Screeps Project";
 var ERR_NOT_IN_RANGE_CODE = -9;
+var ERR_TIRED_CODE = -11;
 var OK_CODE = 0;
 function shouldSignOccupiedController(controller) {
   var _a;
@@ -2400,16 +2401,16 @@ function signOccupiedControllerIfNeeded(creep, controller) {
   }
   const result = creep.signController(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
   if (result === ERR_NOT_IN_RANGE_CODE) {
-    if (typeof creep.moveTo === "function") {
-      creep.moveTo(controller);
+    if (typeof creep.moveTo !== "function") {
+      return "blocked";
     }
-    return "moving";
+    const moveResult = creep.moveTo(controller);
+    return moveResult === OK_CODE || moveResult === ERR_TIRED_CODE ? "moving" : "blocked";
   }
   return result === OK_CODE ? "signed" : "skipped";
 }
 
 // src/creeps/workerRunner.ts
-var OK_CODE2 = 0;
 function runWorker(creep) {
   const selectedTask = selectWorkerTask(creep);
   const currentTask = creep.memory.task;
@@ -2672,9 +2673,7 @@ function executeTask(creep, task, target) {
     case "reserve":
       return creep.reserveController(target);
     case "upgrade":
-      if (signOccupiedControllerIfNeeded(creep, target) !== "skipped") {
-        return OK_CODE2;
-      }
+      signOccupiedControllerIfNeeded(creep, target);
       return creep.upgradeController(target);
   }
 }
@@ -3057,7 +3056,7 @@ function getGameTime2() {
 var ERR_NOT_IN_RANGE_CODE2 = -9;
 var ERR_INVALID_TARGET_CODE = -7;
 var ERR_GCL_NOT_ENOUGH_CODE = -15;
-var OK_CODE3 = 0;
+var OK_CODE2 = 0;
 var CLAIM_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([
   ERR_INVALID_TARGET_CODE,
   ERR_GCL_NOT_ENOUGH_CODE
@@ -3133,7 +3132,7 @@ function selectTargetController(creep, assignment) {
 function executeControllerAction(creep, controller, action) {
   const controllerAction = creep[action];
   if (typeof controllerAction !== "function") {
-    return OK_CODE3;
+    return OK_CODE2;
   }
   return controllerAction.call(creep, controller);
 }
@@ -3155,7 +3154,7 @@ function isTerritoryAssignment(assignment) {
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
-var OK_CODE4 = 0;
+var OK_CODE3 = 0;
 function runEconomy() {
   const creeps = Object.values(Game.creeps);
   const colonies = getOwnedColonies();
@@ -3189,7 +3188,7 @@ function runEconomy() {
         telemetryEvents,
         planningColony.spawns
       );
-      if (!outcome || outcome.result !== OK_CODE4) {
+      if (!outcome || outcome.result !== OK_CODE3) {
         break;
       }
       usedSpawns.add(outcome.spawn);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2326,7 +2326,30 @@ function getGameCreeps() {
   return creeps ? Object.values(creeps) : [];
 }
 
+// src/territory/controllerSigning.ts
+var OCCUPIED_CONTROLLER_SIGN_TEXT = "by Hermes Screeps Project";
+var ERR_NOT_IN_RANGE_CODE = -9;
+var OK_CODE = 0;
+function shouldSignOccupiedController(controller) {
+  var _a;
+  return (controller == null ? void 0 : controller.my) === true && ((_a = controller.sign) == null ? void 0 : _a.text) !== OCCUPIED_CONTROLLER_SIGN_TEXT;
+}
+function signOccupiedControllerIfNeeded(creep, controller) {
+  if (!controller || !shouldSignOccupiedController(controller) || typeof creep.signController !== "function") {
+    return "skipped";
+  }
+  const result = creep.signController(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+  if (result === ERR_NOT_IN_RANGE_CODE) {
+    if (typeof creep.moveTo === "function") {
+      creep.moveTo(controller);
+    }
+    return "moving";
+  }
+  return result === OK_CODE ? "signed" : "skipped";
+}
+
 // src/creeps/workerRunner.ts
+var OK_CODE2 = 0;
 function runWorker(creep) {
   const selectedTask = selectWorkerTask(creep);
   const currentTask = creep.memory.task;
@@ -2589,6 +2612,9 @@ function executeTask(creep, task, target) {
     case "reserve":
       return creep.reserveController(target);
     case "upgrade":
+      if (signOccupiedControllerIfNeeded(creep, target) !== "skipped") {
+        return OK_CODE2;
+      }
       return creep.upgradeController(target);
   }
 }
@@ -2968,10 +2994,10 @@ function getGameTime2() {
 }
 
 // src/territory/territoryRunner.ts
-var ERR_NOT_IN_RANGE_CODE = -9;
+var ERR_NOT_IN_RANGE_CODE2 = -9;
 var ERR_INVALID_TARGET_CODE = -7;
 var ERR_GCL_NOT_ENOUGH_CODE = -15;
-var OK_CODE = 0;
+var OK_CODE3 = 0;
 var CLAIM_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([
   ERR_INVALID_TARGET_CODE,
   ERR_GCL_NOT_ENOUGH_CODE
@@ -3015,7 +3041,7 @@ function runTerritoryControllerCreep(creep) {
     return;
   }
   const result = assignment.action === "claim" ? executeControllerAction(creep, controller, "claimController") : executeControllerAction(creep, controller, "reserveController");
-  if (result === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === "function") {
+  if (result === ERR_NOT_IN_RANGE_CODE2 && typeof creep.moveTo === "function") {
     creep.moveTo(controller);
     return;
   }
@@ -3047,7 +3073,7 @@ function selectTargetController(creep, assignment) {
 function executeControllerAction(creep, controller, action) {
   const controllerAction = creep[action];
   if (typeof controllerAction !== "function") {
-    return OK_CODE;
+    return OK_CODE3;
   }
   return controllerAction.call(creep, controller);
 }
@@ -3069,7 +3095,7 @@ function isTerritoryAssignment(assignment) {
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
-var OK_CODE2 = 0;
+var OK_CODE4 = 0;
 function runEconomy() {
   const creeps = Object.values(Game.creeps);
   const colonies = getOwnedColonies();
@@ -3103,7 +3129,7 @@ function runEconomy() {
         telemetryEvents,
         planningColony.spawns
       );
-      if (!outcome || outcome.result !== OK_CODE2) {
+      if (!outcome || outcome.result !== OK_CODE4) {
         break;
       }
       usedSpawns.add(outcome.spawn);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -3,8 +3,6 @@ import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
 
 type TransferSinkStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION' | 'STRUCTURE_TOWER';
 
-const OK_CODE = 0 as ScreepsReturnCode;
-
 export function runWorker(creep: Creep): void {
   const selectedTask = selectWorkerTask(creep);
   const currentTask = creep.memory.task;
@@ -374,10 +372,7 @@ function executeTask(
     case 'reserve':
       return creep.reserveController(target as StructureController);
     case 'upgrade':
-      if (signOccupiedControllerIfNeeded(creep, target as StructureController) !== 'skipped') {
-        return OK_CODE;
-      }
-
+      signOccupiedControllerIfNeeded(creep, target as StructureController);
       return creep.upgradeController(target as StructureController);
   }
 }

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1,6 +1,9 @@
 import { isWorkerRepairTargetComplete, selectWorkerTask } from '../tasks/workerTasks';
+import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
 
 type TransferSinkStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION' | 'STRUCTURE_TOWER';
+
+const OK_CODE = 0 as ScreepsReturnCode;
 
 export function runWorker(creep: Creep): void {
   const selectedTask = selectWorkerTask(creep);
@@ -371,6 +374,10 @@ function executeTask(
     case 'reserve':
       return creep.reserveController(target as StructureController);
     case 'upgrade':
+      if (signOccupiedControllerIfNeeded(creep, target as StructureController) !== 'skipped') {
+        return OK_CODE;
+      }
+
       return creep.upgradeController(target as StructureController);
   }
 }

--- a/prod/src/territory/controllerSigning.ts
+++ b/prod/src/territory/controllerSigning.ts
@@ -1,0 +1,29 @@
+export const OCCUPIED_CONTROLLER_SIGN_TEXT = 'by Hermes Screeps Project';
+
+const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+const OK_CODE = 0 as ScreepsReturnCode;
+
+export type ControllerSigningResult = 'skipped' | 'signed' | 'moving';
+
+export function shouldSignOccupiedController(controller: StructureController | null | undefined): boolean {
+  return controller?.my === true && controller.sign?.text !== OCCUPIED_CONTROLLER_SIGN_TEXT;
+}
+
+export function signOccupiedControllerIfNeeded(
+  creep: Creep,
+  controller: StructureController | null | undefined
+): ControllerSigningResult {
+  if (!controller || !shouldSignOccupiedController(controller) || typeof creep.signController !== 'function') {
+    return 'skipped';
+  }
+
+  const result = creep.signController(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+  if (result === ERR_NOT_IN_RANGE_CODE) {
+    if (typeof creep.moveTo === 'function') {
+      creep.moveTo(controller);
+    }
+    return 'moving';
+  }
+
+  return result === OK_CODE ? 'signed' : 'skipped';
+}

--- a/prod/src/territory/controllerSigning.ts
+++ b/prod/src/territory/controllerSigning.ts
@@ -1,9 +1,10 @@
 export const OCCUPIED_CONTROLLER_SIGN_TEXT = 'by Hermes Screeps Project';
 
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+const ERR_TIRED_CODE = -11 as ScreepsReturnCode;
 const OK_CODE = 0 as ScreepsReturnCode;
 
-export type ControllerSigningResult = 'skipped' | 'signed' | 'moving';
+export type ControllerSigningResult = 'skipped' | 'signed' | 'moving' | 'blocked';
 
 export function shouldSignOccupiedController(controller: StructureController | null | undefined): boolean {
   return controller?.my === true && controller.sign?.text !== OCCUPIED_CONTROLLER_SIGN_TEXT;
@@ -19,10 +20,12 @@ export function signOccupiedControllerIfNeeded(
 
   const result = creep.signController(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
   if (result === ERR_NOT_IN_RANGE_CODE) {
-    if (typeof creep.moveTo === 'function') {
-      creep.moveTo(controller);
+    if (typeof creep.moveTo !== 'function') {
+      return 'blocked';
     }
-    return 'moving';
+
+    const moveResult = creep.moveTo(controller);
+    return moveResult === OK_CODE || moveResult === ERR_TIRED_CODE ? 'moving' : 'blocked';
   }
 
   return result === OK_CODE ? 'signed' : 'skipped';

--- a/prod/test/controllerSigning.test.ts
+++ b/prod/test/controllerSigning.test.ts
@@ -1,0 +1,88 @@
+import {
+  OCCUPIED_CONTROLLER_SIGN_TEXT,
+  shouldSignOccupiedController,
+  signOccupiedControllerIfNeeded
+} from '../src/territory/controllerSigning';
+
+describe('controller signing', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; OK: number }).ERR_NOT_IN_RANGE = -9;
+    (globalThis as unknown as { OK: number }).OK = 0;
+  });
+
+  it('signs an unsigned owned controller with the occupied-area text', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const creep = {
+      signController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    expect(signOccupiedControllerIfNeeded(creep, controller)).toBe('signed');
+
+    expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('moves toward an incorrectly signed owned controller when signing is out of range', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      sign: { username: 'other', text: 'not ours', time: 123, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const creep = {
+      signController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    expect(signOccupiedControllerIfNeeded(creep, controller)).toBe('moving');
+
+    expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+  });
+
+  it('does not repeat signing when the owned controller already has the required text', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      sign: {
+        username: 'me',
+        text: OCCUPIED_CONTROLLER_SIGN_TEXT,
+        time: 123,
+        datetime: '2026-04-29T00:00:00.000Z'
+      }
+    } as unknown as StructureController;
+    const creep = {
+      signController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    expect(shouldSignOccupiedController(controller)).toBe(false);
+    expect(signOccupiedControllerIfNeeded(creep, controller)).toBe('skipped');
+
+    expect(creep.signController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('skips missing controllers and controllers without own ownership safely', () => {
+    const unownedController = { id: 'controller1', my: false } as StructureController;
+    const hostileController = {
+      id: 'controller2',
+      my: false,
+      owner: { username: 'enemy' }
+    } as StructureController;
+    const creep = {
+      signController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    expect(shouldSignOccupiedController(undefined)).toBe(false);
+    expect(shouldSignOccupiedController(unownedController)).toBe(false);
+    expect(shouldSignOccupiedController(hostileController)).toBe(false);
+    expect(signOccupiedControllerIfNeeded(creep, undefined)).toBe('skipped');
+    expect(signOccupiedControllerIfNeeded(creep, unownedController)).toBe('skipped');
+    expect(signOccupiedControllerIfNeeded(creep, hostileController)).toBe('skipped');
+
+    expect(creep.signController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+});

--- a/prod/test/controllerSigning.test.ts
+++ b/prod/test/controllerSigning.test.ts
@@ -31,10 +31,27 @@ describe('controller signing', () => {
     } as unknown as StructureController;
     const creep = {
       signController: jest.fn().mockReturnValue(-9),
-      moveTo: jest.fn()
+      moveTo: jest.fn().mockReturnValue(0)
     } as unknown as Creep;
 
     expect(signOccupiedControllerIfNeeded(creep, controller)).toBe('moving');
+
+    expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+  });
+
+  it('reports blocked when signing is out of range and movement fails', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      sign: { username: 'other', text: 'not ours', time: 123, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const creep = {
+      signController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn().mockReturnValue(-2)
+    } as unknown as Creep;
+
+    expect(signOccupiedControllerIfNeeded(creep, controller)).toBe('blocked');
 
     expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
     expect(creep.moveTo).toHaveBeenCalledWith(controller);

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -72,12 +72,14 @@ describe('runTerritoryControllerCreep', () => {
     const creep = {
       memory: { role: 'scout', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'scout' } },
       room: { name: 'W1N2' },
-      moveTo: jest.fn()
+      moveTo: jest.fn(),
+      signController: jest.fn()
     } as unknown as Creep;
 
     runTerritoryControllerCreep(creep);
 
     expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.signController).not.toHaveBeenCalled();
     expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'scout' });
     expect(Memory.territory).toBeUndefined();
   });
@@ -222,6 +224,7 @@ describe('runTerritoryControllerCreep', () => {
       },
       room: { name: 'W1N2', controller: { id: 'fallback', my: false } as StructureController },
       claimController: jest.fn().mockReturnValue(0),
+      signController: jest.fn(),
       moveTo: jest.fn()
     } as unknown as Creep;
 
@@ -229,6 +232,7 @@ describe('runTerritoryControllerCreep', () => {
 
     expect(getObjectById).toHaveBeenCalledWith('controller1');
     expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.signController).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -281,14 +281,14 @@ describe('runWorker', () => {
     expect(moveTo).toHaveBeenCalledWith(controller);
   });
 
-  it('signs an incorrectly signed owned upgrade target before upgrading it', () => {
+  it('signs an incorrectly signed owned upgrade target while upgrading it', () => {
     const controller = {
       id: 'controller1',
       my: true,
       sign: { username: 'other', text: 'old sign', time: 123, datetime: '2026-04-29T00:00:00.000Z' }
     } as unknown as StructureController;
     const signController = jest.fn().mockReturnValue(0);
-    const upgradeController = jest.fn();
+    const upgradeController = jest.fn().mockReturnValue(0);
     const moveTo = jest.fn();
     const creep = {
       memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
@@ -308,8 +308,40 @@ describe('runWorker', () => {
     runWorker(creep);
 
     expect(signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
-    expect(upgradeController).not.toHaveBeenCalled();
+    expect(upgradeController).toHaveBeenCalledWith(controller);
     expect(moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('keeps upgrading when signing requires inaccessible range-1 movement', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      sign: { username: 'other', text: 'old sign', time: 123, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const signController = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE);
+    const upgradeController = jest.fn().mockReturnValue(0);
+    const moveTo = jest.fn().mockReturnValue(-2);
+    const creep = {
+      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { controller, find: jest.fn().mockReturnValue([]) },
+      signController,
+      upgradeController,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+
+    runWorker(creep);
+
+    expect(signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(moveTo).toHaveBeenCalledWith(controller);
+    expect(upgradeController).toHaveBeenCalledWith(controller);
     expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1,5 +1,6 @@
 import { runWorker } from '../src/creeps/workerRunner';
 import { CONTROLLER_DOWNGRADE_GUARD_TICKS, IDLE_RAMPART_REPAIR_HITS_CEILING } from '../src/tasks/workerTasks';
+import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
 import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
 
 function withRangeTo<T extends { id: string }>(object: T, rangesByTargetId: Record<string, number>): T {
@@ -278,6 +279,72 @@ describe('runWorker', () => {
     expect(getObjectById).toHaveBeenCalledWith('controller1');
     expect(upgradeController).toHaveBeenCalledWith(controller);
     expect(moveTo).toHaveBeenCalledWith(controller);
+  });
+
+  it('signs an incorrectly signed owned upgrade target before upgrading it', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      sign: { username: 'other', text: 'old sign', time: 123, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const signController = jest.fn().mockReturnValue(0);
+    const upgradeController = jest.fn();
+    const moveTo = jest.fn();
+    const creep = {
+      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { controller, find: jest.fn().mockReturnValue([]) },
+      signController,
+      upgradeController,
+      moveTo
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+
+    runWorker(creep);
+
+    expect(signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(upgradeController).not.toHaveBeenCalled();
+    expect(moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('does not repeat signing for a correctly signed owned upgrade target', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      sign: {
+        username: 'me',
+        text: OCCUPIED_CONTROLLER_SIGN_TEXT,
+        time: 123,
+        datetime: '2026-04-29T00:00:00.000Z'
+      }
+    } as unknown as StructureController;
+    const signController = jest.fn();
+    const upgradeController = jest.fn().mockReturnValue(0);
+    const creep = {
+      memory: { task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { controller, find: jest.fn().mockReturnValue([]) },
+      signController,
+      upgradeController,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+
+    runWorker(creep);
+
+    expect(signController).not.toHaveBeenCalled();
+    expect(upgradeController).toHaveBeenCalledWith(controller);
   });
 
   it('preempts an RCL2 upgrade task for extension construction when downgrade is safe', () => {
@@ -861,6 +928,7 @@ describe('runWorker', () => {
       },
       room,
       reserveController: jest.fn(),
+      signController: jest.fn(),
       moveTo: jest.fn()
     } as unknown as Creep;
     const getObjectById = jest.fn().mockReturnValue(controller);
@@ -874,6 +942,7 @@ describe('runWorker', () => {
     expect(getObjectById).toHaveBeenCalledWith('controller2');
     expect(creep.memory.task).toEqual({ type: 'reserve', targetId: 'controller2' });
     expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.signController).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Closes #229.

## Summary
- Adds centralized controller-signing behavior using the required text `by Hermes Screeps Project`.
- Integrates signing into worker execution without disturbing existing claim/reserve/scout and recovery flows.
- Adds deterministic Jest coverage for missing/wrong/correct signatures and safe skip cases, and regenerates the bundled Screeps artifact.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (17 suites, 340 tests)
- `cd prod && npm run build`
- `cd prod && git diff --exit-code -- prod/dist/main.js`

## Safety
- Production code authored by Codex as `lanyusea's bot <lanyusea@gmail.com>`.
- `prod/node_modules` is an untracked local dependency symlink/infrastructure and is not staged.
