### PR TITLE
feat: score occupation recommendations

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3576,6 +3576,346 @@ function matchesStructureType3(actual, globalName, fallback) {
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 
+// src/territory/occupationRecommendation.ts
+var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
+var TERRITORY_BODY_ENERGY_CAPACITY = 650;
+var MIN_READY_WORKERS = 3;
+var DOWNGRADE_GUARD_TICKS = 5e3;
+var RESERVATION_RENEWAL_TICKS = 1e3;
+var TERRITORY_ROUTE_DISTANCE_SEPARATOR2 = ">";
+var ACTION_SCORE = {
+  occupy: 1e3,
+  reserve: 800,
+  scout: 420
+};
+function buildRuntimeOccupationRecommendationReport(colony, colonyWorkers) {
+  return scoreOccupationRecommendations(buildRuntimeOccupationRecommendationInput(colony, colonyWorkers));
+}
+function scoreOccupationRecommendations(input) {
+  var _a;
+  const candidates = input.candidates.filter((candidate) => candidate.roomName !== input.colonyName).map((candidate) => scoreOccupationCandidate(input, candidate)).sort(compareOccupationRecommendationScores);
+  const next = (_a = candidates.find((candidate) => candidate.evidenceStatus !== "unavailable")) != null ? _a : null;
+  return { candidates, next };
+}
+function buildRuntimeOccupationRecommendationInput(colony, colonyWorkers) {
+  var _a, _b;
+  const colonyName = colony.room.name;
+  return {
+    colonyName,
+    colonyOwnerUsername: getControllerOwnerUsername2(colony.room.controller),
+    energyCapacityAvailable: colony.energyCapacityAvailable,
+    workerCount: colonyWorkers.length,
+    ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
+    ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
+    candidates: buildRuntimeOccupationCandidates(colonyName)
+  };
+}
+function buildRuntimeOccupationCandidates(colonyName) {
+  var _a;
+  const candidatesByRoom = /* @__PURE__ */ new Map();
+  const territoryMemory = getTerritoryMemoryRecord2();
+  let order = 0;
+  if (Array.isArray(territoryMemory == null ? void 0 : territoryMemory.targets)) {
+    for (const rawTarget of territoryMemory.targets) {
+      const target = normalizeTerritoryTarget2(rawTarget);
+      if (!target || target.colony !== colonyName || target.enabled === false) {
+        continue;
+      }
+      upsertOccupationCandidate(candidatesByRoom, {
+        roomName: target.roomName,
+        source: "configured",
+        order,
+        adjacent: false,
+        visible: false,
+        actionHint: target.action,
+        routeDistance: getCachedRouteDistance(colonyName, target.roomName)
+      });
+      order += 1;
+    }
+  }
+  for (const roomName of getAdjacentRoomNames2(colonyName)) {
+    upsertOccupationCandidate(candidatesByRoom, {
+      roomName,
+      source: "adjacent",
+      order,
+      adjacent: true,
+      visible: false,
+      routeDistance: (_a = getCachedRouteDistance(colonyName, roomName)) != null ? _a : 1
+    });
+    order += 1;
+  }
+  return Array.from(candidatesByRoom.values()).map(enrichVisibleOccupationCandidate);
+}
+function upsertOccupationCandidate(candidatesByRoom, candidate) {
+  const existing = candidatesByRoom.get(candidate.roomName);
+  if (!existing) {
+    candidatesByRoom.set(candidate.roomName, candidate);
+    return;
+  }
+  if (candidate.source === "configured" && existing.source !== "configured") {
+    existing.source = "configured";
+    existing.actionHint = candidate.actionHint;
+    existing.order = Math.min(existing.order, candidate.order);
+  }
+  existing.adjacent = existing.adjacent || candidate.adjacent;
+  if (existing.routeDistance === void 0 && candidate.routeDistance !== void 0) {
+    existing.routeDistance = candidate.routeDistance;
+  }
+}
+function enrichVisibleOccupationCandidate(candidate) {
+  var _a;
+  const room = (_a = getGameRooms()) == null ? void 0 : _a[candidate.roomName];
+  if (!room) {
+    return candidate;
+  }
+  const hostileCreeps = findRoomObjects2(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects2(room, "FIND_HOSTILE_STRUCTURES");
+  const sources = findRoomObjects2(room, "FIND_SOURCES");
+  const constructionSites = findRoomObjects2(room, "FIND_MY_CONSTRUCTION_SITES");
+  const ownedStructures = findRoomObjects2(room, "FIND_MY_STRUCTURES");
+  return {
+    ...candidate,
+    visible: true,
+    ...room.controller ? { controller: summarizeController(room.controller) } : {},
+    ...sources ? { sourceCount: sources.length } : {},
+    ...hostileCreeps ? { hostileCreepCount: hostileCreeps.length } : {},
+    ...hostileStructures ? { hostileStructureCount: hostileStructures.length } : {},
+    ...constructionSites ? { constructionSiteCount: constructionSites.length } : {},
+    ...ownedStructures ? { ownedStructureCount: ownedStructures.length } : {}
+  };
+}
+function scoreOccupationCandidate(input, candidate) {
+  var _a, _b;
+  const evidence = [];
+  const preconditions = getColonyReadinessPreconditions(input);
+  const risks = [];
+  const routeDistance = typeof candidate.routeDistance === "number" ? candidate.routeDistance : void 0;
+  let action = "scout";
+  let evidenceStatus = "sufficient";
+  if (candidate.routeDistance === null) {
+    risks.push("no known route from colony");
+    evidenceStatus = "unavailable";
+  } else if (!candidate.visible) {
+    evidence.push("room visibility missing");
+    risks.push("controller, source, and hostile evidence unavailable");
+    evidenceStatus = "insufficient-evidence";
+  } else if (!candidate.controller) {
+    evidence.push("room visible");
+    risks.push("visible room has no controller");
+    evidenceStatus = "unavailable";
+  } else {
+    evidence.push("room visible", "controller visible");
+    const unavailableReason = getControllerUnavailableReason(input, candidate.controller);
+    if (unavailableReason) {
+      risks.push(unavailableReason);
+      evidenceStatus = "unavailable";
+      action = candidate.actionHint === "claim" ? "occupy" : "reserve";
+    } else if (isOwnHealthyReservation(input, candidate.controller)) {
+      evidence.push("own reservation is healthy");
+      evidenceStatus = "unavailable";
+      action = "reserve";
+    } else if (isOwnReservationDueForRenewal(input, candidate.controller)) {
+      evidence.push("own reservation needs renewal");
+      action = "reserve";
+    } else if (candidate.sourceCount === void 0) {
+      evidence.push("controller is available");
+      risks.push("source count evidence missing");
+      evidenceStatus = "insufficient-evidence";
+    } else {
+      evidence.push("controller is available", `${candidate.sourceCount} sources visible`);
+      action = candidate.actionHint === "claim" ? "occupy" : "reserve";
+    }
+  }
+  const hostileCreepCount = (_a = candidate.hostileCreepCount) != null ? _a : 0;
+  const hostileStructureCount = (_b = candidate.hostileStructureCount) != null ? _b : 0;
+  if (hostileCreepCount > 0 || hostileStructureCount > 0) {
+    risks.push("hostile presence visible");
+    evidenceStatus = "unavailable";
+  }
+  const score = calculateOccupationScore(input, candidate, action, evidenceStatus);
+  return {
+    roomName: candidate.roomName,
+    action,
+    score,
+    evidenceStatus,
+    source: candidate.source,
+    evidence,
+    preconditions,
+    risks,
+    ...routeDistance !== void 0 ? { routeDistance } : {},
+    ...candidate.sourceCount !== void 0 ? { sourceCount: candidate.sourceCount } : {},
+    ...candidate.hostileCreepCount !== void 0 ? { hostileCreepCount: candidate.hostileCreepCount } : {},
+    ...candidate.hostileStructureCount !== void 0 ? { hostileStructureCount: candidate.hostileStructureCount } : {}
+  };
+}
+function calculateOccupationScore(input, candidate, action, evidenceStatus) {
+  var _a, _b, _c, _d, _e;
+  const distanceScore = typeof candidate.routeDistance === "number" ? Math.max(0, 80 - candidate.routeDistance * 15) : 0;
+  const sourceScore = typeof candidate.sourceCount === "number" ? Math.min(candidate.sourceCount, 2) * 70 : 0;
+  const supportScore = Math.min((_a = candidate.ownedStructureCount) != null ? _a : 0, 3) * 8 + Math.min((_b = candidate.constructionSiteCount) != null ? _b : 0, 3) * 5;
+  const sourcePriorityScore = candidate.source === "configured" ? 50 : 25;
+  const adjacencyScore = candidate.adjacent ? 25 : 0;
+  const readinessScore = Math.min(input.workerCount, MIN_READY_WORKERS) * 12 + (input.energyCapacityAvailable >= TERRITORY_BODY_ENERGY_CAPACITY ? 30 : 0) + (((_c = input.controllerLevel) != null ? _c : 0) >= 2 ? 30 : 0) + (input.ticksToDowngrade === void 0 || input.ticksToDowngrade > DOWNGRADE_GUARD_TICKS ? 20 : 0);
+  const riskPenalty = ((_d = candidate.hostileCreepCount) != null ? _d : 0) * 160 + ((_e = candidate.hostileStructureCount) != null ? _e : 0) * 120;
+  const evidencePenalty = evidenceStatus === "insufficient-evidence" ? 260 : 0;
+  const unavailablePenalty = evidenceStatus === "unavailable" ? 2e3 : 0;
+  return ACTION_SCORE[action] + sourcePriorityScore + adjacencyScore + distanceScore + sourceScore + supportScore + readinessScore - riskPenalty - evidencePenalty - unavailablePenalty;
+}
+function getColonyReadinessPreconditions(input) {
+  var _a;
+  const preconditions = [];
+  if (input.workerCount < MIN_READY_WORKERS) {
+    preconditions.push("raise worker count before dispatching territory creeps");
+  }
+  if (input.energyCapacityAvailable < TERRITORY_BODY_ENERGY_CAPACITY) {
+    preconditions.push("reach 650 energy capacity for controller work");
+  }
+  if (((_a = input.controllerLevel) != null ? _a : 0) < 2) {
+    preconditions.push("reach controller level 2 before expansion");
+  }
+  if (typeof input.ticksToDowngrade === "number" && input.ticksToDowngrade <= DOWNGRADE_GUARD_TICKS) {
+    preconditions.push("stabilize home controller downgrade timer");
+  }
+  return preconditions;
+}
+function getControllerUnavailableReason(input, controller) {
+  if (isControllerOwnedByColony2(input, controller)) {
+    return "controller already owned by colony account";
+  }
+  if (controller.ownerUsername) {
+    return "controller owned by another account";
+  }
+  if (controller.reservationUsername && controller.reservationUsername !== input.colonyOwnerUsername) {
+    return "controller reserved by another account";
+  }
+  return null;
+}
+function isOwnHealthyReservation(input, controller) {
+  return isOwnReservation(input, controller) && typeof controller.reservationTicksToEnd === "number" && controller.reservationTicksToEnd > RESERVATION_RENEWAL_TICKS;
+}
+function isOwnReservationDueForRenewal(input, controller) {
+  return isOwnReservation(input, controller) && typeof controller.reservationTicksToEnd === "number" && controller.reservationTicksToEnd <= RESERVATION_RENEWAL_TICKS;
+}
+function isOwnReservation(input, controller) {
+  return input.colonyOwnerUsername !== void 0 && controller.reservationUsername === input.colonyOwnerUsername;
+}
+function isControllerOwnedByColony2(input, controller) {
+  return controller.my === true || !!controller.ownerUsername && controller.ownerUsername === input.colonyOwnerUsername;
+}
+function compareOccupationRecommendationScores(left, right) {
+  return right.score - left.score || getEvidenceStatusPriority(left.evidenceStatus) - getEvidenceStatusPriority(right.evidenceStatus) || getActionPriority(left.action) - getActionPriority(right.action) || getSourcePriority(left.source) - getSourcePriority(right.source) || compareOptionalNumbers2(left.routeDistance, right.routeDistance) || left.roomName.localeCompare(right.roomName);
+}
+function getEvidenceStatusPriority(status) {
+  if (status === "sufficient") {
+    return 0;
+  }
+  return status === "insufficient-evidence" ? 1 : 2;
+}
+function getActionPriority(action) {
+  if (action === "occupy") {
+    return 0;
+  }
+  return action === "reserve" ? 1 : 2;
+}
+function getSourcePriority(source) {
+  return source === "configured" ? 0 : 1;
+}
+function compareOptionalNumbers2(left, right) {
+  return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
+}
+function summarizeController(controller) {
+  const ownerUsername = getControllerOwnerUsername2(controller);
+  const reservationUsername = getReservationUsername(controller);
+  const reservationTicksToEnd = getReservationTicksToEnd(controller);
+  return {
+    ...controller.my === true ? { my: true } : {},
+    ...ownerUsername ? { ownerUsername } : {},
+    ...reservationUsername ? { reservationUsername } : {},
+    ...typeof reservationTicksToEnd === "number" ? { reservationTicksToEnd } : {}
+  };
+}
+function getAdjacentRoomNames2(roomName) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (!gameMap || typeof gameMap.describeExits !== "function") {
+    return [];
+  }
+  const exits = gameMap.describeExits(roomName);
+  if (!isRecord3(exits)) {
+    return [];
+  }
+  return EXIT_DIRECTION_ORDER2.flatMap((direction) => {
+    const exitRoom = exits[direction];
+    return typeof exitRoom === "string" && exitRoom.length > 0 ? [exitRoom] : [];
+  });
+}
+function normalizeTerritoryTarget2(rawTarget) {
+  if (!isRecord3(rawTarget)) {
+    return null;
+  }
+  if (typeof rawTarget.colony !== "string" || rawTarget.colony.length === 0 || typeof rawTarget.roomName !== "string" || rawTarget.roomName.length === 0 || rawTarget.action !== "claim" && rawTarget.action !== "reserve") {
+    return null;
+  }
+  return {
+    colony: rawTarget.colony,
+    roomName: rawTarget.roomName,
+    action: rawTarget.action,
+    ...rawTarget.enabled === false ? { enabled: false } : {}
+  };
+}
+function getCachedRouteDistance(fromRoom, targetRoom) {
+  var _a;
+  const routeDistances = (_a = getTerritoryMemoryRecord2()) == null ? void 0 : _a.routeDistances;
+  if (!isRecord3(routeDistances)) {
+    return void 0;
+  }
+  const distance = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR2}${targetRoom}`];
+  return typeof distance === "number" || distance === null ? distance : void 0;
+}
+function findRoomObjects2(room, constantName) {
+  const findConstant = getGlobalNumber(constantName);
+  const find = room.find;
+  if (typeof findConstant !== "number" || typeof find !== "function") {
+    return void 0;
+  }
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return void 0;
+  }
+}
+function getGlobalNumber(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function getControllerOwnerUsername2(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  return typeof username === "string" && username.length > 0 ? username : void 0;
+}
+function getReservationUsername(controller) {
+  var _a;
+  const username = (_a = controller.reservation) == null ? void 0 : _a.username;
+  return typeof username === "string" && username.length > 0 ? username : void 0;
+}
+function getReservationTicksToEnd(controller) {
+  var _a;
+  const ticksToEnd = (_a = controller.reservation) == null ? void 0 : _a.ticksToEnd;
+  return typeof ticksToEnd === "number" ? ticksToEnd : void 0;
+}
+function getGameRooms() {
+  var _a;
+  return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+}
+function getTerritoryMemoryRecord2() {
+  var _a;
+  return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
+}
+function isRecord3(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/telemetry/runtimeSummary.ts
 var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
@@ -3616,7 +3956,8 @@ function summarizeRoom(colony, creeps) {
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
-    constructionPriority: summarizeConstructionPriority(colony, colonyWorkers)
+    constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
+    territoryRecommendation: buildRuntimeOccupationRecommendationReport(colony, colonyWorkers)
   };
 }
 function summarizeSpawn(spawn) {
@@ -3676,9 +4017,9 @@ function buildControllerSummary(room) {
 }
 function summarizeResources(colony, colonyWorkers, events) {
   var _a, _b, _c;
-  const roomStructures = (_a = findRoomObjects2(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const droppedResources = (_b = findRoomObjects2(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _b : [];
-  const sources = (_c = findRoomObjects2(colony.room, "FIND_SOURCES")) != null ? _c : [];
+  const roomStructures = (_a = findRoomObjects3(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const droppedResources = (_b = findRoomObjects3(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _b : [];
+  const sources = (_c = findRoomObjects3(colony.room, "FIND_SOURCES")) != null ? _c : [];
   return {
     storedEnergy: sumEnergyInStores(roomStructures),
     workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
@@ -3689,8 +4030,8 @@ function summarizeResources(colony, colonyWorkers, events) {
 }
 function summarizeCombat(room, events) {
   var _a, _b;
-  const hostileCreeps = (_a = findRoomObjects2(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
-  const hostileStructures = (_b = findRoomObjects2(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
+  const hostileCreeps = (_a = findRoomObjects3(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
+  const hostileStructures = (_b = findRoomObjects3(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
   return {
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -3720,10 +4061,10 @@ function summarizeRoomEventMetrics(room) {
   if (!eventLog) {
     return {};
   }
-  const harvestEvent = getGlobalNumber("EVENT_HARVEST");
-  const transferEvent = getGlobalNumber("EVENT_TRANSFER");
-  const attackEvent = getGlobalNumber("EVENT_ATTACK");
-  const objectDestroyedEvent = getGlobalNumber("EVENT_OBJECT_DESTROYED");
+  const harvestEvent = getGlobalNumber2("EVENT_HARVEST");
+  const transferEvent = getGlobalNumber2("EVENT_TRANSFER");
+  const attackEvent = getGlobalNumber2("EVENT_ATTACK");
+  const objectDestroyedEvent = getGlobalNumber2("EVENT_OBJECT_DESTROYED");
   const resourceEvents = {
     harvestedEnergy: 0,
     transferredEnergy: 0
@@ -3737,10 +4078,10 @@ function summarizeRoomEventMetrics(room) {
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord3(entry) || typeof entry.event !== "number") {
+    if (!isRecord4(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord3(entry.data) ? entry.data : {};
+    const data = isRecord4(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -3767,8 +4108,8 @@ function summarizeRoomEventMetrics(room) {
     ...hasCombatEvents ? { combat: combatEvents } : {}
   };
 }
-function findRoomObjects2(room, constantName) {
-  const findConstant = getGlobalNumber(constantName);
+function findRoomObjects3(room, constantName) {
+  const findConstant = getGlobalNumber2(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return void 0;
@@ -3796,7 +4137,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord3(object) || !isRecord3(object.store)) {
+  if (!isRecord4(object) || !isRecord4(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -3810,7 +4151,7 @@ function getEnergyInStore(object) {
 function sumDroppedEnergy(droppedResources) {
   const energyResource = getEnergyResource2();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord3(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord4(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -3823,7 +4164,7 @@ function getNumericEventData(data, key) {
   const value = data[key];
   return typeof value === "number" ? value : 0;
 }
-function getGlobalNumber(name) {
+function getGlobalNumber2(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -3831,7 +4172,7 @@ function getEnergyResource2() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord3(value) {
+function isRecord4(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3611,7 +3611,6 @@ function buildRuntimeOccupationRecommendationInput(colony, colonyWorkers) {
   };
 }
 function buildRuntimeOccupationCandidates(colonyName) {
-  var _a;
   const candidatesByRoom = /* @__PURE__ */ new Map();
   const territoryMemory = getTerritoryMemoryRecord2();
   let order = 0;
@@ -3634,13 +3633,14 @@ function buildRuntimeOccupationCandidates(colonyName) {
     }
   }
   for (const roomName of getAdjacentRoomNames2(colonyName)) {
+    const cachedRouteDistance = getCachedRouteDistance(colonyName, roomName);
     upsertOccupationCandidate(candidatesByRoom, {
       roomName,
       source: "adjacent",
       order,
       adjacent: true,
       visible: false,
-      routeDistance: (_a = getCachedRouteDistance(colonyName, roomName)) != null ? _a : 1
+      routeDistance: cachedRouteDistance === void 0 ? 1 : cachedRouteDistance
     });
     order += 1;
   }

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -1,5 +1,9 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { buildRuntimeConstructionPriorityReport, type ConstructionPriorityScore } from '../construction/constructionPriority';
+import {
+  buildRuntimeOccupationRecommendationReport,
+  type OccupationRecommendationReport
+} from '../territory/occupationRecommendation';
 
 export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
@@ -40,6 +44,7 @@ interface RuntimeRoomSummary {
   resources: RuntimeResourceSummary;
   combat: RuntimeCombatSummary;
   constructionPriority: RuntimeConstructionPrioritySummary;
+  territoryRecommendation: OccupationRecommendationReport;
 }
 
 interface RuntimeControllerSummary {
@@ -150,7 +155,8 @@ function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSumm
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
-    constructionPriority: summarizeConstructionPriority(colony, colonyWorkers)
+    constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
+    territoryRecommendation: buildRuntimeOccupationRecommendationReport(colony, colonyWorkers)
   };
 }
 

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -1,0 +1,533 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+
+export type OccupationRecommendationAction = 'occupy' | 'reserve' | 'scout';
+export type OccupationRecommendationEvidenceStatus = 'sufficient' | 'insufficient-evidence' | 'unavailable';
+export type OccupationRecommendationCandidateSource = 'configured' | 'adjacent';
+
+export interface OccupationRecommendationReport {
+  candidates: OccupationRecommendationScore[];
+  next: OccupationRecommendationScore | null;
+}
+
+export interface OccupationRecommendationScore {
+  roomName: string;
+  action: OccupationRecommendationAction;
+  score: number;
+  evidenceStatus: OccupationRecommendationEvidenceStatus;
+  source: OccupationRecommendationCandidateSource;
+  evidence: string[];
+  preconditions: string[];
+  risks: string[];
+  routeDistance?: number;
+  sourceCount?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+}
+
+export interface OccupationRecommendationInput {
+  colonyName: string;
+  colonyOwnerUsername?: string;
+  energyCapacityAvailable: number;
+  workerCount: number;
+  controllerLevel?: number;
+  ticksToDowngrade?: number;
+  candidates: OccupationRecommendationCandidateInput[];
+}
+
+export interface OccupationRecommendationCandidateInput {
+  roomName: string;
+  source: OccupationRecommendationCandidateSource;
+  order: number;
+  adjacent: boolean;
+  visible: boolean;
+  actionHint?: TerritoryControlAction;
+  routeDistance?: number | null;
+  controller?: OccupationControllerEvidence;
+  sourceCount?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  constructionSiteCount?: number;
+  ownedStructureCount?: number;
+}
+
+export interface OccupationControllerEvidence {
+  my?: boolean;
+  ownerUsername?: string;
+  reservationUsername?: string;
+  reservationTicksToEnd?: number;
+}
+
+const EXIT_DIRECTION_ORDER = ['1', '3', '5', '7'] as const;
+const TERRITORY_BODY_ENERGY_CAPACITY = 650;
+const MIN_READY_WORKERS = 3;
+const DOWNGRADE_GUARD_TICKS = 5_000;
+const RESERVATION_RENEWAL_TICKS = 1_000;
+const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
+
+// Project vision ordering: territory action dominates resource value; combat/risk only gates or deprioritizes.
+const ACTION_SCORE: Record<OccupationRecommendationAction, number> = {
+  occupy: 1_000,
+  reserve: 800,
+  scout: 420
+};
+
+export function buildRuntimeOccupationRecommendationReport(
+  colony: ColonySnapshot,
+  colonyWorkers: Creep[]
+): OccupationRecommendationReport {
+  return scoreOccupationRecommendations(buildRuntimeOccupationRecommendationInput(colony, colonyWorkers));
+}
+
+export function scoreOccupationRecommendations(
+  input: OccupationRecommendationInput
+): OccupationRecommendationReport {
+  const candidates = input.candidates
+    .filter((candidate) => candidate.roomName !== input.colonyName)
+    .map((candidate) => scoreOccupationCandidate(input, candidate))
+    .sort(compareOccupationRecommendationScores);
+  const next = candidates.find((candidate) => candidate.evidenceStatus !== 'unavailable') ?? null;
+
+  return { candidates, next };
+}
+
+function buildRuntimeOccupationRecommendationInput(
+  colony: ColonySnapshot,
+  colonyWorkers: Creep[]
+): OccupationRecommendationInput {
+  const colonyName = colony.room.name;
+  return {
+    colonyName,
+    colonyOwnerUsername: getControllerOwnerUsername(colony.room.controller),
+    energyCapacityAvailable: colony.energyCapacityAvailable,
+    workerCount: colonyWorkers.length,
+    ...(typeof colony.room.controller?.level === 'number' ? { controllerLevel: colony.room.controller.level } : {}),
+    ...(typeof colony.room.controller?.ticksToDowngrade === 'number'
+      ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade }
+      : {}),
+    candidates: buildRuntimeOccupationCandidates(colonyName)
+  };
+}
+
+function buildRuntimeOccupationCandidates(colonyName: string): OccupationRecommendationCandidateInput[] {
+  const candidatesByRoom = new Map<string, OccupationRecommendationCandidateInput>();
+  const territoryMemory = getTerritoryMemoryRecord();
+  let order = 0;
+
+  if (Array.isArray(territoryMemory?.targets)) {
+    for (const rawTarget of territoryMemory.targets) {
+      const target = normalizeTerritoryTarget(rawTarget);
+      if (!target || target.colony !== colonyName || target.enabled === false) {
+        continue;
+      }
+
+      upsertOccupationCandidate(candidatesByRoom, {
+        roomName: target.roomName,
+        source: 'configured',
+        order,
+        adjacent: false,
+        visible: false,
+        actionHint: target.action,
+        routeDistance: getCachedRouteDistance(colonyName, target.roomName)
+      });
+      order += 1;
+    }
+  }
+
+  for (const roomName of getAdjacentRoomNames(colonyName)) {
+    upsertOccupationCandidate(candidatesByRoom, {
+      roomName,
+      source: 'adjacent',
+      order,
+      adjacent: true,
+      visible: false,
+      routeDistance: getCachedRouteDistance(colonyName, roomName) ?? 1
+    });
+    order += 1;
+  }
+
+  return Array.from(candidatesByRoom.values()).map(enrichVisibleOccupationCandidate);
+}
+
+function upsertOccupationCandidate(
+  candidatesByRoom: Map<string, OccupationRecommendationCandidateInput>,
+  candidate: OccupationRecommendationCandidateInput
+): void {
+  const existing = candidatesByRoom.get(candidate.roomName);
+  if (!existing) {
+    candidatesByRoom.set(candidate.roomName, candidate);
+    return;
+  }
+
+  if (candidate.source === 'configured' && existing.source !== 'configured') {
+    existing.source = 'configured';
+    existing.actionHint = candidate.actionHint;
+    existing.order = Math.min(existing.order, candidate.order);
+  }
+
+  existing.adjacent = existing.adjacent || candidate.adjacent;
+  if (existing.routeDistance === undefined && candidate.routeDistance !== undefined) {
+    existing.routeDistance = candidate.routeDistance;
+  }
+}
+
+function enrichVisibleOccupationCandidate(
+  candidate: OccupationRecommendationCandidateInput
+): OccupationRecommendationCandidateInput {
+  const room = getGameRooms()?.[candidate.roomName];
+  if (!room) {
+    return candidate;
+  }
+
+  const hostileCreeps = findRoomObjects(room, 'FIND_HOSTILE_CREEPS');
+  const hostileStructures = findRoomObjects(room, 'FIND_HOSTILE_STRUCTURES');
+  const sources = findRoomObjects(room, 'FIND_SOURCES');
+  const constructionSites = findRoomObjects(room, 'FIND_MY_CONSTRUCTION_SITES');
+  const ownedStructures = findRoomObjects(room, 'FIND_MY_STRUCTURES');
+
+  return {
+    ...candidate,
+    visible: true,
+    ...(room.controller ? { controller: summarizeController(room.controller) } : {}),
+    ...(sources ? { sourceCount: sources.length } : {}),
+    ...(hostileCreeps ? { hostileCreepCount: hostileCreeps.length } : {}),
+    ...(hostileStructures ? { hostileStructureCount: hostileStructures.length } : {}),
+    ...(constructionSites ? { constructionSiteCount: constructionSites.length } : {}),
+    ...(ownedStructures ? { ownedStructureCount: ownedStructures.length } : {})
+  };
+}
+
+function scoreOccupationCandidate(
+  input: OccupationRecommendationInput,
+  candidate: OccupationRecommendationCandidateInput
+): OccupationRecommendationScore {
+  const evidence: string[] = [];
+  const preconditions = getColonyReadinessPreconditions(input);
+  const risks: string[] = [];
+  const routeDistance = typeof candidate.routeDistance === 'number' ? candidate.routeDistance : undefined;
+  let action: OccupationRecommendationAction = 'scout';
+  let evidenceStatus: OccupationRecommendationEvidenceStatus = 'sufficient';
+
+  if (candidate.routeDistance === null) {
+    risks.push('no known route from colony');
+    evidenceStatus = 'unavailable';
+  } else if (!candidate.visible) {
+    evidence.push('room visibility missing');
+    risks.push('controller, source, and hostile evidence unavailable');
+    evidenceStatus = 'insufficient-evidence';
+  } else if (!candidate.controller) {
+    evidence.push('room visible');
+    risks.push('visible room has no controller');
+    evidenceStatus = 'unavailable';
+  } else {
+    evidence.push('room visible', 'controller visible');
+    const unavailableReason = getControllerUnavailableReason(input, candidate.controller);
+    if (unavailableReason) {
+      risks.push(unavailableReason);
+      evidenceStatus = 'unavailable';
+      action = candidate.actionHint === 'claim' ? 'occupy' : 'reserve';
+    } else if (isOwnHealthyReservation(input, candidate.controller)) {
+      evidence.push('own reservation is healthy');
+      evidenceStatus = 'unavailable';
+      action = 'reserve';
+    } else if (isOwnReservationDueForRenewal(input, candidate.controller)) {
+      evidence.push('own reservation needs renewal');
+      action = 'reserve';
+    } else if (candidate.sourceCount === undefined) {
+      evidence.push('controller is available');
+      risks.push('source count evidence missing');
+      evidenceStatus = 'insufficient-evidence';
+    } else {
+      evidence.push('controller is available', `${candidate.sourceCount} sources visible`);
+      action = candidate.actionHint === 'claim' ? 'occupy' : 'reserve';
+    }
+  }
+
+  const hostileCreepCount = candidate.hostileCreepCount ?? 0;
+  const hostileStructureCount = candidate.hostileStructureCount ?? 0;
+  if (hostileCreepCount > 0 || hostileStructureCount > 0) {
+    risks.push('hostile presence visible');
+    evidenceStatus = 'unavailable';
+  }
+
+  const score = calculateOccupationScore(input, candidate, action, evidenceStatus);
+  return {
+    roomName: candidate.roomName,
+    action,
+    score,
+    evidenceStatus,
+    source: candidate.source,
+    evidence,
+    preconditions,
+    risks,
+    ...(routeDistance !== undefined ? { routeDistance } : {}),
+    ...(candidate.sourceCount !== undefined ? { sourceCount: candidate.sourceCount } : {}),
+    ...(candidate.hostileCreepCount !== undefined ? { hostileCreepCount: candidate.hostileCreepCount } : {}),
+    ...(candidate.hostileStructureCount !== undefined ? { hostileStructureCount: candidate.hostileStructureCount } : {})
+  };
+}
+
+function calculateOccupationScore(
+  input: OccupationRecommendationInput,
+  candidate: OccupationRecommendationCandidateInput,
+  action: OccupationRecommendationAction,
+  evidenceStatus: OccupationRecommendationEvidenceStatus
+): number {
+  const distanceScore =
+    typeof candidate.routeDistance === 'number' ? Math.max(0, 80 - candidate.routeDistance * 15) : 0;
+  const sourceScore = typeof candidate.sourceCount === 'number' ? Math.min(candidate.sourceCount, 2) * 70 : 0;
+  const supportScore =
+    Math.min(candidate.ownedStructureCount ?? 0, 3) * 8 +
+    Math.min(candidate.constructionSiteCount ?? 0, 3) * 5;
+  const sourcePriorityScore = candidate.source === 'configured' ? 50 : 25;
+  const adjacencyScore = candidate.adjacent ? 25 : 0;
+  const readinessScore =
+    Math.min(input.workerCount, MIN_READY_WORKERS) * 12 +
+    (input.energyCapacityAvailable >= TERRITORY_BODY_ENERGY_CAPACITY ? 30 : 0) +
+    ((input.controllerLevel ?? 0) >= 2 ? 30 : 0) +
+    (input.ticksToDowngrade === undefined || input.ticksToDowngrade > DOWNGRADE_GUARD_TICKS ? 20 : 0);
+  const riskPenalty = (candidate.hostileCreepCount ?? 0) * 160 + (candidate.hostileStructureCount ?? 0) * 120;
+  const evidencePenalty = evidenceStatus === 'insufficient-evidence' ? 260 : 0;
+  const unavailablePenalty = evidenceStatus === 'unavailable' ? 2_000 : 0;
+
+  return (
+    ACTION_SCORE[action] +
+    sourcePriorityScore +
+    adjacencyScore +
+    distanceScore +
+    sourceScore +
+    supportScore +
+    readinessScore -
+    riskPenalty -
+    evidencePenalty -
+    unavailablePenalty
+  );
+}
+
+function getColonyReadinessPreconditions(input: OccupationRecommendationInput): string[] {
+  const preconditions: string[] = [];
+  if (input.workerCount < MIN_READY_WORKERS) {
+    preconditions.push('raise worker count before dispatching territory creeps');
+  }
+
+  if (input.energyCapacityAvailable < TERRITORY_BODY_ENERGY_CAPACITY) {
+    preconditions.push('reach 650 energy capacity for controller work');
+  }
+
+  if ((input.controllerLevel ?? 0) < 2) {
+    preconditions.push('reach controller level 2 before expansion');
+  }
+
+  if (typeof input.ticksToDowngrade === 'number' && input.ticksToDowngrade <= DOWNGRADE_GUARD_TICKS) {
+    preconditions.push('stabilize home controller downgrade timer');
+  }
+
+  return preconditions;
+}
+
+function getControllerUnavailableReason(
+  input: OccupationRecommendationInput,
+  controller: OccupationControllerEvidence
+): string | null {
+  if (isControllerOwnedByColony(input, controller)) {
+    return 'controller already owned by colony account';
+  }
+
+  if (controller.ownerUsername) {
+    return 'controller owned by another account';
+  }
+
+  if (controller.reservationUsername && controller.reservationUsername !== input.colonyOwnerUsername) {
+    return 'controller reserved by another account';
+  }
+
+  return null;
+}
+
+function isOwnHealthyReservation(
+  input: OccupationRecommendationInput,
+  controller: OccupationControllerEvidence
+): boolean {
+  return (
+    isOwnReservation(input, controller) &&
+    typeof controller.reservationTicksToEnd === 'number' &&
+    controller.reservationTicksToEnd > RESERVATION_RENEWAL_TICKS
+  );
+}
+
+function isOwnReservationDueForRenewal(
+  input: OccupationRecommendationInput,
+  controller: OccupationControllerEvidence
+): boolean {
+  return (
+    isOwnReservation(input, controller) &&
+    typeof controller.reservationTicksToEnd === 'number' &&
+    controller.reservationTicksToEnd <= RESERVATION_RENEWAL_TICKS
+  );
+}
+
+function isOwnReservation(input: OccupationRecommendationInput, controller: OccupationControllerEvidence): boolean {
+  return (
+    input.colonyOwnerUsername !== undefined &&
+    controller.reservationUsername === input.colonyOwnerUsername
+  );
+}
+
+function isControllerOwnedByColony(
+  input: OccupationRecommendationInput,
+  controller: OccupationControllerEvidence
+): boolean {
+  return (
+    controller.my === true ||
+    (!!controller.ownerUsername && controller.ownerUsername === input.colonyOwnerUsername)
+  );
+}
+
+function compareOccupationRecommendationScores(
+  left: OccupationRecommendationScore,
+  right: OccupationRecommendationScore
+): number {
+  return (
+    right.score - left.score ||
+    getEvidenceStatusPriority(left.evidenceStatus) - getEvidenceStatusPriority(right.evidenceStatus) ||
+    getActionPriority(left.action) - getActionPriority(right.action) ||
+    getSourcePriority(left.source) - getSourcePriority(right.source) ||
+    compareOptionalNumbers(left.routeDistance, right.routeDistance) ||
+    left.roomName.localeCompare(right.roomName)
+  );
+}
+
+function getEvidenceStatusPriority(status: OccupationRecommendationEvidenceStatus): number {
+  if (status === 'sufficient') {
+    return 0;
+  }
+
+  return status === 'insufficient-evidence' ? 1 : 2;
+}
+
+function getActionPriority(action: OccupationRecommendationAction): number {
+  if (action === 'occupy') {
+    return 0;
+  }
+
+  return action === 'reserve' ? 1 : 2;
+}
+
+function getSourcePriority(source: OccupationRecommendationCandidateSource): number {
+  return source === 'configured' ? 0 : 1;
+}
+
+function compareOptionalNumbers(left: number | undefined, right: number | undefined): number {
+  return (left ?? Number.POSITIVE_INFINITY) - (right ?? Number.POSITIVE_INFINITY);
+}
+
+function summarizeController(controller: StructureController): OccupationControllerEvidence {
+  const ownerUsername = getControllerOwnerUsername(controller);
+  const reservationUsername = getReservationUsername(controller);
+  const reservationTicksToEnd = getReservationTicksToEnd(controller);
+
+  return {
+    ...(controller.my === true ? { my: true } : {}),
+    ...(ownerUsername ? { ownerUsername } : {}),
+    ...(reservationUsername ? { reservationUsername } : {}),
+    ...(typeof reservationTicksToEnd === 'number' ? { reservationTicksToEnd } : {})
+  };
+}
+
+function getAdjacentRoomNames(roomName: string): string[] {
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map;
+  if (!gameMap || typeof gameMap.describeExits !== 'function') {
+    return [];
+  }
+
+  const exits = gameMap.describeExits(roomName) as Record<string, string> | null;
+  if (!isRecord(exits)) {
+    return [];
+  }
+
+  return EXIT_DIRECTION_ORDER.flatMap((direction) => {
+    const exitRoom = exits[direction];
+    return typeof exitRoom === 'string' && exitRoom.length > 0 ? [exitRoom] : [];
+  });
+}
+
+function normalizeTerritoryTarget(rawTarget: unknown): TerritoryTargetMemory | null {
+  if (!isRecord(rawTarget)) {
+    return null;
+  }
+
+  if (
+    typeof rawTarget.colony !== 'string' ||
+    rawTarget.colony.length === 0 ||
+    typeof rawTarget.roomName !== 'string' ||
+    rawTarget.roomName.length === 0 ||
+    (rawTarget.action !== 'claim' && rawTarget.action !== 'reserve')
+  ) {
+    return null;
+  }
+
+  return {
+    colony: rawTarget.colony,
+    roomName: rawTarget.roomName,
+    action: rawTarget.action,
+    ...(rawTarget.enabled === false ? { enabled: false } : {})
+  };
+}
+
+function getCachedRouteDistance(fromRoom: string, targetRoom: string): number | null | undefined {
+  const routeDistances = getTerritoryMemoryRecord()?.routeDistances;
+  if (!isRecord(routeDistances)) {
+    return undefined;
+  }
+
+  const distance = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`];
+  return typeof distance === 'number' || distance === null ? distance : undefined;
+}
+
+function findRoomObjects(room: Room, constantName: string): unknown[] | undefined {
+  const findConstant = getGlobalNumber(constantName);
+  const find = (room as unknown as { find?: unknown }).find;
+  if (typeof findConstant !== 'number' || typeof find !== 'function') {
+    return undefined;
+  }
+
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return undefined;
+  }
+}
+
+function getGlobalNumber(name: string): number | undefined {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function getControllerOwnerUsername(controller: StructureController | undefined): string | undefined {
+  const username = (controller as (StructureController & { owner?: { username?: string } }) | undefined)?.owner
+    ?.username;
+  return typeof username === 'string' && username.length > 0 ? username : undefined;
+}
+
+function getReservationUsername(controller: StructureController): string | undefined {
+  const username = (controller as StructureController & { reservation?: { username?: string } }).reservation?.username;
+  return typeof username === 'string' && username.length > 0 ? username : undefined;
+}
+
+function getReservationTicksToEnd(controller: StructureController): number | undefined {
+  const ticksToEnd = (controller as StructureController & { reservation?: { ticksToEnd?: number } }).reservation
+    ?.ticksToEnd;
+  return typeof ticksToEnd === 'number' ? ticksToEnd : undefined;
+}
+
+function getGameRooms(): Game['rooms'] | undefined {
+  return (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+}
+
+function getTerritoryMemoryRecord(): TerritoryMemory | undefined {
+  return (globalThis as { Memory?: Partial<Memory> }).Memory?.territory;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -134,13 +134,14 @@ function buildRuntimeOccupationCandidates(colonyName: string): OccupationRecomme
   }
 
   for (const roomName of getAdjacentRoomNames(colonyName)) {
+    const cachedRouteDistance = getCachedRouteDistance(colonyName, roomName);
     upsertOccupationCandidate(candidatesByRoom, {
       roomName,
       source: 'adjacent',
       order,
       adjacent: true,
       visible: false,
-      routeDistance: getCachedRouteDistance(colonyName, roomName) ?? 1
+      routeDistance: cachedRouteDistance === undefined ? 1 : cachedRouteDistance
     });
     order += 1;
   }

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -1,0 +1,188 @@
+import {
+  scoreOccupationRecommendations,
+  type OccupationRecommendationCandidateInput,
+  type OccupationRecommendationInput
+} from '../src/territory/occupationRecommendation';
+
+describe('occupation recommendation scoring', () => {
+  it('keeps occupy recommendations ahead of richer reserve rooms', () => {
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          source: 'adjacent',
+          adjacent: true,
+          actionHint: 'reserve',
+          sourceCount: 2,
+          routeDistance: 1
+        }),
+        makeCandidate({
+          roomName: 'W3N1',
+          source: 'configured',
+          actionHint: 'claim',
+          sourceCount: 1,
+          routeDistance: 2
+        })
+      ])
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W3N1',
+      action: 'occupy',
+      evidenceStatus: 'sufficient',
+      sourceCount: 1
+    });
+    expect(report.candidates.map((candidate) => candidate.roomName)).toEqual(['W3N1', 'W2N1']);
+  });
+
+  it('recommends scouting when visibility evidence is missing', () => {
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          visible: false,
+          sourceCount: undefined,
+          controller: undefined
+        })
+      ])
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      action: 'scout',
+      evidenceStatus: 'insufficient-evidence'
+    });
+    expect(report.next?.risks).toContain('controller, source, and hostile evidence unavailable');
+  });
+
+  it('filters enemy-owned and hostile rooms before selecting a safe reserve candidate', () => {
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          controller: { ownerUsername: 'enemy' },
+          sourceCount: 2
+        }),
+        makeCandidate({
+          roomName: 'W3N1',
+          hostileCreepCount: 1,
+          sourceCount: 2
+        }),
+        makeCandidate({
+          roomName: 'W4N1',
+          sourceCount: 1,
+          routeDistance: 1
+        })
+      ])
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W4N1',
+      action: 'reserve',
+      evidenceStatus: 'sufficient'
+    });
+    expect(report.candidates.find((candidate) => candidate.roomName === 'W2N1')).toMatchObject({
+      evidenceStatus: 'unavailable',
+      risks: ['controller owned by another account']
+    });
+    expect(report.candidates.find((candidate) => candidate.roomName === 'W3N1')).toMatchObject({
+      evidenceStatus: 'unavailable',
+      hostileCreepCount: 1
+    });
+  });
+
+  it('renews own reservations only when they are near expiry', () => {
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          controller: { reservationUsername: 'me', reservationTicksToEnd: 1_500 },
+          sourceCount: 2
+        }),
+        makeCandidate({
+          roomName: 'W3N1',
+          controller: { reservationUsername: 'me', reservationTicksToEnd: 500 },
+          sourceCount: 1
+        })
+      ])
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W3N1',
+      action: 'reserve',
+      evidenceStatus: 'sufficient'
+    });
+    expect(report.candidates.find((candidate) => candidate.roomName === 'W2N1')).toMatchObject({
+      evidenceStatus: 'unavailable',
+      evidence: ['room visible', 'controller visible', 'own reservation is healthy']
+    });
+  });
+
+  it('carries colony readiness preconditions into otherwise valid recommendations', () => {
+    const report = scoreOccupationRecommendations(
+      makeInput(
+        [
+          makeCandidate({
+            roomName: 'W2N1',
+            sourceCount: 2
+          })
+        ],
+        {
+          energyCapacityAvailable: 300,
+          workerCount: 1,
+          controllerLevel: 1,
+          ticksToDowngrade: 1_000
+        }
+      )
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      action: 'reserve',
+      evidenceStatus: 'sufficient',
+      preconditions: [
+        'raise worker count before dispatching territory creeps',
+        'reach 650 energy capacity for controller work',
+        'reach controller level 2 before expansion',
+        'stabilize home controller downgrade timer'
+      ]
+    });
+  });
+});
+
+function makeInput(
+  candidates: OccupationRecommendationCandidateInput[],
+  overrides: Partial<OccupationRecommendationInput> = {}
+): OccupationRecommendationInput {
+  return {
+    colonyName: 'W1N1',
+    colonyOwnerUsername: 'me',
+    energyCapacityAvailable: 650,
+    workerCount: 3,
+    controllerLevel: 3,
+    ticksToDowngrade: 10_000,
+    candidates,
+    ...overrides
+  };
+}
+
+function makeCandidate(
+  overrides: Partial<OccupationRecommendationCandidateInput>
+): OccupationRecommendationCandidateInput {
+  return {
+    roomName: 'W2N1',
+    source: 'configured',
+    order: 0,
+    adjacent: false,
+    visible: true,
+    actionHint: 'reserve',
+    routeDistance: 1,
+    controller: {},
+    sourceCount: 1,
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    constructionSiteCount: 0,
+    ownedStructureCount: 0,
+    ...overrides
+  };
+}

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -1,10 +1,16 @@
 import {
+  buildRuntimeOccupationRecommendationReport,
   scoreOccupationRecommendations,
   type OccupationRecommendationCandidateInput,
   type OccupationRecommendationInput
 } from '../src/territory/occupationRecommendation';
 
 describe('occupation recommendation scoring', () => {
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  });
+
   it('keeps occupy recommendations ahead of richer reserve rooms', () => {
     const report = scoreOccupationRecommendations(
       makeInput([
@@ -148,6 +154,44 @@ describe('occupation recommendation scoring', () => {
       ]
     });
   });
+
+  it('preserves cached no-route distances for adjacent runtime candidates', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits: jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }))
+      } as unknown as GameMap,
+      rooms: {}
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        routeDistances: { 'W1N1>W1N2': null }
+      }
+    };
+
+    const report = buildRuntimeOccupationRecommendationReport(makeRuntimeColony(), [
+      {} as Creep,
+      {} as Creep,
+      {} as Creep
+    ]);
+
+    const unreachable = report.candidates.find((candidate) => candidate.roomName === 'W1N2');
+    const uncachedAdjacent = report.candidates.find((candidate) => candidate.roomName === 'W2N1');
+
+    expect(unreachable).toMatchObject({
+      roomName: 'W1N2',
+      source: 'adjacent',
+      evidenceStatus: 'unavailable',
+      risks: ['no known route from colony']
+    });
+    expect(unreachable).not.toHaveProperty('routeDistance');
+    expect(uncachedAdjacent).toMatchObject({
+      roomName: 'W2N1',
+      source: 'adjacent',
+      evidenceStatus: 'insufficient-evidence',
+      routeDistance: 1
+    });
+    expect(report.next?.roomName).toBe('W2N1');
+  });
 });
 
 function makeInput(
@@ -184,5 +228,22 @@ function makeCandidate(
     constructionSiteCount: 0,
     ownedStructureCount: 0,
     ...overrides
+  };
+}
+
+function makeRuntimeColony(): { room: Room; spawns: StructureSpawn[]; energyAvailable: number; energyCapacityAvailable: number } {
+  return {
+    room: {
+      name: 'W1N1',
+      controller: {
+        my: true,
+        level: 3,
+        owner: { username: 'me' },
+        ticksToDowngrade: 10_000
+      } as StructureController
+    } as Room,
+    spawns: [],
+    energyAvailable: 650,
+    energyCapacityAvailable: 650
   };
 }

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -161,6 +161,10 @@ describe('runtime telemetry summaries', () => {
               expectedKpiMovement: ['improves spawn/controller survivability under pressure'],
               risk: ['decays without sustained repair budget']
             }
+          },
+          territoryRecommendation: {
+            candidates: [],
+            next: null
           }
         }
       ],
@@ -241,6 +245,39 @@ describe('runtime telemetry summaries', () => {
     expect((room.combat as Record<string, unknown>).events).toBeUndefined();
   });
 
+  it('emits the next occupation recommendation in room telemetry', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }],
+        routeDistances: { 'W1N1>W2N1': 2 }
+      }
+    };
+    (Game.rooms as Record<string, Room>).W2N1 = makeRemoteRoom('W2N1', {
+      controller: { my: false } as StructureController,
+      sourceCount: 2
+    });
+
+    emitRuntimeSummary([colony], [
+      makeWorker({ role: 'worker', colony: 'W1N1' }),
+      makeWorker({ role: 'worker', colony: 'W1N1' }),
+      makeWorker({ role: 'worker', colony: 'W1N1' })
+    ]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const recommendation = room.territoryRecommendation as Record<string, unknown>;
+
+    expect(recommendation.next).toMatchObject({
+      roomName: 'W2N1',
+      action: 'occupy',
+      evidenceStatus: 'sufficient',
+      source: 'configured',
+      routeDistance: 2,
+      sourceCount: 2
+    });
+  });
+
   it('keeps emission gating deterministic', () => {
     expect(shouldEmitRuntimeSummary(1, [])).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [])).toBe(true);
@@ -280,6 +317,8 @@ function clearRuntimeTelemetryGlobals(): void {
   for (const key of RUNTIME_GLOBAL_KEYS) {
     delete globals[key];
   }
+  delete globals.Game;
+  delete globals.Memory;
 }
 
 function makeColony(options: {
@@ -376,6 +415,38 @@ function makeWorker(memory: CreepMemory, energy = 0): Creep {
     memory,
     store: makeEnergyStore(energy)
   } as unknown as Creep;
+}
+
+function makeRemoteRoom(
+  roomName: string,
+  options: {
+    controller?: StructureController;
+    sourceCount?: number;
+    hostileCreepCount?: number;
+    hostileStructureCount?: number;
+  }
+): Room {
+  return {
+    name: roomName,
+    controller: options.controller,
+    find: jest.fn((findType: number): unknown[] => {
+      switch (findType) {
+        case TEST_GLOBALS.FIND_SOURCES:
+          return Array.from({ length: options.sourceCount ?? 0 }, (_value, index) => ({ id: `source${index}` }));
+        case TEST_GLOBALS.FIND_HOSTILE_CREEPS:
+          return Array.from({ length: options.hostileCreepCount ?? 0 }, (_value, index) => ({ id: `hostile${index}` }));
+        case TEST_GLOBALS.FIND_HOSTILE_STRUCTURES:
+          return Array.from({ length: options.hostileStructureCount ?? 0 }, (_value, index) => ({
+            id: `hostile-structure${index}`
+          }));
+        case TEST_GLOBALS.FIND_MY_STRUCTURES:
+        case TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES:
+          return [];
+        default:
+          return [];
+      }
+    })
+  } as unknown as Room;
 }
 
 function makeEnergyStore(energy: number): { getUsedCapacity: (resource?: ResourceConstant) => number } {


### PR DESCRIPTION
## Linked issue
Closes #230

## Summary
- add deterministic adjacent/configured room occupation recommendation scoring
- expose the next occupy/reserve/scout recommendation in runtime summary telemetry
- cover visible, insufficient-evidence, hostile-risk, route, and readiness cases with Jest tests

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (18 suites / 348 tests)
- `npm run build`
- `git diff --exit-code -- dist/main.js` showed generated bundle drift after build; committed `prod/dist/main.js` with the source/test changes

## Safety
- No secrets touched.
- Recommendations are telemetry/scoring only; missing evidence yields scout/insufficient-evidence instead of guessing an occupy target.
