### PR TITLE
feat: prefer dropped energy for worker refills

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1983,7 +1983,7 @@ function findWorkerEnergyAcquisitionCandidates(creep) {
       targetId: source.id
     })
   );
-  const droppedEnergyCandidates = findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).map(
+  const droppedEnergyCandidates = findDroppedResources(creep.room).filter((source) => isUsefulDroppedEnergy(source) && isReachable(creep, source)).map(
     (source) => createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
       type: "pickup",
       targetId: source.id
@@ -2074,6 +2074,18 @@ function getRangeToWorkerEnergyAcquisitionSource(creep, source) {
   }
   const range = position.getRangeTo(source);
   return Number.isFinite(range) ? Math.max(0, range) : null;
+}
+function isReachable(creep, target) {
+  const position = creep.pos;
+  if (typeof (position == null ? void 0 : position.findPathTo) !== "function") {
+    return true;
+  }
+  const range = getRangeBetweenRoomObjects(creep, target);
+  if (range !== null && range <= 1) {
+    return true;
+  }
+  const path = position.findPathTo(target, { ignoreCreeps: true });
+  return Array.isArray(path) && path.length > 0;
 }
 function compareWorkerEnergyAcquisitionCandidates(left, right) {
   return right.score - left.score || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1690,6 +1690,7 @@ var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 var ENERGY_ACQUISITION_RANGE_COST = 50;
 var ENERGY_ACQUISITION_ACTION_TICKS = 1;
 var HARVEST_ENERGY_PER_WORK_PART = 2;
+var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 function selectWorkerTask(creep) {
   const carriedEnergy = getUsedEnergy(creep);
   const urgentReservationRenewalTask = selectUrgentVisibleReservationRenewalTask(creep);
@@ -1983,12 +1984,12 @@ function findWorkerEnergyAcquisitionCandidates(creep) {
       targetId: source.id
     })
   );
-  const droppedEnergyCandidates = findDroppedResources(creep.room).filter((source) => isUsefulDroppedEnergy(source) && isReachable(creep, source)).map(
+  const droppedEnergyCandidates = findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).map(
     (source) => createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
       type: "pickup",
       targetId: source.id
     })
-  );
+  ).sort(compareDroppedEnergyReachabilityPriority).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
   return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
 }
 function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
@@ -2089,6 +2090,9 @@ function isReachable(creep, target) {
 }
 function compareWorkerEnergyAcquisitionCandidates(left, right) {
   return right.score - left.score || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
+}
+function compareDroppedEnergyReachabilityPriority(left, right) {
+  return compareOptionalRanges(left.range, right.range) || right.energy - left.energy || right.score - left.score || String(left.source.id).localeCompare(String(right.source.id));
 }
 function compareSpawnRecoveryEnergyAcquisitionCandidates(left, right) {
   return left.deliveryEta - right.deliveryEta || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -475,7 +475,7 @@ function findWorkerEnergyAcquisitionCandidates(creep: Creep): WorkerEnergyAcquis
       })
     );
   const droppedEnergyCandidates = findDroppedResources(creep.room)
-    .filter(isUsefulDroppedEnergy)
+    .filter((source): source is Resource<ResourceConstant> => isUsefulDroppedEnergy(source) && isReachable(creep, source))
     .map((source) =>
       createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
         type: 'pickup',
@@ -608,6 +608,25 @@ function getRangeToWorkerEnergyAcquisitionSource(
 
   const range = position.getRangeTo(source);
   return Number.isFinite(range) ? Math.max(0, range) : null;
+}
+
+function isReachable(creep: Creep, target: RoomObject): boolean {
+  const position = (creep as Creep & {
+    pos?: {
+      findPathTo?: (target: RoomObject, opts?: { ignoreCreeps?: boolean }) => unknown[];
+    };
+  }).pos;
+  if (typeof position?.findPathTo !== 'function') {
+    return true;
+  }
+
+  const range = getRangeBetweenRoomObjects(creep, target);
+  if (range !== null && range <= 1) {
+    return true;
+  }
+
+  const path = position.findPathTo(target, { ignoreCreeps: true });
+  return Array.isArray(path) && path.length > 0;
 }
 
 function compareWorkerEnergyAcquisitionCandidates(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -15,6 +15,7 @@ const MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 const ENERGY_ACQUISITION_RANGE_COST = 50;
 const ENERGY_ACQUISITION_ACTION_TICKS = 1;
 const HARVEST_ENERGY_PER_WORK_PART = 2;
+const MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
@@ -475,13 +476,16 @@ function findWorkerEnergyAcquisitionCandidates(creep: Creep): WorkerEnergyAcquis
       })
     );
   const droppedEnergyCandidates = findDroppedResources(creep.room)
-    .filter((source): source is Resource<ResourceConstant> => isUsefulDroppedEnergy(source) && isReachable(creep, source))
+    .filter(isUsefulDroppedEnergy)
     .map((source) =>
       createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
         type: 'pickup',
         targetId: source.id
       })
-    );
+    )
+    .sort(compareDroppedEnergyReachabilityPriority)
+    .slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS)
+    .filter((candidate) => isReachable(creep, candidate.source));
 
   return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
 }
@@ -639,6 +643,18 @@ function compareWorkerEnergyAcquisitionCandidates(
     right.energy - left.energy ||
     String(left.source.id).localeCompare(String(right.source.id)) ||
     left.task.type.localeCompare(right.task.type)
+  );
+}
+
+function compareDroppedEnergyReachabilityPriority(
+  left: WorkerEnergyAcquisitionCandidate,
+  right: WorkerEnergyAcquisitionCandidate
+): number {
+  return (
+    compareOptionalRanges(left.range, right.range) ||
+    right.energy - left.energy ||
+    right.score - left.score ||
+    String(left.source.id).localeCompare(String(right.source.id))
   );
 }
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -221,6 +221,50 @@ describe('selectWorkerTask', () => {
     expect(creep.pos.findPathTo).toHaveBeenCalledWith(blockedDroppedEnergy, { ignoreCreeps: true });
   });
 
+  it('bounds dropped energy path checks while preserving nearby pickup preference', () => {
+    const farDroppedEnergy = Array.from(
+      { length: 8 },
+      (_, index) =>
+        ({
+          id: `drop-far-${index}`,
+          resourceType: 'energy',
+          amount: 1_000 + index
+        }) as Resource<ResourceConstant>
+    );
+    const nearDroppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
+    const droppedResources = [...farDroppedEnergy, nearDroppedEnergy];
+    const source = { id: 'source1' } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      if (target.id === 'drop-near') {
+        return 2;
+      }
+
+      const index = Number(target.id.replace('drop-far-', ''));
+      return Number.isFinite(index) ? 10 + index : 99;
+    });
+    const findPathTo = jest.fn((target: { id: string }) => (target.id === 'drop-near' ? [{}] : []));
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return droppedResources;
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo, findPathTo },
+      room: { find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
+    expect(findPathTo.mock.calls.length).toBeLessThan(droppedResources.length);
+    expect(findPathTo).not.toHaveBeenCalledWith(farDroppedEnergy[7], { ignoreCreeps: true });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
   it('keeps dropped energy fallback deterministic when energy globals or stores are partially mocked', () => {
     delete (globalThis as unknown as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY;
     const partialContainer = { id: 'container1', structureType: 'container' } as AnyStructure;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -195,6 +195,32 @@ describe('selectWorkerTask', () => {
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
+  it('falls back to harvesting when visible dropped energy is not reachable', () => {
+    const blockedDroppedEnergy = { id: 'drop-blocked', resourceType: 'energy', amount: 200 } as Resource<ResourceConstant>;
+    const source = { id: 'source1' } as Source;
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [blockedDroppedEnergy];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id: string }) => (target.id === 'drop-blocked' ? 5 : 1)),
+        findPathTo: jest.fn().mockReturnValue([])
+      },
+      room: { find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.pos.findPathTo).toHaveBeenCalledWith(blockedDroppedEnergy, { ignoreCreeps: true });
+  });
+
   it('keeps dropped energy fallback deterministic when energy globals or stores are partially mocked', () => {
     delete (globalThis as unknown as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY;
     const partialContainer = { id: 'container1', structureType: 'container' } as AnyStructure;


### PR DESCRIPTION
Closes #238.

## Summary
- Prefer reachable nearby dropped energy for empty worker refills before assigning fresh harvest work.
- Preserve harvest fallback when dropped energy is unusable/unreachable.
- Add deterministic worker task tests and regenerate the bundled Screeps artifact.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (18 suites, 351 tests)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

## Safety
- Production code authored by Codex as `lanyusea's bot <lanyusea@gmail.com>`.
- `prod/node_modules` is untracked local dependency infrastructure and is not staged.
