### PR TITLE
feat: consume occupation recommendations in planning

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -588,6 +588,346 @@ function getBodyCost(body) {
   return body.reduce((cost, part) => cost + BODY_PART_COSTS[part], 0);
 }
 
+// src/territory/occupationRecommendation.ts
+var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
+var TERRITORY_BODY_ENERGY_CAPACITY = 650;
+var MIN_READY_WORKERS = 3;
+var DOWNGRADE_GUARD_TICKS = 5e3;
+var RESERVATION_RENEWAL_TICKS = 1e3;
+var TERRITORY_ROUTE_DISTANCE_SEPARATOR = ">";
+var ACTION_SCORE = {
+  occupy: 1e3,
+  reserve: 800,
+  scout: 420
+};
+function buildRuntimeOccupationRecommendationReport(colony, colonyWorkers) {
+  return scoreOccupationRecommendations(buildRuntimeOccupationRecommendationInput(colony, colonyWorkers));
+}
+function scoreOccupationRecommendations(input) {
+  var _a;
+  const candidates = input.candidates.filter((candidate) => candidate.roomName !== input.colonyName).map((candidate) => scoreOccupationCandidate(input, candidate)).sort(compareOccupationRecommendationScores);
+  const next = (_a = candidates.find((candidate) => candidate.evidenceStatus !== "unavailable")) != null ? _a : null;
+  return { candidates, next };
+}
+function buildRuntimeOccupationRecommendationInput(colony, colonyWorkers) {
+  var _a, _b;
+  const colonyName = colony.room.name;
+  return {
+    colonyName,
+    colonyOwnerUsername: getControllerOwnerUsername(colony.room.controller),
+    energyCapacityAvailable: colony.energyCapacityAvailable,
+    workerCount: colonyWorkers.length,
+    ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
+    ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
+    candidates: buildRuntimeOccupationCandidates(colonyName)
+  };
+}
+function buildRuntimeOccupationCandidates(colonyName) {
+  const candidatesByRoom = /* @__PURE__ */ new Map();
+  const territoryMemory = getTerritoryMemoryRecord();
+  let order = 0;
+  if (Array.isArray(territoryMemory == null ? void 0 : territoryMemory.targets)) {
+    for (const rawTarget of territoryMemory.targets) {
+      const target = normalizeTerritoryTarget(rawTarget);
+      if (!target || target.colony !== colonyName || target.enabled === false) {
+        continue;
+      }
+      upsertOccupationCandidate(candidatesByRoom, {
+        roomName: target.roomName,
+        source: "configured",
+        order,
+        adjacent: false,
+        visible: false,
+        actionHint: target.action,
+        routeDistance: getCachedRouteDistance(colonyName, target.roomName)
+      });
+      order += 1;
+    }
+  }
+  for (const roomName of getAdjacentRoomNames(colonyName)) {
+    const cachedRouteDistance = getCachedRouteDistance(colonyName, roomName);
+    upsertOccupationCandidate(candidatesByRoom, {
+      roomName,
+      source: "adjacent",
+      order,
+      adjacent: true,
+      visible: false,
+      routeDistance: cachedRouteDistance === void 0 ? 1 : cachedRouteDistance
+    });
+    order += 1;
+  }
+  return Array.from(candidatesByRoom.values()).map(enrichVisibleOccupationCandidate);
+}
+function upsertOccupationCandidate(candidatesByRoom, candidate) {
+  const existing = candidatesByRoom.get(candidate.roomName);
+  if (!existing) {
+    candidatesByRoom.set(candidate.roomName, candidate);
+    return;
+  }
+  if (candidate.source === "configured" && existing.source !== "configured") {
+    existing.source = "configured";
+    existing.actionHint = candidate.actionHint;
+    existing.order = Math.min(existing.order, candidate.order);
+  }
+  existing.adjacent = existing.adjacent || candidate.adjacent;
+  if (existing.routeDistance === void 0 && candidate.routeDistance !== void 0) {
+    existing.routeDistance = candidate.routeDistance;
+  }
+}
+function enrichVisibleOccupationCandidate(candidate) {
+  var _a;
+  const room = (_a = getGameRooms()) == null ? void 0 : _a[candidate.roomName];
+  if (!room) {
+    return candidate;
+  }
+  const hostileCreeps = findRoomObjects(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects(room, "FIND_HOSTILE_STRUCTURES");
+  const sources = findRoomObjects(room, "FIND_SOURCES");
+  const constructionSites = findRoomObjects(room, "FIND_MY_CONSTRUCTION_SITES");
+  const ownedStructures = findRoomObjects(room, "FIND_MY_STRUCTURES");
+  return {
+    ...candidate,
+    visible: true,
+    ...room.controller ? { controller: summarizeController(room.controller) } : {},
+    ...sources ? { sourceCount: sources.length } : {},
+    ...hostileCreeps ? { hostileCreepCount: hostileCreeps.length } : {},
+    ...hostileStructures ? { hostileStructureCount: hostileStructures.length } : {},
+    ...constructionSites ? { constructionSiteCount: constructionSites.length } : {},
+    ...ownedStructures ? { ownedStructureCount: ownedStructures.length } : {}
+  };
+}
+function scoreOccupationCandidate(input, candidate) {
+  var _a, _b;
+  const evidence = [];
+  const preconditions = getColonyReadinessPreconditions(input);
+  const risks = [];
+  const routeDistance = typeof candidate.routeDistance === "number" ? candidate.routeDistance : void 0;
+  let action = "scout";
+  let evidenceStatus = "sufficient";
+  if (candidate.routeDistance === null) {
+    risks.push("no known route from colony");
+    evidenceStatus = "unavailable";
+  } else if (!candidate.visible) {
+    evidence.push("room visibility missing");
+    risks.push("controller, source, and hostile evidence unavailable");
+    evidenceStatus = "insufficient-evidence";
+  } else if (!candidate.controller) {
+    evidence.push("room visible");
+    risks.push("visible room has no controller");
+    evidenceStatus = "unavailable";
+  } else {
+    evidence.push("room visible", "controller visible");
+    const unavailableReason = getControllerUnavailableReason(input, candidate.controller);
+    if (unavailableReason) {
+      risks.push(unavailableReason);
+      evidenceStatus = "unavailable";
+      action = candidate.actionHint === "claim" ? "occupy" : "reserve";
+    } else if (isOwnHealthyReservation(input, candidate.controller)) {
+      evidence.push("own reservation is healthy");
+      evidenceStatus = "unavailable";
+      action = "reserve";
+    } else if (isOwnReservationDueForRenewal(input, candidate.controller)) {
+      evidence.push("own reservation needs renewal");
+      action = "reserve";
+    } else if (candidate.sourceCount === void 0) {
+      evidence.push("controller is available");
+      risks.push("source count evidence missing");
+      evidenceStatus = "insufficient-evidence";
+    } else {
+      evidence.push("controller is available", `${candidate.sourceCount} sources visible`);
+      action = candidate.actionHint === "claim" ? "occupy" : "reserve";
+    }
+  }
+  const hostileCreepCount = (_a = candidate.hostileCreepCount) != null ? _a : 0;
+  const hostileStructureCount = (_b = candidate.hostileStructureCount) != null ? _b : 0;
+  if (hostileCreepCount > 0 || hostileStructureCount > 0) {
+    risks.push("hostile presence visible");
+    evidenceStatus = "unavailable";
+  }
+  const score = calculateOccupationScore(input, candidate, action, evidenceStatus);
+  return {
+    roomName: candidate.roomName,
+    action,
+    score,
+    evidenceStatus,
+    source: candidate.source,
+    evidence,
+    preconditions,
+    risks,
+    ...routeDistance !== void 0 ? { routeDistance } : {},
+    ...candidate.sourceCount !== void 0 ? { sourceCount: candidate.sourceCount } : {},
+    ...candidate.hostileCreepCount !== void 0 ? { hostileCreepCount: candidate.hostileCreepCount } : {},
+    ...candidate.hostileStructureCount !== void 0 ? { hostileStructureCount: candidate.hostileStructureCount } : {}
+  };
+}
+function calculateOccupationScore(input, candidate, action, evidenceStatus) {
+  var _a, _b, _c, _d, _e;
+  const distanceScore = typeof candidate.routeDistance === "number" ? Math.max(0, 80 - candidate.routeDistance * 15) : 0;
+  const sourceScore = typeof candidate.sourceCount === "number" ? Math.min(candidate.sourceCount, 2) * 70 : 0;
+  const supportScore = Math.min((_a = candidate.ownedStructureCount) != null ? _a : 0, 3) * 8 + Math.min((_b = candidate.constructionSiteCount) != null ? _b : 0, 3) * 5;
+  const sourcePriorityScore = candidate.source === "configured" ? 50 : 25;
+  const adjacencyScore = candidate.adjacent ? 25 : 0;
+  const readinessScore = Math.min(input.workerCount, MIN_READY_WORKERS) * 12 + (input.energyCapacityAvailable >= TERRITORY_BODY_ENERGY_CAPACITY ? 30 : 0) + (((_c = input.controllerLevel) != null ? _c : 0) >= 2 ? 30 : 0) + (input.ticksToDowngrade === void 0 || input.ticksToDowngrade > DOWNGRADE_GUARD_TICKS ? 20 : 0);
+  const riskPenalty = ((_d = candidate.hostileCreepCount) != null ? _d : 0) * 160 + ((_e = candidate.hostileStructureCount) != null ? _e : 0) * 120;
+  const evidencePenalty = evidenceStatus === "insufficient-evidence" ? 260 : 0;
+  const unavailablePenalty = evidenceStatus === "unavailable" ? 2e3 : 0;
+  return ACTION_SCORE[action] + sourcePriorityScore + adjacencyScore + distanceScore + sourceScore + supportScore + readinessScore - riskPenalty - evidencePenalty - unavailablePenalty;
+}
+function getColonyReadinessPreconditions(input) {
+  var _a;
+  const preconditions = [];
+  if (input.workerCount < MIN_READY_WORKERS) {
+    preconditions.push("raise worker count before dispatching territory creeps");
+  }
+  if (input.energyCapacityAvailable < TERRITORY_BODY_ENERGY_CAPACITY) {
+    preconditions.push("reach 650 energy capacity for controller work");
+  }
+  if (((_a = input.controllerLevel) != null ? _a : 0) < 2) {
+    preconditions.push("reach controller level 2 before expansion");
+  }
+  if (typeof input.ticksToDowngrade === "number" && input.ticksToDowngrade <= DOWNGRADE_GUARD_TICKS) {
+    preconditions.push("stabilize home controller downgrade timer");
+  }
+  return preconditions;
+}
+function getControllerUnavailableReason(input, controller) {
+  if (isControllerOwnedByColony(input, controller)) {
+    return "controller already owned by colony account";
+  }
+  if (controller.ownerUsername) {
+    return "controller owned by another account";
+  }
+  if (controller.reservationUsername && controller.reservationUsername !== input.colonyOwnerUsername) {
+    return "controller reserved by another account";
+  }
+  return null;
+}
+function isOwnHealthyReservation(input, controller) {
+  return isOwnReservation(input, controller) && typeof controller.reservationTicksToEnd === "number" && controller.reservationTicksToEnd > RESERVATION_RENEWAL_TICKS;
+}
+function isOwnReservationDueForRenewal(input, controller) {
+  return isOwnReservation(input, controller) && typeof controller.reservationTicksToEnd === "number" && controller.reservationTicksToEnd <= RESERVATION_RENEWAL_TICKS;
+}
+function isOwnReservation(input, controller) {
+  return input.colonyOwnerUsername !== void 0 && controller.reservationUsername === input.colonyOwnerUsername;
+}
+function isControllerOwnedByColony(input, controller) {
+  return controller.my === true || !!controller.ownerUsername && controller.ownerUsername === input.colonyOwnerUsername;
+}
+function compareOccupationRecommendationScores(left, right) {
+  return right.score - left.score || getEvidenceStatusPriority(left.evidenceStatus) - getEvidenceStatusPriority(right.evidenceStatus) || getActionPriority(left.action) - getActionPriority(right.action) || getSourcePriority(left.source) - getSourcePriority(right.source) || compareOptionalNumbers(left.routeDistance, right.routeDistance) || left.roomName.localeCompare(right.roomName);
+}
+function getEvidenceStatusPriority(status) {
+  if (status === "sufficient") {
+    return 0;
+  }
+  return status === "insufficient-evidence" ? 1 : 2;
+}
+function getActionPriority(action) {
+  if (action === "occupy") {
+    return 0;
+  }
+  return action === "reserve" ? 1 : 2;
+}
+function getSourcePriority(source) {
+  return source === "configured" ? 0 : 1;
+}
+function compareOptionalNumbers(left, right) {
+  return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
+}
+function summarizeController(controller) {
+  const ownerUsername = getControllerOwnerUsername(controller);
+  const reservationUsername = getReservationUsername(controller);
+  const reservationTicksToEnd = getReservationTicksToEnd(controller);
+  return {
+    ...controller.my === true ? { my: true } : {},
+    ...ownerUsername ? { ownerUsername } : {},
+    ...reservationUsername ? { reservationUsername } : {},
+    ...typeof reservationTicksToEnd === "number" ? { reservationTicksToEnd } : {}
+  };
+}
+function getAdjacentRoomNames(roomName) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (!gameMap || typeof gameMap.describeExits !== "function") {
+    return [];
+  }
+  const exits = gameMap.describeExits(roomName);
+  if (!isRecord(exits)) {
+    return [];
+  }
+  return EXIT_DIRECTION_ORDER.flatMap((direction) => {
+    const exitRoom = exits[direction];
+    return typeof exitRoom === "string" && exitRoom.length > 0 ? [exitRoom] : [];
+  });
+}
+function normalizeTerritoryTarget(rawTarget) {
+  if (!isRecord(rawTarget)) {
+    return null;
+  }
+  if (typeof rawTarget.colony !== "string" || rawTarget.colony.length === 0 || typeof rawTarget.roomName !== "string" || rawTarget.roomName.length === 0 || rawTarget.action !== "claim" && rawTarget.action !== "reserve") {
+    return null;
+  }
+  return {
+    colony: rawTarget.colony,
+    roomName: rawTarget.roomName,
+    action: rawTarget.action,
+    ...rawTarget.enabled === false ? { enabled: false } : {}
+  };
+}
+function getCachedRouteDistance(fromRoom, targetRoom) {
+  var _a;
+  const routeDistances = (_a = getTerritoryMemoryRecord()) == null ? void 0 : _a.routeDistances;
+  if (!isRecord(routeDistances)) {
+    return void 0;
+  }
+  const distance = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`];
+  return typeof distance === "number" || distance === null ? distance : void 0;
+}
+function findRoomObjects(room, constantName) {
+  const findConstant = getGlobalNumber(constantName);
+  const find = room.find;
+  if (typeof findConstant !== "number" || typeof find !== "function") {
+    return void 0;
+  }
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return void 0;
+  }
+}
+function getGlobalNumber(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function getControllerOwnerUsername(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  return typeof username === "string" && username.length > 0 ? username : void 0;
+}
+function getReservationUsername(controller) {
+  var _a;
+  const username = (_a = controller.reservation) == null ? void 0 : _a.username;
+  return typeof username === "string" && username.length > 0 ? username : void 0;
+}
+function getReservationTicksToEnd(controller) {
+  var _a;
+  const ticksToEnd = (_a = controller.reservation) == null ? void 0 : _a.ticksToEnd;
+  return typeof ticksToEnd === "number" ? ticksToEnd : void 0;
+}
+function getGameRooms() {
+  var _a;
+  return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+}
+function getTerritoryMemoryRecord() {
+  var _a;
+  return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/territory/territoryPlanner.ts
 var TERRITORY_CLAIMER_ROLE = "claimer";
 var TERRITORY_SCOUT_ROLE = "scout";
@@ -596,7 +936,7 @@ var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
 var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
-var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
+var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
 var ERR_NO_PATH_CODE = -2;
 var TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL = 0;
@@ -606,7 +946,7 @@ var TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM = 3;
 var TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE = 4;
 var TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
 var MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
-var TERRITORY_ROUTE_DISTANCE_SEPARATOR = ">";
+var TERRITORY_ROUTE_DISTANCE_SEPARATOR2 = ">";
 var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
@@ -788,8 +1128,8 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
 function selectTerritoryTarget(colony, roleCounts, gameTime) {
   var _a;
   const colonyName = colony.room.name;
-  const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
-  const territoryMemory = getTerritoryMemoryRecord();
+  const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
+  const territoryMemory = getTerritoryMemoryRecord2();
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
@@ -801,13 +1141,17 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
     roleCounts,
     routeDistanceLookupContext
   );
-  const configuredCandidates = getConfiguredTerritoryCandidates(
-    colonyName,
-    colonyOwnerUsername,
-    territoryMemory,
-    intents,
-    gameTime,
-    routeDistanceLookupContext
+  const configuredCandidates = applyOccupationRecommendationScores(
+    colony,
+    roleCounts,
+    getConfiguredTerritoryCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      routeDistanceLookupContext
+    )
   );
   const bestSpawnableConfiguredCandidate = selectBestScoredTerritoryCandidate(
     getSpawnableTerritoryCandidates(configuredCandidates, roleCounts)
@@ -815,7 +1159,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
   if (bestSpawnableConfiguredCandidate && bestSpawnableConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
     return toSelectedTerritoryTarget(bestSpawnableConfiguredCandidate);
   }
-  const adjacentCandidates = [
+  const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, [
     ...getAdjacentReserveCandidates(
       colonyName,
       colonyName,
@@ -856,7 +1200,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       !hasBlockingConfiguredTarget,
       routeDistanceLookupContext
     )
-  ];
+  ]);
   const candidates = [...configuredCandidates, ...adjacentCandidates];
   return toSelectedTerritoryTarget(
     (_a = selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts))) != null ? _a : selectBestScoredTerritoryCandidate(candidates)
@@ -897,7 +1241,7 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
-    const target = normalizeTerritoryTarget(rawTarget);
+    const target = normalizeTerritoryTarget2(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
@@ -917,7 +1261,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     return false;
   }
   return territoryMemory.targets.some((rawTarget) => {
-    const target = normalizeTerritoryTarget(rawTarget);
+    const target = normalizeTerritoryTarget2(rawTarget);
     if (!target || target.colony !== colonyName) {
       return false;
     }
@@ -934,7 +1278,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
   });
 }
 function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, source, orderOffset, routeDistanceLookupContext) {
-  const adjacentRooms = getAdjacentRoomNames(originRoomName);
+  const adjacentRooms = getAdjacentRoomNames2(originRoomName);
   if (adjacentRooms.length === 0) {
     return [];
   }
@@ -998,7 +1342,7 @@ function getSatisfiedClaimAdjacentReserveCandidates(colonyName, colonyOwnerUsern
       gameTime,
       includeScoutCandidates,
       "satisfiedClaimAdjacent",
-      (order + 1) * EXIT_DIRECTION_ORDER.length,
+      (order + 1) * EXIT_DIRECTION_ORDER2.length,
       routeDistanceLookupContext
     )
   );
@@ -1022,7 +1366,7 @@ function getSatisfiedReserveAdjacentReserveCandidates(colonyName, colonyOwnerUse
       gameTime,
       includeScoutCandidates,
       "satisfiedReserveAdjacent",
-      (order + 1) * EXIT_DIRECTION_ORDER.length,
+      (order + 1) * EXIT_DIRECTION_ORDER2.length,
       routeDistanceLookupContext
     )
   );
@@ -1046,7 +1390,7 @@ function getActiveReserveAdjacentReserveCandidates(colonyName, colonyOwnerUserna
       gameTime,
       includeScoutCandidates,
       "activeReserveAdjacent",
-      (order + 1) * EXIT_DIRECTION_ORDER.length,
+      (order + 1) * EXIT_DIRECTION_ORDER2.length,
       routeDistanceLookupContext
     )
   );
@@ -1056,7 +1400,7 @@ function getActiveCoveredConfiguredReserveTargets(colonyName, colonyOwnerUsernam
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
-    const target = normalizeTerritoryTarget(rawTarget);
+    const target = normalizeTerritoryTarget2(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || !isVisibleRoomKnown(target.roomName) || getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
@@ -1079,7 +1423,7 @@ function getSatisfiedConfiguredTargets(colonyName, colonyOwnerUsername, territor
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
-    const target = normalizeTerritoryTarget(rawTarget);
+    const target = normalizeTerritoryTarget2(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.action !== action || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
       return [];
     }
@@ -1087,7 +1431,8 @@ function getSatisfiedConfiguredTargets(colonyName, colonyOwnerUsername, territor
   });
 }
 function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwnerUsername, routeDistanceLookupContext) {
-  if (hasKnownNoRoute(colonyName, selection.target.roomName, routeDistanceLookupContext)) {
+  const routeDistance = getKnownRouteLength(colonyName, selection.target.roomName, routeDistanceLookupContext);
+  if (routeDistance === null) {
     return null;
   }
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
@@ -1096,8 +1441,128 @@ function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwn
     source,
     order,
     priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
+    ...routeDistance !== void 0 ? { routeDistance } : {},
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
   };
+}
+function applyOccupationRecommendationScores(colony, roleCounts, candidates) {
+  var _a;
+  const colonyOwnerUsername = (_a = getControllerOwnerUsername2(colony.room.controller)) != null ? _a : void 0;
+  return candidates.flatMap((candidate) => {
+    var _a2, _b;
+    const recommendation = scoreOccupationRecommendations({
+      colonyName: colony.room.name,
+      ...colonyOwnerUsername ? { colonyOwnerUsername } : {},
+      energyCapacityAvailable: colony.energyCapacityAvailable,
+      workerCount: getWorkerCapacity(roleCounts),
+      ...typeof ((_a2 = colony.room.controller) == null ? void 0 : _a2.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
+      ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
+      candidates: [buildOccupationRecommendationCandidate(candidate)]
+    }).candidates[0];
+    if (!recommendation || recommendation.evidenceStatus === "unavailable") {
+      return [];
+    }
+    return [applyOccupationRecommendationScore(candidate, recommendation, roleCounts)];
+  });
+}
+function applyOccupationRecommendationScore(candidate, recommendation, roleCounts) {
+  var _a;
+  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const nextSelection = {
+    target: candidate.target,
+    intentAction,
+    commitTarget: recommendation.evidenceStatus === "sufficient" && intentAction !== "scout" && candidate.commitTarget,
+    ...candidate.followUp ? { followUp: candidate.followUp } : {}
+  };
+  const renewalTicksToEnd = intentAction === "reserve" ? (_a = candidate.renewalTicksToEnd) != null ? _a : null : null;
+  return {
+    ...candidate,
+    intentAction,
+    commitTarget: nextSelection.commitTarget,
+    priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
+    recommendationScore: recommendation.score,
+    ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
+  };
+}
+function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts) {
+  if (recommendation.evidenceStatus === "insufficient-evidence") {
+    if (candidate.source === "configured" && getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.target.action) > 0) {
+      return candidate.intentAction;
+    }
+    return "scout";
+  }
+  if (recommendation.action === "occupy") {
+    return "claim";
+  }
+  return recommendation.action === "reserve" ? "reserve" : candidate.intentAction;
+}
+function buildOccupationRecommendationCandidate(candidate) {
+  const room = getVisibleRoom(candidate.target.roomName);
+  return {
+    roomName: candidate.target.roomName,
+    source: candidate.source === "configured" ? "configured" : "adjacent",
+    order: candidate.order,
+    adjacent: candidate.source !== "configured",
+    visible: room != null,
+    actionHint: candidate.target.action,
+    ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
+    ...room ? buildVisibleOccupationRecommendationEvidence(room, candidate.target.controllerId) : {}
+  };
+}
+function buildVisibleOccupationRecommendationEvidence(room, controllerId) {
+  const controller = getVisibleController(room.name, controllerId);
+  return {
+    ...controller ? { controller: summarizeOccupationController(controller) } : {},
+    sourceCount: countVisibleRoomObjects(room, getFindConstant("FIND_SOURCES")),
+    hostileCreepCount: findVisibleHostileCreeps(room).length,
+    hostileStructureCount: findVisibleHostileStructures(room).length,
+    constructionSiteCount: countVisibleRoomObjects(room, getFindConstant("FIND_MY_CONSTRUCTION_SITES")),
+    ownedStructureCount: countVisibleRoomObjects(room, getFindConstant("FIND_MY_STRUCTURES"))
+  };
+}
+function summarizeOccupationController(controller) {
+  const ownerUsername = getControllerOwnerUsername2(controller);
+  const reservationUsername = getControllerReservationUsername(controller);
+  const reservationTicksToEnd = getControllerReservationTicksToEnd(controller);
+  return {
+    ...controller.my === true ? { my: true } : {},
+    ...ownerUsername ? { ownerUsername } : {},
+    ...reservationUsername ? { reservationUsername } : {},
+    ...typeof reservationTicksToEnd === "number" ? { reservationTicksToEnd } : {}
+  };
+}
+function getControllerReservationUsername(controller) {
+  var _a;
+  const username = (_a = controller.reservation) == null ? void 0 : _a.username;
+  return isNonEmptyString(username) ? username : void 0;
+}
+function getControllerReservationTicksToEnd(controller) {
+  var _a;
+  const ticksToEnd = (_a = controller.reservation) == null ? void 0 : _a.ticksToEnd;
+  return typeof ticksToEnd === "number" ? ticksToEnd : void 0;
+}
+function getVisibleRoom(roomName) {
+  var _a, _b, _c;
+  return (_c = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName]) != null ? _c : null;
+}
+function countVisibleRoomObjects(room, findConstant) {
+  if (typeof findConstant !== "number") {
+    return 0;
+  }
+  const find = room.find;
+  if (typeof find !== "function") {
+    return 0;
+  }
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result.length : 0;
+  } catch {
+    return 0;
+  }
+}
+function getFindConstant(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
 }
 function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   if (renewalTicksToEnd !== null) {
@@ -1112,10 +1577,13 @@ function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
 }
 function compareTerritoryCandidates(left, right) {
-  return left.priority - right.priority || compareOptionalNumbers(left.renewalTicksToEnd, right.renewalTicksToEnd) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
 }
-function compareOptionalNumbers(left, right) {
+function compareOptionalNumbers2(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
+}
+function compareOptionalNumbersDescending(left, right) {
+  return (right != null ? right : Number.NEGATIVE_INFINITY) - (left != null ? left : Number.NEGATIVE_INFINITY);
 }
 function getTerritoryCandidateSourcePriority(source) {
   if (source === "configured") {
@@ -1192,17 +1660,17 @@ function getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) {
   return route.length;
 }
 function getTerritoryRouteDistanceCache() {
-  const territoryMemory = getTerritoryMemoryRecord();
+  const territoryMemory = getTerritoryMemoryRecord2();
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord(territoryMemory.routeDistances)) {
+  if (!isRecord2(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
 }
 function getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom) {
-  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`;
+  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR2}${targetRoom}`;
 }
 function getNoPathResultCode() {
   const noPathCode = globalThis.ERR_NO_PATH;
@@ -1228,7 +1696,7 @@ function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
   }
   return new Set(
     territoryMemory.targets.flatMap((rawTarget) => {
-      const target = normalizeTerritoryTarget(rawTarget);
+      const target = normalizeTerritoryTarget2(rawTarget);
       return (target == null ? void 0 : target.colony) === colonyName ? [target.roomName] : [];
     })
   );
@@ -1239,23 +1707,23 @@ function appendTerritoryTarget(territoryMemory, target) {
   }
   territoryMemory.targets.push(target);
 }
-function getAdjacentRoomNames(roomName) {
+function getAdjacentRoomNames2(roomName) {
   const game = globalThis.Game;
   const gameMap = game == null ? void 0 : game.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord(exits)) {
+  if (!isRecord2(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER2.flatMap((direction) => {
     const exitRoom = exits[direction];
     return isNonEmptyString(exitRoom) ? [exitRoom] : [];
   });
 }
-function normalizeTerritoryTarget(rawTarget) {
-  if (!isRecord(rawTarget)) {
+function normalizeTerritoryTarget2(rawTarget) {
+  if (!isRecord2(rawTarget)) {
     return null;
   }
   if (!isNonEmptyString(rawTarget.colony) || !isNonEmptyString(rawTarget.roomName) || !isTerritoryControlAction(rawTarget.action)) {
@@ -1307,7 +1775,7 @@ function upsertTerritoryIntent(intents, nextIntent) {
   intents.push(nextIntent);
 }
 function normalizeTerritoryIntent(rawIntent) {
-  if (!isRecord(rawIntent)) {
+  if (!isRecord2(rawIntent)) {
     return null;
   }
   if (!isNonEmptyString(rawIntent.colony) || !isNonEmptyString(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
@@ -1325,7 +1793,7 @@ function normalizeTerritoryIntent(rawIntent) {
   };
 }
 function normalizeTerritoryFollowUp(rawFollowUp) {
-  if (!isRecord(rawFollowUp)) {
+  if (!isRecord2(rawFollowUp)) {
     return null;
   }
   if (!isTerritoryFollowUpSource(rawFollowUp.source)) {
@@ -1361,7 +1829,7 @@ function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, actio
   );
 }
 function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime()) {
-  const territoryMemory = getTerritoryMemoryRecord();
+  const territoryMemory = getTerritoryMemoryRecord2();
   if (!territoryMemory) {
     return false;
   }
@@ -1382,7 +1850,7 @@ function selectVisibleTerritoryControllerIntent(creep) {
   if (assignmentIntent && isCreepVisibleTerritoryIntentActionable(creep, assignmentIntent)) {
     return assignmentIntent;
   }
-  const territoryMemory = getTerritoryMemoryRecord();
+  const territoryMemory = getTerritoryMemoryRecord2();
   const colony = (_b = creep.memory) == null ? void 0 : _b.colony;
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents).filter((intent) => isActiveVisibleControllerIntentForCreep(intent, roomName, colony)).sort(compareVisibleControllerIntents);
   return (_c = intents.find((intent) => isCreepVisibleTerritoryIntentActionable(creep, intent))) != null ? _c : null;
@@ -1459,7 +1927,7 @@ function getTerritoryControllerTargetState(controller, action, colonyOwnerUserna
   if (action === "reserve") {
     return getReserveControllerTargetState(controller, colonyOwnerUsername);
   }
-  if (isControllerOwnedByColony(controller, colonyOwnerUsername)) {
+  if (isControllerOwnedByColony2(controller, colonyOwnerUsername)) {
     return "satisfied";
   }
   return isControllerOwned(controller) ? "unavailable" : "available";
@@ -1558,8 +2026,8 @@ function isVisibleRoomMissingController(targetRoom) {
 function isControllerOwned(controller) {
   return controller.owner != null || controller.my === true;
 }
-function isControllerOwnedByColony(controller, colonyOwnerUsername) {
-  const ownerUsername = getControllerOwnerUsername(controller);
+function isControllerOwnedByColony2(controller, colonyOwnerUsername) {
+  const ownerUsername = getControllerOwnerUsername2(controller);
   return controller.my === true || isNonEmptyString(ownerUsername) && ownerUsername === colonyOwnerUsername;
 }
 function getReserveControllerTargetState(controller, colonyOwnerUsername) {
@@ -1613,9 +2081,9 @@ function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
 }
 function getVisibleColonyOwnerUsername(colonyName) {
   const controller = getVisibleController(colonyName);
-  return getControllerOwnerUsername(controller != null ? controller : void 0);
+  return getControllerOwnerUsername2(controller != null ? controller : void 0);
 }
-function getControllerOwnerUsername(controller) {
+function getControllerOwnerUsername2(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString(username) ? username : null;
@@ -1643,14 +2111,14 @@ function getWritableTerritoryMemoryRecord() {
   if (!memory) {
     return null;
   }
-  if (!isRecord(memory.territory)) {
+  if (!isRecord2(memory.territory)) {
     memory.territory = {};
   }
   return memory.territory;
 }
-function getTerritoryMemoryRecord() {
+function getTerritoryMemoryRecord2() {
   const memory = getMemoryRecord();
-  if (!memory || !isRecord(memory.territory)) {
+  if (!memory || !isRecord2(memory.territory)) {
     return null;
   }
   return memory.territory;
@@ -1674,7 +2142,7 @@ function isTerritoryIntentStatus(status) {
 function isNonEmptyString(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord(value) {
+function isRecord2(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -3218,12 +3686,12 @@ function clampScore(score) {
 function buildRuntimeConstructionPriorityState(colony, creeps) {
   var _a, _b, _c;
   const room = colony.room;
-  const ownedConstructionSites = findRoomObjects(room, "FIND_MY_CONSTRUCTION_SITES");
-  const ownedStructures = findRoomObjects(room, "FIND_MY_STRUCTURES");
-  const visibleStructures = findRoomObjects(room, "FIND_STRUCTURES");
-  const hostileCreeps = findRoomObjects(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects(room, "FIND_HOSTILE_STRUCTURES");
-  const sources = findRoomObjects(room, "FIND_SOURCES");
+  const ownedConstructionSites = findRoomObjects2(room, "FIND_MY_CONSTRUCTION_SITES");
+  const ownedStructures = findRoomObjects2(room, "FIND_MY_STRUCTURES");
+  const visibleStructures = findRoomObjects2(room, "FIND_STRUCTURES");
+  const hostileCreeps = findRoomObjects2(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects2(room, "FIND_HOSTILE_STRUCTURES");
+  const sources = findRoomObjects2(room, "FIND_SOURCES");
   const colonyWorkers = creeps.filter((creep) => {
     var _a2, _b2;
     return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && ((_b2 = creep.memory) == null ? void 0 : _b2.colony) === room.name;
@@ -3499,7 +3967,7 @@ function getConstructionSiteRemainingProgress(site) {
   const progress = typeof site.progress === "number" ? site.progress : 0;
   return Math.max(0, progressTotal - progress);
 }
-function findRoomObjects(room, constantName) {
+function findRoomObjects2(room, constantName) {
   const findConstant = globalThis[constantName];
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return null;
@@ -3551,7 +4019,7 @@ function countTerritoryIntents(roomName) {
   }
   return intents.reduce(
     (counts, intent) => {
-      if (!isRecord2(intent)) {
+      if (!isRecord3(intent)) {
         return counts;
       }
       if (intent.colony !== roomName) {
@@ -3567,353 +4035,13 @@ function countTerritoryIntents(roomName) {
     { active: 0, planned: 0 }
   );
 }
-function isRecord2(value) {
+function isRecord3(value) {
   return typeof value === "object" && value !== null;
 }
 function matchesStructureType3(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
-}
-
-// src/territory/occupationRecommendation.ts
-var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
-var TERRITORY_BODY_ENERGY_CAPACITY = 650;
-var MIN_READY_WORKERS = 3;
-var DOWNGRADE_GUARD_TICKS = 5e3;
-var RESERVATION_RENEWAL_TICKS = 1e3;
-var TERRITORY_ROUTE_DISTANCE_SEPARATOR2 = ">";
-var ACTION_SCORE = {
-  occupy: 1e3,
-  reserve: 800,
-  scout: 420
-};
-function buildRuntimeOccupationRecommendationReport(colony, colonyWorkers) {
-  return scoreOccupationRecommendations(buildRuntimeOccupationRecommendationInput(colony, colonyWorkers));
-}
-function scoreOccupationRecommendations(input) {
-  var _a;
-  const candidates = input.candidates.filter((candidate) => candidate.roomName !== input.colonyName).map((candidate) => scoreOccupationCandidate(input, candidate)).sort(compareOccupationRecommendationScores);
-  const next = (_a = candidates.find((candidate) => candidate.evidenceStatus !== "unavailable")) != null ? _a : null;
-  return { candidates, next };
-}
-function buildRuntimeOccupationRecommendationInput(colony, colonyWorkers) {
-  var _a, _b;
-  const colonyName = colony.room.name;
-  return {
-    colonyName,
-    colonyOwnerUsername: getControllerOwnerUsername2(colony.room.controller),
-    energyCapacityAvailable: colony.energyCapacityAvailable,
-    workerCount: colonyWorkers.length,
-    ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
-    ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
-    candidates: buildRuntimeOccupationCandidates(colonyName)
-  };
-}
-function buildRuntimeOccupationCandidates(colonyName) {
-  const candidatesByRoom = /* @__PURE__ */ new Map();
-  const territoryMemory = getTerritoryMemoryRecord2();
-  let order = 0;
-  if (Array.isArray(territoryMemory == null ? void 0 : territoryMemory.targets)) {
-    for (const rawTarget of territoryMemory.targets) {
-      const target = normalizeTerritoryTarget2(rawTarget);
-      if (!target || target.colony !== colonyName || target.enabled === false) {
-        continue;
-      }
-      upsertOccupationCandidate(candidatesByRoom, {
-        roomName: target.roomName,
-        source: "configured",
-        order,
-        adjacent: false,
-        visible: false,
-        actionHint: target.action,
-        routeDistance: getCachedRouteDistance(colonyName, target.roomName)
-      });
-      order += 1;
-    }
-  }
-  for (const roomName of getAdjacentRoomNames2(colonyName)) {
-    const cachedRouteDistance = getCachedRouteDistance(colonyName, roomName);
-    upsertOccupationCandidate(candidatesByRoom, {
-      roomName,
-      source: "adjacent",
-      order,
-      adjacent: true,
-      visible: false,
-      routeDistance: cachedRouteDistance === void 0 ? 1 : cachedRouteDistance
-    });
-    order += 1;
-  }
-  return Array.from(candidatesByRoom.values()).map(enrichVisibleOccupationCandidate);
-}
-function upsertOccupationCandidate(candidatesByRoom, candidate) {
-  const existing = candidatesByRoom.get(candidate.roomName);
-  if (!existing) {
-    candidatesByRoom.set(candidate.roomName, candidate);
-    return;
-  }
-  if (candidate.source === "configured" && existing.source !== "configured") {
-    existing.source = "configured";
-    existing.actionHint = candidate.actionHint;
-    existing.order = Math.min(existing.order, candidate.order);
-  }
-  existing.adjacent = existing.adjacent || candidate.adjacent;
-  if (existing.routeDistance === void 0 && candidate.routeDistance !== void 0) {
-    existing.routeDistance = candidate.routeDistance;
-  }
-}
-function enrichVisibleOccupationCandidate(candidate) {
-  var _a;
-  const room = (_a = getGameRooms()) == null ? void 0 : _a[candidate.roomName];
-  if (!room) {
-    return candidate;
-  }
-  const hostileCreeps = findRoomObjects2(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects2(room, "FIND_HOSTILE_STRUCTURES");
-  const sources = findRoomObjects2(room, "FIND_SOURCES");
-  const constructionSites = findRoomObjects2(room, "FIND_MY_CONSTRUCTION_SITES");
-  const ownedStructures = findRoomObjects2(room, "FIND_MY_STRUCTURES");
-  return {
-    ...candidate,
-    visible: true,
-    ...room.controller ? { controller: summarizeController(room.controller) } : {},
-    ...sources ? { sourceCount: sources.length } : {},
-    ...hostileCreeps ? { hostileCreepCount: hostileCreeps.length } : {},
-    ...hostileStructures ? { hostileStructureCount: hostileStructures.length } : {},
-    ...constructionSites ? { constructionSiteCount: constructionSites.length } : {},
-    ...ownedStructures ? { ownedStructureCount: ownedStructures.length } : {}
-  };
-}
-function scoreOccupationCandidate(input, candidate) {
-  var _a, _b;
-  const evidence = [];
-  const preconditions = getColonyReadinessPreconditions(input);
-  const risks = [];
-  const routeDistance = typeof candidate.routeDistance === "number" ? candidate.routeDistance : void 0;
-  let action = "scout";
-  let evidenceStatus = "sufficient";
-  if (candidate.routeDistance === null) {
-    risks.push("no known route from colony");
-    evidenceStatus = "unavailable";
-  } else if (!candidate.visible) {
-    evidence.push("room visibility missing");
-    risks.push("controller, source, and hostile evidence unavailable");
-    evidenceStatus = "insufficient-evidence";
-  } else if (!candidate.controller) {
-    evidence.push("room visible");
-    risks.push("visible room has no controller");
-    evidenceStatus = "unavailable";
-  } else {
-    evidence.push("room visible", "controller visible");
-    const unavailableReason = getControllerUnavailableReason(input, candidate.controller);
-    if (unavailableReason) {
-      risks.push(unavailableReason);
-      evidenceStatus = "unavailable";
-      action = candidate.actionHint === "claim" ? "occupy" : "reserve";
-    } else if (isOwnHealthyReservation(input, candidate.controller)) {
-      evidence.push("own reservation is healthy");
-      evidenceStatus = "unavailable";
-      action = "reserve";
-    } else if (isOwnReservationDueForRenewal(input, candidate.controller)) {
-      evidence.push("own reservation needs renewal");
-      action = "reserve";
-    } else if (candidate.sourceCount === void 0) {
-      evidence.push("controller is available");
-      risks.push("source count evidence missing");
-      evidenceStatus = "insufficient-evidence";
-    } else {
-      evidence.push("controller is available", `${candidate.sourceCount} sources visible`);
-      action = candidate.actionHint === "claim" ? "occupy" : "reserve";
-    }
-  }
-  const hostileCreepCount = (_a = candidate.hostileCreepCount) != null ? _a : 0;
-  const hostileStructureCount = (_b = candidate.hostileStructureCount) != null ? _b : 0;
-  if (hostileCreepCount > 0 || hostileStructureCount > 0) {
-    risks.push("hostile presence visible");
-    evidenceStatus = "unavailable";
-  }
-  const score = calculateOccupationScore(input, candidate, action, evidenceStatus);
-  return {
-    roomName: candidate.roomName,
-    action,
-    score,
-    evidenceStatus,
-    source: candidate.source,
-    evidence,
-    preconditions,
-    risks,
-    ...routeDistance !== void 0 ? { routeDistance } : {},
-    ...candidate.sourceCount !== void 0 ? { sourceCount: candidate.sourceCount } : {},
-    ...candidate.hostileCreepCount !== void 0 ? { hostileCreepCount: candidate.hostileCreepCount } : {},
-    ...candidate.hostileStructureCount !== void 0 ? { hostileStructureCount: candidate.hostileStructureCount } : {}
-  };
-}
-function calculateOccupationScore(input, candidate, action, evidenceStatus) {
-  var _a, _b, _c, _d, _e;
-  const distanceScore = typeof candidate.routeDistance === "number" ? Math.max(0, 80 - candidate.routeDistance * 15) : 0;
-  const sourceScore = typeof candidate.sourceCount === "number" ? Math.min(candidate.sourceCount, 2) * 70 : 0;
-  const supportScore = Math.min((_a = candidate.ownedStructureCount) != null ? _a : 0, 3) * 8 + Math.min((_b = candidate.constructionSiteCount) != null ? _b : 0, 3) * 5;
-  const sourcePriorityScore = candidate.source === "configured" ? 50 : 25;
-  const adjacencyScore = candidate.adjacent ? 25 : 0;
-  const readinessScore = Math.min(input.workerCount, MIN_READY_WORKERS) * 12 + (input.energyCapacityAvailable >= TERRITORY_BODY_ENERGY_CAPACITY ? 30 : 0) + (((_c = input.controllerLevel) != null ? _c : 0) >= 2 ? 30 : 0) + (input.ticksToDowngrade === void 0 || input.ticksToDowngrade > DOWNGRADE_GUARD_TICKS ? 20 : 0);
-  const riskPenalty = ((_d = candidate.hostileCreepCount) != null ? _d : 0) * 160 + ((_e = candidate.hostileStructureCount) != null ? _e : 0) * 120;
-  const evidencePenalty = evidenceStatus === "insufficient-evidence" ? 260 : 0;
-  const unavailablePenalty = evidenceStatus === "unavailable" ? 2e3 : 0;
-  return ACTION_SCORE[action] + sourcePriorityScore + adjacencyScore + distanceScore + sourceScore + supportScore + readinessScore - riskPenalty - evidencePenalty - unavailablePenalty;
-}
-function getColonyReadinessPreconditions(input) {
-  var _a;
-  const preconditions = [];
-  if (input.workerCount < MIN_READY_WORKERS) {
-    preconditions.push("raise worker count before dispatching territory creeps");
-  }
-  if (input.energyCapacityAvailable < TERRITORY_BODY_ENERGY_CAPACITY) {
-    preconditions.push("reach 650 energy capacity for controller work");
-  }
-  if (((_a = input.controllerLevel) != null ? _a : 0) < 2) {
-    preconditions.push("reach controller level 2 before expansion");
-  }
-  if (typeof input.ticksToDowngrade === "number" && input.ticksToDowngrade <= DOWNGRADE_GUARD_TICKS) {
-    preconditions.push("stabilize home controller downgrade timer");
-  }
-  return preconditions;
-}
-function getControllerUnavailableReason(input, controller) {
-  if (isControllerOwnedByColony2(input, controller)) {
-    return "controller already owned by colony account";
-  }
-  if (controller.ownerUsername) {
-    return "controller owned by another account";
-  }
-  if (controller.reservationUsername && controller.reservationUsername !== input.colonyOwnerUsername) {
-    return "controller reserved by another account";
-  }
-  return null;
-}
-function isOwnHealthyReservation(input, controller) {
-  return isOwnReservation(input, controller) && typeof controller.reservationTicksToEnd === "number" && controller.reservationTicksToEnd > RESERVATION_RENEWAL_TICKS;
-}
-function isOwnReservationDueForRenewal(input, controller) {
-  return isOwnReservation(input, controller) && typeof controller.reservationTicksToEnd === "number" && controller.reservationTicksToEnd <= RESERVATION_RENEWAL_TICKS;
-}
-function isOwnReservation(input, controller) {
-  return input.colonyOwnerUsername !== void 0 && controller.reservationUsername === input.colonyOwnerUsername;
-}
-function isControllerOwnedByColony2(input, controller) {
-  return controller.my === true || !!controller.ownerUsername && controller.ownerUsername === input.colonyOwnerUsername;
-}
-function compareOccupationRecommendationScores(left, right) {
-  return right.score - left.score || getEvidenceStatusPriority(left.evidenceStatus) - getEvidenceStatusPriority(right.evidenceStatus) || getActionPriority(left.action) - getActionPriority(right.action) || getSourcePriority(left.source) - getSourcePriority(right.source) || compareOptionalNumbers2(left.routeDistance, right.routeDistance) || left.roomName.localeCompare(right.roomName);
-}
-function getEvidenceStatusPriority(status) {
-  if (status === "sufficient") {
-    return 0;
-  }
-  return status === "insufficient-evidence" ? 1 : 2;
-}
-function getActionPriority(action) {
-  if (action === "occupy") {
-    return 0;
-  }
-  return action === "reserve" ? 1 : 2;
-}
-function getSourcePriority(source) {
-  return source === "configured" ? 0 : 1;
-}
-function compareOptionalNumbers2(left, right) {
-  return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
-}
-function summarizeController(controller) {
-  const ownerUsername = getControllerOwnerUsername2(controller);
-  const reservationUsername = getReservationUsername(controller);
-  const reservationTicksToEnd = getReservationTicksToEnd(controller);
-  return {
-    ...controller.my === true ? { my: true } : {},
-    ...ownerUsername ? { ownerUsername } : {},
-    ...reservationUsername ? { reservationUsername } : {},
-    ...typeof reservationTicksToEnd === "number" ? { reservationTicksToEnd } : {}
-  };
-}
-function getAdjacentRoomNames2(roomName) {
-  var _a;
-  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
-  if (!gameMap || typeof gameMap.describeExits !== "function") {
-    return [];
-  }
-  const exits = gameMap.describeExits(roomName);
-  if (!isRecord3(exits)) {
-    return [];
-  }
-  return EXIT_DIRECTION_ORDER2.flatMap((direction) => {
-    const exitRoom = exits[direction];
-    return typeof exitRoom === "string" && exitRoom.length > 0 ? [exitRoom] : [];
-  });
-}
-function normalizeTerritoryTarget2(rawTarget) {
-  if (!isRecord3(rawTarget)) {
-    return null;
-  }
-  if (typeof rawTarget.colony !== "string" || rawTarget.colony.length === 0 || typeof rawTarget.roomName !== "string" || rawTarget.roomName.length === 0 || rawTarget.action !== "claim" && rawTarget.action !== "reserve") {
-    return null;
-  }
-  return {
-    colony: rawTarget.colony,
-    roomName: rawTarget.roomName,
-    action: rawTarget.action,
-    ...rawTarget.enabled === false ? { enabled: false } : {}
-  };
-}
-function getCachedRouteDistance(fromRoom, targetRoom) {
-  var _a;
-  const routeDistances = (_a = getTerritoryMemoryRecord2()) == null ? void 0 : _a.routeDistances;
-  if (!isRecord3(routeDistances)) {
-    return void 0;
-  }
-  const distance = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR2}${targetRoom}`];
-  return typeof distance === "number" || distance === null ? distance : void 0;
-}
-function findRoomObjects2(room, constantName) {
-  const findConstant = getGlobalNumber(constantName);
-  const find = room.find;
-  if (typeof findConstant !== "number" || typeof find !== "function") {
-    return void 0;
-  }
-  try {
-    const result = find.call(room, findConstant);
-    return Array.isArray(result) ? result : [];
-  } catch {
-    return void 0;
-  }
-}
-function getGlobalNumber(name) {
-  const value = globalThis[name];
-  return typeof value === "number" ? value : void 0;
-}
-function getControllerOwnerUsername2(controller) {
-  var _a;
-  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return typeof username === "string" && username.length > 0 ? username : void 0;
-}
-function getReservationUsername(controller) {
-  var _a;
-  const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return typeof username === "string" && username.length > 0 ? username : void 0;
-}
-function getReservationTicksToEnd(controller) {
-  var _a;
-  const ticksToEnd = (_a = controller.reservation) == null ? void 0 : _a.ticksToEnd;
-  return typeof ticksToEnd === "number" ? ticksToEnd : void 0;
-}
-function getGameRooms() {
-  var _a;
-  return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
-}
-function getTerritoryMemoryRecord2() {
-  var _a;
-  return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
-}
-function isRecord3(value) {
-  return typeof value === "object" && value !== null;
 }
 
 // src/telemetry/runtimeSummary.ts

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1,6 +1,12 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
+import {
+  scoreOccupationRecommendations,
+  type OccupationControllerEvidence,
+  type OccupationRecommendationCandidateInput,
+  type OccupationRecommendationScore
+} from './occupationRecommendation';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
@@ -53,6 +59,8 @@ interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   order: number;
   priority: number;
   source: TerritoryCandidateSource;
+  recommendationScore?: number;
+  routeDistance?: number;
   renewalTicksToEnd?: number;
 }
 
@@ -345,13 +353,17 @@ function selectTerritoryTarget(
     roleCounts,
     routeDistanceLookupContext
   );
-  const configuredCandidates = getConfiguredTerritoryCandidates(
-    colonyName,
-    colonyOwnerUsername,
-    territoryMemory,
-    intents,
-    gameTime,
-    routeDistanceLookupContext
+  const configuredCandidates = applyOccupationRecommendationScores(
+    colony,
+    roleCounts,
+    getConfiguredTerritoryCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      routeDistanceLookupContext
+    )
   );
   const bestSpawnableConfiguredCandidate = selectBestScoredTerritoryCandidate(
     getSpawnableTerritoryCandidates(configuredCandidates, roleCounts)
@@ -363,7 +375,7 @@ function selectTerritoryTarget(
     return toSelectedTerritoryTarget(bestSpawnableConfiguredCandidate);
   }
 
-  const adjacentCandidates = [
+  const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, [
     ...getAdjacentReserveCandidates(
       colonyName,
       colonyName,
@@ -404,7 +416,7 @@ function selectTerritoryTarget(
       !hasBlockingConfiguredTarget,
       routeDistanceLookupContext
     )
-  ];
+  ]);
   const candidates = [...configuredCandidates, ...adjacentCandidates];
 
   return toSelectedTerritoryTarget(
@@ -809,7 +821,8 @@ function scoreTerritoryCandidate(
   colonyOwnerUsername: string | null,
   routeDistanceLookupContext: RouteDistanceLookupContext
 ): ScoredTerritoryTarget | null {
-  if (hasKnownNoRoute(colonyName, selection.target.roomName, routeDistanceLookupContext)) {
+  const routeDistance = getKnownRouteLength(colonyName, selection.target.roomName, routeDistanceLookupContext);
+  if (routeDistance === null) {
     return null;
   }
 
@@ -819,8 +832,173 @@ function scoreTerritoryCandidate(
     source,
     order,
     priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
+    ...(routeDistance !== undefined ? { routeDistance } : {}),
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
   };
+}
+
+function applyOccupationRecommendationScores(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  candidates: ScoredTerritoryTarget[]
+): ScoredTerritoryTarget[] {
+  const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller) ?? undefined;
+  return candidates.flatMap((candidate) => {
+    const recommendation = scoreOccupationRecommendations({
+      colonyName: colony.room.name,
+      ...(colonyOwnerUsername ? { colonyOwnerUsername } : {}),
+      energyCapacityAvailable: colony.energyCapacityAvailable,
+      workerCount: getWorkerCapacity(roleCounts),
+      ...(typeof colony.room.controller?.level === 'number' ? { controllerLevel: colony.room.controller.level } : {}),
+      ...(typeof colony.room.controller?.ticksToDowngrade === 'number'
+        ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade }
+        : {}),
+      candidates: [buildOccupationRecommendationCandidate(candidate)]
+    }).candidates[0];
+
+    if (!recommendation || recommendation.evidenceStatus === 'unavailable') {
+      return [];
+    }
+
+    return [applyOccupationRecommendationScore(candidate, recommendation, roleCounts)];
+  });
+}
+
+function applyOccupationRecommendationScore(
+  candidate: ScoredTerritoryTarget,
+  recommendation: OccupationRecommendationScore,
+  roleCounts: RoleCounts
+): ScoredTerritoryTarget {
+  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const nextSelection: SelectedTerritoryTarget = {
+    target: candidate.target,
+    intentAction,
+    commitTarget: recommendation.evidenceStatus === 'sufficient' && intentAction !== 'scout' && candidate.commitTarget,
+    ...(candidate.followUp ? { followUp: candidate.followUp } : {})
+  };
+  const renewalTicksToEnd = intentAction === 'reserve' ? candidate.renewalTicksToEnd ?? null : null;
+
+  return {
+    ...candidate,
+    intentAction,
+    commitTarget: nextSelection.commitTarget,
+    priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
+    recommendationScore: recommendation.score,
+    ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
+  };
+}
+
+function getRecommendedTerritoryIntentAction(
+  candidate: ScoredTerritoryTarget,
+  recommendation: OccupationRecommendationScore,
+  roleCounts: RoleCounts
+): TerritoryIntentAction {
+  if (recommendation.evidenceStatus === 'insufficient-evidence') {
+    if (
+      candidate.source === 'configured' &&
+      getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.target.action) > 0
+    ) {
+      return candidate.intentAction;
+    }
+
+    return 'scout';
+  }
+
+  if (recommendation.action === 'occupy') {
+    return 'claim';
+  }
+
+  return recommendation.action === 'reserve' ? 'reserve' : candidate.intentAction;
+}
+
+function buildOccupationRecommendationCandidate(
+  candidate: ScoredTerritoryTarget
+): OccupationRecommendationCandidateInput {
+  const room = getVisibleRoom(candidate.target.roomName);
+  return {
+    roomName: candidate.target.roomName,
+    source: candidate.source === 'configured' ? 'configured' : 'adjacent',
+    order: candidate.order,
+    adjacent: candidate.source !== 'configured',
+    visible: room != null,
+    actionHint: candidate.target.action,
+    ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
+    ...(room ? buildVisibleOccupationRecommendationEvidence(room, candidate.target.controllerId) : {})
+  };
+}
+
+function buildVisibleOccupationRecommendationEvidence(
+  room: Room,
+  controllerId?: Id<StructureController>
+): Pick<
+  OccupationRecommendationCandidateInput,
+  | 'controller'
+  | 'sourceCount'
+  | 'hostileCreepCount'
+  | 'hostileStructureCount'
+  | 'constructionSiteCount'
+  | 'ownedStructureCount'
+> {
+  const controller = getVisibleController(room.name, controllerId);
+  return {
+    ...(controller ? { controller: summarizeOccupationController(controller) } : {}),
+    sourceCount: countVisibleRoomObjects(room, getFindConstant('FIND_SOURCES')),
+    hostileCreepCount: findVisibleHostileCreeps(room).length,
+    hostileStructureCount: findVisibleHostileStructures(room).length,
+    constructionSiteCount: countVisibleRoomObjects(room, getFindConstant('FIND_MY_CONSTRUCTION_SITES')),
+    ownedStructureCount: countVisibleRoomObjects(room, getFindConstant('FIND_MY_STRUCTURES'))
+  };
+}
+
+function summarizeOccupationController(controller: StructureController): OccupationControllerEvidence {
+  const ownerUsername = getControllerOwnerUsername(controller);
+  const reservationUsername = getControllerReservationUsername(controller);
+  const reservationTicksToEnd = getControllerReservationTicksToEnd(controller);
+
+  return {
+    ...(controller.my === true ? { my: true } : {}),
+    ...(ownerUsername ? { ownerUsername } : {}),
+    ...(reservationUsername ? { reservationUsername } : {}),
+    ...(typeof reservationTicksToEnd === 'number' ? { reservationTicksToEnd } : {})
+  };
+}
+
+function getControllerReservationUsername(controller: StructureController): string | undefined {
+  const username = (controller as StructureController & { reservation?: { username?: string } }).reservation?.username;
+  return isNonEmptyString(username) ? username : undefined;
+}
+
+function getControllerReservationTicksToEnd(controller: StructureController): number | undefined {
+  const ticksToEnd = (controller as StructureController & { reservation?: { ticksToEnd?: number } }).reservation
+    ?.ticksToEnd;
+  return typeof ticksToEnd === 'number' ? ticksToEnd : undefined;
+}
+
+function getVisibleRoom(roomName: string): Room | null {
+  return (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[roomName] ?? null;
+}
+
+function countVisibleRoomObjects(room: Room, findConstant: number | undefined): number {
+  if (typeof findConstant !== 'number') {
+    return 0;
+  }
+
+  const find = (room as unknown as { find?: (type: number) => unknown }).find;
+  if (typeof find !== 'function') {
+    return 0;
+  }
+
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function getFindConstant(name: string): number | undefined {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : undefined;
 }
 
 function getTerritoryCandidatePriority(
@@ -851,6 +1029,7 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
     left.priority - right.priority ||
     compareOptionalNumbers(left.renewalTicksToEnd, right.renewalTicksToEnd) ||
     getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) ||
+    compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) ||
     left.order - right.order ||
     left.target.roomName.localeCompare(right.target.roomName) ||
     left.intentAction.localeCompare(right.intentAction)
@@ -859,6 +1038,10 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
 
 function compareOptionalNumbers(left: number | undefined, right: number | undefined): number {
   return (left ?? Number.POSITIVE_INFINITY) - (right ?? Number.POSITIVE_INFINITY);
+}
+
+function compareOptionalNumbersDescending(left: number | undefined, right: number | undefined): number {
+  return (right ?? Number.NEGATIVE_INFINITY) - (left ?? Number.NEGATIVE_INFINITY);
 }
 
 function getTerritoryCandidateSourcePriority(source: TerritoryCandidateSource): number {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -184,7 +184,7 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 3 }, 147)).toBeNull();
   });
 
-  it('plans a claimer-role reserver for an explicit memory target when home survival is safe', () => {
+  it('plans a scout for an explicit memory target when target visibility is missing', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,
       energyCapacityAvailable: 650,
@@ -198,26 +198,26 @@ describe('planSpawn', () => {
 
     expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 139)).toEqual({
       spawn,
-      body: ['claim', 'move'],
-      name: 'claimer-W1N1-W2N1-139',
+      body: ['move'],
+      name: 'scout-W1N1-W2N1-139',
       memory: {
-        role: 'claimer',
+        role: 'scout',
         colony: 'W1N1',
-        territory: { targetRoom: 'W2N1', action: 'reserve' }
+        territory: { targetRoom: 'W2N1', action: 'scout' }
       }
     });
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
         targetRoom: 'W2N1',
-        action: 'reserve',
+        action: 'scout',
         status: 'planned',
         updatedAt: 139
       }
     ]);
   });
 
-  it('plans territory control once the construction-adjusted worker target is satisfied', () => {
+  it('plans territory scouting once the construction-adjusted worker target is satisfied', () => {
     const { colony, spawn } = makeColony({
       roomName: 'W1N10',
       constructionSiteCount: 1,
@@ -233,19 +233,19 @@ describe('planSpawn', () => {
 
     expect(planSpawn(colony, { worker: 4, claimer: 0, claimersByTargetRoom: {} }, 148)).toEqual({
       spawn,
-      body: ['claim', 'move'],
-      name: 'claimer-W1N10-W2N10-148',
+      body: ['move'],
+      name: 'scout-W1N10-W2N10-148',
       memory: {
-        role: 'claimer',
+        role: 'scout',
         colony: 'W1N10',
-        territory: { targetRoom: 'W2N10', action: 'reserve' }
+        territory: { targetRoom: 'W2N10', action: 'scout' }
       }
     });
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N10',
         targetRoom: 'W2N10',
-        action: 'reserve',
+        action: 'scout',
         status: 'planned',
         updatedAt: 148
       }
@@ -327,8 +327,8 @@ describe('planSpawn', () => {
     ]);
   });
 
-  it('records territory intent while waiting for claim body energy', () => {
-    const { colony } = makeColony({
+  it('spawns a scout while waiting for claim body energy and target visibility', () => {
+    const { colony, spawn } = makeColony({
       energyAvailable: 600,
       energyCapacityAvailable: 650,
       controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController
@@ -339,12 +339,21 @@ describe('planSpawn', () => {
       }
     };
 
-    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 141)).toBeNull();
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 141)).toEqual({
+      spawn,
+      body: ['move'],
+      name: 'scout-W1N1-W2N1-141',
+      memory: {
+        role: 'scout',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'scout', controllerId: 'controller2' as Id<StructureController> }
+      }
+    });
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
         targetRoom: 'W2N1',
-        action: 'claim',
+        action: 'scout',
         status: 'planned',
         updatedAt: 141,
         controllerId: 'controller2'
@@ -352,7 +361,7 @@ describe('planSpawn', () => {
     ]);
   });
 
-  it('plans a claim creep when only reserve capacity exists for the recovered target room', () => {
+  it('plans a scout when only reserve capacity exists for an unseen recovered claim target', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,
       energyCapacityAvailable: 650,
@@ -377,19 +386,19 @@ describe('planSpawn', () => {
       )
     ).toEqual({
       spawn,
-      body: ['claim', 'move'],
-      name: 'claimer-W1N1-W2N1-149',
+      body: ['move'],
+      name: 'scout-W1N1-W2N1-149',
       memory: {
-        role: 'claimer',
+        role: 'scout',
         colony: 'W1N1',
-        territory: { targetRoom: 'W2N1', action: 'claim' }
+        territory: { targetRoom: 'W2N1', action: 'scout' }
       }
     });
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
         targetRoom: 'W2N1',
-        action: 'claim',
+        action: 'scout',
         status: 'planned',
         updatedAt: 149
       }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -11,13 +11,16 @@ import {
 
 describe('planTerritoryIntent', () => {
   beforeEach(() => {
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 5;
     (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
     (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
+    (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 8;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 9;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     delete (globalThis as { Game?: Partial<Game> }).Game;
   });
 
-  it('records the first valid enabled target for the colony', () => {
+  it('scouts the first valid enabled target for the colony when visibility is missing', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
@@ -34,14 +37,14 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W3N1',
-      action: 'claim',
+      action: 'scout',
       controllerId: 'controller3'
     });
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
         targetRoom: 'W3N1',
-        action: 'claim',
+        action: 'scout',
         status: 'planned',
         updatedAt: 500,
         controllerId: 'controller3'
@@ -611,7 +614,7 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W3N1',
-      action: 'reserve'
+      action: 'scout'
     });
     expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(Memory.territory?.targets).toEqual([configuredTarget]);
@@ -658,6 +661,130 @@ describe('planTerritoryIntent', () => {
         updatedAt: 547
       }
     ]);
+  });
+
+  it('uses a sufficient visible occupy recommendation as a claim intent', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1', { sourceCount: 2 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 565)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 565
+      }
+    ]);
+  });
+
+  it('uses recommendation scoring to seed the strongest sufficient visible reserve candidate', () => {
+    const colony = makeSafeColony();
+    const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N2: makeRecommendationRoom('W1N2', { sourceCount: 1 }),
+        W2N1: makeRecommendationRoom('W2N1', { sourceCount: 2 })
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 566)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve'
+      }
+    ]);
+  });
+
+  it('excludes a cached no-route recommendation before selecting the next visible reserve candidate', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;
+    const findRoute = jest.fn((fromRoom: string, toRoom: string) =>
+      fromRoom === 'W1N1' && toRoom === 'W2N1' ? -2 : [{ exit: 3, room: toRoom }]
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1', { sourceCount: 2 }),
+        W3N1: makeRecommendationRoom('W3N1', { sourceCount: 1 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ],
+        routeDistances: { 'W1N1>W2N1': null }
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 567)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve'
+    });
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W2N1');
+    expect(Memory.territory?.routeDistances).toEqual({
+      'W1N1>W2N1': null,
+      'W1N1>W3N1': 1
+    });
+  });
+
+  it('does not override a safer visible configured target with a higher-scoring adjacent recommendation', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const describeExits = jest.fn(() => ({ '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1', { sourceCount: 2 }),
+        W3N1: makeRecommendationRoom('W3N1', { sourceCount: 1 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 568)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve'
+    });
+    expect(describeExits).not.toHaveBeenCalled();
+    expect(Memory.territory?.targets).toEqual([configuredTarget]);
   });
 
   it('does not seed visible hostile-owned or self-owned adjacent rooms', () => {
@@ -829,7 +956,7 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
-  it('normalizes malformed existing intents before updating a matching intent', () => {
+  it('normalizes malformed existing intents before recording a scout for missing target evidence', () => {
     const colony = makeSafeColony();
     const unrelatedIntent: TerritoryIntentMemory = {
       colony: 'W9N9',
@@ -863,7 +990,7 @@ describe('planTerritoryIntent', () => {
       ).toEqual({
         colony: 'W1N1',
         targetRoom: 'W2N1',
-        action: 'reserve'
+        action: 'scout'
       });
     }).not.toThrow();
     expect(Memory.territory?.intents).toEqual([
@@ -872,6 +999,13 @@ describe('planTerritoryIntent', () => {
         colony: 'W1N1',
         targetRoom: 'W2N1',
         action: 'reserve',
+        status: 'planned',
+        updatedAt: 451
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'scout',
         status: 'planned',
         updatedAt: 506
       }
@@ -914,7 +1048,7 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('retries stale suppressed claim targets', () => {
+  it('scouts stale suppressed claim targets before retrying controller work', () => {
     const colony = makeSafeColony();
     const suppressionTime = 510;
     const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
@@ -936,12 +1070,23 @@ describe('planTerritoryIntent', () => {
     };
 
     expect(shouldSpawnTerritoryControllerCreep(plan, roleCounts, retryTime)).toBe(true);
-    expect(planTerritoryIntent(colony, roleCounts, 3, retryTime)).toEqual(plan);
+    expect(planTerritoryIntent(colony, roleCounts, 3, retryTime)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'scout'
+    });
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
         targetRoom: 'W2N1',
         action: 'claim',
+        status: 'suppressed',
+        updatedAt: suppressionTime
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'scout',
         status: 'planned',
         updatedAt: retryTime
       }
@@ -974,7 +1119,7 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W3N1',
-      action: 'reserve'
+      action: 'scout'
     });
     expect(Memory.territory?.intents).toEqual([
       {
@@ -987,7 +1132,7 @@ describe('planTerritoryIntent', () => {
       {
         colony: 'W1N1',
         targetRoom: 'W3N1',
-        action: 'reserve',
+        action: 'scout',
         status: 'planned',
         updatedAt: 513
       }
@@ -2283,6 +2428,43 @@ function makeFollowUp(
     originRoom,
     originAction
   };
+}
+
+function makeRecommendationRoom(
+  roomName: string,
+  {
+    controller = { my: false } as StructureController,
+    sourceCount = 1,
+    hostileCreepCount = 0,
+    hostileStructureCount = 0
+  }: {
+    controller?: StructureController;
+    sourceCount?: number;
+    hostileCreepCount?: number;
+    hostileStructureCount?: number;
+  } = {}
+): Room {
+  return {
+    name: roomName,
+    controller,
+    find: jest.fn((findType: number): unknown[] => {
+      switch (findType) {
+        case FIND_SOURCES:
+          return Array.from({ length: sourceCount }, (_value, index) => ({ id: `source${index}` }));
+        case FIND_HOSTILE_CREEPS:
+          return Array.from({ length: hostileCreepCount }, (_value, index) => ({ id: `hostile${index}` }));
+        case FIND_HOSTILE_STRUCTURES:
+          return Array.from({ length: hostileStructureCount }, (_value, index) => ({
+            id: `hostileStructure${index}`
+          }));
+        case FIND_MY_STRUCTURES:
+        case FIND_MY_CONSTRUCTION_SITES:
+          return [];
+        default:
+          return [];
+      }
+    })
+  } as unknown as Room;
 }
 
 function makeSafeColony({


### PR DESCRIPTION
## Summary
- consume occupation recommendation scores when selecting territory candidates
- keep missing-visibility targets on scouting first while visible sufficient recommendations can claim/reserve
- add deterministic coverage for recommendation-driven territory planning and regenerated bundle

Closes #239.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

## Scheduler evidence
- Worktree: `/root/screeps-worktrees/consume-occupation-recommendation-239`
- Commit: `a9ebe8f` authored by `lanyusea's bot <lanyusea@gmail.com>`
