### PR TITLE
feat: persist occupation follow-up intent

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3582,6 +3582,7 @@ var TERRITORY_BODY_ENERGY_CAPACITY = 650;
 var MIN_READY_WORKERS = 3;
 var DOWNGRADE_GUARD_TICKS = 5e3;
 var RESERVATION_RENEWAL_TICKS = 1e3;
+var TERRITORY_SUPPRESSION_RETRY_TICKS2 = 1500;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR2 = ">";
 var ACTION_SCORE = {
   occupy: 1e3,
@@ -3595,7 +3596,35 @@ function scoreOccupationRecommendations(input) {
   var _a;
   const candidates = input.candidates.filter((candidate) => candidate.roomName !== input.colonyName).map((candidate) => scoreOccupationCandidate(input, candidate)).sort(compareOccupationRecommendationScores);
   const next = (_a = candidates.find((candidate) => candidate.evidenceStatus !== "unavailable")) != null ? _a : null;
-  return { candidates, next };
+  return { candidates, next, followUpIntent: buildOccupationRecommendationFollowUpIntent(input, next) };
+}
+function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGameTime2()) {
+  var _a;
+  const followUpIntent = report.followUpIntent;
+  if (!followUpIntent) {
+    return null;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return null;
+  }
+  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIntent = intents.find((intent) => isSameTerritoryIntent(intent, followUpIntent));
+  if (existingIntent && isTerritorySuppressionFresh2(existingIntent, gameTime)) {
+    return null;
+  }
+  const controllerId = (_a = followUpIntent.controllerId) != null ? _a : existingIntent == null ? void 0 : existingIntent.controllerId;
+  const nextIntent = {
+    colony: followUpIntent.colony,
+    targetRoom: followUpIntent.targetRoom,
+    action: followUpIntent.action,
+    status: (existingIntent == null ? void 0 : existingIntent.status) === "active" ? "active" : "planned",
+    updatedAt: gameTime,
+    ...controllerId ? { controllerId } : {}
+  };
+  upsertTerritoryIntent2(intents, nextIntent);
+  return nextIntent;
 }
 function buildRuntimeOccupationRecommendationInput(colony, colonyWorkers) {
   var _a, _b;
@@ -3627,6 +3656,7 @@ function buildRuntimeOccupationCandidates(colonyName) {
         adjacent: false,
         visible: false,
         actionHint: target.action,
+        ...target.controllerId ? { controllerId: target.controllerId } : {},
         routeDistance: getCachedRouteDistance(colonyName, target.roomName)
       });
       order += 1;
@@ -3655,9 +3685,15 @@ function upsertOccupationCandidate(candidatesByRoom, candidate) {
   if (candidate.source === "configured" && existing.source !== "configured") {
     existing.source = "configured";
     existing.actionHint = candidate.actionHint;
+    if (candidate.controllerId) {
+      existing.controllerId = candidate.controllerId;
+    }
     existing.order = Math.min(existing.order, candidate.order);
   }
   existing.adjacent = existing.adjacent || candidate.adjacent;
+  if (!existing.controllerId && candidate.controllerId) {
+    existing.controllerId = candidate.controllerId;
+  }
   if (existing.routeDistance === void 0 && candidate.routeDistance !== void 0) {
     existing.routeDistance = candidate.routeDistance;
   }
@@ -3743,10 +3779,25 @@ function scoreOccupationCandidate(input, candidate) {
     preconditions,
     risks,
     ...routeDistance !== void 0 ? { routeDistance } : {},
+    ...candidate.controllerId ? { controllerId: candidate.controllerId } : {},
     ...candidate.sourceCount !== void 0 ? { sourceCount: candidate.sourceCount } : {},
     ...candidate.hostileCreepCount !== void 0 ? { hostileCreepCount: candidate.hostileCreepCount } : {},
     ...candidate.hostileStructureCount !== void 0 ? { hostileStructureCount: candidate.hostileStructureCount } : {}
   };
+}
+function buildOccupationRecommendationFollowUpIntent(input, next) {
+  if (!next) {
+    return null;
+  }
+  return {
+    colony: input.colonyName,
+    targetRoom: next.roomName,
+    action: getTerritoryIntentAction(next.action),
+    ...next.controllerId ? { controllerId: next.controllerId } : {}
+  };
+}
+function getTerritoryIntentAction(action) {
+  return action === "occupy" ? "claim" : action;
 }
 function calculateOccupationScore(input, candidate, action, evidenceStatus) {
   var _a, _b, _c, _d, _e;
@@ -3860,6 +3911,7 @@ function normalizeTerritoryTarget2(rawTarget) {
     colony: rawTarget.colony,
     roomName: rawTarget.roomName,
     action: rawTarget.action,
+    ...typeof rawTarget.controllerId === "string" ? { controllerId: rawTarget.controllerId } : {},
     ...rawTarget.enabled === false ? { enabled: false } : {}
   };
 }
@@ -3908,12 +3960,72 @@ function getGameRooms() {
   var _a;
   return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
 }
+function getGameTime2() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" ? gameTime : 0;
+}
 function getTerritoryMemoryRecord2() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
+function getWritableTerritoryMemoryRecord2() {
+  const memory = globalThis.Memory;
+  if (!memory) {
+    return null;
+  }
+  if (!isRecord3(memory.territory)) {
+    memory.territory = {};
+  }
+  return memory.territory;
+}
+function normalizeTerritoryIntents2(rawIntents) {
+  return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
+    const normalizedIntent = normalizeTerritoryIntent2(intent);
+    return normalizedIntent ? [normalizedIntent] : [];
+  }) : [];
+}
+function normalizeTerritoryIntent2(rawIntent) {
+  if (!isRecord3(rawIntent)) {
+    return null;
+  }
+  if (!isNonEmptyString2(rawIntent.colony) || !isNonEmptyString2(rawIntent.targetRoom) || !isTerritoryIntentAction2(rawIntent.action) || !isTerritoryIntentStatus2(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
+    return null;
+  }
+  return {
+    colony: rawIntent.colony,
+    targetRoom: rawIntent.targetRoom,
+    action: rawIntent.action,
+    status: rawIntent.status,
+    updatedAt: rawIntent.updatedAt,
+    ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {}
+  };
+}
+function upsertTerritoryIntent2(intents, nextIntent) {
+  const existingIndex = intents.findIndex((intent) => isSameTerritoryIntent(intent, nextIntent));
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+  intents.push(nextIntent);
+}
+function isSameTerritoryIntent(intent, followUpIntent) {
+  return intent.colony === followUpIntent.colony && intent.targetRoom === followUpIntent.targetRoom && intent.action === followUpIntent.action;
+}
+function isTerritorySuppressionFresh2(intent, gameTime) {
+  return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS2;
+}
+function isTerritoryIntentAction2(action) {
+  return action === "claim" || action === "reserve" || action === "scout";
+}
+function isTerritoryIntentStatus2(status) {
+  return status === "planned" || status === "active" || status === "suppressed";
+}
 function isRecord3(value) {
   return typeof value === "object" && value !== null;
+}
+function isNonEmptyString2(value) {
+  return typeof value === "string" && value.length > 0;
 }
 
 // src/telemetry/runtimeSummary.ts
@@ -3925,7 +4037,7 @@ function emitRuntimeSummary(colonies, creeps, events = []) {
   if (colonies.length === 0 && events.length === 0) {
     return;
   }
-  const tick = getGameTime2();
+  const tick = getGameTime3();
   if (!shouldEmitRuntimeSummary(tick, events)) {
     return;
   }
@@ -3946,6 +4058,8 @@ function shouldEmitRuntimeSummary(tick, events) {
 function summarizeRoom(colony, creeps) {
   const colonyWorkers = creeps.filter((creep) => creep.memory.role === "worker" && creep.memory.colony === colony.room.name);
   const eventMetrics = summarizeRoomEventMetrics(colony.room);
+  const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
+  persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime3());
   return {
     roomName: colony.room.name,
     energyAvailable: colony.energyAvailable,
@@ -3957,7 +4071,7 @@ function summarizeRoom(colony, creeps) {
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
     constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
-    territoryRecommendation: buildRuntimeOccupationRecommendationReport(colony, colonyWorkers)
+    territoryRecommendation
   };
 }
 function summarizeSpawn(spawn) {
@@ -4190,7 +4304,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime2() {
+function getGameTime3() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -4251,7 +4365,7 @@ function runTerritoryControllerCreep(creep) {
   }
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime3());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime4());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -4285,7 +4399,7 @@ function moveTowardTargetRoom(creep, targetRoom) {
   }
   creep.moveTo(new RoomPositionCtor(25, 25, targetRoom));
 }
-function getGameTime3() {
+function getGameTime4() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -2,6 +2,7 @@ import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { buildRuntimeConstructionPriorityReport, type ConstructionPriorityScore } from '../construction/constructionPriority';
 import {
   buildRuntimeOccupationRecommendationReport,
+  persistOccupationRecommendationFollowUpIntent,
   type OccupationRecommendationReport
 } from '../territory/occupationRecommendation';
 
@@ -144,6 +145,8 @@ export function shouldEmitRuntimeSummary(tick: number, events: RuntimeTelemetryE
 function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSummary {
   const colonyWorkers = creeps.filter((creep) => creep.memory.role === 'worker' && creep.memory.colony === colony.room.name);
   const eventMetrics = summarizeRoomEventMetrics(colony.room);
+  const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
+  persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime());
 
   return {
     roomName: colony.room.name,
@@ -156,7 +159,7 @@ function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSumm
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
     constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
-    territoryRecommendation: buildRuntimeOccupationRecommendationReport(colony, colonyWorkers)
+    territoryRecommendation
   };
 }
 

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -7,6 +7,7 @@ export type OccupationRecommendationCandidateSource = 'configured' | 'adjacent';
 export interface OccupationRecommendationReport {
   candidates: OccupationRecommendationScore[];
   next: OccupationRecommendationScore | null;
+  followUpIntent: OccupationRecommendationFollowUpIntent | null;
 }
 
 export interface OccupationRecommendationScore {
@@ -19,9 +20,17 @@ export interface OccupationRecommendationScore {
   preconditions: string[];
   risks: string[];
   routeDistance?: number;
+  controllerId?: Id<StructureController>;
   sourceCount?: number;
   hostileCreepCount?: number;
   hostileStructureCount?: number;
+}
+
+export interface OccupationRecommendationFollowUpIntent {
+  colony: string;
+  targetRoom: string;
+  action: TerritoryIntentAction;
+  controllerId?: Id<StructureController>;
 }
 
 export interface OccupationRecommendationInput {
@@ -41,6 +50,7 @@ export interface OccupationRecommendationCandidateInput {
   adjacent: boolean;
   visible: boolean;
   actionHint?: TerritoryControlAction;
+  controllerId?: Id<StructureController>;
   routeDistance?: number | null;
   controller?: OccupationControllerEvidence;
   sourceCount?: number;
@@ -62,6 +72,7 @@ const TERRITORY_BODY_ENERGY_CAPACITY = 650;
 const MIN_READY_WORKERS = 3;
 const DOWNGRADE_GUARD_TICKS = 5_000;
 const RESERVATION_RENEWAL_TICKS = 1_000;
+const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
 
 // Project vision ordering: territory action dominates resource value; combat/risk only gates or deprioritizes.
@@ -87,7 +98,42 @@ export function scoreOccupationRecommendations(
     .sort(compareOccupationRecommendationScores);
   const next = candidates.find((candidate) => candidate.evidenceStatus !== 'unavailable') ?? null;
 
-  return { candidates, next };
+  return { candidates, next, followUpIntent: buildOccupationRecommendationFollowUpIntent(input, next) };
+}
+
+export function persistOccupationRecommendationFollowUpIntent(
+  report: OccupationRecommendationReport,
+  gameTime = getGameTime()
+): TerritoryIntentMemory | null {
+  const followUpIntent = report.followUpIntent;
+  if (!followUpIntent) {
+    return null;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return null;
+  }
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIntent = intents.find((intent) => isSameTerritoryIntent(intent, followUpIntent));
+  if (existingIntent && isTerritorySuppressionFresh(existingIntent, gameTime)) {
+    return null;
+  }
+
+  const controllerId = followUpIntent.controllerId ?? existingIntent?.controllerId;
+  const nextIntent: TerritoryIntentMemory = {
+    colony: followUpIntent.colony,
+    targetRoom: followUpIntent.targetRoom,
+    action: followUpIntent.action,
+    status: existingIntent?.status === 'active' ? 'active' : 'planned',
+    updatedAt: gameTime,
+    ...(controllerId ? { controllerId } : {})
+  };
+
+  upsertTerritoryIntent(intents, nextIntent);
+  return nextIntent;
 }
 
 function buildRuntimeOccupationRecommendationInput(
@@ -127,6 +173,7 @@ function buildRuntimeOccupationCandidates(colonyName: string): OccupationRecomme
         adjacent: false,
         visible: false,
         actionHint: target.action,
+        ...(target.controllerId ? { controllerId: target.controllerId } : {}),
         routeDistance: getCachedRouteDistance(colonyName, target.roomName)
       });
       order += 1;
@@ -162,10 +209,16 @@ function upsertOccupationCandidate(
   if (candidate.source === 'configured' && existing.source !== 'configured') {
     existing.source = 'configured';
     existing.actionHint = candidate.actionHint;
+    if (candidate.controllerId) {
+      existing.controllerId = candidate.controllerId;
+    }
     existing.order = Math.min(existing.order, candidate.order);
   }
 
   existing.adjacent = existing.adjacent || candidate.adjacent;
+  if (!existing.controllerId && candidate.controllerId) {
+    existing.controllerId = candidate.controllerId;
+  }
   if (existing.routeDistance === undefined && candidate.routeDistance !== undefined) {
     existing.routeDistance = candidate.routeDistance;
   }
@@ -261,10 +314,31 @@ function scoreOccupationCandidate(
     preconditions,
     risks,
     ...(routeDistance !== undefined ? { routeDistance } : {}),
+    ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
     ...(candidate.sourceCount !== undefined ? { sourceCount: candidate.sourceCount } : {}),
     ...(candidate.hostileCreepCount !== undefined ? { hostileCreepCount: candidate.hostileCreepCount } : {}),
     ...(candidate.hostileStructureCount !== undefined ? { hostileStructureCount: candidate.hostileStructureCount } : {})
   };
+}
+
+function buildOccupationRecommendationFollowUpIntent(
+  input: OccupationRecommendationInput,
+  next: OccupationRecommendationScore | null
+): OccupationRecommendationFollowUpIntent | null {
+  if (!next) {
+    return null;
+  }
+
+  return {
+    colony: input.colonyName,
+    targetRoom: next.roomName,
+    action: getTerritoryIntentAction(next.action),
+    ...(next.controllerId ? { controllerId: next.controllerId } : {})
+  };
+}
+
+function getTerritoryIntentAction(action: OccupationRecommendationAction): TerritoryIntentAction {
+  return action === 'occupy' ? 'claim' : action;
 }
 
 function calculateOccupationScore(
@@ -470,6 +544,9 @@ function normalizeTerritoryTarget(rawTarget: unknown): TerritoryTargetMemory | n
     colony: rawTarget.colony,
     roomName: rawTarget.roomName,
     action: rawTarget.action,
+    ...(typeof rawTarget.controllerId === 'string'
+      ? { controllerId: rawTarget.controllerId as Id<StructureController> }
+      : {}),
     ...(rawTarget.enabled === false ? { enabled: false } : {})
   };
 }
@@ -525,10 +602,101 @@ function getGameRooms(): Game['rooms'] | undefined {
   return (globalThis as { Game?: Partial<Game> }).Game?.rooms;
 }
 
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof gameTime === 'number' ? gameTime : 0;
+}
+
 function getTerritoryMemoryRecord(): TerritoryMemory | undefined {
   return (globalThis as { Memory?: Partial<Memory> }).Memory?.territory;
 }
 
+function getWritableTerritoryMemoryRecord(): TerritoryMemory | null {
+  const memory = (globalThis as { Memory?: Partial<Memory> }).Memory;
+  if (!memory) {
+    return null;
+  }
+
+  if (!isRecord(memory.territory)) {
+    memory.territory = {};
+  }
+
+  return memory.territory as TerritoryMemory;
+}
+
+function normalizeTerritoryIntents(rawIntents: TerritoryMemory['intents'] | unknown): TerritoryIntentMemory[] {
+  return Array.isArray(rawIntents)
+    ? rawIntents.flatMap((intent) => {
+        const normalizedIntent = normalizeTerritoryIntent(intent);
+        return normalizedIntent ? [normalizedIntent] : [];
+      })
+    : [];
+}
+
+function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | null {
+  if (!isRecord(rawIntent)) {
+    return null;
+  }
+
+  if (
+    !isNonEmptyString(rawIntent.colony) ||
+    !isNonEmptyString(rawIntent.targetRoom) ||
+    !isTerritoryIntentAction(rawIntent.action) ||
+    !isTerritoryIntentStatus(rawIntent.status) ||
+    typeof rawIntent.updatedAt !== 'number'
+  ) {
+    return null;
+  }
+
+  return {
+    colony: rawIntent.colony,
+    targetRoom: rawIntent.targetRoom,
+    action: rawIntent.action,
+    status: rawIntent.status,
+    updatedAt: rawIntent.updatedAt,
+    ...(typeof rawIntent.controllerId === 'string'
+      ? { controllerId: rawIntent.controllerId as Id<StructureController> }
+      : {})
+  };
+}
+
+function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: TerritoryIntentMemory): void {
+  const existingIndex = intents.findIndex((intent) => isSameTerritoryIntent(intent, nextIntent));
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+
+  intents.push(nextIntent);
+}
+
+function isSameTerritoryIntent(
+  intent: Pick<TerritoryIntentMemory, 'colony' | 'targetRoom' | 'action'>,
+  followUpIntent: Pick<TerritoryIntentMemory, 'colony' | 'targetRoom' | 'action'>
+): boolean {
+  return (
+    intent.colony === followUpIntent.colony &&
+    intent.targetRoom === followUpIntent.targetRoom &&
+    intent.action === followUpIntent.action
+  );
+}
+
+function isTerritorySuppressionFresh(intent: TerritoryIntentMemory, gameTime: number): boolean {
+  return intent.status === 'suppressed' && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
+}
+
+function isTerritoryIntentAction(action: unknown): action is TerritoryIntentAction {
+  return action === 'claim' || action === 'reserve' || action === 'scout';
+}
+
+function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {
+  return status === 'planned' || status === 'active' || status === 'suppressed';
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
 }

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -1,5 +1,6 @@
 import {
   buildRuntimeOccupationRecommendationReport,
+  persistOccupationRecommendationFollowUpIntent,
   scoreOccupationRecommendations,
   type OccupationRecommendationCandidateInput,
   type OccupationRecommendationInput
@@ -26,6 +27,7 @@ describe('occupation recommendation scoring', () => {
           roomName: 'W3N1',
           source: 'configured',
           actionHint: 'claim',
+          controllerId: 'controller3' as Id<StructureController>,
           sourceCount: 1,
           routeDistance: 2
         })
@@ -37,6 +39,12 @@ describe('occupation recommendation scoring', () => {
       action: 'occupy',
       evidenceStatus: 'sufficient',
       sourceCount: 1
+    });
+    expect(report.followUpIntent).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      controllerId: 'controller3'
     });
     expect(report.candidates.map((candidate) => candidate.roomName)).toEqual(['W3N1', 'W2N1']);
   });
@@ -58,6 +66,7 @@ describe('occupation recommendation scoring', () => {
       action: 'scout',
       evidenceStatus: 'insufficient-evidence'
     });
+    expect(report.followUpIntent).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'scout' });
     expect(report.next?.risks).toContain('controller, source, and hostile evidence unavailable');
   });
 
@@ -191,6 +200,90 @@ describe('occupation recommendation scoring', () => {
       routeDistance: 1
     });
     expect(report.next?.roomName).toBe('W2N1');
+  });
+
+  it('persists the selected recommendation as a territory follow-up intent', () => {
+    const unrelatedIntent: TerritoryIntentMemory = {
+      colony: 'W9N9',
+      targetRoom: 'W9N8',
+      action: 'reserve',
+      status: 'active',
+      updatedAt: 600
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          null,
+          unrelatedIntent,
+          { colony: 'W1N1', targetRoom: 'W3N1', action: 'claim', updatedAt: 601 }
+        ] as unknown as TerritoryIntentMemory[]
+      }
+    };
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W3N1',
+          actionHint: 'claim',
+          controllerId: 'controller3' as Id<StructureController>,
+          sourceCount: 2
+        })
+      ])
+    );
+
+    expect(persistOccupationRecommendationFollowUpIntent(report, 700)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      status: 'planned',
+      updatedAt: 700,
+      controllerId: 'controller3'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      unrelatedIntent,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 700,
+        controllerId: 'controller3'
+      }
+    ]);
+  });
+
+  it('preserves fresh suppressed territory intents from recommendation persistence', () => {
+    const suppressedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: 900
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [suppressedIntent]
+      }
+    };
+    const report = scoreOccupationRecommendations(makeInput([makeCandidate({ roomName: 'W2N1' })]));
+
+    expect(persistOccupationRecommendationFollowUpIntent(report, 1_000)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([suppressedIntent]);
+  });
+
+  it('does not write territory memory when no recommendation exists', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W1N1'
+        })
+      ])
+    );
+
+    expect(report.next).toBeNull();
+    expect(report.followUpIntent).toBeNull();
+    expect(persistOccupationRecommendationFollowUpIntent(report, 710)).toBeNull();
+    expect(Memory.territory).toBeUndefined();
   });
 });
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -164,7 +164,8 @@ describe('runtime telemetry summaries', () => {
           },
           territoryRecommendation: {
             candidates: [],
-            next: null
+            next: null,
+            followUpIntent: null
           }
         }
       ],
@@ -276,6 +277,20 @@ describe('runtime telemetry summaries', () => {
       routeDistance: 2,
       sourceCount: 2
     });
+    expect(recommendation.followUpIntent).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: RUNTIME_SUMMARY_INTERVAL
+      }
+    ]);
   });
 
   it('keeps emission gating deterministic', () => {


### PR DESCRIPTION
## Summary
- persist the selected occupation recommendation as a territory follow-up intent
- preserve suppressed territory intents and carry controller IDs through recommendations
- surface follow-up intent in runtime summary telemetry and regenerate bundle

Closes #241.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

## Scheduler evidence
- Worktree: `/root/screeps-worktrees/occupation-intent-241`
- Commit: `cc8b26d` authored by `lanyusea's bot <lanyusea@gmail.com>`
