### PR TITLE
feat: spawn claimers from occupation follow-up intent

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1289,11 +1289,20 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       routeDistanceLookupContext
     )
   );
-  const bestSpawnableConfiguredCandidate = selectBestScoredTerritoryCandidate(
-    getSpawnableTerritoryCandidates(configuredCandidates, roleCounts)
+  const persistedIntentCandidates = getPersistedTerritoryIntentCandidates(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    routeDistanceLookupContext
   );
-  if (bestSpawnableConfiguredCandidate && bestSpawnableConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
-    return toSelectedTerritoryTarget(bestSpawnableConfiguredCandidate);
+  const primaryCandidates = [...persistedIntentCandidates, ...configuredCandidates];
+  const bestSpawnablePrimaryCandidate = selectBestScoredTerritoryCandidate(
+    getSpawnableTerritoryCandidates(primaryCandidates, roleCounts)
+  );
+  if (bestSpawnablePrimaryCandidate && bestSpawnablePrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
+    return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
   }
   const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, [
     ...getAdjacentReserveCandidates(
@@ -1337,7 +1346,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       routeDistanceLookupContext
     )
   ]);
-  const candidates = [...configuredCandidates, ...adjacentCandidates];
+  const candidates = [...primaryCandidates, ...adjacentCandidates];
   return toSelectedTerritoryTarget(
     (_a = selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts))) != null ? _a : selectBestScoredTerritoryCandidate(candidates)
   );
@@ -1384,6 +1393,40 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
     const candidate = scoreTerritoryCandidate(
       { target, intentAction: target.action, commitTarget: false },
       "configured",
+      order,
+      colonyName,
+      colonyOwnerUsername,
+      routeDistanceLookupContext
+    );
+    return candidate ? [candidate] : [];
+  });
+}
+function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
+  const seenIntentKeys = /* @__PURE__ */ new Set();
+  const configuredTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
+  return intents.flatMap((intent, order) => {
+    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || intent.status !== "planned" && intent.status !== "active" || !isTerritoryControlAction(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || getVisibleTerritoryTargetState(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername) !== "available") {
+      return [];
+    }
+    const intentKey = `${intent.targetRoom}:${intent.action}`;
+    if (seenIntentKeys.has(intentKey)) {
+      return [];
+    }
+    seenIntentKeys.add(intentKey);
+    const target = {
+      colony: intent.colony,
+      roomName: intent.targetRoom,
+      action: intent.action,
+      ...intent.controllerId ? { controllerId: intent.controllerId } : {}
+    };
+    const candidate = scoreTerritoryCandidate(
+      {
+        target,
+        intentAction: intent.action,
+        commitTarget: false,
+        ...intent.followUp ? { followUp: intent.followUp } : {}
+      },
+      "occupationIntent",
       order,
       colonyName,
       colonyOwnerUsername,
@@ -1722,7 +1765,7 @@ function compareOptionalNumbersDescending(left, right) {
   return (right != null ? right : Number.NEGATIVE_INFINITY) - (left != null ? left : Number.NEGATIVE_INFINITY);
 }
 function getTerritoryCandidateSourcePriority(source) {
-  if (source === "configured") {
+  if (source === "configured" || source === "occupationIntent") {
     return 0;
   }
   if (source === "satisfiedClaimAdjacent") {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -50,6 +50,7 @@ interface SelectedTerritoryTarget {
 
 type TerritoryCandidateSource =
   | 'configured'
+  | 'occupationIntent'
   | 'satisfiedClaimAdjacent'
   | 'satisfiedReserveAdjacent'
   | 'activeReserveAdjacent'
@@ -365,14 +366,23 @@ function selectTerritoryTarget(
       routeDistanceLookupContext
     )
   );
-  const bestSpawnableConfiguredCandidate = selectBestScoredTerritoryCandidate(
-    getSpawnableTerritoryCandidates(configuredCandidates, roleCounts)
+  const persistedIntentCandidates = getPersistedTerritoryIntentCandidates(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    routeDistanceLookupContext
+  );
+  const primaryCandidates = [...persistedIntentCandidates, ...configuredCandidates];
+  const bestSpawnablePrimaryCandidate = selectBestScoredTerritoryCandidate(
+    getSpawnableTerritoryCandidates(primaryCandidates, roleCounts)
   );
   if (
-    bestSpawnableConfiguredCandidate &&
-    bestSpawnableConfiguredCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY
+    bestSpawnablePrimaryCandidate &&
+    bestSpawnablePrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY
   ) {
-    return toSelectedTerritoryTarget(bestSpawnableConfiguredCandidate);
+    return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
   }
 
   const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, [
@@ -417,7 +427,7 @@ function selectTerritoryTarget(
       routeDistanceLookupContext
     )
   ]);
-  const candidates = [...configuredCandidates, ...adjacentCandidates];
+  const candidates = [...primaryCandidates, ...adjacentCandidates];
 
   return toSelectedTerritoryTarget(
     selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts)) ??
@@ -510,6 +520,60 @@ function getConfiguredTerritoryCandidates(
       colonyOwnerUsername,
       routeDistanceLookupContext
     );
+    return candidate ? [candidate] : [];
+  });
+}
+
+function getPersistedTerritoryIntentCandidates(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): ScoredTerritoryTarget[] {
+  const seenIntentKeys = new Set<string>();
+  const configuredTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
+  return intents.flatMap((intent, order) => {
+    if (
+      intent.colony !== colonyName ||
+      intent.targetRoom === colonyName ||
+      configuredTargetRooms.has(intent.targetRoom) ||
+      (intent.status !== 'planned' && intent.status !== 'active') ||
+      !isTerritoryControlAction(intent.action) ||
+      isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) ||
+      getVisibleTerritoryTargetState(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername) !==
+        'available'
+    ) {
+      return [];
+    }
+
+    const intentKey = `${intent.targetRoom}:${intent.action}`;
+    if (seenIntentKeys.has(intentKey)) {
+      return [];
+    }
+    seenIntentKeys.add(intentKey);
+
+    const target: TerritoryTargetMemory = {
+      colony: intent.colony,
+      roomName: intent.targetRoom,
+      action: intent.action,
+      ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
+    };
+    const candidate = scoreTerritoryCandidate(
+      {
+        target,
+        intentAction: intent.action,
+        commitTarget: false,
+        ...(intent.followUp ? { followUp: intent.followUp } : {})
+      },
+      'occupationIntent',
+      order,
+      colonyName,
+      colonyOwnerUsername,
+      routeDistanceLookupContext
+    );
+
     return candidate ? [candidate] : [];
   });
 }
@@ -1045,7 +1109,7 @@ function compareOptionalNumbersDescending(left: number | undefined, right: numbe
 }
 
 function getTerritoryCandidateSourcePriority(source: TerritoryCandidateSource): number {
-  if (source === 'configured') {
+  if (source === 'configured' || source === 'occupationIntent') {
     return 0;
   }
 

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -65,6 +65,14 @@ describe('planSpawn', () => {
     return { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController;
   }
 
+  function makeTerritoryRoom(roomName: string, controller: StructureController): Room {
+    return {
+      name: roomName,
+      controller,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+  }
+
   it('plans a worker when the colony has no workers and an idle spawn', () => {
     const { colony, spawn } = makeColony();
 
@@ -292,6 +300,210 @@ describe('planSpawn', () => {
         updatedAt: 142
       }
     ]);
+  });
+
+  it('plans a claimer from a persisted occupation claim intent when the target is actionable', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeTerritoryRoom('W2N1', {
+          id: 'controller2' as Id<StructureController>,
+          my: false
+        } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 152,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 153)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N1-153',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: {
+          targetRoom: 'W2N1',
+          action: 'claim',
+          controllerId: 'controller2' as Id<StructureController>
+        }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 153,
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
+  it('plans a reserver from a persisted occupation reserve intent with follow-up metadata', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'activeReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N2: makeTerritoryRoom('W2N2', { my: false } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N2',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 154,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 155)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N2-155',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N2', action: 'reserve', followUp }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 155,
+        followUp
+      }
+    ]);
+  });
+
+  it('does not plan a duplicate claimer for the same persisted target and action', () => {
+    const { colony } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N2: makeTerritoryRoom('W2N2', { my: false } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N2',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 156
+          }
+        ]
+      }
+    };
+
+    expect(
+      planSpawn(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W2N2: 1 },
+          claimersByTargetRoomAction: { reserve: { W2N2: 1 } }
+        },
+        157
+      )
+    ).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 157
+      }
+    ]);
+  });
+
+  it('does not count a reserver as coverage for a persisted claim intent on the same target', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N2: makeTerritoryRoom('W2N2', { my: false } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N2',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 158
+          }
+        ]
+      }
+    };
+
+    expect(
+      planSpawn(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W2N2: 1 },
+          claimersByTargetRoomAction: { reserve: { W2N2: 1 } }
+        },
+        159
+      )
+    ).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N2-159',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N2', action: 'claim' }
+      }
+    });
   });
 
   it('plans a cheap scout for an unseen adjacent reserve candidate before reserving it', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1177,6 +1177,40 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
+  it('does not route a persisted claim intent after the visible target is self-owned', () => {
+    const colony = makeSafeColony();
+    const persistedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      status: 'planned',
+      updatedAt: 569
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: true, owner: { username: 'me' } } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [persistedIntent]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 570)).toBeNull();
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'claim' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+        570
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toEqual([persistedIntent]);
+  });
+
   it('scouts adjacent rooms after a configured claim target is owned by the colony account', () => {
     const colony = makeSafeColony();
     const claimedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'claim' };


### PR DESCRIPTION
## Summary
- Closes #244.
- Spawns claimer-capable creeps from persisted occupation follow-up intent.
- Adds territory/spawn planner coverage and updates the generated Screeps bundle.

## Controller verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (19 suites / 373 tests passed)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

## Scheduler notes
- Recovered stale Codex-authored dirty worktree and committed with `lanyusea's bot <lanyusea@gmail.com>`.
- Remaining local untracked `prod/node_modules` is dependency infrastructure only and is not staged.
- Next gate: exact-head independent QA + automated review/check settling before merge.
