### PR TITLE
feat: prioritize urgent energy sinks after refills

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2337,23 +2337,22 @@ function selectWorkerTask(creep) {
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: "upgrade", targetId: controller.id };
   }
+  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
+  const capacityConstructionSite = selectCapacityEnablingConstructionSite(creep, constructionSites, controller);
+  if (capacityConstructionSite && !territoryControllerTask) {
+    return { type: "build", targetId: capacityConstructionSite.id };
+  }
   if (energySink) {
     return { type: "transfer", targetId: energySink.id };
   }
   if (territoryControllerTask) {
     return territoryControllerTask;
   }
-  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
-  const spawnConstructionSite = selectConstructionSite(creep, constructionSites, isSpawnConstructionSite);
-  if (spawnConstructionSite) {
-    return { type: "build", targetId: spawnConstructionSite.id };
+  if (capacityConstructionSite) {
+    return { type: "build", targetId: capacityConstructionSite.id };
   }
   if (controller && shouldRushRcl1Controller(controller)) {
     return { type: "upgrade", targetId: controller.id };
-  }
-  const extensionConstructionSite = selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
-  if (extensionConstructionSite) {
-    return { type: "build", targetId: extensionConstructionSite.id };
   }
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
@@ -2460,6 +2459,16 @@ function selectConstructionSite(creep, constructionSites, predicate = () => true
 }
 function compareConstructionSiteId(left, right) {
   return String(left.id).localeCompare(String(right.id));
+}
+function selectCapacityEnablingConstructionSite(creep, constructionSites, controller) {
+  const spawnConstructionSite = selectConstructionSite(creep, constructionSites, isSpawnConstructionSite);
+  if (spawnConstructionSite) {
+    return spawnConstructionSite;
+  }
+  if (controller && shouldRushRcl1Controller(controller)) {
+    return null;
+  }
+  return selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
 }
 function isSpawnConstructionSite(site) {
   return matchesStructureType2(site.structureType, "STRUCTURE_SPAWN", "spawn");
@@ -3042,6 +3051,8 @@ function runWorker(creep) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptSpendingTaskForEnergySink(currentTask, selectedTask)) {
@@ -3173,6 +3184,22 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task, selecte
   }
   return isRecoverableEnergyTask(selectedTask) && !isSameTask(task, selectedTask);
 }
+function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, selectedTask) {
+  var _a;
+  if (!isEnergyAcquisitionTask(task)) {
+    return false;
+  }
+  if (!selectedTask || isSameTask(task, selectedTask)) {
+    return false;
+  }
+  if (!((_a = creep.store) == null ? void 0 : _a.getUsedCapacity)) {
+    return false;
+  }
+  if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+    return false;
+  }
+  return isUrgentEnergySpendingTask(selectedTask);
+}
 function shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectedTask) {
   var _a, _b;
   if (task.type !== "transfer") {
@@ -3243,6 +3270,25 @@ function isTerritoryControlTask2(task) {
 function isValidTransferTarget(target) {
   return getFreeTransferEnergyCapacity(target) > 0;
 }
+function isUrgentEnergySpendingTask(task) {
+  const target = getTaskTarget(task);
+  if (task.type === "transfer") {
+    return getTransferSinkPriority(target) >= 2;
+  }
+  return task.type === "build" && isCapacityEnablingConstructionSite(target);
+}
+function getTaskTarget(task) {
+  const game = globalThis.Game;
+  const getObjectById = game == null ? void 0 : game.getObjectById;
+  return typeof getObjectById === "function" ? getObjectById(String(task.targetId)) : null;
+}
+function isCapacityEnablingConstructionSite(target) {
+  const structureType = target == null ? void 0 : target.structureType;
+  if (typeof structureType !== "string") {
+    return false;
+  }
+  return matchesCapacityConstructionStructureType(structureType, "STRUCTURE_SPAWN", "spawn") || matchesCapacityConstructionStructureType(structureType, "STRUCTURE_EXTENSION", "extension");
+}
 function getFreeTransferEnergyCapacity(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
@@ -3260,6 +3306,11 @@ function getTransferSinkPriority(target) {
   return matchesTransferSinkStructureType(structureType, "STRUCTURE_TOWER", "tower") ? 1 : 0;
 }
 function matchesTransferSinkStructureType(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+function matchesCapacityConstructionStructureType(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -2,6 +2,7 @@ import { isWorkerRepairTargetComplete, selectWorkerTask } from '../tasks/workerT
 import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
 
 type TransferSinkStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION' | 'STRUCTURE_TOWER';
+type CapacityConstructionStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION';
 
 export function runWorker(creep: Creep): void {
   const selectedTask = selectWorkerTask(creep);
@@ -14,6 +15,8 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptForVisibleTerritoryControllerTask(currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
@@ -186,6 +189,30 @@ function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(
   return isRecoverableEnergyTask(selectedTask) && !isSameTask(task, selectedTask);
 }
 
+function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (!isEnergyAcquisitionTask(task)) {
+    return false;
+  }
+
+  if (!selectedTask || isSameTask(task, selectedTask)) {
+    return false;
+  }
+
+  if (!creep.store?.getUsedCapacity) {
+    return false;
+  }
+
+  if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
+    return false;
+  }
+
+  return isUrgentEnergySpendingTask(selectedTask);
+}
+
 function shouldPreemptTransferTaskForBetterEnergySink(
   creep: Creep,
   task: CreepTaskMemory,
@@ -302,6 +329,33 @@ function isValidTransferTarget(target: unknown): target is AnyStoreStructure {
   return getFreeTransferEnergyCapacity(target) > 0;
 }
 
+function isUrgentEnergySpendingTask(task: CreepTaskMemory): boolean {
+  const target = getTaskTarget(task);
+  if (task.type === 'transfer') {
+    return getTransferSinkPriority(target) >= 2;
+  }
+
+  return task.type === 'build' && isCapacityEnablingConstructionSite(target);
+}
+
+function getTaskTarget(task: CreepTaskMemory): unknown {
+  const game = (globalThis as unknown as { Game?: Partial<Pick<Game, 'getObjectById'>> }).Game;
+  const getObjectById = game?.getObjectById as ((id: string) => unknown) | undefined;
+  return typeof getObjectById === 'function' ? getObjectById(String(task.targetId)) : null;
+}
+
+function isCapacityEnablingConstructionSite(target: unknown): target is ConstructionSite {
+  const structureType = (target as { structureType?: unknown } | null)?.structureType;
+  if (typeof structureType !== 'string') {
+    return false;
+  }
+
+  return (
+    matchesCapacityConstructionStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+    matchesCapacityConstructionStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')
+  );
+}
+
 function getFreeTransferEnergyCapacity(target: unknown): number {
   const store = (target as { store?: { getFreeCapacity?: (resource?: ResourceConstant) => number | null } } | null)
     ?.store;
@@ -331,6 +385,15 @@ function matchesTransferSinkStructureType(
   fallback: string
 ): boolean {
   const constants = globalThis as unknown as Partial<Record<TransferSinkStructureConstantGlobal, string>>;
+  return actual === (constants[globalName] ?? fallback);
+}
+
+function matchesCapacityConstructionStructureType(
+  actual: string,
+  globalName: CapacityConstructionStructureConstantGlobal,
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<Record<CapacityConstructionStructureConstantGlobal, string>>;
   return actual === (constants[globalName] ?? fallback);
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -85,6 +85,12 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'upgrade', targetId: controller.id };
   }
 
+  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
+  const capacityConstructionSite = selectCapacityEnablingConstructionSite(creep, constructionSites, controller);
+  if (capacityConstructionSite && !territoryControllerTask) {
+    return { type: 'build', targetId: capacityConstructionSite.id };
+  }
+
   if (energySink) {
     return { type: 'transfer', targetId: energySink.id as Id<AnyStoreStructure> };
   }
@@ -93,19 +99,12 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return territoryControllerTask;
   }
 
-  const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
-  const spawnConstructionSite = selectConstructionSite(creep, constructionSites, isSpawnConstructionSite);
-  if (spawnConstructionSite) {
-    return { type: 'build', targetId: spawnConstructionSite.id };
+  if (capacityConstructionSite) {
+    return { type: 'build', targetId: capacityConstructionSite.id };
   }
 
   if (controller && shouldRushRcl1Controller(controller)) {
     return { type: 'upgrade', targetId: controller.id };
-  }
-
-  const extensionConstructionSite = selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
-  if (extensionConstructionSite) {
-    return { type: 'build', targetId: extensionConstructionSite.id };
   }
 
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
@@ -264,6 +263,23 @@ function selectConstructionSite(
 
 function compareConstructionSiteId(left: ConstructionSite, right: ConstructionSite): number {
   return String(left.id).localeCompare(String(right.id));
+}
+
+function selectCapacityEnablingConstructionSite(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  controller: StructureController | undefined
+): ConstructionSite | null {
+  const spawnConstructionSite = selectConstructionSite(creep, constructionSites, isSpawnConstructionSite);
+  if (spawnConstructionSite) {
+    return spawnConstructionSite;
+  }
+
+  if (controller && shouldRushRcl1Controller(controller)) {
+    return null;
+  }
+
+  return selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
 }
 
 function isSpawnConstructionSite(site: ConstructionSite): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1185,6 +1185,102 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('spends partially harvested energy on primary refill before continuing harvest', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const creep = {
+      memory: { task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [spawn];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            return type === FIND_SOURCES ? [source] : [];
+          }
+        )
+      },
+      harvest: jest.fn(),
+      transfer: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : source))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.transfer).toHaveBeenCalledWith(spawn, 'energy');
+    expect(creep.harvest).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('spends partially picked-up energy on extension construction before lower-value tower refill', () => {
+    const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 100 } as Resource<ResourceConstant>;
+    const extensionSite = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const lowTower = {
+      id: 'tower-low',
+      structureType: 'tower',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(100),
+        getFreeCapacity: jest.fn().mockReturnValue(500)
+      }
+    } as unknown as StructureTower;
+    const creep = {
+      memory: { task: { type: 'pickup', targetId: 'drop1' as Id<Resource<ResourceConstant>> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(25),
+        getFreeCapacity: jest.fn().mockReturnValue(25)
+      },
+      room: {
+        controller: {
+          id: 'controller1',
+          my: true,
+          level: 2,
+          ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+        } as StructureController,
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureTower) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [lowTower];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            if (type === FIND_CONSTRUCTION_SITES) {
+              return [extensionSite];
+            }
+
+            return type === FIND_DROPPED_RESOURCES ? [droppedEnergy] : [];
+          }
+        )
+      },
+      pickup: jest.fn(),
+      build: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn((id: string) => (id === 'extension-site1' ? extensionSite : droppedEnergy))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'extension-site1' });
+    expect(creep.build).toHaveBeenCalledWith(extensionSite);
+    expect(creep.pickup).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('switches from spending tasks when creep is empty', () => {
     const source = { id: 'source1' } as Source;
     const creep = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1627,6 +1627,30 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
   });
 
+  it.each([
+    ['spawn', 'spawn-site1'],
+    ['extension', 'extension-site1']
+  ])('builds capacity-enabling %s construction before low tower refill', (structureType, id) => {
+    const lowTower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
+    const site = { id, structureType } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [lowTower as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: id });
+  });
+
   it('breaks same-class fillable energy sink range ties by id', () => {
     const laterSpawn = makeEnergySink('spawn-b', 'spawn' as StructureConstant, 300);
     const firstSpawn = makeEnergySink('spawn-a', 'spawn' as StructureConstant, 300);


### PR DESCRIPTION
## Summary
- Closes #245.
- Prioritizes urgent energy sinks after refill handling for worker routing.
- Adds worker task/runner coverage and updates the generated Screeps bundle.

## Controller verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (19 suites / 372 tests passed)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

## Scheduler notes
- Recovered stale Codex-authored dirty worktree and committed with `lanyusea's bot <lanyusea@gmail.com>`.
- Remaining local untracked `prod/node_modules` is dependency infrastructure only and is not staged.
- Next gate: exact-head independent QA + automated review/check settling before merge.
