### PR TITLE
feat: prioritize occupation follow-up urgency

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1615,13 +1615,15 @@ function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwn
     return null;
   }
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
+  const occupationActionableTicks = source === "occupationIntent" ? getOccupationIntentActionableTicks(selection, colonyOwnerUsername) : void 0;
   return {
     ...selection,
     source,
     order,
     priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
     ...routeDistance !== void 0 ? { routeDistance } : {},
-    ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
+    ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {},
+    ...occupationActionableTicks !== void 0 ? { occupationActionableTicks } : {}
   };
 }
 function applyOccupationRecommendationScores(colony, roleCounts, candidates) {
@@ -1720,6 +1722,27 @@ function getControllerReservationTicksToEnd(controller) {
   const ticksToEnd = (_a = controller.reservation) == null ? void 0 : _a.ticksToEnd;
   return typeof ticksToEnd === "number" ? ticksToEnd : void 0;
 }
+function getOccupationIntentActionableTicks(selection, colonyOwnerUsername) {
+  var _a, _b;
+  if (!isTerritoryControlAction(selection.intentAction)) {
+    return void 0;
+  }
+  const controller = getVisibleController(selection.target.roomName, selection.target.controllerId);
+  if (!controller) {
+    return void 0;
+  }
+  if (selection.intentAction === "reserve") {
+    if (isControllerOwned(controller)) {
+      return void 0;
+    }
+    const ownReservationTicksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+    return (_a = ownReservationTicksToEnd != null ? ownReservationTicksToEnd : getControllerReservationTicksToEnd(controller)) != null ? _a : 0;
+  }
+  if (isControllerOwned(controller)) {
+    return typeof controller.ticksToDowngrade === "number" ? controller.ticksToDowngrade : void 0;
+  }
+  return (_b = getControllerReservationTicksToEnd(controller)) != null ? _b : 0;
+}
 function getVisibleRoom(roomName) {
   var _a, _b, _c;
   return (_c = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName]) != null ? _c : null;
@@ -1756,7 +1779,7 @@ function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
 }
 function compareTerritoryCandidates(left, right) {
-  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
 }
 function compareOptionalNumbers2(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -63,6 +63,7 @@ interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   recommendationScore?: number;
   routeDistance?: number;
   renewalTicksToEnd?: number;
+  occupationActionableTicks?: number;
 }
 
 type TerritoryTargetVisibilityState = 'available' | 'satisfied' | 'unavailable';
@@ -891,13 +892,18 @@ function scoreTerritoryCandidate(
   }
 
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
+  const occupationActionableTicks =
+    source === 'occupationIntent'
+      ? getOccupationIntentActionableTicks(selection, colonyOwnerUsername)
+      : undefined;
   return {
     ...selection,
     source,
     order,
     priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
     ...(routeDistance !== undefined ? { routeDistance } : {}),
-    ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
+    ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}),
+    ...(occupationActionableTicks !== undefined ? { occupationActionableTicks } : {})
   };
 }
 
@@ -1038,6 +1044,35 @@ function getControllerReservationTicksToEnd(controller: StructureController): nu
   return typeof ticksToEnd === 'number' ? ticksToEnd : undefined;
 }
 
+function getOccupationIntentActionableTicks(
+  selection: SelectedTerritoryTarget,
+  colonyOwnerUsername: string | null
+): number | undefined {
+  if (!isTerritoryControlAction(selection.intentAction)) {
+    return undefined;
+  }
+
+  const controller = getVisibleController(selection.target.roomName, selection.target.controllerId);
+  if (!controller) {
+    return undefined;
+  }
+
+  if (selection.intentAction === 'reserve') {
+    if (isControllerOwned(controller)) {
+      return undefined;
+    }
+
+    const ownReservationTicksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+    return ownReservationTicksToEnd ?? getControllerReservationTicksToEnd(controller) ?? 0;
+  }
+
+  if (isControllerOwned(controller)) {
+    return typeof controller.ticksToDowngrade === 'number' ? controller.ticksToDowngrade : undefined;
+  }
+
+  return getControllerReservationTicksToEnd(controller) ?? 0;
+}
+
 function getVisibleRoom(roomName: string): Room | null {
   return (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[roomName] ?? null;
 }
@@ -1094,6 +1129,7 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
     compareOptionalNumbers(left.renewalTicksToEnd, right.renewalTicksToEnd) ||
     getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) ||
     compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) ||
+    compareOptionalNumbers(left.occupationActionableTicks, right.occupationActionableTicks) ||
     left.order - right.order ||
     left.target.roomName.localeCompare(right.target.roomName) ||
     left.intentAction.localeCompare(right.intentAction)

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1211,6 +1211,120 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.intents).toEqual([persistedIntent]);
   });
 
+  it('prioritizes lower reservation TTL among persisted occupation claim follow-up intents', () => {
+    const colony = makeSafeColony();
+    const followUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N2', 'claim');
+    const lessUrgentIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      status: 'planned',
+      updatedAt: 571,
+      followUp
+    };
+    const urgentIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      status: 'planned',
+      updatedAt: 572,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: 800 }
+          } as StructureController
+        } as Room,
+        W3N1: {
+          name: 'W3N1',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: 200 }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [lessUrgentIntent, urgentIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 573)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      followUp
+    });
+    expect(Memory.territory?.intents).toEqual([
+      lessUrgentIntent,
+      {
+        ...urgentIntent,
+        updatedAt: 573
+      }
+    ]);
+  });
+
+  it('prioritizes unreserved persisted occupation claim follow-up intents before reserved claims', () => {
+    const colony = makeSafeColony();
+    const followUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N2', 'claim');
+    const reservedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      status: 'planned',
+      updatedAt: 574,
+      followUp
+    };
+    const unreservedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      status: 'planned',
+      updatedAt: 575,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: 100 }
+          } as StructureController
+        } as Room,
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [reservedIntent, unreservedIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 576)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      followUp
+    });
+    expect(Memory.territory?.intents).toEqual([
+      reservedIntent,
+      {
+        ...unreservedIntent,
+        updatedAt: 576
+      }
+    ]);
+  });
+
   it('scouts adjacent rooms after a configured claim target is owned by the colony account', () => {
     const colony = makeSafeColony();
     const claimedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'claim' };


### PR DESCRIPTION
Closes #248.

## Summary
- Prioritizes urgent occupation follow-up targets in territory planning.
- Adds deterministic coverage for follow-up urgency ordering.
- Regenerates `prod/dist/main.js` via the production build.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (19 suites / 379 tests passed)
- `npm run build`

## Scheduler evidence
- Worktree: `/root/screeps-worktrees/territory-followup-urgency`
- Commit: `c1b1f0e` by `lanyusea's bot <lanyusea@gmail.com>`
- Gameplay floor lane: territory/control
