### PR TITLE
feat: route workers to productive energy sinks

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2410,6 +2410,10 @@ function selectWorkerTask(creep) {
     return { type: "build", targetId: roadConstructionSite.id };
   }
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
+    const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller);
+    if (productiveEnergySinkTask) {
+      return productiveEnergySinkTask;
+    }
     return { type: "upgrade", targetId: controller.id };
   }
   const constructionSite = selectConstructionSite(creep, constructionSites);
@@ -2502,6 +2506,41 @@ function selectConstructionSite(creep, constructionSites, predicate = () => true
 }
 function compareConstructionSiteId(left, right) {
   return String(left.id).localeCompare(String(right.id));
+}
+function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller) {
+  const controllerRange = getRangeBetweenRoomObjects(creep, controller);
+  if (controllerRange === null) {
+    return null;
+  }
+  const candidates = [
+    ...constructionSites.map(
+      (site) => createProductiveEnergySinkCandidate(creep, site, { type: "build", targetId: site.id }, 0)
+    ),
+    ...findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget).map(
+      (structure) => createProductiveEnergySinkCandidate(
+        creep,
+        structure,
+        { type: "repair", targetId: structure.id },
+        1
+      )
+    )
+  ].filter(
+    (candidate) => candidate !== null && candidate.range <= controllerRange
+  );
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(compareProductiveEnergySinkCandidates)[0].task;
+}
+function createProductiveEnergySinkCandidate(creep, target, task, taskPriority) {
+  const range = getRangeBetweenRoomObjects(creep, target);
+  if (range === null) {
+    return null;
+  }
+  return { range, task, taskPriority };
+}
+function compareProductiveEnergySinkCandidates(left, right) {
+  return left.range - right.range || left.taskPriority - right.taskPriority || String(left.task.targetId).localeCompare(String(right.task.targetId));
 }
 function selectCapacityEnablingConstructionSite(creep, constructionSites, controller) {
   const spawnConstructionSite = selectConstructionSite(creep, constructionSites, isSpawnConstructionSite);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -27,6 +27,7 @@ type WorkerEnergyAcquisitionSource =
   | SalvageableWorkerEnergySource
   | Resource<ResourceConstant>;
 type WorkerEnergyAcquisitionTask = Extract<CreepTaskMemory, { type: 'pickup' | 'withdraw' }>;
+type ProductiveEnergySinkTask = Extract<CreepTaskMemory, { type: 'build' | 'repair' }>;
 
 interface StoredEnergySourceContext {
   creepOwnerUsername: string | null;
@@ -123,6 +124,11 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
+    const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller);
+    if (productiveEnergySinkTask) {
+      return productiveEnergySinkTask;
+    }
+
     return { type: 'upgrade', targetId: controller.id };
   }
 
@@ -263,6 +269,67 @@ function selectConstructionSite(
 
 function compareConstructionSiteId(left: ConstructionSite, right: ConstructionSite): number {
   return String(left.id).localeCompare(String(right.id));
+}
+
+function selectNearbyProductiveEnergySinkTask(
+  creep: Creep,
+  constructionSites: ConstructionSite[],
+  controller: StructureController
+): ProductiveEnergySinkTask | null {
+  const controllerRange = getRangeBetweenRoomObjects(creep, controller);
+  if (controllerRange === null) {
+    return null;
+  }
+
+  const candidates = [
+    ...constructionSites.map((site) =>
+      createProductiveEnergySinkCandidate(creep, site, { type: 'build', targetId: site.id }, 0)
+    ),
+    ...findVisibleRoomStructures(creep.room)
+      .filter(isSafeRepairTarget)
+      .map((structure) =>
+        createProductiveEnergySinkCandidate(
+          creep,
+          structure,
+          { type: 'repair', targetId: structure.id as Id<Structure> },
+          1
+        )
+      )
+  ].filter(
+    (candidate): candidate is ProductiveEnergySinkCandidate =>
+      candidate !== null && candidate.range <= controllerRange
+  );
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.sort(compareProductiveEnergySinkCandidates)[0].task;
+}
+
+function createProductiveEnergySinkCandidate(
+  creep: Creep,
+  target: ConstructionSite | RepairableWorkerStructure,
+  task: ProductiveEnergySinkTask,
+  taskPriority: number
+): ProductiveEnergySinkCandidate | null {
+  const range = getRangeBetweenRoomObjects(creep, target);
+  if (range === null) {
+    return null;
+  }
+
+  return { range, task, taskPriority };
+}
+
+function compareProductiveEnergySinkCandidates(
+  left: ProductiveEnergySinkCandidate,
+  right: ProductiveEnergySinkCandidate
+): number {
+  return (
+    left.range - right.range ||
+    left.taskPriority - right.taskPriority ||
+    String(left.task.targetId).localeCompare(String(right.task.targetId))
+  );
 }
 
 function selectCapacityEnablingConstructionSite(
@@ -441,6 +508,12 @@ interface WorkerEnergyAcquisitionCandidate {
 
 interface SpawnRecoveryEnergyAcquisitionCandidate extends WorkerEnergyAcquisitionCandidate {
   deliveryEta: number;
+}
+
+interface ProductiveEnergySinkCandidate {
+  range: number;
+  task: ProductiveEnergySinkTask;
+  taskPriority: number;
 }
 
 function selectWorkerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitionTask | null {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -876,6 +876,67 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts controller upgrade for nearby non-critical construction under controller pressure', () => {
+    const fullSpawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const controller = { id: 'controller1', my: true, level: 3 } as StructureController;
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'tower-site1': 2,
+        controller1: 7
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 200 }]
+      }
+    };
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [fullSpawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return type === FIND_CONSTRUCTION_SITES ? [site] : [];
+      })
+    } as unknown as Room;
+    const creep = {
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      pos: { getRangeTo },
+      room,
+      build: jest.fn().mockReturnValue(0),
+      upgradeController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      getObjectById: jest.fn((id: string) => (id === 'tower-site1' ? site : controller))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'tower-site1' });
+    expect(creep.build).toHaveBeenCalledWith(site);
+    expect(creep.upgradeController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('keeps spawn recovery transfer ahead of controller pressure preemption', () => {
     const spawn = {
       id: 'spawn1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2668,6 +2668,76 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it('uses nearby non-critical construction before controller pressure upgrade after urgent refill', () => {
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'tower-site1': 2,
+        controller1: 7
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 200 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
+  });
+
+  it('keeps controller pressure upgrade when non-critical construction is farther than the controller', () => {
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'tower-site1': 9,
+        controller1: 3
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 200 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it.each([
     ['missing', { role: 'worker' }],
     ['empty', { role: 'worker', colony: '' }]
@@ -2754,6 +2824,60 @@ describe('selectWorkerTask', () => {
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
     expect(room.find).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('uses nearby non-critical repair before stored-surplus controller upgrading', () => {
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const road = makeStructure('road-damaged', 'road' as StructureConstant, 4_000, 5_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'road-damaged': 2,
+        controller1: 8
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: makeWorkerTaskRoom({ controller, structures: [storage, road] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-damaged' });
+  });
+
+  it('keeps controller upgrade when a nearby repair target is already complete', () => {
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const fullRoad = makeStructure('road-full', 'road' as StructureConstant, 5_000, 5_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'road-full': 1,
+        controller1: 8
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: makeWorkerTaskRoom({ controller, structures: [storage, fullRoad] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('keeps extension construction before stored-surplus controller upgrading', () => {


### PR DESCRIPTION
Closes #249.

## Summary
- Routes workers carrying energy toward actionable productive sinks before falling back to controller upgrading.
- Preserves urgent spawn/extension refill behavior.
- Adds Jest coverage for productive sink selection and worker runner behavior.
- Regenerates `prod/dist/main.js` via the production build.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (19 suites / 382 tests passed)
- `npm run build`

## Scheduler evidence
- Worktree: `/root/screeps-worktrees/productive-energy-sinks`
- Commit: `9f1aeb9` by `lanyusea's bot <lanyusea@gmail.com>`
- Gameplay floor lane: resources/economy
