### PR TITLE
feat: sustain near-target control worker capacity

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3464,12 +3464,26 @@ var MAX_WORKER_TARGET = 6;
 var sourceCountByRoomName = /* @__PURE__ */ new Map();
 function planSpawn(colony, roleCounts, gameTime, options = {}) {
   const workerTarget = getWorkerTarget(colony, roleCounts);
-  if (getWorkerCapacity(roleCounts) < workerTarget) {
+  const workerCapacity = getWorkerCapacity(roleCounts);
+  const shouldPlanWorkerRecovery = workerCapacity < workerTarget;
+  const nearWorkerTarget = workerCapacity >= workerTarget - 1;
+  if (shouldPlanWorkerRecovery && (!nearWorkerTarget || options.workersOnly)) {
     return planWorkerSpawn(colony, roleCounts, gameTime, options);
   }
   if (options.workersOnly) {
     return null;
   }
+  const territoryWorkerTarget = shouldPlanWorkerRecovery ? workerTarget - 1 : workerTarget;
+  const territorySpawn = planTerritorySpawn(colony, roleCounts, territoryWorkerTarget, gameTime, options);
+  if (territorySpawn) {
+    return territorySpawn;
+  }
+  if (shouldPlanWorkerRecovery) {
+    return planWorkerSpawn(colony, roleCounts, gameTime, options);
+  }
+  return null;
+}
+function planTerritorySpawn(colony, roleCounts, workerTarget, gameTime, options) {
   const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
   if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
     return null;

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -41,7 +41,11 @@ export function planSpawn(
   options: SpawnPlanningOptions = {}
 ): SpawnRequest | null {
   const workerTarget = getWorkerTarget(colony, roleCounts);
-  if (getWorkerCapacity(roleCounts) < workerTarget) {
+  const workerCapacity = getWorkerCapacity(roleCounts);
+  const shouldPlanWorkerRecovery = workerCapacity < workerTarget;
+  const nearWorkerTarget = workerCapacity >= workerTarget - 1;
+
+  if (shouldPlanWorkerRecovery && (!nearWorkerTarget || options.workersOnly)) {
     return planWorkerSpawn(colony, roleCounts, gameTime, options);
   }
 
@@ -49,6 +53,26 @@ export function planSpawn(
     return null;
   }
 
+  const territoryWorkerTarget = shouldPlanWorkerRecovery ? workerTarget - 1 : workerTarget;
+  const territorySpawn = planTerritorySpawn(colony, roleCounts, territoryWorkerTarget, gameTime, options);
+  if (territorySpawn) {
+    return territorySpawn;
+  }
+
+  if (shouldPlanWorkerRecovery) {
+    return planWorkerSpawn(colony, roleCounts, gameTime, options);
+  }
+
+  return null;
+}
+
+function planTerritorySpawn(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  workerTarget: number,
+  gameTime: number,
+  options: SpawnPlanningOptions
+): SpawnRequest | null {
   const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
   if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
     return null;

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -357,7 +357,7 @@ describe('planSpawn', () => {
     ]);
   });
 
-  it('plans a reserver from a persisted occupation reserve intent with follow-up metadata', () => {
+  it('plans a near-target reserver from a persisted occupation reserve intent with follow-up metadata', () => {
     const followUp: TerritoryFollowUpMemory = {
       source: 'activeReserveAdjacent',
       originRoom: 'W1N2',
@@ -388,7 +388,7 @@ describe('planSpawn', () => {
       }
     };
 
-    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 155)).toEqual({
+    expect(planSpawn(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 155)).toEqual({
       spawn,
       body: ['claim', 'move'],
       name: 'claimer-W1N1-W2N2-155',
@@ -617,7 +617,7 @@ describe('planSpawn', () => {
     ]);
   });
 
-  it('keeps territory control absent when the home worker floor is unsafe', () => {
+  it('keeps low worker capacity on worker recovery before territory control', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,
       energyCapacityAvailable: 650,
@@ -629,7 +629,7 @@ describe('planSpawn', () => {
       }
     };
 
-    expect(planSpawn(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 140)).toEqual({
+    expect(planSpawn(colony, { worker: 1, claimer: 0, claimersByTargetRoom: {} }, 140)).toEqual({
       spawn,
       body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
       name: 'worker-W1N1-140',


### PR DESCRIPTION
## Summary
- Lets territory control/reserve follow-up spawn when worker capacity is only one below the worker target.
- Falls back to worker recovery if no eligible territory spawn is available.
- Keeps workersOnly recovery behavior unchanged and updates the generated Screeps bundle.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

Closes #252.