### PR TITLE
feat: add bounded construction backlog worker bonus

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3458,6 +3458,7 @@ function executeTask(creep, task, target) {
 var MIN_WORKER_TARGET = 3;
 var WORKERS_PER_SOURCE = 2;
 var CONSTRUCTION_BACKLOG_WORKER_BONUS = 1;
+var SUBSTANTIAL_CONSTRUCTION_BACKLOG_SITE_COUNT = 5;
 var TERRITORY_SCOUT_BODY = ["move"];
 var TERRITORY_SCOUT_BODY_COST = 50;
 var MAX_WORKER_TARGET = 6;
@@ -3532,22 +3533,28 @@ function getWorkerTarget(colony, roleCounts) {
   const sourceCount = getSourceCount(colony.room);
   const sourceAwareTarget = sourceCount * WORKERS_PER_SOURCE;
   const baseTarget = Math.min(MAX_WORKER_TARGET, Math.max(MIN_WORKER_TARGET, sourceAwareTarget));
-  if (!shouldAddConstructionBacklogWorkerBonus(colony, roleCounts, baseTarget)) {
+  const workerCapacity = getWorkerCapacity(roleCounts);
+  if (workerCapacity < baseTarget || !isConstructionBonusHomeSafe(colony.room.controller)) {
     return baseTarget;
   }
-  return Math.min(MAX_WORKER_TARGET, baseTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
-}
-function shouldAddConstructionBacklogWorkerBonus(colony, roleCounts, baseWorkerTarget) {
-  return getWorkerCapacity(roleCounts) >= baseWorkerTarget && isConstructionBonusHomeSafe(colony.room.controller) && hasActiveConstructionBacklog(colony.room);
+  const constructionBacklogSiteCount = getConstructionBacklogSiteCount(colony.room);
+  if (constructionBacklogSiteCount === 0) {
+    return baseTarget;
+  }
+  const firstBonusTarget = Math.min(MAX_WORKER_TARGET, baseTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
+  if (workerCapacity < firstBonusTarget || constructionBacklogSiteCount < SUBSTANTIAL_CONSTRUCTION_BACKLOG_SITE_COUNT) {
+    return firstBonusTarget;
+  }
+  return Math.min(MAX_WORKER_TARGET, firstBonusTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
 }
 function isConstructionBonusHomeSafe(controller) {
   return (controller == null ? void 0 : controller.my) === true && (typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS);
 }
-function hasActiveConstructionBacklog(room) {
+function getConstructionBacklogSiteCount(room) {
   if (typeof room.find !== "function" || typeof FIND_MY_CONSTRUCTION_SITES !== "number") {
-    return false;
+    return 0;
   }
-  return room.find(FIND_MY_CONSTRUCTION_SITES).length > 0;
+  return room.find(FIND_MY_CONSTRUCTION_SITES).length;
 }
 function getSourceCount(room) {
   const roomName = typeof room.name === "string" && room.name.length > 0 ? room.name : void 0;

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -28,6 +28,7 @@ export interface SpawnPlanningOptions {
 const MIN_WORKER_TARGET = 3;
 const WORKERS_PER_SOURCE = 2;
 const CONSTRUCTION_BACKLOG_WORKER_BONUS = 1;
+const SUBSTANTIAL_CONSTRUCTION_BACKLOG_SITE_COUNT = 5;
 const TERRITORY_SCOUT_BODY: BodyPartConstant[] = ['move'];
 const TERRITORY_SCOUT_BODY_COST = 50;
 // Keep source-aware scaling bounded so unusual source data cannot create runaway early-room spawn pressure.
@@ -130,24 +131,26 @@ function getWorkerTarget(colony: ColonySnapshot, roleCounts: RoleCounts): number
   const sourceCount = getSourceCount(colony.room);
   const sourceAwareTarget = sourceCount * WORKERS_PER_SOURCE;
   const baseTarget = Math.min(MAX_WORKER_TARGET, Math.max(MIN_WORKER_TARGET, sourceAwareTarget));
+  const workerCapacity = getWorkerCapacity(roleCounts);
 
-  if (!shouldAddConstructionBacklogWorkerBonus(colony, roleCounts, baseTarget)) {
+  if (workerCapacity < baseTarget || !isConstructionBonusHomeSafe(colony.room.controller)) {
     return baseTarget;
   }
 
-  return Math.min(MAX_WORKER_TARGET, baseTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
-}
+  const constructionBacklogSiteCount = getConstructionBacklogSiteCount(colony.room);
+  if (constructionBacklogSiteCount === 0) {
+    return baseTarget;
+  }
 
-function shouldAddConstructionBacklogWorkerBonus(
-  colony: ColonySnapshot,
-  roleCounts: RoleCounts,
-  baseWorkerTarget: number
-): boolean {
-  return (
-    getWorkerCapacity(roleCounts) >= baseWorkerTarget &&
-    isConstructionBonusHomeSafe(colony.room.controller) &&
-    hasActiveConstructionBacklog(colony.room)
-  );
+  const firstBonusTarget = Math.min(MAX_WORKER_TARGET, baseTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
+  if (
+    workerCapacity < firstBonusTarget ||
+    constructionBacklogSiteCount < SUBSTANTIAL_CONSTRUCTION_BACKLOG_SITE_COUNT
+  ) {
+    return firstBonusTarget;
+  }
+
+  return Math.min(MAX_WORKER_TARGET, firstBonusTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
 }
 
 function isConstructionBonusHomeSafe(controller: StructureController | undefined): boolean {
@@ -158,12 +161,12 @@ function isConstructionBonusHomeSafe(controller: StructureController | undefined
   );
 }
 
-function hasActiveConstructionBacklog(room: Room): boolean {
+function getConstructionBacklogSiteCount(room: Room): number {
   if (typeof room.find !== 'function' || typeof FIND_MY_CONSTRUCTION_SITES !== 'number') {
-    return false;
+    return 0;
   }
 
-  return room.find(FIND_MY_CONSTRUCTION_SITES).length > 0;
+  return room.find(FIND_MY_CONSTRUCTION_SITES).length;
 }
 
 function getSourceCount(room: Room): number {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -182,14 +182,36 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 4 }, 146)).toBeNull();
   });
 
-  it('does not spend the construction backlog bonus while the home controller needs downgrade recovery', () => {
+  it('adds a second worker target for substantial construction backlog after the first bonus target is safe', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N14',
+      constructionSiteCount: 5,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 147)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W1N14-147',
+      memory: { role: 'worker', colony: 'W1N14' }
+    });
+    expect(planSpawn(colony, { worker: 4 }, 148)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W1N14-148',
+      memory: { role: 'worker', colony: 'W1N14' }
+    });
+    expect(planSpawn(colony, { worker: 5 }, 149)).toBeNull();
+  });
+
+  it('does not spend construction backlog bonuses while the home controller needs downgrade recovery', () => {
     const { colony } = makeColony({
       roomName: 'W1N9',
-      constructionSiteCount: 1,
+      constructionSiteCount: 5,
       controller: { my: true, level: 3, ticksToDowngrade: 5_000 } as StructureController
     });
 
-    expect(planSpawn(colony, { worker: 3 }, 147)).toBeNull();
+    expect(planSpawn(colony, { worker: 3 }, 150)).toBeNull();
   });
 
   it('plans a scout for an explicit memory target when target visibility is missing', () => {
@@ -792,11 +814,11 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 4 }, 126)).toBeNull();
   });
 
-  it('caps the source-aware worker target even with active construction backlog', () => {
+  it('caps the source-aware worker target even with substantial construction backlog', () => {
     const { colony, spawn } = makeColony({
       roomName: 'W1N3',
       sourceCount: 10,
-      constructionSiteCount: 1,
+      constructionSiteCount: 5,
       controller: makeSafeOwnedController()
     });
 


### PR DESCRIPTION
## Summary
- Adds a second bounded worker target only when construction backlog is substantial and the first bonus target is already safe.
- Keeps controller downgrade safety and MAX_WORKER_TARGET bounds intact.
- Updates spawn planner tests and the generated Screeps bundle.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

Closes #253.