### PR TITLE
feat: prefer visible adjacent controller follow-ups

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1262,7 +1262,7 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
 }
 function selectTerritoryTarget(colony, roleCounts, gameTime) {
-  var _a;
+  var _a, _b;
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord2();
@@ -1302,7 +1302,30 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
     getSpawnableTerritoryCandidates(primaryCandidates, roleCounts)
   );
   if (bestSpawnablePrimaryCandidate && bestSpawnablePrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
-    return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+    if (!shouldEvaluateVisibleAdjacentFollowUpPreference(bestSpawnablePrimaryCandidate)) {
+      return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+    }
+    const visibleAdjacentFollowUpCandidates = applyOccupationRecommendationScores(
+      colony,
+      roleCounts,
+      getVisibleAdjacentFollowUpReserveCandidates(
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        roleCounts,
+        routeDistanceLookupContext
+      )
+    );
+    if (visibleAdjacentFollowUpCandidates.length === 0) {
+      return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+    }
+    return toSelectedTerritoryTarget(
+      (_a = selectBestScoredTerritoryCandidate(
+        getSpawnableTerritoryCandidates([...primaryCandidates, ...visibleAdjacentFollowUpCandidates], roleCounts)
+      )) != null ? _a : bestSpawnablePrimaryCandidate
+    );
   }
   const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, [
     ...getAdjacentReserveCandidates(
@@ -1317,25 +1340,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       0,
       routeDistanceLookupContext
     ),
-    ...getSatisfiedClaimAdjacentReserveCandidates(
-      colonyName,
-      colonyOwnerUsername,
-      territoryMemory,
-      intents,
-      gameTime,
-      !hasBlockingConfiguredTarget,
-      routeDistanceLookupContext
-    ),
-    ...getSatisfiedReserveAdjacentReserveCandidates(
-      colonyName,
-      colonyOwnerUsername,
-      territoryMemory,
-      intents,
-      gameTime,
-      !hasBlockingConfiguredTarget,
-      routeDistanceLookupContext
-    ),
-    ...getActiveReserveAdjacentReserveCandidates(
+    ...getAdjacentFollowUpReserveCandidates(
       colonyName,
       colonyOwnerUsername,
       territoryMemory,
@@ -1348,7 +1353,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
   ]);
   const candidates = [...primaryCandidates, ...adjacentCandidates];
   return toSelectedTerritoryTarget(
-    (_a = selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts))) != null ? _a : selectBestScoredTerritoryCandidate(candidates)
+    (_b = selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts))) != null ? _b : selectBestScoredTerritoryCandidate(candidates)
   );
 }
 function selectBestScoredTerritoryCandidate(candidates) {
@@ -1367,6 +1372,9 @@ function toSelectedTerritoryTarget(candidate) {
     commitTarget: candidate.commitTarget,
     ...candidate.followUp ? { followUp: candidate.followUp } : {}
   } : null;
+}
+function shouldEvaluateVisibleAdjacentFollowUpPreference(candidate) {
+  return candidate.priority === TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE && candidate.target.action === "reserve";
 }
 function getSpawnableTerritoryCandidates(candidates, roleCounts) {
   return candidates.filter((candidate) => {
@@ -1502,6 +1510,50 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
     }
     return [];
   });
+}
+function getVisibleAdjacentFollowUpReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, roleCounts, routeDistanceLookupContext) {
+  return getAdjacentFollowUpReserveCandidates(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    roleCounts,
+    false,
+    routeDistanceLookupContext
+  );
+}
+function getAdjacentFollowUpReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, roleCounts, includeScoutCandidates, routeDistanceLookupContext) {
+  return [
+    ...getSatisfiedClaimAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      routeDistanceLookupContext
+    ),
+    ...getSatisfiedReserveAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      routeDistanceLookupContext
+    ),
+    ...getActiveReserveAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      roleCounts,
+      includeScoutCandidates,
+      routeDistanceLookupContext
+    )
+  ];
 }
 function getSatisfiedClaimAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, routeDistanceLookupContext) {
   return getSatisfiedConfiguredClaimTargets(
@@ -1662,6 +1714,7 @@ function applyOccupationRecommendationScore(candidate, recommendation, roleCount
     commitTarget: nextSelection.commitTarget,
     priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
     recommendationScore: recommendation.score,
+    recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
   };
 }
@@ -1779,7 +1832,37 @@ function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
 }
 function compareTerritoryCandidates(left, right) {
-  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+}
+function compareVisibleAdjacentFollowUpPreference(left, right) {
+  if (shouldPreferVisibleAdjacentFollowUp(left, right)) {
+    return -1;
+  }
+  return shouldPreferVisibleAdjacentFollowUp(right, left) ? 1 : 0;
+}
+function shouldPreferVisibleAdjacentFollowUp(candidate, other) {
+  return isVisibleAdjacentControllerFollowUpCandidate(candidate) && isLowerConfidenceDistantSameActionCandidate(other, candidate);
+}
+function isVisibleAdjacentControllerFollowUpCandidate(candidate) {
+  return isTerritoryFollowUpSource2(candidate.source) && candidate.intentAction === candidate.target.action && isTerritoryControlAction(candidate.intentAction) && candidate.recommendationEvidenceStatus === "sufficient" && isTerritoryTargetVisible(candidate.target);
+}
+function isLowerConfidenceDistantSameActionCandidate(candidate, followUpCandidate) {
+  if (candidate.target.action !== followUpCandidate.target.action || !isPrimaryTerritoryCandidateSource(candidate.source) || !isFartherTerritoryCandidate(candidate, followUpCandidate)) {
+    return false;
+  }
+  if (candidate.recommendationEvidenceStatus !== "sufficient" || !isTerritoryTargetVisible(candidate.target)) {
+    return true;
+  }
+  return typeof candidate.recommendationScore === "number" && typeof followUpCandidate.recommendationScore === "number" && followUpCandidate.recommendationScore > candidate.recommendationScore;
+}
+function isPrimaryTerritoryCandidateSource(source) {
+  return source === "configured" || source === "occupationIntent";
+}
+function isFartherTerritoryCandidate(candidate, other) {
+  var _a, _b;
+  const candidateDistance = (_a = candidate.routeDistance) != null ? _a : Number.POSITIVE_INFINITY;
+  const otherDistance = (_b = other.routeDistance) != null ? _b : Number.POSITIVE_INFINITY;
+  return candidateDistance > otherDistance;
 }
 function compareOptionalNumbers2(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -5,6 +5,7 @@ import {
   scoreOccupationRecommendations,
   type OccupationControllerEvidence,
   type OccupationRecommendationCandidateInput,
+  type OccupationRecommendationEvidenceStatus,
   type OccupationRecommendationScore
 } from './occupationRecommendation';
 
@@ -61,6 +62,7 @@ interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   priority: number;
   source: TerritoryCandidateSource;
   recommendationScore?: number;
+  recommendationEvidenceStatus?: OccupationRecommendationEvidenceStatus;
   routeDistance?: number;
   renewalTicksToEnd?: number;
   occupationActionableTicks?: number;
@@ -383,7 +385,32 @@ function selectTerritoryTarget(
     bestSpawnablePrimaryCandidate &&
     bestSpawnablePrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY
   ) {
-    return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+    if (!shouldEvaluateVisibleAdjacentFollowUpPreference(bestSpawnablePrimaryCandidate)) {
+      return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+    }
+
+    const visibleAdjacentFollowUpCandidates = applyOccupationRecommendationScores(
+      colony,
+      roleCounts,
+      getVisibleAdjacentFollowUpReserveCandidates(
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        roleCounts,
+        routeDistanceLookupContext
+      )
+    );
+    if (visibleAdjacentFollowUpCandidates.length === 0) {
+      return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+    }
+
+    return toSelectedTerritoryTarget(
+      selectBestScoredTerritoryCandidate(
+        getSpawnableTerritoryCandidates([...primaryCandidates, ...visibleAdjacentFollowUpCandidates], roleCounts)
+      ) ?? bestSpawnablePrimaryCandidate
+    );
   }
 
   const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, [
@@ -399,25 +426,7 @@ function selectTerritoryTarget(
       0,
       routeDistanceLookupContext
     ),
-    ...getSatisfiedClaimAdjacentReserveCandidates(
-      colonyName,
-      colonyOwnerUsername,
-      territoryMemory,
-      intents,
-      gameTime,
-      !hasBlockingConfiguredTarget,
-      routeDistanceLookupContext
-    ),
-    ...getSatisfiedReserveAdjacentReserveCandidates(
-      colonyName,
-      colonyOwnerUsername,
-      territoryMemory,
-      intents,
-      gameTime,
-      !hasBlockingConfiguredTarget,
-      routeDistanceLookupContext
-    ),
-    ...getActiveReserveAdjacentReserveCandidates(
+    ...getAdjacentFollowUpReserveCandidates(
       colonyName,
       colonyOwnerUsername,
       territoryMemory,
@@ -456,6 +465,10 @@ function toSelectedTerritoryTarget(candidate: ScoredTerritoryTarget | null): Sel
         ...(candidate.followUp ? { followUp: candidate.followUp } : {})
       }
     : null;
+}
+
+function shouldEvaluateVisibleAdjacentFollowUpPreference(candidate: ScoredTerritoryTarget): boolean {
+  return candidate.priority === TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE && candidate.target.action === 'reserve';
 }
 
 function getSpawnableTerritoryCandidates(
@@ -690,6 +703,69 @@ function getAdjacentReserveCandidates(
 
     return [];
   });
+}
+
+function getVisibleAdjacentFollowUpReserveCandidates(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  roleCounts: RoleCounts,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): ScoredTerritoryTarget[] {
+  return getAdjacentFollowUpReserveCandidates(
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    roleCounts,
+    false,
+    routeDistanceLookupContext
+  );
+}
+
+function getAdjacentFollowUpReserveCandidates(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  roleCounts: RoleCounts,
+  includeScoutCandidates: boolean,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): ScoredTerritoryTarget[] {
+  return [
+    ...getSatisfiedClaimAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      routeDistanceLookupContext
+    ),
+    ...getSatisfiedReserveAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      includeScoutCandidates,
+      routeDistanceLookupContext
+    ),
+    ...getActiveReserveAdjacentReserveCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      roleCounts,
+      includeScoutCandidates,
+      routeDistanceLookupContext
+    )
+  ];
 }
 
 function getSatisfiedClaimAdjacentReserveCandidates(
@@ -954,6 +1030,7 @@ function applyOccupationRecommendationScore(
     commitTarget: nextSelection.commitTarget,
     priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
     recommendationScore: recommendation.score,
+    recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
   };
 }
@@ -1127,6 +1204,7 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
   return (
     left.priority - right.priority ||
     compareOptionalNumbers(left.renewalTicksToEnd, right.renewalTicksToEnd) ||
+    compareVisibleAdjacentFollowUpPreference(left, right) ||
     getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) ||
     compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) ||
     compareOptionalNumbers(left.occupationActionableTicks, right.occupationActionableTicks) ||
@@ -1134,6 +1212,70 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
     left.target.roomName.localeCompare(right.target.roomName) ||
     left.intentAction.localeCompare(right.intentAction)
   );
+}
+
+function compareVisibleAdjacentFollowUpPreference(
+  left: ScoredTerritoryTarget,
+  right: ScoredTerritoryTarget
+): number {
+  if (shouldPreferVisibleAdjacentFollowUp(left, right)) {
+    return -1;
+  }
+
+  return shouldPreferVisibleAdjacentFollowUp(right, left) ? 1 : 0;
+}
+
+function shouldPreferVisibleAdjacentFollowUp(
+  candidate: ScoredTerritoryTarget,
+  other: ScoredTerritoryTarget
+): boolean {
+  return (
+    isVisibleAdjacentControllerFollowUpCandidate(candidate) &&
+    isLowerConfidenceDistantSameActionCandidate(other, candidate)
+  );
+}
+
+function isVisibleAdjacentControllerFollowUpCandidate(candidate: ScoredTerritoryTarget): boolean {
+  return (
+    isTerritoryFollowUpSource(candidate.source) &&
+    candidate.intentAction === candidate.target.action &&
+    isTerritoryControlAction(candidate.intentAction) &&
+    candidate.recommendationEvidenceStatus === 'sufficient' &&
+    isTerritoryTargetVisible(candidate.target)
+  );
+}
+
+function isLowerConfidenceDistantSameActionCandidate(
+  candidate: ScoredTerritoryTarget,
+  followUpCandidate: ScoredTerritoryTarget
+): boolean {
+  if (
+    candidate.target.action !== followUpCandidate.target.action ||
+    !isPrimaryTerritoryCandidateSource(candidate.source) ||
+    !isFartherTerritoryCandidate(candidate, followUpCandidate)
+  ) {
+    return false;
+  }
+
+  if (candidate.recommendationEvidenceStatus !== 'sufficient' || !isTerritoryTargetVisible(candidate.target)) {
+    return true;
+  }
+
+  return (
+    typeof candidate.recommendationScore === 'number' &&
+    typeof followUpCandidate.recommendationScore === 'number' &&
+    followUpCandidate.recommendationScore > candidate.recommendationScore
+  );
+}
+
+function isPrimaryTerritoryCandidateSource(source: TerritoryCandidateSource): boolean {
+  return source === 'configured' || source === 'occupationIntent';
+}
+
+function isFartherTerritoryCandidate(candidate: ScoredTerritoryTarget, other: ScoredTerritoryTarget): boolean {
+  const candidateDistance = candidate.routeDistance ?? Number.POSITIVE_INFINITY;
+  const otherDistance = other.routeDistance ?? Number.POSITIVE_INFINITY;
+  return candidateDistance > otherDistance;
 }
 
 function compareOptionalNumbers(left: number | undefined, right: number | undefined): number {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1908,6 +1908,111 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('prefers a visible adjacent reserve follow-up over a lower-confidence distant reserve', () => {
+    const colony = makeSafeColony();
+    const distantTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W9N1', action: 'reserve' };
+    const satisfiedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const describeExits = jest.fn((roomName: string) => (roomName === 'W1N2' ? { '3': 'W2N2' } : {}));
+    const findRoute = jest.fn((_fromRoom: string, toRoom: string) =>
+      Array.from({ length: toRoom === 'W9N1' ? 4 : toRoom === 'W2N2' ? 2 : 1 }, (_value, index) => ({
+        exit: 3,
+        room: `${toRoom}-${index}`
+      }))
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits, findRoute } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: makeRecommendationRoom('W1N2', {
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        }),
+        W2N2: makeRecommendationRoom('W2N2', { sourceCount: 2 }),
+        W9N1: makeRecommendationRoom('W9N1', { sourceCount: 1 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [distantTarget, satisfiedTarget]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 577);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N2', action: 'reserve', followUp });
+    expect(describeExits).toHaveBeenCalledWith('W1N2');
+    expect(describeExits).not.toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toEqual([
+      distantTarget,
+      satisfiedTarget,
+      {
+        colony: 'W1N1',
+        roomName: 'W2N2',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 577,
+        followUp
+      }
+    ]);
+  });
+
+  it('keeps a stronger visible configured reserve before adjacent follow-up expansion', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W9N1', action: 'reserve' };
+    const satisfiedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const describeExits = jest.fn((roomName: string) => (roomName === 'W1N2' ? { '3': 'W2N2' } : {}));
+    const findRoute = jest.fn((_fromRoom: string, toRoom: string) =>
+      Array.from({ length: toRoom === 'W9N1' ? 2 : toRoom === 'W2N2' ? 3 : 1 }, (_value, index) => ({
+        exit: 3,
+        room: `${toRoom}-${index}`
+      }))
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits, findRoute } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: makeRecommendationRoom('W1N2', {
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        }),
+        W2N2: makeRecommendationRoom('W2N2', { sourceCount: 1 }),
+        W9N1: makeRecommendationRoom('W9N1', { sourceCount: 2 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget, satisfiedTarget]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 578);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W9N1', action: 'reserve' });
+    expect(describeExits).toHaveBeenCalledWith('W1N2');
+    expect(Memory.territory?.targets).toEqual([configuredTarget, satisfiedTarget]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W9N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 578
+      }
+    ]);
+  });
+
   it('extends from an actively covered visible reservation before home-adjacent reserve pressure', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };


### PR DESCRIPTION
## Summary
- Prefer safe visible adjacent controller opportunities when ranking same-action territory follow-up candidates.
- Preserve hostile/suppression/workersOnly/controller guard safety fallbacks.
- Add territory planner regression coverage and refresh `prod/dist/main.js`.

Closes #256.

## Verification
From `prod/` in `/root/screeps-worktrees/visible-adjacent-controller-followup-256`:
- `npm run typecheck`
- `npm test -- --runInBand` (19 suites, 387 tests)
- `npm run build`

## Scheduler evidence
- Codex-authored commit: `e16566e lanyusea's bot <lanyusea@gmail.com> feat: prefer visible adjacent controller follow-ups`
- Controller recovery was commit-only after prior Codex process disappeared with verified dirty worktree.
