### PR TITLE
feat: guard urgent spawn refills from spending

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2478,13 +2478,13 @@ function selectWorkerTask(creep) {
   if (isTerritoryControlTask(territoryControllerTask)) {
     return territoryControllerTask;
   }
-  const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  if (spawnOrExtensionEnergySink) {
-    return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
-  }
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: "upgrade", targetId: controller.id };
+  }
+  const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
+  if (spawnOrExtensionEnergySink) {
+    return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
   }
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
   const capacityConstructionSite = selectCapacityEnablingConstructionSite(creep, constructionSites, controller);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2436,6 +2436,7 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
+var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -2478,9 +2479,9 @@ function selectWorkerTask(creep) {
   if (isTerritoryControlTask(territoryControllerTask)) {
     return territoryControllerTask;
   }
-  const energySink = selectFillableEnergySink(creep);
-  if (energySink && !isTowerEnergySink(energySink)) {
-    return { type: "transfer", targetId: energySink.id };
+  const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
+  if (spawnOrExtensionEnergySink && shouldGuardUrgentSpawnRefill(creep.room)) {
+    return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
   }
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
@@ -2491,8 +2492,9 @@ function selectWorkerTask(creep) {
   if (capacityConstructionSite && !territoryControllerTask) {
     return { type: "build", targetId: capacityConstructionSite.id };
   }
-  if (energySink) {
-    return { type: "transfer", targetId: energySink.id };
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
+  if (priorityTowerEnergySink) {
+    return { type: "transfer", targetId: priorityTowerEnergySink.id };
   }
   if (territoryControllerTask) {
     return territoryControllerTask;
@@ -2542,14 +2544,20 @@ function isFillableEnergySink(structure) {
   return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType2(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
 function selectFillableEnergySink(creep) {
+  var _a;
+  return (_a = selectSpawnOrExtensionEnergySink(creep)) != null ? _a : selectPriorityTowerEnergySink(creep);
+}
+function selectSpawnOrExtensionEnergySink(creep) {
+  return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isSpawnOrExtensionEnergySink), creep);
+}
+function selectPriorityTowerEnergySink(creep) {
+  return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink), creep);
+}
+function findFillableEnergySinks(creep) {
   const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
     filter: isFillableEnergySink
   });
-  const spawnOrExtension = selectClosestEnergySink(creep, energySinks.filter(isSpawnOrExtensionEnergySink));
-  if (spawnOrExtension) {
-    return spawnOrExtension;
-  }
-  return selectClosestEnergySink(creep, energySinks.filter(isPriorityTowerEnergySink));
+  return energySinks;
 }
 function isSpawnEnergySink(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn");
@@ -2566,7 +2574,7 @@ function isTowerEnergySink(structure) {
 function isPriorityTowerEnergySink(structure) {
   return isTowerEnergySink(structure) && getStoredEnergy2(structure) < TOWER_REFILL_ENERGY_FLOOR;
 }
-function selectClosestEnergySink(creep, energySinks) {
+function selectClosestEnergySink(energySinks, creep) {
   var _a;
   if (energySinks.length === 0) {
     return null;
@@ -2585,6 +2593,10 @@ function selectClosestEnergySink(creep, energySinks) {
     return (_a = position.findClosestByRange(energySinksByStableId)) != null ? _a : energySinksByStableId[0];
   }
   return energySinksByStableId[0];
+}
+function shouldGuardUrgentSpawnRefill(room) {
+  const energyAvailable = room.energyAvailable;
+  return typeof energyAvailable !== "number" || !Number.isFinite(energyAvailable) || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 function compareEnergySinkId(left, right) {
   return String(left.id).localeCompare(String(right.id));

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2436,7 +2436,6 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
-var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -2480,7 +2479,7 @@ function selectWorkerTask(creep) {
     return territoryControllerTask;
   }
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  if (spawnOrExtensionEnergySink && shouldGuardUrgentSpawnRefill(creep.room)) {
+  if (spawnOrExtensionEnergySink) {
     return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
   }
   const controller = creep.room.controller;
@@ -2593,10 +2592,6 @@ function selectClosestEnergySink(energySinks, creep) {
     return (_a = position.findClosestByRange(energySinksByStableId)) != null ? _a : energySinksByStableId[0];
   }
   return energySinksByStableId[0];
-}
-function shouldGuardUrgentSpawnRefill(room) {
-  const energyAvailable = room.energyAvailable;
-  return typeof energyAvailable !== "number" || !Number.isFinite(energyAvailable) || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 function compareEnergySinkId(left, right) {
   return String(left.id).localeCompare(String(right.id));

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3248,6 +3248,8 @@ function runWorker(creep) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptSpendingTaskForEnergySink(currentTask, selectedTask)) {
@@ -3419,6 +3421,12 @@ function shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectedTask)
   const selectedTarget = Game.getObjectById(selectedTask.targetId);
   return getTransferSinkPriority(selectedTarget) > getTransferSinkPriority(currentTarget);
 }
+function shouldPreemptTransferTaskForControllerDowngradeGuard(creep, task, selectedTask) {
+  if (task.type !== "transfer") {
+    return false;
+  }
+  return isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
 function shouldPreemptSpendingTaskForControllerPressure(creep, task, selectedTask) {
   var _a;
   if (!isEnergySpendingTask(task) || task.type === "upgrade") {
@@ -3446,6 +3454,14 @@ function shouldPreemptUpgradeTask(creep, task, selectedTask) {
 function isOwnedControllerUpgradeTask(creep, task) {
   var _a, _b;
   return (task == null ? void 0 : task.type) === "upgrade" && ((_b = (_a = creep.room) == null ? void 0 : _a.controller) == null ? void 0 : _b.my) === true && task.targetId === creep.room.controller.id;
+}
+function isDowngradeGuardUpgradeTask(creep, task) {
+  var _a;
+  if (!isOwnedControllerUpgradeTask(creep, task)) {
+    return false;
+  }
+  const ticksToDowngrade = (_a = creep.room.controller) == null ? void 0 : _a.ticksToDowngrade;
+  return typeof ticksToDowngrade === "number" && ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
 }
 function isSameTask(left, right) {
   return left.type === right.type && left.targetId === right.targetId;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1,4 +1,8 @@
-import { isWorkerRepairTargetComplete, selectWorkerTask } from '../tasks/workerTasks';
+import {
+  CONTROLLER_DOWNGRADE_GUARD_TICKS,
+  isWorkerRepairTargetComplete,
+  selectWorkerTask
+} from '../tasks/workerTasks';
 import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
 
 type TransferSinkStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION' | 'STRUCTURE_TOWER';
@@ -17,6 +21,8 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
@@ -247,6 +253,18 @@ function shouldPreemptTransferTaskForBetterEnergySink(
   return getTransferSinkPriority(selectedTarget) > getTransferSinkPriority(currentTarget);
 }
 
+function shouldPreemptTransferTaskForControllerDowngradeGuard(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (task.type !== 'transfer') {
+    return false;
+  }
+
+  return isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+
 function shouldPreemptSpendingTaskForControllerPressure(
   creep: Creep,
   task: CreepTaskMemory,
@@ -293,6 +311,18 @@ function isOwnedControllerUpgradeTask(
     creep.room?.controller?.my === true &&
     task.targetId === creep.room.controller.id
   );
+}
+
+function isDowngradeGuardUpgradeTask(
+  creep: Creep,
+  task: CreepTaskMemory | null
+): task is Extract<CreepTaskMemory, { type: 'upgrade' }> {
+  if (!isOwnedControllerUpgradeTask(creep, task)) {
+    return false;
+  }
+
+  const ticksToDowngrade = creep.room.controller?.ticksToDowngrade;
+  return typeof ticksToDowngrade === 'number' && ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
 }
 
 function isSameTask(left: CreepTaskMemory, right: CreepTaskMemory): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -78,7 +78,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  if (spawnOrExtensionEnergySink && shouldGuardUrgentSpawnRefill(creep.room)) {
+  if (spawnOrExtensionEnergySink) {
     return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
   }
 
@@ -234,15 +234,6 @@ function selectClosestEnergySink<T extends FillableEnergySink>(energySinks: T[],
   }
 
   return energySinksByStableId[0];
-}
-
-function shouldGuardUrgentSpawnRefill(room: Room): boolean {
-  const energyAvailable = (room as Room & { energyAvailable?: unknown }).energyAvailable;
-  return (
-    typeof energyAvailable !== 'number' ||
-    !Number.isFinite(energyAvailable) ||
-    energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD
-  );
 }
 
 function compareEnergySinkId(left: FillableEnergySink, right: FillableEnergySink): number {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -77,14 +77,14 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return territoryControllerTask;
   }
 
-  const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  if (spawnOrExtensionEnergySink) {
-    return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
-  }
-
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller)) {
     return { type: 'upgrade', targetId: controller.id };
+  }
+
+  const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
+  if (spawnOrExtensionEnergySink) {
+    return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
   }
 
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -8,6 +8,7 @@ export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 export const TOWER_REFILL_ENERGY_FLOOR = 500;
+export const URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -76,9 +77,9 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return territoryControllerTask;
   }
 
-  const energySink = selectFillableEnergySink(creep);
-  if (energySink && !isTowerEnergySink(energySink)) {
-    return { type: 'transfer', targetId: energySink.id as Id<AnyStoreStructure> };
+  const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
+  if (spawnOrExtensionEnergySink && shouldGuardUrgentSpawnRefill(creep.room)) {
+    return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
   }
 
   const controller = creep.room.controller;
@@ -92,8 +93,9 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'build', targetId: capacityConstructionSite.id };
   }
 
-  if (energySink) {
-    return { type: 'transfer', targetId: energySink.id as Id<AnyStoreStructure> };
+  const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
+  if (priorityTowerEnergySink) {
+    return { type: 'transfer', targetId: priorityTowerEnergySink.id as Id<AnyStoreStructure> };
   }
 
   if (territoryControllerTask) {
@@ -164,16 +166,23 @@ function isFillableEnergySink(structure: AnyOwnedStructure): structure is Fillab
 }
 
 function selectFillableEnergySink(creep: Creep): FillableEnergySink | null {
+  return selectSpawnOrExtensionEnergySink(creep) ?? selectPriorityTowerEnergySink(creep);
+}
+
+function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | StructureExtension | null {
+  return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isSpawnOrExtensionEnergySink), creep);
+}
+
+function selectPriorityTowerEnergySink(creep: Creep): StructureTower | null {
+  return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink), creep);
+}
+
+function findFillableEnergySinks(creep: Creep): FillableEnergySink[] {
   const energySinks = creep.room.find(FIND_MY_STRUCTURES, {
     filter: isFillableEnergySink
   });
 
-  const spawnOrExtension = selectClosestEnergySink(creep, energySinks.filter(isSpawnOrExtensionEnergySink));
-  if (spawnOrExtension) {
-    return spawnOrExtension;
-  }
-
-  return selectClosestEnergySink(creep, energySinks.filter(isPriorityTowerEnergySink));
+  return energySinks;
 }
 
 function isSpawnEnergySink(structure: FillableEnergySink): structure is StructureSpawn {
@@ -196,7 +205,7 @@ function isPriorityTowerEnergySink(structure: FillableEnergySink): structure is 
   return isTowerEnergySink(structure) && getStoredEnergy(structure) < TOWER_REFILL_ENERGY_FLOOR;
 }
 
-function selectClosestEnergySink<T extends FillableEnergySink>(creep: Creep, energySinks: T[]): T | null {
+function selectClosestEnergySink<T extends FillableEnergySink>(energySinks: T[], creep: Creep): T | null {
   if (energySinks.length === 0) {
     return null;
   }
@@ -225,6 +234,15 @@ function selectClosestEnergySink<T extends FillableEnergySink>(creep: Creep, ene
   }
 
   return energySinksByStableId[0];
+}
+
+function shouldGuardUrgentSpawnRefill(room: Room): boolean {
+  const energyAvailable = (room as Room & { energyAvailable?: unknown }).energyAvailable;
+  return (
+    typeof energyAvailable !== 'number' ||
+    !Number.isFinite(energyAvailable) ||
+    energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD
+  );
 }
 
 function compareEnergySinkId(left: FillableEnergySink, right: FillableEnergySink): number {

--- a/prod/test/mvpEconomyLifecycle.test.ts
+++ b/prod/test/mvpEconomyLifecycle.test.ts
@@ -1,5 +1,6 @@
 import { runEconomy } from '../src/economy/economyLoop';
 import { WORKER_REPLACEMENT_TICKS_TO_LIVE } from '../src/creeps/roleCounts';
+import { URGENT_SPAWN_REFILL_ENERGY_THRESHOLD } from '../src/tasks/workerTasks';
 
 describe('MVP economy lifecycle', () => {
   let logSpy: jest.SpyInstance<void, [message?: unknown, ...optionalParams: unknown[]]>;
@@ -90,6 +91,7 @@ describe('MVP economy lifecycle', () => {
     fullWorker.store.getFreeCapacity.mockReturnValue(0);
     fullWorker.room = {
       ...room,
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
       find: jest.fn((type) => (type === 3 ? [spawn] : []))
     } as unknown as Room;
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -589,14 +589,14 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
-  it('keeps construction work when spawn refill pressure has cleared', () => {
+  it('preempts construction for fillable spawn energy after urgent pressure has cleared', () => {
     const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
     const spawn = {
       id: 'spawn1',
       structureType: 'spawn',
       store: { getFreeCapacity: jest.fn().mockReturnValue(100) }
     } as unknown as StructureSpawn;
-    const build = jest.fn().mockReturnValue(0);
+    const transfer = jest.fn().mockReturnValue(0);
     const creep = {
       memory: { task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
       store: {
@@ -616,18 +616,20 @@ describe('runWorker', () => {
           }
         )
       },
-      build,
+      build: jest.fn(),
+      transfer,
       moveTo: jest.fn()
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      getObjectById: jest.fn().mockReturnValue(site)
+      getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : site))
     };
 
     runWorker(creep);
 
-    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
-    expect(Game.getObjectById).toHaveBeenCalledWith('site1');
-    expect(build).toHaveBeenCalledWith(site);
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(Game.getObjectById).toHaveBeenCalledWith('spawn1');
+    expect(transfer).toHaveBeenCalledWith(spawn, 'energy');
+    expect(creep.build).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -448,6 +448,51 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts active spawn refill for the downgrade guard', () => {
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const creep = {
+      memory: { task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        controller,
+        find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          return [];
+        })
+      },
+      transfer: jest.fn(),
+      upgradeController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn((id: string) => (id === 'controller1' ? controller : spawn))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(creep.upgradeController).toHaveBeenCalledWith(controller);
+    expect(creep.transfer).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('preempts an RCL3 upgrade task for extension construction when downgrade is safe', () => {
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
     const controller = {
@@ -1036,6 +1081,66 @@ describe('runWorker', () => {
     expect(getObjectById).not.toHaveBeenCalled();
     expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
     expect(creep.build).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps active tower refill ahead of normal controller pressure upgrades', () => {
+    const tower = {
+      id: 'tower1',
+      structureType: 'tower',
+      store: {
+        getFreeCapacity: jest.fn().mockReturnValue(200),
+        getUsedCapacity: jest.fn().mockReturnValue(600)
+      }
+    } as unknown as StructureTower;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 200 }]
+      }
+    };
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureTower) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [tower];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const creep = {
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'transfer', targetId: 'tower1' as Id<AnyStoreStructure> }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      transfer: jest.fn().mockReturnValue(0),
+      upgradeController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker1: creep },
+      getObjectById: jest.fn((id: string) => (id === 'tower1' ? tower : controller))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'tower1' });
+    expect(creep.transfer).toHaveBeenCalledWith(tower, 'energy');
+    expect(creep.upgradeController).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1,5 +1,9 @@
 import { runWorker } from '../src/creeps/workerRunner';
-import { CONTROLLER_DOWNGRADE_GUARD_TICKS, IDLE_RAMPART_REPAIR_HITS_CEILING } from '../src/tasks/workerTasks';
+import {
+  CONTROLLER_DOWNGRADE_GUARD_TICKS,
+  IDLE_RAMPART_REPAIR_HITS_CEILING,
+  URGENT_SPAWN_REFILL_ENERGY_THRESHOLD
+} from '../src/tasks/workerTasks';
 import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
 import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
 
@@ -558,6 +562,7 @@ describe('runWorker', () => {
         getFreeCapacity: jest.fn().mockReturnValue(0)
       },
       room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
         find: jest.fn(
           (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
             if (type === FIND_MY_STRUCTURES) {
@@ -581,6 +586,48 @@ describe('runWorker', () => {
     expect(creep.memory.task).toEqual({ type: 'transfer', targetId: id });
     expect(Game.getObjectById).not.toHaveBeenCalled();
     expect(creep.build).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps construction work when spawn refill pressure has cleared', () => {
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(100) }
+    } as unknown as StructureSpawn;
+    const build = jest.fn().mockReturnValue(0);
+    const creep = {
+      memory: { task: { type: 'build', targetId: 'site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [spawn];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            return type === FIND_CONSTRUCTION_SITES ? [site] : [];
+          }
+        )
+      },
+      build,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(site)
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(Game.getObjectById).toHaveBeenCalledWith('site1');
+    expect(build).toHaveBeenCalledWith(site);
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3163,25 +3163,28 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
-  it('keeps spawn refill priority over the downgrade guard', () => {
-    const spawn = {
-      id: 'spawn1',
-      structureType: 'spawn',
+  it.each([
+    ['spawn', 'spawn1', CONTROLLER_DOWNGRADE_GUARD_TICKS],
+    ['extension', 'extension1', CONTROLLER_DOWNGRADE_GUARD_TICKS - 1]
+  ])('keeps low-downgrade guard before %s refill', (structureType, sinkId, ticksToDowngrade) => {
+    const energySink = {
+      id: sinkId,
+      structureType,
       store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
-    } as unknown as StructureSpawn;
+    } as unknown as StructureSpawn | StructureExtension;
     const site = { id: 'site1' } as ConstructionSite;
     const controller = {
       id: 'controller1',
       my: true,
-      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+      ticksToDowngrade
     } as StructureController;
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
       room: {
         controller,
-        find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+        find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
           if (type === 3) {
-            const structures = [spawn];
+            const structures = [energySink];
             return options?.filter ? structures.filter(options.filter) : structures;
           }
 
@@ -3190,7 +3193,7 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('keeps build priority for low downgrade data on unowned controllers', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2625,7 +2625,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
-  it('keeps construction spending when spawn refill is no longer urgent', () => {
+  it('keeps spawn refill active when urgent threshold has cleared before construction', () => {
     const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
     const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 100);
@@ -2645,11 +2645,11 @@ describe('selectWorkerTask', () => {
       })
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'container-site1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
-  it('keeps controller progress when spawn refill is no longer urgent and no construction remains', () => {
-    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 100);
+  it('keeps extension refill active when urgent threshold has cleared before controller progress', () => {
+    const extension = makeEnergySink('extension1', 'extension' as StructureConstant, 100);
     const controller = {
       id: 'controller1',
       my: true,
@@ -2661,11 +2661,11 @@ describe('selectWorkerTask', () => {
       room: makeWorkerTaskRoom({
         controller,
         energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
-        myStructures: [spawn as AnyOwnedStructure]
+        myStructures: [extension as AnyOwnedStructure]
       })
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension1' });
   });
 
   it('builds RCL2 extension construction before controller progress guard when STRUCTURE_EXTENSION is missing', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3,6 +3,7 @@ import {
   CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   TOWER_REFILL_ENERGY_FLOOR,
+  URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
 import {
@@ -97,17 +98,20 @@ function makeSalvageEnergySource(
 function makeWorkerTaskRoom({
   constructionSites = [],
   controller = { id: 'controller1', my: true, level: 3 } as StructureController,
+  energyAvailable,
   myStructures = [],
   structures = []
 }: {
   constructionSites?: ConstructionSite[];
   controller?: StructureController;
+  energyAvailable?: number;
   myStructures?: AnyOwnedStructure[];
   structures?: AnyStructure[];
 } = {}): Room {
   return {
     name: 'W1N1',
     controller,
+    ...(energyAvailable === undefined ? {} : { energyAvailable }),
     find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
       if (type === FIND_MY_STRUCTURES) {
         return options?.filter ? myStructures.filter(options.filter) : myStructures;
@@ -2596,6 +2600,72 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('guards critically low spawn energy from construction spending', () => {
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 101);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [roadSite, containerSite],
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('keeps construction spending when spawn refill is no longer urgent', () => {
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 100);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [roadSite, containerSite],
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'container-site1' });
+  });
+
+  it('keeps controller progress when spawn refill is no longer urgent and no construction remains', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 100);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('builds RCL2 extension construction before controller progress guard when STRUCTURE_EXTENSION is missing', () => {


### PR DESCRIPTION
## Summary
- Guard urgent spawn/extension refill needs from being starved by construction or upgrade spending.
- Preserve emergency worker recovery, productive sink routing, and controller downgrade safety behavior.
- Add low-spawn-energy refill priority and fallback regression coverage; refresh `prod/dist/main.js`.

Closes #257.

## Verification
From `prod/` in `/root/screeps-worktrees/urgent-spawn-refill-guard-257`:
- `npm run typecheck`
- `npm test -- --runInBand` (19 suites, 389 tests)
- `npm run build`

## Scheduler evidence
- Codex-authored commit: `c021cb2 lanyusea's bot <lanyusea@gmail.com> feat: guard urgent spawn refills from spending`
- Controller recovery was commit-only after prior Codex process disappeared with verified dirty worktree.
