### PR TITLE
feat: preserve territory follow-up through suppression

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1398,8 +1398,19 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
     if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
+    const followUp = getPersistedTerritoryIntentFollowUp(
+      intents,
+      target.colony,
+      target.roomName,
+      target.action
+    );
     const candidate = scoreTerritoryCandidate(
-      { target, intentAction: target.action, commitTarget: false },
+      {
+        target,
+        intentAction: target.action,
+        commitTarget: false,
+        ...followUp ? { followUp } : {}
+      },
       "configured",
       order,
       colonyName,
@@ -2054,10 +2065,23 @@ function upsertTerritoryIntent2(intents, nextIntent) {
     (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action
   );
   if (existingIndex >= 0) {
-    intents[existingIndex] = nextIntent;
+    const existingIntent = intents[existingIndex];
+    intents[existingIndex] = {
+      ...nextIntent,
+      ...!nextIntent.followUp && existingIntent.followUp ? { followUp: existingIntent.followUp } : {}
+    };
     return;
   }
   intents.push(nextIntent);
+}
+function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action) {
+  let selectedIntent = null;
+  for (const intent of intents) {
+    if (intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action && intent.followUp && (!selectedIntent || intent.updatedAt > selectedIntent.updatedAt)) {
+      selectedIntent = intent;
+    }
+  }
+  return selectedIntent == null ? void 0 : selectedIntent.followUp;
 }
 function normalizeTerritoryIntent2(rawIntent) {
   if (!isRecord2(rawIntent)) {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -526,8 +526,19 @@ function getConfiguredTerritoryCandidates(
       return [];
     }
 
+    const followUp = getPersistedTerritoryIntentFollowUp(
+      intents,
+      target.colony,
+      target.roomName,
+      target.action
+    );
     const candidate = scoreTerritoryCandidate(
-      { target, intentAction: target.action, commitTarget: false },
+      {
+        target,
+        intentAction: target.action,
+        commitTarget: false,
+        ...(followUp ? { followUp } : {})
+      },
       'configured',
       order,
       colonyName,
@@ -1549,11 +1560,37 @@ function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: Ter
   );
 
   if (existingIndex >= 0) {
-    intents[existingIndex] = nextIntent;
+    const existingIntent = intents[existingIndex];
+    intents[existingIndex] = {
+      ...nextIntent,
+      ...(!nextIntent.followUp && existingIntent.followUp ? { followUp: existingIntent.followUp } : {})
+    };
     return;
   }
 
   intents.push(nextIntent);
+}
+
+function getPersistedTerritoryIntentFollowUp(
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  targetRoom: string,
+  action: TerritoryIntentAction
+): TerritoryFollowUpMemory | undefined {
+  let selectedIntent: TerritoryIntentMemory | null = null;
+  for (const intent of intents) {
+    if (
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      intent.action === action &&
+      intent.followUp &&
+      (!selectedIntent || intent.updatedAt > selectedIntent.updatedAt)
+    ) {
+      selectedIntent = intent;
+    }
+  }
+
+  return selectedIntent?.followUp;
 }
 
 function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | null {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3,6 +3,7 @@ import {
   buildTerritoryCreepMemory,
   planTerritoryIntent,
   shouldSpawnTerritoryControllerCreep,
+  suppressTerritoryIntent,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
   TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
   TERRITORY_RESERVATION_RENEWAL_TICKS,
@@ -1961,6 +1962,88 @@ describe('planTerritoryIntent', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: 577,
+        followUp
+      }
+    ]);
+  });
+
+  it('preserves a visible adjacent reserve follow-up through suppression and retry', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const suppressionTime = 580;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const describeExits = jest.fn((roomName: string) => (roomName === 'W1N2' ? { '3': 'W2N2' } : {}));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        } as Room,
+        W2N2: { name: 'W2N2', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 579)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N2',
+      action: 'reserve',
+      followUp
+    });
+
+    suppressTerritoryIntent('W1N1', { targetRoom: 'W2N2', action: 'reserve' }, suppressionTime);
+
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: suppressionTime,
+        followUp
+      }
+    ]);
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, suppressionTime + 1)
+    ).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: suppressionTime,
+        followUp
+      }
+    ]);
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N2',
+      action: 'reserve',
+      followUp
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: retryTime,
         followUp
       }
     ]);


### PR DESCRIPTION
## Summary
- Preserve adjacent territory follow-up metadata when a temporary suppression/defer path replaces an existing territory intent.
- Reuse persisted follow-up metadata when retrying the configured visible adjacent controller opportunity after suppression clears.
- Add deterministic coverage for a visible adjacent reserve follow-up surviving suppression and retry; refresh `prod/dist/main.js`.

Closes #260.

## Verification
From `prod/` in `/root/screeps-worktrees/territory-followup-suppression-260`:
- `npm run typecheck`
- `npm test -- --runInBand` (19 suites, 388 tests)
- `npm run build`

## Scheduler evidence
- Codex-authored commit: `8aec7fa lanyusea's bot <lanyusea@gmail.com> feat: preserve territory follow-up through suppression`
- Controller recovery was commit-only after prior Codex process disappeared with verified dirty worktree.
