### PR TITLE
feat: expose follow-up demand to spawn planning

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1072,6 +1072,7 @@ var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
 var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 var TERRITORY_SUPPRESSION_RETRY_TICKS2 = 1500;
+var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
 var ERR_NO_PATH_CODE = -2;
@@ -1121,6 +1122,25 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
   }
   const activeCoverageCount = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action);
   return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount);
+}
+function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime2()) {
+  var _a;
+  if (!plan || !isTerritoryControlAction(plan.action)) {
+    return 0;
+  }
+  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
+    return 0;
+  }
+  if (getVisibleTerritoryTargetState(
+    plan.targetRoom,
+    plan.action,
+    plan.controllerId,
+    getVisibleColonyOwnerUsername(plan.colony)
+  ) !== "available") {
+    return 0;
+  }
+  const demand = getCurrentTerritoryFollowUpDemand(plan, gameTime);
+  return (_a = demand == null ? void 0 : demand.workerCount) != null ? _a : 0;
 }
 function buildTerritoryCreepMemory(plan) {
   return {
@@ -1247,6 +1267,7 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
     ...followUp ? { followUp } : {}
   };
   upsertTerritoryIntent2(intents, suppressedIntent);
+  removeTerritoryFollowUpDemand(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
 function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   if (getWorkerCapacity(roleCounts) < workerTarget) {
@@ -2053,6 +2074,7 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null) {
     ...plan.followUp ? { followUp: plan.followUp } : {}
   };
   upsertTerritoryIntent2(intents, nextIntent);
+  recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
 }
 function normalizeTerritoryIntents2(rawIntents) {
   return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
@@ -2083,6 +2105,66 @@ function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action
   }
   return selectedIntent == null ? void 0 : selectedIntent.followUp;
 }
+function recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime) {
+  const demands = pruneCurrentTerritoryFollowUpDemands(territoryMemory, gameTime);
+  if (!plan.followUp || !isTerritoryControlAction(plan.action)) {
+    return;
+  }
+  upsertTerritoryFollowUpDemand(demands, {
+    type: "followUpPreparation",
+    colony: plan.colony,
+    targetRoom: plan.targetRoom,
+    action: plan.action,
+    workerCount: TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND,
+    updatedAt: gameTime,
+    followUp: plan.followUp
+  });
+  territoryMemory.demands = demands;
+}
+function pruneCurrentTerritoryFollowUpDemands(territoryMemory, gameTime) {
+  const currentDemands = normalizeTerritoryFollowUpDemands(territoryMemory.demands).filter(
+    (demand) => demand.updatedAt === gameTime
+  );
+  if (currentDemands.length > 0) {
+    territoryMemory.demands = currentDemands;
+  } else {
+    delete territoryMemory.demands;
+  }
+  return currentDemands;
+}
+function upsertTerritoryFollowUpDemand(demands, nextDemand) {
+  const existingIndex = demands.findIndex(
+    (demand) => demand.type === nextDemand.type && demand.colony === nextDemand.colony && demand.targetRoom === nextDemand.targetRoom && demand.action === nextDemand.action
+  );
+  if (existingIndex >= 0) {
+    demands[existingIndex] = nextDemand;
+    return;
+  }
+  demands.push(nextDemand);
+}
+function removeTerritoryFollowUpDemand(territoryMemory, colony, targetRoom, action) {
+  if (!isTerritoryControlAction(action)) {
+    return;
+  }
+  const demands = normalizeTerritoryFollowUpDemands(territoryMemory.demands).filter(
+    (demand) => !(demand.colony === colony && demand.targetRoom === targetRoom && demand.action === action)
+  );
+  if (demands.length > 0) {
+    territoryMemory.demands = demands;
+  } else {
+    delete territoryMemory.demands;
+  }
+}
+function getCurrentTerritoryFollowUpDemand(plan, gameTime) {
+  var _a;
+  const territoryMemory = getTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return null;
+  }
+  return (_a = normalizeTerritoryFollowUpDemands(territoryMemory.demands).find(
+    (demand) => demand.updatedAt === gameTime && demand.colony === plan.colony && demand.targetRoom === plan.targetRoom && demand.action === plan.action
+  )) != null ? _a : null;
+}
 function normalizeTerritoryIntent2(rawIntent) {
   if (!isRecord2(rawIntent)) {
     return null;
@@ -2100,6 +2182,43 @@ function normalizeTerritoryIntent2(rawIntent) {
     ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
     ...followUp ? { followUp } : {}
   };
+}
+function normalizeTerritoryFollowUpDemands(rawDemands) {
+  return Array.isArray(rawDemands) ? rawDemands.flatMap((demand) => {
+    const normalizedDemand = normalizeTerritoryFollowUpDemand(demand);
+    return normalizedDemand ? [normalizedDemand] : [];
+  }) : [];
+}
+function normalizeTerritoryFollowUpDemand(rawDemand) {
+  if (!isRecord2(rawDemand)) {
+    return null;
+  }
+  if (rawDemand.type !== "followUpPreparation" || !isNonEmptyString2(rawDemand.colony) || !isNonEmptyString2(rawDemand.targetRoom) || !isTerritoryControlAction(rawDemand.action) || typeof rawDemand.updatedAt !== "number") {
+    return null;
+  }
+  const followUp = normalizeTerritoryFollowUp2(rawDemand.followUp);
+  const workerCount = getBoundedTerritoryFollowUpWorkerDemand(rawDemand.workerCount);
+  if (!followUp || workerCount <= 0) {
+    return null;
+  }
+  return {
+    type: "followUpPreparation",
+    colony: rawDemand.colony,
+    targetRoom: rawDemand.targetRoom,
+    action: rawDemand.action,
+    workerCount,
+    updatedAt: rawDemand.updatedAt,
+    followUp
+  };
+}
+function getBoundedTerritoryFollowUpWorkerDemand(rawWorkerCount) {
+  if (typeof rawWorkerCount !== "number") {
+    return TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND;
+  }
+  if (!Number.isFinite(rawWorkerCount)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND, Math.floor(rawWorkerCount)));
 }
 function normalizeTerritoryFollowUp2(rawFollowUp) {
   if (!isRecord2(rawFollowUp)) {
@@ -3582,18 +3701,24 @@ function planSpawn(colony, roleCounts, gameTime, options = {}) {
     return null;
   }
   const territoryWorkerTarget = shouldPlanWorkerRecovery ? workerTarget - 1 : workerTarget;
-  const territorySpawn = planTerritorySpawn(colony, roleCounts, territoryWorkerTarget, gameTime, options);
-  if (territorySpawn) {
-    return territorySpawn;
+  const territoryIntent = planTerritoryIntent(colony, roleCounts, territoryWorkerTarget, gameTime);
+  if (territoryIntent) {
+    const demandedWorkerTarget = getWorkerTargetWithTerritoryDemand(workerTarget, territoryIntent, gameTime);
+    if (workerCapacity < demandedWorkerTarget) {
+      return planWorkerSpawn(colony, roleCounts, gameTime, options);
+    }
+    const territorySpawn = planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, options);
+    if (territorySpawn) {
+      return territorySpawn;
+    }
   }
   if (shouldPlanWorkerRecovery) {
     return planWorkerSpawn(colony, roleCounts, gameTime, options);
   }
   return null;
 }
-function planTerritorySpawn(colony, roleCounts, workerTarget, gameTime, options) {
-  const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
-  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
+function planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, options) {
+  if (!shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
     return null;
   }
   const spawn = colony.spawns.find((candidate) => !candidate.spawning);
@@ -3611,6 +3736,10 @@ function planTerritorySpawn(colony, roleCounts, workerTarget, gameTime, options)
     name: appendSpawnNameSuffix(`${roleName}-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`, options),
     memory: buildTerritoryCreepMemory(territoryIntent)
   };
+}
+function getWorkerTargetWithTerritoryDemand(workerTarget, territoryIntent, gameTime) {
+  const demandWorkerCount = getTerritoryFollowUpPreparationWorkerDemand(territoryIntent, gameTime);
+  return Math.min(MAX_WORKER_TARGET + TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND, workerTarget + demandWorkerCount);
 }
 function planWorkerSpawn(colony, roleCounts, gameTime, options) {
   const spawn = colony.spawns.find((candidate) => !candidate.spawning);

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -8,9 +8,12 @@ import {
 } from './bodyBuilder';
 import {
   buildTerritoryCreepMemory,
+  getTerritoryFollowUpPreparationWorkerDemand,
   planTerritoryIntent,
   shouldSpawnTerritoryControllerCreep,
-  TERRITORY_DOWNGRADE_GUARD_TICKS
+  TERRITORY_DOWNGRADE_GUARD_TICKS,
+  TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND,
+  type TerritoryIntentPlan
 } from '../territory/territoryPlanner';
 
 export interface SpawnRequest {
@@ -55,9 +58,17 @@ export function planSpawn(
   }
 
   const territoryWorkerTarget = shouldPlanWorkerRecovery ? workerTarget - 1 : workerTarget;
-  const territorySpawn = planTerritorySpawn(colony, roleCounts, territoryWorkerTarget, gameTime, options);
-  if (territorySpawn) {
-    return territorySpawn;
+  const territoryIntent = planTerritoryIntent(colony, roleCounts, territoryWorkerTarget, gameTime);
+  if (territoryIntent) {
+    const demandedWorkerTarget = getWorkerTargetWithTerritoryDemand(workerTarget, territoryIntent, gameTime);
+    if (workerCapacity < demandedWorkerTarget) {
+      return planWorkerSpawn(colony, roleCounts, gameTime, options);
+    }
+
+    const territorySpawn = planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, options);
+    if (territorySpawn) {
+      return territorySpawn;
+    }
   }
 
   if (shouldPlanWorkerRecovery) {
@@ -70,12 +81,11 @@ export function planSpawn(
 function planTerritorySpawn(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
-  workerTarget: number,
+  territoryIntent: TerritoryIntentPlan,
   gameTime: number,
   options: SpawnPlanningOptions
 ): SpawnRequest | null {
-  const territoryIntent = planTerritoryIntent(colony, roleCounts, workerTarget, gameTime);
-  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
+  if (!shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
     return null;
   }
 
@@ -96,6 +106,15 @@ function planTerritorySpawn(
     name: appendSpawnNameSuffix(`${roleName}-${colony.room.name}-${territoryIntent.targetRoom}-${gameTime}`, options),
     memory: buildTerritoryCreepMemory(territoryIntent)
   };
+}
+
+function getWorkerTargetWithTerritoryDemand(
+  workerTarget: number,
+  territoryIntent: TerritoryIntentPlan,
+  gameTime: number
+): number {
+  const demandWorkerCount = getTerritoryFollowUpPreparationWorkerDemand(territoryIntent, gameTime);
+  return Math.min(MAX_WORKER_TARGET + TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND, workerTarget + demandWorkerCount);
 }
 
 function planWorkerSpawn(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -16,6 +16,7 @@ export const TERRITORY_RESERVATION_RENEWAL_TICKS = 1_000;
 export const TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 export const TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
+export const TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 
 const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
 const MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
@@ -131,6 +132,33 @@ export function shouldSpawnTerritoryControllerCreep(
   return (
     activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount)
   );
+}
+
+export function getTerritoryFollowUpPreparationWorkerDemand(
+  plan: TerritoryIntentPlan | null,
+  gameTime = getGameTime()
+): number {
+  if (!plan || !isTerritoryControlAction(plan.action)) {
+    return 0;
+  }
+
+  if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
+    return 0;
+  }
+
+  if (
+    getVisibleTerritoryTargetState(
+      plan.targetRoom,
+      plan.action,
+      plan.controllerId,
+      getVisibleColonyOwnerUsername(plan.colony)
+    ) !== 'available'
+  ) {
+    return 0;
+  }
+
+  const demand = getCurrentTerritoryFollowUpDemand(plan, gameTime);
+  return demand?.workerCount ?? 0;
 }
 
 export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemory {
@@ -316,6 +344,7 @@ export function suppressTerritoryIntent(
   };
 
   upsertTerritoryIntent(intents, suppressedIntent);
+  removeTerritoryFollowUpDemand(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
 
 export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {
@@ -1540,6 +1569,7 @@ function recordTerritoryIntent(
   };
 
   upsertTerritoryIntent(intents, nextIntent);
+  recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
 }
 
 function normalizeTerritoryIntents(rawIntents: TerritoryMemory['intents'] | unknown): TerritoryIntentMemory[] {
@@ -1593,6 +1623,104 @@ function getPersistedTerritoryIntentFollowUp(
   return selectedIntent?.followUp;
 }
 
+function recordTerritoryFollowUpDemand(
+  territoryMemory: TerritoryMemory,
+  plan: TerritoryIntentPlan,
+  gameTime: number
+): void {
+  const demands = pruneCurrentTerritoryFollowUpDemands(territoryMemory, gameTime);
+  if (!plan.followUp || !isTerritoryControlAction(plan.action)) {
+    return;
+  }
+
+  upsertTerritoryFollowUpDemand(demands, {
+    type: 'followUpPreparation',
+    colony: plan.colony,
+    targetRoom: plan.targetRoom,
+    action: plan.action,
+    workerCount: TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND,
+    updatedAt: gameTime,
+    followUp: plan.followUp
+  });
+  territoryMemory.demands = demands;
+}
+
+function pruneCurrentTerritoryFollowUpDemands(
+  territoryMemory: TerritoryMemory,
+  gameTime: number
+): TerritoryFollowUpDemandMemory[] {
+  const currentDemands = normalizeTerritoryFollowUpDemands(territoryMemory.demands).filter(
+    (demand) => demand.updatedAt === gameTime
+  );
+  if (currentDemands.length > 0) {
+    territoryMemory.demands = currentDemands;
+  } else {
+    delete territoryMemory.demands;
+  }
+
+  return currentDemands;
+}
+
+function upsertTerritoryFollowUpDemand(
+  demands: TerritoryFollowUpDemandMemory[],
+  nextDemand: TerritoryFollowUpDemandMemory
+): void {
+  const existingIndex = demands.findIndex(
+    (demand) =>
+      demand.type === nextDemand.type &&
+      demand.colony === nextDemand.colony &&
+      demand.targetRoom === nextDemand.targetRoom &&
+      demand.action === nextDemand.action
+  );
+
+  if (existingIndex >= 0) {
+    demands[existingIndex] = nextDemand;
+    return;
+  }
+
+  demands.push(nextDemand);
+}
+
+function removeTerritoryFollowUpDemand(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  targetRoom: string,
+  action: TerritoryIntentAction
+): void {
+  if (!isTerritoryControlAction(action)) {
+    return;
+  }
+
+  const demands = normalizeTerritoryFollowUpDemands(territoryMemory.demands).filter(
+    (demand) => !(demand.colony === colony && demand.targetRoom === targetRoom && demand.action === action)
+  );
+  if (demands.length > 0) {
+    territoryMemory.demands = demands;
+  } else {
+    delete territoryMemory.demands;
+  }
+}
+
+function getCurrentTerritoryFollowUpDemand(
+  plan: TerritoryIntentPlan,
+  gameTime: number
+): TerritoryFollowUpDemandMemory | null {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return null;
+  }
+
+  return (
+    normalizeTerritoryFollowUpDemands(territoryMemory.demands).find(
+      (demand) =>
+        demand.updatedAt === gameTime &&
+        demand.colony === plan.colony &&
+        demand.targetRoom === plan.targetRoom &&
+        demand.action === plan.action
+    ) ?? null
+  );
+}
+
 function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | null {
   if (!isRecord(rawIntent)) {
     return null;
@@ -1620,6 +1748,59 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
       : {}),
     ...(followUp ? { followUp } : {})
   };
+}
+
+function normalizeTerritoryFollowUpDemands(rawDemands: unknown): TerritoryFollowUpDemandMemory[] {
+  return Array.isArray(rawDemands)
+    ? rawDemands.flatMap((demand) => {
+        const normalizedDemand = normalizeTerritoryFollowUpDemand(demand);
+        return normalizedDemand ? [normalizedDemand] : [];
+      })
+    : [];
+}
+
+function normalizeTerritoryFollowUpDemand(rawDemand: unknown): TerritoryFollowUpDemandMemory | null {
+  if (!isRecord(rawDemand)) {
+    return null;
+  }
+
+  if (
+    rawDemand.type !== 'followUpPreparation' ||
+    !isNonEmptyString(rawDemand.colony) ||
+    !isNonEmptyString(rawDemand.targetRoom) ||
+    !isTerritoryControlAction(rawDemand.action) ||
+    typeof rawDemand.updatedAt !== 'number'
+  ) {
+    return null;
+  }
+
+  const followUp = normalizeTerritoryFollowUp(rawDemand.followUp);
+  const workerCount = getBoundedTerritoryFollowUpWorkerDemand(rawDemand.workerCount);
+  if (!followUp || workerCount <= 0) {
+    return null;
+  }
+
+  return {
+    type: 'followUpPreparation',
+    colony: rawDemand.colony,
+    targetRoom: rawDemand.targetRoom,
+    action: rawDemand.action,
+    workerCount,
+    updatedAt: rawDemand.updatedAt,
+    followUp
+  };
+}
+
+function getBoundedTerritoryFollowUpWorkerDemand(rawWorkerCount: unknown): number {
+  if (typeof rawWorkerCount !== 'number') {
+    return TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND;
+  }
+
+  if (!Number.isFinite(rawWorkerCount)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND, Math.floor(rawWorkerCount)));
 }
 
 function normalizeTerritoryFollowUp(rawFollowUp: unknown): TerritoryFollowUpMemory | null {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -17,11 +17,13 @@ declare global {
 
   type TerritoryControlAction = 'claim' | 'reserve';
   type TerritoryIntentAction = TerritoryControlAction | 'scout';
+  type TerritoryDemandType = 'followUpPreparation';
   type TerritoryFollowUpSource = 'satisfiedClaimAdjacent' | 'satisfiedReserveAdjacent' | 'activeReserveAdjacent';
 
   interface TerritoryMemory {
     targets?: TerritoryTargetMemory[];
     intents?: TerritoryIntentMemory[];
+    demands?: TerritoryFollowUpDemandMemory[];
     routeDistances?: Record<string, number | null>;
   }
 
@@ -47,6 +49,16 @@ declare global {
     source: TerritoryFollowUpSource;
     originRoom: string;
     originAction: TerritoryControlAction;
+  }
+
+  interface TerritoryFollowUpDemandMemory {
+    type: TerritoryDemandType;
+    colony: string;
+    targetRoom: string;
+    action: TerritoryControlAction;
+    workerCount: number;
+    updatedAt: number;
+    followUp: TerritoryFollowUpMemory;
   }
 
   interface CreepTerritoryMemory {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -379,7 +379,7 @@ describe('planSpawn', () => {
     ]);
   });
 
-  it('plans a near-target reserver from a persisted occupation reserve intent with follow-up metadata', () => {
+  it('uses a selected follow-up demand to plan one support worker before a reserver', () => {
     const followUp: TerritoryFollowUpMemory = {
       source: 'activeReserveAdjacent',
       originRoom: 'W1N2',
@@ -410,7 +410,67 @@ describe('planSpawn', () => {
       }
     };
 
-    expect(planSpawn(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 155)).toEqual({
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 155)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      name: 'worker-W1N1-155',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: 155,
+        followUp
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 155,
+        followUp
+      }
+    ]);
+  });
+
+  it('plans a reserver from a persisted follow-up intent once support demand is satisfied', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'activeReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N2: makeTerritoryRoom('W2N2', { my: false } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N2',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 154,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 4, claimer: 0, claimersByTargetRoom: {} }, 155)).toEqual({
       spawn,
       body: ['claim', 'move'],
       name: 'claimer-W1N1-W2N2-155',
@@ -426,6 +486,17 @@ describe('planSpawn', () => {
         targetRoom: 'W2N2',
         action: 'reserve',
         status: 'planned',
+        updatedAt: 155,
+        followUp
+      }
+    ]);
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        workerCount: 1,
         updatedAt: 155,
         followUp
       }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1909,6 +1909,129 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('records one bounded preparation demand for a selected visible follow-up target per planning window', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const describeExits = jest.fn((roomName: string) => (roomName === 'W1N2' ? { '3': 'W2N2' } : {}));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        } as Room,
+        W2N2: { name: 'W2N2', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 590)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N2',
+      action: 'reserve',
+      followUp
+    });
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 590)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N2',
+      action: 'reserve',
+      followUp
+    });
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: 590,
+        followUp
+      }
+    ]);
+  });
+
+  it('does not record a preparation demand for a suppressed follow-up target', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const suppressedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N2',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: 591
+    };
+    const describeExits = jest.fn((roomName: string) => (roomName === 'W1N2' ? { '3': 'W2N2' } : {}));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        } as Room,
+        W2N2: { name: 'W2N2', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget],
+        intents: [suppressedIntent]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 592)).toBeNull();
+    expect(Memory.territory?.demands).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([suppressedIntent]);
+  });
+
+  it('does not record a preparation demand for an unavailable follow-up target', () => {
+    const colony = makeSafeColony();
+    const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const describeExits = jest.fn((roomName: string) => (roomName === 'W1N2' ? { '3': 'W2N2' } : {}));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        } as Room,
+        W2N2: {
+          name: 'W2N2',
+          controller: { my: false, owner: { username: 'enemy' } } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [configuredTarget]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 593)).toBeNull();
+    expect(Memory.territory?.demands).toBeUndefined();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
   it('prefers a visible adjacent reserve follow-up over a lower-confidence distant reserve', () => {
     const colony = makeSafeColony();
     const distantTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W9N1', action: 'reserve' };


### PR DESCRIPTION
## Summary
- Expose selected territory follow-up preparation demand through territory memory.
- Let spawn planning create one support worker before spawning the follow-up reserver/claimer when demand is not yet satisfied.
- Add regression coverage for bounded demand recording, suppression/unavailable filtering, and spawn planner behavior; refresh `prod/dist/main.js`.

Closes #268.

## Verification
From `prod/` in `/root/screeps-worktrees/territory-followup-demand-268`:
- `npm run typecheck`
- `npm test -- --runInBand` (19 suites, 392 tests)
- `npm run build`
- `git diff --check`

## Scheduler evidence
- Codex-authored implementation commit: `ad85933 lanyusea's bot <lanyusea@gmail.com> feat: expose follow-up demand to spawn planning`
- Branch reconciled with current `origin/main` (`e0b00b6`) and merge commit author repaired by Codex: `28b92ce lanyusea's bot <lanyusea@gmail.com>`.
- Transient `.git-local/` and `prod/node_modules` were left untracked and excluded.