### PR TITLE
feat: prefer recovered territory follow-up intents

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1398,18 +1398,20 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
     if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
-    const followUp = getPersistedTerritoryIntentFollowUp(
+    const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
       intents,
       target.colony,
       target.roomName,
-      target.action
+      target.action,
+      gameTime
     );
     const candidate = scoreTerritoryCandidate(
       {
         target,
         intentAction: target.action,
         commitTarget: false,
-        ...followUp ? { followUp } : {}
+        ...persistedFollowUp ? { followUp: persistedFollowUp.followUp } : {},
+        ...(persistedFollowUp == null ? void 0 : persistedFollowUp.recovered) ? { recoveredFollowUp: true } : {}
       },
       "configured",
       order,
@@ -1424,7 +1426,8 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
   const seenIntentKeys = /* @__PURE__ */ new Set();
   const configuredTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return intents.flatMap((intent, order) => {
-    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || intent.status !== "planned" && intent.status !== "active" || !isTerritoryControlAction(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || getVisibleTerritoryTargetState(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername) !== "available") {
+    const recoveredFollowUp = isRecoveredTerritoryFollowUpIntent(intent, gameTime);
+    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || getVisibleTerritoryTargetState(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
     const intentKey = `${intent.targetRoom}:${intent.action}`;
@@ -1443,7 +1446,8 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
         target,
         intentAction: intent.action,
         commitTarget: false,
-        ...intent.followUp ? { followUp: intent.followUp } : {}
+        ...intent.followUp ? { followUp: intent.followUp } : {},
+        ...recoveredFollowUp ? { recoveredFollowUp: true } : {}
       },
       "occupationIntent",
       order,
@@ -1843,7 +1847,13 @@ function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
 }
 function compareTerritoryCandidates(left, right) {
-  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || compareRecoveredFollowUpPreference(left, right) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+}
+function compareRecoveredFollowUpPreference(left, right) {
+  if (left.recoveredFollowUp === right.recoveredFollowUp) {
+    return 0;
+  }
+  return left.recoveredFollowUp ? -1 : 1;
 }
 function compareVisibleAdjacentFollowUpPreference(left, right) {
   if (shouldPreferVisibleAdjacentFollowUp(left, right)) {
@@ -2074,14 +2084,20 @@ function upsertTerritoryIntent2(intents, nextIntent) {
   }
   intents.push(nextIntent);
 }
-function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action) {
+function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action, gameTime) {
   let selectedIntent = null;
   for (const intent of intents) {
     if (intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action && intent.followUp && (!selectedIntent || intent.updatedAt > selectedIntent.updatedAt)) {
       selectedIntent = intent;
     }
   }
-  return selectedIntent == null ? void 0 : selectedIntent.followUp;
+  if (!(selectedIntent == null ? void 0 : selectedIntent.followUp)) {
+    return null;
+  }
+  return {
+    followUp: selectedIntent.followUp,
+    recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime)
+  };
 }
 function normalizeTerritoryIntent2(rawIntent) {
   if (!isRecord2(rawIntent)) {
@@ -2148,6 +2164,9 @@ function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getG
 }
 function isTerritorySuppressionFresh2(intent, gameTime) {
   return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS2;
+}
+function isRecoveredTerritoryFollowUpIntent(intent, gameTime) {
+  return intent.followUp !== void 0 && intent.status === "suppressed" && gameTime - intent.updatedAt > TERRITORY_SUPPRESSION_RETRY_TICKS2;
 }
 function selectVisibleTerritoryControllerIntent(creep) {
   var _a, _b, _c;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -47,6 +47,7 @@ interface SelectedTerritoryTarget {
   intentAction: TerritoryIntentAction;
   commitTarget: boolean;
   followUp?: TerritoryFollowUpMemory;
+  recoveredFollowUp?: boolean;
 }
 
 type TerritoryCandidateSource =
@@ -72,6 +73,11 @@ type TerritoryTargetVisibilityState = 'available' | 'satisfied' | 'unavailable';
 
 interface RouteDistanceLookupContext {
   revalidatedNoRouteCacheKeys: Set<string>;
+}
+
+interface PersistedTerritoryIntentFollowUp {
+  followUp: TerritoryFollowUpMemory;
+  recovered: boolean;
 }
 
 export function planTerritoryIntent(
@@ -526,18 +532,20 @@ function getConfiguredTerritoryCandidates(
       return [];
     }
 
-    const followUp = getPersistedTerritoryIntentFollowUp(
+    const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
       intents,
       target.colony,
       target.roomName,
-      target.action
+      target.action,
+      gameTime
     );
     const candidate = scoreTerritoryCandidate(
       {
         target,
         intentAction: target.action,
         commitTarget: false,
-        ...(followUp ? { followUp } : {})
+        ...(persistedFollowUp ? { followUp: persistedFollowUp.followUp } : {}),
+        ...(persistedFollowUp?.recovered ? { recoveredFollowUp: true } : {})
       },
       'configured',
       order,
@@ -560,11 +568,12 @@ function getPersistedTerritoryIntentCandidates(
   const seenIntentKeys = new Set<string>();
   const configuredTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return intents.flatMap((intent, order) => {
+    const recoveredFollowUp = isRecoveredTerritoryFollowUpIntent(intent, gameTime);
     if (
       intent.colony !== colonyName ||
       intent.targetRoom === colonyName ||
       configuredTargetRooms.has(intent.targetRoom) ||
-      (intent.status !== 'planned' && intent.status !== 'active') ||
+      (intent.status !== 'planned' && intent.status !== 'active' && !recoveredFollowUp) ||
       !isTerritoryControlAction(intent.action) ||
       isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) ||
       getVisibleTerritoryTargetState(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername) !==
@@ -590,7 +599,8 @@ function getPersistedTerritoryIntentCandidates(
         target,
         intentAction: intent.action,
         commitTarget: false,
-        ...(intent.followUp ? { followUp: intent.followUp } : {})
+        ...(intent.followUp ? { followUp: intent.followUp } : {}),
+        ...(recoveredFollowUp ? { recoveredFollowUp: true } : {})
       },
       'occupationIntent',
       order,
@@ -1219,10 +1229,19 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
     getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) ||
     compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) ||
     compareOptionalNumbers(left.occupationActionableTicks, right.occupationActionableTicks) ||
+    compareRecoveredFollowUpPreference(left, right) ||
     left.order - right.order ||
     left.target.roomName.localeCompare(right.target.roomName) ||
     left.intentAction.localeCompare(right.intentAction)
   );
+}
+
+function compareRecoveredFollowUpPreference(left: ScoredTerritoryTarget, right: ScoredTerritoryTarget): number {
+  if (left.recoveredFollowUp === right.recoveredFollowUp) {
+    return 0;
+  }
+
+  return left.recoveredFollowUp ? -1 : 1;
 }
 
 function compareVisibleAdjacentFollowUpPreference(
@@ -1575,8 +1594,9 @@ function getPersistedTerritoryIntentFollowUp(
   intents: TerritoryIntentMemory[],
   colony: string,
   targetRoom: string,
-  action: TerritoryIntentAction
-): TerritoryFollowUpMemory | undefined {
+  action: TerritoryIntentAction,
+  gameTime: number
+): PersistedTerritoryIntentFollowUp | null {
   let selectedIntent: TerritoryIntentMemory | null = null;
   for (const intent of intents) {
     if (
@@ -1590,7 +1610,14 @@ function getPersistedTerritoryIntentFollowUp(
     }
   }
 
-  return selectedIntent?.followUp;
+  if (!selectedIntent?.followUp) {
+    return null;
+  }
+
+  return {
+    followUp: selectedIntent.followUp,
+    recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime)
+  };
 }
 
 function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | null {
@@ -1706,6 +1733,14 @@ function isTerritoryIntentSuppressed(
 
 function isTerritorySuppressionFresh(intent: TerritoryIntentMemory, gameTime: number): boolean {
   return intent.status === 'suppressed' && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
+}
+
+function isRecoveredTerritoryFollowUpIntent(intent: TerritoryIntentMemory, gameTime: number): boolean {
+  return (
+    intent.followUp !== undefined &&
+    intent.status === 'suppressed' &&
+    gameTime - intent.updatedAt > TERRITORY_SUPPRESSION_RETRY_TICKS
+  );
 }
 
 function selectVisibleTerritoryControllerIntent(creep: Creep): TerritoryIntentMemory | null {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2049,6 +2049,79 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('prefers a recovered follow-up intent over an equivalent generic configured target after suppression retry', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const recoveredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const suppressionTime = 581;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const suppressedFollowUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: suppressionTime,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1'),
+        W3N1: makeRecommendationRoom('W3N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, recoveredTarget],
+        intents: [suppressedFollowUpIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, suppressionTime + 1)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      suppressedFollowUpIntent,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: suppressionTime + 1
+      }
+    ]);
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      followUp
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: retryTime,
+        followUp
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: suppressionTime + 1
+      }
+    ]);
+  });
+
   it('keeps a stronger visible configured reserve before adjacent follow-up expansion', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W9N1', action: 'reserve' };


### PR DESCRIPTION
## Summary
- Prefer recovered territory follow-up intents deterministically after suppression clears.
- Preserve existing unavailable/hostile/owned-room safety filtering while giving eligible follow-up candidates a bounded selection boost.
- Add territory planner regression coverage and refresh `prod/dist/main.js`.

Closes #264.

## Verification
From `prod/` in `/root/screeps-worktrees/territory-followup-ready-264` after reconciling with current `origin/main`:
- `npm run typecheck`
- `npm test -- --runInBand` (19 suites, 396 tests)
- `npm run build`
- `git diff --check`

## Scheduler evidence
- Recovered useful dirty Codex edits from the prior issue #264 worktree after its Codex process was no longer active.
- Reconciled branch with current `origin/main` (`86ce143`) before verification.
- Codex-authored commit: `a06f177 lanyusea's bot <lanyusea@gmail.com> feat: prefer recovered territory follow-up intents`.
- Untracked `prod/node_modules` symlink is dependency infrastructure and was excluded.
