### PR TITLE
feat: cool down recovered follow-up retries

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -595,6 +595,7 @@ var MIN_READY_WORKERS = 3;
 var DOWNGRADE_GUARD_TICKS = 5e3;
 var RESERVATION_RENEWAL_TICKS = 1e3;
 var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
+var TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR = ">";
 var ACTION_SCORE = {
   occupy: 1e3,
@@ -623,7 +624,7 @@ function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGam
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const existingIntent = intents.find((intent) => isSameTerritoryIntent(intent, followUpIntent));
-  if (existingIntent && isTerritorySuppressionFresh(existingIntent, gameTime)) {
+  if (existingIntent && (isTerritorySuppressionFresh(existingIntent, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDown(existingIntent, gameTime) || isRecoveredTerritoryFollowUpRetryPending(existingIntent))) {
     return null;
   }
   const controllerId = (_a = followUpIntent.controllerId) != null ? _a : existingIntent == null ? void 0 : existingIntent.controllerId;
@@ -1013,6 +1014,7 @@ function normalizeTerritoryIntent(rawIntent) {
     action: rawIntent.action,
     status: rawIntent.status,
     updatedAt: rawIntent.updatedAt,
+    ...followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
     ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
     ...followUp ? { followUp } : {}
   };
@@ -1048,6 +1050,12 @@ function isSameTerritoryIntent(intent, followUpIntent) {
 function isTerritorySuppressionFresh(intent, gameTime) {
   return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
 }
+function isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime) {
+  return intent.followUp !== void 0 && isFiniteNumber(intent.lastAttemptAt) && gameTime >= intent.lastAttemptAt && gameTime - intent.lastAttemptAt <= TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS;
+}
+function isRecoveredTerritoryFollowUpRetryPending(intent) {
+  return intent.followUp !== void 0 && intent.status === "suppressed" && isFiniteNumber(intent.lastAttemptAt);
+}
 function isTerritoryIntentAction(action) {
   return action === "claim" || action === "reserve" || action === "scout";
 }
@@ -1063,6 +1071,9 @@ function isRecord(value) {
 function isNonEmptyString(value) {
   return typeof value === "string" && value.length > 0;
 }
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
 
 // src/territory/territoryPlanner.ts
 var TERRITORY_CLAIMER_ROLE = "claimer";
@@ -1072,6 +1083,7 @@ var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
 var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 var TERRITORY_SUPPRESSION_RETRY_TICKS2 = 1500;
+var TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS2 = 50;
 var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
@@ -1085,6 +1097,7 @@ var TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
 var MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR2 = ">";
 var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
+var recoveredTerritoryFollowUpRetryMetadata = /* @__PURE__ */ new WeakMap();
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
@@ -1101,9 +1114,42 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
     ...target.controllerId ? { controllerId: target.controllerId } : {},
     ...selection.followUp ? { followUp: selection.followUp } : {}
   };
+  if (selection.recoveredFollowUp === true && typeof selection.recoveredFollowUpSuppressedAt === "number") {
+    recoveredTerritoryFollowUpRetryMetadata.set(plan, { suppressedAt: selection.recoveredFollowUpSuppressedAt });
+  }
   const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? "active" : "planned";
   recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
   return plan;
+}
+function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime2()) {
+  if (!plan || !plan.followUp || !isTerritoryControlAction(plan.action)) {
+    return;
+  }
+  const recoveredFollowUpMetadata = recoveredTerritoryFollowUpRetryMetadata.get(plan);
+  if (!recoveredFollowUpMetadata) {
+    return;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return;
+  }
+  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIndex = intents.findIndex(
+    (intent) => intent.colony === plan.colony && intent.targetRoom === plan.targetRoom && intent.action === plan.action
+  );
+  if (existingIndex < 0) {
+    return;
+  }
+  const existingIntent = intents[existingIndex];
+  intents[existingIndex] = {
+    ...existingIntent,
+    status: "suppressed",
+    updatedAt: recoveredFollowUpMetadata.suppressedAt,
+    followUp: plan.followUp,
+    lastAttemptAt: gameTime
+  };
+  removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
 }
 function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime2()) {
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
@@ -1391,7 +1437,9 @@ function toSelectedTerritoryTarget(candidate) {
     target: candidate.target,
     intentAction: candidate.intentAction,
     commitTarget: candidate.commitTarget,
-    ...candidate.followUp ? { followUp: candidate.followUp } : {}
+    ...candidate.followUp ? { followUp: candidate.followUp } : {},
+    ...candidate.recoveredFollowUp ? { recoveredFollowUp: true } : {},
+    ...typeof candidate.recoveredFollowUpSuppressedAt === "number" ? { recoveredFollowUpSuppressedAt: candidate.recoveredFollowUpSuppressedAt } : {}
   } : null;
 }
 function shouldEvaluateVisibleAdjacentFollowUpPreference(candidate) {
@@ -1426,13 +1474,17 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
       target.action,
       gameTime
     );
+    if (persistedFollowUp == null ? void 0 : persistedFollowUp.coolingDown) {
+      return [];
+    }
     const candidate = scoreTerritoryCandidate(
       {
         target,
         intentAction: target.action,
         commitTarget: false,
         ...persistedFollowUp ? { followUp: persistedFollowUp.followUp } : {},
-        ...(persistedFollowUp == null ? void 0 : persistedFollowUp.recovered) ? { recoveredFollowUp: true } : {}
+        ...(persistedFollowUp == null ? void 0 : persistedFollowUp.recovered) ? { recoveredFollowUp: true } : {},
+        ...typeof (persistedFollowUp == null ? void 0 : persistedFollowUp.suppressedAt) === "number" ? { recoveredFollowUpSuppressedAt: persistedFollowUp.suppressedAt } : {}
       },
       "configured",
       order,
@@ -1448,7 +1500,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
   const configuredTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return intents.flatMap((intent, order) => {
     const recoveredFollowUp = isRecoveredTerritoryFollowUpIntent(intent, gameTime);
-    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || getVisibleTerritoryTargetState(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername) !== "available") {
+    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || getVisibleTerritoryTargetState(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
     const intentKey = `${intent.targetRoom}:${intent.action}`;
@@ -1468,7 +1520,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
         intentAction: intent.action,
         commitTarget: false,
         ...intent.followUp ? { followUp: intent.followUp } : {},
-        ...recoveredFollowUp ? { recoveredFollowUp: true } : {}
+        ...recoveredFollowUp ? { recoveredFollowUp: true, recoveredFollowUpSuppressedAt: intent.updatedAt } : {}
       },
       "occupationIntent",
       order,
@@ -1508,7 +1560,7 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return adjacentRooms.flatMap((roomName, order) => {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName === colonyName || existingTargetRooms.has(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime)) {
+    if (roomName === colonyName || existingTargetRooms.has(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
       return [];
     }
     const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
@@ -2118,7 +2170,9 @@ function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action
   }
   return {
     followUp: selectedIntent.followUp,
-    recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime)
+    recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime),
+    coolingDown: isRecoveredTerritoryFollowUpAttemptCoolingDown2(selectedIntent, gameTime),
+    ...selectedIntent.status === "suppressed" ? { suppressedAt: selectedIntent.updatedAt } : {}
   };
 }
 function recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime) {
@@ -2195,6 +2249,7 @@ function normalizeTerritoryIntent2(rawIntent) {
     action: rawIntent.action,
     status: rawIntent.status,
     updatedAt: rawIntent.updatedAt,
+    ...followUp && isFiniteNumber2(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
     ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
     ...followUp ? { followUp } : {}
   };
@@ -2285,7 +2340,18 @@ function isTerritorySuppressionFresh2(intent, gameTime) {
   return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS2;
 }
 function isRecoveredTerritoryFollowUpIntent(intent, gameTime) {
-  return intent.followUp !== void 0 && intent.status === "suppressed" && gameTime - intent.updatedAt > TERRITORY_SUPPRESSION_RETRY_TICKS2;
+  if (intent.followUp === void 0 || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime)) {
+    return false;
+  }
+  return intent.status === "suppressed" && gameTime - intent.updatedAt > TERRITORY_SUPPRESSION_RETRY_TICKS2;
+}
+function isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) {
+  return intent.followUp !== void 0 && isFiniteNumber2(intent.lastAttemptAt) && gameTime >= intent.lastAttemptAt && gameTime - intent.lastAttemptAt <= TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS2;
+}
+function isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colony, targetRoom, action, gameTime) {
+  return intents.some(
+    (intent) => intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action && isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime)
+  );
 }
 function selectVisibleTerritoryControllerIntent(creep) {
   var _a, _b, _c;
@@ -2588,6 +2654,9 @@ function isTerritoryIntentStatus2(status) {
 }
 function isNonEmptyString2(value) {
   return typeof value === "string" && value.length > 0;
+}
+function isFiniteNumber2(value) {
+  return typeof value === "number" && Number.isFinite(value);
 }
 function isRecord2(value) {
   return typeof value === "object" && value !== null;
@@ -3747,7 +3816,12 @@ function planSpawn(colony, roleCounts, gameTime, options = {}) {
   if (territoryIntent) {
     const demandedWorkerTarget = getWorkerTargetWithTerritoryDemand(workerTarget, territoryIntent, gameTime);
     if (workerCapacity < demandedWorkerTarget) {
-      return planWorkerSpawn(colony, roleCounts, gameTime, options);
+      const workerSpawn = planWorkerSpawn(colony, roleCounts, gameTime, options);
+      if (workerSpawn) {
+        return workerSpawn;
+      }
+      recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
+      return null;
     }
     const territorySpawn = planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, options);
     if (territorySpawn) {
@@ -3755,8 +3829,12 @@ function planSpawn(colony, roleCounts, gameTime, options = {}) {
     }
   }
   if (shouldPlanWorkerRecovery) {
-    return planWorkerSpawn(colony, roleCounts, gameTime, options);
+    const workerSpawn = planWorkerSpawn(colony, roleCounts, gameTime, options);
+    if (workerSpawn) {
+      return workerSpawn;
+    }
   }
+  recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
   return null;
 }
 function planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, options) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3841,7 +3841,7 @@ function planSpawn(colony, roleCounts, gameTime, options = {}) {
       if (workerSpawn) {
         return workerSpawn;
       }
-      recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
+      recordRecoveredFollowUpCooldownIfControllerCreepNeeded(territoryIntent, roleCounts, gameTime);
       return null;
     }
     const territorySpawn = planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, options);
@@ -3855,8 +3855,14 @@ function planSpawn(colony, roleCounts, gameTime, options = {}) {
       return workerSpawn;
     }
   }
-  recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
+  recordRecoveredFollowUpCooldownIfControllerCreepNeeded(territoryIntent, roleCounts, gameTime);
   return null;
+}
+function recordRecoveredFollowUpCooldownIfControllerCreepNeeded(territoryIntent, roleCounts, gameTime) {
+  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
+    return;
+  }
+  recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
 }
 function planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, options) {
   if (!shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -10,6 +10,7 @@ import {
   buildTerritoryCreepMemory,
   getTerritoryFollowUpPreparationWorkerDemand,
   planTerritoryIntent,
+  recordRecoveredTerritoryFollowUpRetryCooldown,
   shouldSpawnTerritoryControllerCreep,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
   TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND,
@@ -62,7 +63,13 @@ export function planSpawn(
   if (territoryIntent) {
     const demandedWorkerTarget = getWorkerTargetWithTerritoryDemand(workerTarget, territoryIntent, gameTime);
     if (workerCapacity < demandedWorkerTarget) {
-      return planWorkerSpawn(colony, roleCounts, gameTime, options);
+      const workerSpawn = planWorkerSpawn(colony, roleCounts, gameTime, options);
+      if (workerSpawn) {
+        return workerSpawn;
+      }
+
+      recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
+      return null;
     }
 
     const territorySpawn = planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, options);
@@ -72,8 +79,13 @@ export function planSpawn(
   }
 
   if (shouldPlanWorkerRecovery) {
-    return planWorkerSpawn(colony, roleCounts, gameTime, options);
+    const workerSpawn = planWorkerSpawn(colony, roleCounts, gameTime, options);
+    if (workerSpawn) {
+      return workerSpawn;
+    }
   }
+
+  recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
 
   return null;
 }

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -68,7 +68,7 @@ export function planSpawn(
         return workerSpawn;
       }
 
-      recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
+      recordRecoveredFollowUpCooldownIfControllerCreepNeeded(territoryIntent, roleCounts, gameTime);
       return null;
     }
 
@@ -85,9 +85,21 @@ export function planSpawn(
     }
   }
 
-  recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
+  recordRecoveredFollowUpCooldownIfControllerCreepNeeded(territoryIntent, roleCounts, gameTime);
 
   return null;
+}
+
+function recordRecoveredFollowUpCooldownIfControllerCreepNeeded(
+  territoryIntent: TerritoryIntentPlan | null,
+  roleCounts: RoleCounts,
+  gameTime: number
+): void {
+  if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {
+    return;
+  }
+
+  recordRecoveredTerritoryFollowUpRetryCooldown(territoryIntent, gameTime);
 }
 
 function planTerritorySpawn(

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -74,6 +74,7 @@ const MIN_READY_WORKERS = 3;
 const DOWNGRADE_GUARD_TICKS = 5_000;
 const RESERVATION_RENEWAL_TICKS = 1_000;
 const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
+const TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
 
 // Project vision ordering: territory action dominates resource value; combat/risk only gates or deprioritizes.
@@ -119,7 +120,12 @@ export function persistOccupationRecommendationFollowUpIntent(
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const existingIntent = intents.find((intent) => isSameTerritoryIntent(intent, followUpIntent));
-  if (existingIntent && isTerritorySuppressionFresh(existingIntent, gameTime)) {
+  if (
+    existingIntent &&
+    (isTerritorySuppressionFresh(existingIntent, gameTime) ||
+      isRecoveredTerritoryFollowUpAttemptCoolingDown(existingIntent, gameTime) ||
+      isRecoveredTerritoryFollowUpRetryPending(existingIntent))
+  ) {
     return null;
   }
 
@@ -658,6 +664,7 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
     action: rawIntent.action,
     status: rawIntent.status,
     updatedAt: rawIntent.updatedAt,
+    ...(followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {}),
     ...(typeof rawIntent.controllerId === 'string'
       ? { controllerId: rawIntent.controllerId as Id<StructureController> }
       : {}),
@@ -711,6 +718,19 @@ function isTerritorySuppressionFresh(intent: TerritoryIntentMemory, gameTime: nu
   return intent.status === 'suppressed' && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
 }
 
+function isRecoveredTerritoryFollowUpAttemptCoolingDown(intent: TerritoryIntentMemory, gameTime: number): boolean {
+  return (
+    intent.followUp !== undefined &&
+    isFiniteNumber(intent.lastAttemptAt) &&
+    gameTime >= intent.lastAttemptAt &&
+    gameTime - intent.lastAttemptAt <= TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS
+  );
+}
+
+function isRecoveredTerritoryFollowUpRetryPending(intent: TerritoryIntentMemory): boolean {
+  return intent.followUp !== undefined && intent.status === 'suppressed' && isFiniteNumber(intent.lastAttemptAt);
+}
+
 function isTerritoryIntentAction(action: unknown): action is TerritoryIntentAction {
   return action === 'claim' || action === 'reserve' || action === 'scout';
 }
@@ -733,4 +753,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
 }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -16,6 +16,7 @@ export const TERRITORY_RESERVATION_RENEWAL_TICKS = 1_000;
 export const TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 export const TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
+export const TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 export const TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 
 const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
@@ -49,6 +50,7 @@ interface SelectedTerritoryTarget {
   commitTarget: boolean;
   followUp?: TerritoryFollowUpMemory;
   recoveredFollowUp?: boolean;
+  recoveredFollowUpSuppressedAt?: number;
 }
 
 type TerritoryCandidateSource =
@@ -79,7 +81,18 @@ interface RouteDistanceLookupContext {
 interface PersistedTerritoryIntentFollowUp {
   followUp: TerritoryFollowUpMemory;
   recovered: boolean;
+  coolingDown: boolean;
+  suppressedAt?: number;
 }
+
+interface RecoveredTerritoryFollowUpRetryMetadata {
+  suppressedAt: number;
+}
+
+const recoveredTerritoryFollowUpRetryMetadata = new WeakMap<
+  TerritoryIntentPlan,
+  RecoveredTerritoryFollowUpRetryMetadata
+>();
 
 export function planTerritoryIntent(
   colony: ColonySnapshot,
@@ -104,10 +117,52 @@ export function planTerritoryIntent(
     ...(target.controllerId ? { controllerId: target.controllerId } : {}),
     ...(selection.followUp ? { followUp: selection.followUp } : {})
   };
+  if (selection.recoveredFollowUp === true && typeof selection.recoveredFollowUpSuppressedAt === 'number') {
+    recoveredTerritoryFollowUpRetryMetadata.set(plan, { suppressedAt: selection.recoveredFollowUpSuppressedAt });
+  }
   const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? 'active' : 'planned';
   recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
 
   return plan;
+}
+
+export function recordRecoveredTerritoryFollowUpRetryCooldown(
+  plan: TerritoryIntentPlan | null,
+  gameTime = getGameTime()
+): void {
+  if (!plan || !plan.followUp || !isTerritoryControlAction(plan.action)) {
+    return;
+  }
+
+  const recoveredFollowUpMetadata = recoveredTerritoryFollowUpRetryMetadata.get(plan);
+  if (!recoveredFollowUpMetadata) {
+    return;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIndex = intents.findIndex(
+    (intent) =>
+      intent.colony === plan.colony && intent.targetRoom === plan.targetRoom && intent.action === plan.action
+  );
+  if (existingIndex < 0) {
+    return;
+  }
+
+  const existingIntent = intents[existingIndex];
+  intents[existingIndex] = {
+    ...existingIntent,
+    status: 'suppressed',
+    updatedAt: recoveredFollowUpMetadata.suppressedAt,
+    followUp: plan.followUp,
+    lastAttemptAt: gameTime
+  };
+  removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
 }
 
 export function shouldSpawnTerritoryControllerCreep(
@@ -497,7 +552,11 @@ function toSelectedTerritoryTarget(candidate: ScoredTerritoryTarget | null): Sel
         target: candidate.target,
         intentAction: candidate.intentAction,
         commitTarget: candidate.commitTarget,
-        ...(candidate.followUp ? { followUp: candidate.followUp } : {})
+        ...(candidate.followUp ? { followUp: candidate.followUp } : {}),
+        ...(candidate.recoveredFollowUp ? { recoveredFollowUp: true } : {}),
+        ...(typeof candidate.recoveredFollowUpSuppressedAt === 'number'
+          ? { recoveredFollowUpSuppressedAt: candidate.recoveredFollowUpSuppressedAt }
+          : {})
       }
     : null;
 }
@@ -568,13 +627,20 @@ function getConfiguredTerritoryCandidates(
       target.action,
       gameTime
     );
+    if (persistedFollowUp?.coolingDown) {
+      return [];
+    }
+
     const candidate = scoreTerritoryCandidate(
       {
         target,
         intentAction: target.action,
         commitTarget: false,
         ...(persistedFollowUp ? { followUp: persistedFollowUp.followUp } : {}),
-        ...(persistedFollowUp?.recovered ? { recoveredFollowUp: true } : {})
+        ...(persistedFollowUp?.recovered ? { recoveredFollowUp: true } : {}),
+        ...(typeof persistedFollowUp?.suppressedAt === 'number'
+          ? { recoveredFollowUpSuppressedAt: persistedFollowUp.suppressedAt }
+          : {})
       },
       'configured',
       order,
@@ -602,6 +668,7 @@ function getPersistedTerritoryIntentCandidates(
       intent.colony !== colonyName ||
       intent.targetRoom === colonyName ||
       configuredTargetRooms.has(intent.targetRoom) ||
+      isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime) ||
       (intent.status !== 'planned' && intent.status !== 'active' && !recoveredFollowUp) ||
       !isTerritoryControlAction(intent.action) ||
       isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) ||
@@ -629,7 +696,7 @@ function getPersistedTerritoryIntentCandidates(
         intentAction: intent.action,
         commitTarget: false,
         ...(intent.followUp ? { followUp: intent.followUp } : {}),
-        ...(recoveredFollowUp ? { recoveredFollowUp: true } : {})
+        ...(recoveredFollowUp ? { recoveredFollowUp: true, recoveredFollowUpSuppressedAt: intent.updatedAt } : {})
       },
       'occupationIntent',
       order,
@@ -707,7 +774,8 @@ function getAdjacentReserveCandidates(
     if (
       roomName === colonyName ||
       existingTargetRooms.has(roomName) ||
-      isTerritoryTargetSuppressed(target, intents, gameTime)
+      isTerritoryTargetSuppressed(target, intents, gameTime) ||
+      isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, 'reserve', gameTime)
     ) {
       return [];
     }
@@ -1646,7 +1714,9 @@ function getPersistedTerritoryIntentFollowUp(
 
   return {
     followUp: selectedIntent.followUp,
-    recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime)
+    recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime),
+    coolingDown: isRecoveredTerritoryFollowUpAttemptCoolingDown(selectedIntent, gameTime),
+    ...(selectedIntent.status === 'suppressed' ? { suppressedAt: selectedIntent.updatedAt } : {})
   };
 }
 
@@ -1770,6 +1840,7 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
     action: rawIntent.action,
     status: rawIntent.status,
     updatedAt: rawIntent.updatedAt,
+    ...(followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {}),
     ...(typeof rawIntent.controllerId === 'string'
       ? { controllerId: rawIntent.controllerId as Id<StructureController> }
       : {}),
@@ -1917,10 +1988,35 @@ function isTerritorySuppressionFresh(intent: TerritoryIntentMemory, gameTime: nu
 }
 
 function isRecoveredTerritoryFollowUpIntent(intent: TerritoryIntentMemory, gameTime: number): boolean {
+  if (intent.followUp === undefined || isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime)) {
+    return false;
+  }
+
+  return intent.status === 'suppressed' && gameTime - intent.updatedAt > TERRITORY_SUPPRESSION_RETRY_TICKS;
+}
+
+function isRecoveredTerritoryFollowUpAttemptCoolingDown(intent: TerritoryIntentMemory, gameTime: number): boolean {
   return (
     intent.followUp !== undefined &&
-    intent.status === 'suppressed' &&
-    gameTime - intent.updatedAt > TERRITORY_SUPPRESSION_RETRY_TICKS
+    isFiniteNumber(intent.lastAttemptAt) &&
+    gameTime >= intent.lastAttemptAt &&
+    gameTime - intent.lastAttemptAt <= TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS
+  );
+}
+
+function isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  targetRoom: string,
+  action: TerritoryIntentAction,
+  gameTime: number
+): boolean {
+  return intents.some(
+    (intent) =>
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      intent.action === action &&
+      isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime)
   );
 }
 
@@ -2365,6 +2461,10 @@ function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemo
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -41,6 +41,7 @@ declare global {
     action: TerritoryIntentAction;
     status: 'planned' | 'active' | 'suppressed';
     updatedAt: number;
+    lastAttemptAt?: number;
     controllerId?: Id<StructureController>;
     followUp?: TerritoryFollowUpMemory;
   }

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -6,6 +6,7 @@ import {
   type OccupationRecommendationInput,
   type OccupationRecommendationReport
 } from '../src/territory/occupationRecommendation';
+import { TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS } from '../src/territory/territoryPlanner';
 
 describe('occupation recommendation scoring', () => {
   afterEach(() => {
@@ -363,6 +364,38 @@ describe('occupation recommendation scoring', () => {
     const report = scoreOccupationRecommendations(makeInput([makeCandidate({ roomName: 'W2N1' })]));
 
     expect(persistOccupationRecommendationFollowUpIntent(report, 1_000)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([suppressedIntent]);
+  });
+
+  it('preserves recovered follow-up cooldown markers from recommendation persistence', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    const retryTime = 1_000;
+    const suppressedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: 900,
+      lastAttemptAt: retryTime,
+      followUp
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [suppressedIntent]
+      }
+    };
+    const report = scoreOccupationRecommendations(makeInput([makeCandidate({ roomName: 'W2N1' })]));
+
+    expect(
+      persistOccupationRecommendationFollowUpIntent(
+        report,
+        retryTime + TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS + 1
+      )
+    ).toBeNull();
     expect(Memory.territory?.intents).toEqual([suppressedIntent]);
   });
 

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1,6 +1,10 @@
 import { planSpawn } from '../src/spawn/spawnPlanner';
 import { ColonySnapshot } from '../src/colony/colonyRegistry';
-import { TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
+import {
+  TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS,
+  TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
+  TERRITORY_SUPPRESSION_RETRY_TICKS
+} from '../src/territory/territoryPlanner';
 
 describe('planSpawn', () => {
   beforeEach(() => {
@@ -498,6 +502,98 @@ describe('planSpawn', () => {
         action: 'reserve',
         workerCount: 1,
         updatedAt: 155,
+        followUp
+      }
+    ]);
+  });
+
+  it('cools down a recovered follow-up when no spawn action is available', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'activeReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    const suppressionTime = 160;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const eligibleTime = retryTime + TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS + 1;
+    const busy = { remainingTime: 5 } as Spawning;
+    const { colony: busyColony } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController(),
+      spawning: busy
+    });
+    const { colony: idleColony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    const recoveringRoleCounts = { worker: 3, claimer: 0, claimersByTargetRoom: {} };
+    const readyRoleCounts = { worker: 4, claimer: 0, claimersByTargetRoom: {} };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N2: makeTerritoryRoom('W2N2', { my: false } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N2',
+            action: 'reserve',
+            status: 'suppressed',
+            updatedAt: suppressionTime,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planSpawn(busyColony, recoveringRoleCounts, retryTime)).toBeNull();
+    expect(Memory.territory?.demands).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: suppressionTime,
+        lastAttemptAt: retryTime,
+        followUp
+      }
+    ]);
+
+    expect(planSpawn(idleColony, recoveringRoleCounts, retryTime + 1)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: suppressionTime,
+        lastAttemptAt: retryTime,
+        followUp
+      }
+    ]);
+
+    expect(planSpawn(idleColony, readyRoleCounts, eligibleTime)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: `claimer-W1N1-W2N2-${eligibleTime}`,
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N2', action: 'reserve', followUp }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: eligibleTime,
         followUp
       }
     ]);

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -599,6 +599,134 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('keeps a recovered follow-up active when live controller coverage already satisfies it', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'activeReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    const suppressionTime = 170;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const { colony } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    const roleCounts = {
+      worker: 4,
+      claimer: 1,
+      claimersByTargetRoom: { W2N2: 1 },
+      claimersByTargetRoomAction: { reserve: { W2N2: 1 } }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N2: makeTerritoryRoom('W2N2', { my: false } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N2',
+            action: 'reserve',
+            status: 'suppressed',
+            updatedAt: suppressionTime,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planSpawn(colony, roleCounts, retryTime)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: retryTime,
+        followUp
+      }
+    ]);
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: retryTime,
+        followUp
+      }
+    ]);
+  });
+
+  it('does not cool down a covered recovered follow-up when support worker spawn is unavailable', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'activeReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    const suppressionTime = 180;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const busy = { remainingTime: 5 } as Spawning;
+    const { colony } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController(),
+      spawning: busy
+    });
+    const roleCounts = {
+      worker: 3,
+      claimer: 1,
+      claimersByTargetRoom: { W2N2: 1 },
+      claimersByTargetRoomAction: { reserve: { W2N2: 1 } }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N2: makeTerritoryRoom('W2N2', { my: false } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N2',
+            action: 'reserve',
+            status: 'suppressed',
+            updatedAt: suppressionTime,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planSpawn(colony, roleCounts, retryTime)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: retryTime,
+        followUp
+      }
+    ]);
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: retryTime,
+        followUp
+      }
+    ]);
+  });
+
   it('does not plan a duplicate claimer for the same persisted target and action', () => {
     const { colony } = makeColony({
       energyAvailable: 650,

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2,9 +2,11 @@ import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   buildTerritoryCreepMemory,
   planTerritoryIntent,
+  recordRecoveredTerritoryFollowUpRetryCooldown,
   shouldSpawnTerritoryControllerCreep,
   suppressTerritoryIntent,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
+  TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS,
   TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
   TERRITORY_RESERVATION_RENEWAL_TICKS,
   TERRITORY_SUPPRESSION_RETRY_TICKS
@@ -2243,6 +2245,136 @@ describe('planTerritoryIntent', () => {
         updatedAt: suppressionTime + 1
       }
     ]);
+  });
+
+  it('cools down recovered follow-up attempts before retrying them again', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const recoveredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const suppressionTime = 582;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const cooledRetryTime = retryTime + TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS + 1;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1'),
+        W3N1: makeRecommendationRoom('W3N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, recoveredTarget],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            status: 'suppressed',
+            updatedAt: suppressionTime,
+            followUp
+          }
+        ]
+      }
+    };
+
+    const recoveredPlan = planTerritoryIntent(
+      colony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      retryTime
+    );
+    expect(recoveredPlan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      followUp
+    });
+
+    recordRecoveredTerritoryFollowUpRetryCooldown(recoveredPlan, retryTime);
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime + 1)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: suppressionTime,
+        lastAttemptAt: retryTime,
+        followUp
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: retryTime + 1
+      }
+    ]);
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, cooledRetryTime)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      followUp
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: cooledRetryTime,
+        followUp
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: retryTime + 1
+      }
+    ]);
+  });
+
+  it('keeps recovered follow-up safety filters ahead of retry cooldown markers', () => {
+    const colony = makeSafeColony();
+    const recoveredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const suppressionTime = 583;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const suppressedFollowUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: suppressionTime,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W3N1: makeRecommendationRoom('W3N1', {
+          controller: { my: false, owner: { username: 'enemy' } } as StructureController
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [recoveredTarget],
+        intents: [suppressedFollowUpIntent]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([suppressedFollowUpIntent]);
   });
 
   it('keeps a stronger visible configured reserve before adjacent follow-up expansion', () => {


### PR DESCRIPTION
## Summary
- Adds bounded cooldown tracking for recovered territory follow-up attempts so the bot does not retry the same temporarily unactionable follow-up every tick.
- Preserves eligibility after cooldown and keeps hostile/owned/unavailable-room guards intact.
- Updates spawn/territory planner coverage and rebuilds `prod/dist/main.js`.

## Verification
- Controller: `npm run typecheck` ✅
- Controller: `npm test -- --runInBand` ✅ (407 tests)
- Controller: `npm run build` ✅
- Controller: `git diff --check` ✅

## Issue
Closes #274
