### PR TITLE
feat: select alternate territory follow-up during cooldown

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1558,6 +1558,15 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime)) {
       return true;
     }
+    if (isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(
+      intents,
+      colonyName,
+      target.roomName,
+      target.action,
+      gameTime
+    )) {
+      return false;
+    }
     if (getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) > 0) {
       return false;
     }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -758,6 +758,18 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       return true;
     }
 
+    if (
+      isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(
+        intents,
+        colonyName,
+        target.roomName,
+        target.action,
+        gameTime
+      )
+    ) {
+      return false;
+    }
+
     if (getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) > 0) {
       return false;
     }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2345,6 +2345,53 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('scouts an alternate adjacent room while a recovered follow-up target is cooling down', () => {
+    const colony = makeSafeColony();
+    const recoveredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const suppressionTime = 584;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const cooldownTime = retryTime + 1;
+    const coolingDownFollowUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: suppressionTime,
+      lastAttemptAt: retryTime,
+      followUp
+    };
+    const describeExits = jest.fn((roomName: string) => (roomName === 'W1N1' ? { '1': 'W1N2' } : {}));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [recoveredTarget],
+        intents: [coolingDownFollowUpIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, cooldownTime)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'scout'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.intents).toEqual([
+      coolingDownFollowUpIntent,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: cooldownTime
+      }
+    ]);
+  });
+
   it('keeps recovered follow-up safety filters ahead of retry cooldown markers', () => {
     const colony = makeSafeColony();
     const recoveredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };


### PR DESCRIPTION
## Summary
- lets territory planning skip a recovered follow-up while it is cooling down and continue to an alternate safe territory/control intent
- keeps safety filtering intact for unavailable/owned/hostile/invalid rooms
- adds Jest coverage for alternate selection while cooldown is active
- refreshes generated `prod/dist/main.js`

Closes #277.

## Verification
- `git diff --check`
- from `prod/`: `npm run typecheck`
- from `prod/`: `npm test -- --runInBand` (19 suites / 410 tests passed)
- from `prod/`: `npm run build`

## Scheduler evidence
- Worktree: `/root/screeps-worktrees/territory-cooldown-alternate-277`
- Commit: `5475f4f lanyusea's bot <lanyusea@gmail.com> feat: select alternate territory follow-up during cooldown`
- Untracked dependency infrastructure (`prod/node_modules`) was intentionally not staged.