### PR TITLE
feat: spend carried energy during reserved follow-up capacity

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2679,6 +2679,7 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
+var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -2726,10 +2727,7 @@ function selectWorkerTask(creep) {
     return { type: "upgrade", targetId: controller.id };
   }
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  if (spawnOrExtensionEnergySink && shouldReserveRefillForTerritoryFollowUp(creep)) {
-    return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
-  }
-  if (spawnOrExtensionEnergySink) {
+  if (spawnOrExtensionEnergySink && shouldPrioritizeSpawnOrExtensionRefill(creep)) {
     return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
   }
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
@@ -2779,6 +2777,9 @@ function selectWorkerTask(creep) {
   }
   if (controller == null ? void 0 : controller.my) {
     return { type: "upgrade", targetId: controller.id };
+  }
+  if (spawnOrExtensionEnergySink) {
+    return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
   }
   return null;
 }
@@ -3307,7 +3308,17 @@ function hasActiveTerritoryPressure(creep) {
   }
   return territoryMemory.intents.some((intent) => isActiveTerritoryPressureIntent(intent, colonyName));
 }
-function shouldReserveRefillForTerritoryFollowUp(creep) {
+function shouldPrioritizeSpawnOrExtensionRefill(creep) {
+  if (hasUrgentSpawnOrExtensionRefillDemand(creep)) {
+    return true;
+  }
+  return !hasReservedTerritoryFollowUpRefillCapacity(creep);
+}
+function hasUrgentSpawnOrExtensionRefillDemand(creep) {
+  const energyAvailable = creep.room.energyAvailable;
+  return typeof energyAvailable === "number" && energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
+}
+function hasReservedTerritoryFollowUpRefillCapacity(creep) {
   return hasActiveTerritoryFollowUpPreparationDemand(getCreepColonyName(creep));
 }
 function getCreepColonyName(creep) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3312,7 +3312,10 @@ function shouldPrioritizeSpawnOrExtensionRefill(creep) {
   if (hasUrgentSpawnOrExtensionRefillDemand(creep)) {
     return true;
   }
-  return !hasReservedTerritoryFollowUpRefillCapacity(creep);
+  if (!hasReservedTerritoryFollowUpRefillCapacity(creep)) {
+    return true;
+  }
+  return hasUsefulTerritoryFollowUpRefillCapacity(creep);
 }
 function hasUrgentSpawnOrExtensionRefillDemand(creep) {
   const energyAvailable = creep.room.energyAvailable;
@@ -3320,6 +3323,23 @@ function hasUrgentSpawnOrExtensionRefillDemand(creep) {
 }
 function hasReservedTerritoryFollowUpRefillCapacity(creep) {
   return hasActiveTerritoryFollowUpPreparationDemand(getCreepColonyName(creep));
+}
+function hasUsefulTerritoryFollowUpRefillCapacity(creep) {
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
+  if (energyAvailable === null || energyCapacityAvailable === null) {
+    return false;
+  }
+  const followUpEnergyTarget = Math.min(TERRITORY_CONTROLLER_BODY_COST, energyCapacityAvailable);
+  return energyAvailable < followUpEnergyTarget;
+}
+function getRoomEnergyAvailable(room) {
+  const energyAvailable = room.energyAvailable;
+  return typeof energyAvailable === "number" && Number.isFinite(energyAvailable) ? energyAvailable : null;
+}
+function getRoomEnergyCapacityAvailable(room) {
+  const energyCapacityAvailable = room.energyCapacityAvailable;
+  return typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable) ? energyCapacityAvailable : null;
 }
 function getCreepColonyName(creep) {
   var _a;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3,6 +3,7 @@ import {
   selectUrgentVisibleReservationRenewalTask,
   selectVisibleTerritoryControllerTask
 } from '../territory/territoryPlanner';
+import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
 
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
@@ -999,7 +1000,11 @@ function shouldPrioritizeSpawnOrExtensionRefill(creep: Creep): boolean {
     return true;
   }
 
-  return !hasReservedTerritoryFollowUpRefillCapacity(creep);
+  if (!hasReservedTerritoryFollowUpRefillCapacity(creep)) {
+    return true;
+  }
+
+  return hasUsefulTerritoryFollowUpRefillCapacity(creep);
 }
 
 function hasUrgentSpawnOrExtensionRefillDemand(creep: Creep): boolean {
@@ -1009,6 +1014,29 @@ function hasUrgentSpawnOrExtensionRefillDemand(creep: Creep): boolean {
 
 function hasReservedTerritoryFollowUpRefillCapacity(creep: Creep): boolean {
   return hasActiveTerritoryFollowUpPreparationDemand(getCreepColonyName(creep));
+}
+
+function hasUsefulTerritoryFollowUpRefillCapacity(creep: Creep): boolean {
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
+  if (energyAvailable === null || energyCapacityAvailable === null) {
+    return false;
+  }
+
+  const followUpEnergyTarget = Math.min(TERRITORY_CONTROLLER_BODY_COST, energyCapacityAvailable);
+  return energyAvailable < followUpEnergyTarget;
+}
+
+function getRoomEnergyAvailable(room: Room): number | null {
+  const energyAvailable = (room as Room & { energyAvailable?: number }).energyAvailable;
+  return typeof energyAvailable === 'number' && Number.isFinite(energyAvailable) ? energyAvailable : null;
+}
+
+function getRoomEnergyCapacityAvailable(room: Room): number | null {
+  const energyCapacityAvailable = (room as Room & { energyCapacityAvailable?: number }).energyCapacityAvailable;
+  return typeof energyCapacityAvailable === 'number' && Number.isFinite(energyCapacityAvailable)
+    ? energyCapacityAvailable
+    : null;
 }
 
 function getCreepColonyName(creep: Creep): string | null {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -84,11 +84,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  if (spawnOrExtensionEnergySink && shouldReserveRefillForTerritoryFollowUp(creep)) {
-    return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
-  }
-
-  if (spawnOrExtensionEnergySink) {
+  if (spawnOrExtensionEnergySink && shouldPrioritizeSpawnOrExtensionRefill(creep)) {
     return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
   }
 
@@ -151,6 +147,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
 
   if (controller?.my) {
     return { type: 'upgrade', targetId: controller.id };
+  }
+
+  if (spawnOrExtensionEnergySink) {
+    return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
   }
 
   return null;
@@ -994,7 +994,20 @@ function hasActiveTerritoryPressure(creep: Creep): boolean {
   return territoryMemory.intents.some((intent) => isActiveTerritoryPressureIntent(intent, colonyName));
 }
 
-function shouldReserveRefillForTerritoryFollowUp(creep: Creep): boolean {
+function shouldPrioritizeSpawnOrExtensionRefill(creep: Creep): boolean {
+  if (hasUrgentSpawnOrExtensionRefillDemand(creep)) {
+    return true;
+  }
+
+  return !hasReservedTerritoryFollowUpRefillCapacity(creep);
+}
+
+function hasUrgentSpawnOrExtensionRefillDemand(creep: Creep): boolean {
+  const energyAvailable = (creep.room as Room & { energyAvailable?: number }).energyAvailable;
+  return typeof energyAvailable === 'number' && energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
+}
+
+function hasReservedTerritoryFollowUpRefillCapacity(creep: Creep): boolean {
   return hasActiveTerritoryFollowUpPreparationDemand(getCreepColonyName(creep));
 }
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2758,7 +2758,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
-  it('reserves spawn refill for active follow-up demand before non-critical construction', () => {
+  it('reserves urgent spawn refill for active follow-up demand before non-critical construction', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
     const controller = {
@@ -2782,11 +2782,74 @@ describe('selectWorkerTask', () => {
       room: makeWorkerTaskRoom({
         constructionSites: [site],
         controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
         myStructures: [spawn as AnyOwnedStructure]
       })
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('spends carried energy on construction when follow-up refill capacity is reserved and room energy is safe', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      time: 510
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        demands: [makeFollowUpDemand(510)]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('spends carried energy on controller upgrade when follow-up refill capacity is reserved and no construction remains', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      time: 511
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        demands: [makeFollowUpDemand(511)]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('uses active follow-up demand as territory pressure once refill capacity is full', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -6,6 +6,7 @@ import {
   URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
+import { TERRITORY_CONTROLLER_BODY_COST } from '../src/spawn/bodyBuilder';
 import {
   TERRITORY_RESERVATION_COMFORT_TICKS,
   TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
@@ -99,12 +100,14 @@ function makeWorkerTaskRoom({
   constructionSites = [],
   controller = { id: 'controller1', my: true, level: 3 } as StructureController,
   energyAvailable,
+  energyCapacityAvailable,
   myStructures = [],
   structures = []
 }: {
   constructionSites?: ConstructionSite[];
   controller?: StructureController;
   energyAvailable?: number;
+  energyCapacityAvailable?: number;
   myStructures?: AnyOwnedStructure[];
   structures?: AnyStructure[];
 } = {}): Room {
@@ -112,6 +115,7 @@ function makeWorkerTaskRoom({
     name: 'W1N1',
     controller,
     ...(energyAvailable === undefined ? {} : { energyAvailable }),
+    ...(energyCapacityAvailable === undefined ? {} : { energyCapacityAvailable }),
     find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
       if (type === FIND_MY_STRUCTURES) {
         return options?.filter ? myStructures.filter(options.filter) : myStructures;
@@ -2783,6 +2787,7 @@ describe('selectWorkerTask', () => {
         constructionSites: [site],
         controller,
         energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        energyCapacityAvailable: TERRITORY_CONTROLLER_BODY_COST,
         myStructures: [spawn as AnyOwnedStructure]
       })
     } as unknown as Creep;
@@ -2790,8 +2795,8 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
-  it('spends carried energy on construction when follow-up refill capacity is reserved and room energy is safe', () => {
-    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+  it('keeps follow-up spawn refill before construction until controller-body energy is ready', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 450);
     const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
     const controller = {
       id: 'controller1',
@@ -2815,6 +2820,40 @@ describe('selectWorkerTask', () => {
         constructionSites: [site],
         controller,
         energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        energyCapacityAvailable: TERRITORY_CONTROLLER_BODY_COST,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('spends carried energy on construction when follow-up energy target is ready', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      time: 512
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        demands: [makeFollowUpDemand(512)]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+        energyCapacityAvailable: 800,
         myStructures: [spawn as AnyOwnedStructure]
       })
     } as unknown as Creep;
@@ -2822,7 +2861,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
-  it('spends carried energy on controller upgrade when follow-up refill capacity is reserved and no construction remains', () => {
+  it('spends carried energy on controller upgrade when follow-up energy target is ready and no construction remains', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const controller = {
       id: 'controller1',
@@ -2832,11 +2871,11 @@ describe('selectWorkerTask', () => {
     } as StructureController;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       creeps: {},
-      time: 511
+      time: 513
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
-        demands: [makeFollowUpDemand(511)]
+        demands: [makeFollowUpDemand(513)]
       }
     };
     const creep = {
@@ -2844,7 +2883,8 @@ describe('selectWorkerTask', () => {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
       room: makeWorkerTaskRoom({
         controller,
-        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+        energyCapacityAvailable: 800,
         myStructures: [spawn as AnyOwnedStructure]
       })
     } as unknown as Creep;


### PR DESCRIPTION
## Summary
- routes carried worker energy to productive construction/upgrade sinks when follow-up spawn capacity is reserved and urgent refill is not needed
- preserves emergency spawn/refill priority over productive spending
- adds Jest coverage for reserved-capacity/no-idle behavior
- refreshes generated `prod/dist/main.js`

Closes #276.

## Verification
- `git diff --check`
- from `prod/`: `npm run typecheck`
- from `prod/`: `npm test -- --runInBand` (19 suites / 411 tests passed)
- from `prod/`: `npm run build`

## Scheduler evidence
- Worktree: `/root/screeps-worktrees/productive-energy-spend-276`
- Commit: `80f2483 lanyusea's bot <lanyusea@gmail.com> feat: spend carried energy during reserved follow-up capacity`
- Untracked dependency infrastructure (`prod/node_modules`) was intentionally not staged.