### PR TITLE
feat: gate follow-up targets on spawn readiness

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1097,6 +1097,7 @@ var TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
 var MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR2 = ">";
 var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
+var TERRITORY_SCOUT_BODY_COST = 50;
 var recoveredTerritoryFollowUpRetryMetadata = /* @__PURE__ */ new WeakMap();
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
@@ -1341,13 +1342,14 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
 }
 function selectTerritoryTarget(colony, roleCounts, gameTime) {
-  var _a, _b;
+  var _a, _b, _c;
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord2();
   const intents = normalizeTerritoryIntents2(territoryMemory == null ? void 0 : territoryMemory.intents);
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
+    colony,
     territoryMemory,
     colonyName,
     colonyOwnerUsername,
@@ -1378,7 +1380,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
   );
   const primaryCandidates = [...persistedIntentCandidates, ...configuredCandidates];
   const bestSpawnablePrimaryCandidate = selectBestScoredTerritoryCandidate(
-    getSpawnableTerritoryCandidates(primaryCandidates, roleCounts)
+    getSpawnableTerritoryCandidates(primaryCandidates, roleCounts, colony)
   );
   if (bestSpawnablePrimaryCandidate && bestSpawnablePrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
     if (!shouldEvaluateVisibleAdjacentFollowUpPreference(bestSpawnablePrimaryCandidate)) {
@@ -1402,7 +1404,11 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
     }
     return toSelectedTerritoryTarget(
       (_a = selectBestScoredTerritoryCandidate(
-        getSpawnableTerritoryCandidates([...primaryCandidates, ...visibleAdjacentFollowUpCandidates], roleCounts)
+        getSpawnableTerritoryCandidates(
+          [...primaryCandidates, ...visibleAdjacentFollowUpCandidates],
+          roleCounts,
+          colony
+        )
       )) != null ? _a : bestSpawnablePrimaryCandidate
     );
   }
@@ -1432,7 +1438,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
   ]);
   const candidates = [...primaryCandidates, ...adjacentCandidates];
   return toSelectedTerritoryTarget(
-    (_b = selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts))) != null ? _b : selectBestScoredTerritoryCandidate(candidates)
+    (_c = (_b = selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts, colony))) != null ? _b : selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony))) != null ? _c : selectBestScoredTerritoryCandidate(candidates)
   );
 }
 function selectBestScoredTerritoryCandidate(candidates) {
@@ -1457,15 +1463,33 @@ function toSelectedTerritoryTarget(candidate) {
 function shouldEvaluateVisibleAdjacentFollowUpPreference(candidate) {
   return candidate.priority === TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE && candidate.target.action === "reserve";
 }
-function getSpawnableTerritoryCandidates(candidates, roleCounts) {
+function getSpawnableTerritoryCandidates(candidates, roleCounts, colony) {
   return candidates.filter((candidate) => {
-    const activeCoverageCount = getTerritoryCreepCountForTarget(
-      roleCounts,
-      candidate.target.roomName,
-      candidate.intentAction
-    );
-    return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount);
+    return isTerritoryCandidateSpawnRequired(candidate, roleCounts) && isTerritoryCandidateSpawnReady(candidate, colony);
   });
+}
+function getActionableTerritoryCandidates(candidates, roleCounts, colony) {
+  return candidates.filter(
+    (candidate) => !isTerritoryCandidateSpawnRequired(candidate, roleCounts) || isTerritoryCandidateSpawnReady(candidate, colony)
+  );
+}
+function isTerritoryCandidateSpawnRequired(candidate, roleCounts) {
+  const activeCoverageCount = getTerritoryCreepCountForTarget(
+    roleCounts,
+    candidate.target.roomName,
+    candidate.intentAction
+  );
+  return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount);
+}
+function isTerritoryCandidateSpawnReady(candidate, colony) {
+  return isTerritoryIntentActionSpawnReady(colony, candidate.intentAction);
+}
+function isTerritoryIntentActionSpawnReady(colony, action) {
+  const bodyCost = getTerritoryIntentActionBodyCost(action);
+  return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
+}
+function getTerritoryIntentActionBodyCost(action) {
+  return action === "scout" ? TERRITORY_SCOUT_BODY_COST : TERRITORY_CONTROLLER_BODY_COST;
 }
 function shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount) {
   return activeCoverageCount < TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET && candidate.intentAction === "reserve" && typeof candidate.renewalTicksToEnd === "number" && candidate.renewalTicksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
@@ -1543,7 +1567,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
     return candidate ? [candidate] : [];
   });
 }
-function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime, roleCounts, routeDistanceLookupContext) {
+function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, colonyName, colonyOwnerUsername, intents, gameTime, roleCounts, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return false;
   }
@@ -1570,8 +1594,14 @@ function hasBlockingConfiguredTerritoryTargetForColony(territoryMemory, colonyNa
     if (getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) > 0) {
       return false;
     }
+    if (isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, gameTime, colony)) {
+      return false;
+    }
     return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
   });
+}
+function isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, gameTime, colony) {
+  return getPersistedTerritoryIntentFollowUp(intents, target.colony, target.roomName, target.action, gameTime) !== null && !isTerritoryIntentActionSpawnReady(colony, target.action);
 }
 function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, source, orderOffset, routeDistanceLookupContext) {
   const adjacentRooms = getAdjacentRoomNames2(originRoomName);
@@ -3858,7 +3888,7 @@ var WORKERS_PER_SOURCE = 2;
 var CONSTRUCTION_BACKLOG_WORKER_BONUS = 1;
 var SUBSTANTIAL_CONSTRUCTION_BACKLOG_SITE_COUNT = 5;
 var TERRITORY_SCOUT_BODY = ["move"];
-var TERRITORY_SCOUT_BODY_COST = 50;
+var TERRITORY_SCOUT_BODY_COST2 = 50;
 var MAX_WORKER_TARGET = 6;
 var sourceCountByRoomName = /* @__PURE__ */ new Map();
 function planSpawn(colony, roleCounts, gameTime, options = {}) {
@@ -3962,7 +3992,7 @@ function canAffordBody(body, energyAvailable) {
 }
 function buildTerritorySpawnBody(energyAvailable, action) {
   if (action === "scout") {
-    return energyAvailable >= TERRITORY_SCOUT_BODY_COST ? [...TERRITORY_SCOUT_BODY] : [];
+    return energyAvailable >= TERRITORY_SCOUT_BODY_COST2 ? [...TERRITORY_SCOUT_BODY] : [];
   }
   return buildTerritoryControllerBody(energyAvailable);
 }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -31,6 +31,7 @@ const TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
 const MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
 const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
 const TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
+const TERRITORY_SCOUT_BODY_COST = 50;
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -457,6 +458,7 @@ function selectTerritoryTarget(
   const intents = normalizeTerritoryIntents(territoryMemory?.intents);
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
+    colony,
     territoryMemory,
     colonyName,
     colonyOwnerUsername,
@@ -487,7 +489,7 @@ function selectTerritoryTarget(
   );
   const primaryCandidates = [...persistedIntentCandidates, ...configuredCandidates];
   const bestSpawnablePrimaryCandidate = selectBestScoredTerritoryCandidate(
-    getSpawnableTerritoryCandidates(primaryCandidates, roleCounts)
+    getSpawnableTerritoryCandidates(primaryCandidates, roleCounts, colony)
   );
   if (
     bestSpawnablePrimaryCandidate &&
@@ -516,7 +518,11 @@ function selectTerritoryTarget(
 
     return toSelectedTerritoryTarget(
       selectBestScoredTerritoryCandidate(
-        getSpawnableTerritoryCandidates([...primaryCandidates, ...visibleAdjacentFollowUpCandidates], roleCounts)
+        getSpawnableTerritoryCandidates(
+          [...primaryCandidates, ...visibleAdjacentFollowUpCandidates],
+          roleCounts,
+          colony
+        )
       ) ?? bestSpawnablePrimaryCandidate
     );
   }
@@ -548,7 +554,8 @@ function selectTerritoryTarget(
   const candidates = [...primaryCandidates, ...adjacentCandidates];
 
   return toSelectedTerritoryTarget(
-    selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts)) ??
+    selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts, colony)) ??
+      selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony)) ??
       selectBestScoredTerritoryCandidate(candidates)
   );
 }
@@ -585,19 +592,48 @@ function shouldEvaluateVisibleAdjacentFollowUpPreference(candidate: ScoredTerrit
 
 function getSpawnableTerritoryCandidates(
   candidates: ScoredTerritoryTarget[],
-  roleCounts: RoleCounts
+  roleCounts: RoleCounts,
+  colony: ColonySnapshot
 ): ScoredTerritoryTarget[] {
   return candidates.filter((candidate) => {
-    const activeCoverageCount = getTerritoryCreepCountForTarget(
-      roleCounts,
-      candidate.target.roomName,
-      candidate.intentAction
-    );
     return (
-      activeCoverageCount === 0 ||
-      shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount)
+      isTerritoryCandidateSpawnRequired(candidate, roleCounts) &&
+      isTerritoryCandidateSpawnReady(candidate, colony)
     );
   });
+}
+
+function getActionableTerritoryCandidates(
+  candidates: ScoredTerritoryTarget[],
+  roleCounts: RoleCounts,
+  colony: ColonySnapshot
+): ScoredTerritoryTarget[] {
+  return candidates.filter(
+    (candidate) =>
+      !isTerritoryCandidateSpawnRequired(candidate, roleCounts) || isTerritoryCandidateSpawnReady(candidate, colony)
+  );
+}
+
+function isTerritoryCandidateSpawnRequired(candidate: ScoredTerritoryTarget, roleCounts: RoleCounts): boolean {
+  const activeCoverageCount = getTerritoryCreepCountForTarget(
+    roleCounts,
+    candidate.target.roomName,
+    candidate.intentAction
+  );
+  return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount);
+}
+
+function isTerritoryCandidateSpawnReady(candidate: ScoredTerritoryTarget, colony: ColonySnapshot): boolean {
+  return isTerritoryIntentActionSpawnReady(colony, candidate.intentAction);
+}
+
+function isTerritoryIntentActionSpawnReady(colony: ColonySnapshot, action: TerritoryIntentAction): boolean {
+  const bodyCost = getTerritoryIntentActionBodyCost(action);
+  return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
+}
+
+function getTerritoryIntentActionBodyCost(action: TerritoryIntentAction): number {
+  return action === 'scout' ? TERRITORY_SCOUT_BODY_COST : TERRITORY_CONTROLLER_BODY_COST;
 }
 
 function shouldSpawnEmergencyReservationRenewalCandidate(
@@ -728,6 +764,7 @@ function getPersistedTerritoryIntentCandidates(
 }
 
 function hasBlockingConfiguredTerritoryTargetForColony(
+  colony: ColonySnapshot,
   territoryMemory: Record<string, unknown> | null,
   colonyName: string,
   colonyOwnerUsername: string | null,
@@ -774,11 +811,27 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       return false;
     }
 
+    if (isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, gameTime, colony)) {
+      return false;
+    }
+
     return (
       getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !==
       'satisfied'
     );
   });
+}
+
+function isConfiguredFollowUpTargetBlockedBySpawnReadiness(
+  target: TerritoryTargetMemory,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  colony: ColonySnapshot
+): boolean {
+  return (
+    getPersistedTerritoryIntentFollowUp(intents, target.colony, target.roomName, target.action, gameTime) !== null &&
+    !isTerritoryIntentActionSpawnReady(colony, target.action)
+  );
 }
 
 function getAdjacentReserveCandidates(

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -599,6 +599,72 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('uses a ready alternate while a recovered follow-up lacks claim body energy', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'activeReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    const suppressionTime = 165;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const { colony, spawn } = makeColony({
+      energyAvailable: 50,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    const describeExits = jest.fn(() => ({ '1': 'W1N3' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W2N2: makeTerritoryRoom('W2N2', { my: false } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N2', action: 'reserve' }],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N2',
+            action: 'reserve',
+            status: 'suppressed',
+            updatedAt: suppressionTime,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, retryTime)).toEqual({
+      spawn,
+      body: ['move'],
+      name: `scout-W1N1-W1N3-${retryTime}`,
+      memory: {
+        role: 'scout',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W1N3', action: 'scout' }
+      }
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: suppressionTime,
+        followUp
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N3',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: retryTime
+      }
+    ]);
+  });
+
   it('keeps a recovered follow-up active when live controller coverage already satisfies it', () => {
     const followUp: TerritoryFollowUpMemory = {
       source: 'activeReserveAdjacent',


### PR DESCRIPTION
## Summary
- gates territory follow-up target selection on spawn readiness so an unaffordable claim/reserve target does not monopolize follow-up selection
- keeps emergency worker recovery above territory follow-up behavior
- adds Jest coverage for insufficient-energy primary target plus viable alternate behavior
- refreshes generated `prod/dist/main.js`

Closes #280.

## Verification
- `git diff --check`
- from `prod/`: `npm run typecheck`
- from `prod/`: `npm test -- --runInBand` (19 suites / 414 tests passed)
- from `prod/`: `npm run build`

## Scheduler evidence
- Worktree: `/root/screeps-worktrees/territory-followup-spawn-readiness-280`
- Commit: `b3be061 lanyusea's bot <lanyusea@gmail.com> feat: gate follow-up targets on spawn readiness`
- Reconciled onto `origin/main` at `c580677` before verification/commit.
- Untracked dependency infrastructure (`prod/node_modules`) was intentionally not staged.
