### PR TITLE
fix: remove fake roadmap KPI placeholders

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -479,7 +479,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-04-29 13:20:28 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-04-29 13:25:33 CST</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -855,14 +855,14 @@ main {
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">230</p>
+            <p class="process-value">233</p>
             <p class="process-label">Total commits</p>
             <p class="process-detail">repository history <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">154</p>
+            <p class="process-value">158</p>
             <p class="process-label">Total PRs</p>
             <p class="process-detail">149 merged <span class="process-chip">+1</span></p>
           </article>
@@ -892,7 +892,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-29T05:20:28Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-29T05:25:33Z</footer>
   </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -479,7 +479,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-04-29 00:42:35 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-04-29 13:20:28 CST</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -506,7 +506,13 @@ main {
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">1.5</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">3</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
-              <polyline data-kpi-placeholder="line" fill="none" stroke="#9f6a3a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" stroke-opacity="0.44" points="70.0,190.0 141.7,190.0 213.3,190.0 285.0,190.0 356.7,190.0 428.3,190.0 500.0,190.0"/><circle data-kpi-placeholder="point" cx="70.0" cy="190.0" r="4.5" fill="none" stroke="#9f6a3a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="141.7" cy="190.0" r="4.5" fill="none" stroke="#9f6a3a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="213.3" cy="190.0" r="4.5" fill="none" stroke="#9f6a3a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="285.0" cy="190.0" r="4.5" fill="none" stroke="#9f6a3a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="356.7" cy="190.0" r="4.5" fill="none" stroke="#9f6a3a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="428.3" cy="190.0" r="4.5" fill="none" stroke="#9f6a3a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="500.0" cy="190.0" r="4.5" fill="none" stroke="#9f6a3a" stroke-width="2" stroke-opacity="0.68"/><polyline data-kpi-placeholder="line" fill="none" stroke="#77716a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" stroke-opacity="0.44" points="70.0,190.0 141.7,190.0 213.3,190.0 285.0,190.0 356.7,190.0 428.3,190.0 500.0,190.0"/><circle data-kpi-placeholder="point" cx="70.0" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="141.7" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="213.3" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="285.0" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="356.7" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="428.3" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="500.0" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><polyline data-kpi-placeholder="line" fill="none" stroke="#c8945a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" stroke-opacity="0.44" points="70.0,190.0 141.7,190.0 213.3,190.0 285.0,190.0 356.7,190.0 428.3,190.0 500.0,190.0"/><circle data-kpi-placeholder="point" cx="70.0" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="141.7" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="213.3" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="285.0" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="356.7" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="428.3" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="500.0" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/>
+
+
+              <g data-kpi-unavailable="true">
+                <rect x="122.0" y="66.0" width="326.0" height="74" rx="10" fill="#fbfaf7" stroke="#d8cabc" stroke-width="1.2"/>
+                <text x="285.0" y="100.0" text-anchor="middle" fill="#3e352d" font-size="17" font-weight="800">No observed KPI data</text>
+                <text x="285.0" y="125.0" text-anchor="middle" fill="#8b6d55" font-size="13">Real reducer history is unavailable; chart is intentionally blank.</text>
+              </g>
               <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">4/23</text>
 <text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">4/24</text>
 <text x="213.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">4/25</text>
@@ -535,7 +541,13 @@ main {
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">0.5</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">1</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
-              <polyline data-kpi-placeholder="line" fill="none" stroke="#25211c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" stroke-opacity="0.44" points="70.0,190.0 141.7,190.0 213.3,190.0 285.0,190.0 356.7,190.0 428.3,190.0 500.0,190.0"/><circle data-kpi-placeholder="point" cx="70.0" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="141.7" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="213.3" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="285.0" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="356.7" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="428.3" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="500.0" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><polyline data-kpi-placeholder="line" fill="none" stroke="#66605a" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" stroke-opacity="0.44" points="70.0,190.0 141.7,190.0 213.3,190.0 285.0,190.0 356.7,190.0 428.3,190.0 500.0,190.0"/><circle data-kpi-placeholder="point" cx="70.0" cy="190.0" r="4.5" fill="none" stroke="#66605a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="141.7" cy="190.0" r="4.5" fill="none" stroke="#66605a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="213.3" cy="190.0" r="4.5" fill="none" stroke="#66605a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="285.0" cy="190.0" r="4.5" fill="none" stroke="#66605a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="356.7" cy="190.0" r="4.5" fill="none" stroke="#66605a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="428.3" cy="190.0" r="4.5" fill="none" stroke="#66605a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="500.0" cy="190.0" r="4.5" fill="none" stroke="#66605a" stroke-width="2" stroke-opacity="0.68"/><polyline data-kpi-placeholder="line" fill="none" stroke="#c8945a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" stroke-opacity="0.44" points="70.0,190.0 141.7,190.0 213.3,190.0 285.0,190.0 356.7,190.0 428.3,190.0 500.0,190.0"/><circle data-kpi-placeholder="point" cx="70.0" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="141.7" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="213.3" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="285.0" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="356.7" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="428.3" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="500.0" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/>
+
+
+              <g data-kpi-unavailable="true">
+                <rect x="122.0" y="66.0" width="326.0" height="74" rx="10" fill="#fbfaf7" stroke="#d8cabc" stroke-width="1.2"/>
+                <text x="285.0" y="100.0" text-anchor="middle" fill="#3e352d" font-size="17" font-weight="800">No observed KPI data</text>
+                <text x="285.0" y="125.0" text-anchor="middle" fill="#8b6d55" font-size="13">Real reducer history is unavailable; chart is intentionally blank.</text>
+              </g>
               <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">4/23</text>
 <text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">4/24</text>
 <text x="213.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">4/25</text>
@@ -564,7 +576,13 @@ main {
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="195.0" text-anchor="end" fill="#8b6d55" font-size="15">0</text><line x1="70.0" y1="107.0" x2="500.0" y2="107.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="112.0" text-anchor="end" fill="#8b6d55" font-size="15">0.5</text><line x1="70.0" y1="24.0" x2="500.0" y2="24.0" stroke="#e4d7c8" stroke-width="1"/><text x="58.0" y="29.0" text-anchor="end" fill="#8b6d55" font-size="15">1</text>
               <line x1="70.0" y1="24.0" x2="70.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
               <line x1="70.0" y1="190.0" x2="500.0" y2="190.0" stroke="#cdbba7" stroke-width="1.5"/>
-              <polyline data-kpi-placeholder="line" fill="none" stroke="#25211c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" stroke-opacity="0.44" points="70.0,190.0 141.7,190.0 213.3,190.0 285.0,190.0 356.7,190.0 428.3,190.0 500.0,190.0"/><circle data-kpi-placeholder="point" cx="70.0" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="141.7" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="213.3" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="285.0" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="356.7" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="428.3" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="500.0" cy="190.0" r="4.5" fill="none" stroke="#25211c" stroke-width="2" stroke-opacity="0.68"/><polyline data-kpi-placeholder="line" fill="none" stroke="#77716a" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" stroke-opacity="0.44" points="70.0,190.0 141.7,190.0 213.3,190.0 285.0,190.0 356.7,190.0 428.3,190.0 500.0,190.0"/><circle data-kpi-placeholder="point" cx="70.0" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="141.7" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="213.3" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="285.0" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="356.7" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="428.3" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="500.0" cy="190.0" r="4.5" fill="none" stroke="#77716a" stroke-width="2" stroke-opacity="0.68"/><polyline data-kpi-placeholder="line" fill="none" stroke="#c8945a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" stroke-opacity="0.44" points="70.0,190.0 141.7,190.0 213.3,190.0 285.0,190.0 356.7,190.0 428.3,190.0 500.0,190.0"/><circle data-kpi-placeholder="point" cx="70.0" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="141.7" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="213.3" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="285.0" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="356.7" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="428.3" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/><circle data-kpi-placeholder="point" cx="500.0" cy="190.0" r="4.5" fill="none" stroke="#c8945a" stroke-width="2" stroke-opacity="0.68"/>
+
+
+              <g data-kpi-unavailable="true">
+                <rect x="122.0" y="66.0" width="326.0" height="74" rx="10" fill="#fbfaf7" stroke="#d8cabc" stroke-width="1.2"/>
+                <text x="285.0" y="100.0" text-anchor="middle" fill="#3e352d" font-size="17" font-weight="800">No observed KPI data</text>
+                <text x="285.0" y="125.0" text-anchor="middle" fill="#8b6d55" font-size="13">Real reducer history is unavailable; chart is intentionally blank.</text>
+              </g>
               <text x="70.0" y="226" text-anchor="middle" fill="#7b6654" font-size="15">4/23</text>
 <text x="141.7" y="226" text-anchor="middle" fill="#7b6654" font-size="15">4/24</text>
 <text x="213.3" y="226" text-anchor="middle" fill="#7b6654" font-size="15">4/25</text>
@@ -837,23 +855,23 @@ main {
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">199</p>
+            <p class="process-value">230</p>
             <p class="process-label">Total commits</p>
             <p class="process-detail">repository history <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">125</p>
+            <p class="process-value">154</p>
             <p class="process-label">Total PRs</p>
-            <p class="process-detail">117 merged <span class="process-chip">+1</span></p>
+            <p class="process-detail">149 merged <span class="process-chip">+1</span></p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">94</p>
+            <p class="process-value">126</p>
             <p class="process-label">Total issues</p>
-            <p class="process-detail">7 open <span class="process-chip">+0</span></p>
+            <p class="process-detail">8 open <span class="process-chip">+0</span></p>
           </article>
 
 
@@ -874,7 +892,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-28T16:42:35Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-29T05:20:28Z</footer>
   </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -479,7 +479,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-04-29 13:40:59 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-04-29 13:48:26 CST</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -855,7 +855,7 @@ main {
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">234</p>
+            <p class="process-value">235</p>
             <p class="process-label">Total commits</p>
             <p class="process-detail">repository history</p>
           </article>
@@ -892,7 +892,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-29T05:40:59Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-29T05:48:26Z</footer>
   </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -479,7 +479,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-04-29 13:25:33 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-04-29 13:40:59 CST</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -855,44 +855,44 @@ main {
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">233</p>
+            <p class="process-value">234</p>
             <p class="process-label">Total commits</p>
-            <p class="process-detail">repository history <span class="process-chip">+1</span></p>
+            <p class="process-detail">repository history</p>
           </article>
 
 
           <article class="process-card">
             <p class="process-value">158</p>
             <p class="process-label">Total PRs</p>
-            <p class="process-detail">149 merged <span class="process-chip">+1</span></p>
+            <p class="process-detail">149 merged</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">126</p>
+            <p class="process-value">128</p>
             <p class="process-label">Total issues</p>
-            <p class="process-detail">8 open <span class="process-chip">+0</span></p>
+            <p class="process-detail">10 open</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">0</p>
+            <p class="process-value">1</p>
             <p class="process-label">Official deploys</p>
-            <p class="process-detail">official deploy evidence <span class="process-chip">+0</span></p>
+            <p class="process-detail">official deploy evidence</p>
           </article>
 
 
           <article class="process-card">
             <p class="process-value">1</p>
             <p class="process-label">Private smoke tests</p>
-            <p class="process-detail">smoke/report evidence <span class="process-chip">+0</span></p>
+            <p class="process-detail">smoke/report evidence</p>
           </article>
 
         </div>
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-29T05:25:33Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-04-29T05:40:59Z</footer>
   </div>
 </body>
 </html>

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,90 +3,111 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-04-28T16:42:35Z",
-  "generatedAtCst": "2026-04-29 00:42:35 CST",
+  "generatedAt": "2026-04-29T05:20:28Z",
+  "generatedAtCst": "2026-04-29 13:20:28 CST",
   "github": {
     "fetchErrors": [],
     "fetched": true,
     "issues": [
       {
-        "createdAt": "2026-04-28T16:39:22Z",
-        "domain": "Change-control",
+        "createdAt": "2026-04-29T04:54:03Z",
+        "domain": "Bot capability",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:phase-b-spawn-lifecycle"
+        ],
+        "milestone": "",
+        "number": 280,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P1: Territory: gate follow-up target selection on spawn readiness",
+        "type": "Issue",
+        "updatedAt": "2026-04-29T04:54:52Z",
+        "url": "https://github.com/lanyusea/screeps/issues/280"
+      },
+      {
+        "createdAt": "2026-04-29T02:56:34Z",
+        "domain": "Agent OS",
         "kind": "ops",
         "labels": [
           "kind:ops",
           "priority:p1",
           "roadmap"
         ],
-        "milestone": "",
-        "number": 218,
+        "milestone": "P0: Agent OS / Discord visibility gate",
+        "number": 273,
         "priority": "P1",
         "state": "OPEN",
         "status": "Ready",
-        "title": "P1: increase autonomous development concurrency capacity by 1.5x",
+        "title": "P1: Agent OS: prevent research scaffold closure false positives",
         "type": "Issue",
-        "updatedAt": "2026-04-28T16:42:39Z",
-        "url": "https://github.com/lanyusea/screeps/issues/218"
+        "updatedAt": "2026-04-29T02:56:34Z",
+        "url": "https://github.com/lanyusea/screeps/issues/273"
       },
       {
-        "createdAt": "2026-04-28T16:31:38Z",
+        "createdAt": "2026-04-29T01:21:14Z",
         "domain": "Runtime monitor",
-        "kind": "docs",
+        "kind": "code",
         "labels": [
-          "kind:docs",
+          "blocked",
+          "kind:code",
+          "priority:p2",
+          "roadmap",
+          "roadmap:phase-c-telemetry"
+        ],
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "number": 266,
+        "priority": "P2",
+        "state": "OPEN",
+        "status": "Backlog",
+        "title": "P2: Gameplay Evolution: offline RL and hierarchical strategy recommendation prototype",
+        "type": "Issue",
+        "updatedAt": "2026-04-29T04:10:47Z",
+        "url": "https://github.com/lanyusea/screeps/issues/266"
+      },
+      {
+        "createdAt": "2026-04-29T01:21:01Z",
+        "domain": "Runtime monitor",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:phase-c-telemetry"
+        ],
+        "milestone": "Phase C: Runtime telemetry / monitor gate",
+        "number": 265,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P1: Gameplay Evolution: strategy registry and shadow evaluator",
+        "type": "Issue",
+        "updatedAt": "2026-04-29T04:54:02Z",
+        "url": "https://github.com/lanyusea/screeps/issues/265"
+      },
+      {
+        "createdAt": "2026-04-28T17:32:14Z",
+        "domain": "Change-control",
+        "kind": "bug",
+        "labels": [
+          "kind:bug",
           "priority:p1",
           "roadmap",
           "roadmap:phase-c-telemetry"
         ],
         "milestone": "",
-        "number": 216,
+        "number": 226,
         "priority": "P1",
         "state": "OPEN",
         "status": "Ready",
-        "title": "P1: GitHub Pages roadmap KPI charts need placeholder lines and data points",
+        "title": "P1: Roadmap Official deploys metric ignores deploy evidence JSON",
         "type": "Issue",
-        "updatedAt": "2026-04-28T16:40:27Z",
-        "url": "https://github.com/lanyusea/screeps/issues/216"
-      },
-      {
-        "createdAt": "2026-04-28T16:17:14Z",
-        "domain": "Bot capability",
-        "kind": "code",
-        "labels": [
-          "kind:code",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-b-spawn-lifecycle"
-        ],
-        "milestone": "",
-        "number": 215,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1: Bot Capability: extend territory pressure after reservation renewal",
-        "type": "Issue",
-        "updatedAt": "2026-04-28T16:34:45Z",
-        "url": "https://github.com/lanyusea/screeps/issues/215"
-      },
-      {
-        "createdAt": "2026-04-28T15:58:44Z",
-        "domain": "Bot capability",
-        "kind": "code",
-        "labels": [
-          "kind:code",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-b-spawn-lifecycle"
-        ],
-        "milestone": "",
-        "number": 213,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1: Bot Capability: improve resource economy flow after worker throughput",
-        "type": "Issue",
-        "updatedAt": "2026-04-28T16:15:05Z",
-        "url": "https://github.com/lanyusea/screeps/issues/213"
+        "updatedAt": "2026-04-29T05:13:27Z",
+        "url": "https://github.com/lanyusea/screeps/issues/226"
       },
       {
         "createdAt": "2026-04-26T17:09:40Z",
@@ -105,7 +126,7 @@
         "status": "Ready",
         "title": "P1: Phase E: gameplay release cadence and emergency hotfix gate are not enforced",
         "type": "Issue",
-        "updatedAt": "2026-04-28T16:26:49Z",
+        "updatedAt": "2026-04-29T04:57:41Z",
         "url": "https://github.com/lanyusea/screeps/issues/63"
       },
       {
@@ -125,7 +146,7 @@
         "status": "Ready",
         "title": "P1: Gameplay Evolution\u4e13\u9879\uff1avision-driven game-result review to roadmap/task loop",
         "type": "Issue",
-        "updatedAt": "2026-04-28T10:51:06Z",
+        "updatedAt": "2026-04-28T17:55:49Z",
         "url": "https://github.com/lanyusea/screeps/issues/59"
       },
       {
@@ -160,7 +181,7 @@
           "number": 63,
           "priority": "P1",
           "state": "",
-          "status": "In progress",
+          "status": "In review",
           "title": "Gameplay release cadence and emergency hotfix evidence",
           "type": "Issue",
           "updatedAt": "",
@@ -2401,6 +2422,10 @@
               "status": "Ready"
             },
             {
+              "cards": [],
+              "status": "In progress"
+            },
+            {
               "cards": [
                 {
                   "domain": "Official MMO",
@@ -2411,7 +2436,7 @@
                   "number": 63,
                   "priority": "P1",
                   "state": "",
-                  "status": "In progress",
+                  "status": "In review",
                   "title": "Gameplay release cadence and emergency hotfix evidence",
                   "type": "Issue",
                   "updatedAt": "",
@@ -2419,10 +2444,6 @@
                   "visionLayer": "foundation blocker"
                 }
               ],
-              "status": "In progress"
-            },
-            {
-              "cards": [],
               "status": "In review"
             },
             {
@@ -3414,17 +3435,17 @@
       {
         "instrumented": true,
         "label": "Open roadmap issues",
-        "value": 7
+        "value": 8
       },
       {
         "instrumented": true,
         "label": "Open PRs",
-        "value": 3
+        "value": 0
       },
       {
         "instrumented": true,
         "label": "Blocked cards",
-        "value": 0
+        "value": 1
       },
       {
         "instrumented": true,
@@ -3434,12 +3455,12 @@
       {
         "instrumented": true,
         "label": "In progress",
-        "value": 2
+        "value": 1
       },
       {
         "instrumented": true,
         "label": "In review",
-        "value": 0
+        "value": 1
       }
     ],
     "projectItems": [
@@ -4203,7 +4224,7 @@
       {
         "blockedBy": "",
         "domain": "Official MMO",
-        "evidence": "Official deploy SUCCESS 2026-04-29T00:23+08: run 25064761914 on main 3b4ce0a; uploaded prod/dist/main.js SHA256 ab4ff700c8524d1d4fedb3daf18a63bd8db794215c6e07d08ee41691ceef2f89 to Screeps branch main; activeWorld set to main; branchCode and activeWorld code matched in deploy evidence JSON.",
+        "evidence": "Deployment floor SATISFIED for main 5840cda60f808d716ed72895031925420008d697 via official deploy run 25090124434; deploy JSON and postdeploy summary/alert sidecars archived.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -4216,7 +4237,7 @@
         "number": 63,
         "priority": "P1",
         "state": "",
-        "status": "In progress",
+        "status": "In review",
         "title": "P1: Phase E: gameplay release cadence and emergency hotfix gate are not enforced",
         "type": "Issue",
         "updatedAt": "",
@@ -5340,77 +5361,7 @@
         "url": "https://github.com/lanyusea/screeps/pull/123"
       }
     ],
-    "pullRequests": [
-      {
-        "checks": {
-          "failure": 0,
-          "pending": 0,
-          "success": 2,
-          "total": 2
-        },
-        "createdAt": "2026-04-28T16:42:19Z",
-        "domain": "Docs/process",
-        "isDraft": false,
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "number": 219,
-        "priority": "P1",
-        "reviewDecision": "",
-        "state": "OPEN",
-        "status": "In review",
-        "title": "docs: scale autonomous dev concurrency",
-        "type": "PullRequest",
-        "updatedAt": "2026-04-28T16:42:59Z",
-        "url": "https://github.com/lanyusea/screeps/pull/219"
-      },
-      {
-        "checks": {
-          "failure": 0,
-          "pending": 0,
-          "success": 2,
-          "total": 2
-        },
-        "createdAt": "2026-04-28T16:32:43Z",
-        "domain": "Bot capability",
-        "isDraft": false,
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "number": 217,
-        "priority": "P1",
-        "reviewDecision": "",
-        "state": "OPEN",
-        "status": "In review",
-        "title": "feat: extend territory pressure after reservation renewal",
-        "type": "PullRequest",
-        "updatedAt": "2026-04-28T16:35:19Z",
-        "url": "https://github.com/lanyusea/screeps/pull/217"
-      },
-      {
-        "checks": {
-          "failure": 0,
-          "pending": 0,
-          "success": 2,
-          "total": 2
-        },
-        "createdAt": "2026-04-28T16:14:45Z",
-        "domain": "Bot capability",
-        "isDraft": false,
-        "kind": "code",
-        "labels": [],
-        "milestone": "",
-        "number": 214,
-        "priority": "P1",
-        "reviewDecision": "",
-        "state": "OPEN",
-        "status": "In review",
-        "title": "feat: improve resource economy flow after worker throughput",
-        "type": "PullRequest",
-        "updatedAt": "2026-04-28T16:41:40Z",
-        "url": "https://github.com/lanyusea/screeps/pull/214"
-      }
-    ],
+    "pullRequests": [],
     "roadmapCards": [
       {
         "domain": "Change-control",
@@ -6205,34 +6156,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -6367,6 +6290,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6375,34 +6326,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -6537,6 +6460,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6545,34 +6496,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -6707,6 +6630,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6715,34 +6666,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -6877,6 +6800,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6885,34 +6836,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -7047,6 +6970,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7055,34 +7006,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -7217,6 +7140,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7225,34 +7176,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -7387,6 +7310,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7395,34 +7346,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -7557,6 +7480,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7565,34 +7516,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -7727,6 +7650,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7735,34 +7686,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -7897,6 +7820,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7905,34 +7856,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -8067,6 +7990,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8075,34 +8026,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -8237,6 +8160,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8245,34 +8196,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -8407,6 +8330,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8415,34 +8366,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -8577,6 +8500,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8585,34 +8536,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -8747,6 +8670,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8755,34 +8706,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -8917,6 +8840,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8925,34 +8876,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "observed",
           "value": 0.0
@@ -9087,6 +9010,34 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "observed",
           "value": 0.0
         }
@@ -9095,34 +9046,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -9257,6 +9180,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9265,34 +9216,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -9427,6 +9350,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9435,34 +9386,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -9597,6 +9520,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9605,34 +9556,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -9767,6 +9690,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9775,34 +9726,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -9937,6 +9860,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9945,34 +9896,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -10107,6 +10030,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10115,34 +10066,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "observed",
           "value": 0.0
@@ -10277,6 +10200,34 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "observed",
           "value": 0.0
         }
@@ -10285,34 +10236,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -10447,6 +10370,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10455,34 +10406,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -10617,6 +10540,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10625,34 +10576,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -10787,6 +10710,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10795,34 +10746,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -10957,6 +10880,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10965,34 +10916,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -11127,6 +11050,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11135,34 +11086,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -11297,6 +11220,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11305,34 +11256,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -11467,6 +11390,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11475,34 +11426,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -11637,6 +11560,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11645,34 +11596,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:40:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:41:08Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:43:01Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:44:17Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:46:35Z",
           "status": "not instrumented",
           "value": null
@@ -11807,6 +11730,34 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-28T16:42:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:12:23Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:14:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:17:35Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:20:28Z",
           "status": "not instrumented",
           "value": null
         }
@@ -12250,21 +12201,21 @@
         "delta": "+1",
         "detail": "repository history",
         "label": "Total commits",
-        "value": 199
+        "value": 230
       },
       {
         "delta": "+1",
-        "detail": "117 merged",
+        "detail": "149 merged",
         "label": "Total PRs",
         "source": "github",
-        "value": 125
+        "value": 154
       },
       {
         "delta": "+0",
-        "detail": "7 open",
+        "detail": "8 open",
         "label": "Total issues",
         "source": "github",
-        "value": 94
+        "value": 126
       },
       {
         "delta": "+0",
@@ -12340,8 +12291,8 @@
       "matchedFiles": 0,
       "reason": "",
       "runtimeSummaryLines": 0,
-      "scannedFiles": 95787,
-      "skippedFileCount": 2189
+      "scannedFiles": 96120,
+      "skippedFileCount": 2190
     },
     "window": {
       "firstTick": null,

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,12 +3,52 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-04-29T05:25:33Z",
-  "generatedAtCst": "2026-04-29 13:25:33 CST",
+  "generatedAt": "2026-04-29T05:40:59Z",
+  "generatedAtCst": "2026-04-29 13:40:59 CST",
   "github": {
     "fetchErrors": [],
     "fetched": true,
     "issues": [
+      {
+        "createdAt": "2026-04-29T05:30:12Z",
+        "domain": "Bot capability",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:phase-b-spawn-lifecycle"
+        ],
+        "milestone": "",
+        "number": 286,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P1: Economy: refill spawn and extensions before non-urgent spending",
+        "type": "Issue",
+        "updatedAt": "2026-04-29T05:31:19Z",
+        "url": "https://github.com/lanyusea/screeps/issues/286"
+      },
+      {
+        "createdAt": "2026-04-29T05:29:56Z",
+        "domain": "Bot capability",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:phase-b-spawn-lifecycle"
+        ],
+        "milestone": "",
+        "number": 285,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P1: Economy: rank productive energy sinks after follow-up refill readiness",
+        "type": "Issue",
+        "updatedAt": "2026-04-29T05:31:13Z",
+        "url": "https://github.com/lanyusea/screeps/issues/285"
+      },
       {
         "createdAt": "2026-04-29T04:54:03Z",
         "domain": "Bot capability",
@@ -106,7 +146,7 @@
         "status": "Ready",
         "title": "P1: Roadmap Official deploys metric ignores deploy evidence JSON",
         "type": "Issue",
-        "updatedAt": "2026-04-29T05:13:27Z",
+        "updatedAt": "2026-04-29T05:28:42Z",
         "url": "https://github.com/lanyusea/screeps/issues/226"
       },
       {
@@ -3435,7 +3475,7 @@
       {
         "instrumented": true,
         "label": "Open roadmap issues",
-        "value": 8
+        "value": 10
       },
       {
         "instrumented": true,
@@ -5365,8 +5405,8 @@
       {
         "checks": {
           "failure": 0,
-          "pending": 1,
-          "success": 1,
+          "pending": 0,
+          "success": 2,
           "total": 2
         },
         "createdAt": "2026-04-29T05:26:14Z",
@@ -5382,14 +5422,14 @@
         "status": "In review",
         "title": "fix: count official deploy evidence json",
         "type": "PullRequest",
-        "updatedAt": "2026-04-29T05:26:19Z",
+        "updatedAt": "2026-04-29T05:26:52Z",
         "url": "https://github.com/lanyusea/screeps/pull/284"
       },
       {
         "checks": {
           "failure": 0,
-          "pending": 1,
-          "success": 1,
+          "pending": 0,
+          "success": 2,
           "total": 2
         },
         "createdAt": "2026-04-29T05:22:50Z",
@@ -5405,7 +5445,7 @@
         "status": "In review",
         "title": "fix: remove fake roadmap KPI placeholders",
         "type": "PullRequest",
-        "updatedAt": "2026-04-29T05:26:07Z",
+        "updatedAt": "2026-04-29T05:27:34Z",
         "url": "https://github.com/lanyusea/screeps/pull/282"
       },
       {
@@ -5428,7 +5468,7 @@
         "status": "In review",
         "title": "feat: add passive strategy shadow evaluator",
         "type": "PullRequest",
-        "updatedAt": "2026-04-29T05:22:55Z",
+        "updatedAt": "2026-04-29T05:29:12Z",
         "url": "https://github.com/lanyusea/screeps/pull/283"
       },
       {
@@ -5451,7 +5491,7 @@
         "status": "In review",
         "title": "feat: gate follow-up targets on spawn readiness",
         "type": "PullRequest",
-        "updatedAt": "2026-04-29T05:26:14Z",
+        "updatedAt": "2026-04-29T05:29:12Z",
         "url": "https://github.com/lanyusea/screeps/pull/281"
       }
     ],
@@ -6249,27 +6289,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -6411,6 +6430,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6419,27 +6459,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -6581,6 +6600,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6589,27 +6629,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -6751,6 +6770,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6759,27 +6799,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -6921,6 +6940,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6929,27 +6969,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -7091,6 +7110,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7099,27 +7139,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -7261,6 +7280,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7269,27 +7309,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -7431,6 +7450,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7439,27 +7479,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -7601,6 +7620,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7609,27 +7649,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -7771,6 +7790,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7779,27 +7819,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -7941,6 +7960,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7949,27 +7989,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -8111,6 +8130,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8119,27 +8159,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -8281,6 +8300,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8289,27 +8329,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -8451,6 +8470,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8459,27 +8499,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -8621,6 +8640,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8629,27 +8669,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -8791,6 +8810,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8799,27 +8839,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -8961,6 +8980,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8969,27 +9009,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "observed",
           "value": 0.0
@@ -9131,6 +9150,27 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "observed",
           "value": 0.0
         }
@@ -9139,27 +9179,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -9301,6 +9320,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9309,27 +9349,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -9471,6 +9490,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9479,27 +9519,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -9641,6 +9660,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9649,27 +9689,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -9811,6 +9830,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9819,27 +9859,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -9981,6 +10000,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9989,27 +10029,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -10151,6 +10170,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10159,27 +10199,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "observed",
           "value": 0.0
@@ -10321,6 +10340,27 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "observed",
           "value": 0.0
         }
@@ -10329,27 +10369,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -10491,6 +10510,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10499,27 +10539,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -10661,6 +10680,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10669,27 +10709,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -10831,6 +10850,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10839,27 +10879,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -11001,6 +11020,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11009,27 +11049,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -11171,6 +11190,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11179,27 +11219,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -11341,6 +11360,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11349,27 +11389,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -11511,6 +11530,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11519,27 +11559,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -11681,6 +11700,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11689,27 +11729,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:49:10Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:51:00Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-04-27T07:54:37Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:38:52Z",
           "status": "not instrumented",
           "value": null
@@ -11851,6 +11870,27 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:25:33Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:35:00Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:36:41Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:40:59Z",
           "status": "not instrumented",
           "value": null
         }
@@ -12294,7 +12334,7 @@
         "delta": "+1",
         "detail": "repository history",
         "label": "Total commits",
-        "value": 233
+        "value": 234
       },
       {
         "delta": "+1",
@@ -12305,16 +12345,16 @@
       },
       {
         "delta": "+0",
-        "detail": "8 open",
+        "detail": "10 open",
         "label": "Total issues",
         "source": "github",
-        "value": 126
+        "value": 128
       },
       {
         "delta": "+0",
         "detail": "official deploy evidence",
         "label": "Official deploys",
-        "value": 0
+        "value": 1
       },
       {
         "delta": "+0",
@@ -12377,12 +12417,15 @@
   },
   "runtimeReport": {
     "source": {
-      "inputPaths": [],
+      "inputPaths": [
+        "",
+        ""
+      ],
       "matchedFiles": 0,
-      "reason": "runtime KPI bridge unavailable",
+      "reason": "",
       "runtimeSummaryLines": 0,
-      "scannedFiles": 0,
-      "skippedFileCount": 0
+      "scannedFiles": 96126,
+      "skippedFileCount": 2190
     },
     "window": {
       "firstTick": null,

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,8 +3,8 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-04-29T05:40:59Z",
-  "generatedAtCst": "2026-04-29 13:40:59 CST",
+  "generatedAt": "2026-04-29T05:48:26Z",
+  "generatedAtCst": "2026-04-29 13:48:26 CST",
   "github": {
     "fetchErrors": [],
     "fetched": true,
@@ -5422,7 +5422,7 @@
         "status": "In review",
         "title": "fix: count official deploy evidence json",
         "type": "PullRequest",
-        "updatedAt": "2026-04-29T05:26:52Z",
+        "updatedAt": "2026-04-29T05:46:02Z",
         "url": "https://github.com/lanyusea/screeps/pull/284"
       },
       {
@@ -5445,7 +5445,7 @@
         "status": "In review",
         "title": "fix: remove fake roadmap KPI placeholders",
         "type": "PullRequest",
-        "updatedAt": "2026-04-29T05:27:34Z",
+        "updatedAt": "2026-04-29T05:46:41Z",
         "url": "https://github.com/lanyusea/screeps/pull/282"
       },
       {
@@ -6289,13 +6289,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -6451,6 +6444,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6459,13 +6459,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -6621,6 +6614,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6629,13 +6629,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -6791,6 +6784,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6799,13 +6799,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -6961,6 +6954,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6969,13 +6969,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -7131,6 +7124,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7139,13 +7139,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -7301,6 +7294,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7309,13 +7309,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -7471,6 +7464,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7479,13 +7479,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -7641,6 +7634,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7649,13 +7649,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -7811,6 +7804,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7819,13 +7819,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -7981,6 +7974,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7989,13 +7989,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -8151,6 +8144,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8159,13 +8159,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -8321,6 +8314,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8329,13 +8329,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -8491,6 +8484,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8499,13 +8499,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -8661,6 +8654,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8669,13 +8669,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -8831,6 +8824,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8839,13 +8839,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -9001,6 +8994,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9009,13 +9009,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "observed",
           "value": 0.0
@@ -9171,6 +9164,13 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "observed",
           "value": 0.0
         }
@@ -9179,13 +9179,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -9341,6 +9334,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9349,13 +9349,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -9511,6 +9504,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9519,13 +9519,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -9681,6 +9674,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9689,13 +9689,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -9851,6 +9844,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9859,13 +9859,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -10021,6 +10014,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10029,13 +10029,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -10191,6 +10184,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10199,13 +10199,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "observed",
           "value": 0.0
@@ -10361,6 +10354,13 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "observed",
           "value": 0.0
         }
@@ -10369,13 +10369,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -10531,6 +10524,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10539,13 +10539,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -10701,6 +10694,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10709,13 +10709,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -10871,6 +10864,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10879,13 +10879,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -11041,6 +11034,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11049,13 +11049,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -11211,6 +11204,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11219,13 +11219,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -11381,6 +11374,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11389,13 +11389,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -11551,6 +11544,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11559,13 +11559,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -11721,6 +11714,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11729,13 +11729,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T08:38:52Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T08:43:05Z",
           "status": "not instrumented",
           "value": null
@@ -11891,6 +11884,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:40:59Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:48:26Z",
           "status": "not instrumented",
           "value": null
         }
@@ -12334,7 +12334,7 @@
         "delta": "+1",
         "detail": "repository history",
         "label": "Total commits",
-        "value": 234
+        "value": 235
       },
       {
         "delta": "+1",
@@ -12424,7 +12424,7 @@
       "matchedFiles": 0,
       "reason": "",
       "runtimeSummaryLines": 0,
-      "scannedFiles": 96126,
+      "scannedFiles": 96128,
       "skippedFileCount": 2190
     },
     "window": {

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,8 +3,8 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-04-29T05:20:28Z",
-  "generatedAtCst": "2026-04-29 13:20:28 CST",
+  "generatedAt": "2026-04-29T05:25:33Z",
+  "generatedAtCst": "2026-04-29 13:25:33 CST",
   "github": {
     "fetchErrors": [],
     "fetched": true,
@@ -26,7 +26,7 @@
         "status": "Ready",
         "title": "P1: Territory: gate follow-up target selection on spawn readiness",
         "type": "Issue",
-        "updatedAt": "2026-04-29T04:54:52Z",
+        "updatedAt": "2026-04-29T05:24:34Z",
         "url": "https://github.com/lanyusea/screeps/issues/280"
       },
       {
@@ -86,7 +86,7 @@
         "status": "Ready",
         "title": "P1: Gameplay Evolution: strategy registry and shadow evaluator",
         "type": "Issue",
-        "updatedAt": "2026-04-29T04:54:02Z",
+        "updatedAt": "2026-04-29T05:24:37Z",
         "url": "https://github.com/lanyusea/screeps/issues/265"
       },
       {
@@ -126,7 +126,7 @@
         "status": "Ready",
         "title": "P1: Phase E: gameplay release cadence and emergency hotfix gate are not enforced",
         "type": "Issue",
-        "updatedAt": "2026-04-29T04:57:41Z",
+        "updatedAt": "2026-04-29T05:24:31Z",
         "url": "https://github.com/lanyusea/screeps/issues/63"
       },
       {
@@ -3440,7 +3440,7 @@
       {
         "instrumented": true,
         "label": "Open PRs",
-        "value": 0
+        "value": 4
       },
       {
         "instrumented": true,
@@ -5361,7 +5361,100 @@
         "url": "https://github.com/lanyusea/screeps/pull/123"
       }
     ],
-    "pullRequests": [],
+    "pullRequests": [
+      {
+        "checks": {
+          "failure": 0,
+          "pending": 1,
+          "success": 1,
+          "total": 2
+        },
+        "createdAt": "2026-04-29T05:26:14Z",
+        "domain": "Change-control",
+        "isDraft": false,
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "number": 284,
+        "priority": "P1",
+        "reviewDecision": "",
+        "state": "OPEN",
+        "status": "In review",
+        "title": "fix: count official deploy evidence json",
+        "type": "PullRequest",
+        "updatedAt": "2026-04-29T05:26:19Z",
+        "url": "https://github.com/lanyusea/screeps/pull/284"
+      },
+      {
+        "checks": {
+          "failure": 0,
+          "pending": 1,
+          "success": 1,
+          "total": 2
+        },
+        "createdAt": "2026-04-29T05:22:50Z",
+        "domain": "Bot capability",
+        "isDraft": false,
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "number": 282,
+        "priority": "P1",
+        "reviewDecision": "",
+        "state": "OPEN",
+        "status": "In review",
+        "title": "fix: remove fake roadmap KPI placeholders",
+        "type": "PullRequest",
+        "updatedAt": "2026-04-29T05:26:07Z",
+        "url": "https://github.com/lanyusea/screeps/pull/282"
+      },
+      {
+        "checks": {
+          "failure": 0,
+          "pending": 0,
+          "success": 2,
+          "total": 2
+        },
+        "createdAt": "2026-04-29T05:22:50Z",
+        "domain": "Bot capability",
+        "isDraft": false,
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "number": 283,
+        "priority": "P1",
+        "reviewDecision": "",
+        "state": "OPEN",
+        "status": "In review",
+        "title": "feat: add passive strategy shadow evaluator",
+        "type": "PullRequest",
+        "updatedAt": "2026-04-29T05:22:55Z",
+        "url": "https://github.com/lanyusea/screeps/pull/283"
+      },
+      {
+        "checks": {
+          "failure": 0,
+          "pending": 0,
+          "success": 2,
+          "total": 2
+        },
+        "createdAt": "2026-04-29T05:22:32Z",
+        "domain": "Bot capability",
+        "isDraft": false,
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "number": 281,
+        "priority": "P1",
+        "reviewDecision": "",
+        "state": "OPEN",
+        "status": "In review",
+        "title": "feat: gate follow-up targets on spawn readiness",
+        "type": "PullRequest",
+        "updatedAt": "2026-04-29T05:26:14Z",
+        "url": "https://github.com/lanyusea/screeps/pull/281"
+      }
+    ],
     "roadmapCards": [
       {
         "domain": "Change-control",
@@ -6156,13 +6249,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -6318,6 +6404,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6326,13 +6419,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -6488,6 +6574,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6496,13 +6589,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -6658,6 +6744,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6666,13 +6759,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -6828,6 +6914,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -6836,13 +6929,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -6998,6 +7084,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7006,13 +7099,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -7168,6 +7254,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7176,13 +7269,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -7338,6 +7424,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7346,13 +7439,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -7508,6 +7594,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7516,13 +7609,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -7678,6 +7764,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7686,13 +7779,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -7848,6 +7934,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -7856,13 +7949,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -8018,6 +8104,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8026,13 +8119,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -8188,6 +8274,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8196,13 +8289,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -8358,6 +8444,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8366,13 +8459,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -8528,6 +8614,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8536,13 +8629,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -8698,6 +8784,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8706,13 +8799,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -8868,6 +8954,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -8876,13 +8969,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "observed",
           "value": 0.0
@@ -9038,6 +9124,13 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "observed",
           "value": 0.0
         }
@@ -9046,13 +9139,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -9208,6 +9294,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9216,13 +9309,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -9378,6 +9464,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9386,13 +9479,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -9548,6 +9634,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9556,13 +9649,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -9718,6 +9804,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9726,13 +9819,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -9888,6 +9974,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -9896,13 +9989,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -10058,6 +10144,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10066,13 +10159,6 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "observed",
           "value": 0.0
@@ -10228,6 +10314,13 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "observed",
           "value": 0.0
         }
@@ -10236,13 +10329,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -10398,6 +10484,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10406,13 +10499,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -10568,6 +10654,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10576,13 +10669,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -10738,6 +10824,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10746,13 +10839,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -10908,6 +10994,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -10916,13 +11009,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -11078,6 +11164,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11086,13 +11179,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -11248,6 +11334,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11256,13 +11349,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -11418,6 +11504,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11426,13 +11519,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -11588,6 +11674,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -11596,13 +11689,6 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-04-27T07:46:35Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
           "sampledAt": "2026-04-27T07:49:10Z",
           "status": "not instrumented",
           "value": null
@@ -11758,6 +11844,13 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-04-29T05:20:28Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-04-29T05:25:33Z",
           "status": "not instrumented",
           "value": null
         }
@@ -12201,14 +12294,14 @@
         "delta": "+1",
         "detail": "repository history",
         "label": "Total commits",
-        "value": 230
+        "value": 233
       },
       {
         "delta": "+1",
         "detail": "149 merged",
         "label": "Total PRs",
         "source": "github",
-        "value": 154
+        "value": 158
       },
       {
         "delta": "+0",
@@ -12284,15 +12377,12 @@
   },
   "runtimeReport": {
     "source": {
-      "inputPaths": [
-        "",
-        ""
-      ],
+      "inputPaths": [],
       "matchedFiles": 0,
-      "reason": "",
+      "reason": "runtime KPI bridge unavailable",
       "runtimeSummaryLines": 0,
-      "scannedFiles": 96120,
-      "skippedFileCount": 2190
+      "scannedFiles": 0,
+      "skippedFileCount": 0
     },
     "window": {
       "firstTick": null,

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4e7811479c13a30868eae1fd108ead820e468e360d2f438b05dcd9286a754492
-size 323584
+oid sha256:39f08af3f4fd767554ed88fcb13817a4a9d4e346a256e9262bbf148fa25d7106
+size 344064

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39f08af3f4fd767554ed88fcb13817a4a9d4e346a256e9262bbf148fa25d7106
-size 344064
+oid sha256:7ba3ea9543c847c05c38e60db0cd6da8129ffa8a7be4873597fa3f8cff9108dc
+size 348160

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d67790da9c2d16cdd47ceab0e74a00d1fbaf35fa94043c5893880e2d78f71fe
-size 319488
+oid sha256:4e7811479c13a30868eae1fd108ead820e468e360d2f438b05dcd9286a754492
+size 323584

--- a/docs/roadmap-kpi.sqlite
+++ b/docs/roadmap-kpi.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4bc40d4669b77ecb4abbeef58ba71d71e689d43220582d01d75a905356f05fa
-size 286720
+oid sha256:9d67790da9c2d16cdd47ceab0e74a00d1fbaf35fa94043c5893880e2d78f71fe
+size 319488

--- a/scripts/check-roadmap-kpi-placeholders.py
+++ b/scripts/check-roadmap-kpi-placeholders.py
@@ -112,12 +112,18 @@ def validate_kpi_html(
                 f"{label}: {title} missing legend label {series_label}",
             )
 
-        all_null_series = [series for series in card.get("series", ()) if is_all_null_series(generator, series)]
+        all_values = [
+            value
+            for series in card.get("series", ())
+            for value in series.get("values", ())
+            if isinstance(series, dict)
+        ]
+        all_values_missing = bool(all_values) and all(generator.chart_number(value) is None for value in all_values)
         placeholder_lines = find_tags(body, "polyline", 'data-kpi-placeholder="line"')
         placeholder_points = find_tags(body, "circle", 'data-kpi-placeholder="point"')
         assert_check(failures, not placeholder_lines, f"{label}: {title} must not render fake placeholder KPI lines")
         assert_check(failures, not placeholder_points, f"{label}: {title} must not render fake placeholder KPI points")
-        if not all_null_series:
+        if not all_values_missing:
             continue
 
         assert_check(
@@ -183,6 +189,12 @@ def validate_process_metrics(data: JsonObject, failures: list[str]) -> None:
             failures,
             isinstance(official_deploys, int) and official_deploys >= evidence_count,
             "docs/roadmap-data.json: Official deploys must reflect observed official deploy evidence instead of reporting 0",
+        )
+    else:
+        assert_check(
+            failures,
+            official_deploys != 0,
+            "docs/roadmap-data.json: Official deploys must not report 0 when no deploy evidence is observed",
         )
 
 

--- a/scripts/check-roadmap-kpi-placeholders.py
+++ b/scripts/check-roadmap-kpi-placeholders.py
@@ -132,7 +132,7 @@ def validate_kpi_html(
         )
 
 
-def committed_page_inputs(repo_root: Path) -> tuple[str, list[JsonObject]] | None:
+def committed_page_inputs(repo_root: Path) -> tuple[str, list[JsonObject], JsonObject] | None:
     html_path = repo_root / "docs" / "index.html"
     data_path = repo_root / "docs" / "roadmap-data.json"
     if not html_path.exists() or not data_path.exists():
@@ -141,7 +141,49 @@ def committed_page_inputs(repo_root: Path) -> tuple[str, list[JsonObject]] | Non
     cards = data.get("report", {}).get("kpiCards", [])
     if not isinstance(cards, list):
         raise RuntimeError("docs/roadmap-data.json report.kpiCards is not a list")
-    return html_path.read_text(encoding="utf-8"), [card for card in cards if isinstance(card, dict)]
+    return html_path.read_text(encoding="utf-8"), [card for card in cards if isinstance(card, dict)], data
+
+
+def deploy_evidence_count(data: JsonObject) -> int:
+    github = data.get("github", {})
+    if not isinstance(github, dict):
+        return 0
+    evidence: set[str] = set()
+    for collection_name in ("issues", "projectItems"):
+        collection = github.get(collection_name)
+        if not isinstance(collection, list):
+            continue
+        for item in collection:
+            if not isinstance(item, dict):
+                continue
+            text = " ".join(str(item.get(key) or "") for key in ("title", "status", "evidence", "nextAction")).lower()
+            run_ids = re.findall(r"official deploy run\s+(\d+)", text)
+            for run_id in run_ids:
+                evidence.add(f"run:{run_id}")
+            if not run_ids and "deployment floor satisfied" in text and "official deploy" in text:
+                evidence.add(f"item:{item.get('number', len(evidence))}")
+    return len(evidence)
+
+
+def process_card_value(data: JsonObject, label: str) -> Any:
+    cards = data.get("report", {}).get("processCards", [])
+    if not isinstance(cards, list):
+        return None
+    for card in cards:
+        if isinstance(card, dict) and card.get("label") == label:
+            return card.get("value")
+    return None
+
+
+def validate_process_metrics(data: JsonObject, failures: list[str]) -> None:
+    evidence_count = deploy_evidence_count(data)
+    official_deploys = process_card_value(data, "Official deploys")
+    if evidence_count:
+        assert_check(
+            failures,
+            isinstance(official_deploys, int) and official_deploys >= evidence_count,
+            "docs/roadmap-data.json: Official deploys must reflect observed official deploy evidence instead of reporting 0",
+        )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -155,8 +197,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     committed_inputs = committed_page_inputs(repo_root)
     if committed_inputs is not None:
-        committed_html, committed_cards = committed_inputs
+        committed_html, committed_cards, committed_data = committed_inputs
         validate_kpi_html("docs/index.html", committed_html, committed_cards, generator, failures)
+        validate_process_metrics(committed_data, failures)
 
     if failures:
         print("Roadmap KPI placeholder check failed:", file=sys.stderr)

--- a/scripts/check-roadmap-kpi-placeholders.py
+++ b/scripts/check-roadmap-kpi-placeholders.py
@@ -113,31 +113,23 @@ def validate_kpi_html(
             )
 
         all_null_series = [series for series in card.get("series", ()) if is_all_null_series(generator, series)]
+        placeholder_lines = find_tags(body, "polyline", 'data-kpi-placeholder="line"')
+        placeholder_points = find_tags(body, "circle", 'data-kpi-placeholder="point"')
+        assert_check(failures, not placeholder_lines, f"{label}: {title} must not render fake placeholder KPI lines")
+        assert_check(failures, not placeholder_points, f"{label}: {title} must not render fake placeholder KPI points")
         if not all_null_series:
             continue
 
-        placeholder_lines = find_tags(body, "polyline", 'data-kpi-placeholder="line"')
-        placeholder_points = find_tags(body, "circle", 'data-kpi-placeholder="point"')
-        expected_lines = len(all_null_series)
-        expected_points = sum(len(list(series.get("values", ()))) for series in all_null_series)
-
         assert_check(
             failures,
-            len(placeholder_lines) == expected_lines,
-            f"{label}: {title} should render {expected_lines} placeholder lines, saw {len(placeholder_lines)}",
+            'data-kpi-unavailable="true"' in body,
+            f"{label}: {title} all-null KPI chart should explicitly mark data as unavailable",
         )
         assert_check(
             failures,
-            len(placeholder_points) == expected_points,
-            f"{label}: {title} should render {expected_points} placeholder points, saw {len(placeholder_points)}",
+            "No observed KPI data" in html.unescape(body),
+            f"{label}: {title} all-null KPI chart should say no observed KPI data",
         )
-        for line in placeholder_lines:
-            assert_check(failures, tag_has_attribute(line, "stroke-dasharray"), f"{label}: {title} placeholder line is not dashed")
-            assert_check(failures, tag_has_attribute(line, "stroke-opacity"), f"{label}: {title} placeholder line is not muted")
-        for point in placeholder_points:
-            assert_check(failures, 'fill="none"' in point, f"{label}: {title} placeholder point is not hollow")
-            assert_check(failures, tag_has_attribute(point, "stroke"), f"{label}: {title} placeholder point has no stroke")
-            assert_check(failures, tag_has_attribute(point, "stroke-opacity"), f"{label}: {title} placeholder point is not muted")
 
 
 def committed_page_inputs(repo_root: Path) -> tuple[str, list[JsonObject]] | None:

--- a/scripts/check-roadmap-renderer.js
+++ b/scripts/check-roadmap-renderer.js
@@ -105,6 +105,13 @@ if (fs.existsSync(htmlPath)) {
     `KPI chart titles should be Territory, Resources, Combat; saw ${JSON.stringify(kpiTitles)}`
   );
 
+  const territoryCard = body.match(/<div class="card kpi">[\s\S]*?<h3>Territory<\/h3>[\s\S]*?<\/div><\/div>/);
+  assert(Boolean(territoryCard), 'Territory KPI card is missing');
+  if (territoryCard) {
+    const territoryText = tagText(territoryCard[0]);
+    assert(!territoryText.includes('Latest monitor RCL: 3'), 'Territory KPI must not use fallback RCL 3 when no monitor evidence exists');
+  }
+
   const resourcesCard = body.match(/<div class="card kpi">[\s\S]*?<h3>Resources<\/h3>[\s\S]*?<\/div><\/div>/);
   assert(Boolean(resourcesCard), 'Resources KPI card is missing');
   if (resourcesCard) {

--- a/scripts/check-roadmap-renderer.js
+++ b/scripts/check-roadmap-renderer.js
@@ -104,6 +104,18 @@ if (fs.existsSync(htmlPath)) {
     JSON.stringify(kpiTitles) === JSON.stringify(['Territory', 'Resources', 'Combat']),
     `KPI chart titles should be Territory, Resources, Combat; saw ${JSON.stringify(kpiTitles)}`
   );
+
+  const resourcesCard = body.match(/<div class="card kpi">[\s\S]*?<h3>Resources<\/h3>[\s\S]*?<\/div><\/div>/);
+  assert(Boolean(resourcesCard), 'Resources KPI card is missing');
+  if (resourcesCard) {
+    const resourcesText = tagText(resourcesCard[0]);
+    assert(resourcesCard[0].includes('data-kpi-unavailable="true"'), 'Resources KPI must mark unavailable data instead of drawing fake zeros');
+    assert(resourcesText.includes('No observed KPI data'), 'Resources KPI must state that no observed KPI data is available');
+    assert(!resourcesText.includes('Stored energy 0') && !resourcesText.includes('Harvest delta 0') && !resourcesText.includes('Worker carried 0'), 'Resources KPI must not label fake zero energy values');
+  }
+
+  const unavailableCards = [...body.matchAll(/data-kpi-unavailable="true"/g)].length;
+  assert(unavailableCards >= 1, 'At least one unavailable KPI block should be explicit when reducer data is missing');
 }
 
 if (failures.length > 0) {

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -2460,11 +2460,7 @@ def build_report_process_cards(
     )
     if issue_error is not None and cached_issue_card:
         total_issues = cached_issue_card.get("value", INSUFFICIENT_EVIDENCE)
-    official_deploy_count = count_process_evidence(
-        repo_root,
-        required_terms=("official", "deploy evidence"),
-        excluded_terms=("temporary official MMO link validation",),
-    )
+    official_deploy_count = count_official_deploy_evidence(repo_root, github_snapshot)
     private_smoke_count = count_private_smoke_process_reports(repo_root)
 
     return [
@@ -2598,6 +2594,39 @@ def count_process_evidence(
         ):
             count += 1
     return count
+
+
+def count_official_deploy_evidence(repo_root: Path, github_snapshot: JsonObject) -> int:
+    evidence: set[str] = set()
+    artifact_dir = repo_root / "runtime-artifacts" / "official-screeps-deploy"
+    if artifact_dir.is_dir():
+        for path in artifact_dir.glob("official-screeps-deploy-*.json"):
+            evidence.add(f"artifact:{path.name}")
+
+    process_count = count_process_evidence(
+        repo_root,
+        required_terms=("official", "deploy evidence"),
+        excluded_terms=("temporary official MMO link validation",),
+    )
+    for index in range(process_count):
+        evidence.add(f"process:{index}")
+
+    for collection_name in ("issues", "projectItems"):
+        collection = github_snapshot.get(collection_name)
+        if not isinstance(collection, list):
+            continue
+        for item in collection:
+            if not isinstance(item, dict):
+                continue
+            text = " ".join(
+                str(item.get(key) or "") for key in ("title", "status", "evidence", "nextAction")
+            ).lower()
+            run_ids = re.findall(r"official deploy run\s+(\d+)", text)
+            for run_id in run_ids:
+                evidence.add(f"run:{run_id}")
+            if not run_ids and "deployment floor satisfied" in text and "official deploy" in text:
+                evidence.add(f"item:{item.get('number', len(evidence))}")
+    return len(evidence)
 
 
 def count_private_smoke_process_reports(repo_root: Path) -> int:
@@ -4061,7 +4090,7 @@ def render_process_card(card: JsonObject) -> str:
           <article class="process-card">
             <p class="process-value">{esc(card["value"])}</p>
             <p class="process-label">{esc(card["label"])}</p>
-            <p class="process-detail">{esc(card["detail"])} <span class="process-chip">{esc(card["delta"])}</span></p>
+            <p class="process-detail">{esc(card["detail"])}</p>
           </article>
 """
 

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -2461,6 +2461,8 @@ def build_report_process_cards(
     if issue_error is not None and cached_issue_card:
         total_issues = cached_issue_card.get("value", INSUFFICIENT_EVIDENCE)
     official_deploy_count = count_official_deploy_evidence(repo_root, github_snapshot)
+    official_deploy_value: int | str = official_deploy_count if official_deploy_count > 0 else INSUFFICIENT_EVIDENCE
+    official_deploy_detail = "official deploy evidence" if official_deploy_count > 0 else "evidence unavailable"
     private_smoke_count = count_private_smoke_process_reports(repo_root)
 
     return [
@@ -2490,9 +2492,9 @@ def build_report_process_cards(
             "source": "github" if issue_error is None else "cached" if cached_issue_card else "unavailable",
         },
         {
-            "value": official_deploy_count,
+            "value": official_deploy_value,
             "label": "Official deploys",
-            "detail": "official deploy evidence",
+            "detail": official_deploy_detail,
             "delta": "+0",
         },
         {

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -2895,6 +2895,18 @@ main {
   margin-top: 18px;
 }
 
+.sparkline.unavailable {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+  background: rgba(255, 253, 247, 0.68);
+}
+
 .card-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -3130,9 +3142,9 @@ def render_sparkline(points: Sequence[JsonObject], accent: str) -> str:
     observed = [point for point in points if point.get("observed") and isinstance(point.get("value"), (int, float))]
     if not observed:
         return """
-          <svg class="sparkline" role="img" aria-label="No observed history yet" viewBox="0 0 240 68">
-            <line x1="8" y1="36" x2="232" y2="36" stroke="#ded2c3" stroke-width="2" stroke-dasharray="5 5"/>
-          </svg>
+          <div class="sparkline unavailable" data-sparkline-unavailable="true" role="img" aria-label="No observed metric history yet">
+            No observed history
+          </div>
 """
     values = [float(point["value"]) for point in observed]
     min_value = min(values)
@@ -3901,24 +3913,6 @@ def render_kpi_svg(card: JsonObject) -> str:
             series_parts.append(
                 f'<polyline fill="none" stroke="{color}" stroke-width="{width_attr}" stroke-linecap="round" stroke-linejoin="round"{dash} points="{points}"/>'
             )
-        if not coords and values and all(chart_number(raw_value) is None for raw_value in values):
-            # Missing telemetry is not observed data, so it remains out of the JSON
-            # value stream and does not get labels. The public visual still needs a
-            # readable chart shape: render-only zero-baseline placeholders show the
-            # dates without implying that runtime KPI values were observed.
-            placeholder_points = [(x_for(index), y_for(0.0)) for index, _ in enumerate(values)]
-            if len(placeholder_points) > 1:
-                points = " ".join(f"{x:.1f},{y:.1f}" for x, y in placeholder_points)
-                series_parts.append(
-                    f'<polyline data-kpi-placeholder="line" fill="none" stroke="{color}" stroke-width="{width_attr}" '
-                    f'stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="5 7" '
-                    f'stroke-opacity="0.44" points="{points}"/>'
-                )
-            for x, y in placeholder_points:
-                series_parts.append(
-                    f'<circle data-kpi-placeholder="point" cx="{x:.1f}" cy="{y:.1f}" r="4.5" fill="none" '
-                    f'stroke="{color}" stroke-width="2" stroke-opacity="0.68"/>'
-                )
         for x, y, value in coords:
             if value == y_max:
                 text_y = y + 22
@@ -3938,6 +3932,22 @@ def render_kpi_svg(card: JsonObject) -> str:
         )
         legend_x += 142 if len(series["label"]) < 11 else 164
 
+    all_series_values = [
+        chart_number(value)
+        for series in card.get("series", ())
+        if isinstance(series, dict)
+        for value in series.get("values", ())
+    ]
+    has_observed_value = any(value is not None for value in all_series_values)
+    unavailable_overlay = ""
+    if not has_observed_value:
+        unavailable_overlay = f'''
+              <g data-kpi-unavailable="true">
+                <rect x="{x0 + 52:.1f}" y="{y0 + 42:.1f}" width="{width - 104:.1f}" height="74" rx="10" fill="#fbfaf7" stroke="#d8cabc" stroke-width="1.2"/>
+                <text x="{x0 + width / 2:.1f}" y="{y0 + 76:.1f}" text-anchor="middle" fill="#3e352d" font-size="17" font-weight="800">No observed KPI data</text>
+                <text x="{x0 + width / 2:.1f}" y="{y0 + 101:.1f}" text-anchor="middle" fill="#8b6d55" font-size="13">Real reducer history is unavailable; chart is intentionally blank.</text>
+              </g>'''
+
     return f"""
             <svg class="chart-svg" role="img" aria-label="{esc(card["title"])} 7 day trend" viewBox="0 0 560 260">
               <text x="{x0:.1f}" y="12" fill="#9a5d25" font-size="14" font-weight="900">{esc(card["pill"])}</text>
@@ -3945,6 +3955,7 @@ def render_kpi_svg(card: JsonObject) -> str:
               <line x1="{x0:.1f}" y1="{y0:.1f}" x2="{x0:.1f}" y2="{y0 + height:.1f}" stroke="#cdbba7" stroke-width="1.5"/>
               <line x1="{x0:.1f}" y1="{y0 + height:.1f}" x2="{x0 + width:.1f}" y2="{y0 + height:.1f}" stroke="#cdbba7" stroke-width="1.5"/>
               {''.join(series_parts)}
+              {unavailable_overlay}
               {date_labels}
               {''.join(legend_parts)}
             </svg>

--- a/scripts/render-screeps-roadmap.js
+++ b/scripts/render-screeps-roadmap.js
@@ -88,13 +88,12 @@ const items = (projectRaw.items || []).map(it => ({
 const byNumber = Object.fromEntries(items.filter(i => i.number).map(i => [i.number, i]));
 
 const latestSummarySvg = sh("find runtime-artifacts/screeps-monitor -name 'summary-*.svg' -type f -printf '%T@ %p\\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2-", '');
-let rcl = 0;
+let rcl = null;
 if (latestSummarySvg && fs.existsSync(latestSummarySvg)) {
   const svg = fs.readFileSync(latestSummarySvg, 'utf8');
   const m = svg.match(/Controller\s+R(\d+)/i);
   if (m) rcl = Number(m[1]);
 }
-if (!rcl) rcl = 3;
 
 const today = new Date();
 const days = Array.from({length: 7}, (_, i) => {
@@ -107,7 +106,7 @@ const kpiCharts = [
     {name:'Owned rooms', values: missing7d()},
     {name:'RCL', values: missing7d()},
     {name:'Room gain', values: missing7d(), dashed:true}
-  ], note:`No observed seven-day territory KPI history is available. Latest monitor RCL: ${rcl || 'unavailable'}.` },
+  ], note:`No observed seven-day territory KPI history is available. Latest monitor RCL: ${rcl === null ? 'not observed' : rcl}.` },
   { title: 'Resources', subtitle: 'stored energy · harvest delta · carried energy', unit: 'energy', color: '#5c8456', unavailable: true, series: [
     {name:'Stored energy', values: missing7d(), dashed:true},
     {name:'Harvest delta', values: missing7d(), dashed:true},
@@ -159,6 +158,16 @@ function visibleKanbanItems(items) {
   return items.filter(it => it.column !== 'online' || !shownDone.has(it.id));
 }
 
+function explicitOfficialDeployEvidence() {
+  const evidence = new Set();
+  for (const item of items) {
+    const text = [item.title, item.status, item.evidence, item.next].join(' ').toLowerCase();
+    const runMatches = [...text.matchAll(/official deploy run\s+(\d+)/g)];
+    for (const match of runMatches) evidence.add(`run:${match[1]}`);
+    if (runMatches.length === 0 && text.includes('deployment floor satisfied') && text.includes('official deploy')) evidence.add(`item:${item.number || item.id}`);
+  }
+  return evidence.size;
+}
 function countFiles(command, observedCommand = '') {
   const observed = observedCommand ? sh(observedCommand, 'missing') === 'present' : true;
   if (!observed) return { value: null, observed: false };
@@ -166,12 +175,23 @@ function countFiles(command, observedCommand = '') {
 }
 const officialDeployEvidence = countFiles(
   "find runtime-artifacts/official-screeps-deploy -maxdepth 1 -type f -name 'official-screeps-deploy-*.json' 2>/dev/null | wc -l",
-  "test -d runtime-artifacts/official-screeps-deploy && echo present || echo missing"
+  "test -d runtime-artifacts/official-screeps-deploy && find runtime-artifacts/official-screeps-deploy -maxdepth 1 -type f -name 'official-screeps-deploy-*.json' >/dev/null && echo present || echo missing"
 );
-const officialDeploys = officialDeployEvidence.value;
-let privateTests = num(sh("find /root/screeps /root/.hermes -type f \( -iname '*private*smoke*report*.json' -o -iname '*screeps-private-smoke*.json' \) 2>/dev/null | wc -l", '0'));
+const projectOfficialDeploys = explicitOfficialDeployEvidence();
+const officialDeploys = officialDeployEvidence.observed
+  ? Math.max(officialDeployEvidence.value, projectOfficialDeploys)
+  : (projectOfficialDeploys || null);
+function explicitPrivateSmokeEvidence() {
+  const evidence = new Set();
+  for (const item of items) {
+    const text = [item.title, item.status, item.evidence, item.next].join(' ').toLowerCase();
+    if (text.includes('smoke') && text.includes('evidence')) evidence.add(`item:${item.number || item.id}`);
+  }
+  return evidence.size;
+}
+let privateTests = explicitPrivateSmokeEvidence();
 if (privateTests === 0) {
-  console.warn('No private smoke test reports found; rendering actual private smoke count 0.');
+  console.warn('No private smoke evidence found in GitHub Project; rendering not observed.');
 }
 const metrics = {
   commits: commitCount,
@@ -241,14 +261,13 @@ function kanban(title, subtitle, items) {
   const vis = visibleKanbanItems(items);
   const body = columns.map(([key,label]) => {
     const col = vis.filter(i => i.column === key);
-    return `<div class="kan-col"><div class="kan-title">${esc(label)} <span>${col.length}</span></div>${col.map(i => `<div class="ticket"><div class="ticket-top"><b>${esc(short(i.title, 58))}</b><span>${esc(i.priority || '')}</span></div><p>${esc(short(i.next || i.domain || i.status, 92))}</p></div>`).join('') || '<div class="empty">—</div>'}</div>`;
+    return `<div class="kan-col"><div class="kan-title">${esc(label)} <span>${col.length}</span></div>${col.map(i => `<div class="ticket"><div class="ticket-top"><b>${esc(short(i.title, 58))}</b><span>${esc(i.priority || '')}</span></div><p>${esc(short(i.next || i.domain || i.status, 92))}</p></div>`).join('') || `<div class="empty">No ${esc(label)} cards</div>`}</div>`;
   }).join('');
   return `<section class="section"><div class="section-title"><h2>${esc(title)}</h2></div><div class="kanban">${body}</div></section>`;
 }
 function metric(label, value, key, note) {
-  const deltaHtml = typeof value === 'number' ? `<span>${esc(delta(key))}</span>` : '';
   const valueStyle = typeof value === 'number' ? '' : ' style="font-size:34px;line-height:1.05"';
-  return `<div class="card metric"><div class="metric-value"${valueStyle}>${esc(value)}</div><div class="metric-label">${esc(label)}</div><div class="metric-note">${esc(note || '')}${deltaHtml}</div></div>`;
+  return `<div class="card metric"><div class="metric-value"${valueStyle}>${esc(value)}</div><div class="metric-label">${esc(label)}</div><div class="metric-note">${esc(note || '')}</div></div>`;
 }
 
 const html = `<!doctype html><html><head><meta charset="utf-8"><style>
@@ -263,8 +282,13 @@ ${kanban('04 Foundation Kanban', 'Reliability / P0 and Foundation Gates; data co
   metric('Total commits', metrics.commits, 'commits', `HEAD ${head}`),
   metric('Total PRs', metrics.prs, 'prs', `${prs.filter(p=>p.state==='MERGED').length} merged`),
   metric('Total issues', metrics.issues, 'issues', `${issues.filter(i=>i.state==='OPEN').length} open`),
-  metric('Official game deploys', officialDeployEvidence.observed ? officialDeploys : 'not observed', 'officialDeploys', officialDeployEvidence.observed ? 'official deploy evidence' : 'evidence directory unavailable'),
-  metric('Private smoke tests', metrics.privateTests, 'privateTests', 'smoke/report evidence')
+  metric(
+    'Official game deploys',
+    typeof officialDeploys === 'number' ? officialDeploys : 'not observed',
+    'officialDeploys',
+    projectOfficialDeploys ? 'GitHub Project official deploy evidence' : officialDeployEvidence.observed ? 'runtime artifact evidence' : 'evidence unavailable'
+  ),
+  metric('Private smoke tests', privateTests > 0 ? metrics.privateTests : 'not observed', 'privateTests', privateTests > 0 ? 'GitHub Project smoke evidence' : 'evidence unavailable')
 ].join('')}</div></section>
 <div class="footer">format ${formatVersion} · repo ${head} · generated ${new Date().toISOString()}</div>
 </div></body></html>`;

--- a/scripts/render-screeps-roadmap.js
+++ b/scripts/render-screeps-roadmap.js
@@ -48,6 +48,11 @@ function json(cmd, fallback) {
 }
 function esc(v) { return String(v ?? '—').replace(/[&<>"']/g, s => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[s])); }
 function num(v) { const n = Number(v); return Number.isFinite(n) ? n : 0; }
+function observedNumber(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
 function short(s, n=68) { s = String(s || '—'); return s.length > n ? s.slice(0, n - 1) + '…' : s; }
 function englishText(v, fallback = 'No current evidence available') {
   const text = String(v ?? '')
@@ -96,23 +101,23 @@ const days = Array.from({length: 7}, (_, i) => {
   const d = new Date(today); d.setDate(today.getDate() - (6 - i));
   return `${d.getMonth()+1}/${d.getDate()}`;
 });
-function series(current, previous = 0) { return Array.from({length:7}, (_, i) => i === 6 ? current : previous); }
+const missing7d = () => Array.from({length: 7}, () => null);
 const kpiCharts = [
-  { title: 'Territory', subtitle: 'owned rooms · RCL · room gain', unit: 'rooms/RCL', color: '#8f6235', series: [
-    {name:'Owned rooms', values: series(1, 1)},
-    {name:'RCL', values: series(rcl, rcl)},
-    {name:'Room gain', values: series(0, 0), dashed:true}
-  ], note:'Seven-day history is still being wired; current points come from official room monitor and Project evidence.' },
-  { title: 'Resources', subtitle: 'stored energy · harvest delta · carried energy', unit: 'energy', color: '#5c8456', series: [
-    {name:'Stored energy', values: series(0, 0), dashed:true},
-    {name:'Harvest delta', values: series(0, 0), dashed:true},
-    {name:'Worker carried', values: series(0, 0), dashed:true}
-  ], note:'Resource payload fields are in place; reducer and seven-day aggregation remain part of #29.' },
-  { title: 'Combat', subtitle: 'enemy kills · hostile count · own loss', unit: 'events', color: '#a33b2f', series: [
-    {name:'Enemy kills', values: series(0, 0), dashed:true},
-    {name:'Hostiles seen', values: series(0, 0)},
-    {name:'Own loss', values: series(0, 0), dashed:true}
-  ], note:'Kill/loss event aggregation is not wired yet; current hostile monitor state is no-alert.' }
+  { title: 'Territory', subtitle: 'owned rooms · RCL · room gain', unit: 'rooms/RCL', color: '#8f6235', unavailable: true, series: [
+    {name:'Owned rooms', values: missing7d()},
+    {name:'RCL', values: missing7d()},
+    {name:'Room gain', values: missing7d(), dashed:true}
+  ], note:`No observed seven-day territory KPI history is available. Latest monitor RCL: ${rcl || 'unavailable'}.` },
+  { title: 'Resources', subtitle: 'stored energy · harvest delta · carried energy', unit: 'energy', color: '#5c8456', unavailable: true, series: [
+    {name:'Stored energy', values: missing7d(), dashed:true},
+    {name:'Harvest delta', values: missing7d(), dashed:true},
+    {name:'Worker carried', values: missing7d(), dashed:true}
+  ], note:'No observed resource KPI history is available; reducer-backed energy data must be connected before plotting.' },
+  { title: 'Combat', subtitle: 'enemy kills · hostile count · own loss', unit: 'events', color: '#a33b2f', unavailable: true, series: [
+    {name:'Enemy kills', values: missing7d(), dashed:true},
+    {name:'Hostiles seen', values: missing7d()},
+    {name:'Own loss', values: missing7d(), dashed:true}
+  ], note:'No observed combat KPI history is available; ownership-aware kill/loss aggregation must be connected before plotting.' }
 ];
 
 const roadmapCards = [
@@ -154,7 +159,16 @@ function visibleKanbanItems(items) {
   return items.filter(it => it.column !== 'online' || !shownDone.has(it.id));
 }
 
-const officialDeploys = 0;
+function countFiles(command, observedCommand = '') {
+  const observed = observedCommand ? sh(observedCommand, 'missing') === 'present' : true;
+  if (!observed) return { value: null, observed: false };
+  return { value: num(sh(command, '0')), observed: true };
+}
+const officialDeployEvidence = countFiles(
+  "find runtime-artifacts/official-screeps-deploy -maxdepth 1 -type f -name 'official-screeps-deploy-*.json' 2>/dev/null | wc -l",
+  "test -d runtime-artifacts/official-screeps-deploy && echo present || echo missing"
+);
+const officialDeploys = officialDeployEvidence.value;
 let privateTests = num(sh("find /root/screeps /root/.hermes -type f \( -iname '*private*smoke*report*.json' -o -iname '*screeps-private-smoke*.json' \) 2>/dev/null | wc -l", '0'));
 if (privateTests === 0) {
   console.warn('No private smoke test reports found; rendering actual private smoke count 0.');
@@ -175,9 +189,10 @@ function delta(key) {
 
 function lineChart(chart, width=430, height=215) {
   const pad = {l:54,r:24,t:28,b:40};
-  const vals = chart.series.flatMap(s => s.values).map(num);
-  const rawMax = Math.max(1, ...vals);
-  const rawMin = Math.min(0, ...vals);
+  const observedVals = chart.series.flatMap(s => s.values).map(observedNumber).filter(v => v !== null);
+  const hasObserved = observedVals.length > 0 && !chart.unavailable;
+  const rawMax = hasObserved ? Math.max(1, ...observedVals) : 1;
+  const rawMin = hasObserved ? Math.min(0, ...observedVals) : 0;
   const max = rawMax === rawMin ? rawMax + 1 : rawMax;
   const min = rawMin;
   const x = i => pad.l + i * ((width - pad.l - pad.r) / 6);
@@ -189,18 +204,35 @@ function lineChart(chart, width=430, height=215) {
     const label = Number.isInteger(v) ? String(v) : v.toFixed(1);
     return `<line x1="${pad.l}" x2="${width-pad.r}" y1="${yy.toFixed(1)}" y2="${yy.toFixed(1)}" class="gridline"/><text x="${pad.l-10}" y="${(yy+4).toFixed(1)}" text-anchor="end" class="axis">${esc(label)}</text>`;
   }).join('') + `<line x1="${pad.l}" x2="${pad.l}" y1="${pad.t}" y2="${height-pad.b}" class="axisline"/>`;
-  const paths = chart.series.map((s, idx) => {
-    const d = s.values.map((v,i) => `${i?'L':'M'}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(' ');
-    return `<path d="${d}" fill="none" stroke="${colors[idx%colors.length]}" stroke-width="3.2" stroke-linecap="round" ${s.dashed?'stroke-dasharray="8 7"':''}/>`;
-  }).join('');
-  const points = chart.series.map((s, idx) => s.values.map((v,i) => {
-    const px = x(i), py = y(v);
+  const paths = hasObserved ? chart.series.map((s, idx) => {
+    const segments = [];
+    let current = [];
+    s.values.forEach((raw, i) => {
+      const value = observedNumber(raw);
+      if (value === null) {
+        if (current.length > 1) segments.push(current);
+        current = [];
+        return;
+      }
+      current.push([x(i), y(value)]);
+    });
+    if (current.length > 1) segments.push(current);
+    return segments.map(segment => {
+      const d = segment.map(([px, py], i) => `${i?'L':'M'}${px.toFixed(1)},${py.toFixed(1)}`).join(' ');
+      return `<path d="${d}" fill="none" stroke="${colors[idx%colors.length]}" stroke-width="3.2" stroke-linecap="round" ${s.dashed?'stroke-dasharray="8 7"':''}/>`;
+    }).join('');
+  }).join('') : '';
+  const points = hasObserved ? chart.series.map((s, idx) => s.values.map((raw,i) => {
+    const value = observedNumber(raw);
+    if (value === null) return '';
+    const px = x(i), py = y(value);
     const dy = idx === 0 ? -10 : (idx === 1 ? 17 : -24);
-    return `<circle cx="${px.toFixed(1)}" cy="${py.toFixed(1)}" r="3.8" fill="${colors[idx%colors.length]}" stroke="#fffdf7" stroke-width="1.4"/><text x="${px.toFixed(1)}" y="${(py+dy).toFixed(1)}" text-anchor="middle" class="point-label">${esc(v)}</text>`;
-  }).join('')).join('');
+    return `<circle cx="${px.toFixed(1)}" cy="${py.toFixed(1)}" r="3.8" fill="${colors[idx%colors.length]}" stroke="#fffdf7" stroke-width="1.4"/><text x="${px.toFixed(1)}" y="${(py+dy).toFixed(1)}" text-anchor="middle" class="point-label">${esc(value)}</text>`;
+  }).join('')).join('') : '';
+  const unavailable = hasObserved ? '' : `<g data-kpi-unavailable="true"><rect x="${pad.l+28}" y="${pad.t+36}" width="${width-pad.l-pad.r-56}" height="74" rx="12" fill="#fffdf7" stroke="#dbcbb7"/><text x="${width/2}" y="${pad.t+68}" text-anchor="middle" class="no-data-title">No observed KPI data</text><text x="${width/2}" y="${pad.t+92}" text-anchor="middle" class="no-data-copy">Real reducer history unavailable; chart intentionally blank.</text></g>`;
   const labels = days.map((d,i) => `<text x="${x(i)}" y="${height-12}" text-anchor="middle" class="axis">${esc(d)}</text>`).join('');
   const legend = chart.series.map((s,i) => `<span><i style="background:${colors[i%3]};${s.dashed?'border-top:2px dashed #2e2a24;background:transparent;height:0;':''}"></i>${esc(s.name)}</span>`).join('');
-  return `<div class="card kpi"><div class="kpi-head"><div><h3>${esc(chart.title)}</h3><p>${esc(chart.subtitle)}</p></div><b>${esc(chart.unit)}</b></div><svg viewBox="0 0 ${width} ${height}">${yAxis}<line x1="${pad.l}" x2="${width-pad.r}" y1="${height-pad.b}" y2="${height-pad.b}" class="axisline"/>${paths}${points}${labels}<text x="${pad.l}" y="15" class="axis unit-label">${esc(chart.unit)}</text></svg><div class="legend">${legend}</div><div class="micro-note">${esc(chart.note)}</div></div>`;
+  return `<div class="card kpi"><div class="kpi-head"><div><h3>${esc(chart.title)}</h3><p>${esc(chart.subtitle)}</p></div><b>${esc(chart.unit)}</b></div><svg viewBox="0 0 ${width} ${height}">${yAxis}<line x1="${pad.l}" x2="${width-pad.r}" y1="${height-pad.b}" y2="${height-pad.b}" class="axisline"/>${paths}${points}${unavailable}${labels}<text x="${pad.l}" y="15" class="axis unit-label">${esc(chart.unit)}</text></svg><div class="legend">${legend}</div><div class="micro-note">${esc(chart.note)}</div></div>`;
 }
 function roadmapCard([h,g,n,p,d]) {
   return `<div class="card road"><h3>${esc(h)}</h3><div class="row"><b>Goal</b><span>${esc(g)}</span></div><div class="row"><b>Next</b><span>${esc(n)}</span></div><div class="progress"><strong>${esc(p)}%</strong><i><em style="width:${Math.max(0, Math.min(100, num(p)))}%"></em></i></div><div class="done">Proof: ${esc(d)}</div></div>`;
@@ -214,7 +246,9 @@ function kanban(title, subtitle, items) {
   return `<section class="section"><div class="section-title"><h2>${esc(title)}</h2></div><div class="kanban">${body}</div></section>`;
 }
 function metric(label, value, key, note) {
-  return `<div class="card metric"><div class="metric-value">${esc(value)}</div><div class="metric-label">${esc(label)}</div><div class="metric-note">${esc(note || '')}<span>${esc(delta(key))}</span></div></div>`;
+  const deltaHtml = typeof value === 'number' ? `<span>${esc(delta(key))}</span>` : '';
+  const valueStyle = typeof value === 'number' ? '' : ' style="font-size:34px;line-height:1.05"';
+  return `<div class="card metric"><div class="metric-value"${valueStyle}>${esc(value)}</div><div class="metric-label">${esc(label)}</div><div class="metric-note">${esc(note || '')}${deltaHtml}</div></div>`;
 }
 
 const html = `<!doctype html><html><head><meta charset="utf-8"><style>
@@ -229,7 +263,7 @@ ${kanban('04 Foundation Kanban', 'Reliability / P0 and Foundation Gates; data co
   metric('Total commits', metrics.commits, 'commits', `HEAD ${head}`),
   metric('Total PRs', metrics.prs, 'prs', `${prs.filter(p=>p.state==='MERGED').length} merged`),
   metric('Total issues', metrics.issues, 'issues', `${issues.filter(i=>i.state==='OPEN').length} open`),
-  metric('Official game deploys', metrics.officialDeploys, 'officialDeploys', 'official deploy evidence'),
+  metric('Official game deploys', officialDeployEvidence.observed ? officialDeploys : 'not observed', 'officialDeploys', officialDeployEvidence.observed ? 'official deploy evidence' : 'evidence directory unavailable'),
   metric('Private smoke tests', metrics.privateTests, 'privateTests', 'smoke/report evidence')
 ].join('')}</div></section>
 <div class="footer">format ${formatVersion} · repo ${head} · generated ${new Date().toISOString()}</div>


### PR DESCRIPTION
## Summary
- Remove fake zero/placeholder KPI lines from the Discord roadmap image renderer.
- Render unavailable KPI history as explicit `No observed KPI data` blank states in both roadmap image and GitHub Pages output.
- Keep missing reducer data as missing/null instead of converting it to zero trend geometry.
- Count official deploy/private-smoke delivery metrics only from explicit evidence and remove unexplained delta chips / dash-only empty states.
- Add regression checks so Resources/Combat/Territory KPI charts cannot silently regress to fake zero series.

Fixes #226

## Verification
- `python3 -m py_compile scripts/generate-roadmap-page.py scripts/check-roadmap-kpi-placeholders.py`
- `python3 scripts/generate-roadmap-page.py --repo . --docs-dir docs --db docs/roadmap-kpi.sqlite`
- `python3 -B scripts/check-roadmap-kpi-placeholders.py /root/screeps-worktrees/roadmap-kpi-placeholders`
- `node scripts/check-roadmap-renderer.js /root/screeps-worktrees/roadmap-kpi-placeholders`
- `node scripts/render-screeps-roadmap.js /root/screeps-worktrees/roadmap-kpi-placeholders /tmp/screeps-roadmap-kpi-fixed.png`
- `git diff --check`
- Visual QA of `/tmp/screeps-roadmap-kpi-fixed.png`: KPI cards show explicit no-data states, no fake zero trend lines, no fallback RCL 3, empty Kanban columns have explicit labels, delivery metrics use evidence-labeled counts.

## Notes
- This PR does not fabricate 7-day Screeps KPI history. Until reducer-backed history is connected, charts intentionally remain blank and say so.
- Future changes must not introduce placeholder/fake KPI data; if data is unavailable, ask in the decisions channel before choosing display behavior.