### PR TITLE
feat: add passive strategy shadow evaluator

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -20,7 +20,13 @@ var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: tru
 // src/main.ts
 var main_exports = {};
 __export(main_exports, {
-  loop: () => loop
+  DEFAULT_STRATEGY_REGISTRY: () => DEFAULT_STRATEGY_REGISTRY,
+  DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG: () => DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG,
+  STRATEGY_REGISTRY_SCHEMA_VERSION: () => STRATEGY_REGISTRY_SCHEMA_VERSION,
+  evaluateStrategyShadowReplay: () => evaluateStrategyShadowReplay,
+  loop: () => loop,
+  validateStrategyRegistry: () => validateStrategyRegistry,
+  validateStrategyRegistryEntry: () => validateStrategyRegistryEntry
 });
 module.exports = __toCommonJS(main_exports);
 
@@ -5301,6 +5307,1096 @@ var Kernel = class {
   }
 };
 
+// src/strategy/strategyRegistry.ts
+var STRATEGY_REGISTRY_SCHEMA_VERSION = 1;
+var ISSUE_265_URL = "https://github.com/lanyusea/screeps/issues/265";
+var RL_RESEARCH_PATH = "docs/research/2026-04-29-screeps-rl-self-evolving-strategy-paper.md";
+var DEFAULT_STRATEGY_REGISTRY = [
+  {
+    id: "construction-priority.incumbent.v1",
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: "1.0.0",
+    family: "construction-priority",
+    title: "Current construction priority scoring shadow baseline",
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ["runtime-summary"],
+      shards: ["shardX"],
+      rooms: ["E48S28"],
+      minRcl: 1,
+      maxRcl: 4,
+      notes: "Reads emitted constructionPriority candidate summaries; does not alter construction selection."
+    },
+    knobBounds: [
+      numberKnob("baseScoreWeight", "Weight applied to the already-emitted incumbent score.", 0, 3, 0.1),
+      numberKnob("territorySignalWeight", "Weight for territory-first expected KPI signals.", 0, 30, 1),
+      numberKnob("resourceSignalWeight", "Weight for resource-scaling expected KPI signals.", 0, 30, 1),
+      numberKnob("killSignalWeight", "Weight for enemy-kill or defense-posture signals.", 0, 30, 1),
+      numberKnob("riskPenalty", "Penalty per visible risk or blocking precondition.", 0, 30, 1)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 6,
+      resourceSignalWeight: 4,
+      killSignalWeight: 6,
+      riskPenalty: 4
+    },
+    rolloutStatus: "incumbent",
+    evidenceLinks: [
+      { label: "Issue #265", source: "issue", url: ISSUE_265_URL },
+      { label: "RL/self-evolving strategy paper", source: "docs", path: RL_RESEARCH_PATH }
+    ],
+    rollback: passiveRollback("construction-priority.incumbent.v1")
+  },
+  {
+    id: "construction-priority.territory-shadow.v1",
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: "1.0.0",
+    family: "construction-priority",
+    title: "Territory-first construction priority shadow candidate",
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ["runtime-summary"],
+      shards: ["shardX"],
+      rooms: ["E48S28"],
+      minRcl: 1,
+      maxRcl: 4,
+      notes: "Replays only saved constructionPriority candidates with a higher territory signal weight."
+    },
+    knobBounds: [
+      numberKnob("baseScoreWeight", "Weight applied to the already-emitted incumbent score.", 0, 3, 0.1),
+      numberKnob("territorySignalWeight", "Weight for territory-first expected KPI signals.", 0, 30, 1),
+      numberKnob("resourceSignalWeight", "Weight for resource-scaling expected KPI signals.", 0, 30, 1),
+      numberKnob("killSignalWeight", "Weight for enemy-kill or defense-posture signals.", 0, 30, 1),
+      numberKnob("riskPenalty", "Penalty per visible risk or blocking precondition.", 0, 30, 1)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 22,
+      resourceSignalWeight: 3,
+      killSignalWeight: 5,
+      riskPenalty: 4
+    },
+    rolloutStatus: "shadow",
+    evidenceLinks: [
+      { label: "Issue #265", source: "issue", url: ISSUE_265_URL },
+      { label: "Fixture replay coverage", source: "test", path: "prod/test/strategyShadowEvaluator.test.ts" }
+    ],
+    rollback: passiveRollback("construction-priority.incumbent.v1")
+  },
+  {
+    id: "expansion-remote.incumbent.v1",
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: "1.0.0",
+    family: "expansion-remote-candidate",
+    title: "Current expansion and remote candidate scoring shadow baseline",
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ["runtime-summary", "room-snapshot"],
+      shards: ["shardX"],
+      rooms: ["E48S28"],
+      minRcl: 1,
+      notes: "Reads territoryRecommendation candidates from saved summaries; it never writes Memory intents."
+    },
+    knobBounds: [
+      numberKnob("baseScoreWeight", "Weight applied to the emitted occupation score.", 0, 3, 0.1),
+      numberKnob("territorySignalWeight", "Weight for occupy/reserve/scout territory ordering.", 0, 40, 1),
+      numberKnob("resourceSignalWeight", "Weight for visible source and support evidence.", 0, 30, 1),
+      numberKnob("killSignalWeight", "Weight for hostile suppression opportunity.", 0, 30, 1),
+      numberKnob("riskPenalty", "Penalty for hostile, route, or evidence risk.", 0, 40, 1)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 8,
+      resourceSignalWeight: 5,
+      killSignalWeight: 2,
+      riskPenalty: 10
+    },
+    rolloutStatus: "incumbent",
+    evidenceLinks: [
+      { label: "Issue #265", source: "issue", url: ISSUE_265_URL },
+      { label: "Gameplay evolution roadmap", source: "docs", path: "docs/ops/gameplay-evolution-roadmap.md" }
+    ],
+    rollback: passiveRollback("expansion-remote.incumbent.v1")
+  },
+  {
+    id: "expansion-remote.territory-shadow.v1",
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: "1.0.0",
+    family: "expansion-remote-candidate",
+    title: "Territory-first expansion and remote candidate shadow model",
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ["runtime-summary", "room-snapshot"],
+      shards: ["shardX"],
+      rooms: ["E48S28"],
+      minRcl: 1,
+      notes: "Emphasizes occupy/reserve candidates in offline ranking reports only."
+    },
+    knobBounds: [
+      numberKnob("baseScoreWeight", "Weight applied to the emitted occupation score.", 0, 3, 0.1),
+      numberKnob("territorySignalWeight", "Weight for occupy/reserve/scout territory ordering.", 0, 40, 1),
+      numberKnob("resourceSignalWeight", "Weight for visible source and support evidence.", 0, 30, 1),
+      numberKnob("killSignalWeight", "Weight for hostile suppression opportunity.", 0, 30, 1),
+      numberKnob("riskPenalty", "Penalty for hostile, route, or evidence risk.", 0, 40, 1)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 26,
+      resourceSignalWeight: 4,
+      killSignalWeight: 2,
+      riskPenalty: 10
+    },
+    rolloutStatus: "shadow",
+    evidenceLinks: [
+      { label: "Issue #265", source: "issue", url: ISSUE_265_URL },
+      { label: "Fixture replay coverage", source: "test", path: "prod/test/strategyShadowEvaluator.test.ts" }
+    ],
+    rollback: passiveRollback("expansion-remote.incumbent.v1")
+  },
+  {
+    id: "defense-repair.incumbent.v1",
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: "1.0.0",
+    family: "defense-posture-repair-threshold",
+    title: "Current defense posture and repair threshold shadow baseline",
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ["runtime-summary", "room-snapshot"],
+      shards: ["shardX"],
+      rooms: ["E48S28"],
+      minRcl: 1,
+      notes: "Ranks observed rooms by hostile and repair pressure from saved artifacts only."
+    },
+    knobBounds: [
+      numberKnob("baseScoreWeight", "Weight applied to observed hostile and damage pressure.", 0, 3, 0.1),
+      numberKnob("territorySignalWeight", "Weight for controller survival and held-room protection.", 0, 30, 1),
+      numberKnob("resourceSignalWeight", "Weight for storage and productive-structure protection.", 0, 30, 1),
+      numberKnob("killSignalWeight", "Weight for hostile presence and tower/rampart readiness.", 0, 40, 1),
+      numberKnob("riskPenalty", "Penalty for unavailable or insufficient observations.", 0, 30, 1),
+      numberKnob("repairCriticalHitsRatio", "Critical repair hit ratio threshold.", 0.01, 1, 0.01)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 12,
+      resourceSignalWeight: 6,
+      killSignalWeight: 18,
+      riskPenalty: 4,
+      repairCriticalHitsRatio: 0.5
+    },
+    rolloutStatus: "incumbent",
+    evidenceLinks: [
+      { label: "Issue #265", source: "issue", url: ISSUE_265_URL },
+      { label: "Runtime room monitor runbook", source: "docs", path: "docs/ops/runtime-room-monitor.md" }
+    ],
+    rollback: passiveRollback("defense-repair.incumbent.v1")
+  }
+];
+function validateStrategyRegistryEntry(entry) {
+  const issues = [];
+  if (entry.schemaVersion !== STRATEGY_REGISTRY_SCHEMA_VERSION) {
+    issues.push(`unsupported schemaVersion ${entry.schemaVersion}`);
+  }
+  if (!entry.id) {
+    issues.push("missing strategy id");
+  }
+  if (!entry.version) {
+    issues.push("missing strategy version");
+  }
+  if (!entry.owner.issue || entry.owner.issue <= 0) {
+    issues.push("missing owning issue");
+  }
+  if (entry.supportedContext.artifactTypes.length === 0) {
+    issues.push("supported context must name at least one artifact type");
+  }
+  if (entry.knobBounds.length === 0) {
+    issues.push("strategy must declare bounded knobs");
+  }
+  const declaredKnobs = /* @__PURE__ */ new Set();
+  for (const knob of entry.knobBounds) {
+    if (declaredKnobs.has(knob.name)) {
+      issues.push(`duplicate knob ${knob.name}`);
+    }
+    declaredKnobs.add(knob.name);
+    if (!(knob.name in entry.defaultValues)) {
+      issues.push(`missing default for knob ${knob.name}`);
+      continue;
+    }
+    const defaultValue = entry.defaultValues[knob.name];
+    if (!isKnobDefaultWithinBounds(defaultValue, knob.bounds)) {
+      issues.push(`default for knob ${knob.name} is outside declared bounds`);
+    }
+  }
+  for (const defaultName of Object.keys(entry.defaultValues)) {
+    if (!declaredKnobs.has(defaultName)) {
+      issues.push(`default declared without knob bounds: ${defaultName}`);
+    }
+  }
+  if (entry.evidenceLinks.length === 0) {
+    issues.push("missing evidence links");
+  }
+  if (!entry.rollback.disableFlag) {
+    issues.push("missing rollback disable flag");
+  }
+  if (entry.rollback.stopConditions.length === 0) {
+    issues.push("missing rollback stop conditions");
+  }
+  return { valid: issues.length === 0, issues };
+}
+function validateStrategyRegistry(entries) {
+  const issues = [];
+  const ids = /* @__PURE__ */ new Set();
+  for (const entry of entries) {
+    if (ids.has(entry.id)) {
+      issues.push(`duplicate strategy id ${entry.id}`);
+    }
+    ids.add(entry.id);
+    const entryResult = validateStrategyRegistryEntry(entry);
+    issues.push(...entryResult.issues.map((issue) => `${entry.id}: ${issue}`));
+  }
+  return { valid: issues.length === 0, issues };
+}
+function getStrategyNumberDefault(entry, knobName, fallback = 0) {
+  const value = entry.defaultValues[knobName];
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+function numberKnob(name, description, min, max, step) {
+  return {
+    name,
+    description,
+    bounds: {
+      kind: "number",
+      min,
+      max,
+      ...step !== void 0 ? { step } : {}
+    }
+  };
+}
+function passiveRollback(rollbackToStrategyId) {
+  return {
+    disabledByDefault: true,
+    disableFlag: "strategyShadowEvaluator.enabled=false",
+    rollbackToStrategyId,
+    stopConditions: [
+      "shadow report is noisy or expensive",
+      "artifact parsing cannot be proven deterministic",
+      "any candidate output is accidentally wired into live Screeps actions"
+    ],
+    notes: "The first slice is pure offline/shadow evaluation; disabling the evaluator leaves live behavior unchanged."
+  };
+}
+function isKnobDefaultWithinBounds(value, bounds) {
+  switch (bounds.kind) {
+    case "number":
+      return typeof value === "number" && Number.isFinite(value) && value >= bounds.min && value <= bounds.max;
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value) && value >= bounds.min && value <= bounds.max;
+    case "boolean":
+      return typeof value === "boolean";
+    case "enum":
+      return typeof value === "string" && bounds.values.includes(value);
+    default:
+      return false;
+  }
+}
+
+// src/strategy/kpiEvaluator.ts
+var STRATEGY_RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
+var DEFAULT_STRATEGY_RELIABILITY_THRESHOLDS = {
+  minArtifactCount: 1,
+  maxLoopExceptionCount: 0,
+  maxTelemetrySilenceTicks: 0,
+  controllerDowngradeRiskTicks: 5e3,
+  maxControllerDowngradeRiskRooms: 0,
+  maxSpawnCollapseRooms: 0
+};
+function parseStrategyEvaluationArtifacts(input) {
+  if (typeof input !== "string") {
+    const rawArtifacts = Array.isArray(input) ? input : [input];
+    return rawArtifacts.flatMap((rawArtifact) => {
+      const artifact = normalizeStrategyEvaluationArtifact(rawArtifact);
+      return artifact ? [artifact] : [];
+    });
+  }
+  const trimmedInput = input.trim();
+  if (trimmedInput.length === 0) {
+    return [];
+  }
+  const wholeJson = parseJson(trimmedInput);
+  if (wholeJson !== null) {
+    return parseStrategyEvaluationArtifacts(wholeJson);
+  }
+  return trimmedInput.split(/\r?\n/).flatMap((line) => {
+    const parsedLine = parseArtifactLine(line);
+    const artifact = parsedLine === null ? null : normalizeStrategyEvaluationArtifact(parsedLine);
+    return artifact ? [artifact] : [];
+  });
+}
+function normalizeStrategyEvaluationArtifact(rawArtifact) {
+  if (!isRecord5(rawArtifact)) {
+    return null;
+  }
+  if (rawArtifact.type === "runtime-summary" || Array.isArray(rawArtifact.rooms)) {
+    return normalizeRuntimeSummaryArtifact(rawArtifact);
+  }
+  if (rawArtifact.artifactType === "runtime-summary") {
+    return normalizeRuntimeSummaryArtifact(rawArtifact);
+  }
+  if (rawArtifact.artifactType === "room-snapshot" || Array.isArray(rawArtifact.objects) || isRecord5(rawArtifact.objects)) {
+    return normalizeRoomSnapshotArtifact(rawArtifact);
+  }
+  return null;
+}
+function reduceStrategyKpis(artifacts, thresholds = DEFAULT_STRATEGY_RELIABILITY_THRESHOLDS) {
+  const reliabilityMetrics = buildInitialReliabilityMetrics(artifacts);
+  const territoryComponents = {
+    ownedRooms: 0,
+    reservedOrRemoteRooms: 0,
+    roomGain: 0,
+    controllerLevels: 0,
+    controllerProgress: 0,
+    territoryRecommendation: 0
+  };
+  const resourceComponents = {
+    storedEnergy: 0,
+    workerCarriedEnergy: 0,
+    droppedEnergy: 0,
+    harvestedEnergy: 0,
+    transferredEnergy: 0,
+    visibleSources: 0
+  };
+  const killComponents = {
+    creepKills: 0,
+    objectKills: 0,
+    attackDamage: 0,
+    hostilePressureObserved: 0
+  };
+  let firstOwnedRoomCount;
+  let lastOwnedRoomCount = 0;
+  for (const artifact of artifacts) {
+    if (artifact.artifactType === "runtime-summary") {
+      const ownedRoomCount = reduceRuntimeSummaryArtifact(
+        artifact,
+        reliabilityMetrics,
+        territoryComponents,
+        resourceComponents,
+        killComponents,
+        thresholds
+      );
+      if (firstOwnedRoomCount === void 0) {
+        firstOwnedRoomCount = ownedRoomCount;
+      }
+      lastOwnedRoomCount = ownedRoomCount;
+    } else {
+      const ownedRoomCount = reduceRoomSnapshotArtifact(
+        artifact,
+        territoryComponents,
+        resourceComponents,
+        killComponents
+      );
+      if (firstOwnedRoomCount === void 0) {
+        firstOwnedRoomCount = ownedRoomCount;
+      }
+      lastOwnedRoomCount = ownedRoomCount;
+    }
+  }
+  territoryComponents.roomGain = lastOwnedRoomCount - (firstOwnedRoomCount != null ? firstOwnedRoomCount : lastOwnedRoomCount);
+  return {
+    reliability: evaluateReliabilityFloor(reliabilityMetrics, thresholds),
+    territory: {
+      score: territoryComponents.ownedRooms * 1e4 + territoryComponents.reservedOrRemoteRooms * 3e3 + territoryComponents.roomGain * 5e3 + territoryComponents.controllerLevels * 800 + territoryComponents.controllerProgress / 100 + territoryComponents.territoryRecommendation,
+      components: territoryComponents
+    },
+    resources: {
+      score: resourceComponents.storedEnergy + resourceComponents.workerCarriedEnergy + resourceComponents.droppedEnergy / 2 + resourceComponents.harvestedEnergy * 3 + resourceComponents.transferredEnergy + resourceComponents.visibleSources * 500,
+      components: resourceComponents
+    },
+    kills: {
+      score: killComponents.creepKills * 1e3 + killComponents.objectKills * 250 + killComponents.attackDamage + killComponents.hostilePressureObserved * 25,
+      components: killComponents
+    }
+  };
+}
+function normalizeRuntimeSummaryArtifact(rawArtifact) {
+  const rooms = Array.isArray(rawArtifact.rooms) ? rawArtifact.rooms.flatMap((rawRoom) => {
+    const room = normalizeRuntimeSummaryRoom(rawRoom);
+    return room ? [room] : [];
+  }) : [];
+  return {
+    artifactType: "runtime-summary",
+    ...isFiniteNumber3(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
+    rooms,
+    ...isRecord5(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {},
+    ...isRecord5(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {}
+  };
+}
+function normalizeRuntimeSummaryRoom(rawRoom) {
+  if (!isRecord5(rawRoom) || !isNonEmptyString3(rawRoom.roomName)) {
+    return null;
+  }
+  return {
+    roomName: rawRoom.roomName,
+    ...isFiniteNumber3(rawRoom.energyAvailable) ? { energyAvailable: rawRoom.energyAvailable } : {},
+    ...isFiniteNumber3(rawRoom.energyCapacity) ? { energyCapacity: rawRoom.energyCapacity } : {},
+    ...isFiniteNumber3(rawRoom.workerCount) ? { workerCount: rawRoom.workerCount } : {},
+    ...Array.isArray(rawRoom.spawnStatus) ? { spawnStatus: rawRoom.spawnStatus.map(normalizeSpawnStatus) } : {},
+    ...isRecord5(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {},
+    ...isRecord5(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {},
+    ...isRecord5(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {},
+    ...isRecord5(rawRoom.constructionPriority) ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) } : {},
+    ...isRecord5(rawRoom.territoryRecommendation) ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) } : {}
+  };
+}
+function normalizeRoomSnapshotArtifact(rawArtifact) {
+  if (!Array.isArray(rawArtifact.objects) && !isRecord5(rawArtifact.objects)) {
+    return null;
+  }
+  const objects = Array.isArray(rawArtifact.objects) ? rawArtifact.objects.flatMap((rawObject) => isRecord5(rawObject) ? [rawObject] : []) : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
+    if (!isRecord5(rawObject)) {
+      return [];
+    }
+    return [{ ...rawObject, id }];
+  });
+  return {
+    artifactType: "room-snapshot",
+    ...isFiniteNumber3(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
+    ...isNonEmptyString3(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {},
+    ...isNonEmptyString3(rawArtifact.room) ? { roomName: rawArtifact.room } : {},
+    ...isNonEmptyString3(rawArtifact.owner) ? { owner: rawArtifact.owner } : {},
+    objects
+  };
+}
+function parseArtifactLine(line) {
+  const trimmedLine = line.trim();
+  if (trimmedLine.length === 0) {
+    return null;
+  }
+  const jsonText = trimmedLine.startsWith(STRATEGY_RUNTIME_SUMMARY_PREFIX) ? trimmedLine.slice(STRATEGY_RUNTIME_SUMMARY_PREFIX.length) : trimmedLine;
+  return parseJson(jsonText);
+}
+function parseJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+function normalizeSpawnStatus(rawStatus) {
+  if (!isRecord5(rawStatus)) {
+    return {};
+  }
+  return {
+    ...isNonEmptyString3(rawStatus.name) ? { name: rawStatus.name } : {},
+    ...isNonEmptyString3(rawStatus.status) ? { status: rawStatus.status } : {},
+    ...isNonEmptyString3(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {},
+    ...isFiniteNumber3(rawStatus.remainingTime) ? { remainingTime: rawStatus.remainingTime } : {}
+  };
+}
+function normalizeControllerSummary(rawController) {
+  return {
+    level: isFiniteNumber3(rawController.level) ? rawController.level : 0,
+    ...isFiniteNumber3(rawController.progress) ? { progress: rawController.progress } : {},
+    ...isFiniteNumber3(rawController.progressTotal) ? { progressTotal: rawController.progressTotal } : {},
+    ...isFiniteNumber3(rawController.ticksToDowngrade) ? { ticksToDowngrade: rawController.ticksToDowngrade } : {}
+  };
+}
+function normalizeResourceSummary(rawResources) {
+  return {
+    ...isFiniteNumber3(rawResources.storedEnergy) ? { storedEnergy: rawResources.storedEnergy } : {},
+    ...isFiniteNumber3(rawResources.workerCarriedEnergy) ? { workerCarriedEnergy: rawResources.workerCarriedEnergy } : {},
+    ...isFiniteNumber3(rawResources.droppedEnergy) ? { droppedEnergy: rawResources.droppedEnergy } : {},
+    ...isFiniteNumber3(rawResources.sourceCount) ? { sourceCount: rawResources.sourceCount } : {},
+    ...isRecord5(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {}
+  };
+}
+function normalizeResourceEvents(rawEvents) {
+  return {
+    ...isFiniteNumber3(rawEvents.harvestedEnergy) ? { harvestedEnergy: rawEvents.harvestedEnergy } : {},
+    ...isFiniteNumber3(rawEvents.transferredEnergy) ? { transferredEnergy: rawEvents.transferredEnergy } : {}
+  };
+}
+function normalizeCombatSummary(rawCombat) {
+  return {
+    ...isFiniteNumber3(rawCombat.hostileCreepCount) ? { hostileCreepCount: rawCombat.hostileCreepCount } : {},
+    ...isFiniteNumber3(rawCombat.hostileStructureCount) ? { hostileStructureCount: rawCombat.hostileStructureCount } : {},
+    ...isRecord5(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {}
+  };
+}
+function normalizeCombatEvents(rawEvents) {
+  return {
+    ...isFiniteNumber3(rawEvents.attackCount) ? { attackCount: rawEvents.attackCount } : {},
+    ...isFiniteNumber3(rawEvents.attackDamage) ? { attackDamage: rawEvents.attackDamage } : {},
+    ...isFiniteNumber3(rawEvents.objectDestroyedCount) ? { objectDestroyedCount: rawEvents.objectDestroyedCount } : {},
+    ...isFiniteNumber3(rawEvents.creepDestroyedCount) ? { creepDestroyedCount: rawEvents.creepDestroyedCount } : {}
+  };
+}
+function normalizeConstructionPrioritySummary(rawSummary) {
+  var _a;
+  return {
+    ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeConstructionCandidate) } : {},
+    ...rawSummary.nextPrimary === null ? { nextPrimary: null } : isRecord5(rawSummary.nextPrimary) ? { nextPrimary: (_a = normalizeConstructionCandidate(rawSummary.nextPrimary)[0]) != null ? _a : null } : {}
+  };
+}
+function normalizeConstructionCandidate(rawCandidate) {
+  if (!isRecord5(rawCandidate) || !isNonEmptyString3(rawCandidate.buildItem)) {
+    return [];
+  }
+  return [
+    {
+      buildItem: rawCandidate.buildItem,
+      ...isNonEmptyString3(rawCandidate.room) ? { room: rawCandidate.room } : {},
+      ...isFiniteNumber3(rawCandidate.score) ? { score: rawCandidate.score } : {},
+      ...isNonEmptyString3(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString3) } : {},
+      ...Array.isArray(rawCandidate.expectedKpiMovement) ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString3) } : {},
+      ...Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString3) } : {}
+    }
+  ];
+}
+function normalizeTerritoryRecommendationSummary(rawSummary) {
+  var _a;
+  return {
+    ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeTerritoryCandidate) } : {},
+    ...rawSummary.next === null ? { next: null } : isRecord5(rawSummary.next) ? { next: (_a = normalizeTerritoryCandidate(rawSummary.next)[0]) != null ? _a : null } : {},
+    ...rawSummary.followUpIntent !== void 0 ? { followUpIntent: rawSummary.followUpIntent } : {}
+  };
+}
+function normalizeTerritoryCandidate(rawCandidate) {
+  if (!isRecord5(rawCandidate) || !isNonEmptyString3(rawCandidate.roomName)) {
+    return [];
+  }
+  return [
+    {
+      roomName: rawCandidate.roomName,
+      ...isNonEmptyString3(rawCandidate.action) ? { action: rawCandidate.action } : {},
+      ...isFiniteNumber3(rawCandidate.score) ? { score: rawCandidate.score } : {},
+      ...isNonEmptyString3(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {},
+      ...isNonEmptyString3(rawCandidate.source) ? { source: rawCandidate.source } : {},
+      ...Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString3) } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString3) } : {},
+      ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString3) } : {},
+      ...isFiniteNumber3(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {},
+      ...isFiniteNumber3(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {},
+      ...isFiniteNumber3(rawCandidate.hostileCreepCount) ? { hostileCreepCount: rawCandidate.hostileCreepCount } : {},
+      ...isFiniteNumber3(rawCandidate.hostileStructureCount) ? { hostileStructureCount: rawCandidate.hostileStructureCount } : {}
+    }
+  ];
+}
+function normalizeCpuSummary(rawCpu) {
+  return {
+    ...isFiniteNumber3(rawCpu.used) ? { used: rawCpu.used } : {},
+    ...isFiniteNumber3(rawCpu.bucket) ? { bucket: rawCpu.bucket } : {}
+  };
+}
+function normalizeReliabilitySignals(rawReliability) {
+  return {
+    ...isFiniteNumber3(rawReliability.loopExceptionCount) ? { loopExceptionCount: rawReliability.loopExceptionCount } : {},
+    ...isFiniteNumber3(rawReliability.telemetrySilenceTicks) ? { telemetrySilenceTicks: rawReliability.telemetrySilenceTicks } : {},
+    ...isFiniteNumber3(rawReliability.globalResetCount) ? { globalResetCount: rawReliability.globalResetCount } : {}
+  };
+}
+function reduceRuntimeSummaryArtifact(artifact, reliabilityMetrics, territoryComponents, resourceComponents, killComponents, thresholds) {
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _A, _B, _C, _D, _E, _F, _G, _H, _I, _J, _K, _L, _M, _N;
+  reliabilityMetrics.loopExceptionCount += (_b = (_a = artifact.reliability) == null ? void 0 : _a.loopExceptionCount) != null ? _b : 0;
+  reliabilityMetrics.telemetrySilenceTicks += (_d = (_c = artifact.reliability) == null ? void 0 : _c.telemetrySilenceTicks) != null ? _d : 0;
+  reliabilityMetrics.globalResetCount += (_f = (_e = artifact.reliability) == null ? void 0 : _e.globalResetCount) != null ? _f : 0;
+  if (typeof ((_g = artifact.cpu) == null ? void 0 : _g.bucket) === "number") {
+    reliabilityMetrics.minCpuBucket = reliabilityMetrics.minCpuBucket === void 0 ? artifact.cpu.bucket : Math.min(reliabilityMetrics.minCpuBucket, artifact.cpu.bucket);
+  }
+  let ownedRoomCount = 0;
+  for (const room of artifact.rooms) {
+    if (room.controller) {
+      ownedRoomCount += 1;
+      territoryComponents.controllerLevels += room.controller.level;
+      territoryComponents.controllerProgress += (_h = room.controller.progress) != null ? _h : 0;
+      if (typeof room.controller.ticksToDowngrade === "number" && room.controller.ticksToDowngrade <= thresholds.controllerDowngradeRiskTicks) {
+        reliabilityMetrics.controllerDowngradeRiskRooms += 1;
+      }
+    }
+    if (((_i = room.workerCount) != null ? _i : 1) <= 0 && ((_k = (_j = room.spawnStatus) == null ? void 0 : _j.length) != null ? _k : 0) <= 0) {
+      reliabilityMetrics.spawnCollapseRooms += 1;
+    }
+    resourceComponents.storedEnergy += (_m = (_l = room.resources) == null ? void 0 : _l.storedEnergy) != null ? _m : 0;
+    resourceComponents.workerCarriedEnergy += (_o = (_n = room.resources) == null ? void 0 : _n.workerCarriedEnergy) != null ? _o : 0;
+    resourceComponents.droppedEnergy += (_q = (_p = room.resources) == null ? void 0 : _p.droppedEnergy) != null ? _q : 0;
+    resourceComponents.visibleSources += (_s = (_r = room.resources) == null ? void 0 : _r.sourceCount) != null ? _s : 0;
+    resourceComponents.harvestedEnergy += (_v = (_u = (_t = room.resources) == null ? void 0 : _t.events) == null ? void 0 : _u.harvestedEnergy) != null ? _v : 0;
+    resourceComponents.transferredEnergy += (_y = (_x = (_w = room.resources) == null ? void 0 : _w.events) == null ? void 0 : _x.transferredEnergy) != null ? _y : 0;
+    killComponents.creepKills += (_B = (_A = (_z = room.combat) == null ? void 0 : _z.events) == null ? void 0 : _A.creepDestroyedCount) != null ? _B : 0;
+    killComponents.objectKills += (_E = (_D = (_C = room.combat) == null ? void 0 : _C.events) == null ? void 0 : _D.objectDestroyedCount) != null ? _E : 0;
+    killComponents.attackDamage += (_H = (_G = (_F = room.combat) == null ? void 0 : _F.events) == null ? void 0 : _G.attackDamage) != null ? _H : 0;
+    killComponents.hostilePressureObserved += ((_J = (_I = room.combat) == null ? void 0 : _I.hostileCreepCount) != null ? _J : 0) + ((_L = (_K = room.combat) == null ? void 0 : _K.hostileStructureCount) != null ? _L : 0);
+    const territoryCandidates = (_N = (_M = room.territoryRecommendation) == null ? void 0 : _M.candidates) != null ? _N : [];
+    territoryComponents.reservedOrRemoteRooms += territoryCandidates.filter(
+      (candidate) => candidate.action === "occupy" || candidate.action === "reserve"
+    ).length;
+    territoryComponents.territoryRecommendation += Math.max(
+      0,
+      ...territoryCandidates.map((candidate) => {
+        var _a2;
+        return (_a2 = candidate.score) != null ? _a2 : 0;
+      })
+    );
+  }
+  territoryComponents.ownedRooms = Math.max(territoryComponents.ownedRooms, ownedRoomCount);
+  return ownedRoomCount;
+}
+function reduceRoomSnapshotArtifact(artifact, territoryComponents, resourceComponents, killComponents) {
+  var _a, _b;
+  const controller = artifact.objects.find((object) => object.type === "controller");
+  const ownedController = controller && isOwnedSnapshotObject(controller, artifact.owner);
+  const ownedRoomCount = ownedController ? 1 : 0;
+  if (ownedController) {
+    territoryComponents.ownedRooms = Math.max(territoryComponents.ownedRooms, 1);
+    territoryComponents.controllerLevels += (_a = controller.level) != null ? _a : 0;
+  }
+  for (const object of artifact.objects) {
+    if (object.type === "source") {
+      resourceComponents.visibleSources += 1;
+    }
+    if (object.type === "resource" && (object.resourceType === void 0 || object.resourceType === "energy")) {
+      resourceComponents.droppedEnergy += (_b = object.amount) != null ? _b : 0;
+    }
+    resourceComponents.storedEnergy += getSnapshotObjectEnergy(object);
+    if (object.type === "creep" && !isOwnedSnapshotObject(object, artifact.owner)) {
+      killComponents.hostilePressureObserved += 1;
+    }
+  }
+  return ownedRoomCount;
+}
+function evaluateReliabilityFloor(metrics, thresholds) {
+  var _a, _b;
+  const reasons = [];
+  if (metrics.artifactCount < thresholds.minArtifactCount) {
+    reasons.push(`artifact count ${metrics.artifactCount} below floor ${thresholds.minArtifactCount}`);
+  }
+  if (metrics.loopExceptionCount > thresholds.maxLoopExceptionCount) {
+    reasons.push(`loop exceptions ${metrics.loopExceptionCount} exceed ${thresholds.maxLoopExceptionCount}`);
+  }
+  if (metrics.telemetrySilenceTicks > thresholds.maxTelemetrySilenceTicks) {
+    reasons.push(`telemetry silence ${metrics.telemetrySilenceTicks} ticks exceeds ${thresholds.maxTelemetrySilenceTicks}`);
+  }
+  if (thresholds.minCpuBucket !== void 0 && ((_a = metrics.minCpuBucket) != null ? _a : thresholds.minCpuBucket) < thresholds.minCpuBucket) {
+    reasons.push(`minimum CPU bucket ${(_b = metrics.minCpuBucket) != null ? _b : "unknown"} below ${thresholds.minCpuBucket}`);
+  }
+  if (metrics.controllerDowngradeRiskRooms > thresholds.maxControllerDowngradeRiskRooms) {
+    reasons.push(
+      `controller downgrade risk rooms ${metrics.controllerDowngradeRiskRooms} exceed ${thresholds.maxControllerDowngradeRiskRooms}`
+    );
+  }
+  if (metrics.spawnCollapseRooms > thresholds.maxSpawnCollapseRooms) {
+    reasons.push(`spawn collapse rooms ${metrics.spawnCollapseRooms} exceed ${thresholds.maxSpawnCollapseRooms}`);
+  }
+  return {
+    passed: reasons.length === 0,
+    reasons,
+    metrics
+  };
+}
+function buildInitialReliabilityMetrics(artifacts) {
+  return {
+    artifactCount: artifacts.length,
+    runtimeSummaryCount: artifacts.filter((artifact) => artifact.artifactType === "runtime-summary").length,
+    roomSnapshotCount: artifacts.filter((artifact) => artifact.artifactType === "room-snapshot").length,
+    loopExceptionCount: 0,
+    telemetrySilenceTicks: 0,
+    globalResetCount: 0,
+    controllerDowngradeRiskRooms: 0,
+    spawnCollapseRooms: 0
+  };
+}
+function getSnapshotObjectEnergy(object) {
+  var _a;
+  if (typeof object.energy === "number") {
+    return object.energy;
+  }
+  const storeEnergy = (_a = object.store) == null ? void 0 : _a.energy;
+  return typeof storeEnergy === "number" ? storeEnergy : 0;
+}
+function isOwnedSnapshotObject(object, owner) {
+  var _a;
+  if (object.my === true) {
+    return true;
+  }
+  if (!owner) {
+    return false;
+  }
+  return object.user === owner || ((_a = object.owner) == null ? void 0 : _a.username) === owner;
+}
+function isRecord5(value) {
+  return typeof value === "object" && value !== null;
+}
+function isFiniteNumber3(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+function isNonEmptyString3(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+// src/strategy/shadowEvaluator.ts
+var DEFAULT_INCUMBENT_STRATEGY_IDS = {
+  "construction-priority": "construction-priority.incumbent.v1",
+  "expansion-remote-candidate": "expansion-remote.incumbent.v1",
+  "defense-posture-repair-threshold": "defense-repair.incumbent.v1"
+};
+var DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG = {
+  enabled: false,
+  incumbentStrategyIds: DEFAULT_INCUMBENT_STRATEGY_IDS,
+  candidateStrategyIds: []
+};
+function evaluateStrategyShadowReplay(input = {}) {
+  var _a, _b;
+  const registry = (_a = input.registry) != null ? _a : DEFAULT_STRATEGY_REGISTRY;
+  const artifacts = parseStrategyEvaluationArtifacts((_b = input.artifacts) != null ? _b : []);
+  const kpi = reduceStrategyKpis(artifacts);
+  const config = normalizeShadowConfig(input.config);
+  if (!config.enabled) {
+    return {
+      enabled: false,
+      artifactCount: artifacts.length,
+      kpi,
+      modelReports: [],
+      disabledReason: "strategy shadow evaluator disabled",
+      warnings: []
+    };
+  }
+  const registryById = new Map(registry.map((entry) => [entry.id, entry]));
+  const candidateStrategyIds = config.candidateStrategyIds.length > 0 ? config.candidateStrategyIds : registry.filter((entry) => entry.rolloutStatus === "shadow").map((entry) => entry.id);
+  const warnings = [];
+  const modelReports = [];
+  for (const candidateStrategyId of candidateStrategyIds) {
+    const candidate = registryById.get(candidateStrategyId);
+    if (!candidate) {
+      warnings.push(`candidate strategy not found: ${candidateStrategyId}`);
+      continue;
+    }
+    const incumbentStrategyId = config.incumbentStrategyIds[candidate.family];
+    const incumbent = incumbentStrategyId ? registryById.get(incumbentStrategyId) : void 0;
+    if (!incumbentStrategyId || !incumbent) {
+      warnings.push(`incumbent strategy not found for ${candidate.id}`);
+      continue;
+    }
+    if (incumbent.family !== candidate.family) {
+      warnings.push(`incumbent ${incumbent.id} does not match candidate family ${candidate.family}`);
+      continue;
+    }
+    modelReports.push(evaluateModelPair(artifacts, incumbent, candidate));
+  }
+  return {
+    enabled: true,
+    artifactCount: artifacts.length,
+    kpi,
+    modelReports,
+    warnings
+  };
+}
+function normalizeShadowConfig(config) {
+  var _a, _b, _c;
+  return {
+    enabled: (_a = config == null ? void 0 : config.enabled) != null ? _a : DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG.enabled,
+    incumbentStrategyIds: {
+      ...DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG.incumbentStrategyIds,
+      ...(_b = config == null ? void 0 : config.incumbentStrategyIds) != null ? _b : {}
+    },
+    candidateStrategyIds: (_c = config == null ? void 0 : config.candidateStrategyIds) != null ? _c : DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG.candidateStrategyIds
+  };
+}
+function evaluateModelPair(artifacts, incumbent, candidate) {
+  const rankingDiffs = [];
+  artifacts.forEach((artifact, artifactIndex) => {
+    const rankingGroups = buildRankingGroups(artifact, artifactIndex, candidate.family);
+    for (const group of rankingGroups) {
+      const incumbentRanking = scoreRankingItems(group.items, incumbent);
+      const candidateRanking = scoreRankingItems(group.items, candidate);
+      const rankingDiff = buildRankingDiff(group, incumbentRanking, candidateRanking);
+      if (rankingDiff.changedTop || rankingDiff.rankChanges.length > 0) {
+        rankingDiffs.push(rankingDiff);
+      }
+    }
+  });
+  return {
+    incumbentStrategyId: incumbent.id,
+    candidateStrategyId: candidate.id,
+    family: candidate.family,
+    rankingDiffs
+  };
+}
+function buildRankingGroups(artifact, artifactIndex, family) {
+  if (artifact.artifactType === "runtime-summary") {
+    return buildRuntimeSummaryRankingGroups(artifact, artifactIndex, family);
+  }
+  return buildRoomSnapshotRankingGroups(artifact, artifactIndex, family);
+}
+function buildRuntimeSummaryRankingGroups(artifact, artifactIndex, family) {
+  const groups = [];
+  for (const room of artifact.rooms) {
+    const items = buildRuntimeRoomRankingItems(room, artifactIndex, artifact.tick, family);
+    if (items.length > 0) {
+      groups.push({
+        context: family,
+        ...artifact.tick !== void 0 ? { tick: artifact.tick } : {},
+        roomName: room.roomName,
+        items
+      });
+    }
+  }
+  return groups;
+}
+function buildRoomSnapshotRankingGroups(artifact, artifactIndex, family) {
+  if (family !== "defense-posture-repair-threshold") {
+    return [];
+  }
+  const repairItems = artifact.objects.flatMap(
+    (object) => buildRepairRankingItem(artifact, object, artifactIndex, artifact.tick)
+  );
+  if (repairItems.length === 0) {
+    return [];
+  }
+  return [
+    {
+      context: family,
+      ...artifact.tick !== void 0 ? { tick: artifact.tick } : {},
+      ...artifact.roomName ? { roomName: artifact.roomName } : {},
+      items: repairItems
+    }
+  ];
+}
+function buildRuntimeRoomRankingItems(room, artifactIndex, tick, family) {
+  var _a, _b, _c, _d;
+  switch (family) {
+    case "construction-priority":
+      return ((_b = (_a = room.constructionPriority) == null ? void 0 : _a.candidates) != null ? _b : []).map(
+        (candidate) => buildConstructionRankingItem(room, candidate, artifactIndex, tick)
+      );
+    case "expansion-remote-candidate":
+      return ((_d = (_c = room.territoryRecommendation) == null ? void 0 : _c.candidates) != null ? _d : []).map(
+        (candidate) => buildTerritoryRankingItem(room, candidate, artifactIndex, tick)
+      );
+    case "defense-posture-repair-threshold":
+      return [buildRuntimeDefenseRankingItem(room, artifactIndex, tick)];
+    default:
+      return [];
+  }
+}
+function buildConstructionRankingItem(room, candidate, artifactIndex, tick) {
+  var _a, _b, _c, _d, _e, _f, _g, _h;
+  const text = [
+    candidate.buildItem,
+    ...(_a = candidate.expectedKpiMovement) != null ? _a : [],
+    ...(_b = candidate.preconditions) != null ? _b : [],
+    ...(_c = candidate.risk) != null ? _c : []
+  ].join(" ");
+  const signals = classifyStrategyText(text);
+  return {
+    itemId: `${room.roomName}:construction:${candidate.buildItem}`,
+    label: candidate.buildItem,
+    context: "construction-priority",
+    artifactIndex,
+    ...tick !== void 0 ? { tick } : {},
+    roomName: room.roomName,
+    baseScore: (_d = candidate.score) != null ? _d : 0,
+    signals: {
+      territory: signals.territory,
+      resources: signals.resources,
+      kills: signals.kills,
+      reliability: signals.reliability + urgencyReliabilitySignal(candidate.urgency),
+      risk: ((_f = (_e = candidate.risk) == null ? void 0 : _e.length) != null ? _f : 0) + ((_h = (_g = candidate.preconditions) == null ? void 0 : _g.length) != null ? _h : 0) * 2
+    }
+  };
+}
+function buildTerritoryRankingItem(room, candidate, artifactIndex, tick) {
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i;
+  const actionTerritorySignal = candidate.action === "occupy" ? 8 : candidate.action === "reserve" ? 6 : 2;
+  const hostileRisk = ((_a = candidate.hostileCreepCount) != null ? _a : 0) * 5 + ((_b = candidate.hostileStructureCount) != null ? _b : 0) * 4;
+  const evidenceRisk = candidate.evidenceStatus === "unavailable" ? 12 : candidate.evidenceStatus === "insufficient-evidence" ? 5 : 0;
+  return {
+    itemId: `${room.roomName}:territory:${candidate.roomName}:${(_c = candidate.action) != null ? _c : "unknown"}`,
+    label: `${(_d = candidate.action) != null ? _d : "score"} ${candidate.roomName}`,
+    context: "expansion-remote-candidate",
+    artifactIndex,
+    ...tick !== void 0 ? { tick } : {},
+    roomName: room.roomName,
+    baseScore: (_e = candidate.score) != null ? _e : 0,
+    signals: {
+      territory: actionTerritorySignal + (candidate.source === "configured" ? 2 : 0),
+      resources: Math.min((_f = candidate.sourceCount) != null ? _f : 0, 3) * 2,
+      kills: hostileRisk > 0 ? 1 : 0,
+      reliability: candidate.evidenceStatus === "sufficient" ? 1 : 0,
+      risk: hostileRisk + evidenceRisk + ((_h = (_g = candidate.risks) == null ? void 0 : _g.length) != null ? _h : 0) + Math.max(0, ((_i = candidate.routeDistance) != null ? _i : 1) - 1)
+    }
+  };
+}
+function buildRuntimeDefenseRankingItem(room, artifactIndex, tick) {
+  var _a, _b, _c, _d, _e, _f, _g;
+  const hostilePressure = ((_b = (_a = room.combat) == null ? void 0 : _a.hostileCreepCount) != null ? _b : 0) * 15 + ((_d = (_c = room.combat) == null ? void 0 : _c.hostileStructureCount) != null ? _d : 0) * 8;
+  const downgradePressure = typeof ((_e = room.controller) == null ? void 0 : _e.ticksToDowngrade) === "number" ? Math.max(0, 5e3 - room.controller.ticksToDowngrade) / 500 : 0;
+  const baseScore = hostilePressure + downgradePressure;
+  return {
+    itemId: `${room.roomName}:defense-posture`,
+    label: `defense posture ${room.roomName}`,
+    context: "defense-posture-repair-threshold",
+    artifactIndex,
+    ...tick !== void 0 ? { tick } : {},
+    roomName: room.roomName,
+    baseScore,
+    signals: {
+      territory: downgradePressure > 0 ? 3 : 1,
+      resources: ((_g = (_f = room.resources) == null ? void 0 : _f.storedEnergy) != null ? _g : 0) > 0 ? 1 : 0,
+      kills: hostilePressure > 0 ? 4 : 0,
+      reliability: downgradePressure > 0 || hostilePressure > 0 ? 3 : 1,
+      risk: baseScore === 0 ? 1 : 0
+    }
+  };
+}
+function buildRepairRankingItem(artifact, object, artifactIndex, tick) {
+  var _a, _b, _c, _d;
+  if (!isDamageableSnapshotStructure(object) || typeof object.hits !== "number" || typeof object.hitsMax !== "number") {
+    return [];
+  }
+  const damageRatio = object.hitsMax > 0 ? Math.max(0, 1 - object.hits / object.hitsMax) : 0;
+  if (damageRatio <= 0) {
+    return [];
+  }
+  const roomName = (_a = artifact.roomName) != null ? _a : object.room;
+  const criticalStructureSignal = object.type === "spawn" || object.type === "tower" || object.type === "storage" ? 3 : 1;
+  return [
+    {
+      itemId: `${roomName != null ? roomName : "unknown"}:repair:${(_b = object.type) != null ? _b : "structure"}:${(_c = object.id) != null ? _c : "unknown"}`,
+      label: `repair ${(_d = object.type) != null ? _d : "structure"}`,
+      context: "defense-posture-repair-threshold",
+      artifactIndex,
+      ...tick !== void 0 ? { tick } : {},
+      ...roomName ? { roomName } : {},
+      baseScore: damageRatio * 100,
+      signals: {
+        territory: object.type === "spawn" || object.type === "tower" ? criticalStructureSignal : 1,
+        resources: object.type === "storage" || object.type === "container" ? criticalStructureSignal : 1,
+        kills: object.type === "rampart" || object.type === "tower" ? criticalStructureSignal : 0,
+        reliability: criticalStructureSignal,
+        risk: damageRatio >= 0.5 ? 0 : 1
+      }
+    }
+  ];
+}
+function scoreRankingItems(items, entry) {
+  return items.map((item) => ({
+    ...item,
+    strategyScore: calculateStrategyScore(item, entry),
+    rank: 0
+  })).sort(compareScoredRankingItems).map((item, index) => ({
+    ...item,
+    rank: index + 1
+  }));
+}
+function calculateStrategyScore(item, entry) {
+  const baseScoreWeight = getStrategyNumberDefault(entry, "baseScoreWeight", 1);
+  const territorySignalWeight = getStrategyNumberDefault(entry, "territorySignalWeight", 0);
+  const resourceSignalWeight = getStrategyNumberDefault(entry, "resourceSignalWeight", 0);
+  const killSignalWeight = getStrategyNumberDefault(entry, "killSignalWeight", 0);
+  const riskPenalty = getStrategyNumberDefault(entry, "riskPenalty", 0);
+  return item.baseScore * baseScoreWeight + item.signals.territory * territorySignalWeight + item.signals.resources * resourceSignalWeight + item.signals.kills * killSignalWeight + item.signals.reliability * Math.max(territorySignalWeight, killSignalWeight) - item.signals.risk * riskPenalty;
+}
+function compareScoredRankingItems(left, right) {
+  return right.strategyScore - left.strategyScore || right.baseScore - left.baseScore || left.label.localeCompare(right.label) || left.itemId.localeCompare(right.itemId);
+}
+function buildRankingDiff(group, incumbentRanking, candidateRanking) {
+  var _a, _b;
+  const incumbentTop = incumbentRanking[0] ? summarizeRankedItem(incumbentRanking[0]) : null;
+  const candidateTop = candidateRanking[0] ? summarizeRankedItem(candidateRanking[0]) : null;
+  const incumbentRanks = new Map(incumbentRanking.map((item) => [item.itemId, item]));
+  const candidateRanks = new Map(candidateRanking.map((item) => [item.itemId, item]));
+  const itemIds = Array.from(/* @__PURE__ */ new Set([...incumbentRanks.keys(), ...candidateRanks.keys()])).sort();
+  const rankChanges = itemIds.flatMap((itemId) => {
+    var _a2, _b2;
+    const incumbentItem = incumbentRanks.get(itemId);
+    const candidateItem = candidateRanks.get(itemId);
+    if ((incumbentItem == null ? void 0 : incumbentItem.rank) === (candidateItem == null ? void 0 : candidateItem.rank)) {
+      return [];
+    }
+    const label = (_b2 = (_a2 = incumbentItem == null ? void 0 : incumbentItem.label) != null ? _a2 : candidateItem == null ? void 0 : candidateItem.label) != null ? _b2 : itemId;
+    const incumbentRank = incumbentItem == null ? void 0 : incumbentItem.rank;
+    const candidateRank = candidateItem == null ? void 0 : candidateItem.rank;
+    return [
+      {
+        itemId,
+        label,
+        ...incumbentRank !== void 0 ? { incumbentRank } : {},
+        ...candidateRank !== void 0 ? { candidateRank } : {},
+        ...incumbentRank !== void 0 && candidateRank !== void 0 ? { delta: incumbentRank - candidateRank } : {}
+      }
+    ];
+  });
+  return {
+    artifactIndex: (_b = (_a = group.items[0]) == null ? void 0 : _a.artifactIndex) != null ? _b : 0,
+    ...group.tick !== void 0 ? { tick: group.tick } : {},
+    ...group.roomName ? { roomName: group.roomName } : {},
+    context: group.context,
+    incumbentTop,
+    candidateTop,
+    changedTop: (incumbentTop == null ? void 0 : incumbentTop.itemId) !== (candidateTop == null ? void 0 : candidateTop.itemId),
+    rankChanges
+  };
+}
+function summarizeRankedItem(item) {
+  return {
+    itemId: item.itemId,
+    label: item.label,
+    rank: item.rank,
+    score: roundScore(item.strategyScore),
+    baseScore: roundScore(item.baseScore)
+  };
+}
+function classifyStrategyText(text) {
+  const normalizedText = text.toLowerCase();
+  return {
+    territory: countSignalWords(normalizedText, [
+      "territory",
+      "remote",
+      "controller",
+      "rcl",
+      "expansion",
+      "claim",
+      "reserve",
+      "room"
+    ]),
+    resources: countSignalWords(normalizedText, [
+      "energy",
+      "resource",
+      "resources",
+      "harvest",
+      "storage",
+      "source",
+      "throughput",
+      "capacity",
+      "worker"
+    ]),
+    kills: countSignalWords(normalizedText, ["kill", "enemy", "hostile", "tower", "rampart", "defense", "survivability"]),
+    reliability: countSignalWords(normalizedText, ["spawn", "recovery", "downgrade", "repair", "safe", "survival"]),
+    risk: countSignalWords(normalizedText, ["risk", "blocked", "decay", "hostile", "unavailable", "missing"])
+  };
+}
+function urgencyReliabilitySignal(urgency) {
+  switch (urgency) {
+    case "critical":
+      return 3;
+    case "high":
+      return 2;
+    case "medium":
+      return 1;
+    default:
+      return 0;
+  }
+}
+function countSignalWords(text, words) {
+  return words.reduce((count, word) => count + (text.includes(word) ? 1 : 0), 0);
+}
+function roundScore(score) {
+  return Math.round(score * 1e3) / 1e3;
+}
+function isDamageableSnapshotStructure(object) {
+  return object.type === "constructedWall" || object.type === "container" || object.type === "extension" || object.type === "rampart" || object.type === "road" || object.type === "spawn" || object.type === "storage" || object.type === "tower";
+}
+
 // src/main.ts
 var kernel = new Kernel();
 function loop() {
@@ -5308,5 +6404,11 @@ function loop() {
 }
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
-  loop
+  DEFAULT_STRATEGY_REGISTRY,
+  DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG,
+  STRATEGY_REGISTRY_SCHEMA_VERSION,
+  evaluateStrategyShadowReplay,
+  loop,
+  validateStrategyRegistry,
+  validateStrategyRegistryEntry
 });

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5942,23 +5942,24 @@ function reduceRuntimeSummaryArtifact(artifact, reliabilityMetrics, territoryCom
   return ownedRoomCount;
 }
 function reduceRoomSnapshotArtifact(artifact, territoryComponents, resourceComponents, killComponents) {
-  var _a, _b;
+  var _a, _b, _c;
   const controller = artifact.objects.find((object) => object.type === "controller");
-  const ownedController = controller && isOwnedSnapshotObject(controller, artifact.owner);
+  const snapshotOwner = (_a = artifact.owner) != null ? _a : getSnapshotObjectOwner(controller);
+  const ownedController = controller && isOwnedSnapshotObject(controller, snapshotOwner);
   const ownedRoomCount = ownedController ? 1 : 0;
   if (ownedController) {
     territoryComponents.ownedRooms = Math.max(territoryComponents.ownedRooms, 1);
-    territoryComponents.controllerLevels += (_a = controller.level) != null ? _a : 0;
+    territoryComponents.controllerLevels += (_b = controller.level) != null ? _b : 0;
   }
   for (const object of artifact.objects) {
     if (object.type === "source") {
       resourceComponents.visibleSources += 1;
     }
     if (object.type === "resource" && (object.resourceType === void 0 || object.resourceType === "energy")) {
-      resourceComponents.droppedEnergy += (_b = object.amount) != null ? _b : 0;
+      resourceComponents.droppedEnergy += (_c = object.amount) != null ? _c : 0;
     }
     resourceComponents.storedEnergy += getSnapshotObjectEnergy(object);
-    if (object.type === "creep" && !isOwnedSnapshotObject(object, artifact.owner)) {
+    if (object.type === "creep" && !isOwnedSnapshotObject(object, snapshotOwner)) {
       killComponents.hostilePressureObserved += 1;
     }
   }
@@ -6012,6 +6013,15 @@ function getSnapshotObjectEnergy(object) {
   }
   const storeEnergy = (_a = object.store) == null ? void 0 : _a.energy;
   return typeof storeEnergy === "number" ? storeEnergy : 0;
+}
+function getSnapshotObjectOwner(object) {
+  var _a;
+  const objectUser = object == null ? void 0 : object.user;
+  if (isNonEmptyString3(objectUser)) {
+    return objectUser;
+  }
+  const ownerUsername = (_a = object == null ? void 0 : object.owner) == null ? void 0 : _a.username;
+  return isNonEmptyString3(ownerUsername) ? ownerUsername : void 0;
 }
 function isOwnedSnapshotObject(object, owner) {
   var _a;

--- a/prod/src/main.ts
+++ b/prod/src/main.ts
@@ -1,4 +1,11 @@
 import { Kernel } from './kernel/Kernel';
+export {
+  DEFAULT_STRATEGY_REGISTRY,
+  STRATEGY_REGISTRY_SCHEMA_VERSION,
+  validateStrategyRegistry,
+  validateStrategyRegistryEntry
+} from './strategy/strategyRegistry';
+export { DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG, evaluateStrategyShadowReplay } from './strategy/shadowEvaluator';
 
 const kernel = new Kernel();
 

--- a/prod/src/strategy/kpiEvaluator.ts
+++ b/prod/src/strategy/kpiEvaluator.ts
@@ -685,7 +685,8 @@ function reduceRoomSnapshotArtifact(
   killComponents: Record<string, number>
 ): number {
   const controller = artifact.objects.find((object) => object.type === 'controller');
-  const ownedController = controller && isOwnedSnapshotObject(controller, artifact.owner);
+  const snapshotOwner = artifact.owner ?? getSnapshotObjectOwner(controller);
+  const ownedController = controller && isOwnedSnapshotObject(controller, snapshotOwner);
   const ownedRoomCount = ownedController ? 1 : 0;
   if (ownedController) {
     territoryComponents.ownedRooms = Math.max(territoryComponents.ownedRooms, 1);
@@ -703,7 +704,7 @@ function reduceRoomSnapshotArtifact(
 
     resourceComponents.storedEnergy += getSnapshotObjectEnergy(object);
 
-    if (object.type === 'creep' && !isOwnedSnapshotObject(object, artifact.owner)) {
+    if (object.type === 'creep' && !isOwnedSnapshotObject(object, snapshotOwner)) {
       killComponents.hostilePressureObserved += 1;
     }
   }
@@ -795,6 +796,16 @@ function getSnapshotObjectEnergy(object: StrategyRoomSnapshotObject): number {
 
   const storeEnergy = object.store?.energy;
   return typeof storeEnergy === 'number' ? storeEnergy : 0;
+}
+
+function getSnapshotObjectOwner(object: StrategyRoomSnapshotObject | undefined): string | undefined {
+  const objectUser = object?.user;
+  if (isNonEmptyString(objectUser)) {
+    return objectUser;
+  }
+
+  const ownerUsername = object?.owner?.username;
+  return isNonEmptyString(ownerUsername) ? ownerUsername : undefined;
 }
 
 function isOwnedSnapshotObject(object: StrategyRoomSnapshotObject, owner: string | undefined): boolean {

--- a/prod/src/strategy/kpiEvaluator.ts
+++ b/prod/src/strategy/kpiEvaluator.ts
@@ -1,0 +1,822 @@
+import type { StrategyArtifactType } from './strategyRegistry';
+
+export const STRATEGY_RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
+
+export interface StrategyRuntimeSummaryArtifact {
+  artifactType: 'runtime-summary';
+  tick?: number;
+  rooms: StrategyRuntimeSummaryRoom[];
+  cpu?: StrategyCpuSummary;
+  reliability?: StrategyArtifactReliabilitySignals;
+}
+
+export interface StrategyRuntimeSummaryRoom {
+  roomName: string;
+  energyAvailable?: number;
+  energyCapacity?: number;
+  workerCount?: number;
+  spawnStatus?: StrategyRuntimeSpawnStatus[];
+  controller?: StrategyRuntimeControllerSummary;
+  resources?: StrategyRuntimeResourceSummary;
+  combat?: StrategyRuntimeCombatSummary;
+  constructionPriority?: StrategyRuntimeConstructionPrioritySummary;
+  territoryRecommendation?: StrategyRuntimeTerritoryRecommendationSummary;
+}
+
+export interface StrategyRuntimeSpawnStatus {
+  name?: string;
+  status?: string;
+  creepName?: string;
+  remainingTime?: number;
+}
+
+export interface StrategyRuntimeControllerSummary {
+  level: number;
+  progress?: number;
+  progressTotal?: number;
+  ticksToDowngrade?: number;
+}
+
+export interface StrategyRuntimeResourceSummary {
+  storedEnergy?: number;
+  workerCarriedEnergy?: number;
+  droppedEnergy?: number;
+  sourceCount?: number;
+  events?: StrategyRuntimeResourceEventSummary;
+}
+
+export interface StrategyRuntimeResourceEventSummary {
+  harvestedEnergy?: number;
+  transferredEnergy?: number;
+}
+
+export interface StrategyRuntimeCombatSummary {
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  events?: StrategyRuntimeCombatEventSummary;
+}
+
+export interface StrategyRuntimeCombatEventSummary {
+  attackCount?: number;
+  attackDamage?: number;
+  objectDestroyedCount?: number;
+  creepDestroyedCount?: number;
+}
+
+export interface StrategyRuntimeConstructionPrioritySummary {
+  candidates?: StrategyRuntimeConstructionPriorityCandidate[];
+  nextPrimary?: StrategyRuntimeConstructionPriorityCandidate | null;
+}
+
+export interface StrategyRuntimeConstructionPriorityCandidate {
+  buildItem: string;
+  room?: string;
+  score?: number;
+  urgency?: string;
+  preconditions?: string[];
+  expectedKpiMovement?: string[];
+  risk?: string[];
+}
+
+export interface StrategyRuntimeTerritoryRecommendationSummary {
+  candidates?: StrategyRuntimeTerritoryCandidate[];
+  next?: StrategyRuntimeTerritoryCandidate | null;
+  followUpIntent?: unknown;
+}
+
+export interface StrategyRuntimeTerritoryCandidate {
+  roomName: string;
+  action?: string;
+  score?: number;
+  evidenceStatus?: string;
+  source?: string;
+  evidence?: string[];
+  preconditions?: string[];
+  risks?: string[];
+  routeDistance?: number;
+  sourceCount?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+}
+
+export interface StrategyCpuSummary {
+  used?: number;
+  bucket?: number;
+}
+
+export interface StrategyRoomSnapshotArtifact {
+  artifactType: 'room-snapshot';
+  tick?: number;
+  roomName?: string;
+  owner?: string;
+  objects: StrategyRoomSnapshotObject[];
+}
+
+export interface StrategyRoomSnapshotObject {
+  id?: string;
+  type?: string;
+  room?: string;
+  user?: string;
+  owner?: { username?: string };
+  my?: boolean;
+  level?: number;
+  hits?: number;
+  hitsMax?: number;
+  amount?: number;
+  resourceType?: string;
+  energy?: number;
+  store?: Record<string, unknown>;
+}
+
+export interface StrategyArtifactReliabilitySignals {
+  loopExceptionCount?: number;
+  telemetrySilenceTicks?: number;
+  globalResetCount?: number;
+}
+
+export type StrategyEvaluationArtifact = StrategyRuntimeSummaryArtifact | StrategyRoomSnapshotArtifact;
+
+export interface StrategyReliabilityThresholds {
+  minArtifactCount: number;
+  maxLoopExceptionCount: number;
+  maxTelemetrySilenceTicks: number;
+  minCpuBucket?: number;
+  controllerDowngradeRiskTicks: number;
+  maxControllerDowngradeRiskRooms: number;
+  maxSpawnCollapseRooms: number;
+}
+
+export interface StrategyReliabilityMetrics {
+  artifactCount: number;
+  runtimeSummaryCount: number;
+  roomSnapshotCount: number;
+  loopExceptionCount: number;
+  telemetrySilenceTicks: number;
+  globalResetCount: number;
+  controllerDowngradeRiskRooms: number;
+  spawnCollapseRooms: number;
+  minCpuBucket?: number;
+}
+
+export interface StrategyReliabilityEvaluation {
+  passed: boolean;
+  reasons: string[];
+  metrics: StrategyReliabilityMetrics;
+}
+
+export interface StrategyKpiDimension {
+  score: number;
+  components: Record<string, number>;
+}
+
+export interface StrategyKpiVector {
+  reliability: StrategyReliabilityEvaluation;
+  territory: StrategyKpiDimension;
+  resources: StrategyKpiDimension;
+  kills: StrategyKpiDimension;
+}
+
+export const DEFAULT_STRATEGY_RELIABILITY_THRESHOLDS: StrategyReliabilityThresholds = {
+  minArtifactCount: 1,
+  maxLoopExceptionCount: 0,
+  maxTelemetrySilenceTicks: 0,
+  controllerDowngradeRiskTicks: 5_000,
+  maxControllerDowngradeRiskRooms: 0,
+  maxSpawnCollapseRooms: 0
+};
+
+export function parseStrategyEvaluationArtifacts(input: string | unknown | unknown[]): StrategyEvaluationArtifact[] {
+  if (typeof input !== 'string') {
+    const rawArtifacts = Array.isArray(input) ? input : [input];
+    return rawArtifacts.flatMap((rawArtifact) => {
+      const artifact = normalizeStrategyEvaluationArtifact(rawArtifact);
+      return artifact ? [artifact] : [];
+    });
+  }
+
+  const trimmedInput = input.trim();
+  if (trimmedInput.length === 0) {
+    return [];
+  }
+
+  const wholeJson = parseJson(trimmedInput);
+  if (wholeJson !== null) {
+    return parseStrategyEvaluationArtifacts(wholeJson);
+  }
+
+  return trimmedInput.split(/\r?\n/).flatMap((line) => {
+    const parsedLine = parseArtifactLine(line);
+    const artifact = parsedLine === null ? null : normalizeStrategyEvaluationArtifact(parsedLine);
+    return artifact ? [artifact] : [];
+  });
+}
+
+export function normalizeStrategyEvaluationArtifact(rawArtifact: unknown): StrategyEvaluationArtifact | null {
+  if (!isRecord(rawArtifact)) {
+    return null;
+  }
+
+  if (rawArtifact.type === 'runtime-summary' || Array.isArray(rawArtifact.rooms)) {
+    return normalizeRuntimeSummaryArtifact(rawArtifact);
+  }
+
+  if (rawArtifact.artifactType === 'runtime-summary') {
+    return normalizeRuntimeSummaryArtifact(rawArtifact);
+  }
+
+  if (rawArtifact.artifactType === 'room-snapshot' || Array.isArray(rawArtifact.objects) || isRecord(rawArtifact.objects)) {
+    return normalizeRoomSnapshotArtifact(rawArtifact);
+  }
+
+  return null;
+}
+
+export function reduceStrategyKpis(
+  artifacts: StrategyEvaluationArtifact[],
+  thresholds: StrategyReliabilityThresholds = DEFAULT_STRATEGY_RELIABILITY_THRESHOLDS
+): StrategyKpiVector {
+  const reliabilityMetrics = buildInitialReliabilityMetrics(artifacts);
+  const territoryComponents: Record<string, number> = {
+    ownedRooms: 0,
+    reservedOrRemoteRooms: 0,
+    roomGain: 0,
+    controllerLevels: 0,
+    controllerProgress: 0,
+    territoryRecommendation: 0
+  };
+  const resourceComponents: Record<string, number> = {
+    storedEnergy: 0,
+    workerCarriedEnergy: 0,
+    droppedEnergy: 0,
+    harvestedEnergy: 0,
+    transferredEnergy: 0,
+    visibleSources: 0
+  };
+  const killComponents: Record<string, number> = {
+    creepKills: 0,
+    objectKills: 0,
+    attackDamage: 0,
+    hostilePressureObserved: 0
+  };
+  let firstOwnedRoomCount: number | undefined;
+  let lastOwnedRoomCount = 0;
+
+  for (const artifact of artifacts) {
+    if (artifact.artifactType === 'runtime-summary') {
+      const ownedRoomCount = reduceRuntimeSummaryArtifact(
+        artifact,
+        reliabilityMetrics,
+        territoryComponents,
+        resourceComponents,
+        killComponents,
+        thresholds
+      );
+      if (firstOwnedRoomCount === undefined) {
+        firstOwnedRoomCount = ownedRoomCount;
+      }
+      lastOwnedRoomCount = ownedRoomCount;
+    } else {
+      const ownedRoomCount = reduceRoomSnapshotArtifact(
+        artifact,
+        territoryComponents,
+        resourceComponents,
+        killComponents
+      );
+      if (firstOwnedRoomCount === undefined) {
+        firstOwnedRoomCount = ownedRoomCount;
+      }
+      lastOwnedRoomCount = ownedRoomCount;
+    }
+  }
+
+  territoryComponents.roomGain = lastOwnedRoomCount - (firstOwnedRoomCount ?? lastOwnedRoomCount);
+
+  return {
+    reliability: evaluateReliabilityFloor(reliabilityMetrics, thresholds),
+    territory: {
+      score:
+        territoryComponents.ownedRooms * 10_000 +
+        territoryComponents.reservedOrRemoteRooms * 3_000 +
+        territoryComponents.roomGain * 5_000 +
+        territoryComponents.controllerLevels * 800 +
+        territoryComponents.controllerProgress / 100 +
+        territoryComponents.territoryRecommendation,
+      components: territoryComponents
+    },
+    resources: {
+      score:
+        resourceComponents.storedEnergy +
+        resourceComponents.workerCarriedEnergy +
+        resourceComponents.droppedEnergy / 2 +
+        resourceComponents.harvestedEnergy * 3 +
+        resourceComponents.transferredEnergy +
+        resourceComponents.visibleSources * 500,
+      components: resourceComponents
+    },
+    kills: {
+      score:
+        killComponents.creepKills * 1_000 +
+        killComponents.objectKills * 250 +
+        killComponents.attackDamage +
+        killComponents.hostilePressureObserved * 25,
+      components: killComponents
+    }
+  };
+}
+
+export function buildStrategyKpiVector(options: {
+  reliabilityPassed?: boolean;
+  reliabilityReasons?: string[];
+  territory?: number;
+  resources?: number;
+  kills?: number;
+}): StrategyKpiVector {
+  const reliabilityMetrics: StrategyReliabilityMetrics = {
+    artifactCount: 1,
+    runtimeSummaryCount: 1,
+    roomSnapshotCount: 0,
+    loopExceptionCount: options.reliabilityPassed === false ? 1 : 0,
+    telemetrySilenceTicks: 0,
+    globalResetCount: 0,
+    controllerDowngradeRiskRooms: 0,
+    spawnCollapseRooms: 0
+  };
+
+  return {
+    reliability: {
+      passed: options.reliabilityPassed ?? true,
+      reasons: options.reliabilityReasons ?? (options.reliabilityPassed === false ? ['reliability floor failed'] : []),
+      metrics: reliabilityMetrics
+    },
+    territory: { score: options.territory ?? 0, components: {} },
+    resources: { score: options.resources ?? 0, components: {} },
+    kills: { score: options.kills ?? 0, components: {} }
+  };
+}
+
+export function compareStrategyKpiVectors(left: StrategyKpiVector, right: StrategyKpiVector): number {
+  const reliabilityComparison = compareReliability(left.reliability, right.reliability);
+  if (reliabilityComparison !== 0) {
+    return reliabilityComparison;
+  }
+
+  return (
+    compareNumber(left.territory.score, right.territory.score) ||
+    compareNumber(left.resources.score, right.resources.score) ||
+    compareNumber(left.kills.score, right.kills.score)
+  );
+}
+
+export function getArtifactType(artifact: StrategyEvaluationArtifact): StrategyArtifactType {
+  return artifact.artifactType;
+}
+
+function normalizeRuntimeSummaryArtifact(rawArtifact: Record<string, unknown>): StrategyRuntimeSummaryArtifact | null {
+  const rooms = Array.isArray(rawArtifact.rooms)
+    ? rawArtifact.rooms.flatMap((rawRoom) => {
+        const room = normalizeRuntimeSummaryRoom(rawRoom);
+        return room ? [room] : [];
+      })
+    : [];
+
+  return {
+    artifactType: 'runtime-summary',
+    ...(isFiniteNumber(rawArtifact.tick) ? { tick: rawArtifact.tick } : {}),
+    rooms,
+    ...(isRecord(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {}),
+    ...(isRecord(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {})
+  };
+}
+
+function normalizeRuntimeSummaryRoom(rawRoom: unknown): StrategyRuntimeSummaryRoom | null {
+  if (!isRecord(rawRoom) || !isNonEmptyString(rawRoom.roomName)) {
+    return null;
+  }
+
+  return {
+    roomName: rawRoom.roomName,
+    ...(isFiniteNumber(rawRoom.energyAvailable) ? { energyAvailable: rawRoom.energyAvailable } : {}),
+    ...(isFiniteNumber(rawRoom.energyCapacity) ? { energyCapacity: rawRoom.energyCapacity } : {}),
+    ...(isFiniteNumber(rawRoom.workerCount) ? { workerCount: rawRoom.workerCount } : {}),
+    ...(Array.isArray(rawRoom.spawnStatus) ? { spawnStatus: rawRoom.spawnStatus.map(normalizeSpawnStatus) } : {}),
+    ...(isRecord(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {}),
+    ...(isRecord(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {}),
+    ...(isRecord(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {}),
+    ...(isRecord(rawRoom.constructionPriority)
+      ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) }
+      : {}),
+    ...(isRecord(rawRoom.territoryRecommendation)
+      ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) }
+      : {})
+  };
+}
+
+function normalizeRoomSnapshotArtifact(rawArtifact: Record<string, unknown>): StrategyRoomSnapshotArtifact | null {
+  if (!Array.isArray(rawArtifact.objects) && !isRecord(rawArtifact.objects)) {
+    return null;
+  }
+
+  const objects = Array.isArray(rawArtifact.objects)
+    ? rawArtifact.objects.flatMap((rawObject) => (isRecord(rawObject) ? [rawObject as StrategyRoomSnapshotObject] : []))
+    : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
+        if (!isRecord(rawObject)) {
+          return [];
+        }
+
+        return [{ ...rawObject, id } as StrategyRoomSnapshotObject];
+      });
+
+  return {
+    artifactType: 'room-snapshot',
+    ...(isFiniteNumber(rawArtifact.tick) ? { tick: rawArtifact.tick } : {}),
+    ...(isNonEmptyString(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {}),
+    ...(isNonEmptyString(rawArtifact.room) ? { roomName: rawArtifact.room } : {}),
+    ...(isNonEmptyString(rawArtifact.owner) ? { owner: rawArtifact.owner } : {}),
+    objects
+  };
+}
+
+function parseArtifactLine(line: string): unknown | null {
+  const trimmedLine = line.trim();
+  if (trimmedLine.length === 0) {
+    return null;
+  }
+
+  const jsonText = trimmedLine.startsWith(STRATEGY_RUNTIME_SUMMARY_PREFIX)
+    ? trimmedLine.slice(STRATEGY_RUNTIME_SUMMARY_PREFIX.length)
+    : trimmedLine;
+  return parseJson(jsonText);
+}
+
+function parseJson(text: string): unknown | null {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeSpawnStatus(rawStatus: unknown): StrategyRuntimeSpawnStatus {
+  if (!isRecord(rawStatus)) {
+    return {};
+  }
+
+  return {
+    ...(isNonEmptyString(rawStatus.name) ? { name: rawStatus.name } : {}),
+    ...(isNonEmptyString(rawStatus.status) ? { status: rawStatus.status } : {}),
+    ...(isNonEmptyString(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {}),
+    ...(isFiniteNumber(rawStatus.remainingTime) ? { remainingTime: rawStatus.remainingTime } : {})
+  };
+}
+
+function normalizeControllerSummary(rawController: Record<string, unknown>): StrategyRuntimeControllerSummary {
+  return {
+    level: isFiniteNumber(rawController.level) ? rawController.level : 0,
+    ...(isFiniteNumber(rawController.progress) ? { progress: rawController.progress } : {}),
+    ...(isFiniteNumber(rawController.progressTotal) ? { progressTotal: rawController.progressTotal } : {}),
+    ...(isFiniteNumber(rawController.ticksToDowngrade) ? { ticksToDowngrade: rawController.ticksToDowngrade } : {})
+  };
+}
+
+function normalizeResourceSummary(rawResources: Record<string, unknown>): StrategyRuntimeResourceSummary {
+  return {
+    ...(isFiniteNumber(rawResources.storedEnergy) ? { storedEnergy: rawResources.storedEnergy } : {}),
+    ...(isFiniteNumber(rawResources.workerCarriedEnergy)
+      ? { workerCarriedEnergy: rawResources.workerCarriedEnergy }
+      : {}),
+    ...(isFiniteNumber(rawResources.droppedEnergy) ? { droppedEnergy: rawResources.droppedEnergy } : {}),
+    ...(isFiniteNumber(rawResources.sourceCount) ? { sourceCount: rawResources.sourceCount } : {}),
+    ...(isRecord(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {})
+  };
+}
+
+function normalizeResourceEvents(rawEvents: Record<string, unknown>): StrategyRuntimeResourceEventSummary {
+  return {
+    ...(isFiniteNumber(rawEvents.harvestedEnergy) ? { harvestedEnergy: rawEvents.harvestedEnergy } : {}),
+    ...(isFiniteNumber(rawEvents.transferredEnergy) ? { transferredEnergy: rawEvents.transferredEnergy } : {})
+  };
+}
+
+function normalizeCombatSummary(rawCombat: Record<string, unknown>): StrategyRuntimeCombatSummary {
+  return {
+    ...(isFiniteNumber(rawCombat.hostileCreepCount) ? { hostileCreepCount: rawCombat.hostileCreepCount } : {}),
+    ...(isFiniteNumber(rawCombat.hostileStructureCount)
+      ? { hostileStructureCount: rawCombat.hostileStructureCount }
+      : {}),
+    ...(isRecord(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {})
+  };
+}
+
+function normalizeCombatEvents(rawEvents: Record<string, unknown>): StrategyRuntimeCombatEventSummary {
+  return {
+    ...(isFiniteNumber(rawEvents.attackCount) ? { attackCount: rawEvents.attackCount } : {}),
+    ...(isFiniteNumber(rawEvents.attackDamage) ? { attackDamage: rawEvents.attackDamage } : {}),
+    ...(isFiniteNumber(rawEvents.objectDestroyedCount) ? { objectDestroyedCount: rawEvents.objectDestroyedCount } : {}),
+    ...(isFiniteNumber(rawEvents.creepDestroyedCount) ? { creepDestroyedCount: rawEvents.creepDestroyedCount } : {})
+  };
+}
+
+function normalizeConstructionPrioritySummary(
+  rawSummary: Record<string, unknown>
+): StrategyRuntimeConstructionPrioritySummary {
+  return {
+    ...(Array.isArray(rawSummary.candidates)
+      ? { candidates: rawSummary.candidates.flatMap(normalizeConstructionCandidate) }
+      : {}),
+    ...(rawSummary.nextPrimary === null
+      ? { nextPrimary: null }
+      : isRecord(rawSummary.nextPrimary)
+        ? { nextPrimary: normalizeConstructionCandidate(rawSummary.nextPrimary)[0] ?? null }
+        : {})
+  };
+}
+
+function normalizeConstructionCandidate(rawCandidate: unknown): StrategyRuntimeConstructionPriorityCandidate[] {
+  if (!isRecord(rawCandidate) || !isNonEmptyString(rawCandidate.buildItem)) {
+    return [];
+  }
+
+  return [
+    {
+      buildItem: rawCandidate.buildItem,
+      ...(isNonEmptyString(rawCandidate.room) ? { room: rawCandidate.room } : {}),
+      ...(isFiniteNumber(rawCandidate.score) ? { score: rawCandidate.score } : {}),
+      ...(isNonEmptyString(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {}),
+      ...(Array.isArray(rawCandidate.preconditions)
+        ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString) }
+        : {}),
+      ...(Array.isArray(rawCandidate.expectedKpiMovement)
+        ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString) }
+        : {}),
+      ...(Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString) } : {})
+    }
+  ];
+}
+
+function normalizeTerritoryRecommendationSummary(
+  rawSummary: Record<string, unknown>
+): StrategyRuntimeTerritoryRecommendationSummary {
+  return {
+    ...(Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeTerritoryCandidate) } : {}),
+    ...(rawSummary.next === null
+      ? { next: null }
+      : isRecord(rawSummary.next)
+        ? { next: normalizeTerritoryCandidate(rawSummary.next)[0] ?? null }
+        : {}),
+    ...(rawSummary.followUpIntent !== undefined ? { followUpIntent: rawSummary.followUpIntent } : {})
+  };
+}
+
+function normalizeTerritoryCandidate(rawCandidate: unknown): StrategyRuntimeTerritoryCandidate[] {
+  if (!isRecord(rawCandidate) || !isNonEmptyString(rawCandidate.roomName)) {
+    return [];
+  }
+
+  return [
+    {
+      roomName: rawCandidate.roomName,
+      ...(isNonEmptyString(rawCandidate.action) ? { action: rawCandidate.action } : {}),
+      ...(isFiniteNumber(rawCandidate.score) ? { score: rawCandidate.score } : {}),
+      ...(isNonEmptyString(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {}),
+      ...(isNonEmptyString(rawCandidate.source) ? { source: rawCandidate.source } : {}),
+      ...(Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString) } : {}),
+      ...(Array.isArray(rawCandidate.preconditions)
+        ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString) }
+        : {}),
+      ...(Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString) } : {}),
+      ...(isFiniteNumber(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {}),
+      ...(isFiniteNumber(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {}),
+      ...(isFiniteNumber(rawCandidate.hostileCreepCount)
+        ? { hostileCreepCount: rawCandidate.hostileCreepCount }
+        : {}),
+      ...(isFiniteNumber(rawCandidate.hostileStructureCount)
+        ? { hostileStructureCount: rawCandidate.hostileStructureCount }
+        : {})
+    }
+  ];
+}
+
+function normalizeCpuSummary(rawCpu: Record<string, unknown>): StrategyCpuSummary {
+  return {
+    ...(isFiniteNumber(rawCpu.used) ? { used: rawCpu.used } : {}),
+    ...(isFiniteNumber(rawCpu.bucket) ? { bucket: rawCpu.bucket } : {})
+  };
+}
+
+function normalizeReliabilitySignals(rawReliability: Record<string, unknown>): StrategyArtifactReliabilitySignals {
+  return {
+    ...(isFiniteNumber(rawReliability.loopExceptionCount)
+      ? { loopExceptionCount: rawReliability.loopExceptionCount }
+      : {}),
+    ...(isFiniteNumber(rawReliability.telemetrySilenceTicks)
+      ? { telemetrySilenceTicks: rawReliability.telemetrySilenceTicks }
+      : {}),
+    ...(isFiniteNumber(rawReliability.globalResetCount) ? { globalResetCount: rawReliability.globalResetCount } : {})
+  };
+}
+
+function reduceRuntimeSummaryArtifact(
+  artifact: StrategyRuntimeSummaryArtifact,
+  reliabilityMetrics: StrategyReliabilityMetrics,
+  territoryComponents: Record<string, number>,
+  resourceComponents: Record<string, number>,
+  killComponents: Record<string, number>,
+  thresholds: StrategyReliabilityThresholds
+): number {
+  reliabilityMetrics.loopExceptionCount += artifact.reliability?.loopExceptionCount ?? 0;
+  reliabilityMetrics.telemetrySilenceTicks += artifact.reliability?.telemetrySilenceTicks ?? 0;
+  reliabilityMetrics.globalResetCount += artifact.reliability?.globalResetCount ?? 0;
+  if (typeof artifact.cpu?.bucket === 'number') {
+    reliabilityMetrics.minCpuBucket =
+      reliabilityMetrics.minCpuBucket === undefined
+        ? artifact.cpu.bucket
+        : Math.min(reliabilityMetrics.minCpuBucket, artifact.cpu.bucket);
+  }
+
+  let ownedRoomCount = 0;
+  for (const room of artifact.rooms) {
+    if (room.controller) {
+      ownedRoomCount += 1;
+      territoryComponents.controllerLevels += room.controller.level;
+      territoryComponents.controllerProgress += room.controller.progress ?? 0;
+      if (
+        typeof room.controller.ticksToDowngrade === 'number' &&
+        room.controller.ticksToDowngrade <= thresholds.controllerDowngradeRiskTicks
+      ) {
+        reliabilityMetrics.controllerDowngradeRiskRooms += 1;
+      }
+    }
+
+    if ((room.workerCount ?? 1) <= 0 && (room.spawnStatus?.length ?? 0) <= 0) {
+      reliabilityMetrics.spawnCollapseRooms += 1;
+    }
+
+    resourceComponents.storedEnergy += room.resources?.storedEnergy ?? 0;
+    resourceComponents.workerCarriedEnergy += room.resources?.workerCarriedEnergy ?? 0;
+    resourceComponents.droppedEnergy += room.resources?.droppedEnergy ?? 0;
+    resourceComponents.visibleSources += room.resources?.sourceCount ?? 0;
+    resourceComponents.harvestedEnergy += room.resources?.events?.harvestedEnergy ?? 0;
+    resourceComponents.transferredEnergy += room.resources?.events?.transferredEnergy ?? 0;
+
+    killComponents.creepKills += room.combat?.events?.creepDestroyedCount ?? 0;
+    killComponents.objectKills += room.combat?.events?.objectDestroyedCount ?? 0;
+    killComponents.attackDamage += room.combat?.events?.attackDamage ?? 0;
+    killComponents.hostilePressureObserved +=
+      (room.combat?.hostileCreepCount ?? 0) + (room.combat?.hostileStructureCount ?? 0);
+
+    const territoryCandidates = room.territoryRecommendation?.candidates ?? [];
+    territoryComponents.reservedOrRemoteRooms += territoryCandidates.filter((candidate) =>
+      candidate.action === 'occupy' || candidate.action === 'reserve'
+    ).length;
+    territoryComponents.territoryRecommendation += Math.max(
+      0,
+      ...territoryCandidates.map((candidate) => candidate.score ?? 0)
+    );
+  }
+
+  territoryComponents.ownedRooms = Math.max(territoryComponents.ownedRooms, ownedRoomCount);
+  return ownedRoomCount;
+}
+
+function reduceRoomSnapshotArtifact(
+  artifact: StrategyRoomSnapshotArtifact,
+  territoryComponents: Record<string, number>,
+  resourceComponents: Record<string, number>,
+  killComponents: Record<string, number>
+): number {
+  const controller = artifact.objects.find((object) => object.type === 'controller');
+  const ownedController = controller && isOwnedSnapshotObject(controller, artifact.owner);
+  const ownedRoomCount = ownedController ? 1 : 0;
+  if (ownedController) {
+    territoryComponents.ownedRooms = Math.max(territoryComponents.ownedRooms, 1);
+    territoryComponents.controllerLevels += controller.level ?? 0;
+  }
+
+  for (const object of artifact.objects) {
+    if (object.type === 'source') {
+      resourceComponents.visibleSources += 1;
+    }
+
+    if (object.type === 'resource' && (object.resourceType === undefined || object.resourceType === 'energy')) {
+      resourceComponents.droppedEnergy += object.amount ?? 0;
+    }
+
+    resourceComponents.storedEnergy += getSnapshotObjectEnergy(object);
+
+    if (object.type === 'creep' && !isOwnedSnapshotObject(object, artifact.owner)) {
+      killComponents.hostilePressureObserved += 1;
+    }
+  }
+
+  return ownedRoomCount;
+}
+
+function evaluateReliabilityFloor(
+  metrics: StrategyReliabilityMetrics,
+  thresholds: StrategyReliabilityThresholds
+): StrategyReliabilityEvaluation {
+  const reasons: string[] = [];
+
+  if (metrics.artifactCount < thresholds.minArtifactCount) {
+    reasons.push(`artifact count ${metrics.artifactCount} below floor ${thresholds.minArtifactCount}`);
+  }
+
+  if (metrics.loopExceptionCount > thresholds.maxLoopExceptionCount) {
+    reasons.push(`loop exceptions ${metrics.loopExceptionCount} exceed ${thresholds.maxLoopExceptionCount}`);
+  }
+
+  if (metrics.telemetrySilenceTicks > thresholds.maxTelemetrySilenceTicks) {
+    reasons.push(`telemetry silence ${metrics.telemetrySilenceTicks} ticks exceeds ${thresholds.maxTelemetrySilenceTicks}`);
+  }
+
+  if (thresholds.minCpuBucket !== undefined && (metrics.minCpuBucket ?? thresholds.minCpuBucket) < thresholds.minCpuBucket) {
+    reasons.push(`minimum CPU bucket ${metrics.minCpuBucket ?? 'unknown'} below ${thresholds.minCpuBucket}`);
+  }
+
+  if (metrics.controllerDowngradeRiskRooms > thresholds.maxControllerDowngradeRiskRooms) {
+    reasons.push(
+      `controller downgrade risk rooms ${metrics.controllerDowngradeRiskRooms} exceed ${thresholds.maxControllerDowngradeRiskRooms}`
+    );
+  }
+
+  if (metrics.spawnCollapseRooms > thresholds.maxSpawnCollapseRooms) {
+    reasons.push(`spawn collapse rooms ${metrics.spawnCollapseRooms} exceed ${thresholds.maxSpawnCollapseRooms}`);
+  }
+
+  return {
+    passed: reasons.length === 0,
+    reasons,
+    metrics
+  };
+}
+
+function buildInitialReliabilityMetrics(artifacts: StrategyEvaluationArtifact[]): StrategyReliabilityMetrics {
+  return {
+    artifactCount: artifacts.length,
+    runtimeSummaryCount: artifacts.filter((artifact) => artifact.artifactType === 'runtime-summary').length,
+    roomSnapshotCount: artifacts.filter((artifact) => artifact.artifactType === 'room-snapshot').length,
+    loopExceptionCount: 0,
+    telemetrySilenceTicks: 0,
+    globalResetCount: 0,
+    controllerDowngradeRiskRooms: 0,
+    spawnCollapseRooms: 0
+  };
+}
+
+function compareReliability(left: StrategyReliabilityEvaluation, right: StrategyReliabilityEvaluation): number {
+  if (left.passed !== right.passed) {
+    return left.passed ? 1 : -1;
+  }
+
+  if (!left.passed && !right.passed) {
+    return (
+      compareNumber(right.reasons.length, left.reasons.length) ||
+      compareNumber(right.metrics.loopExceptionCount, left.metrics.loopExceptionCount) ||
+      compareNumber(right.metrics.telemetrySilenceTicks, left.metrics.telemetrySilenceTicks) ||
+      compareNumber(right.metrics.controllerDowngradeRiskRooms, left.metrics.controllerDowngradeRiskRooms)
+    );
+  }
+
+  return 0;
+}
+
+function compareNumber(left: number, right: number): number {
+  if (left === right) {
+    return 0;
+  }
+
+  return left > right ? 1 : -1;
+}
+
+function getSnapshotObjectEnergy(object: StrategyRoomSnapshotObject): number {
+  if (typeof object.energy === 'number') {
+    return object.energy;
+  }
+
+  const storeEnergy = object.store?.energy;
+  return typeof storeEnergy === 'number' ? storeEnergy : 0;
+}
+
+function isOwnedSnapshotObject(object: StrategyRoomSnapshotObject, owner: string | undefined): boolean {
+  if (object.my === true) {
+    return true;
+  }
+
+  if (!owner) {
+    return false;
+  }
+
+  return object.user === owner || object.owner?.username === owner;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/prod/src/strategy/shadowEvaluator.ts
+++ b/prod/src/strategy/shadowEvaluator.ts
@@ -1,0 +1,573 @@
+import {
+  DEFAULT_STRATEGY_REGISTRY,
+  getStrategyNumberDefault,
+  type StrategyModelFamily,
+  type StrategyRegistryEntry
+} from './strategyRegistry';
+import {
+  parseStrategyEvaluationArtifacts,
+  reduceStrategyKpis,
+  type StrategyEvaluationArtifact,
+  type StrategyKpiVector,
+  type StrategyRoomSnapshotArtifact,
+  type StrategyRoomSnapshotObject,
+  type StrategyRuntimeConstructionPriorityCandidate,
+  type StrategyRuntimeSummaryArtifact,
+  type StrategyRuntimeSummaryRoom,
+  type StrategyRuntimeTerritoryCandidate
+} from './kpiEvaluator';
+
+export interface StrategyShadowEvaluatorConfig {
+  enabled: boolean;
+  incumbentStrategyIds: Partial<Record<StrategyModelFamily, string>>;
+  candidateStrategyIds: string[];
+}
+
+export interface StrategyShadowReplayInput {
+  artifacts?: string | unknown | unknown[] | StrategyEvaluationArtifact[];
+  registry?: StrategyRegistryEntry[];
+  config?: Partial<StrategyShadowEvaluatorConfig>;
+}
+
+export interface StrategyShadowReplayReport {
+  enabled: boolean;
+  artifactCount: number;
+  kpi: StrategyKpiVector;
+  modelReports: StrategyShadowModelReport[];
+  disabledReason?: string;
+  warnings: string[];
+}
+
+export interface StrategyShadowModelReport {
+  incumbentStrategyId: string;
+  candidateStrategyId: string;
+  family: StrategyModelFamily;
+  rankingDiffs: StrategyRankingDiff[];
+}
+
+export interface StrategyRankingDiff {
+  artifactIndex: number;
+  tick?: number;
+  roomName?: string;
+  context: string;
+  incumbentTop: StrategyRankedItemSummary | null;
+  candidateTop: StrategyRankedItemSummary | null;
+  changedTop: boolean;
+  rankChanges: StrategyRankChange[];
+}
+
+export interface StrategyRankChange {
+  itemId: string;
+  label: string;
+  incumbentRank?: number;
+  candidateRank?: number;
+  delta?: number;
+}
+
+export interface StrategyRankedItemSummary {
+  itemId: string;
+  label: string;
+  rank: number;
+  score: number;
+  baseScore: number;
+}
+
+interface StrategyRankingItem {
+  itemId: string;
+  label: string;
+  context: string;
+  artifactIndex: number;
+  tick?: number;
+  roomName?: string;
+  baseScore: number;
+  signals: StrategyRankingSignals;
+}
+
+interface StrategyScoredRankingItem extends StrategyRankingItem {
+  rank: number;
+  strategyScore: number;
+}
+
+interface StrategyRankingSignals {
+  territory: number;
+  resources: number;
+  kills: number;
+  reliability: number;
+  risk: number;
+}
+
+const DEFAULT_INCUMBENT_STRATEGY_IDS: Record<StrategyModelFamily, string> = {
+  'construction-priority': 'construction-priority.incumbent.v1',
+  'expansion-remote-candidate': 'expansion-remote.incumbent.v1',
+  'defense-posture-repair-threshold': 'defense-repair.incumbent.v1'
+};
+
+export const DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG: StrategyShadowEvaluatorConfig = {
+  enabled: false,
+  incumbentStrategyIds: DEFAULT_INCUMBENT_STRATEGY_IDS,
+  candidateStrategyIds: []
+};
+
+export function evaluateStrategyShadowReplay(input: StrategyShadowReplayInput = {}): StrategyShadowReplayReport {
+  const registry = input.registry ?? DEFAULT_STRATEGY_REGISTRY;
+  const artifacts = parseStrategyEvaluationArtifacts(input.artifacts ?? []);
+  const kpi = reduceStrategyKpis(artifacts);
+  const config = normalizeShadowConfig(input.config);
+
+  if (!config.enabled) {
+    return {
+      enabled: false,
+      artifactCount: artifacts.length,
+      kpi,
+      modelReports: [],
+      disabledReason: 'strategy shadow evaluator disabled',
+      warnings: []
+    };
+  }
+
+  const registryById = new Map(registry.map((entry) => [entry.id, entry]));
+  const candidateStrategyIds =
+    config.candidateStrategyIds.length > 0
+      ? config.candidateStrategyIds
+      : registry.filter((entry) => entry.rolloutStatus === 'shadow').map((entry) => entry.id);
+  const warnings: string[] = [];
+  const modelReports: StrategyShadowModelReport[] = [];
+
+  for (const candidateStrategyId of candidateStrategyIds) {
+    const candidate = registryById.get(candidateStrategyId);
+    if (!candidate) {
+      warnings.push(`candidate strategy not found: ${candidateStrategyId}`);
+      continue;
+    }
+
+    const incumbentStrategyId = config.incumbentStrategyIds[candidate.family];
+    const incumbent = incumbentStrategyId ? registryById.get(incumbentStrategyId) : undefined;
+    if (!incumbentStrategyId || !incumbent) {
+      warnings.push(`incumbent strategy not found for ${candidate.id}`);
+      continue;
+    }
+
+    if (incumbent.family !== candidate.family) {
+      warnings.push(`incumbent ${incumbent.id} does not match candidate family ${candidate.family}`);
+      continue;
+    }
+
+    modelReports.push(evaluateModelPair(artifacts, incumbent, candidate));
+  }
+
+  return {
+    enabled: true,
+    artifactCount: artifacts.length,
+    kpi,
+    modelReports,
+    warnings
+  };
+}
+
+function normalizeShadowConfig(config: Partial<StrategyShadowEvaluatorConfig> | undefined): StrategyShadowEvaluatorConfig {
+  return {
+    enabled: config?.enabled ?? DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG.enabled,
+    incumbentStrategyIds: {
+      ...DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG.incumbentStrategyIds,
+      ...(config?.incumbentStrategyIds ?? {})
+    },
+    candidateStrategyIds: config?.candidateStrategyIds ?? DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG.candidateStrategyIds
+  };
+}
+
+function evaluateModelPair(
+  artifacts: StrategyEvaluationArtifact[],
+  incumbent: StrategyRegistryEntry,
+  candidate: StrategyRegistryEntry
+): StrategyShadowModelReport {
+  const rankingDiffs: StrategyRankingDiff[] = [];
+
+  artifacts.forEach((artifact, artifactIndex) => {
+    const rankingGroups = buildRankingGroups(artifact, artifactIndex, candidate.family);
+    for (const group of rankingGroups) {
+      const incumbentRanking = scoreRankingItems(group.items, incumbent);
+      const candidateRanking = scoreRankingItems(group.items, candidate);
+      const rankingDiff = buildRankingDiff(group, incumbentRanking, candidateRanking);
+      if (rankingDiff.changedTop || rankingDiff.rankChanges.length > 0) {
+        rankingDiffs.push(rankingDiff);
+      }
+    }
+  });
+
+  return {
+    incumbentStrategyId: incumbent.id,
+    candidateStrategyId: candidate.id,
+    family: candidate.family,
+    rankingDiffs
+  };
+}
+
+function buildRankingGroups(
+  artifact: StrategyEvaluationArtifact,
+  artifactIndex: number,
+  family: StrategyModelFamily
+): Array<{ context: string; tick?: number; roomName?: string; items: StrategyRankingItem[] }> {
+  if (artifact.artifactType === 'runtime-summary') {
+    return buildRuntimeSummaryRankingGroups(artifact, artifactIndex, family);
+  }
+
+  return buildRoomSnapshotRankingGroups(artifact, artifactIndex, family);
+}
+
+function buildRuntimeSummaryRankingGroups(
+  artifact: StrategyRuntimeSummaryArtifact,
+  artifactIndex: number,
+  family: StrategyModelFamily
+): Array<{ context: string; tick?: number; roomName?: string; items: StrategyRankingItem[] }> {
+  const groups: Array<{ context: string; tick?: number; roomName?: string; items: StrategyRankingItem[] }> = [];
+
+  for (const room of artifact.rooms) {
+    const items = buildRuntimeRoomRankingItems(room, artifactIndex, artifact.tick, family);
+    if (items.length > 0) {
+      groups.push({
+        context: family,
+        ...(artifact.tick !== undefined ? { tick: artifact.tick } : {}),
+        roomName: room.roomName,
+        items
+      });
+    }
+  }
+
+  return groups;
+}
+
+function buildRoomSnapshotRankingGroups(
+  artifact: StrategyRoomSnapshotArtifact,
+  artifactIndex: number,
+  family: StrategyModelFamily
+): Array<{ context: string; tick?: number; roomName?: string; items: StrategyRankingItem[] }> {
+  if (family !== 'defense-posture-repair-threshold') {
+    return [];
+  }
+
+  const repairItems = artifact.objects.flatMap((object) =>
+    buildRepairRankingItem(artifact, object, artifactIndex, artifact.tick)
+  );
+  if (repairItems.length === 0) {
+    return [];
+  }
+
+  return [
+    {
+      context: family,
+      ...(artifact.tick !== undefined ? { tick: artifact.tick } : {}),
+      ...(artifact.roomName ? { roomName: artifact.roomName } : {}),
+      items: repairItems
+    }
+  ];
+}
+
+function buildRuntimeRoomRankingItems(
+  room: StrategyRuntimeSummaryRoom,
+  artifactIndex: number,
+  tick: number | undefined,
+  family: StrategyModelFamily
+): StrategyRankingItem[] {
+  switch (family) {
+    case 'construction-priority':
+      return (room.constructionPriority?.candidates ?? []).map((candidate) =>
+        buildConstructionRankingItem(room, candidate, artifactIndex, tick)
+      );
+    case 'expansion-remote-candidate':
+      return (room.territoryRecommendation?.candidates ?? []).map((candidate) =>
+        buildTerritoryRankingItem(room, candidate, artifactIndex, tick)
+      );
+    case 'defense-posture-repair-threshold':
+      return [buildRuntimeDefenseRankingItem(room, artifactIndex, tick)];
+    default:
+      return [];
+  }
+}
+
+function buildConstructionRankingItem(
+  room: StrategyRuntimeSummaryRoom,
+  candidate: StrategyRuntimeConstructionPriorityCandidate,
+  artifactIndex: number,
+  tick: number | undefined
+): StrategyRankingItem {
+  const text = [
+    candidate.buildItem,
+    ...(candidate.expectedKpiMovement ?? []),
+    ...(candidate.preconditions ?? []),
+    ...(candidate.risk ?? [])
+  ].join(' ');
+  const signals = classifyStrategyText(text);
+
+  return {
+    itemId: `${room.roomName}:construction:${candidate.buildItem}`,
+    label: candidate.buildItem,
+    context: 'construction-priority',
+    artifactIndex,
+    ...(tick !== undefined ? { tick } : {}),
+    roomName: room.roomName,
+    baseScore: candidate.score ?? 0,
+    signals: {
+      territory: signals.territory,
+      resources: signals.resources,
+      kills: signals.kills,
+      reliability: signals.reliability + urgencyReliabilitySignal(candidate.urgency),
+      risk: (candidate.risk?.length ?? 0) + (candidate.preconditions?.length ?? 0) * 2
+    }
+  };
+}
+
+function buildTerritoryRankingItem(
+  room: StrategyRuntimeSummaryRoom,
+  candidate: StrategyRuntimeTerritoryCandidate,
+  artifactIndex: number,
+  tick: number | undefined
+): StrategyRankingItem {
+  const actionTerritorySignal = candidate.action === 'occupy' ? 8 : candidate.action === 'reserve' ? 6 : 2;
+  const hostileRisk = (candidate.hostileCreepCount ?? 0) * 5 + (candidate.hostileStructureCount ?? 0) * 4;
+  const evidenceRisk =
+    candidate.evidenceStatus === 'unavailable' ? 12 : candidate.evidenceStatus === 'insufficient-evidence' ? 5 : 0;
+
+  return {
+    itemId: `${room.roomName}:territory:${candidate.roomName}:${candidate.action ?? 'unknown'}`,
+    label: `${candidate.action ?? 'score'} ${candidate.roomName}`,
+    context: 'expansion-remote-candidate',
+    artifactIndex,
+    ...(tick !== undefined ? { tick } : {}),
+    roomName: room.roomName,
+    baseScore: candidate.score ?? 0,
+    signals: {
+      territory: actionTerritorySignal + (candidate.source === 'configured' ? 2 : 0),
+      resources: Math.min(candidate.sourceCount ?? 0, 3) * 2,
+      kills: hostileRisk > 0 ? 1 : 0,
+      reliability: candidate.evidenceStatus === 'sufficient' ? 1 : 0,
+      risk: hostileRisk + evidenceRisk + (candidate.risks?.length ?? 0) + Math.max(0, (candidate.routeDistance ?? 1) - 1)
+    }
+  };
+}
+
+function buildRuntimeDefenseRankingItem(
+  room: StrategyRuntimeSummaryRoom,
+  artifactIndex: number,
+  tick: number | undefined
+): StrategyRankingItem {
+  const hostilePressure = (room.combat?.hostileCreepCount ?? 0) * 15 + (room.combat?.hostileStructureCount ?? 0) * 8;
+  const downgradePressure =
+    typeof room.controller?.ticksToDowngrade === 'number'
+      ? Math.max(0, 5_000 - room.controller.ticksToDowngrade) / 500
+      : 0;
+  const baseScore = hostilePressure + downgradePressure;
+
+  return {
+    itemId: `${room.roomName}:defense-posture`,
+    label: `defense posture ${room.roomName}`,
+    context: 'defense-posture-repair-threshold',
+    artifactIndex,
+    ...(tick !== undefined ? { tick } : {}),
+    roomName: room.roomName,
+    baseScore,
+    signals: {
+      territory: downgradePressure > 0 ? 3 : 1,
+      resources: (room.resources?.storedEnergy ?? 0) > 0 ? 1 : 0,
+      kills: hostilePressure > 0 ? 4 : 0,
+      reliability: downgradePressure > 0 || hostilePressure > 0 ? 3 : 1,
+      risk: baseScore === 0 ? 1 : 0
+    }
+  };
+}
+
+function buildRepairRankingItem(
+  artifact: StrategyRoomSnapshotArtifact,
+  object: StrategyRoomSnapshotObject,
+  artifactIndex: number,
+  tick: number | undefined
+): StrategyRankingItem[] {
+  if (!isDamageableSnapshotStructure(object) || typeof object.hits !== 'number' || typeof object.hitsMax !== 'number') {
+    return [];
+  }
+
+  const damageRatio = object.hitsMax > 0 ? Math.max(0, 1 - object.hits / object.hitsMax) : 0;
+  if (damageRatio <= 0) {
+    return [];
+  }
+
+  const roomName = artifact.roomName ?? object.room;
+  const criticalStructureSignal = object.type === 'spawn' || object.type === 'tower' || object.type === 'storage' ? 3 : 1;
+
+  return [
+    {
+      itemId: `${roomName ?? 'unknown'}:repair:${object.type ?? 'structure'}:${object.id ?? 'unknown'}`,
+      label: `repair ${object.type ?? 'structure'}`,
+      context: 'defense-posture-repair-threshold',
+      artifactIndex,
+      ...(tick !== undefined ? { tick } : {}),
+      ...(roomName ? { roomName } : {}),
+      baseScore: damageRatio * 100,
+      signals: {
+        territory: object.type === 'spawn' || object.type === 'tower' ? criticalStructureSignal : 1,
+        resources: object.type === 'storage' || object.type === 'container' ? criticalStructureSignal : 1,
+        kills: object.type === 'rampart' || object.type === 'tower' ? criticalStructureSignal : 0,
+        reliability: criticalStructureSignal,
+        risk: damageRatio >= 0.5 ? 0 : 1
+      }
+    }
+  ];
+}
+
+function scoreRankingItems(items: StrategyRankingItem[], entry: StrategyRegistryEntry): StrategyScoredRankingItem[] {
+  return items
+    .map((item) => ({
+      ...item,
+      strategyScore: calculateStrategyScore(item, entry),
+      rank: 0
+    }))
+    .sort(compareScoredRankingItems)
+    .map((item, index) => ({
+      ...item,
+      rank: index + 1
+    }));
+}
+
+function calculateStrategyScore(item: StrategyRankingItem, entry: StrategyRegistryEntry): number {
+  const baseScoreWeight = getStrategyNumberDefault(entry, 'baseScoreWeight', 1);
+  const territorySignalWeight = getStrategyNumberDefault(entry, 'territorySignalWeight', 0);
+  const resourceSignalWeight = getStrategyNumberDefault(entry, 'resourceSignalWeight', 0);
+  const killSignalWeight = getStrategyNumberDefault(entry, 'killSignalWeight', 0);
+  const riskPenalty = getStrategyNumberDefault(entry, 'riskPenalty', 0);
+
+  return (
+    item.baseScore * baseScoreWeight +
+    item.signals.territory * territorySignalWeight +
+    item.signals.resources * resourceSignalWeight +
+    item.signals.kills * killSignalWeight +
+    item.signals.reliability * Math.max(territorySignalWeight, killSignalWeight) -
+    item.signals.risk * riskPenalty
+  );
+}
+
+function compareScoredRankingItems(left: StrategyScoredRankingItem, right: StrategyScoredRankingItem): number {
+  return (
+    right.strategyScore - left.strategyScore ||
+    right.baseScore - left.baseScore ||
+    left.label.localeCompare(right.label) ||
+    left.itemId.localeCompare(right.itemId)
+  );
+}
+
+function buildRankingDiff(
+  group: { context: string; tick?: number; roomName?: string; items: StrategyRankingItem[] },
+  incumbentRanking: StrategyScoredRankingItem[],
+  candidateRanking: StrategyScoredRankingItem[]
+): StrategyRankingDiff {
+  const incumbentTop = incumbentRanking[0] ? summarizeRankedItem(incumbentRanking[0]) : null;
+  const candidateTop = candidateRanking[0] ? summarizeRankedItem(candidateRanking[0]) : null;
+  const incumbentRanks = new Map(incumbentRanking.map((item) => [item.itemId, item]));
+  const candidateRanks = new Map(candidateRanking.map((item) => [item.itemId, item]));
+  const itemIds = Array.from(new Set([...incumbentRanks.keys(), ...candidateRanks.keys()])).sort();
+  const rankChanges = itemIds.flatMap((itemId): StrategyRankChange[] => {
+    const incumbentItem = incumbentRanks.get(itemId);
+    const candidateItem = candidateRanks.get(itemId);
+    if (incumbentItem?.rank === candidateItem?.rank) {
+      return [];
+    }
+
+    const label = incumbentItem?.label ?? candidateItem?.label ?? itemId;
+    const incumbentRank = incumbentItem?.rank;
+    const candidateRank = candidateItem?.rank;
+    return [
+      {
+        itemId,
+        label,
+        ...(incumbentRank !== undefined ? { incumbentRank } : {}),
+        ...(candidateRank !== undefined ? { candidateRank } : {}),
+        ...(incumbentRank !== undefined && candidateRank !== undefined
+          ? { delta: incumbentRank - candidateRank }
+          : {})
+      }
+    ];
+  });
+
+  return {
+    artifactIndex: group.items[0]?.artifactIndex ?? 0,
+    ...(group.tick !== undefined ? { tick: group.tick } : {}),
+    ...(group.roomName ? { roomName: group.roomName } : {}),
+    context: group.context,
+    incumbentTop,
+    candidateTop,
+    changedTop: incumbentTop?.itemId !== candidateTop?.itemId,
+    rankChanges
+  };
+}
+
+function summarizeRankedItem(item: StrategyScoredRankingItem): StrategyRankedItemSummary {
+  return {
+    itemId: item.itemId,
+    label: item.label,
+    rank: item.rank,
+    score: roundScore(item.strategyScore),
+    baseScore: roundScore(item.baseScore)
+  };
+}
+
+function classifyStrategyText(text: string): StrategyRankingSignals {
+  const normalizedText = text.toLowerCase();
+  return {
+    territory: countSignalWords(normalizedText, [
+      'territory',
+      'remote',
+      'controller',
+      'rcl',
+      'expansion',
+      'claim',
+      'reserve',
+      'room'
+    ]),
+    resources: countSignalWords(normalizedText, [
+      'energy',
+      'resource',
+      'resources',
+      'harvest',
+      'storage',
+      'source',
+      'throughput',
+      'capacity',
+      'worker'
+    ]),
+    kills: countSignalWords(normalizedText, ['kill', 'enemy', 'hostile', 'tower', 'rampart', 'defense', 'survivability']),
+    reliability: countSignalWords(normalizedText, ['spawn', 'recovery', 'downgrade', 'repair', 'safe', 'survival']),
+    risk: countSignalWords(normalizedText, ['risk', 'blocked', 'decay', 'hostile', 'unavailable', 'missing'])
+  };
+}
+
+function urgencyReliabilitySignal(urgency: string | undefined): number {
+  switch (urgency) {
+    case 'critical':
+      return 3;
+    case 'high':
+      return 2;
+    case 'medium':
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function countSignalWords(text: string, words: string[]): number {
+  return words.reduce((count, word) => count + (text.includes(word) ? 1 : 0), 0);
+}
+
+function roundScore(score: number): number {
+  return Math.round(score * 1_000) / 1_000;
+}
+
+function isDamageableSnapshotStructure(object: StrategyRoomSnapshotObject): boolean {
+  return (
+    object.type === 'constructedWall' ||
+    object.type === 'container' ||
+    object.type === 'extension' ||
+    object.type === 'rampart' ||
+    object.type === 'road' ||
+    object.type === 'spawn' ||
+    object.type === 'storage' ||
+    object.type === 'tower'
+  );
+}

--- a/prod/src/strategy/strategyRegistry.ts
+++ b/prod/src/strategy/strategyRegistry.ts
@@ -1,0 +1,415 @@
+export const STRATEGY_REGISTRY_SCHEMA_VERSION = 1;
+
+export type StrategyModelFamily =
+  | 'construction-priority'
+  | 'expansion-remote-candidate'
+  | 'defense-posture-repair-threshold';
+
+export type StrategyArtifactType = 'runtime-summary' | 'room-snapshot';
+export type StrategyRolloutStatus = 'incumbent' | 'shadow' | 'disabled' | 'retired';
+export type StrategyKnobValue = number | string | boolean;
+
+export interface StrategySupportedContext {
+  artifactTypes: StrategyArtifactType[];
+  shards?: string[];
+  rooms?: string[];
+  minRcl?: number;
+  maxRcl?: number;
+  notes: string;
+}
+
+export interface StrategyNumberKnobBounds {
+  kind: 'number';
+  min: number;
+  max: number;
+  step?: number;
+}
+
+export interface StrategyIntegerKnobBounds {
+  kind: 'integer';
+  min: number;
+  max: number;
+  step?: number;
+}
+
+export interface StrategyBooleanKnobBounds {
+  kind: 'boolean';
+}
+
+export interface StrategyEnumKnobBounds {
+  kind: 'enum';
+  values: string[];
+}
+
+export type StrategyKnobBounds =
+  | StrategyNumberKnobBounds
+  | StrategyIntegerKnobBounds
+  | StrategyBooleanKnobBounds
+  | StrategyEnumKnobBounds;
+
+export interface StrategyKnobDefinition {
+  name: string;
+  description: string;
+  bounds: StrategyKnobBounds;
+}
+
+export interface StrategyEvidenceLink {
+  label: string;
+  source: 'issue' | 'pr' | 'docs' | 'artifact' | 'test';
+  url?: string;
+  path?: string;
+}
+
+export interface StrategyRollbackFields {
+  disabledByDefault: boolean;
+  disableFlag: string;
+  rollbackToStrategyId?: string;
+  stopConditions: string[];
+  notes: string;
+}
+
+export interface StrategyOwnerReference {
+  issue: number;
+  pr?: number;
+}
+
+export interface StrategyRegistryEntry {
+  id: string;
+  schemaVersion: number;
+  version: string;
+  family: StrategyModelFamily;
+  title: string;
+  owner: StrategyOwnerReference;
+  supportedContext: StrategySupportedContext;
+  knobBounds: StrategyKnobDefinition[];
+  defaultValues: Record<string, StrategyKnobValue>;
+  rolloutStatus: StrategyRolloutStatus;
+  evidenceLinks: StrategyEvidenceLink[];
+  rollback: StrategyRollbackFields;
+}
+
+export interface StrategyRegistryValidationResult {
+  valid: boolean;
+  issues: string[];
+}
+
+const ISSUE_265_URL = 'https://github.com/lanyusea/screeps/issues/265';
+const RL_RESEARCH_PATH = 'docs/research/2026-04-29-screeps-rl-self-evolving-strategy-paper.md';
+
+export const DEFAULT_STRATEGY_REGISTRY: StrategyRegistryEntry[] = [
+  {
+    id: 'construction-priority.incumbent.v1',
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: '1.0.0',
+    family: 'construction-priority',
+    title: 'Current construction priority scoring shadow baseline',
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ['runtime-summary'],
+      shards: ['shardX'],
+      rooms: ['E48S28'],
+      minRcl: 1,
+      maxRcl: 4,
+      notes: 'Reads emitted constructionPriority candidate summaries; does not alter construction selection.'
+    },
+    knobBounds: [
+      numberKnob('baseScoreWeight', 'Weight applied to the already-emitted incumbent score.', 0, 3, 0.1),
+      numberKnob('territorySignalWeight', 'Weight for territory-first expected KPI signals.', 0, 30, 1),
+      numberKnob('resourceSignalWeight', 'Weight for resource-scaling expected KPI signals.', 0, 30, 1),
+      numberKnob('killSignalWeight', 'Weight for enemy-kill or defense-posture signals.', 0, 30, 1),
+      numberKnob('riskPenalty', 'Penalty per visible risk or blocking precondition.', 0, 30, 1)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 6,
+      resourceSignalWeight: 4,
+      killSignalWeight: 6,
+      riskPenalty: 4
+    },
+    rolloutStatus: 'incumbent',
+    evidenceLinks: [
+      { label: 'Issue #265', source: 'issue', url: ISSUE_265_URL },
+      { label: 'RL/self-evolving strategy paper', source: 'docs', path: RL_RESEARCH_PATH }
+    ],
+    rollback: passiveRollback('construction-priority.incumbent.v1')
+  },
+  {
+    id: 'construction-priority.territory-shadow.v1',
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: '1.0.0',
+    family: 'construction-priority',
+    title: 'Territory-first construction priority shadow candidate',
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ['runtime-summary'],
+      shards: ['shardX'],
+      rooms: ['E48S28'],
+      minRcl: 1,
+      maxRcl: 4,
+      notes: 'Replays only saved constructionPriority candidates with a higher territory signal weight.'
+    },
+    knobBounds: [
+      numberKnob('baseScoreWeight', 'Weight applied to the already-emitted incumbent score.', 0, 3, 0.1),
+      numberKnob('territorySignalWeight', 'Weight for territory-first expected KPI signals.', 0, 30, 1),
+      numberKnob('resourceSignalWeight', 'Weight for resource-scaling expected KPI signals.', 0, 30, 1),
+      numberKnob('killSignalWeight', 'Weight for enemy-kill or defense-posture signals.', 0, 30, 1),
+      numberKnob('riskPenalty', 'Penalty per visible risk or blocking precondition.', 0, 30, 1)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 22,
+      resourceSignalWeight: 3,
+      killSignalWeight: 5,
+      riskPenalty: 4
+    },
+    rolloutStatus: 'shadow',
+    evidenceLinks: [
+      { label: 'Issue #265', source: 'issue', url: ISSUE_265_URL },
+      { label: 'Fixture replay coverage', source: 'test', path: 'prod/test/strategyShadowEvaluator.test.ts' }
+    ],
+    rollback: passiveRollback('construction-priority.incumbent.v1')
+  },
+  {
+    id: 'expansion-remote.incumbent.v1',
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: '1.0.0',
+    family: 'expansion-remote-candidate',
+    title: 'Current expansion and remote candidate scoring shadow baseline',
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ['runtime-summary', 'room-snapshot'],
+      shards: ['shardX'],
+      rooms: ['E48S28'],
+      minRcl: 1,
+      notes: 'Reads territoryRecommendation candidates from saved summaries; it never writes Memory intents.'
+    },
+    knobBounds: [
+      numberKnob('baseScoreWeight', 'Weight applied to the emitted occupation score.', 0, 3, 0.1),
+      numberKnob('territorySignalWeight', 'Weight for occupy/reserve/scout territory ordering.', 0, 40, 1),
+      numberKnob('resourceSignalWeight', 'Weight for visible source and support evidence.', 0, 30, 1),
+      numberKnob('killSignalWeight', 'Weight for hostile suppression opportunity.', 0, 30, 1),
+      numberKnob('riskPenalty', 'Penalty for hostile, route, or evidence risk.', 0, 40, 1)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 8,
+      resourceSignalWeight: 5,
+      killSignalWeight: 2,
+      riskPenalty: 10
+    },
+    rolloutStatus: 'incumbent',
+    evidenceLinks: [
+      { label: 'Issue #265', source: 'issue', url: ISSUE_265_URL },
+      { label: 'Gameplay evolution roadmap', source: 'docs', path: 'docs/ops/gameplay-evolution-roadmap.md' }
+    ],
+    rollback: passiveRollback('expansion-remote.incumbent.v1')
+  },
+  {
+    id: 'expansion-remote.territory-shadow.v1',
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: '1.0.0',
+    family: 'expansion-remote-candidate',
+    title: 'Territory-first expansion and remote candidate shadow model',
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ['runtime-summary', 'room-snapshot'],
+      shards: ['shardX'],
+      rooms: ['E48S28'],
+      minRcl: 1,
+      notes: 'Emphasizes occupy/reserve candidates in offline ranking reports only.'
+    },
+    knobBounds: [
+      numberKnob('baseScoreWeight', 'Weight applied to the emitted occupation score.', 0, 3, 0.1),
+      numberKnob('territorySignalWeight', 'Weight for occupy/reserve/scout territory ordering.', 0, 40, 1),
+      numberKnob('resourceSignalWeight', 'Weight for visible source and support evidence.', 0, 30, 1),
+      numberKnob('killSignalWeight', 'Weight for hostile suppression opportunity.', 0, 30, 1),
+      numberKnob('riskPenalty', 'Penalty for hostile, route, or evidence risk.', 0, 40, 1)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 26,
+      resourceSignalWeight: 4,
+      killSignalWeight: 2,
+      riskPenalty: 10
+    },
+    rolloutStatus: 'shadow',
+    evidenceLinks: [
+      { label: 'Issue #265', source: 'issue', url: ISSUE_265_URL },
+      { label: 'Fixture replay coverage', source: 'test', path: 'prod/test/strategyShadowEvaluator.test.ts' }
+    ],
+    rollback: passiveRollback('expansion-remote.incumbent.v1')
+  },
+  {
+    id: 'defense-repair.incumbent.v1',
+    schemaVersion: STRATEGY_REGISTRY_SCHEMA_VERSION,
+    version: '1.0.0',
+    family: 'defense-posture-repair-threshold',
+    title: 'Current defense posture and repair threshold shadow baseline',
+    owner: { issue: 265 },
+    supportedContext: {
+      artifactTypes: ['runtime-summary', 'room-snapshot'],
+      shards: ['shardX'],
+      rooms: ['E48S28'],
+      minRcl: 1,
+      notes: 'Ranks observed rooms by hostile and repair pressure from saved artifacts only.'
+    },
+    knobBounds: [
+      numberKnob('baseScoreWeight', 'Weight applied to observed hostile and damage pressure.', 0, 3, 0.1),
+      numberKnob('territorySignalWeight', 'Weight for controller survival and held-room protection.', 0, 30, 1),
+      numberKnob('resourceSignalWeight', 'Weight for storage and productive-structure protection.', 0, 30, 1),
+      numberKnob('killSignalWeight', 'Weight for hostile presence and tower/rampart readiness.', 0, 40, 1),
+      numberKnob('riskPenalty', 'Penalty for unavailable or insufficient observations.', 0, 30, 1),
+      numberKnob('repairCriticalHitsRatio', 'Critical repair hit ratio threshold.', 0.01, 1, 0.01)
+    ],
+    defaultValues: {
+      baseScoreWeight: 1,
+      territorySignalWeight: 12,
+      resourceSignalWeight: 6,
+      killSignalWeight: 18,
+      riskPenalty: 4,
+      repairCriticalHitsRatio: 0.5
+    },
+    rolloutStatus: 'incumbent',
+    evidenceLinks: [
+      { label: 'Issue #265', source: 'issue', url: ISSUE_265_URL },
+      { label: 'Runtime room monitor runbook', source: 'docs', path: 'docs/ops/runtime-room-monitor.md' }
+    ],
+    rollback: passiveRollback('defense-repair.incumbent.v1')
+  }
+];
+
+export function validateStrategyRegistryEntry(entry: StrategyRegistryEntry): StrategyRegistryValidationResult {
+  const issues: string[] = [];
+
+  if (entry.schemaVersion !== STRATEGY_REGISTRY_SCHEMA_VERSION) {
+    issues.push(`unsupported schemaVersion ${entry.schemaVersion}`);
+  }
+
+  if (!entry.id) {
+    issues.push('missing strategy id');
+  }
+
+  if (!entry.version) {
+    issues.push('missing strategy version');
+  }
+
+  if (!entry.owner.issue || entry.owner.issue <= 0) {
+    issues.push('missing owning issue');
+  }
+
+  if (entry.supportedContext.artifactTypes.length === 0) {
+    issues.push('supported context must name at least one artifact type');
+  }
+
+  if (entry.knobBounds.length === 0) {
+    issues.push('strategy must declare bounded knobs');
+  }
+
+  const declaredKnobs = new Set<string>();
+  for (const knob of entry.knobBounds) {
+    if (declaredKnobs.has(knob.name)) {
+      issues.push(`duplicate knob ${knob.name}`);
+    }
+    declaredKnobs.add(knob.name);
+
+    if (!(knob.name in entry.defaultValues)) {
+      issues.push(`missing default for knob ${knob.name}`);
+      continue;
+    }
+
+    const defaultValue = entry.defaultValues[knob.name];
+    if (!isKnobDefaultWithinBounds(defaultValue, knob.bounds)) {
+      issues.push(`default for knob ${knob.name} is outside declared bounds`);
+    }
+  }
+
+  for (const defaultName of Object.keys(entry.defaultValues)) {
+    if (!declaredKnobs.has(defaultName)) {
+      issues.push(`default declared without knob bounds: ${defaultName}`);
+    }
+  }
+
+  if (entry.evidenceLinks.length === 0) {
+    issues.push('missing evidence links');
+  }
+
+  if (!entry.rollback.disableFlag) {
+    issues.push('missing rollback disable flag');
+  }
+
+  if (entry.rollback.stopConditions.length === 0) {
+    issues.push('missing rollback stop conditions');
+  }
+
+  return { valid: issues.length === 0, issues };
+}
+
+export function validateStrategyRegistry(entries: StrategyRegistryEntry[]): StrategyRegistryValidationResult {
+  const issues: string[] = [];
+  const ids = new Set<string>();
+
+  for (const entry of entries) {
+    if (ids.has(entry.id)) {
+      issues.push(`duplicate strategy id ${entry.id}`);
+    }
+    ids.add(entry.id);
+
+    const entryResult = validateStrategyRegistryEntry(entry);
+    issues.push(...entryResult.issues.map((issue) => `${entry.id}: ${issue}`));
+  }
+
+  return { valid: issues.length === 0, issues };
+}
+
+export function getStrategyNumberDefault(entry: StrategyRegistryEntry, knobName: string, fallback = 0): number {
+  const value = entry.defaultValues[knobName];
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function numberKnob(
+  name: string,
+  description: string,
+  min: number,
+  max: number,
+  step?: number
+): StrategyKnobDefinition {
+  return {
+    name,
+    description,
+    bounds: {
+      kind: 'number',
+      min,
+      max,
+      ...(step !== undefined ? { step } : {})
+    }
+  };
+}
+
+function passiveRollback(rollbackToStrategyId: string): StrategyRollbackFields {
+  return {
+    disabledByDefault: true,
+    disableFlag: 'strategyShadowEvaluator.enabled=false',
+    rollbackToStrategyId,
+    stopConditions: [
+      'shadow report is noisy or expensive',
+      'artifact parsing cannot be proven deterministic',
+      'any candidate output is accidentally wired into live Screeps actions'
+    ],
+    notes: 'The first slice is pure offline/shadow evaluation; disabling the evaluator leaves live behavior unchanged.'
+  };
+}
+
+function isKnobDefaultWithinBounds(value: StrategyKnobValue, bounds: StrategyKnobBounds): boolean {
+  switch (bounds.kind) {
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value) && value >= bounds.min && value <= bounds.max;
+    case 'integer':
+      return typeof value === 'number' && Number.isInteger(value) && value >= bounds.min && value <= bounds.max;
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'enum':
+      return typeof value === 'string' && bounds.values.includes(value);
+    default:
+      return false;
+  }
+}

--- a/prod/test/fixtures/strategyShadowReplayFixture.ts
+++ b/prod/test/fixtures/strategyShadowReplayFixture.ts
@@ -1,0 +1,147 @@
+const STRATEGY_SHADOW_REPLAY_RUNTIME_SUMMARY = {
+  type: 'runtime-summary',
+  tick: 200,
+  rooms: [
+    {
+      roomName: 'E48S28',
+      energyAvailable: 350,
+      energyCapacity: 550,
+      workerCount: 4,
+      spawnStatus: [{ name: 'Spawn1', status: 'idle' }],
+      controller: {
+        level: 3,
+        progress: 12_000,
+        progressTotal: 135_000,
+        ticksToDowngrade: 8_000
+      },
+      resources: {
+        storedEnergy: 420,
+        workerCarriedEnergy: 120,
+        droppedEnergy: 30,
+        sourceCount: 2,
+        events: {
+          harvestedEnergy: 80,
+          transferredEnergy: 65
+        }
+      },
+      combat: {
+        hostileCreepCount: 0,
+        hostileStructureCount: 0,
+        events: {
+          attackCount: 0,
+          attackDamage: 0,
+          objectDestroyedCount: 0,
+          creepDestroyedCount: 0
+        }
+      },
+      constructionPriority: {
+        candidates: [
+          {
+            buildItem: 'build extension capacity',
+            room: 'E48S28',
+            score: 70,
+            urgency: 'high',
+            preconditions: [],
+            expectedKpiMovement: ['raises spawn energy capacity', 'unlocks larger workers and faster RCL progress'],
+            risk: ['adds build backlog before roads/containers if worker capacity is low']
+          },
+          {
+            buildItem: 'build remote road/container logistics',
+            room: 'E48S28',
+            score: 62,
+            urgency: 'medium',
+            preconditions: [],
+            expectedKpiMovement: [
+              'opens remote territory route',
+              'supports reserve room economy',
+              'improves harvest throughput'
+            ],
+            risk: []
+          },
+          {
+            buildItem: 'build rampart defense',
+            room: 'E48S28',
+            score: 45,
+            urgency: 'medium',
+            preconditions: [],
+            expectedKpiMovement: ['improves spawn/controller survivability under pressure'],
+            risk: ['decays without sustained repair budget']
+          }
+        ],
+        nextPrimary: {
+          buildItem: 'build extension capacity',
+          room: 'E48S28',
+          score: 70,
+          urgency: 'high',
+          preconditions: [],
+          expectedKpiMovement: ['raises spawn energy capacity', 'unlocks larger workers and faster RCL progress'],
+          risk: ['adds build backlog before roads/containers if worker capacity is low']
+        }
+      },
+      territoryRecommendation: {
+        candidates: [
+          {
+            roomName: 'E48S27',
+            action: 'reserve',
+            score: 850,
+            evidenceStatus: 'sufficient',
+            source: 'configured',
+            evidence: ['room visible', 'controller is available', '2 sources visible'],
+            preconditions: [],
+            risks: [],
+            routeDistance: 2,
+            sourceCount: 2
+          },
+          {
+            roomName: 'E49S28',
+            action: 'occupy',
+            score: 820,
+            evidenceStatus: 'sufficient',
+            source: 'configured',
+            evidence: ['room visible', 'controller is available', '1 source visible'],
+            preconditions: [],
+            risks: [],
+            routeDistance: 1,
+            sourceCount: 1
+          },
+          {
+            roomName: 'E47S28',
+            action: 'scout',
+            score: 420,
+            evidenceStatus: 'insufficient-evidence',
+            source: 'adjacent',
+            evidence: ['room visibility missing'],
+            preconditions: [],
+            risks: ['controller, source, and hostile evidence unavailable'],
+            routeDistance: 1
+          }
+        ],
+        next: {
+          roomName: 'E48S27',
+          action: 'reserve',
+          score: 850,
+          evidenceStatus: 'sufficient',
+          source: 'configured',
+          evidence: ['room visible', 'controller is available', '2 sources visible'],
+          preconditions: [],
+          risks: [],
+          routeDistance: 2,
+          sourceCount: 2
+        },
+        followUpIntent: {
+          colony: 'E48S28',
+          targetRoom: 'E48S27',
+          action: 'reserve'
+        }
+      }
+    }
+  ],
+  cpu: {
+    used: 5.2,
+    bucket: 9_000
+  }
+};
+
+export const STRATEGY_SHADOW_REPLAY_FIXTURE = `#runtime-summary ${JSON.stringify(
+  STRATEGY_SHADOW_REPLAY_RUNTIME_SUMMARY
+)}`;

--- a/prod/test/main.test.ts
+++ b/prod/test/main.test.ts
@@ -1,4 +1,4 @@
-import { loop } from '../src/main';
+import { evaluateStrategyShadowReplay, loop } from '../src/main';
 
 describe('main loop entrypoint', () => {
   beforeEach(() => {
@@ -13,5 +13,9 @@ describe('main loop entrypoint', () => {
   it('runs the kernel without throwing', () => {
     expect(() => loop()).not.toThrow();
     expect(Memory.meta.version).toBe(1);
+  });
+
+  it('ships the shadow evaluator as a passive export', () => {
+    expect(evaluateStrategyShadowReplay().enabled).toBe(false);
   });
 });

--- a/prod/test/strategyKpiEvaluator.test.ts
+++ b/prod/test/strategyKpiEvaluator.test.ts
@@ -127,4 +127,30 @@ describe('strategy KPI evaluator', () => {
     expect(kpi.territory.components.controllerLevels).toBe(3);
     expect(kpi.resources.components.visibleSources).toBe(2);
   });
+
+  it('infers room snapshot ownership from controller metadata when artifact owner is absent', () => {
+    for (const { controller, controllerLevel } of [
+      { controller: { id: 'controller', type: 'controller', owner: { username: 'bot' }, level: 4 }, controllerLevel: 4 },
+      { controller: { id: 'controller', type: 'controller', user: 'bot', level: 5 }, controllerLevel: 5 }
+    ]) {
+      const artifacts = parseStrategyEvaluationArtifacts([
+        {
+          artifactType: 'room-snapshot',
+          roomName: 'E48S28',
+          tick: 13,
+          objects: [
+            controller,
+            { id: 'harvester', type: 'creep', user: 'bot' },
+            { id: 'invader', type: 'creep', owner: { username: 'enemy' } }
+          ]
+        }
+      ]);
+
+      const kpi = reduceStrategyKpis(artifacts);
+
+      expect(kpi.territory.components.ownedRooms).toBe(1);
+      expect(kpi.territory.components.controllerLevels).toBe(controllerLevel);
+      expect(kpi.kills.components.hostilePressureObserved).toBe(1);
+    }
+  });
 });

--- a/prod/test/strategyKpiEvaluator.test.ts
+++ b/prod/test/strategyKpiEvaluator.test.ts
@@ -1,0 +1,130 @@
+import {
+  buildStrategyKpiVector,
+  compareStrategyKpiVectors,
+  parseStrategyEvaluationArtifacts,
+  reduceStrategyKpis
+} from '../src/strategy/kpiEvaluator';
+
+describe('strategy KPI evaluator', () => {
+  it('keeps reliability as a hard floor before later rewards', () => {
+    const reliableButSmall = buildStrategyKpiVector({
+      reliabilityPassed: true,
+      territory: 1,
+      resources: 0,
+      kills: 0
+    });
+    const unreliableButRich = buildStrategyKpiVector({
+      reliabilityPassed: false,
+      territory: 10_000_000,
+      resources: 10_000_000,
+      kills: 10_000_000
+    });
+
+    expect(compareStrategyKpiVectors(reliableButSmall, unreliableButRich)).toBeGreaterThan(0);
+  });
+
+  it('keeps territory ahead of resources and kills', () => {
+    const territoryWinner = buildStrategyKpiVector({
+      reliabilityPassed: true,
+      territory: 2,
+      resources: 0,
+      kills: 0
+    });
+    const laterRewardWinner = buildStrategyKpiVector({
+      reliabilityPassed: true,
+      territory: 1,
+      resources: 1_000_000,
+      kills: 1_000_000
+    });
+
+    expect(compareStrategyKpiVectors(territoryWinner, laterRewardWinner)).toBeGreaterThan(0);
+  });
+
+  it('keeps resources ahead of kills after reliability and territory tie', () => {
+    const resourceWinner = buildStrategyKpiVector({
+      reliabilityPassed: true,
+      territory: 1,
+      resources: 2,
+      kills: 0
+    });
+    const killWinner = buildStrategyKpiVector({
+      reliabilityPassed: true,
+      territory: 1,
+      resources: 1,
+      kills: 1_000_000
+    });
+
+    expect(compareStrategyKpiVectors(resourceWinner, killWinner)).toBeGreaterThan(0);
+  });
+
+  it('reduces runtime-summary reliability failures before KPI scoring', () => {
+    const [artifact] = parseStrategyEvaluationArtifacts({
+      type: 'runtime-summary',
+      tick: 10,
+      reliability: { loopExceptionCount: 1 },
+      rooms: [
+        {
+          roomName: 'E48S28',
+          controller: { level: 3, progress: 40_000, ticksToDowngrade: 8_000 },
+          resources: { storedEnergy: 10_000, workerCarriedEnergy: 500, sourceCount: 2 },
+          combat: { events: { creepDestroyedCount: 5 } }
+        }
+      ]
+    });
+
+    const kpi = reduceStrategyKpis([artifact!]);
+
+    expect(kpi.reliability.passed).toBe(false);
+    expect(kpi.reliability.reasons).toContain('loop exceptions 1 exceed 0');
+    expect(kpi.territory.score).toBeGreaterThan(0);
+    expect(kpi.resources.score).toBeGreaterThan(0);
+    expect(kpi.kills.score).toBeGreaterThan(0);
+  });
+
+  it('can reduce a room snapshot artifact without runtime APIs', () => {
+    const artifacts = parseStrategyEvaluationArtifacts({
+      artifactType: 'room-snapshot',
+      roomName: 'E48S28',
+      tick: 11,
+      owner: 'bot',
+      objects: {
+        controller: { type: 'controller', my: true, level: 2 },
+        source1: { type: 'source' },
+        source2: { type: 'source' },
+        storage: { type: 'storage', store: { energy: 350 } },
+        hostile: { type: 'creep', owner: { username: 'enemy' } }
+      }
+    });
+
+    const kpi = reduceStrategyKpis(artifacts);
+
+    expect(kpi.reliability.passed).toBe(true);
+    expect(kpi.territory.components.ownedRooms).toBe(1);
+    expect(kpi.resources.components.visibleSources).toBe(2);
+    expect(kpi.resources.components.storedEnergy).toBe(350);
+    expect(kpi.kills.components.hostilePressureObserved).toBe(1);
+  });
+
+  it('accepts already-normalized room snapshot artifacts', () => {
+    const artifacts = parseStrategyEvaluationArtifacts([
+      {
+        artifactType: 'room-snapshot',
+        roomName: 'E48S28',
+        tick: 12,
+        owner: 'bot',
+        objects: [
+          { id: 'controller', type: 'controller', owner: { username: 'bot' }, level: 3 },
+          { id: 'source1', type: 'source' },
+          { id: 'source2', type: 'source' }
+        ]
+      }
+    ]);
+
+    const kpi = reduceStrategyKpis(artifacts);
+
+    expect(artifacts).toHaveLength(1);
+    expect(kpi.territory.components.ownedRooms).toBe(1);
+    expect(kpi.territory.components.controllerLevels).toBe(3);
+    expect(kpi.resources.components.visibleSources).toBe(2);
+  });
+});

--- a/prod/test/strategyRegistry.test.ts
+++ b/prod/test/strategyRegistry.test.ts
@@ -1,0 +1,27 @@
+import {
+  DEFAULT_STRATEGY_REGISTRY,
+  STRATEGY_REGISTRY_SCHEMA_VERSION,
+  validateStrategyRegistry
+} from '../src/strategy/strategyRegistry';
+
+describe('strategy registry schema', () => {
+  it('records bounded passive strategy metadata for the initial model families', () => {
+    const result = validateStrategyRegistry(DEFAULT_STRATEGY_REGISTRY);
+
+    expect(result).toEqual({ valid: true, issues: [] });
+    expect(new Set(DEFAULT_STRATEGY_REGISTRY.map((entry) => entry.family))).toEqual(
+      new Set(['construction-priority', 'expansion-remote-candidate', 'defense-posture-repair-threshold'])
+    );
+
+    for (const entry of DEFAULT_STRATEGY_REGISTRY) {
+      expect(entry.schemaVersion).toBe(STRATEGY_REGISTRY_SCHEMA_VERSION);
+      expect(entry.owner.issue).toBe(265);
+      expect(entry.supportedContext.artifactTypes.length).toBeGreaterThan(0);
+      expect(entry.knobBounds.length).toBeGreaterThan(0);
+      expect(Object.keys(entry.defaultValues).sort()).toEqual(entry.knobBounds.map((knob) => knob.name).sort());
+      expect(entry.evidenceLinks.length).toBeGreaterThan(0);
+      expect(entry.rollback.disabledByDefault).toBe(true);
+      expect(entry.rollback.disableFlag).toBe('strategyShadowEvaluator.enabled=false');
+    }
+  });
+});

--- a/prod/test/strategyShadowEvaluator.test.ts
+++ b/prod/test/strategyShadowEvaluator.test.ts
@@ -1,0 +1,81 @@
+import { STRATEGY_SHADOW_REPLAY_FIXTURE } from './fixtures/strategyShadowReplayFixture';
+import { evaluateStrategyShadowReplay } from '../src/strategy/shadowEvaluator';
+
+describe('strategy shadow evaluator', () => {
+  it('is passive and disabled by default', () => {
+    const report = evaluateStrategyShadowReplay({
+      artifacts: STRATEGY_SHADOW_REPLAY_FIXTURE
+    });
+
+    expect(report.enabled).toBe(false);
+    expect(report.disabledReason).toBe('strategy shadow evaluator disabled');
+    expect(report.artifactCount).toBe(1);
+    expect(report.modelReports).toEqual([]);
+  });
+
+  it('replays a fixture and reports candidate-vs-incumbent ranking diffs without live actions', () => {
+    const report = evaluateStrategyShadowReplay({
+      artifacts: STRATEGY_SHADOW_REPLAY_FIXTURE,
+      config: {
+        enabled: true,
+        candidateStrategyIds: [
+          'construction-priority.territory-shadow.v1',
+          'expansion-remote.territory-shadow.v1'
+        ]
+      }
+    });
+
+    expect(report.enabled).toBe(true);
+    expect(report.warnings).toEqual([]);
+    expect(report.kpi.reliability.passed).toBe(true);
+
+    const constructionReport = report.modelReports.find((modelReport) => modelReport.family === 'construction-priority');
+    expect(constructionReport?.rankingDiffs).toHaveLength(1);
+    expect(constructionReport?.rankingDiffs[0]).toMatchObject({
+      artifactIndex: 0,
+      tick: 200,
+      roomName: 'E48S28',
+      context: 'construction-priority',
+      changedTop: true,
+      incumbentTop: {
+        label: 'build extension capacity',
+        rank: 1
+      },
+      candidateTop: {
+        label: 'build remote road/container logistics',
+        rank: 1
+      },
+      rankChanges: [
+        {
+          label: 'build extension capacity',
+          incumbentRank: 1,
+          candidateRank: 2,
+          delta: -1
+        },
+        {
+          label: 'build remote road/container logistics',
+          incumbentRank: 2,
+          candidateRank: 1,
+          delta: 1
+        }
+      ]
+    });
+
+    const expansionReport = report.modelReports.find(
+      (modelReport) => modelReport.family === 'expansion-remote-candidate'
+    );
+    expect(expansionReport?.rankingDiffs).toHaveLength(1);
+    expect(expansionReport?.rankingDiffs[0]).toMatchObject({
+      context: 'expansion-remote-candidate',
+      changedTop: true,
+      incumbentTop: {
+        label: 'reserve E48S27',
+        rank: 1
+      },
+      candidateTop: {
+        label: 'occupy E49S28',
+        rank: 1
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- adds a passive strategy registry with version/rollout/evidence metadata for bounded strategy models
- adds a lexicographic KPI evaluator preserving reliability, territory, resources, then kills ordering
- adds an offline/shadow replay evaluator and fixture coverage without changing live actions
- wires passive evaluator availability into runtime code/tests and refreshes generated `prod/dist/main.js`

Closes #265.

## Verification
- `git diff --check`
- from `prod/`: `npm run typecheck`
- from `prod/`: `npm test -- --runInBand` (22 suites / 423 tests passed)
- from `prod/`: `npm run build`

## Scheduler evidence
- Worktree: `/root/screeps-worktrees/strategy-registry-shadow-265`
- Commit: `aa836cd lanyusea's bot <lanyusea@gmail.com> feat: add passive strategy shadow evaluator`
- Reconciled onto `origin/main` at `c580677` before verification/commit.
- Untracked dependency infrastructure (`prod/node_modules`) was intentionally not staged.
