### PR TITLE
fix: gate roadmap RCL fallback check on monitor evidence

### DIFF
--- a/scripts/check-roadmap-renderer.js
+++ b/scripts/check-roadmap-renderer.js
@@ -105,9 +105,12 @@ if (fs.existsSync(htmlPath)) {
     `KPI chart titles should be Territory, Resources, Combat; saw ${JSON.stringify(kpiTitles)}`
   );
 
+  const latestSummaryDir = path.join(repo, 'runtime-artifacts', 'screeps-monitor');
+  const hasMonitorSummary = fs.existsSync(latestSummaryDir)
+    && fs.readdirSync(latestSummaryDir).some(name => /^summary-.*\.svg$/.test(name));
   const territoryCard = body.match(/<div class="card kpi">[\s\S]*?<h3>Territory<\/h3>[\s\S]*?<\/div><\/div>/);
   assert(Boolean(territoryCard), 'Territory KPI card is missing');
-  if (territoryCard) {
+  if (territoryCard && !hasMonitorSummary) {
     const territoryText = tagText(territoryCard[0]);
     assert(!territoryText.includes('Latest monitor RCL: 3'), 'Territory KPI must not use fallback RCL 3 when no monitor evidence exists');
   }


### PR DESCRIPTION
## Summary
- Fix the roadmap renderer regression check so it only rejects `Latest monitor RCL: 3` when there is no monitor summary evidence.
- Keeps the no-placeholder guard intact while allowing an observed RCL 3 from a real runtime monitor SVG on the canonical `/root/screeps` checkout.

## Verification
- `npm ci`
- `python3 -m py_compile scripts/generate-roadmap-page.py scripts/check-roadmap-kpi-placeholders.py`
- `python3 -B scripts/check-roadmap-kpi-placeholders.py /root/screeps-worktrees/roadmap-rcl-check-evidence`
- `node scripts/check-roadmap-renderer.js /root/screeps-worktrees/roadmap-rcl-check-evidence`
- `python3 scripts/test_generate_roadmap_page.py`
- `git diff --check`

## Context
This is a follow-up to #282 after post-merge verification on the canonical checkout found the check was too strict when real monitor evidence exists.