### PR TITLE
feat: rank productive energy sinks after refill readiness

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2748,6 +2748,14 @@ function selectWorkerTask(creep) {
   if (priorityTowerEnergySink) {
     return { type: "transfer", targetId: priorityTowerEnergySink.id };
   }
+  const readyFollowUpProductiveEnergySinkTask = selectReadyFollowUpProductiveEnergySinkTask(
+    creep,
+    capacityConstructionSite,
+    controller
+  );
+  if (readyFollowUpProductiveEnergySinkTask) {
+    return readyFollowUpProductiveEnergySinkTask;
+  }
   if (territoryControllerTask) {
     return territoryControllerTask;
   }
@@ -2920,6 +2928,19 @@ function selectCapacityEnablingConstructionSite(creep, constructionSites, contro
     return null;
   }
   return selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
+}
+function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstructionSite, controller) {
+  if (!hasReadyTerritoryFollowUpEnergy(creep)) {
+    return null;
+  }
+  if (capacityConstructionSite) {
+    return { type: "build", targetId: capacityConstructionSite.id };
+  }
+  if (controller && shouldRushRcl1Controller(controller)) {
+    return null;
+  }
+  const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
+  return criticalRepairTarget ? { type: "repair", targetId: criticalRepairTarget.id } : null;
 }
 function isSpawnConstructionSite(site) {
   return matchesStructureType2(site.structureType, "STRUCTURE_SPAWN", "spawn");
@@ -3308,7 +3329,7 @@ function hasActiveTerritoryPressure(creep) {
   if (!colonyName) {
     return false;
   }
-  if (hasActiveTerritoryFollowUpPreparationDemand(colonyName)) {
+  if (hasReadyTerritoryFollowUpEnergy(creep)) {
     return true;
   }
   const territoryMemory = (_a = globalThis.Memory) == null ? void 0 : _a.territory;
@@ -3341,6 +3362,18 @@ function hasUsefulTerritoryFollowUpRefillCapacity(creep) {
   }
   const followUpEnergyTarget = Math.min(TERRITORY_CONTROLLER_BODY_COST, energyCapacityAvailable);
   return energyAvailable < followUpEnergyTarget;
+}
+function hasReadyTerritoryFollowUpEnergy(creep) {
+  if (!hasReservedTerritoryFollowUpRefillCapacity(creep)) {
+    return false;
+  }
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
+  if (energyAvailable === null || energyCapacityAvailable === null) {
+    return false;
+  }
+  const followUpEnergyTarget = Math.min(TERRITORY_CONTROLLER_BODY_COST, energyCapacityAvailable);
+  return energyAvailable >= followUpEnergyTarget;
 }
 function getRoomEnergyAvailable(room) {
   const energyAvailable = room.energyAvailable;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -100,6 +100,15 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'transfer', targetId: priorityTowerEnergySink.id as Id<AnyStoreStructure> };
   }
 
+  const readyFollowUpProductiveEnergySinkTask = selectReadyFollowUpProductiveEnergySinkTask(
+    creep,
+    capacityConstructionSite,
+    controller
+  );
+  if (readyFollowUpProductiveEnergySinkTask) {
+    return readyFollowUpProductiveEnergySinkTask;
+  }
+
   if (territoryControllerTask) {
     return territoryControllerTask;
   }
@@ -362,6 +371,27 @@ function selectCapacityEnablingConstructionSite(
   }
 
   return selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
+}
+
+function selectReadyFollowUpProductiveEnergySinkTask(
+  creep: Creep,
+  capacityConstructionSite: ConstructionSite | null,
+  controller: StructureController | undefined
+): ProductiveEnergySinkTask | null {
+  if (!hasReadyTerritoryFollowUpEnergy(creep)) {
+    return null;
+  }
+
+  if (capacityConstructionSite) {
+    return { type: 'build', targetId: capacityConstructionSite.id };
+  }
+
+  if (controller && shouldRushRcl1Controller(controller)) {
+    return null;
+  }
+
+  const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
+  return criticalRepairTarget ? { type: 'repair', targetId: criticalRepairTarget.id as Id<Structure> } : null;
 }
 
 function isSpawnConstructionSite(site: ConstructionSite): boolean {
@@ -983,7 +1013,7 @@ function hasActiveTerritoryPressure(creep: Creep): boolean {
     return false;
   }
 
-  if (hasActiveTerritoryFollowUpPreparationDemand(colonyName)) {
+  if (hasReadyTerritoryFollowUpEnergy(creep)) {
     return true;
   }
 
@@ -1025,6 +1055,21 @@ function hasUsefulTerritoryFollowUpRefillCapacity(creep: Creep): boolean {
 
   const followUpEnergyTarget = Math.min(TERRITORY_CONTROLLER_BODY_COST, energyCapacityAvailable);
   return energyAvailable < followUpEnergyTarget;
+}
+
+function hasReadyTerritoryFollowUpEnergy(creep: Creep): boolean {
+  if (!hasReservedTerritoryFollowUpRefillCapacity(creep)) {
+    return false;
+  }
+
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
+  if (energyAvailable === null || energyCapacityAvailable === null) {
+    return false;
+  }
+
+  const followUpEnergyTarget = Math.min(TERRITORY_CONTROLLER_BODY_COST, energyCapacityAvailable);
+  return energyAvailable >= followUpEnergyTarget;
 }
 
 function getRoomEnergyAvailable(room: Room): number | null {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2892,6 +2892,107 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it('builds follow-up-ready capacity construction before fallback territory upgrading', () => {
+    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller2',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      time: 514
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        demands: [makeFollowUpDemand(514)],
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 514 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+        energyCapacityAvailable: 800
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
+  });
+
+  it('repairs follow-up-ready critical infrastructure before fallback territory upgrading', () => {
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000);
+    const controller = {
+      id: 'controller2',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      time: 515
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        demands: [makeFollowUpDemand(515)],
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 515 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+        energyCapacityAvailable: 800,
+        structures: [road]
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-critical' });
+  });
+
+  it('keeps emergency refill before productive follow-up spending', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;
+    const controller = {
+      id: 'controller2',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      time: 516
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        demands: [makeFollowUpDemand(516)],
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 516 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        energyCapacityAvailable: 800,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
   it('uses active follow-up demand as territory pressure once refill capacity is full', () => {
     const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
     const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
@@ -2912,6 +3013,8 @@ describe('selectWorkerTask', () => {
       room: makeWorkerTaskRoom({
         constructionSites: [site],
         controller,
+        energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+        energyCapacityAvailable: 800,
         myStructures: [fullSpawn as AnyOwnedStructure]
       })
     } as unknown as Creep;


### PR DESCRIPTION
Closes #285.

## Summary
- ranks productive energy sinks after follow-up refill readiness
- adds worker task coverage for productive sink ordering
- updates bundled `prod/dist/main.js`

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (19 suites, 416 tests passed)
- `cd prod && npm run build`
- post-commit `cd prod && npm run build && git diff --exit-code -- prod/dist/main.js`

## Scheduler notes
- Recovered from existing Codex-authored dirty worktree `/root/screeps-worktrees/productive-energy-sink-ranking-285`.
- Commit author preserved as `lanyusea's bot <lanyusea@gmail.com>`.
