### PR TITLE
fix: source roadmap image deploy metric from report data

### DIFF
--- a/scripts/check-roadmap-renderer.js
+++ b/scripts/check-roadmap-renderer.js
@@ -124,6 +124,21 @@ if (fs.existsSync(htmlPath)) {
     assert(!resourcesText.includes('Stored energy 0') && !resourcesText.includes('Harvest delta 0') && !resourcesText.includes('Worker carried 0'), 'Resources KPI must not label fake zero energy values');
   }
 
+  const officialDeployCard = (() => {
+    try {
+      const roadmapData = JSON.parse(fs.readFileSync(path.join(repo, 'docs', 'roadmap-data.json'), 'utf8'));
+      return (roadmapData.report?.processCards || []).find(card => card.label === 'Official deploys');
+    } catch {
+      return null;
+    }
+  })();
+  if (officialDeployCard && Number.isFinite(Number(officialDeployCard.value))) {
+    assert(
+      text.includes(`${Number(officialDeployCard.value)} Official game deploys`),
+      `Official game deploys should match docs/roadmap-data.json value ${officialDeployCard.value}`
+    );
+  }
+
   const unavailableCards = [...body.matchAll(/data-kpi-unavailable="true"/g)].length;
   assert(unavailableCards >= 1, 'At least one unavailable KPI block should be explicit when reducer data is missing');
 }

--- a/scripts/render-screeps-roadmap.js
+++ b/scripts/render-screeps-roadmap.js
@@ -178,9 +178,19 @@ const officialDeployEvidence = countFiles(
   "test -d runtime-artifacts/official-screeps-deploy && find runtime-artifacts/official-screeps-deploy -maxdepth 1 -type f -name 'official-screeps-deploy-*.json' >/dev/null && echo present || echo missing"
 );
 const projectOfficialDeploys = explicitOfficialDeployEvidence();
-const officialDeploys = officialDeployEvidence.observed
-  ? Math.max(officialDeployEvidence.value, projectOfficialDeploys)
-  : (projectOfficialDeploys || null);
+function readRoadmapProcessMetric(label) {
+  try {
+    const raw = fs.readFileSync(path.join(repo, 'docs', 'roadmap-data.json'), 'utf8');
+    const data = JSON.parse(raw);
+    const cards = data?.report?.processCards;
+    if (!Array.isArray(cards)) return null;
+    return cards.find(card => card && card.label === label) || null;
+  } catch {
+    return null;
+  }
+}
+const officialDeployCard = readRoadmapProcessMetric('Official deploys');
+const officialDeploys = Number.isFinite(Number(officialDeployCard?.value)) ? Number(officialDeployCard.value) : (projectOfficialDeploys || null);
 function explicitPrivateSmokeEvidence() {
   const evidence = new Set();
   for (const item of items) {
@@ -286,7 +296,7 @@ ${kanban('04 Foundation Kanban', 'Reliability / P0 and Foundation Gates; data co
     'Official game deploys',
     typeof officialDeploys === 'number' ? officialDeploys : 'not observed',
     'officialDeploys',
-    projectOfficialDeploys ? 'GitHub Project official deploy evidence' : officialDeployEvidence.observed ? 'runtime artifact evidence' : 'evidence unavailable'
+    officialDeployCard ? String(officialDeployCard.detail || 'roadmap-data official deploy evidence') : projectOfficialDeploys ? 'GitHub Project official deploy evidence' : 'evidence unavailable'
   ),
   metric('Private smoke tests', privateTests > 0 ? metrics.privateTests : 'not observed', 'privateTests', privateTests > 0 ? 'GitHub Project smoke evidence' : 'evidence unavailable')
 ].join('')}</div></section>


### PR DESCRIPTION
## Summary
- Make the Discord roadmap image renderer source `Official game deploys` from `docs/roadmap-data.json` process metrics, matching the GitHub Pages/report generator instead of raw artifact-file counts.
- Add a renderer regression check that the image metric matches the committed roadmap-data process card.

## Verification
- `npm ci`
- `python3 -m py_compile scripts/generate-roadmap-page.py scripts/check-roadmap-kpi-placeholders.py`
- `python3 -B scripts/check-roadmap-kpi-placeholders.py /root/screeps-worktrees/roadmap-renderer-process-metrics`
- `node scripts/check-roadmap-renderer.js /root/screeps-worktrees/roadmap-renderer-process-metrics`
- `python3 scripts/test_generate_roadmap_page.py`
- `node scripts/render-screeps-roadmap.js /root/screeps-worktrees/roadmap-renderer-process-metrics /tmp/screeps-roadmap-kpi-process-metrics.png`
- `git diff --check`

## Context
Post-merge visual QA after #282/#287 found the image could show raw deploy artifact-file count (`29`) while the report data showed the evidence-based official deploy count (`1`). This PR makes the image use the same data source as the page/report.