### PR TITLE
feat: prefer actionable controller follow-up opportunities

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1385,12 +1385,12 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
     routeDistanceLookupContext
   );
   const primaryCandidates = [...persistedIntentCandidates, ...configuredCandidates];
-  const bestSpawnablePrimaryCandidate = selectBestScoredTerritoryCandidate(
-    getSpawnableTerritoryCandidates(primaryCandidates, roleCounts, colony)
+  const bestReadyPrimaryCandidate = selectBestScoredTerritoryCandidate(
+    getReadyTerritoryCandidates(primaryCandidates, roleCounts, colony)
   );
-  if (bestSpawnablePrimaryCandidate && bestSpawnablePrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
-    if (!shouldEvaluateVisibleAdjacentFollowUpPreference(bestSpawnablePrimaryCandidate)) {
-      return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+  if (bestReadyPrimaryCandidate && bestReadyPrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
+    if (!shouldEvaluateVisibleAdjacentFollowUpPreference(bestReadyPrimaryCandidate)) {
+      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
     }
     const visibleAdjacentFollowUpCandidates = applyOccupationRecommendationScores(
       colony,
@@ -1406,16 +1406,16 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       )
     );
     if (visibleAdjacentFollowUpCandidates.length === 0) {
-      return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
     }
     return toSelectedTerritoryTarget(
       (_a = selectBestScoredTerritoryCandidate(
-        getSpawnableTerritoryCandidates(
+        getReadyTerritoryCandidates(
           [...primaryCandidates, ...visibleAdjacentFollowUpCandidates],
           roleCounts,
           colony
         )
-      )) != null ? _a : bestSpawnablePrimaryCandidate
+      )) != null ? _a : bestReadyPrimaryCandidate
     );
   }
   const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, [
@@ -1444,7 +1444,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
   ]);
   const candidates = [...primaryCandidates, ...adjacentCandidates];
   return toSelectedTerritoryTarget(
-    (_c = (_b = selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts, colony))) != null ? _b : selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony))) != null ? _c : selectBestScoredTerritoryCandidate(candidates)
+    (_c = (_b = selectBestScoredTerritoryCandidate(getReadyTerritoryCandidates(candidates, roleCounts, colony))) != null ? _b : selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony))) != null ? _c : selectBestScoredTerritoryCandidate(candidates)
   );
 }
 function selectBestScoredTerritoryCandidate(candidates) {
@@ -1469,15 +1469,29 @@ function toSelectedTerritoryTarget(candidate) {
 function shouldEvaluateVisibleAdjacentFollowUpPreference(candidate) {
   return candidate.priority === TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE && candidate.target.action === "reserve";
 }
-function getSpawnableTerritoryCandidates(candidates, roleCounts, colony) {
-  return candidates.filter((candidate) => {
-    return isTerritoryCandidateSpawnRequired(candidate, roleCounts) && isTerritoryCandidateSpawnReady(candidate, colony);
-  });
+function getReadyTerritoryCandidates(candidates, roleCounts, colony) {
+  return withImmediateControllerFollowUpState(candidates, roleCounts).filter(
+    (candidate) => candidate.immediateControllerFollowUp === true || isTerritoryCandidateSpawnRequired(candidate, roleCounts) && isTerritoryCandidateSpawnReady(candidate, colony)
+  );
 }
 function getActionableTerritoryCandidates(candidates, roleCounts, colony) {
-  return candidates.filter(
+  return withImmediateControllerFollowUpState(candidates, roleCounts).filter(
     (candidate) => !isTerritoryCandidateSpawnRequired(candidate, roleCounts) || isTerritoryCandidateSpawnReady(candidate, colony)
   );
+}
+function withImmediateControllerFollowUpState(candidates, roleCounts) {
+  return candidates.map((candidate) => {
+    if (!isImmediateControllerFollowUpCandidate(candidate, roleCounts)) {
+      return candidate;
+    }
+    return {
+      ...candidate,
+      immediateControllerFollowUp: true
+    };
+  });
+}
+function isImmediateControllerFollowUpCandidate(candidate, roleCounts) {
+  return candidate.followUp !== void 0 && isTerritoryControlAction(candidate.intentAction) && getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.intentAction) > 0;
 }
 function isTerritoryCandidateSpawnRequired(candidate, roleCounts) {
   const activeCoverageCount = getTerritoryCreepCountForTarget(
@@ -1977,7 +1991,15 @@ function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
 }
 function compareTerritoryCandidates(left, right) {
-  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || compareRecoveredFollowUpPreference(left, right) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || compareImmediateControllerFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || compareRecoveredFollowUpPreference(left, right) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+}
+function compareImmediateControllerFollowUpPreference(left, right) {
+  const leftImmediate = left.immediateControllerFollowUp === true;
+  const rightImmediate = right.immediateControllerFollowUp === true;
+  if (leftImmediate === rightImmediate) {
+    return 0;
+  }
+  return leftImmediate ? -1 : 1;
 }
 function compareRecoveredFollowUpPreference(left, right) {
   if (left.recoveredFollowUp === right.recoveredFollowUp) {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -70,6 +70,7 @@ interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   recommendationEvidenceStatus?: OccupationRecommendationEvidenceStatus;
   routeDistance?: number;
   renewalTicksToEnd?: number;
+  immediateControllerFollowUp?: boolean;
   occupationActionableTicks?: number;
 }
 
@@ -488,15 +489,15 @@ function selectTerritoryTarget(
     routeDistanceLookupContext
   );
   const primaryCandidates = [...persistedIntentCandidates, ...configuredCandidates];
-  const bestSpawnablePrimaryCandidate = selectBestScoredTerritoryCandidate(
-    getSpawnableTerritoryCandidates(primaryCandidates, roleCounts, colony)
+  const bestReadyPrimaryCandidate = selectBestScoredTerritoryCandidate(
+    getReadyTerritoryCandidates(primaryCandidates, roleCounts, colony)
   );
   if (
-    bestSpawnablePrimaryCandidate &&
-    bestSpawnablePrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY
+    bestReadyPrimaryCandidate &&
+    bestReadyPrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY
   ) {
-    if (!shouldEvaluateVisibleAdjacentFollowUpPreference(bestSpawnablePrimaryCandidate)) {
-      return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+    if (!shouldEvaluateVisibleAdjacentFollowUpPreference(bestReadyPrimaryCandidate)) {
+      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
     }
 
     const visibleAdjacentFollowUpCandidates = applyOccupationRecommendationScores(
@@ -513,17 +514,17 @@ function selectTerritoryTarget(
       )
     );
     if (visibleAdjacentFollowUpCandidates.length === 0) {
-      return toSelectedTerritoryTarget(bestSpawnablePrimaryCandidate);
+      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
     }
 
     return toSelectedTerritoryTarget(
       selectBestScoredTerritoryCandidate(
-        getSpawnableTerritoryCandidates(
+        getReadyTerritoryCandidates(
           [...primaryCandidates, ...visibleAdjacentFollowUpCandidates],
           roleCounts,
           colony
         )
-      ) ?? bestSpawnablePrimaryCandidate
+      ) ?? bestReadyPrimaryCandidate
     );
   }
 
@@ -554,7 +555,7 @@ function selectTerritoryTarget(
   const candidates = [...primaryCandidates, ...adjacentCandidates];
 
   return toSelectedTerritoryTarget(
-    selectBestScoredTerritoryCandidate(getSpawnableTerritoryCandidates(candidates, roleCounts, colony)) ??
+    selectBestScoredTerritoryCandidate(getReadyTerritoryCandidates(candidates, roleCounts, colony)) ??
       selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony)) ??
       selectBestScoredTerritoryCandidate(candidates)
   );
@@ -590,17 +591,17 @@ function shouldEvaluateVisibleAdjacentFollowUpPreference(candidate: ScoredTerrit
   return candidate.priority === TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE && candidate.target.action === 'reserve';
 }
 
-function getSpawnableTerritoryCandidates(
+function getReadyTerritoryCandidates(
   candidates: ScoredTerritoryTarget[],
   roleCounts: RoleCounts,
   colony: ColonySnapshot
 ): ScoredTerritoryTarget[] {
-  return candidates.filter((candidate) => {
-    return (
-      isTerritoryCandidateSpawnRequired(candidate, roleCounts) &&
-      isTerritoryCandidateSpawnReady(candidate, colony)
-    );
-  });
+  return withImmediateControllerFollowUpState(candidates, roleCounts).filter(
+    (candidate) =>
+      candidate.immediateControllerFollowUp === true ||
+      (isTerritoryCandidateSpawnRequired(candidate, roleCounts) &&
+        isTerritoryCandidateSpawnReady(candidate, colony))
+  );
 }
 
 function getActionableTerritoryCandidates(
@@ -608,9 +609,36 @@ function getActionableTerritoryCandidates(
   roleCounts: RoleCounts,
   colony: ColonySnapshot
 ): ScoredTerritoryTarget[] {
-  return candidates.filter(
+  return withImmediateControllerFollowUpState(candidates, roleCounts).filter(
     (candidate) =>
       !isTerritoryCandidateSpawnRequired(candidate, roleCounts) || isTerritoryCandidateSpawnReady(candidate, colony)
+  );
+}
+
+function withImmediateControllerFollowUpState(
+  candidates: ScoredTerritoryTarget[],
+  roleCounts: RoleCounts
+): ScoredTerritoryTarget[] {
+  return candidates.map((candidate) => {
+    if (!isImmediateControllerFollowUpCandidate(candidate, roleCounts)) {
+      return candidate;
+    }
+
+    return {
+      ...candidate,
+      immediateControllerFollowUp: true
+    };
+  });
+}
+
+function isImmediateControllerFollowUpCandidate(
+  candidate: ScoredTerritoryTarget,
+  roleCounts: RoleCounts
+): boolean {
+  return (
+    candidate.followUp !== undefined &&
+    isTerritoryControlAction(candidate.intentAction) &&
+    getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.intentAction) > 0
   );
 }
 
@@ -1406,6 +1434,7 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
     left.priority - right.priority ||
     compareOptionalNumbers(left.renewalTicksToEnd, right.renewalTicksToEnd) ||
     compareVisibleAdjacentFollowUpPreference(left, right) ||
+    compareImmediateControllerFollowUpPreference(left, right) ||
     getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) ||
     compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) ||
     compareOptionalNumbers(left.occupationActionableTicks, right.occupationActionableTicks) ||
@@ -1414,6 +1443,19 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
     left.target.roomName.localeCompare(right.target.roomName) ||
     left.intentAction.localeCompare(right.intentAction)
   );
+}
+
+function compareImmediateControllerFollowUpPreference(
+  left: ScoredTerritoryTarget,
+  right: ScoredTerritoryTarget
+): number {
+  const leftImmediate = left.immediateControllerFollowUp === true;
+  const rightImmediate = right.immediateControllerFollowUp === true;
+  if (leftImmediate === rightImmediate) {
+    return 0;
+  }
+
+  return leftImmediate ? -1 : 1;
 }
 
 function compareRecoveredFollowUpPreference(left: ScoredTerritoryTarget, right: ScoredTerritoryTarget): number {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2345,6 +2345,86 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('prefers an active controller follow-up over spawn-ready generic territory work while preserving cooldowns', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const activeFollowUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const coolingDownFollowUpTarget: TerritoryTargetMemory = {
+      colony: 'W1N1',
+      roomName: 'W4N1',
+      action: 'reserve'
+    };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const suppressionTime = 586;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 2;
+    const activeFollowUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 585,
+      followUp
+    };
+    const coolingDownFollowUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W4N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: suppressionTime,
+      lastAttemptAt: retryTime - 1,
+      followUp
+    };
+    const roleCounts = {
+      worker: 3,
+      claimer: 2,
+      claimersByTargetRoom: { W3N1: 1, W4N1: 1 },
+      claimersByTargetRoomAction: { reserve: { W3N1: 1, W4N1: 1 } }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', { sourceCount: 2 }),
+        W3N1: makeRecommendationRoom('W3N1', { sourceCount: 1 }),
+        W4N1: makeRecommendationRoom('W4N1', { sourceCount: 2 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, activeFollowUpTarget, coolingDownFollowUpTarget],
+        intents: [activeFollowUpIntent, coolingDownFollowUpIntent]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, roleCounts, 3, retryTime);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      followUp
+    });
+    expect(shouldSpawnTerritoryControllerCreep(plan!, roleCounts, retryTime)).toBe(false);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        ...activeFollowUpIntent,
+        status: 'active',
+        updatedAt: retryTime
+      },
+      coolingDownFollowUpIntent
+    ]);
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: retryTime,
+        followUp
+      }
+    ]);
+  });
+
   it('scouts an alternate adjacent room while a recovered follow-up target is cooling down', () => {
     const colony = makeSafeColony();
     const recoveredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };


### PR DESCRIPTION
## Summary
- ranks controller follow-up candidates by actionable ownership/visibility state before weaker fallback signals
- adds territory planner coverage for actionable controller follow-up ordering
- refreshes the bundled Screeps artifact

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

Closes #290.
