### PR TITLE
feat: keep territory follow-up active until control evidence changes

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1352,7 +1352,14 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord2();
-  const intents = normalizeTerritoryIntents2(territoryMemory == null ? void 0 : territoryMemory.intents);
+  let intents = normalizeTerritoryIntents2(territoryMemory == null ? void 0 : territoryMemory.intents);
+  const sanitizedFollowUps = sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyOwnerUsername);
+  if (sanitizedFollowUps.changed) {
+    intents = sanitizedFollowUps.intents;
+    if (territoryMemory) {
+      territoryMemory.intents = intents;
+    }
+  }
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     colony,
@@ -1539,6 +1546,7 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
         intentAction: target.action,
         commitTarget: false,
         ...persistedFollowUp ? { followUp: persistedFollowUp.followUp } : {},
+        ...persistedFollowUp ? { persistedFollowUp: true } : {},
         ...(persistedFollowUp == null ? void 0 : persistedFollowUp.recovered) ? { recoveredFollowUp: true } : {},
         ...typeof (persistedFollowUp == null ? void 0 : persistedFollowUp.suppressedAt) === "number" ? { recoveredFollowUpSuppressedAt: persistedFollowUp.suppressedAt } : {}
       },
@@ -1576,6 +1584,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
         intentAction: intent.action,
         commitTarget: false,
         ...intent.followUp ? { followUp: intent.followUp } : {},
+        ...intent.followUp ? { persistedFollowUp: true } : {},
         ...recoveredFollowUp ? { recoveredFollowUp: true, recoveredFollowUpSuppressedAt: intent.updatedAt } : {}
       },
       "occupationIntent",
@@ -1991,7 +2000,7 @@ function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
 }
 function compareTerritoryCandidates(left, right) {
-  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || compareImmediateControllerFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || compareRecoveredFollowUpPreference(left, right) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || compareImmediateControllerFollowUpPreference(left, right) || comparePersistedControllerFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || compareRecoveredFollowUpPreference(left, right) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
 }
 function compareImmediateControllerFollowUpPreference(left, right) {
   const leftImmediate = left.immediateControllerFollowUp === true;
@@ -2000,6 +2009,17 @@ function compareImmediateControllerFollowUpPreference(left, right) {
     return 0;
   }
   return leftImmediate ? -1 : 1;
+}
+function comparePersistedControllerFollowUpPreference(left, right) {
+  const leftPersisted = isPersistedControllerFollowUpCandidate(left);
+  const rightPersisted = isPersistedControllerFollowUpCandidate(right);
+  if (leftPersisted === rightPersisted) {
+    return 0;
+  }
+  return leftPersisted ? -1 : 1;
+}
+function isPersistedControllerFollowUpCandidate(candidate) {
+  return candidate.persistedFollowUp === true && candidate.followUp !== void 0 && isTerritoryControlAction(candidate.intentAction);
 }
 function compareRecoveredFollowUpPreference(left, right) {
   if (left.recoveredFollowUp === right.recoveredFollowUp) {
@@ -2236,6 +2256,49 @@ function upsertTerritoryIntent2(intents, nextIntent) {
     return;
   }
   intents.push(nextIntent);
+}
+function sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyOwnerUsername) {
+  let changed = false;
+  const sanitizedIntents = intents.map((intent) => {
+    if (intent.colony !== colonyName || intent.followUp === void 0 || intent.status === "suppressed") {
+      return intent;
+    }
+    if (!isTerritoryControlAction(intent.action) || isPersistedTerritoryFollowUpStillActionable(intent, intent.action, colonyOwnerUsername)) {
+      return intent;
+    }
+    changed = true;
+    return omitTerritoryIntentFollowUp(intent);
+  });
+  return { intents: sanitizedIntents, changed };
+}
+function isPersistedTerritoryFollowUpStillActionable(intent, action, colonyOwnerUsername) {
+  const controllerState = getVisibleTerritoryControllerEvidenceState(
+    intent.targetRoom,
+    action,
+    intent.controllerId,
+    colonyOwnerUsername
+  );
+  return controllerState === null || controllerState === "available";
+}
+function getVisibleTerritoryControllerEvidenceState(targetRoom, action, controllerId, colonyOwnerUsername) {
+  if (isVisibleRoomMissingController(targetRoom)) {
+    return "unavailable";
+  }
+  const controller = getVisibleController(targetRoom, controllerId);
+  if (!controller) {
+    return null;
+  }
+  return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername);
+}
+function omitTerritoryIntentFollowUp(intent) {
+  return {
+    colony: intent.colony,
+    targetRoom: intent.targetRoom,
+    action: intent.action,
+    status: intent.status,
+    updatedAt: intent.updatedAt,
+    ...intent.controllerId ? { controllerId: intent.controllerId } : {}
+  };
 }
 function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action, gameTime) {
   let selectedIntent = null;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -50,6 +50,7 @@ interface SelectedTerritoryTarget {
   intentAction: TerritoryIntentAction;
   commitTarget: boolean;
   followUp?: TerritoryFollowUpMemory;
+  persistedFollowUp?: boolean;
   recoveredFollowUp?: boolean;
   recoveredFollowUpSuppressedAt?: number;
 }
@@ -456,7 +457,14 @@ function selectTerritoryTarget(
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
-  const intents = normalizeTerritoryIntents(territoryMemory?.intents);
+  let intents = normalizeTerritoryIntents(territoryMemory?.intents);
+  const sanitizedFollowUps = sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyOwnerUsername);
+  if (sanitizedFollowUps.changed) {
+    intents = sanitizedFollowUps.intents;
+    if (territoryMemory) {
+      territoryMemory.intents = intents;
+    }
+  }
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     colony,
@@ -719,6 +727,7 @@ function getConfiguredTerritoryCandidates(
         intentAction: target.action,
         commitTarget: false,
         ...(persistedFollowUp ? { followUp: persistedFollowUp.followUp } : {}),
+        ...(persistedFollowUp ? { persistedFollowUp: true } : {}),
         ...(persistedFollowUp?.recovered ? { recoveredFollowUp: true } : {}),
         ...(typeof persistedFollowUp?.suppressedAt === 'number'
           ? { recoveredFollowUpSuppressedAt: persistedFollowUp.suppressedAt }
@@ -778,6 +787,7 @@ function getPersistedTerritoryIntentCandidates(
         intentAction: intent.action,
         commitTarget: false,
         ...(intent.followUp ? { followUp: intent.followUp } : {}),
+        ...(intent.followUp ? { persistedFollowUp: true } : {}),
         ...(recoveredFollowUp ? { recoveredFollowUp: true, recoveredFollowUpSuppressedAt: intent.updatedAt } : {})
       },
       'occupationIntent',
@@ -1435,6 +1445,7 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
     compareOptionalNumbers(left.renewalTicksToEnd, right.renewalTicksToEnd) ||
     compareVisibleAdjacentFollowUpPreference(left, right) ||
     compareImmediateControllerFollowUpPreference(left, right) ||
+    comparePersistedControllerFollowUpPreference(left, right) ||
     getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) ||
     compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) ||
     compareOptionalNumbers(left.occupationActionableTicks, right.occupationActionableTicks) ||
@@ -1456,6 +1467,27 @@ function compareImmediateControllerFollowUpPreference(
   }
 
   return leftImmediate ? -1 : 1;
+}
+
+function comparePersistedControllerFollowUpPreference(
+  left: ScoredTerritoryTarget,
+  right: ScoredTerritoryTarget
+): number {
+  const leftPersisted = isPersistedControllerFollowUpCandidate(left);
+  const rightPersisted = isPersistedControllerFollowUpCandidate(right);
+  if (leftPersisted === rightPersisted) {
+    return 0;
+  }
+
+  return leftPersisted ? -1 : 1;
+}
+
+function isPersistedControllerFollowUpCandidate(candidate: ScoredTerritoryTarget): boolean {
+  return (
+    candidate.persistedFollowUp === true &&
+    candidate.followUp !== undefined &&
+    isTerritoryControlAction(candidate.intentAction)
+  );
 }
 
 function compareRecoveredFollowUpPreference(left: ScoredTerritoryTarget, right: ScoredTerritoryTarget): number {
@@ -1811,6 +1843,74 @@ function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: Ter
   }
 
   intents.push(nextIntent);
+}
+
+function sanitizeInvalidPersistedTerritoryFollowUps(
+  intents: TerritoryIntentMemory[],
+  colonyName: string,
+  colonyOwnerUsername: string | null
+): { intents: TerritoryIntentMemory[]; changed: boolean } {
+  let changed = false;
+  const sanitizedIntents = intents.map((intent) => {
+    if (intent.colony !== colonyName || intent.followUp === undefined || intent.status === 'suppressed') {
+      return intent;
+    }
+
+    if (
+      !isTerritoryControlAction(intent.action) ||
+      isPersistedTerritoryFollowUpStillActionable(intent, intent.action, colonyOwnerUsername)
+    ) {
+      return intent;
+    }
+
+    changed = true;
+    return omitTerritoryIntentFollowUp(intent);
+  });
+
+  return { intents: sanitizedIntents, changed };
+}
+
+function isPersistedTerritoryFollowUpStillActionable(
+  intent: TerritoryIntentMemory,
+  action: TerritoryControlAction,
+  colonyOwnerUsername: string | null
+): boolean {
+  const controllerState = getVisibleTerritoryControllerEvidenceState(
+    intent.targetRoom,
+    action,
+    intent.controllerId,
+    colonyOwnerUsername
+  );
+  return controllerState === null || controllerState === 'available';
+}
+
+function getVisibleTerritoryControllerEvidenceState(
+  targetRoom: string,
+  action: TerritoryControlAction,
+  controllerId: Id<StructureController> | undefined,
+  colonyOwnerUsername: string | null
+): TerritoryTargetVisibilityState | null {
+  if (isVisibleRoomMissingController(targetRoom)) {
+    return 'unavailable';
+  }
+
+  const controller = getVisibleController(targetRoom, controllerId);
+  if (!controller) {
+    return null;
+  }
+
+  return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername);
+}
+
+function omitTerritoryIntentFollowUp(intent: TerritoryIntentMemory): TerritoryIntentMemory {
+  return {
+    colony: intent.colony,
+    targetRoom: intent.targetRoom,
+    action: intent.action,
+    status: intent.status,
+    updatedAt: intent.updatedAt,
+    ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
+  };
 }
 
 function getPersistedTerritoryIntentFollowUp(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2425,6 +2425,118 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('keeps a planned controller follow-up before higher-scored generic reserve work', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const followUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const followUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 588,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', { sourceCount: 2 }),
+        W3N1: makeRecommendationRoom('W3N1', { sourceCount: 1 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, followUpTarget],
+        intents: [followUpIntent]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 589);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      followUp
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        ...followUpIntent,
+        updatedAt: 589
+      }
+    ]);
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: 589,
+        followUp
+      }
+    ]);
+  });
+
+  it('drops persisted follow-up metadata after visible controller evidence satisfies the target', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const staleFollowUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const staleFollowUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 590,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1'),
+        W3N1: makeRecommendationRoom('W3N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, staleFollowUpTarget],
+        intents: [staleFollowUpIntent]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 591);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 590
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 591
+      }
+    ]);
+    expect(Memory.territory?.demands).toBeUndefined();
+  });
+
   it('scouts an alternate adjacent room while a recovered follow-up target is cooling down', () => {
     const colony = makeSafeColony();
     const recoveredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };


### PR DESCRIPTION
## Summary
- Keeps a valid actionable territory/controller follow-up preferred while the room lacks visible evidence that the control task has started/completed or become invalid.
- Adds focused territory planner coverage for persistence and stale invalidation behavior.
- Regenerates `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites, 431 tests passed)
- `cd prod && npm run build`

Closes #292
