### PR TITLE
feat: refill spawn extensions before non-urgent spending

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2746,7 +2746,6 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
-var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -2794,7 +2793,7 @@ function selectWorkerTask(creep) {
     return { type: "upgrade", targetId: controller.id };
   }
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  if (spawnOrExtensionEnergySink && shouldPrioritizeSpawnOrExtensionRefill(creep)) {
+  if (spawnOrExtensionEnergySink) {
     return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
   }
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
@@ -2852,9 +2851,6 @@ function selectWorkerTask(creep) {
   }
   if (controller == null ? void 0 : controller.my) {
     return { type: "upgrade", targetId: controller.id };
-  }
-  if (spawnOrExtensionEnergySink) {
-    return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
   }
   return null;
 }
@@ -3396,30 +3392,8 @@ function hasActiveTerritoryPressure(creep) {
   }
   return territoryMemory.intents.some((intent) => isActiveTerritoryPressureIntent(intent, colonyName));
 }
-function shouldPrioritizeSpawnOrExtensionRefill(creep) {
-  if (hasUrgentSpawnOrExtensionRefillDemand(creep)) {
-    return true;
-  }
-  if (!hasReservedTerritoryFollowUpRefillCapacity(creep)) {
-    return true;
-  }
-  return hasUsefulTerritoryFollowUpRefillCapacity(creep);
-}
-function hasUrgentSpawnOrExtensionRefillDemand(creep) {
-  const energyAvailable = creep.room.energyAvailable;
-  return typeof energyAvailable === "number" && energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
-}
 function hasReservedTerritoryFollowUpRefillCapacity(creep) {
   return hasActiveTerritoryFollowUpPreparationDemand(getCreepColonyName(creep));
-}
-function hasUsefulTerritoryFollowUpRefillCapacity(creep) {
-  const energyAvailable = getRoomEnergyAvailable(creep.room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
-  if (energyAvailable === null || energyCapacityAvailable === null) {
-    return false;
-  }
-  const followUpEnergyTarget = Math.min(TERRITORY_CONTROLLER_BODY_COST, energyCapacityAvailable);
-  return energyAvailable < followUpEnergyTarget;
 }
 function hasReadyTerritoryFollowUpEnergy(creep) {
   if (!hasReservedTerritoryFollowUpRefillCapacity(creep)) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -85,7 +85,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
-  if (spawnOrExtensionEnergySink && shouldPrioritizeSpawnOrExtensionRefill(creep)) {
+  if (spawnOrExtensionEnergySink) {
     return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
   }
 
@@ -157,10 +157,6 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
 
   if (controller?.my) {
     return { type: 'upgrade', targetId: controller.id };
-  }
-
-  if (spawnOrExtensionEnergySink) {
-    return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
   }
 
   return null;
@@ -1025,36 +1021,8 @@ function hasActiveTerritoryPressure(creep: Creep): boolean {
   return territoryMemory.intents.some((intent) => isActiveTerritoryPressureIntent(intent, colonyName));
 }
 
-function shouldPrioritizeSpawnOrExtensionRefill(creep: Creep): boolean {
-  if (hasUrgentSpawnOrExtensionRefillDemand(creep)) {
-    return true;
-  }
-
-  if (!hasReservedTerritoryFollowUpRefillCapacity(creep)) {
-    return true;
-  }
-
-  return hasUsefulTerritoryFollowUpRefillCapacity(creep);
-}
-
-function hasUrgentSpawnOrExtensionRefillDemand(creep: Creep): boolean {
-  const energyAvailable = (creep.room as Room & { energyAvailable?: number }).energyAvailable;
-  return typeof energyAvailable === 'number' && energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
-}
-
 function hasReservedTerritoryFollowUpRefillCapacity(creep: Creep): boolean {
   return hasActiveTerritoryFollowUpPreparationDemand(getCreepColonyName(creep));
-}
-
-function hasUsefulTerritoryFollowUpRefillCapacity(creep: Creep): boolean {
-  const energyAvailable = getRoomEnergyAvailable(creep.room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
-  if (energyAvailable === null || energyCapacityAvailable === null) {
-    return false;
-  }
-
-  const followUpEnergyTarget = Math.min(TERRITORY_CONTROLLER_BODY_COST, energyCapacityAvailable);
-  return energyAvailable < followUpEnergyTarget;
 }
 
 function hasReadyTerritoryFollowUpEnergy(creep: Creep): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2828,7 +2828,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
-  it('spends carried energy on construction when follow-up energy target is ready', () => {
+  it('keeps spawn refill before construction when follow-up energy target is ready', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
     const controller = {
@@ -2858,11 +2858,11 @@ describe('selectWorkerTask', () => {
       })
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
-  it('spends carried energy on controller upgrade when follow-up energy target is ready and no construction remains', () => {
-    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+  it('keeps extension refill before controller upgrade when follow-up energy target is ready', () => {
+    const extension = makeEnergySink('extension1', 'extension' as StructureConstant, 50);
     const controller = {
       id: 'controller1',
       my: true,
@@ -2885,11 +2885,52 @@ describe('selectWorkerTask', () => {
         controller,
         energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
         energyCapacityAvailable: 800,
-        myStructures: [spawn as AnyOwnedStructure]
+        myStructures: [extension as AnyOwnedStructure]
       })
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension1' });
+  });
+
+  it('keeps spawn refill before nearby non-urgent repair when follow-up energy target is ready', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const road = makeStructure('road-worn', 'road' as StructureConstant, 4_000, 5_000);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'road-worn': 2,
+        controller1: 5
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      time: 514
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        demands: [makeFollowUpDemand(514)]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: makeWorkerTaskRoom({
+        controller,
+        energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+        energyCapacityAvailable: 800,
+        myStructures: [spawn as AnyOwnedStructure],
+        structures: [road]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
   });
 
   it('builds follow-up-ready capacity construction before fallback territory upgrading', () => {


### PR DESCRIPTION
## Summary
- Reconciles the recovered #286 economy slice on top of current `main`.
- Keeps carried-energy workers focused on spawn/extension refill before non-urgent spending.
- Updates focused worker task coverage and regenerates `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites, 430 tests passed)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #286
