### PR TITLE
feat: expose territory follow-up execution hints

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2402,7 +2402,7 @@ function recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime) {
   if (!nextHint) {
     setTerritoryFollowUpExecutionHints(
       territoryMemory,
-      currentHints.filter((hint) => hint.colony !== plan.colony)
+      hasActiveTerritoryFollowUpIntentForColony(intents, plan.colony) ? currentHints : currentHints.filter((hint) => hint.colony !== plan.colony)
     );
     return;
   }
@@ -2449,8 +2449,14 @@ function isTerritoryFollowUpExecutionHintStillActive(hint, intents) {
 function findMatchingActiveTerritoryFollowUpIntent(hint, intents) {
   var _a;
   return (_a = intents.find(
-    (intent) => intent.colony === hint.colony && intent.targetRoom === hint.targetRoom && intent.action === hint.action && (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0
+    (intent) => intent.colony === hint.colony && intent.targetRoom === hint.targetRoom && intent.action === hint.action && isActiveTerritoryFollowUpIntent(intent)
   )) != null ? _a : null;
+}
+function hasActiveTerritoryFollowUpIntentForColony(intents, colony) {
+  return intents.some((intent) => intent.colony === colony && isActiveTerritoryFollowUpIntent(intent));
+}
+function isActiveTerritoryFollowUpIntent(intent) {
+  return (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0;
 }
 function buildTerritoryFollowUpExecutionHint(plan, gameTime) {
   if (!plan.followUp) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1157,6 +1157,7 @@ function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameT
     lastAttemptAt: gameTime
   };
   removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
+  removeTerritoryFollowUpExecutionHint(territoryMemory, plan.colony, plan.targetRoom, plan.action);
 }
 function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime2()) {
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
@@ -1206,6 +1207,17 @@ function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameT
   return normalizeTerritoryFollowUpDemands(territoryMemory.demands).some(
     (demand) => demand.updatedAt === gameTime && demand.colony === colony && demand.workerCount > 0
   );
+}
+function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
+  const territoryMemory = getTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return [];
+  }
+  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  return getBoundedActiveTerritoryFollowUpExecutionHints(
+    normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
+    intents
+  ).filter((hint) => !isNonEmptyString2(colony) || hint.colony === colony);
 }
 function buildTerritoryCreepMemory(plan) {
   return {
@@ -1333,6 +1345,7 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
   };
   upsertTerritoryIntent2(intents, suppressedIntent);
   removeTerritoryFollowUpDemand(territoryMemory, colony, assignment.targetRoom, assignment.action);
+  removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
 function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   if (getWorkerCapacity(roleCounts) < workerTarget) {
@@ -1360,6 +1373,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       territoryMemory.intents = intents;
     }
   }
+  refreshTerritoryFollowUpExecutionHints(territoryMemory, intents);
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     colony,
@@ -2236,6 +2250,7 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null) {
   };
   upsertTerritoryIntent2(intents, nextIntent);
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
+  recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
 }
 function normalizeTerritoryIntents2(rawIntents) {
   return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
@@ -2376,6 +2391,157 @@ function getCurrentTerritoryFollowUpDemand(plan, gameTime) {
   return (_a = normalizeTerritoryFollowUpDemands(territoryMemory.demands).find(
     (demand) => demand.updatedAt === gameTime && demand.colony === plan.colony && demand.targetRoom === plan.targetRoom && demand.action === plan.action
   )) != null ? _a : null;
+}
+function recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime) {
+  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  const currentHints = getBoundedActiveTerritoryFollowUpExecutionHints(
+    normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
+    intents
+  );
+  const nextHint = buildTerritoryFollowUpExecutionHint(plan, gameTime);
+  if (!nextHint) {
+    setTerritoryFollowUpExecutionHints(
+      territoryMemory,
+      currentHints.filter((hint) => hint.colony !== plan.colony)
+    );
+    return;
+  }
+  upsertTerritoryFollowUpExecutionHint(currentHints, nextHint);
+  setTerritoryFollowUpExecutionHints(territoryMemory, currentHints);
+}
+function refreshTerritoryFollowUpExecutionHints(territoryMemory, intents) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.executionHints)) {
+    return;
+  }
+  setTerritoryFollowUpExecutionHints(
+    territoryMemory,
+    getBoundedActiveTerritoryFollowUpExecutionHints(
+      normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
+      intents
+    )
+  );
+}
+function getBoundedActiveTerritoryFollowUpExecutionHints(hints, intents) {
+  const latestHintByColony = /* @__PURE__ */ new Map();
+  for (const hint of hints) {
+    if (!isTerritoryFollowUpExecutionHintStillActive(hint, intents)) {
+      continue;
+    }
+    const existingHint = latestHintByColony.get(hint.colony);
+    if (!existingHint || hint.updatedAt > existingHint.updatedAt || hint.updatedAt === existingHint.updatedAt && hint.targetRoom.localeCompare(existingHint.targetRoom) < 0) {
+      latestHintByColony.set(hint.colony, hint);
+    }
+  }
+  return Array.from(latestHintByColony.values()).sort((left, right) => left.colony.localeCompare(right.colony));
+}
+function isTerritoryFollowUpExecutionHintStillActive(hint, intents) {
+  const matchingIntent = findMatchingActiveTerritoryFollowUpIntent(hint, intents);
+  if (!(matchingIntent == null ? void 0 : matchingIntent.followUp) || !isSameTerritoryFollowUp(hint.followUp, matchingIntent.followUp)) {
+    return false;
+  }
+  return getTerritoryFollowUpExecutionHintReason(
+    matchingIntent.targetRoom,
+    matchingIntent.action,
+    matchingIntent.controllerId,
+    getVisibleColonyOwnerUsername(matchingIntent.colony)
+  ) !== null;
+}
+function findMatchingActiveTerritoryFollowUpIntent(hint, intents) {
+  var _a;
+  return (_a = intents.find(
+    (intent) => intent.colony === hint.colony && intent.targetRoom === hint.targetRoom && intent.action === hint.action && (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0
+  )) != null ? _a : null;
+}
+function buildTerritoryFollowUpExecutionHint(plan, gameTime) {
+  if (!plan.followUp) {
+    return null;
+  }
+  const reason = getTerritoryFollowUpExecutionHintReason(
+    plan.targetRoom,
+    plan.action,
+    plan.controllerId,
+    getVisibleColonyOwnerUsername(plan.colony)
+  );
+  if (reason === null) {
+    return null;
+  }
+  return {
+    type: "activeFollowUpExecution",
+    colony: plan.colony,
+    targetRoom: plan.targetRoom,
+    action: plan.action,
+    reason,
+    updatedAt: gameTime,
+    ...plan.controllerId ? { controllerId: plan.controllerId } : {},
+    followUp: plan.followUp
+  };
+}
+function getTerritoryFollowUpExecutionHintReason(targetRoom, action, controllerId, colonyOwnerUsername) {
+  if (getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) !== "available") {
+    return null;
+  }
+  if (action === "scout") {
+    return "followUpTargetStillUnseen";
+  }
+  const controllerEvidenceState = getVisibleTerritoryControllerEvidenceState(
+    targetRoom,
+    action,
+    controllerId,
+    colonyOwnerUsername
+  );
+  return controllerEvidenceState === null ? "controlEvidenceStillMissing" : "visibleControlEvidenceStillActionable";
+}
+function upsertTerritoryFollowUpExecutionHint(hints, nextHint) {
+  const existingIndex = hints.findIndex((hint) => hint.colony === nextHint.colony);
+  if (existingIndex >= 0) {
+    hints[existingIndex] = nextHint;
+    return;
+  }
+  hints.push(nextHint);
+}
+function removeTerritoryFollowUpExecutionHint(territoryMemory, colony, targetRoom, action) {
+  const hints = normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints).filter(
+    (hint) => !(hint.colony === colony && hint.targetRoom === targetRoom && hint.action === action)
+  );
+  setTerritoryFollowUpExecutionHints(territoryMemory, hints);
+}
+function setTerritoryFollowUpExecutionHints(territoryMemory, hints) {
+  if (hints.length > 0) {
+    territoryMemory.executionHints = hints;
+  } else {
+    delete territoryMemory.executionHints;
+  }
+}
+function normalizeTerritoryFollowUpExecutionHints(rawHints) {
+  return Array.isArray(rawHints) ? rawHints.flatMap((hint) => {
+    const normalizedHint = normalizeTerritoryFollowUpExecutionHint(hint);
+    return normalizedHint ? [normalizedHint] : [];
+  }) : [];
+}
+function normalizeTerritoryFollowUpExecutionHint(rawHint) {
+  if (!isRecord2(rawHint)) {
+    return null;
+  }
+  if (rawHint.type !== "activeFollowUpExecution" || !isNonEmptyString2(rawHint.colony) || !isNonEmptyString2(rawHint.targetRoom) || !isTerritoryIntentAction2(rawHint.action) || !isTerritoryExecutionHintReason(rawHint.reason) || typeof rawHint.updatedAt !== "number") {
+    return null;
+  }
+  const followUp = normalizeTerritoryFollowUp2(rawHint.followUp);
+  if (!followUp) {
+    return null;
+  }
+  return {
+    type: "activeFollowUpExecution",
+    colony: rawHint.colony,
+    targetRoom: rawHint.targetRoom,
+    action: rawHint.action,
+    reason: rawHint.reason,
+    updatedAt: rawHint.updatedAt,
+    ...typeof rawHint.controllerId === "string" ? { controllerId: rawHint.controllerId } : {},
+    followUp
+  };
+}
+function isSameTerritoryFollowUp(left, right) {
+  return left.source === right.source && left.originRoom === right.originRoom && left.originAction === right.originAction;
 }
 function normalizeTerritoryIntent2(rawIntent) {
   if (!isRecord2(rawIntent)) {
@@ -2793,6 +2959,9 @@ function isTerritoryFollowUpSource2(source) {
 }
 function isTerritoryIntentStatus2(status) {
   return status === "planned" || status === "active" || status === "suppressed";
+}
+function isTerritoryExecutionHintReason(reason) {
+  return reason === "controlEvidenceStillMissing" || reason === "followUpTargetStillUnseen" || reason === "visibleControlEvidenceStillActionable";
 }
 function isNonEmptyString2(value) {
   return typeof value === "string" && value.length > 0;
@@ -4993,8 +5162,13 @@ function summarizeRoom(colony, creeps) {
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
     constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
-    territoryRecommendation
+    territoryRecommendation,
+    ...buildTerritoryExecutionHintSummary(colony.room.name)
   };
+}
+function buildTerritoryExecutionHintSummary(colonyName) {
+  const territoryExecutionHints = getActiveTerritoryFollowUpExecutionHints(colonyName);
+  return territoryExecutionHints.length > 0 ? { territoryExecutionHints } : {};
 }
 function summarizeSpawn(spawn) {
   if (!spawn.spawning) {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -5,6 +5,7 @@ import {
   persistOccupationRecommendationFollowUpIntent,
   type OccupationRecommendationReport
 } from '../territory/occupationRecommendation';
+import { getActiveTerritoryFollowUpExecutionHints } from '../territory/territoryPlanner';
 
 export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
@@ -46,6 +47,7 @@ interface RuntimeRoomSummary {
   combat: RuntimeCombatSummary;
   constructionPriority: RuntimeConstructionPrioritySummary;
   territoryRecommendation: OccupationRecommendationReport;
+  territoryExecutionHints?: TerritoryExecutionHintMemory[];
 }
 
 interface RuntimeControllerSummary {
@@ -159,8 +161,16 @@ function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSumm
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
     constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
-    territoryRecommendation
+    territoryRecommendation,
+    ...buildTerritoryExecutionHintSummary(colony.room.name)
   };
+}
+
+function buildTerritoryExecutionHintSummary(
+  colonyName: string
+): { territoryExecutionHints?: TerritoryExecutionHintMemory[] } {
+  const territoryExecutionHints = getActiveTerritoryFollowUpExecutionHints(colonyName);
+  return territoryExecutionHints.length > 0 ? { territoryExecutionHints } : {};
 }
 
 function summarizeSpawn(spawn: StructureSpawn): RuntimeSpawnStatus {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -166,6 +166,7 @@ export function recordRecoveredTerritoryFollowUpRetryCooldown(
     lastAttemptAt: gameTime
   };
   removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
+  removeTerritoryFollowUpExecutionHint(territoryMemory, plan.colony, plan.targetRoom, plan.action);
 }
 
 export function shouldSpawnTerritoryControllerCreep(
@@ -241,6 +242,21 @@ export function hasActiveTerritoryFollowUpPreparationDemand(
   return normalizeTerritoryFollowUpDemands(territoryMemory.demands).some(
     (demand) => demand.updatedAt === gameTime && demand.colony === colony && demand.workerCount > 0
   );
+}
+
+export function getActiveTerritoryFollowUpExecutionHints(
+  colony: string | null | undefined = undefined
+): TerritoryExecutionHintMemory[] {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return [];
+  }
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  return getBoundedActiveTerritoryFollowUpExecutionHints(
+    normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
+    intents
+  ).filter((hint) => !isNonEmptyString(colony) || hint.colony === colony);
 }
 
 export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemory {
@@ -427,6 +443,7 @@ export function suppressTerritoryIntent(
 
   upsertTerritoryIntent(intents, suppressedIntent);
   removeTerritoryFollowUpDemand(territoryMemory, colony, assignment.targetRoom, assignment.action);
+  removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
 
 export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {
@@ -465,6 +482,7 @@ function selectTerritoryTarget(
       territoryMemory.intents = intents;
     }
   }
+  refreshTerritoryFollowUpExecutionHints(territoryMemory, intents);
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     colony,
@@ -1814,6 +1832,7 @@ function recordTerritoryIntent(
 
   upsertTerritoryIntent(intents, nextIntent);
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
+  recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
 }
 
 function normalizeTerritoryIntents(rawIntents: TerritoryMemory['intents'] | unknown): TerritoryIntentMemory[] {
@@ -2040,6 +2059,247 @@ function getCurrentTerritoryFollowUpDemand(
         demand.targetRoom === plan.targetRoom &&
         demand.action === plan.action
     ) ?? null
+  );
+}
+
+function recordTerritoryFollowUpExecutionHint(
+  territoryMemory: TerritoryMemory,
+  plan: TerritoryIntentPlan,
+  gameTime: number
+): void {
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  const currentHints = getBoundedActiveTerritoryFollowUpExecutionHints(
+    normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
+    intents
+  );
+  const nextHint = buildTerritoryFollowUpExecutionHint(plan, gameTime);
+  if (!nextHint) {
+    setTerritoryFollowUpExecutionHints(
+      territoryMemory,
+      currentHints.filter((hint) => hint.colony !== plan.colony)
+    );
+    return;
+  }
+
+  upsertTerritoryFollowUpExecutionHint(currentHints, nextHint);
+  setTerritoryFollowUpExecutionHints(territoryMemory, currentHints);
+}
+
+function refreshTerritoryFollowUpExecutionHints(
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[]
+): void {
+  if (!territoryMemory || !Array.isArray(territoryMemory.executionHints)) {
+    return;
+  }
+
+  setTerritoryFollowUpExecutionHints(
+    territoryMemory,
+    getBoundedActiveTerritoryFollowUpExecutionHints(
+      normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
+      intents
+    )
+  );
+}
+
+function getBoundedActiveTerritoryFollowUpExecutionHints(
+  hints: TerritoryExecutionHintMemory[],
+  intents: TerritoryIntentMemory[]
+): TerritoryExecutionHintMemory[] {
+  const latestHintByColony = new Map<string, TerritoryExecutionHintMemory>();
+  for (const hint of hints) {
+    if (!isTerritoryFollowUpExecutionHintStillActive(hint, intents)) {
+      continue;
+    }
+
+    const existingHint = latestHintByColony.get(hint.colony);
+    if (
+      !existingHint ||
+      hint.updatedAt > existingHint.updatedAt ||
+      (hint.updatedAt === existingHint.updatedAt && hint.targetRoom.localeCompare(existingHint.targetRoom) < 0)
+    ) {
+      latestHintByColony.set(hint.colony, hint);
+    }
+  }
+
+  return Array.from(latestHintByColony.values()).sort((left, right) => left.colony.localeCompare(right.colony));
+}
+
+function isTerritoryFollowUpExecutionHintStillActive(
+  hint: TerritoryExecutionHintMemory,
+  intents: TerritoryIntentMemory[]
+): boolean {
+  const matchingIntent = findMatchingActiveTerritoryFollowUpIntent(hint, intents);
+  if (!matchingIntent?.followUp || !isSameTerritoryFollowUp(hint.followUp, matchingIntent.followUp)) {
+    return false;
+  }
+
+  return (
+    getTerritoryFollowUpExecutionHintReason(
+      matchingIntent.targetRoom,
+      matchingIntent.action,
+      matchingIntent.controllerId,
+      getVisibleColonyOwnerUsername(matchingIntent.colony)
+    ) !== null
+  );
+}
+
+function findMatchingActiveTerritoryFollowUpIntent(
+  hint: TerritoryExecutionHintMemory,
+  intents: TerritoryIntentMemory[]
+): TerritoryIntentMemory | null {
+  return (
+    intents.find(
+      (intent) =>
+        intent.colony === hint.colony &&
+        intent.targetRoom === hint.targetRoom &&
+        intent.action === hint.action &&
+        (intent.status === 'planned' || intent.status === 'active') &&
+        intent.followUp !== undefined
+    ) ?? null
+  );
+}
+
+function buildTerritoryFollowUpExecutionHint(
+  plan: TerritoryIntentPlan,
+  gameTime: number
+): TerritoryExecutionHintMemory | null {
+  if (!plan.followUp) {
+    return null;
+  }
+
+  const reason = getTerritoryFollowUpExecutionHintReason(
+    plan.targetRoom,
+    plan.action,
+    plan.controllerId,
+    getVisibleColonyOwnerUsername(plan.colony)
+  );
+  if (reason === null) {
+    return null;
+  }
+
+  return {
+    type: 'activeFollowUpExecution',
+    colony: plan.colony,
+    targetRoom: plan.targetRoom,
+    action: plan.action,
+    reason,
+    updatedAt: gameTime,
+    ...(plan.controllerId ? { controllerId: plan.controllerId } : {}),
+    followUp: plan.followUp
+  };
+}
+
+function getTerritoryFollowUpExecutionHintReason(
+  targetRoom: string,
+  action: TerritoryIntentAction,
+  controllerId: Id<StructureController> | undefined,
+  colonyOwnerUsername: string | null
+): TerritoryExecutionHintReason | null {
+  if (getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) !== 'available') {
+    return null;
+  }
+
+  if (action === 'scout') {
+    return 'followUpTargetStillUnseen';
+  }
+
+  const controllerEvidenceState = getVisibleTerritoryControllerEvidenceState(
+    targetRoom,
+    action,
+    controllerId,
+    colonyOwnerUsername
+  );
+  return controllerEvidenceState === null
+    ? 'controlEvidenceStillMissing'
+    : 'visibleControlEvidenceStillActionable';
+}
+
+function upsertTerritoryFollowUpExecutionHint(
+  hints: TerritoryExecutionHintMemory[],
+  nextHint: TerritoryExecutionHintMemory
+): void {
+  const existingIndex = hints.findIndex((hint) => hint.colony === nextHint.colony);
+  if (existingIndex >= 0) {
+    hints[existingIndex] = nextHint;
+    return;
+  }
+
+  hints.push(nextHint);
+}
+
+function removeTerritoryFollowUpExecutionHint(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  targetRoom: string,
+  action: TerritoryIntentAction
+): void {
+  const hints = normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints).filter(
+    (hint) => !(hint.colony === colony && hint.targetRoom === targetRoom && hint.action === action)
+  );
+  setTerritoryFollowUpExecutionHints(territoryMemory, hints);
+}
+
+function setTerritoryFollowUpExecutionHints(
+  territoryMemory: TerritoryMemory | Record<string, unknown>,
+  hints: TerritoryExecutionHintMemory[]
+): void {
+  if (hints.length > 0) {
+    territoryMemory.executionHints = hints;
+  } else {
+    delete territoryMemory.executionHints;
+  }
+}
+
+function normalizeTerritoryFollowUpExecutionHints(rawHints: unknown): TerritoryExecutionHintMemory[] {
+  return Array.isArray(rawHints)
+    ? rawHints.flatMap((hint) => {
+        const normalizedHint = normalizeTerritoryFollowUpExecutionHint(hint);
+        return normalizedHint ? [normalizedHint] : [];
+      })
+    : [];
+}
+
+function normalizeTerritoryFollowUpExecutionHint(rawHint: unknown): TerritoryExecutionHintMemory | null {
+  if (!isRecord(rawHint)) {
+    return null;
+  }
+
+  if (
+    rawHint.type !== 'activeFollowUpExecution' ||
+    !isNonEmptyString(rawHint.colony) ||
+    !isNonEmptyString(rawHint.targetRoom) ||
+    !isTerritoryIntentAction(rawHint.action) ||
+    !isTerritoryExecutionHintReason(rawHint.reason) ||
+    typeof rawHint.updatedAt !== 'number'
+  ) {
+    return null;
+  }
+
+  const followUp = normalizeTerritoryFollowUp(rawHint.followUp);
+  if (!followUp) {
+    return null;
+  }
+
+  return {
+    type: 'activeFollowUpExecution',
+    colony: rawHint.colony,
+    targetRoom: rawHint.targetRoom,
+    action: rawHint.action,
+    reason: rawHint.reason,
+    updatedAt: rawHint.updatedAt,
+    ...(typeof rawHint.controllerId === 'string'
+      ? { controllerId: rawHint.controllerId as Id<StructureController> }
+      : {}),
+    followUp
+  };
+}
+
+function isSameTerritoryFollowUp(left: TerritoryFollowUpMemory, right: TerritoryFollowUpMemory): boolean {
+  return (
+    left.source === right.source &&
+    left.originRoom === right.originRoom &&
+    left.originAction === right.originAction
   );
 }
 
@@ -2682,6 +2942,14 @@ function isTerritoryFollowUpSource(source: unknown): source is TerritoryFollowUp
 
 function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {
   return status === 'planned' || status === 'active' || status === 'suppressed';
+}
+
+function isTerritoryExecutionHintReason(reason: unknown): reason is TerritoryExecutionHintReason {
+  return (
+    reason === 'controlEvidenceStillMissing' ||
+    reason === 'followUpTargetStillUnseen' ||
+    reason === 'visibleControlEvidenceStillActionable'
+  );
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2076,7 +2076,9 @@ function recordTerritoryFollowUpExecutionHint(
   if (!nextHint) {
     setTerritoryFollowUpExecutionHints(
       territoryMemory,
-      currentHints.filter((hint) => hint.colony !== plan.colony)
+      hasActiveTerritoryFollowUpIntentForColony(intents, plan.colony)
+        ? currentHints
+        : currentHints.filter((hint) => hint.colony !== plan.colony)
     );
     return;
   }
@@ -2154,10 +2156,17 @@ function findMatchingActiveTerritoryFollowUpIntent(
         intent.colony === hint.colony &&
         intent.targetRoom === hint.targetRoom &&
         intent.action === hint.action &&
-        (intent.status === 'planned' || intent.status === 'active') &&
-        intent.followUp !== undefined
+        isActiveTerritoryFollowUpIntent(intent)
     ) ?? null
   );
+}
+
+function hasActiveTerritoryFollowUpIntentForColony(intents: TerritoryIntentMemory[], colony: string): boolean {
+  return intents.some((intent) => intent.colony === colony && isActiveTerritoryFollowUpIntent(intent));
+}
+
+function isActiveTerritoryFollowUpIntent(intent: TerritoryIntentMemory): boolean {
+  return (intent.status === 'planned' || intent.status === 'active') && intent.followUp !== undefined;
 }
 
 function buildTerritoryFollowUpExecutionHint(

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -19,11 +19,16 @@ declare global {
   type TerritoryIntentAction = TerritoryControlAction | 'scout';
   type TerritoryDemandType = 'followUpPreparation';
   type TerritoryFollowUpSource = 'satisfiedClaimAdjacent' | 'satisfiedReserveAdjacent' | 'activeReserveAdjacent';
+  type TerritoryExecutionHintReason =
+    | 'controlEvidenceStillMissing'
+    | 'followUpTargetStillUnseen'
+    | 'visibleControlEvidenceStillActionable';
 
   interface TerritoryMemory {
     targets?: TerritoryTargetMemory[];
     intents?: TerritoryIntentMemory[];
     demands?: TerritoryFollowUpDemandMemory[];
+    executionHints?: TerritoryExecutionHintMemory[];
     routeDistances?: Record<string, number | null>;
   }
 
@@ -59,6 +64,17 @@ declare global {
     action: TerritoryControlAction;
     workerCount: number;
     updatedAt: number;
+    followUp: TerritoryFollowUpMemory;
+  }
+
+  interface TerritoryExecutionHintMemory {
+    type: 'activeFollowUpExecution';
+    colony: string;
+    targetRoom: string;
+    action: TerritoryIntentAction;
+    reason: TerritoryExecutionHintReason;
+    updatedAt: number;
+    controllerId?: Id<StructureController>;
     followUp: TerritoryFollowUpMemory;
   }
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -293,6 +293,49 @@ describe('runtime telemetry summaries', () => {
     ]);
   });
 
+  it('emits active territory follow-up execution hints in room telemetry', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    const executionHint: TerritoryExecutionHintMemory = {
+      type: 'activeFollowUpExecution',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      reason: 'visibleControlEvidenceStillActionable',
+      updatedAt: RUNTIME_SUMMARY_INTERVAL - 1,
+      followUp
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 1,
+            followUp
+          }
+        ],
+        executionHints: [executionHint]
+      }
+    };
+    (Game.rooms as Record<string, Room>).W2N1 = makeRemoteRoom('W2N1', {
+      controller: { my: false } as StructureController,
+      sourceCount: 1
+    });
+
+    emitRuntimeSummary([colony], []);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.territoryExecutionHints).toEqual([executionHint]);
+  });
+
   it('keeps emission gating deterministic', () => {
     expect(shouldEmitRuntimeSummary(1, [])).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [])).toBe(true);

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2588,6 +2588,53 @@ describe('planTerritoryIntent', () => {
     expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([]);
   });
 
+  it('preserves an active execution hint when a live follow-up intent remains behind a scout plan', () => {
+    const colony = makeSafeColony();
+    colony.energyAvailable = 50;
+    (colony.room as Room & { energyAvailable: number }).energyAvailable = 50;
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const followUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const followUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 596,
+      followUp
+    };
+    const existingHint: TerritoryExecutionHintMemory = {
+      type: 'activeFollowUpExecution',
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      reason: 'visibleControlEvidenceStillActionable',
+      updatedAt: 596,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W3N1: makeRecommendationRoom('W3N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, followUpTarget],
+        intents: [followUpIntent],
+        executionHints: [existingHint]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 597)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'scout'
+    });
+    expect(Memory.territory?.executionHints).toEqual([existingHint]);
+    expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([existingHint]);
+  });
+
   it('drops persisted follow-up metadata after visible controller evidence satisfies the target', () => {
     const colony = makeSafeColony();
     const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1,6 +1,7 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   buildTerritoryCreepMemory,
+  getActiveTerritoryFollowUpExecutionHints,
   planTerritoryIntent,
   recordRecoveredTerritoryFollowUpRetryCooldown,
   shouldSpawnTerritoryControllerCreep,
@@ -2479,6 +2480,114 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('records and refreshes one active execution hint for a persisted actionable follow-up', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const followUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const followUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 592,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', { sourceCount: 2 }),
+        W3N1: makeRecommendationRoom('W3N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, followUpTarget],
+        intents: [followUpIntent],
+        executionHints: [
+          {
+            type: 'activeFollowUpExecution',
+            colony: 'W1N1',
+            targetRoom: 'W9N9',
+            action: 'reserve',
+            reason: 'visibleControlEvidenceStillActionable',
+            updatedAt: 591,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 593)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      followUp
+    });
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 594)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      followUp
+    });
+
+    const expectedHint: TerritoryExecutionHintMemory = {
+      type: 'activeFollowUpExecution',
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      reason: 'visibleControlEvidenceStillActionable',
+      updatedAt: 594,
+      followUp
+    };
+    expect(Memory.territory?.executionHints).toEqual([expectedHint]);
+    expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([expectedHint]);
+  });
+
+  it('clears a stale execution hint when the matching follow-up intent is gone', () => {
+    const colony = makeSafeColony();
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 595
+          }
+        ],
+        executionHints: [
+          {
+            type: 'activeFollowUpExecution',
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            reason: 'visibleControlEvidenceStillActionable',
+            updatedAt: 595,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 596)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.executionHints).toBeUndefined();
+    expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([]);
+  });
+
   it('drops persisted follow-up metadata after visible controller evidence satisfies the target', () => {
     const colony = makeSafeColony();
     const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
@@ -2507,7 +2616,18 @@ describe('planTerritoryIntent', () => {
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
         targets: [genericTarget, staleFollowUpTarget],
-        intents: [staleFollowUpIntent]
+        intents: [staleFollowUpIntent],
+        executionHints: [
+          {
+            type: 'activeFollowUpExecution',
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            reason: 'visibleControlEvidenceStillActionable',
+            updatedAt: 590,
+            followUp
+          }
+        ]
       }
     };
 
@@ -2535,6 +2655,7 @@ describe('planTerritoryIntent', () => {
       }
     ]);
     expect(Memory.territory?.demands).toBeUndefined();
+    expect(Memory.territory?.executionHints).toBeUndefined();
   });
 
   it('scouts an alternate adjacent room while a recovered follow-up target is cooling down', () => {


### PR DESCRIPTION
## Summary
- Exposes active territory follow-up execution hints in runtime summaries while the selected follow-up remains actionable.
- Persists bounded execution hints in territory memory and clears them when intents are suppressed/recovered or visible control evidence changes.
- Adds focused Jest coverage for hint persistence, cleanup, and runtime-summary output.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`

Recovered by scheduler from an accidentally dirty main worktree into the proper issue worktree; commit authored by Codex as required.

Closes #296
