### PR TITLE
feat: execute stalled territory control follow-ups

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1081,6 +1081,30 @@ function isFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+// src/territory/controllerSigning.ts
+var OCCUPIED_CONTROLLER_SIGN_TEXT = "by Hermes Screeps Project";
+var ERR_NOT_IN_RANGE_CODE = -9;
+var ERR_TIRED_CODE = -11;
+var OK_CODE = 0;
+function shouldSignOccupiedController(controller) {
+  var _a;
+  return (controller == null ? void 0 : controller.my) === true && ((_a = controller.sign) == null ? void 0 : _a.text) !== OCCUPIED_CONTROLLER_SIGN_TEXT;
+}
+function signOccupiedControllerIfNeeded(creep, controller) {
+  if (!controller || !shouldSignOccupiedController(controller) || typeof creep.signController !== "function") {
+    return "skipped";
+  }
+  const result = creep.signController(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+  if (result === ERR_NOT_IN_RANGE_CODE) {
+    if (typeof creep.moveTo !== "function") {
+      return "blocked";
+    }
+    const moveResult = creep.moveTo(controller);
+    return moveResult === OK_CODE || moveResult === ERR_TIRED_CODE ? "moving" : "blocked";
+  }
+  return result === OK_CODE ? "signed" : "skipped";
+}
+
 // src/territory/territoryPlanner.ts
 var TERRITORY_CLAIMER_ROLE = "claimer";
 var TERRITORY_SCOUT_ROLE = "scout";
@@ -1298,7 +1322,7 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
     return !isVisibleRoomMissingController(assignment.targetRoom);
   }
   if (assignment.action === "claim" && controller.my === true) {
-    return false;
+    return shouldSignOccupiedController(controller);
   }
   const actorUsername = getTerritoryActorUsername(creep, colony);
   const targetState = getTerritoryControllerTargetState(controller, assignment.action, actorUsername);
@@ -1309,7 +1333,7 @@ function isVisibleTerritoryAssignmentComplete(assignment, creep) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
-  return (controller == null ? void 0 : controller.my) === true;
+  return (controller == null ? void 0 : controller.my) === true && (!shouldSignOccupiedController(controller) || isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom));
 }
 function suppressTerritoryIntent(colony, assignment, gameTime) {
   if (!isNonEmptyString2(colony) || !isNonEmptyString2(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
@@ -3630,30 +3654,6 @@ function getGameCreeps() {
   return creeps ? Object.values(creeps) : [];
 }
 
-// src/territory/controllerSigning.ts
-var OCCUPIED_CONTROLLER_SIGN_TEXT = "by Hermes Screeps Project";
-var ERR_NOT_IN_RANGE_CODE = -9;
-var ERR_TIRED_CODE = -11;
-var OK_CODE = 0;
-function shouldSignOccupiedController(controller) {
-  var _a;
-  return (controller == null ? void 0 : controller.my) === true && ((_a = controller.sign) == null ? void 0 : _a.text) !== OCCUPIED_CONTROLLER_SIGN_TEXT;
-}
-function signOccupiedControllerIfNeeded(creep, controller) {
-  if (!controller || !shouldSignOccupiedController(controller) || typeof creep.signController !== "function") {
-    return "skipped";
-  }
-  const result = creep.signController(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
-  if (result === ERR_NOT_IN_RANGE_CODE) {
-    if (typeof creep.moveTo !== "function") {
-      return "blocked";
-    }
-    const moveResult = creep.moveTo(controller);
-    return moveResult === OK_CODE || moveResult === ERR_TIRED_CODE ? "moving" : "blocked";
-  }
-  return result === OK_CODE ? "signed" : "skipped";
-}
-
 // src/creeps/workerRunner.ts
 function runWorker(creep) {
   const selectedTask = selectWorkerTask(creep);
@@ -5244,6 +5244,9 @@ function runTerritoryControllerCreep(creep) {
     if (assignment.action === "reserve") {
       suppressTerritoryAssignment(creep, assignment);
     } else {
+      if (signOccupiedControllerIfNeeded(creep, controller) === "moving") {
+        return;
+      }
       completeTerritoryAssignment(creep);
     }
     return;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1345,7 +1345,17 @@ function isVisibleTerritoryAssignmentComplete(assignment, creep) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
-  return (controller == null ? void 0 : controller.my) === true && (!shouldSignOccupiedController(controller) || isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom));
+  return (controller == null ? void 0 : controller.my) === true && !shouldSignOccupiedController(controller);
+}
+function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, creep) {
+  if (assignment.action !== "claim" || !isNonEmptyString2(assignment.targetRoom)) {
+    return false;
+  }
+  if (!isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
+    return false;
+  }
+  const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
+  return (controller == null ? void 0 : controller.my) === true && shouldSignOccupiedController(controller);
 }
 function suppressTerritoryIntent(colony, assignment, gameTime) {
   if (!isNonEmptyString2(colony) || !isNonEmptyString2(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
@@ -5405,6 +5415,9 @@ function runTerritoryControllerCreep(creep) {
     return;
   }
   if (!isVisibleTerritoryAssignmentSafe(assignment, creep.memory.colony, creep)) {
+    if (isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, creep)) {
+      return;
+    }
     suppressTerritoryAssignment(creep, assignment);
     return;
   }
@@ -5424,7 +5437,8 @@ function runTerritoryControllerCreep(creep) {
     if (assignment.action === "reserve") {
       suppressTerritoryAssignment(creep, assignment);
     } else {
-      if (signOccupiedControllerIfNeeded(creep, controller) === "moving") {
+      const signingResult = signOccupiedControllerIfNeeded(creep, controller);
+      if (signingResult === "moving" || signingResult === "blocked") {
         return;
       }
       completeTerritoryAssignment(creep);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -8,6 +8,7 @@ import {
   type OccupationRecommendationEvidenceStatus,
   type OccupationRecommendationScore
 } from './occupationRecommendation';
+import { shouldSignOccupiedController } from './controllerSigning';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
@@ -374,7 +375,7 @@ export function isVisibleTerritoryAssignmentSafe(
   }
 
   if (assignment.action === 'claim' && controller.my === true) {
-    return false;
+    return shouldSignOccupiedController(controller);
   }
 
   const actorUsername = getTerritoryActorUsername(creep, colony);
@@ -391,7 +392,10 @@ export function isVisibleTerritoryAssignmentComplete(
   }
 
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
-  return controller?.my === true;
+  return (
+    controller?.my === true &&
+    (!shouldSignOccupiedController(controller) || isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom))
+  );
 }
 
 export function suppressTerritoryIntent(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -408,10 +408,23 @@ export function isVisibleTerritoryAssignmentComplete(
   }
 
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
-  return (
-    controller?.my === true &&
-    (!shouldSignOccupiedController(controller) || isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom))
-  );
+  return controller?.my === true && !shouldSignOccupiedController(controller);
+}
+
+export function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(
+  assignment: CreepTerritoryMemory,
+  creep?: Creep
+): boolean {
+  if (assignment.action !== 'claim' || !isNonEmptyString(assignment.targetRoom)) {
+    return false;
+  }
+
+  if (!isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
+    return false;
+  }
+
+  const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
+  return controller?.my === true && shouldSignOccupiedController(controller);
 }
 
 export function suppressTerritoryIntent(

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -4,6 +4,7 @@ import {
   isVisibleTerritoryAssignmentSafe,
   suppressTerritoryIntent
 } from './territoryPlanner';
+import { signOccupiedControllerIfNeeded } from './controllerSigning';
 
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
@@ -52,6 +53,10 @@ export function runTerritoryControllerCreep(creep: Creep): void {
     if (assignment.action === 'reserve') {
       suppressTerritoryAssignment(creep, assignment);
     } else {
+      if (signOccupiedControllerIfNeeded(creep, controller) === 'moving') {
+        return;
+      }
+
       completeTerritoryAssignment(creep);
     }
     return;

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -1,5 +1,6 @@
 import {
   canCreepReserveTerritoryController,
+  isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry,
   isVisibleTerritoryAssignmentComplete,
   isVisibleTerritoryAssignmentSafe,
   suppressTerritoryIntent
@@ -30,6 +31,10 @@ export function runTerritoryControllerCreep(creep: Creep): void {
   }
 
   if (!isVisibleTerritoryAssignmentSafe(assignment, creep.memory.colony, creep)) {
+    if (isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, creep)) {
+      return;
+    }
+
     suppressTerritoryAssignment(creep, assignment);
     return;
   }
@@ -53,7 +58,8 @@ export function runTerritoryControllerCreep(creep: Creep): void {
     if (assignment.action === 'reserve') {
       suppressTerritoryAssignment(creep, assignment);
     } else {
-      if (signOccupiedControllerIfNeeded(creep, controller) === 'moving') {
+      const signingResult = signOccupiedControllerIfNeeded(creep, controller);
+      if (signingResult === 'moving' || signingResult === 'blocked') {
         return;
       }
 

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -3,6 +3,7 @@ import {
   TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
   TERRITORY_RESERVATION_RENEWAL_TICKS
 } from '../src/territory/territoryPlanner';
+import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
 import { runTerritoryControllerCreep } from '../src/territory/territoryRunner';
 
 describe('runTerritoryControllerCreep', () => {
@@ -257,7 +258,12 @@ describe('runTerritoryControllerCreep', () => {
     const sharedIntents: TerritoryIntentMemory[] = [
       { colony: 'W1N1', targetRoom: 'W1N2', action: 'claim', status: 'active', updatedAt: 508 }
     ];
-    const controller = { id: 'controller1', my: true, owner: { username: 'me' } } as StructureController;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      owner: { username: 'me' },
+      sign: { username: 'me', text: OCCUPIED_CONTROLLER_SIGN_TEXT, time: 500, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 509,
       rooms: {
@@ -281,6 +287,100 @@ describe('runTerritoryControllerCreep', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
     expect(creep.memory.territory).toBeUndefined();
     expect(Memory.territory?.intents).toEqual(sharedIntents);
+  });
+
+  it('keeps a completed follow-up claim assignment active while moving to sign the claimed controller', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedClaimAdjacent',
+      originRoom: 'W1N1',
+      originAction: 'claim'
+    };
+    const controller = {
+      id: 'controller1',
+      my: true,
+      owner: { username: 'me' },
+      sign: { username: 'enemy', text: 'not ours', time: 500, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 510,
+      rooms: {
+        W1N2: { name: 'W1N2', controller } as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim', followUp } },
+      room: { name: 'W1N1' },
+      claimController: jest.fn(),
+      signController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.signController).not.toHaveBeenCalled();
+    expect(creep.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W1N2' });
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'claim', followUp });
+    expect(Memory.territory).toBeUndefined();
+  });
+
+  it('signs a claimed controller before clearing the follow-up territory assignment', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedClaimAdjacent',
+      originRoom: 'W1N1',
+      originAction: 'claim'
+    };
+    const controller = {
+      id: 'controller1',
+      my: true,
+      owner: { username: 'me' },
+      sign: { username: 'enemy', text: 'not ours', time: 500, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim', followUp } },
+      room: { name: 'W1N2', controller },
+      claimController: jest.fn(),
+      signController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory).toBeUndefined();
+  });
+
+  it('keeps the claim assignment while moving into controller-signing range', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedClaimAdjacent',
+      originRoom: 'W1N1',
+      originAction: 'claim'
+    };
+    const controller = {
+      id: 'controller1',
+      my: true,
+      owner: { username: 'me' },
+      sign: { username: 'enemy', text: 'not ours', time: 500, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim', followUp } },
+      room: { name: 'W1N2', controller },
+      claimController: jest.fn(),
+      signController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn().mockReturnValue(0)
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'claim', followUp });
+    expect(Memory.territory).toBeUndefined();
   });
 
   it('suppresses a claim assignment when the target room has no controller', () => {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -325,6 +325,53 @@ describe('runTerritoryControllerCreep', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
+  it('keeps an unsafe claimed controller assignment active when it still needs signing', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedClaimAdjacent',
+      originRoom: 'W1N1',
+      originAction: 'claim'
+    };
+    const controller = {
+      id: 'controller1',
+      my: true,
+      owner: { username: 'me' },
+      sign: { username: 'enemy', text: 'not ours', time: 500, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const hostile = { id: 'enemy1' } as Creep;
+    const intents: TerritoryIntentMemory[] = [
+      { colony: 'W1N1', targetRoom: 'W1N2', action: 'claim', status: 'active', updatedAt: 510 }
+    ];
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 511,
+      rooms: {
+        W1N2: {
+          name: 'W1N2',
+          controller,
+          find: jest.fn((type: number) => (type === FIND_HOSTILE_CREEPS ? [hostile] : []))
+        } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: { intents }
+    };
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim', followUp } },
+      room: { name: 'W1N1' },
+      claimController: jest.fn(),
+      signController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.signController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'claim', followUp });
+    expect(Memory.territory?.intents).toEqual(intents);
+  });
+
   it('signs a claimed controller before clearing the follow-up territory assignment', () => {
     const followUp: TerritoryFollowUpMemory = {
       source: 'satisfiedClaimAdjacent',
@@ -372,6 +419,35 @@ describe('runTerritoryControllerCreep', () => {
       claimController: jest.fn(),
       signController: jest.fn().mockReturnValue(-9),
       moveTo: jest.fn().mockReturnValue(0)
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'claim', followUp });
+    expect(Memory.territory).toBeUndefined();
+  });
+
+  it('keeps the claim assignment when controller signing is blocked', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedClaimAdjacent',
+      originRoom: 'W1N1',
+      originAction: 'claim'
+    };
+    const controller = {
+      id: 'controller1',
+      my: true,
+      owner: { username: 'me' },
+      sign: { username: 'enemy', text: 'not ours', time: 500, datetime: '2026-04-29T00:00:00.000Z' }
+    } as unknown as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim', followUp } },
+      room: { name: 'W1N2', controller },
+      claimController: jest.fn(),
+      signController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn().mockReturnValue(-7)
     } as unknown as Creep;
 
     runTerritoryControllerCreep(creep);


### PR DESCRIPTION
## Summary
- Keeps territory control follow-up assignments actionable when an already-owned controller still needs the project sign, instead of completing/suppressing the assignment immediately.
- Lets territory controller creeps sign occupied controllers before completing a claim assignment.
- Adds focused territory runner coverage and updates the bundled Screeps artifact.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

Recovered from the prior scheduler Codex lane after reconciling onto current `origin/main`; implementation commit authored by Codex as required.

Closes #295
