### PR TITLE
feat: reserve energy for spawn refill

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2809,6 +2809,7 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
+var NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -2889,6 +2890,9 @@ function selectWorkerTask(creep) {
   if (criticalRepairTarget) {
     return { type: "repair", targetId: criticalRepairTarget.id };
   }
+  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
+    return null;
+  }
   const containerConstructionSite = selectConstructionSite(creep, constructionSites, isContainerConstructionSite);
   if (containerConstructionSite) {
     return { type: "build", targetId: containerConstructionSite.id };
@@ -2917,6 +2921,29 @@ function selectWorkerTask(creep) {
   }
   return null;
 }
+function estimateNearTermSpawnExtensionRefillReserve(room) {
+  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(room);
+  if (spawnExtensionEnergyStructures.length === 0) {
+    return 0;
+  }
+  const roomRefillShortfall = estimateRoomEnergyRefillShortfall(room);
+  const immediateRefillCapacity = spawnExtensionEnergyStructures.reduce(
+    (total, structure) => total + getFreeStoredEnergyCapacity(structure),
+    0
+  );
+  const immediateRefillReserve = roomRefillShortfall === null ? immediateRefillCapacity : Math.min(immediateRefillCapacity, roomRefillShortfall);
+  return Math.max(
+    immediateRefillReserve,
+    estimateNearTermSpawnCompletionRefillReserve(room, spawnExtensionEnergyStructures)
+  );
+}
+function estimateNearTermSpawnCompletionRefillReserve(room, spawnExtensionEnergyStructures) {
+  var _a;
+  if (!spawnExtensionEnergyStructures.some(isNearTermSpawningSpawn)) {
+    return 0;
+  }
+  return Math.max(0, (_a = getRoomEnergyCapacityAvailable(room)) != null ? _a : 0);
+}
 function isTerritoryControlTask(task) {
   return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
 }
@@ -2939,8 +2966,25 @@ function findFillableEnergySinks(creep) {
   });
   return energySinks;
 }
+function findSpawnExtensionEnergyStructures(room) {
+  if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  return room.find(FIND_MY_STRUCTURES).filter((structure) => isSpawnExtensionEnergyStructure(structure));
+}
+function isSpawnExtensionEnergyStructure(structure) {
+  return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;
+}
 function isSpawnEnergySink(structure) {
   return matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+}
+function isNearTermSpawningSpawn(structure) {
+  var _a;
+  if (!matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn")) {
+    return false;
+  }
+  const remainingTime = (_a = structure.spawning) == null ? void 0 : _a.remainingTime;
+  return typeof remainingTime === "number" && remainingTime > 0 && remainingTime <= NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS;
 }
 function isSpawnOrExtensionEnergySink(structure) {
   return isSpawnEnergySink(structure) || isExtensionEnergySink(structure);
@@ -3424,6 +3468,9 @@ function shouldGuardControllerDowngrade(controller) {
 function shouldRushRcl1Controller(controller) {
   return controller.my === true && controller.level === 1;
 }
+function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) {
+  return getUsedEnergy(creep) > 0 && estimateNearTermSpawnExtensionRefillReserve(creep.room) > 0;
+}
 function shouldApplyControllerPressureLane(creep, controller) {
   if (controller.my !== true || controller.level < 2) {
     return false;
@@ -3477,6 +3524,14 @@ function getRoomEnergyAvailable(room) {
 function getRoomEnergyCapacityAvailable(room) {
   const energyCapacityAvailable = room.energyCapacityAvailable;
   return typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable) ? energyCapacityAvailable : null;
+}
+function estimateRoomEnergyRefillShortfall(room) {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  if (energyAvailable === null || energyCapacityAvailable === null) {
+    return null;
+  }
+  return Math.max(0, Math.ceil(Math.max(0, energyCapacityAvailable) - Math.max(0, energyAvailable)));
 }
 function getCreepColonyName(creep) {
   var _a;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -11,6 +11,7 @@ export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 export const TOWER_REFILL_ENERGY_FLOOR = 500;
 export const URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
+export const NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -25,6 +26,7 @@ type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
 type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal;
 type SalvageableWorkerEnergySource = Tombstone | Ruin;
 type FillableEnergySink = StructureSpawn | StructureExtension | StructureTower;
+type SpawnExtensionEnergyStructure = StructureSpawn | StructureExtension;
 type WorkerEnergyAcquisitionSource =
   | StoredWorkerEnergySource
   | SalvageableWorkerEnergySource
@@ -126,6 +128,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'repair', targetId: criticalRepairTarget.id as Id<Structure> };
   }
 
+  if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
+    return null;
+  }
+
   const containerConstructionSite = selectConstructionSite(creep, constructionSites, isContainerConstructionSite);
   if (containerConstructionSite) {
     return { type: 'build', targetId: containerConstructionSite.id };
@@ -162,6 +168,37 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   return null;
 }
 
+export function estimateNearTermSpawnExtensionRefillReserve(room: Room): number {
+  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(room);
+  if (spawnExtensionEnergyStructures.length === 0) {
+    return 0;
+  }
+
+  const roomRefillShortfall = estimateRoomEnergyRefillShortfall(room);
+  const immediateRefillCapacity = spawnExtensionEnergyStructures.reduce(
+    (total, structure) => total + getFreeStoredEnergyCapacity(structure),
+    0
+  );
+  const immediateRefillReserve =
+    roomRefillShortfall === null ? immediateRefillCapacity : Math.min(immediateRefillCapacity, roomRefillShortfall);
+
+  return Math.max(
+    immediateRefillReserve,
+    estimateNearTermSpawnCompletionRefillReserve(room, spawnExtensionEnergyStructures)
+  );
+}
+
+function estimateNearTermSpawnCompletionRefillReserve(
+  room: Room,
+  spawnExtensionEnergyStructures: SpawnExtensionEnergyStructure[]
+): number {
+  if (!spawnExtensionEnergyStructures.some(isNearTermSpawningSpawn)) {
+    return 0;
+  }
+
+  return Math.max(0, getRoomEnergyCapacityAvailable(room) ?? 0);
+}
+
 function isTerritoryControlTask(task: CreepTaskMemory | null): task is Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }> {
   return task?.type === 'claim' || task?.type === 'reserve';
 }
@@ -196,8 +233,39 @@ function findFillableEnergySinks(creep: Creep): FillableEnergySink[] {
   return energySinks;
 }
 
+function findSpawnExtensionEnergyStructures(room: Room): SpawnExtensionEnergyStructure[] {
+  if (typeof FIND_MY_STRUCTURES !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  return room
+    .find(FIND_MY_STRUCTURES)
+    .filter((structure): structure is SpawnExtensionEnergyStructure => isSpawnExtensionEnergyStructure(structure));
+}
+
+function isSpawnExtensionEnergyStructure(structure: AnyOwnedStructure): structure is SpawnExtensionEnergyStructure {
+  return (
+    (matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+      matchesStructureType(structure.structureType, 'STRUCTURE_EXTENSION', 'extension')) &&
+    'store' in structure
+  );
+}
+
 function isSpawnEnergySink(structure: FillableEnergySink): structure is StructureSpawn {
   return matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn');
+}
+
+function isNearTermSpawningSpawn(structure: SpawnExtensionEnergyStructure): structure is StructureSpawn {
+  if (!matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn')) {
+    return false;
+  }
+
+  const remainingTime = ((structure as StructureSpawn).spawning as Spawning | null | undefined)?.remainingTime;
+  return (
+    typeof remainingTime === 'number' &&
+    remainingTime > 0 &&
+    remainingTime <= NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS
+  );
 }
 
 function isSpawnOrExtensionEnergySink(structure: FillableEnergySink): structure is StructureSpawn | StructureExtension {
@@ -978,6 +1046,10 @@ function shouldRushRcl1Controller(controller: StructureController): boolean {
   return controller.my === true && controller.level === 1;
 }
 
+function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep: Creep): boolean {
+  return getUsedEnergy(creep) > 0 && estimateNearTermSpawnExtensionRefillReserve(creep.room) > 0;
+}
+
 function shouldApplyControllerPressureLane(creep: Creep, controller: StructureController): boolean {
   if (controller.my !== true || controller.level < 2) {
     return false;
@@ -1050,6 +1122,16 @@ function getRoomEnergyCapacityAvailable(room: Room): number | null {
   return typeof energyCapacityAvailable === 'number' && Number.isFinite(energyCapacityAvailable)
     ? energyCapacityAvailable
     : null;
+}
+
+function estimateRoomEnergyRefillShortfall(room: Room): number | null {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  if (energyAvailable === null || energyCapacityAvailable === null) {
+    return null;
+  }
+
+  return Math.max(0, Math.ceil(Math.max(0, energyCapacityAvailable) - Math.max(0, energyAvailable)));
 }
 
 function getCreepColonyName(creep: Creep): string | null {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4,6 +4,7 @@ import {
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   TOWER_REFILL_ENERGY_FLOOR,
   URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+  estimateNearTermSpawnExtensionRefillReserve,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
 import { TERRITORY_CONTROLLER_BODY_COST } from '../src/spawn/bodyBuilder';
@@ -1748,6 +1749,88 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
+  it('estimates no near-term refill reserve when spawn and extensions are full', () => {
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const fullExtension = makeEnergySink('extension-full', 'extension' as StructureConstant, 0);
+    const room = makeWorkerTaskRoom({
+      energyAvailable: 350,
+      energyCapacityAvailable: 350,
+      myStructures: [fullSpawn as AnyOwnedStructure, fullExtension as AnyOwnedStructure]
+    });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(0);
+  });
+
+  it('estimates partial near-term refill reserve from spawn and extension capacity', () => {
+    const spawn = makeEnergySink('spawn-partial', 'spawn' as StructureConstant, 100);
+    const extension = makeEnergySink('extension-partial', 'extension' as StructureConstant, 100);
+    const room = makeWorkerTaskRoom({
+      energyAvailable: 350,
+      energyCapacityAvailable: 400,
+      myStructures: [spawn as AnyOwnedStructure, extension as AnyOwnedStructure]
+    });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(50);
+  });
+
+  it('defers non-urgent spending while a near-term refill reserve exists', () => {
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [roadSite],
+        controller,
+        energyAvailable: 400,
+        energyCapacityAvailable: 400,
+        myStructures: [busyFullSpawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(creep.room)).toBe(400);
+    expect(selectWorkerTask(creep)).toBeNull();
+  });
+
+  it('keeps controller downgrade guard ahead of near-term refill reserve', () => {
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [roadSite],
+        controller,
+        energyAvailable: 400,
+        energyCapacityAvailable: 400,
+        myStructures: [busyFullSpawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(creep.room)).toBe(400);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('reserves a safe visible territory target before spawn recovery resource collection', () => {


### PR DESCRIPTION
## Summary
- Adds a near-term spawn/extension refill reserve so workers can defer non-urgent build/repair/upgrade spending while refill capacity is still useful.
- Preserves emergency and downgrade handling ahead of the new reserve behavior.
- Adds focused worker task coverage and updates the bundled Screeps artifact.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

Recovered from the prior scheduler Codex lane; implementation commit authored by Codex as required.

Closes #298
