### PR TITLE
feat: spend refill reserve on productive work

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3653,7 +3653,9 @@ function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) {
 }
 function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, refillReserve) {
   const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(creep.room);
-  const loadedWorkers = getSameRoomLoadedWorkers(creep).filter((worker) => getUsedEnergy(worker) > 0).sort(
+  const loadedWorkers = dedupeCreepsByStableKey(
+    getSameRoomLoadedWorkers(creep).filter((worker) => getUsedEnergy(worker) > 0)
+  ).sort(
     (left, right) => compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
   );
   let reservedEnergy = 0;
@@ -3666,10 +3668,30 @@ function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, refil
   return true;
 }
 function compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures) {
-  return compareOptionalRanges(
+  return getUsedEnergy(right) - getUsedEnergy(left) || compareOptionalRanges(
     getClosestNearTermRefillRange(left, spawnExtensionEnergyStructures),
     getClosestNearTermRefillRange(right, spawnExtensionEnergyStructures)
-  ) || getUsedEnergy(left) - getUsedEnergy(right) || getCreepStableSortKey(left).localeCompare(getCreepStableSortKey(right));
+  ) || getCreepStableSortKey(left).localeCompare(getCreepStableSortKey(right));
+}
+function dedupeCreepsByStableKey(creeps) {
+  const seenStableKeys = /* @__PURE__ */ new Set();
+  const seenCreeps = /* @__PURE__ */ new Set();
+  const uniqueCreeps = [];
+  for (const creep of creeps) {
+    if (seenCreeps.has(creep)) {
+      continue;
+    }
+    seenCreeps.add(creep);
+    const stableKey = getCreepStableSortKey(creep);
+    if (stableKey.length > 0) {
+      if (seenStableKeys.has(stableKey)) {
+        continue;
+      }
+      seenStableKeys.add(stableKey);
+    }
+    uniqueCreeps.push(creep);
+  }
+  return uniqueCreeps;
 }
 function getClosestNearTermRefillRange(creep, spawnExtensionEnergyStructures) {
   let closestRange = null;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3644,7 +3644,58 @@ function shouldRushRcl1Controller(controller) {
   return controller.my === true && controller.level === 1;
 }
 function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) {
-  return getUsedEnergy(creep) > 0 && estimateNearTermSpawnExtensionRefillReserve(creep.room) > 0;
+  const carriedEnergy = getUsedEnergy(creep);
+  if (carriedEnergy <= 0) {
+    return false;
+  }
+  const refillReserve = estimateNearTermSpawnExtensionRefillReserve(creep.room);
+  return refillReserve > 0 && isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, refillReserve);
+}
+function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, refillReserve) {
+  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(creep.room);
+  const loadedWorkers = getSameRoomLoadedWorkers(creep).filter((worker) => getUsedEnergy(worker) > 0).sort(
+    (left, right) => compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
+  );
+  let reservedEnergy = 0;
+  for (const worker of loadedWorkers) {
+    if (isSameCreep(worker, creep)) {
+      return reservedEnergy < refillReserve;
+    }
+    reservedEnergy += getUsedEnergy(worker);
+  }
+  return true;
+}
+function compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures) {
+  return compareOptionalRanges(
+    getClosestNearTermRefillRange(left, spawnExtensionEnergyStructures),
+    getClosestNearTermRefillRange(right, spawnExtensionEnergyStructures)
+  ) || getUsedEnergy(left) - getUsedEnergy(right) || getCreepStableSortKey(left).localeCompare(getCreepStableSortKey(right));
+}
+function getClosestNearTermRefillRange(creep, spawnExtensionEnergyStructures) {
+  let closestRange = null;
+  for (const structure of spawnExtensionEnergyStructures) {
+    const range = getRangeBetweenRoomObjects(creep, structure);
+    if (range === null) {
+      continue;
+    }
+    closestRange = closestRange === null ? range : Math.min(closestRange, range);
+  }
+  return closestRange;
+}
+function isSameCreep(left, right) {
+  if (left === right) {
+    return true;
+  }
+  const leftKey = getCreepStableSortKey(left);
+  return leftKey.length > 0 && leftKey === getCreepStableSortKey(right);
+}
+function getCreepStableSortKey(creep) {
+  const name = creep.name;
+  if (typeof name === "string" && name.length > 0) {
+    return name;
+  }
+  const id = creep.id;
+  return typeof id === "string" && id.length > 0 ? id : "";
 }
 function shouldApplyControllerPressureLane(creep, controller) {
   if (controller.my !== true || controller.level < 2) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1047,7 +1047,85 @@ function shouldRushRcl1Controller(controller: StructureController): boolean {
 }
 
 function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep: Creep): boolean {
-  return getUsedEnergy(creep) > 0 && estimateNearTermSpawnExtensionRefillReserve(creep.room) > 0;
+  const carriedEnergy = getUsedEnergy(creep);
+  if (carriedEnergy <= 0) {
+    return false;
+  }
+
+  const refillReserve = estimateNearTermSpawnExtensionRefillReserve(creep.room);
+  return refillReserve > 0 && isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, refillReserve);
+}
+
+function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep: Creep, refillReserve: number): boolean {
+  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(creep.room);
+  const loadedWorkers = getSameRoomLoadedWorkers(creep)
+    .filter((worker) => getUsedEnergy(worker) > 0)
+    .sort((left, right) =>
+      compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
+    );
+  let reservedEnergy = 0;
+
+  for (const worker of loadedWorkers) {
+    if (isSameCreep(worker, creep)) {
+      return reservedEnergy < refillReserve;
+    }
+
+    reservedEnergy += getUsedEnergy(worker);
+  }
+
+  return true;
+}
+
+function compareNearTermRefillReserveWorkers(
+  left: Creep,
+  right: Creep,
+  spawnExtensionEnergyStructures: SpawnExtensionEnergyStructure[]
+): number {
+  return (
+    compareOptionalRanges(
+      getClosestNearTermRefillRange(left, spawnExtensionEnergyStructures),
+      getClosestNearTermRefillRange(right, spawnExtensionEnergyStructures)
+    ) ||
+    getUsedEnergy(left) - getUsedEnergy(right) ||
+    getCreepStableSortKey(left).localeCompare(getCreepStableSortKey(right))
+  );
+}
+
+function getClosestNearTermRefillRange(
+  creep: Creep,
+  spawnExtensionEnergyStructures: SpawnExtensionEnergyStructure[]
+): number | null {
+  let closestRange: number | null = null;
+
+  for (const structure of spawnExtensionEnergyStructures) {
+    const range = getRangeBetweenRoomObjects(creep, structure);
+    if (range === null) {
+      continue;
+    }
+
+    closestRange = closestRange === null ? range : Math.min(closestRange, range);
+  }
+
+  return closestRange;
+}
+
+function isSameCreep(left: Creep, right: Creep): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  const leftKey = getCreepStableSortKey(left);
+  return leftKey.length > 0 && leftKey === getCreepStableSortKey(right);
+}
+
+function getCreepStableSortKey(creep: Creep): string {
+  const name = (creep as Creep & { name?: unknown }).name;
+  if (typeof name === 'string' && name.length > 0) {
+    return name;
+  }
+
+  const id = (creep as Creep & { id?: unknown }).id;
+  return typeof id === 'string' && id.length > 0 ? id : '';
 }
 
 function shouldApplyControllerPressureLane(creep: Creep, controller: StructureController): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1058,8 +1058,9 @@ function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep: Creep)
 
 function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep: Creep, refillReserve: number): boolean {
   const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(creep.room);
-  const loadedWorkers = getSameRoomLoadedWorkers(creep)
-    .filter((worker) => getUsedEnergy(worker) > 0)
+  const loadedWorkers = dedupeCreepsByStableKey(
+    getSameRoomLoadedWorkers(creep).filter((worker) => getUsedEnergy(worker) > 0)
+  )
     .sort((left, right) =>
       compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
     );
@@ -1082,13 +1083,40 @@ function compareNearTermRefillReserveWorkers(
   spawnExtensionEnergyStructures: SpawnExtensionEnergyStructure[]
 ): number {
   return (
+    getUsedEnergy(right) - getUsedEnergy(left) ||
     compareOptionalRanges(
       getClosestNearTermRefillRange(left, spawnExtensionEnergyStructures),
       getClosestNearTermRefillRange(right, spawnExtensionEnergyStructures)
     ) ||
-    getUsedEnergy(left) - getUsedEnergy(right) ||
     getCreepStableSortKey(left).localeCompare(getCreepStableSortKey(right))
   );
+}
+
+function dedupeCreepsByStableKey(creeps: Creep[]): Creep[] {
+  const seenStableKeys = new Set<string>();
+  const seenCreeps = new Set<Creep>();
+  const uniqueCreeps: Creep[] = [];
+
+  for (const creep of creeps) {
+    if (seenCreeps.has(creep)) {
+      continue;
+    }
+
+    seenCreeps.add(creep);
+
+    const stableKey = getCreepStableSortKey(creep);
+    if (stableKey.length > 0) {
+      if (seenStableKeys.has(stableKey)) {
+        continue;
+      }
+
+      seenStableKeys.add(stableKey);
+    }
+
+    uniqueCreeps.push(creep);
+  }
+
+  return uniqueCreeps;
 }
 
 function getClosestNearTermRefillRange(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -24,6 +24,16 @@ function makeLoadedWorker(room: Room, task?: CreepTaskMemory): Creep {
   } as unknown as Creep;
 }
 
+function makeRefillReserveWorker(room: Room, name: string, energy: number, rangeToRefill: number): Creep {
+  return {
+    name,
+    memory: { role: 'worker' },
+    store: { getUsedCapacity: jest.fn().mockReturnValue(energy) },
+    pos: { getRangeTo: jest.fn().mockReturnValue(rangeToRefill) },
+    room
+  } as unknown as Creep;
+}
+
 function setGameCreeps(creeps: Record<string, Creep>): void {
   (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps };
 }
@@ -1847,6 +1857,66 @@ describe('selectWorkerTask', () => {
       room
     } as unknown as Creep;
     setGameCreeps({ ReserveA: reserveWorkerA, ReserveB: reserveWorkerB });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(100);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('deduplicates reserve workers by stable key before counting reserved refill energy', () => {
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 100,
+      energyCapacityAvailable: 100,
+      myStructures: [busyFullSpawn as AnyOwnedStructure]
+    });
+    const reserveWorker = makeRefillReserveWorker(room, 'ReserveA', 50, 1);
+    const duplicateReserveWorker = makeRefillReserveWorker(room, 'ReserveA', 50, 2);
+    const creep = makeRefillReserveWorker(room, 'Builder', 50, 9);
+    setGameCreeps({ ReserveA: reserveWorker, ReserveAAlias: duplicateReserveWorker });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(100);
+    expect(selectWorkerTask(creep)).toBeNull();
+  });
+
+  it('reserves higher-energy workers before range tie-breakers for near-term refill capacity', () => {
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 100,
+      energyCapacityAvailable: 100,
+      myStructures: [busyFullSpawn as AnyOwnedStructure]
+    });
+    const lowEnergyReserveWorker = makeRefillReserveWorker(room, 'LowReserve', 50, 1);
+    const highEnergyReserveWorker = makeRefillReserveWorker(room, 'HighReserve', 100, 9);
+    const creep = makeRefillReserveWorker(room, 'ZBuilder', 50, 1);
+    setGameCreeps({ LowReserve: lowEnergyReserveWorker, HighReserve: highEnergyReserveWorker });
 
     expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(100);
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1804,6 +1804,102 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toBeNull();
   });
 
+  it('spends carried energy productively when other loaded workers cover the near-term refill reserve', () => {
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: 100,
+      energyCapacityAvailable: 100,
+      myStructures: [busyFullSpawn as AnyOwnedStructure]
+    });
+    const reserveWorkerA = {
+      name: 'ReserveA',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo: jest.fn().mockReturnValue(1) },
+      room
+    } as unknown as Creep;
+    const reserveWorkerB = {
+      name: 'ReserveB',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo: jest.fn().mockReturnValue(2) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo: jest.fn().mockReturnValue(9) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ ReserveA: reserveWorkerA, ReserveB: reserveWorkerB });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(100);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('keeps emergency spawn refill before surplus spending while a near-term reserve is active', () => {
+    const spawningSpawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(1) }
+    } as unknown as StructureSpawn;
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [roadSite],
+      controller,
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      energyCapacityAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+      myStructures: [spawningSpawn as AnyOwnedStructure]
+    });
+    const reserveWorkerA = {
+      name: 'ReserveA',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(100) },
+      pos: { getRangeTo: jest.fn().mockReturnValue(1) },
+      room
+    } as unknown as Creep;
+    const reserveWorkerB = {
+      name: 'ReserveB',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(100) },
+      pos: { getRangeTo: jest.fn().mockReturnValue(2) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo: jest.fn().mockReturnValue(9) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ ReserveA: reserveWorkerA, ReserveB: reserveWorkerB });
+
+    expect(estimateNearTermSpawnExtensionRefillReserve(room)).toBe(URGENT_SPAWN_REFILL_ENERGY_THRESHOLD);
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
   it('keeps controller downgrade guard ahead of near-term refill reserve', () => {
     const busyFullSpawn = {
       id: 'spawn-busy',


### PR DESCRIPTION
## Summary
- Adds a productive worker energy-spending path while spawn/extension refill reserve is active.
- Preserves emergency spawn refill and controller downgrade guard priority.
- Adds focused worker task coverage and updates the bundled Screeps artifact.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 442 tests)
- `cd prod && npm run build`

Closes #301
