### PR TITLE
feat: sustain territory follow-up roles

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -486,7 +486,7 @@ function countCreepsByRole(creeps, colonyName) {
           counts2.workerCapacity = ((_a = counts2.workerCapacity) != null ? _a : 0) + 1;
         }
       }
-      if (isColonyClaimer(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
+      if (isColonyClaimer(creep, colonyName) && canSatisfyTerritoryControllerCapacity(creep)) {
         counts2.claimer = ((_b = counts2.claimer) != null ? _b : 0) + 1;
         const targetRoom = (_c = creep.memory.territory) == null ? void 0 : _c.targetRoom;
         if (targetRoom) {
@@ -540,6 +540,26 @@ function isColonyScout(creep, colonyName) {
 }
 function canSatisfyRoleCapacity(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
+}
+function canSatisfyTerritoryControllerCapacity(creep) {
+  return canSatisfyRoleCapacity(creep) && hasActiveClaimPart(creep);
+}
+function hasActiveClaimPart(creep) {
+  var _a;
+  const claimPart = getBodyPartConstant("CLAIM", "claim");
+  const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
+  if (typeof activeClaimParts === "number") {
+    return activeClaimParts > 0;
+  }
+  if (!Array.isArray(creep.body)) {
+    return true;
+  }
+  return creep.body.some((part) => part.type === claimPart && part.hits > 0);
+}
+function getBodyPartConstant(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
 }
 
 // src/spawn/bodyBuilder.ts
@@ -2810,14 +2830,14 @@ function canRenewReservation(activeClaimParts, reservationTicksToEnd) {
 }
 function getActiveControllerClaimPartCount(creep) {
   var _a;
-  const claimPart = getBodyPartConstant("CLAIM", "claim");
+  const claimPart = getBodyPartConstant2("CLAIM", "claim");
   const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
   if (typeof activeClaimParts === "number") {
     return activeClaimParts;
   }
   return Array.isArray(creep.body) ? creep.body.filter((part) => part.type === claimPart && part.hits > 0).length : 0;
 }
-function getBodyPartConstant(globalName, fallback) {
+function getBodyPartConstant2(globalName, fallback) {
   var _a;
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
@@ -5573,6 +5593,10 @@ function runTerritoryControllerCreep(creep) {
     }
     return;
   }
+  if (isTerritoryControlAction2(assignment.action) && isCreepKnownToHaveNoActiveClaimParts(creep)) {
+    completeTerritoryAssignment(creep);
+    return;
+  }
   if (assignment.action === "reserve" && !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return;
   }
@@ -5624,6 +5648,26 @@ function getGameTime4() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
+}
+function isCreepKnownToHaveNoActiveClaimParts(creep) {
+  var _a;
+  const claimPart = getBodyPartConstant3("CLAIM", "claim");
+  const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
+  if (typeof activeClaimParts === "number") {
+    return activeClaimParts <= 0;
+  }
+  if (!Array.isArray(creep.body)) {
+    return false;
+  }
+  return !creep.body.some((part) => part.type === claimPart && part.hits > 0);
+}
+function getBodyPartConstant3(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function isTerritoryControlAction2(action) {
+  return action === "claim" || action === "reserve";
 }
 function isTerritoryAssignment(assignment) {
   return typeof (assignment == null ? void 0 : assignment.targetRoom) === "string" && assignment.targetRoom.length > 0 && (assignment.action === "claim" || assignment.action === "reserve" || assignment.action === "scout");

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -552,9 +552,16 @@ function hasActiveClaimPart(creep) {
     return activeClaimParts > 0;
   }
   if (!Array.isArray(creep.body)) {
-    return true;
+    return false;
   }
-  return creep.body.some((part) => part.type === claimPart && part.hits > 0);
+  return creep.body.some((part) => isActiveBodyPart(part, claimPart));
+}
+function isActiveBodyPart(part, bodyPartType) {
+  if (typeof part !== "object" || part === null) {
+    return false;
+  }
+  const bodyPart = part;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
 }
 function getBodyPartConstant(globalName, fallback) {
   var _a;
@@ -2833,9 +2840,16 @@ function getActiveControllerClaimPartCount(creep) {
   const claimPart = getBodyPartConstant2("CLAIM", "claim");
   const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
   if (typeof activeClaimParts === "number") {
-    return activeClaimParts;
+    return activeClaimParts > 0 ? activeClaimParts : 0;
   }
-  return Array.isArray(creep.body) ? creep.body.filter((part) => part.type === claimPart && part.hits > 0).length : 0;
+  return Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart2(part, claimPart)).length : 0;
+}
+function isActiveBodyPart2(part, bodyPartType) {
+  if (typeof part !== "object" || part === null) {
+    return false;
+  }
+  const bodyPart = part;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
 }
 function getBodyPartConstant2(globalName, fallback) {
   var _a;
@@ -5594,7 +5608,7 @@ function runTerritoryControllerCreep(creep) {
     return;
   }
   if (isTerritoryControlAction2(assignment.action) && isCreepKnownToHaveNoActiveClaimParts(creep)) {
-    completeTerritoryAssignment(creep);
+    suppressTerritoryAssignment(creep, assignment);
     return;
   }
   if (assignment.action === "reserve" && !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
@@ -5659,7 +5673,14 @@ function isCreepKnownToHaveNoActiveClaimParts(creep) {
   if (!Array.isArray(creep.body)) {
     return false;
   }
-  return !creep.body.some((part) => part.type === claimPart && part.hits > 0);
+  return !creep.body.some((part) => isActiveBodyPart3(part, claimPart));
+}
+function isActiveBodyPart3(part, bodyPartType) {
+  if (typeof part !== "object" || part === null) {
+    return false;
+  }
+  const bodyPart = part;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
 }
 function getBodyPartConstant3(globalName, fallback) {
   var _a;

--- a/prod/src/creeps/roleCounts.ts
+++ b/prod/src/creeps/roleCounts.ts
@@ -22,7 +22,7 @@ export function countCreepsByRole(creeps: Creep[], colonyName: string): RoleCoun
           counts.workerCapacity = (counts.workerCapacity ?? 0) + 1;
         }
       }
-      if (isColonyClaimer(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
+      if (isColonyClaimer(creep, colonyName) && canSatisfyTerritoryControllerCapacity(creep)) {
         counts.claimer = (counts.claimer ?? 0) + 1;
         const targetRoom = creep.memory.territory?.targetRoom;
         if (targetRoom) {
@@ -87,4 +87,27 @@ function isColonyScout(creep: Creep, colonyName: string): boolean {
 
 function canSatisfyRoleCapacity(creep: Creep): boolean {
   return creep.ticksToLive === undefined || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
+}
+
+function canSatisfyTerritoryControllerCapacity(creep: Creep): boolean {
+  return canSatisfyRoleCapacity(creep) && hasActiveClaimPart(creep);
+}
+
+function hasActiveClaimPart(creep: Creep): boolean {
+  const claimPart = getBodyPartConstant('CLAIM', 'claim');
+  const activeClaimParts = creep.getActiveBodyparts?.(claimPart);
+  if (typeof activeClaimParts === 'number') {
+    return activeClaimParts > 0;
+  }
+
+  if (!Array.isArray(creep.body)) {
+    return true;
+  }
+
+  return creep.body.some((part) => part.type === claimPart && part.hits > 0);
+}
+
+function getBodyPartConstant(globalName: 'CLAIM', fallback: BodyPartConstant): BodyPartConstant {
+  const constants = globalThis as unknown as Partial<Record<'CLAIM', BodyPartConstant>>;
+  return constants[globalName] ?? fallback;
 }

--- a/prod/src/creeps/roleCounts.ts
+++ b/prod/src/creeps/roleCounts.ts
@@ -101,10 +101,19 @@ function hasActiveClaimPart(creep: Creep): boolean {
   }
 
   if (!Array.isArray(creep.body)) {
-    return true;
+    return false;
   }
 
-  return creep.body.some((part) => part.type === claimPart && part.hits > 0);
+  return creep.body.some((part) => isActiveBodyPart(part, claimPart));
+}
+
+function isActiveBodyPart(part: unknown, bodyPartType: BodyPartConstant): boolean {
+  if (typeof part !== 'object' || part === null) {
+    return false;
+  }
+
+  const bodyPart = part as Partial<BodyPartDefinition>;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === 'number' && bodyPart.hits > 0;
 }
 
 function getBodyPartConstant(globalName: 'CLAIM', fallback: BodyPartConstant): BodyPartConstant {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2703,10 +2703,19 @@ function getActiveControllerClaimPartCount(creep: Creep): number {
   const claimPart = getBodyPartConstant('CLAIM', 'claim');
   const activeClaimParts = creep.getActiveBodyparts?.(claimPart);
   if (typeof activeClaimParts === 'number') {
-    return activeClaimParts;
+    return activeClaimParts > 0 ? activeClaimParts : 0;
   }
 
-  return Array.isArray(creep.body) ? creep.body.filter((part) => part.type === claimPart && part.hits > 0).length : 0;
+  return Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart(part, claimPart)).length : 0;
+}
+
+function isActiveBodyPart(part: unknown, bodyPartType: BodyPartConstant): boolean {
+  if (typeof part !== 'object' || part === null) {
+    return false;
+  }
+
+  const bodyPart = part as Partial<BodyPartDefinition>;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === 'number' && bodyPart.hits > 0;
 }
 
 function getBodyPartConstant(globalName: 'CLAIM', fallback: BodyPartConstant): BodyPartConstant {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -69,7 +69,7 @@ export function runTerritoryControllerCreep(creep: Creep): void {
   }
 
   if (isTerritoryControlAction(assignment.action) && isCreepKnownToHaveNoActiveClaimParts(creep)) {
-    completeTerritoryAssignment(creep);
+    suppressTerritoryAssignment(creep, assignment);
     return;
   }
 
@@ -160,7 +160,16 @@ function isCreepKnownToHaveNoActiveClaimParts(creep: Creep): boolean {
     return false;
   }
 
-  return !creep.body.some((part) => part.type === claimPart && part.hits > 0);
+  return !creep.body.some((part) => isActiveBodyPart(part, claimPart));
+}
+
+function isActiveBodyPart(part: unknown, bodyPartType: BodyPartConstant): boolean {
+  if (typeof part !== 'object' || part === null) {
+    return false;
+  }
+
+  const bodyPart = part as Partial<BodyPartDefinition>;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === 'number' && bodyPart.hits > 0;
 }
 
 function getBodyPartConstant(globalName: 'CLAIM', fallback: BodyPartConstant): BodyPartConstant {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -68,6 +68,11 @@ export function runTerritoryControllerCreep(creep: Creep): void {
     return;
   }
 
+  if (isTerritoryControlAction(assignment.action) && isCreepKnownToHaveNoActiveClaimParts(creep)) {
+    completeTerritoryAssignment(creep);
+    return;
+  }
+
   if (
     assignment.action === 'reserve' &&
     !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)
@@ -142,6 +147,29 @@ function moveTowardTargetRoom(creep: Creep, targetRoom: string): void {
 function getGameTime(): number {
   const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
   return typeof gameTime === 'number' ? gameTime : 0;
+}
+
+function isCreepKnownToHaveNoActiveClaimParts(creep: Creep): boolean {
+  const claimPart = getBodyPartConstant('CLAIM', 'claim');
+  const activeClaimParts = creep.getActiveBodyparts?.(claimPart);
+  if (typeof activeClaimParts === 'number') {
+    return activeClaimParts <= 0;
+  }
+
+  if (!Array.isArray(creep.body)) {
+    return false;
+  }
+
+  return !creep.body.some((part) => part.type === claimPart && part.hits > 0);
+}
+
+function getBodyPartConstant(globalName: 'CLAIM', fallback: BodyPartConstant): BodyPartConstant {
+  const constants = globalThis as unknown as Partial<Record<'CLAIM', BodyPartConstant>>;
+  return constants[globalName] ?? fallback;
+}
+
+function isTerritoryControlAction(action: CreepTerritoryMemory['action']): action is TerritoryControlAction {
+  return action === 'claim' || action === 'reserve';
 }
 
 function isTerritoryAssignment(assignment: CreepTerritoryMemory | undefined): assignment is CreepTerritoryMemory {

--- a/prod/test/roleCounts.test.ts
+++ b/prod/test/roleCounts.test.ts
@@ -86,4 +86,22 @@ describe('countCreepsByRole', () => {
       claimersByTargetRoomAction: { claim: { W2N1: 1 } }
     });
   });
+
+  it('excludes claimers with no active CLAIM parts from territory capacity', () => {
+    const damagedClaimer = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'reserve' } },
+      getActiveBodyparts: jest.fn().mockReturnValue(0)
+    } as unknown as Creep;
+    const healthyClaimer = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W3N1', action: 'reserve' } },
+      getActiveBodyparts: jest.fn().mockReturnValue(1)
+    } as unknown as Creep;
+
+    expect(countCreepsByRole([damagedClaimer, healthyClaimer], 'W1N1')).toEqual({
+      worker: 0,
+      claimer: 1,
+      claimersByTargetRoom: { W3N1: 1 },
+      claimersByTargetRoomAction: { reserve: { W3N1: 1 } }
+    });
+  });
 });

--- a/prod/test/roleCounts.test.ts
+++ b/prod/test/roleCounts.test.ts
@@ -4,7 +4,8 @@ describe('countCreepsByRole', () => {
   it('counts creeps by memory role and colony', () => {
     const worker = { memory: { role: 'worker', colony: 'W1N1' } } as Creep;
     const claimer = {
-      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'reserve' } }
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'reserve' } },
+      body: [{ type: 'claim', hits: 100 }]
     } as Creep;
     const scout = {
       memory: { role: 'scout', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'scout' } }
@@ -68,15 +69,18 @@ describe('countCreepsByRole', () => {
   it('excludes colony claimers at replacement age from territory capacity', () => {
     const healthyClaimer = {
       memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'claim' } },
-      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1
+      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1,
+      body: [{ type: 'claim', hits: 100 }]
     } as Creep;
     const expiringClaimer = {
       memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'claim' } },
-      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE
+      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE,
+      body: [{ type: 'claim', hits: 100 }]
     } as Creep;
     const foreignClaimer = {
       memory: { role: 'claimer', colony: 'W2N2', territory: { targetRoom: 'W2N1', action: 'claim' } },
-      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1
+      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1,
+      body: [{ type: 'claim', hits: 100 }]
     } as Creep;
 
     expect(countCreepsByRole([healthyClaimer, expiringClaimer, foreignClaimer], 'W1N1')).toEqual({
@@ -102,6 +106,27 @@ describe('countCreepsByRole', () => {
       claimer: 1,
       claimersByTargetRoom: { W3N1: 1 },
       claimersByTargetRoomAction: { reserve: { W3N1: 1 } }
+    });
+  });
+
+  it('excludes claimers with missing or malformed body data from territory capacity', () => {
+    const missingBodyClaimer = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'reserve' } }
+    } as Creep;
+    const malformedBodyClaimer = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W3N1', action: 'reserve' } },
+      body: [null, { type: 'claim' }, { type: 'claim', hits: 0 }, { type: 'work', hits: 100 }]
+    } as unknown as Creep;
+    const healthyClaimer = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W4N1', action: 'reserve' } },
+      body: [{ type: 'claim', hits: 100 }]
+    } as Creep;
+
+    expect(countCreepsByRole([missingBodyClaimer, malformedBodyClaimer, healthyClaimer], 'W1N1')).toEqual({
+      worker: 0,
+      claimer: 1,
+      claimersByTargetRoom: { W4N1: 1 },
+      claimersByTargetRoomAction: { reserve: { W4N1: 1 } }
     });
   });
 });

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -254,7 +254,7 @@ describe('runTerritoryControllerCreep', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
-  it('clears an unworkable follow-up claim assignment without suppressing the target', () => {
+  it('suppresses an unworkable follow-up claim assignment so the planner stops requeueing it', () => {
     const followUp: TerritoryFollowUpMemory = {
       source: 'satisfiedClaimAdjacent',
       originRoom: 'W1N1',
@@ -267,6 +267,10 @@ describe('runTerritoryControllerCreep', () => {
       status: 'active',
       updatedAt: 511,
       followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 512,
+      getObjectById: jest.fn().mockReturnValue(null)
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: { intents: [activeIntent] }
@@ -285,7 +289,57 @@ describe('runTerritoryControllerCreep', () => {
     expect(creep.claimController).not.toHaveBeenCalled();
     expect(creep.moveTo).not.toHaveBeenCalled();
     expect(creep.memory.territory).toBeUndefined();
-    expect(Memory.territory?.intents).toEqual([activeIntent]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        ...activeIntent,
+        status: 'suppressed',
+        updatedAt: 512
+      }
+    ]);
+  });
+
+  it('suppresses an unworkable follow-up reserve assignment so the planner stops requeueing it', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedReserveAdjacent',
+      originRoom: 'W1N1',
+      originAction: 'reserve'
+    };
+    const activeIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve',
+      status: 'active',
+      updatedAt: 513,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 514,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: { intents: [activeIntent] }
+    };
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve', followUp } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(0),
+      reserveController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        ...activeIntent,
+        status: 'suppressed',
+        updatedAt: 514
+      }
+    ]);
   });
 
   it('clears completed claim assignments without suppressing shared upgrade intent', () => {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -254,6 +254,40 @@ describe('runTerritoryControllerCreep', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
+  it('clears an unworkable follow-up claim assignment without suppressing the target', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedClaimAdjacent',
+      originRoom: 'W1N1',
+      originAction: 'claim'
+    };
+    const activeIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'claim',
+      status: 'active',
+      updatedAt: 511,
+      followUp
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: { intents: [activeIntent] }
+    };
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim', followUp } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(0),
+      claimController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([activeIntent]);
+  });
+
   it('clears completed claim assignments without suppressing shared upgrade intent', () => {
     const sharedIntents: TerritoryIntentMemory[] = [
       { colony: 'W1N1', targetRoom: 'W1N2', action: 'claim', status: 'active', updatedAt: 508 }


### PR DESCRIPTION
## Summary
- Sustains territory follow-up execution by keeping required territory/control role capacity visible to role planning.
- Adds focused territory runner and role-count coverage.
- Keeps `prod/dist/main.js` synchronized.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

Closes #303.

Scheduler note: recovered from completed Codex edits after the original process disappeared from the Hermes registry; Codex commit author preserved.