### PR TITLE
feat: prefer useful worker energy sinks

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3968,6 +3968,7 @@ function getGameCreeps() {
 }
 
 // src/creeps/workerRunner.ts
+var MAX_IMMEDIATE_RESELECT_EXECUTIONS = 1;
 function runWorker(creep) {
   const selectedTask = selectWorkerTask(creep);
   const currentTask = creep.memory.task;
@@ -3994,7 +3995,7 @@ function runWorker(creep) {
   }
   executeAssignedTask(creep, selectedTask);
 }
-function executeAssignedTask(creep, selectedTask) {
+function executeAssignedTask(creep, selectedTask, immediateReselectExecutions = 0) {
   let task = creep.memory.task;
   if (!task || !canExecuteTask(creep, task)) {
     return;
@@ -4026,7 +4027,10 @@ function executeAssignedTask(creep, selectedTask) {
   const result = executeTask(creep, task, target);
   if (task.type === "transfer" && result === ERR_FULL) {
     delete creep.memory.task;
-    assignNextTask(creep);
+    const nextTask = assignNextTask(creep);
+    if (nextTask && !isSameTask(task, nextTask) && immediateReselectExecutions < MAX_IMMEDIATE_RESELECT_EXECUTIONS) {
+      executeAssignedTask(creep, nextTask, immediateReselectExecutions + 1);
+    }
     return;
   }
   if (result === ERR_NOT_IN_RANGE) {
@@ -4068,6 +4072,7 @@ function assignNextTask(creep) {
   if (task) {
     creep.memory.task = task;
   }
+  return task;
 }
 function shouldReplaceTask(creep, task) {
   var _a, _b;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -8,6 +8,8 @@ import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
 type TransferSinkStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION' | 'STRUCTURE_TOWER';
 type CapacityConstructionStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION';
 
+const MAX_IMMEDIATE_RESELECT_EXECUTIONS = 1;
+
 export function runWorker(creep: Creep): void {
   const selectedTask = selectWorkerTask(creep);
   const currentTask = creep.memory.task;
@@ -37,7 +39,11 @@ export function runWorker(creep: Creep): void {
   executeAssignedTask(creep, selectedTask);
 }
 
-function executeAssignedTask(creep: Creep, selectedTask: CreepTaskMemory | null): void {
+function executeAssignedTask(
+  creep: Creep,
+  selectedTask: CreepTaskMemory | null,
+  immediateReselectExecutions = 0
+): void {
   let task: CreepTaskMemory | null | undefined = creep.memory.task;
   if (!task || !canExecuteTask(creep, task)) {
     return;
@@ -75,7 +81,14 @@ function executeAssignedTask(creep: Creep, selectedTask: CreepTaskMemory | null)
   const result = executeTask(creep, task, target);
   if (task.type === 'transfer' && result === ERR_FULL) {
     delete creep.memory.task;
-    assignNextTask(creep);
+    const nextTask = assignNextTask(creep);
+    if (
+      nextTask &&
+      !isSameTask(task, nextTask) &&
+      immediateReselectExecutions < MAX_IMMEDIATE_RESELECT_EXECUTIONS
+    ) {
+      executeAssignedTask(creep, nextTask, immediateReselectExecutions + 1);
+    }
     return;
   }
 
@@ -121,11 +134,13 @@ function canExecuteTask(creep: Creep, task: CreepTaskMemory): boolean {
   }
 }
 
-function assignNextTask(creep: Creep): void {
+function assignNextTask(creep: Creep): CreepTaskMemory | null {
   const task = selectWorkerTask(creep);
   if (task) {
     creep.memory.task = task;
   }
+
+  return task;
 }
 
 function shouldReplaceTask(creep: Creep, task: CreepTaskMemory): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1671,7 +1671,7 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
-  it('reselects a worker task without moving when transfer returns ERR_FULL', () => {
+  it('reselects and executes a productive worker task when transfer returns ERR_FULL', () => {
     const site = { id: 'site1' } as ConstructionSite;
     const spawn = {
       id: 'spawn1',
@@ -1696,17 +1696,17 @@ describe('runWorker', () => {
       },
       transfer: jest.fn().mockReturnValue(ERR_FULL),
       moveTo: jest.fn(),
-      build: jest.fn()
+      build: jest.fn().mockReturnValue(0)
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      getObjectById: jest.fn().mockReturnValue(spawn)
+      getObjectById: jest.fn((id: string) => (id === 'site1' ? site : spawn))
     };
 
     runWorker(creep);
 
     expect(creep.transfer).toHaveBeenCalledWith(spawn, 'energy');
     expect(creep.memory.task).toEqual({ type: 'build', targetId: 'site1' });
+    expect(creep.build).toHaveBeenCalledWith(site);
     expect(creep.moveTo).not.toHaveBeenCalled();
-    expect(creep.build).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Improves worker energy sink selection so carried energy is directed toward useful economy work.
- Adds focused worker runner coverage.
- Keeps `prod/dist/main.js` synchronized.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`

Closes #304.

Scheduler note: recovered from completed Codex edits after the original process disappeared from the Hermes registry; Codex commit author preserved.