### PR TITLE
feat: continue post-deploy territory control behavior

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1408,6 +1408,42 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
   removeTerritoryFollowUpDemand(territoryMemory, colony, assignment.targetRoom, assignment.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
+function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
+  if (!isNonEmptyString2(colony) || !isNonEmptyString2(assignment.targetRoom) || assignment.action !== "reserve") {
+    return;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return;
+  }
+  const followUp = normalizeTerritoryFollowUp2(assignment.followUp);
+  const plan = {
+    colony,
+    targetRoom: assignment.targetRoom,
+    action: "reserve",
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
+    ...followUp ? { followUp } : {}
+  };
+  appendTerritoryTargetIfMissing(territoryMemory, {
+    colony,
+    roomName: assignment.targetRoom,
+    action: "reserve",
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
+  });
+  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  upsertTerritoryIntent2(intents, {
+    colony: plan.colony,
+    targetRoom: plan.targetRoom,
+    action: plan.action,
+    status: "active",
+    updatedAt: gameTime,
+    ...plan.controllerId ? { controllerId: plan.controllerId } : {},
+    ...plan.followUp ? { followUp: plan.followUp } : {}
+  });
+  recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
+  recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
+}
 function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   if (getWorkerCapacity(roleCounts) < workerTarget) {
     return false;
@@ -2259,6 +2295,15 @@ function appendTerritoryTarget(territoryMemory, target) {
     territoryMemory.targets = [];
   }
   territoryMemory.targets.push(target);
+}
+function appendTerritoryTargetIfMissing(territoryMemory, target) {
+  if (Array.isArray(territoryMemory.targets) && territoryMemory.targets.some((rawTarget) => {
+    const existingTarget = normalizeTerritoryTarget2(rawTarget);
+    return (existingTarget == null ? void 0 : existingTarget.colony) === target.colony && existingTarget.roomName === target.roomName && existingTarget.action === target.action;
+  })) {
+    return;
+  }
+  appendTerritoryTarget(territoryMemory, target);
 }
 function getAdjacentRoomNames2(roomName) {
   const game = globalThis.Game;
@@ -5624,9 +5669,36 @@ function runTerritoryControllerCreep(creep) {
     creep.moveTo(controller);
     return;
   }
+  if (assignment.action === "claim" && result === ERR_GCL_NOT_ENOUGH_CODE && tryFallbackClaimAssignmentToReserve(creep, assignment, controller)) {
+    return;
+  }
   if (assignment.action === "claim" && CLAIM_FATAL_RESULT_CODES.has(result) || assignment.action === "reserve" && RESERVE_FATAL_RESULT_CODES.has(result)) {
     suppressTerritoryAssignment(creep, assignment);
   }
+}
+function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
+  if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
+    return false;
+  }
+  const gameTime = getGameTime4();
+  const reserveAssignment = {
+    targetRoom: assignment.targetRoom,
+    action: "reserve",
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
+    ...assignment.followUp ? { followUp: assignment.followUp } : {}
+  };
+  suppressTerritoryIntent(creep.memory.colony, assignment, gameTime);
+  recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, gameTime);
+  creep.memory.territory = reserveAssignment;
+  const reserveResult = executeControllerAction(creep, controller, "reserveController");
+  if (reserveResult === ERR_NOT_IN_RANGE_CODE2 && typeof creep.moveTo === "function") {
+    creep.moveTo(controller);
+    return true;
+  }
+  if (RESERVE_FATAL_RESULT_CODES.has(reserveResult)) {
+    suppressTerritoryAssignment(creep, reserveAssignment);
+  }
+  return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
   suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime4());

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -463,6 +463,50 @@ export function suppressTerritoryIntent(
   removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
 
+export function recordTerritoryReserveFallbackIntent(
+  colony: string | undefined,
+  assignment: CreepTerritoryMemory,
+  gameTime: number
+): void {
+  if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || assignment.action !== 'reserve') {
+    return;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const followUp = normalizeTerritoryFollowUp(assignment.followUp);
+  const plan: TerritoryIntentPlan = {
+    colony,
+    targetRoom: assignment.targetRoom,
+    action: 'reserve',
+    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {}),
+    ...(followUp ? { followUp } : {})
+  };
+  appendTerritoryTargetIfMissing(territoryMemory, {
+    colony,
+    roomName: assignment.targetRoom,
+    action: 'reserve',
+    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {})
+  });
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  upsertTerritoryIntent(intents, {
+    colony: plan.colony,
+    targetRoom: plan.targetRoom,
+    action: plan.action,
+    status: 'active',
+    updatedAt: gameTime,
+    ...(plan.controllerId ? { controllerId: plan.controllerId } : {}),
+    ...(plan.followUp ? { followUp: plan.followUp } : {})
+  });
+  recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
+  recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
+}
+
 export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {
   if (getWorkerCapacity(roleCounts) < workerTarget) {
     return false;
@@ -1776,6 +1820,24 @@ function appendTerritoryTarget(territoryMemory: TerritoryMemory, target: Territo
   }
 
   territoryMemory.targets.push(target);
+}
+
+function appendTerritoryTargetIfMissing(territoryMemory: TerritoryMemory, target: TerritoryTargetMemory): void {
+  if (
+    Array.isArray(territoryMemory.targets) &&
+    territoryMemory.targets.some((rawTarget) => {
+      const existingTarget = normalizeTerritoryTarget(rawTarget);
+      return (
+        existingTarget?.colony === target.colony &&
+        existingTarget.roomName === target.roomName &&
+        existingTarget.action === target.action
+      );
+    })
+  ) {
+    return;
+  }
+
+  appendTerritoryTarget(territoryMemory, target);
 }
 
 function getAdjacentRoomNames(roomName: string): string[] {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -3,6 +3,7 @@ import {
   isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry,
   isVisibleTerritoryAssignmentComplete,
   isVisibleTerritoryAssignmentSafe,
+  recordTerritoryReserveFallbackIntent,
   suppressTerritoryIntent
 } from './territoryPlanner';
 import { signOccupiedControllerIfNeeded } from './controllerSigning';
@@ -91,11 +92,56 @@ export function runTerritoryControllerCreep(creep: Creep): void {
   }
 
   if (
+    assignment.action === 'claim' &&
+    result === ERR_GCL_NOT_ENOUGH_CODE &&
+    tryFallbackClaimAssignmentToReserve(creep, assignment, controller)
+  ) {
+    return;
+  }
+
+  if (
     (assignment.action === 'claim' && CLAIM_FATAL_RESULT_CODES.has(result)) ||
     (assignment.action === 'reserve' && RESERVE_FATAL_RESULT_CODES.has(result))
   ) {
     suppressTerritoryAssignment(creep, assignment);
   }
+}
+
+function tryFallbackClaimAssignmentToReserve(
+  creep: Creep,
+  assignment: CreepTerritoryMemory,
+  controller: StructureController
+): boolean {
+  if (
+    typeof creep.reserveController !== 'function' ||
+    !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)
+  ) {
+    return false;
+  }
+
+  const gameTime = getGameTime();
+  const reserveAssignment: CreepTerritoryMemory = {
+    targetRoom: assignment.targetRoom,
+    action: 'reserve',
+    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {}),
+    ...(assignment.followUp ? { followUp: assignment.followUp } : {})
+  };
+
+  suppressTerritoryIntent(creep.memory.colony, assignment, gameTime);
+  recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, gameTime);
+  creep.memory.territory = reserveAssignment;
+
+  const reserveResult = executeControllerAction(creep, controller, 'reserveController');
+  if (reserveResult === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {
+    creep.moveTo(controller);
+    return true;
+  }
+
+  if (RESERVE_FATAL_RESULT_CODES.has(reserveResult)) {
+    suppressTerritoryAssignment(creep, reserveAssignment);
+  }
+
+  return true;
 }
 
 function suppressTerritoryAssignment(creep: Creep, assignment: CreepTerritoryMemory): void {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -674,6 +674,109 @@ describe('runTerritoryControllerCreep', () => {
     ]);
   });
 
+  it('falls back to reserving a follow-up claim target when GCL blocks claiming', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedClaimAdjacent',
+      originRoom: 'W1N1',
+      originAction: 'claim'
+    };
+    const claimTarget: TerritoryTargetMemory = {
+      colony: 'W1N1',
+      roomName: 'W1N2',
+      action: 'claim'
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 515,
+      rooms: {
+        W1N2: {
+          name: 'W1N2',
+          controller: { id: 'controller1', my: false } as StructureController,
+          find: jest.fn().mockReturnValue([])
+        } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [claimTarget],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 514,
+            followUp
+          }
+        ]
+      }
+    };
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim', followUp } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      claimController: jest.fn().mockReturnValue(-15),
+      reserveController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve', followUp });
+    expect(Memory.territory?.targets).toEqual([
+      claimTarget,
+      {
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 515,
+        followUp
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 515,
+        followUp
+      }
+    ]);
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: 515,
+        followUp
+      }
+    ]);
+    expect(Memory.territory?.executionHints).toEqual([
+      {
+        type: 'activeFollowUpExecution',
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        reason: 'visibleControlEvidenceStillActionable',
+        updatedAt: 515,
+        followUp
+      }
+    ]);
+  });
+
   it('suppresses an enemy-owned reserve target without issuing the impossible reserve call', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 504,


### PR DESCRIPTION
Closes #309.

## Summary
- Adds a follow-up territory control planner/runner slice for controller-reserve style behavior.
- Keeps the implementation focused in `prod/src/territory` with Jest coverage in `prod/test/territoryRunner.test.ts`.
- Rebuilds `prod/dist/main.js`.

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` (22 suites, 454 tests passed)
- `npm run build`
- `git diff --check`

Authorship: Codex-authored commit `bb36c64` by `lanyusea's bot <lanyusea@gmail.com>`.
