### PR TITLE
fix: persist runtime monitor KPI artifacts

### DIFF
--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -26,7 +26,7 @@ from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 
 DEFAULT_API_URL = "https://screeps.com"
@@ -1923,25 +1923,54 @@ def runtime_summary_artifact_name(now: datetime | None = None) -> str:
     return f"runtime-summary-monitor-{timestamp.strftime('%Y%m%dT%H%M%SZ')}.log"
 
 
-def unique_path(path: Path) -> Path:
-    if not path.exists():
-        return path
+def iter_path_candidates(path: Path) -> Iterable[Path]:
+    yield path
     for index in range(2, 1000):
-        candidate = path.with_name(f"{path.stem}-{index}{path.suffix}")
+        yield path.with_name(f"{path.stem}-{index}{path.suffix}")
+
+
+def unique_path(path: Path) -> Path:
+    for candidate in iter_path_candidates(path):
         if not candidate.exists():
             return candidate
     raise FileExistsError(f"could not choose a unique artifact path for {path}")
 
 
+def link_artifact_exclusively(temp_path: Path, path: Path) -> Path:
+    for candidate in iter_path_candidates(path):
+        try:
+            os.link(temp_path, candidate)
+            return candidate
+        except FileExistsError:
+            continue
+    raise FileExistsError(f"could not choose a unique artifact path for {path}")
+
+
 def write_runtime_summary_artifact(snapshots: list[RoomSnapshot], out_dir: Path) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
-    path = unique_path(out_dir / runtime_summary_artifact_name())
+    target = out_dir / runtime_summary_artifact_name()
     payload = runtime_summary_artifact_line(snapshots)
-    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=str(out_dir), delete=False) as handle:
-        handle.write(payload)
-        temp_name = handle.name
-    os.replace(temp_name, path)
-    return path.resolve()
+    temp_fd: int | None = None
+    temp_path: Path | None = None
+    try:
+        temp_fd, temp_name = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=str(out_dir))
+        temp_path = Path(temp_name)
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
+            temp_fd = None
+            handle.write(payload)
+        linked_path = link_artifact_exclusively(temp_path, target)
+        return linked_path.resolve()
+    finally:
+        if temp_fd is not None:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
 
 
 def redact_secrets(text: str, secrets: list[str]) -> str:

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -1851,6 +1851,11 @@ def store_energy(obj: dict[str, Any]) -> int | float:
     return energy if energy is not None else 0
 
 
+def confirmed_foreign_owner(obj: dict[str, Any], owner_username: str | None) -> bool:
+    username = room_owner(obj)
+    return bool(username is not None and username != owner_username)
+
+
 def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
     objects = snapshot.objects
     owned_structures = [obj for obj in structure_objects(objects) if is_owned_object(obj, snapshot.owner)]
@@ -1872,7 +1877,7 @@ def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
     hostile_structures = [
         obj
         for obj in structure_objects(objects)
-        if obj.get("my") is False or (snapshot.owner and room_owner(obj) and room_owner(obj) != snapshot.owner)
+        if confirmed_foreign_owner(obj, snapshot.owner)
     ]
     controller = next((obj for obj in structure_objects(objects) if obj.get("type") == "controller"), None)
 

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -24,6 +24,7 @@ import urllib.parse
 import urllib.request
 from collections import Counter
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +33,7 @@ DEFAULT_API_URL = "https://screeps.com"
 DEFAULT_OUT_DIR = Path("/root/screeps/runtime-artifacts/screeps-monitor")
 DEFAULT_STATE_FILE = Path("/root/.hermes/screeps-runtime-monitor/state.json")
 DEFAULT_CACHE_DIR = Path("/root/.hermes/screeps-runtime-monitor/terrain-cache")
+DEFAULT_RUNTIME_SUMMARY_OUT_DIR = Path("/root/screeps/runtime-artifacts/runtime-summary-console")
 DEFAULT_DEBOUNCE_SECONDS = 300
 DEFAULT_SHARD = "shardX"
 DEFAULT_ROOM = "E48S28"
@@ -1831,6 +1833,112 @@ def summarize_rooms(snapshots: list[RoomSnapshot]) -> dict[str, Any]:
     }
 
 
+def number_value(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    return None
+
+
+def store_energy(obj: dict[str, Any]) -> int | float:
+    store = obj.get("store")
+    if isinstance(store, dict):
+        energy = number_value(store.get("energy"))
+        if energy is not None:
+            return energy
+    energy = number_value(obj.get("energy"))
+    return energy if energy is not None else 0
+
+
+def runtime_summary_room(snapshot: RoomSnapshot) -> dict[str, Any]:
+    objects = snapshot.objects
+    owned_structures = [obj for obj in structure_objects(objects) if is_owned_object(obj, snapshot.owner)]
+    owned_creeps = [
+        obj
+        for obj in objects.values()
+        if isinstance(obj, dict) and obj.get("type") == "creep" and is_owned_object(obj, snapshot.owner)
+    ]
+    sources = [obj for obj in objects.values() if isinstance(obj, dict) and obj.get("type") == "source"]
+    dropped_energy = [
+        obj
+        for obj in objects.values()
+        if isinstance(obj, dict)
+        and obj.get("type") == "resource"
+        and obj.get("resourceType") == "energy"
+        and number_value(obj.get("amount")) is not None
+    ]
+    hostiles = detect_hostile_creeps(objects, snapshot.owner)
+    hostile_structures = [
+        obj
+        for obj in structure_objects(objects)
+        if obj.get("my") is False or (snapshot.owner and room_owner(obj) and room_owner(obj) != snapshot.owner)
+    ]
+    controller = next((obj for obj in structure_objects(objects) if obj.get("type") == "controller"), None)
+
+    controller_summary: dict[str, Any] = {}
+    if controller is not None:
+        for key in ("level", "progress", "progressTotal", "ticksToDowngrade"):
+            controller_summary[key] = number_value(controller.get(key))
+
+    return {
+        "roomName": snapshot.ref.room,
+        "shard": snapshot.ref.shard,
+        "controller": controller_summary,
+        "resources": {
+            "storedEnergy": sum(store_energy(obj) for obj in owned_structures),
+            "workerCarriedEnergy": sum(store_energy(obj) for obj in owned_creeps),
+            "droppedEnergy": sum(number_value(obj.get("amount")) or 0 for obj in dropped_energy),
+            "sourceCount": len(sources),
+        },
+        "combat": {
+            "hostileCreepCount": len(hostiles),
+            "hostileStructureCount": len(hostile_structures),
+        },
+    }
+
+
+def runtime_summary_payload_from_snapshots(snapshots: list[RoomSnapshot]) -> dict[str, Any]:
+    ticks = [snapshot.tick for snapshot in snapshots if isinstance(snapshot.tick, int)]
+    return {
+        "type": "runtime-summary",
+        "tick": max(ticks) if ticks else None,
+        "rooms": [runtime_summary_room(snapshot) for snapshot in snapshots],
+        "source": "screeps-runtime-monitor",
+    }
+
+
+def runtime_summary_artifact_line(snapshots: list[RoomSnapshot]) -> str:
+    payload = runtime_summary_payload_from_snapshots(snapshots)
+    return "#runtime-summary " + json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+
+
+def runtime_summary_artifact_name(now: datetime | None = None) -> str:
+    timestamp = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return f"runtime-summary-monitor-{timestamp.strftime('%Y%m%dT%H%M%SZ')}.log"
+
+
+def unique_path(path: Path) -> Path:
+    if not path.exists():
+        return path
+    for index in range(2, 1000):
+        candidate = path.with_name(f"{path.stem}-{index}{path.suffix}")
+        if not candidate.exists():
+            return candidate
+    raise FileExistsError(f"could not choose a unique artifact path for {path}")
+
+
+def write_runtime_summary_artifact(snapshots: list[RoomSnapshot], out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = unique_path(out_dir / runtime_summary_artifact_name())
+    payload = runtime_summary_artifact_line(snapshots)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=str(out_dir), delete=False) as handle:
+        handle.write(payload)
+        temp_name = handle.name
+    os.replace(temp_name, path)
+    return path.resolve()
+
+
 def redact_secrets(text: str, secrets: list[str]) -> str:
     redacted = text
     for secret in secrets:
@@ -1866,6 +1974,13 @@ def command_summary(args: argparse.Namespace) -> int:
         images.append(image)
         room_summaries.append(room_summary(snapshot, image=image))
 
+    runtime_summary_artifact: str | None = None
+    if not args.no_runtime_summary_artifact:
+        try:
+            runtime_summary_artifact = str(write_runtime_summary_artifact(snapshots, Path(args.runtime_summary_out_dir)))
+        except Exception as exc:  # noqa: BLE001 - keep image delivery alive; report sanitized warning
+            warnings.append(f"runtime-summary artifact unavailable: {short_text(exc, 160)}")
+
     payload = {
         "ok": True,
         "mode": "summary",
@@ -1873,6 +1988,7 @@ def command_summary(args: argparse.Namespace) -> int:
         "images": images,
         "rooms": [snapshot.ref.key for snapshot in snapshots],
         "room_summaries": room_summaries,
+        "runtime_summary_artifact": runtime_summary_artifact,
         "warnings": warnings,
     }
     print_json(payload, [ctx.token])
@@ -1963,6 +2079,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     summary = subcommands.add_parser("summary", help="render summary PNGs for owned rooms")
     add_live_options(summary)
+    summary.add_argument(
+        "--runtime-summary-out-dir",
+        default=str(DEFAULT_RUNTIME_SUMMARY_OUT_DIR),
+        help="Directory for reducer-compatible #runtime-summary artifacts written from the same live room snapshot.",
+    )
+    summary.add_argument(
+        "--no-runtime-summary-artifact",
+        action="store_true",
+        help="Do not write a reducer-compatible #runtime-summary artifact while rendering summary images.",
+    )
     summary.set_defaults(func=command_summary)
 
     alert = subcommands.add_parser("alert", help="evaluate alert rules and render alert PNGs when needed")

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -433,6 +433,7 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
             objects={
                 "controller-1": {"_id": "controller-1", "type": "controller", "user": "owner-id", "level": 3},
                 "road-1": {"_id": "road-1", "type": "road", "hits": 100, "hitsMax": 500},
+                "unknown-foreign-flag": {"_id": "unknown-foreign-flag", "type": "rampart", "my": False},
             },
             tick=265632,
             owner=None,
@@ -442,6 +443,28 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
 
         self.assertEqual(payload["rooms"][0]["combat"]["hostileStructureCount"], 0)
+
+    def test_runtime_summary_counts_confirmed_foreign_owned_structures(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E48S28"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects={
+                "tower-1": {
+                    "_id": "tower-1",
+                    "type": "tower",
+                    "owner": {"username": "Invader"},
+                    "hits": 3000,
+                    "hitsMax": 3000,
+                },
+            },
+            tick=265633,
+            owner="lanyusea",
+            info={},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+
+        self.assertEqual(payload["rooms"][0]["combat"]["hostileStructureCount"], 1)
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -5,6 +5,7 @@ import importlib.util
 import copy
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -465,6 +466,27 @@ class RuntimeKpiArtifactTests(unittest.TestCase):
         payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
 
         self.assertEqual(payload["rooms"][0]["combat"]["hostileStructureCount"], 1)
+
+    def test_runtime_summary_artifact_write_does_not_overwrite_existing_path(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E48S28"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects={},
+            tick=265634,
+            owner="lanyusea",
+            info={},
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            out_dir = Path(temp_dir)
+            target = out_dir / monitor.runtime_summary_artifact_name()
+            target.write_text("existing evidence\n", encoding="utf-8")
+
+            written = monitor.write_runtime_summary_artifact([snapshot], out_dir)
+
+            self.assertEqual(target.read_text(encoding="utf-8"), "existing evidence\n")
+            self.assertEqual(written.name, target.with_name(f"{target.stem}-2{target.suffix}").name)
+            self.assertTrue(written.read_text(encoding="utf-8").startswith("#runtime-summary "))
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_runtime_monitor_tactical_response.py
+++ b/scripts/test_screeps_runtime_monitor_tactical_response.py
@@ -335,5 +335,114 @@ class TacticalResponseBridgeTest(unittest.TestCase):
         self.assertEqual(report["triggers"][0]["structure_type"], "spawn")
 
 
+
+class RuntimeKpiArtifactTests(unittest.TestCase):
+    def test_runtime_summary_payload_uses_live_room_snapshot_metrics(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E48S28"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects={
+                "controller-1": {
+                    "_id": "controller-1",
+                    "type": "controller",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "level": 3,
+                    "progress": 1250,
+                    "progressTotal": 45000,
+                    "ticksToDowngrade": 19876,
+                    "x": 24,
+                    "y": 24,
+                },
+                "spawn-1": {
+                    "_id": "spawn-1",
+                    "type": "spawn",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "store": {"energy": 265},
+                    "x": 25,
+                    "y": 23,
+                },
+                "extension-1": {
+                    "_id": "extension-1",
+                    "type": "extension",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "store": {"energy": 50},
+                    "x": 26,
+                    "y": 23,
+                },
+                "worker-1": {
+                    "_id": "worker-1",
+                    "type": "creep",
+                    "my": True,
+                    "owner": {"username": "lanyusea"},
+                    "store": {"energy": 61},
+                    "x": 27,
+                    "y": 23,
+                },
+                "source-1": {"_id": "source-1", "type": "source", "energy": 2846, "x": 20, "y": 20},
+                "hostile-1": {
+                    "_id": "hostile-1",
+                    "type": "creep",
+                    "my": False,
+                    "owner": {"username": "Invader"},
+                    "x": 10,
+                    "y": 10,
+                },
+            },
+            tick=265630,
+            owner="lanyusea",
+            info={},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+
+        self.assertEqual(payload["type"], "runtime-summary")
+        self.assertEqual(payload["tick"], 265630)
+        self.assertEqual(payload["rooms"][0]["roomName"], "E48S28")
+        self.assertEqual(payload["rooms"][0]["controller"]["level"], 3)
+        self.assertEqual(payload["rooms"][0]["controller"]["progress"], 1250)
+        self.assertEqual(payload["rooms"][0]["resources"]["storedEnergy"], 315)
+        self.assertEqual(payload["rooms"][0]["resources"]["workerCarriedEnergy"], 61)
+        self.assertEqual(payload["rooms"][0]["resources"]["sourceCount"], 1)
+        self.assertEqual(payload["rooms"][0]["combat"]["hostileCreepCount"], 1)
+
+    def test_runtime_summary_artifact_line_is_bridge_compatible(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E48S28"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects={},
+            tick=265631,
+            owner="lanyusea",
+            info={},
+        )
+
+        line = monitor.runtime_summary_artifact_line([snapshot])
+
+        self.assertTrue(line.startswith("#runtime-summary "))
+        self.assertTrue(line.endswith("\n"))
+        payload = json.loads(line.split(" ", 1)[1])
+        self.assertEqual(payload["tick"], 265631)
+        self.assertEqual(payload["rooms"][0]["roomName"], "E48S28")
+
+    def test_runtime_summary_does_not_label_unknown_structures_as_hostile(self) -> None:
+        snapshot = monitor.RoomSnapshot(
+            ref=monitor.RoomRef(shard="shardX", room="E48S28"),
+            terrain="0" * monitor.TERRAIN_CELLS,
+            objects={
+                "controller-1": {"_id": "controller-1", "type": "controller", "user": "owner-id", "level": 3},
+                "road-1": {"_id": "road-1", "type": "road", "hits": 100, "hitsMax": 500},
+            },
+            tick=265632,
+            owner=None,
+            info={},
+        )
+
+        payload = monitor.runtime_summary_payload_from_snapshots([snapshot])
+
+        self.assertEqual(payload["rooms"][0]["combat"]["hostileStructureCount"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Persist reducer-compatible `#runtime-summary` artifacts from the same live room snapshot used by the runtime summary image job.
- Add runtime monitor KPI payload helpers for controller, resource, and combat fields so the roadmap bridge can consume `<#1497588267057680385>` evidence without fake placeholders.
- Guard against labeling unknown/neutral structures as hostile.

## Verification
- `python3 scripts/test_screeps_runtime_monitor_tactical_response.py`
- `python3 scripts/test_screeps_runtime_summary_console_capture.py`
- `python3 scripts/test_generate_roadmap_page.py`
- `python3 -m py_compile scripts/screeps-runtime-monitor.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/generate-roadmap-page.py`
- Live local run from worktree wrote `/root/screeps/runtime-artifacts/runtime-summary-console/runtime-summary-monitor-20260429T124557Z.log`.
- `python3 scripts/screeps_runtime_kpi_artifact_bridge.py --format json` then reported `matchedFiles=1`, `runtimeSummaryLines=1`, `territory/resources/combat: observed`.

## Notes
- Official console websocket capture still returned zero messages during a 180s manual capture, so this PR fixes the immediate path by deriving machine-readable KPI artifacts from the already-working runtime monitor snapshot job.
- No placeholder/fake data is introduced. Values are computed from the same live room objects used to render the runtime-summary image.
