### PR TITLE
fix: gate official deploys on live survival

### DIFF
--- a/.github/workflows/official-screeps-deploy.yml
+++ b/.github/workflows/official-screeps-deploy.yml
@@ -62,7 +62,9 @@ jobs:
           cache-dependency-path: prod/package-lock.json
 
       - name: Run deploy helper unit tests
-        run: python3 -m unittest scripts/test_screeps_official_deploy.py
+        run: |
+          python3 -m unittest scripts/test_screeps_official_deploy.py
+          python3 scripts/screeps-runtime-monitor.py self-test
 
       - name: Install production dependencies
         working-directory: prod
@@ -124,6 +126,28 @@ jobs:
             $activate_flag \
             --confirm "$CONFIRMATION" \
             --evidence-path "$EVIDENCE_DIR/official-screeps-deploy.json"
+
+      - name: Post-deploy live survival gate
+        if: ${{ inputs.mode == 'deploy' }}
+        env:
+          SCREEPS_AUTH_TOKEN: ${{ secrets.SCREEPS_AUTH_TOKEN }}
+          SCREEPS_ALERT_DEBOUNCE_SECONDS: "0"
+          SCREEPS_MONITOR_STATE_FILE: runtime-artifacts/official-screeps-deploy/postdeploy-monitor-state.json
+          SCREEPS_MONITOR_CACHE_DIR: runtime-artifacts/screeps-monitor/terrain-cache
+        run: |
+          python3 scripts/screeps-runtime-monitor.py summary \
+            --room "$SCREEPS_SHARD/$SCREEPS_ROOM" \
+            --out-dir runtime-artifacts/screeps-monitor \
+            > "$EVIDENCE_DIR/postdeploy-summary.json"
+          python3 scripts/screeps-runtime-monitor.py alert \
+            --room "$SCREEPS_SHARD/$SCREEPS_ROOM" \
+            --out-dir runtime-artifacts/screeps-monitor \
+            --force-alert-image \
+            > "$EVIDENCE_DIR/postdeploy-alert.json"
+          python3 scripts/screeps-runtime-monitor.py health-gate \
+            --summary "$EVIDENCE_DIR/postdeploy-summary.json" \
+            --alert "$EVIDENCE_DIR/postdeploy-alert.json" \
+            > "$EVIDENCE_DIR/postdeploy-health-gate.json"
 
       - name: Upload deploy evidence
         if: ${{ always() }}

--- a/scripts/screeps-runtime-monitor.py
+++ b/scripts/screeps-runtime-monitor.py
@@ -172,6 +172,8 @@ TACTICAL_REASON_CATEGORY_MAP = {
     "critical_structure_missing": ["owned_structure_disappearance"],
     "spawn_destroyed": ["spawn_collapse"],
     "spawn_collapse": ["spawn_collapse"],
+    "room_ownership_lost": ["spawn_collapse"],
+    "room_dead": ["spawn_collapse"],
     "no_workers_no_recovery": ["spawn_collapse"],
     "no_spawn_recovery": ["spawn_collapse"],
     "controller_downgrade_risk": ["downgrade_risk"],
@@ -322,6 +324,7 @@ class RoomSnapshot:
     tick: int | str | None
     owner: str | None
     info: dict[str, Any]
+    expected_owner: str | None = None
 
     @property
     def counts(self) -> Counter:
@@ -374,9 +377,7 @@ def is_owned_object(obj: dict[str, Any], owner_username: str | None) -> bool:
     return bool(owner_username and username == owner_username)
 
 
-def infer_owner(objects: dict[str, dict[str, Any]], configured_owner: str | None) -> str | None:
-    if configured_owner:
-        return configured_owner
+def infer_owner(objects: dict[str, dict[str, Any]], _configured_owner: str | None = None) -> str | None:
     for obj in objects.values():
         if not isinstance(obj, dict):
             continue
@@ -384,6 +385,12 @@ def infer_owner(objects: dict[str, dict[str, Any]], configured_owner: str | None
             username = room_owner(obj)
             if username:
                 return username
+    for obj in objects.values():
+        if not isinstance(obj, dict) or obj.get("type") != "controller":
+            continue
+        username = room_owner(obj)
+        if username:
+            return username
     return None
 
 
@@ -643,6 +650,7 @@ def collect_snapshots(ctx: RuntimeContext, room_arg: str | None) -> tuple[list[R
                     tick=tick,
                     owner=owner,
                     info=event.get("info") if isinstance(event.get("info"), dict) else {},
+                    expected_owner=configured_owner,
                 )
             )
         except Exception as exc:  # noqa: BLE001 - report room-level failures without secrets
@@ -744,6 +752,80 @@ def build_missing_reason(ref: RoomRef, object_id: str, previous: dict[str, Any])
     }
 
 
+def count_owned_objects(objects: dict[str, dict[str, Any]], owner_username: str | None, object_type: str) -> int:
+    return sum(
+        1
+        for obj in objects.values()
+        if isinstance(obj, dict) and obj.get("type") == object_type and is_owned_object(obj, owner_username)
+    )
+
+
+def count_owned_spawns(structures: dict[str, dict[str, Any]]) -> int:
+    return sum(
+        1
+        for structure in structures.values()
+        if isinstance(structure, dict) and structure.get("type") == "spawn" and structure.get("owned") is True
+    )
+
+
+def previous_critical_spawn_count(previous_structures: dict[str, Any]) -> int:
+    return sum(
+        1
+        for structure in previous_structures.values()
+        if isinstance(structure, dict)
+        and structure.get("type") == "spawn"
+        and structure.get("owned") is True
+        and structure.get("critical") is True
+    )
+
+
+def build_survival_reason(ref: RoomRef, kind: str, message: str, **details: Any) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "room": ref.key,
+        "message": message,
+        "signature": f"{kind}:{ref.key}",
+        **details,
+    }
+
+
+def should_preserve_previous_baseline(
+    previous_structures: dict[str, Any], current_structures: dict[str, dict[str, Any]], reasons: list[dict[str, Any]]
+) -> bool:
+    if not previous_structures or current_structures:
+        return False
+    survival_kinds = {"room_ownership_lost", "spawn_collapse", "room_dead"}
+    return any(reason.get("kind") in survival_kinds for reason in reasons)
+
+
+def build_next_room_state(
+    snapshot: RoomSnapshot,
+    previous_room_state: dict[str, Any],
+    previous_structures: dict[str, Any],
+    current_structures: dict[str, dict[str, Any]],
+    alerts: dict[str, Any],
+    detected: list[dict[str, Any]],
+    now: int,
+    owned_creeps: int,
+    owned_spawns: int,
+) -> dict[str, Any]:
+    structures = previous_structures if should_preserve_previous_baseline(previous_structures, current_structures, detected) else current_structures
+    previous_owner = previous_room_state.get("owner")
+    owner = snapshot.owner or (previous_owner if should_preserve_previous_baseline(previous_structures, current_structures, detected) else None)
+    return {
+        "baseline_established": True,
+        "observed_at": now,
+        "tick": snapshot.tick,
+        "owner": owner,
+        "owner_observed": snapshot.owner,
+        "expected_owner": snapshot.expected_owner,
+        "owned_creeps": owned_creeps,
+        "owned_spawns": owned_spawns,
+        "structures": structures,
+        "alerts": alerts,
+    }
+
+
 def evaluate_room_alert(
     snapshot: RoomSnapshot,
     previous_room_state: dict[str, Any] | None,
@@ -759,13 +841,58 @@ def evaluate_room_alert(
         previous_alerts = {}
 
     current_structures = structure_snapshot(snapshot.objects, snapshot.owner)
+    current_owned_spawns = count_owned_spawns(current_structures)
+    current_owned_creeps = count_owned_objects(snapshot.objects, snapshot.owner, "creep")
     baseline_established = bool(previous_room_state.get("baseline_established"))
+    previous_owner = previous_room_state.get("owner")
+    expected_owner = snapshot.expected_owner if snapshot.expected_owner else previous_owner
+    previous_owned_spawns = previous_room_state.get("owned_spawns")
+    previous_owned_creeps = previous_room_state.get("owned_creeps")
+    previous_spawn_count = previous_critical_spawn_count(previous_structures)
     detected: list[dict[str, Any]] = []
 
     for hostile in detect_hostile_creeps(snapshot.objects, snapshot.owner):
         detected.append(build_hostile_reason(snapshot.ref, hostile))
 
+    if expected_owner and snapshot.owner != expected_owner:
+        detected.append(
+            build_survival_reason(
+                snapshot.ref,
+                "room_ownership_lost",
+                f"room owner changed from {expected_owner} to {snapshot.owner or 'none'}",
+                previous_owner=expected_owner,
+                current_owner=snapshot.owner,
+            )
+        )
+
     if baseline_established:
+        if previous_spawn_count > 0 and current_owned_spawns == 0:
+            detected.append(
+                build_survival_reason(
+                    snapshot.ref,
+                    "spawn_collapse",
+                    f"owned spawn count dropped from {previous_spawn_count} to 0",
+                    previous_owned_spawns=previous_spawn_count,
+                    current_owned_spawns=current_owned_spawns,
+                    current_owned_creeps=current_owned_creeps,
+                )
+            )
+        if (
+            current_owned_spawns == 0
+            and current_owned_creeps == 0
+            and (previous_owned_spawns in (None, 0) or previous_spawn_count == 0)
+            and previous_owned_creeps in (None, 0)
+        ):
+            detected.append(
+                build_survival_reason(
+                    snapshot.ref,
+                    "room_dead",
+                    "room has no owned creeps and no owned spawn recovery path",
+                    current_owned_spawns=current_owned_spawns,
+                    current_owned_creeps=current_owned_creeps,
+                )
+            )
+
         for object_id, current in current_structures.items():
             previous = previous_structures.get(object_id)
             if not isinstance(previous, dict):
@@ -795,14 +922,17 @@ def evaluate_room_alert(
         alerts[signature] = now
         emitted.append(reason)
 
-    next_state = {
-        "baseline_established": True,
-        "observed_at": now,
-        "tick": snapshot.tick,
-        "owner": snapshot.owner,
-        "structures": current_structures,
-        "alerts": alerts,
-    }
+    next_state = build_next_room_state(
+        snapshot,
+        previous_room_state,
+        previous_structures,
+        current_structures,
+        alerts,
+        detected,
+        now,
+        current_owned_creeps,
+        current_owned_spawns,
+    )
     return emitted, suppressed, next_state
 
 
@@ -1808,6 +1938,9 @@ def render_room_snapshot(
 
 def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, Any]:
     hostiles = detect_hostile_creeps(snapshot.objects, snapshot.owner)
+    structures = structure_objects(snapshot.objects)
+    owned_creeps = count_owned_objects(snapshot.objects, snapshot.owner, "creep")
+    owned_spawns = count_owned_objects(snapshot.objects, snapshot.owner, "spawn")
     summary = {
         "room": snapshot.ref.key,
         "shard": snapshot.ref.shard,
@@ -1815,9 +1948,13 @@ def room_summary(snapshot: RoomSnapshot, image: str | None = None) -> dict[str, 
         "tick": snapshot.tick,
         "objects": len(snapshot.objects),
         "creeps": snapshot.counts.get("creep", 0),
-        "structures": len(structure_objects(snapshot.objects)),
+        "owned_creeps": owned_creeps,
+        "structures": len(structures),
+        "spawns": sum(1 for structure in structures if structure.get("type") == "spawn"),
+        "owned_spawns": owned_spawns,
         "hostiles": len(hostiles),
         "owner": snapshot.owner,
+        "expected_owner": snapshot.expected_owner,
     }
     if image:
         summary["image"] = image
@@ -1997,6 +2134,91 @@ def print_json(payload: dict[str, Any], secrets: list[str]) -> None:
     sys.stdout.write("\n")
 
 
+def load_json_file(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise RuntimeError(f"expected object JSON in {path}")
+    return value
+
+
+def resolve_owned_count(room_summary_payload: dict[str, Any], owned_key: str, fallback_key: str) -> Any:
+    owned_value = room_summary_payload.get(owned_key)
+    if isinstance(owned_value, (int, float)):
+        return owned_value
+    return room_summary_payload.get(fallback_key)
+
+
+def evaluate_postdeploy_health_gate(summary_payload: dict[str, Any], alert_payload: dict[str, Any]) -> dict[str, Any]:
+    reasons: list[dict[str, Any]] = []
+    if summary_payload.get("ok") is not True:
+        reasons.append({"kind": "postdeploy_summary_failed", "message": "post-deploy summary did not report ok=true"})
+    if alert_payload.get("ok") is not True:
+        reasons.append({"kind": "postdeploy_alert_failed", "message": "post-deploy alert did not report ok=true"})
+    if alert_payload.get("alert") is True:
+        for reason in alert_payload.get("reasons") if isinstance(alert_payload.get("reasons"), list) else []:
+            if isinstance(reason, dict):
+                reasons.append({"kind": "postdeploy_active_alert", "message": reason.get("message", "runtime alert active"), "source": reason})
+
+    room_summaries = summary_payload.get("room_summaries")
+    if not isinstance(room_summaries, list) or not room_summaries:
+        reasons.append({"kind": "postdeploy_no_room_summary", "message": "post-deploy summary has no room_summaries"})
+    else:
+        for room in room_summaries:
+            if not isinstance(room, dict):
+                continue
+            creeps = resolve_owned_count(room, "owned_creeps", "creeps")
+            structures = room.get("structures")
+            spawns = resolve_owned_count(room, "owned_spawns", "spawns")
+            owner = room.get("owner")
+            room_name = room.get("room")
+            owner_missing = owner is None or owner == ""
+            if owner_missing:
+                creeps = 0
+                spawns = 0
+            if owner_missing and (not isinstance(spawns, (int, float)) or spawns <= 0):
+                reasons.append(
+                    {
+                        "kind": "postdeploy_owner_missing",
+                        "room": room_name,
+                        "message": f"{room_name}: owner missing and no spawn recovery is visible",
+                    }
+                )
+            if not owner_missing and (not isinstance(spawns, (int, float)) or spawns <= 0):
+                reasons.append(
+                    {
+                        "kind": "postdeploy_no_owned_spawn",
+                        "room": room_name,
+                        "message": f"{room_name}: no owned spawn recovery path is visible after deploy",
+                    }
+                )
+            if (
+                isinstance(creeps, (int, float))
+                and creeps <= 0
+                and (not isinstance(spawns, (int, float)) or spawns <= 0)
+            ):
+                reasons.append(
+                    {
+                        "kind": "postdeploy_room_dead",
+                        "room": room_name,
+                        "creeps": creeps,
+                        "structures": structures,
+                        "spawns": spawns,
+                        "owner": owner,
+                        "message": f"{room_name}: no creeps, no spawn, and <=1 visible structure after deploy",
+                    }
+                )
+    return {"ok": not reasons, "reasons": reasons}
+
+
+def command_health_gate(args: argparse.Namespace) -> int:
+    summary_payload = load_json_file(args.summary)
+    alert_payload = load_json_file(args.alert)
+    result = evaluate_postdeploy_health_gate(summary_payload, alert_payload)
+    print_json(result, [os.environ.get("SCREEPS_AUTH_TOKEN", "")])
+    return 0 if result["ok"] else 1
+
+
 def command_summary(args: argparse.Namespace) -> int:
     ctx = context_from_env()
     snapshots, warnings = collect_snapshots(ctx, args.room)
@@ -2130,6 +2352,11 @@ def build_parser() -> argparse.ArgumentParser:
     alert.add_argument("--force-alert-image", action="store_true", help="render alert-style image even when no alert is emitted")
     alert.set_defaults(func=command_alert)
 
+    health_gate = subcommands.add_parser("health-gate", help="fail when post-deploy summary/alert evidence violates survival invariants")
+    health_gate.add_argument("--summary", required=True, help="summary JSON path produced by the summary command")
+    health_gate.add_argument("--alert", required=True, help="alert JSON path produced by the alert command")
+    health_gate.set_defaults(func=command_health_gate)
+
     tactical_response = subcommands.add_parser(
         "tactical-response",
         help="classify runtime alert JSON into a bounded tactical emergency response payload",
@@ -2257,11 +2484,112 @@ def command_self_test(_args: argparse.Namespace) -> int:
             }
             snapshot = self.make_snapshot({})
             emitted, _suppressed, _next_state = evaluate_room_alert(snapshot, previous, now=100, debounce_seconds=300)
-            self.assertEqual(emitted[0]["kind"], "critical_structure_missing")
+            self.assertIn("critical_structure_missing", [reason["kind"] for reason in emitted])
+
+        def test_room_loss_alert_preserves_healthy_baseline(self) -> None:
+            previous = {
+                "baseline_established": True,
+                "owner": "owner",
+                "owned_creeps": 3,
+                "owned_spawns": 1,
+                "structures": {
+                    "spawn1": {
+                        "type": "spawn",
+                        "x": 25,
+                        "y": 25,
+                        "hits": 5000,
+                        "hitsMax": 5000,
+                        "owned": True,
+                        "damageable": True,
+                        "critical": True,
+                    }
+                },
+            }
+            snapshot = RoomSnapshot(
+                ref=RoomRef("shardTest", "E1N1"),
+                terrain="0" * TERRAIN_CELLS,
+                objects=normalize_objects(
+                    {
+                        "ctrl": {"type": "controller", "x": 5, "y": 36, "level": 3},
+                        "site": {"type": "constructionSite", "structureType": "extension", "x": 6, "y": 36},
+                    }
+                ),
+                tick=2,
+                owner=None,
+                info={},
+                expected_owner="owner",
+            )
+
+            emitted, _suppressed, next_state = evaluate_room_alert(snapshot, previous, now=100, debounce_seconds=300)
+
+            self.assertIn("room_ownership_lost", [reason["kind"] for reason in emitted])
+            self.assertIn("spawn_collapse", [reason["kind"] for reason in emitted])
+            self.assertEqual(next_state["owner"], "owner")
+            self.assertIn("spawn1", next_state["structures"])
+
+        def test_expected_owner_does_not_mask_observed_owner_loss(self) -> None:
+            snapshot = RoomSnapshot(
+                ref=RoomRef("shardTest", "E1N1"),
+                terrain="0" * TERRAIN_CELLS,
+                objects=normalize_objects({"ctrl": {"type": "controller", "x": 5, "y": 36, "level": 3}}),
+                tick=2,
+                owner=None,
+                info={},
+                expected_owner="owner",
+            )
+
+            emitted, _suppressed, _next_state = evaluate_room_alert(snapshot, {}, now=100, debounce_seconds=300)
+
+            self.assertIn("room_ownership_lost", [reason["kind"] for reason in emitted])
+
+        def test_dead_room_alerts_even_after_baseline_was_already_cleared(self) -> None:
+            previous = {
+                "baseline_established": True,
+                "owner": None,
+                "structures": {},
+                "owned_creeps": 0,
+                "owned_spawns": 0,
+            }
+            snapshot = RoomSnapshot(
+                ref=RoomRef("shardTest", "E1N1"),
+                terrain="0" * TERRAIN_CELLS,
+                objects=normalize_objects({"ctrl": {"type": "controller", "x": 5, "y": 36, "level": 3}}),
+                tick=3,
+                owner=None,
+                info={},
+            )
+
+            emitted, _suppressed, _next_state = evaluate_room_alert(snapshot, previous, now=100, debounce_seconds=300)
+
+            self.assertIn("room_dead", [reason["kind"] for reason in emitted])
+
+        def test_dead_room_alerts_when_cleared_baseline_has_no_survival_counts(self) -> None:
+            previous = {"baseline_established": True, "owner": None, "structures": {}}
+            snapshot = RoomSnapshot(
+                ref=RoomRef("shardTest", "E1N1"),
+                terrain="0" * TERRAIN_CELLS,
+                objects=normalize_objects({"ctrl": {"type": "controller", "x": 5, "y": 36, "level": 3}}),
+                tick=3,
+                owner=None,
+                info={},
+            )
+
+            emitted, _suppressed, _next_state = evaluate_room_alert(snapshot, previous, now=100, debounce_seconds=300)
+
+            self.assertIn("room_dead", [reason["kind"] for reason in emitted])
 
         def test_debounce_suppresses_identical_alert(self) -> None:
             snapshot = self.make_snapshot(
                 {
+                    "spawn1": {
+                        "type": "spawn",
+                        "my": True,
+                        "owner": {"username": "owner"},
+                        "x": 25,
+                        "y": 25,
+                        "hits": 5000,
+                        "hitsMax": 5000,
+                    },
                     "h1": {
                         "type": "creep",
                         "my": False,
@@ -2334,6 +2662,91 @@ def command_self_test(_args: argparse.Namespace) -> int:
             self.assertEqual(report["severity"], "none")
             self.assertEqual(report["scheduler"]["recommended_output"], "[SILENT]")
             self.assertEqual(report["next_actions"][0]["id"], "return_silent")
+
+        def test_postdeploy_health_gate_rejects_dead_room_even_when_alert_is_silent(self) -> None:
+            result = evaluate_postdeploy_health_gate(
+                {
+                    "ok": True,
+                    "mode": "summary",
+                    "room_summaries": [
+                        {"room": "shardTest/E1N1", "creeps": 0, "structures": 1, "owner": None}
+                    ],
+                },
+                {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+            )
+
+            self.assertFalse(result["ok"])
+            self.assertIn("postdeploy_room_dead", [reason["kind"] for reason in result["reasons"]])
+
+        def test_postdeploy_health_gate_accepts_respawn_spawn_recovery(self) -> None:
+            result = evaluate_postdeploy_health_gate(
+                {
+                    "ok": True,
+                    "mode": "summary",
+                    "room_summaries": [
+                        {
+                            "room": "shardTest/E1N1",
+                            "creeps": 0,
+                            "owned_creeps": 0,
+                            "structures": 2,
+                            "owner": "owner",
+                            "spawns": 1,
+                            "owned_spawns": 1,
+                        }
+                    ],
+                },
+                {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+            )
+
+            self.assertTrue(result["ok"])
+
+        def test_postdeploy_health_gate_rejects_enemy_spawn_without_owned_recovery(self) -> None:
+            result = evaluate_postdeploy_health_gate(
+                {
+                    "ok": True,
+                    "mode": "summary",
+                    "room_summaries": [
+                        {
+                            "room": "shardTest/E1N1",
+                            "creeps": 2,
+                            "owned_creeps": 0,
+                            "structures": 8,
+                            "owner": None,
+                            "expected_owner": "owner",
+                            "spawns": 1,
+                            "owned_spawns": 0,
+                        }
+                    ],
+                },
+                {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+            )
+
+            self.assertFalse(result["ok"])
+            self.assertIn("postdeploy_room_dead", [reason["kind"] for reason in result["reasons"]])
+
+        def test_postdeploy_health_gate_rejects_owned_room_without_spawn_even_with_worker(self) -> None:
+            result = evaluate_postdeploy_health_gate(
+                {
+                    "ok": True,
+                    "mode": "summary",
+                    "room_summaries": [
+                        {
+                            "room": "shardTest/E1N1",
+                            "creeps": 1,
+                            "owned_creeps": 1,
+                            "structures": 4,
+                            "owner": "owner",
+                            "expected_owner": "owner",
+                            "spawns": 0,
+                            "owned_spawns": 0,
+                        }
+                    ],
+                },
+                {"ok": True, "mode": "alert", "alert": False, "reasons": []},
+            )
+
+            self.assertFalse(result["ok"])
+            self.assertIn("postdeploy_no_owned_spawn", [reason["kind"] for reason in result["reasons"]])
 
         def test_tactical_response_classifies_hostile_alert(self) -> None:
             report = build_tactical_response_report(


### PR DESCRIPTION
## Summary
- Add hard runtime-alert survival invariants for room loss, spawn collapse, and dead-room states.
- Preserve the last healthy monitor baseline instead of overwriting it with owner=null / structures={} after room loss.
- Add a post-deploy health gate that fails if summary+alert evidence shows owner missing, zero creeps, no spawn, or active runtime alerts.
- Wire official-screeps-deploy to run monitor self-tests and collect/fail on post-deploy summary/alert/health evidence.

## Verification
- `python3 scripts/screeps-runtime-monitor.py self-test`
- `python3 -m unittest scripts/test_screeps_official_deploy.py`
- `npm run typecheck`
- `npm test -- --runInBand`
- `npm run build`
- Live monitor on `shardX/E48S28` with new code emits `room_dead` and health-gate fails for current `0 creeps / no spawn / owner null` state.

Fixes #313.
