### PR TITLE
feat: continue post-merge resource throughput behavior

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3106,6 +3106,7 @@ var ENERGY_ACQUISITION_RANGE_COST = 50;
 var ENERGY_ACQUISITION_ACTION_TICKS = 1;
 var HARVEST_ENERGY_PER_WORK_PART = 2;
 var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
+var nearTermSpawnExtensionRefillReserveCache = null;
 function selectWorkerTask(creep) {
   const carriedEnergy = getUsedEnergy(creep);
   const urgentReservationRenewalTask = selectUrgentVisibleReservationRenewalTask(creep);
@@ -3209,8 +3210,7 @@ function selectWorkerTask(creep) {
   }
   return null;
 }
-function estimateNearTermSpawnExtensionRefillReserve(room) {
-  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(room);
+function estimateNearTermSpawnExtensionRefillReserveFromStructures(room, spawnExtensionEnergyStructures) {
   if (spawnExtensionEnergyStructures.length === 0) {
     return 0;
   }
@@ -3764,24 +3764,71 @@ function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) {
   if (carriedEnergy <= 0) {
     return false;
   }
-  const refillReserve = estimateNearTermSpawnExtensionRefillReserve(creep.room);
-  return refillReserve > 0 && isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, refillReserve);
+  const reserveContext = getNearTermSpawnExtensionRefillReserveContext(creep.room);
+  return reserveContext.refillReserve > 0 && isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, reserveContext);
 }
-function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, refillReserve) {
-  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(creep.room);
-  const loadedWorkers = dedupeCreepsByStableKey(
-    getSameRoomLoadedWorkers(creep).filter((worker) => getUsedEnergy(worker) > 0)
-  ).sort(
-    (left, right) => compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
+function getNearTermSpawnExtensionRefillReserveContext(room) {
+  const gameTick = getGameTick();
+  const roomName = getRoomName(room);
+  if (gameTick === null || roomName === null) {
+    return createNearTermSpawnExtensionRefillReserveContext(room);
+  }
+  if (!nearTermSpawnExtensionRefillReserveCache || nearTermSpawnExtensionRefillReserveCache.tick !== gameTick) {
+    nearTermSpawnExtensionRefillReserveCache = {
+      roomsByName: /* @__PURE__ */ new Map(),
+      tick: gameTick
+    };
+  }
+  const cachedContext = nearTermSpawnExtensionRefillReserveCache.roomsByName.get(roomName);
+  if ((cachedContext == null ? void 0 : cachedContext.room) === room) {
+    return cachedContext;
+  }
+  const context = createNearTermSpawnExtensionRefillReserveContext(room);
+  nearTermSpawnExtensionRefillReserveCache.roomsByName.set(roomName, context);
+  return context;
+}
+function createNearTermSpawnExtensionRefillReserveContext(room) {
+  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(room);
+  const refillReserve = estimateNearTermSpawnExtensionRefillReserveFromStructures(
+    room,
+    spawnExtensionEnergyStructures
   );
+  const sortedLoadedWorkers = refillReserve > 0 ? dedupeCreepsByStableKey(getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, room))).sort(
+    (left, right) => compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
+  ) : [];
+  return {
+    refillReserve,
+    room,
+    sortedLoadedWorkers,
+    spawnExtensionEnergyStructures
+  };
+}
+function getGameTick() {
+  var _a;
+  const time = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof time === "number" && Number.isFinite(time) ? time : null;
+}
+function getRoomName(room) {
+  return typeof room.name === "string" && room.name.length > 0 ? room.name : null;
+}
+function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, reserveContext) {
+  const loadedWorkers = getNearTermRefillReserveLoadedWorkers(creep, reserveContext);
   let reservedEnergy = 0;
   for (const worker of loadedWorkers) {
     if (isSameCreep(worker, creep)) {
-      return reservedEnergy < refillReserve;
+      return reservedEnergy < reserveContext.refillReserve;
     }
     reservedEnergy += getUsedEnergy(worker);
   }
   return true;
+}
+function getNearTermRefillReserveLoadedWorkers(creep, reserveContext) {
+  if (reserveContext.sortedLoadedWorkers.some((worker) => isSameCreep(worker, creep))) {
+    return reserveContext.sortedLoadedWorkers;
+  }
+  return dedupeCreepsByStableKey([...reserveContext.sortedLoadedWorkers, creep]).sort(
+    (left, right) => compareNearTermRefillReserveWorkers(left, right, reserveContext.spawnExtensionEnergyStructures)
+  );
 }
 function compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures) {
   return getUsedEnergy(right) - getUsedEnergy(left) || compareOptionalRanges(

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4023,6 +4023,8 @@ function runWorker(creep) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptSpendingTaskForNearTermSpawnExtensionRefill(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptSpendingTaskForEnergySink(currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptSpendingTaskForControllerPressure(creep, currentTask, selectedTask)) {
@@ -4137,6 +4139,9 @@ function shouldPreemptSpendingTaskForEnergySink(task, selectedTask) {
     return false;
   }
   return (selectedTask == null ? void 0 : selectedTask.type) === "transfer" && !isSameTask(task, selectedTask);
+}
+function shouldPreemptSpendingTaskForNearTermSpawnExtensionRefill(creep, task, selectedTask) {
+  return selectedTask === null && isEnergySpendingTask(task) && shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep);
 }
 function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, task, selectedTask) {
   var _a, _b, _c;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1,7 +1,8 @@
 import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
   isWorkerRepairTargetComplete,
-  selectWorkerTask
+  selectWorkerTask,
+  shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill
 } from '../tasks/workerTasks';
 import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
 
@@ -27,6 +28,8 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptSpendingTaskForNearTermSpawnExtensionRefill(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptSpendingTaskForEnergySink(currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
@@ -182,6 +185,18 @@ function shouldPreemptSpendingTaskForEnergySink(
   }
 
   return selectedTask?.type === 'transfer' && !isSameTask(task, selectedTask);
+}
+
+function shouldPreemptSpendingTaskForNearTermSpawnExtensionRefill(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  return (
+    selectedTask === null &&
+    isEnergySpendingTask(task) &&
+    shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)
+  );
 }
 
 function shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -40,6 +40,20 @@ interface StoredEnergySourceContext {
   room: Room;
 }
 
+interface NearTermSpawnExtensionRefillReserveContext {
+  refillReserve: number;
+  room: Room;
+  sortedLoadedWorkers: Creep[];
+  spawnExtensionEnergyStructures: SpawnExtensionEnergyStructure[];
+}
+
+interface NearTermSpawnExtensionRefillReserveCache {
+  roomsByName: Map<string, NearTermSpawnExtensionRefillReserveContext>;
+  tick: number;
+}
+
+let nearTermSpawnExtensionRefillReserveCache: NearTermSpawnExtensionRefillReserveCache | null = null;
+
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const carriedEnergy = getUsedEnergy(creep);
   const urgentReservationRenewalTask = selectUrgentVisibleReservationRenewalTask(creep);
@@ -170,6 +184,13 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
 
 export function estimateNearTermSpawnExtensionRefillReserve(room: Room): number {
   const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(room);
+  return estimateNearTermSpawnExtensionRefillReserveFromStructures(room, spawnExtensionEnergyStructures);
+}
+
+function estimateNearTermSpawnExtensionRefillReserveFromStructures(
+  room: Room,
+  spawnExtensionEnergyStructures: SpawnExtensionEnergyStructure[]
+): number {
   if (spawnExtensionEnergyStructures.length === 0) {
     return 0;
   }
@@ -1056,29 +1077,100 @@ export function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep:
     return false;
   }
 
-  const refillReserve = estimateNearTermSpawnExtensionRefillReserve(creep.room);
-  return refillReserve > 0 && isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, refillReserve);
+  const reserveContext = getNearTermSpawnExtensionRefillReserveContext(creep.room);
+  return (
+    reserveContext.refillReserve > 0 &&
+    isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, reserveContext)
+  );
 }
 
-function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep: Creep, refillReserve: number): boolean {
-  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(creep.room);
-  const loadedWorkers = dedupeCreepsByStableKey(
-    getSameRoomLoadedWorkers(creep).filter((worker) => getUsedEnergy(worker) > 0)
-  )
-    .sort((left, right) =>
-      compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
-    );
+function getNearTermSpawnExtensionRefillReserveContext(room: Room): NearTermSpawnExtensionRefillReserveContext {
+  const gameTick = getGameTick();
+  const roomName = getRoomName(room);
+  if (gameTick === null || roomName === null) {
+    return createNearTermSpawnExtensionRefillReserveContext(room);
+  }
+
+  if (!nearTermSpawnExtensionRefillReserveCache || nearTermSpawnExtensionRefillReserveCache.tick !== gameTick) {
+    nearTermSpawnExtensionRefillReserveCache = {
+      roomsByName: new Map<string, NearTermSpawnExtensionRefillReserveContext>(),
+      tick: gameTick
+    };
+  }
+
+  const cachedContext = nearTermSpawnExtensionRefillReserveCache.roomsByName.get(roomName);
+  if (cachedContext?.room === room) {
+    return cachedContext;
+  }
+
+  const context = createNearTermSpawnExtensionRefillReserveContext(room);
+  nearTermSpawnExtensionRefillReserveCache.roomsByName.set(roomName, context);
+  return context;
+}
+
+function createNearTermSpawnExtensionRefillReserveContext(
+  room: Room
+): NearTermSpawnExtensionRefillReserveContext {
+  const spawnExtensionEnergyStructures = findSpawnExtensionEnergyStructures(room);
+  const refillReserve = estimateNearTermSpawnExtensionRefillReserveFromStructures(
+    room,
+    spawnExtensionEnergyStructures
+  );
+  const sortedLoadedWorkers =
+    refillReserve > 0
+      ? dedupeCreepsByStableKey(getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, room)))
+          .sort((left, right) =>
+            compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
+          )
+      : [];
+
+  return {
+    refillReserve,
+    room,
+    sortedLoadedWorkers,
+    spawnExtensionEnergyStructures
+  };
+}
+
+function getGameTick(): number | null {
+  const time = (globalThis as unknown as { Game?: Partial<Game> }).Game?.time;
+  return typeof time === 'number' && Number.isFinite(time) ? time : null;
+}
+
+function getRoomName(room: Room): string | null {
+  return typeof room.name === 'string' && room.name.length > 0 ? room.name : null;
+}
+
+function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(
+  creep: Creep,
+  reserveContext: NearTermSpawnExtensionRefillReserveContext
+): boolean {
+  const loadedWorkers = getNearTermRefillReserveLoadedWorkers(creep, reserveContext);
   let reservedEnergy = 0;
 
   for (const worker of loadedWorkers) {
     if (isSameCreep(worker, creep)) {
-      return reservedEnergy < refillReserve;
+      return reservedEnergy < reserveContext.refillReserve;
     }
 
     reservedEnergy += getUsedEnergy(worker);
   }
 
   return true;
+}
+
+function getNearTermRefillReserveLoadedWorkers(
+  creep: Creep,
+  reserveContext: NearTermSpawnExtensionRefillReserveContext
+): Creep[] {
+  if (reserveContext.sortedLoadedWorkers.some((worker) => isSameCreep(worker, creep))) {
+    return reserveContext.sortedLoadedWorkers;
+  }
+
+  return dedupeCreepsByStableKey([...reserveContext.sortedLoadedWorkers, creep])
+    .sort((left, right) =>
+      compareNearTermRefillReserveWorkers(left, right, reserveContext.spawnExtensionEnergyStructures)
+    );
 }
 
 function compareNearTermRefillReserveWorkers(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1050,7 +1050,7 @@ function shouldRushRcl1Controller(controller: StructureController): boolean {
   return controller.my === true && controller.level === 1;
 }
 
-function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep: Creep): boolean {
+export function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep: Creep): boolean {
   const carriedEnergy = getUsedEnergy(creep);
   if (carriedEnergy <= 0) {
     return false;

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -816,12 +816,17 @@ describe('runWorker', () => {
     const getObjectById = jest.fn().mockReturnValue(site);
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       creeps: { Builder: creep },
-      getObjectById
+      getObjectById,
+      time: 123
     };
 
     runWorker(creep);
 
+    const spawnExtensionLookups = (room.find as jest.Mock).mock.calls.filter(
+      ([type]) => type === FIND_MY_STRUCTURES
+    );
     expect(creep.memory.task).toBeUndefined();
+    expect(spawnExtensionLookups).toHaveLength(3);
     expect(getObjectById).not.toHaveBeenCalled();
     expect(build).not.toHaveBeenCalled();
     expect(moveTo).not.toHaveBeenCalled();

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -779,6 +779,54 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('pauses active construction when this worker must reserve energy for near-term spawn refill', () => {
+    const busyFullSpawn = {
+      id: 'spawn-busy',
+      structureType: 'spawn',
+      spawning: { remainingTime: 10 },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+    } as unknown as StructureSpawn;
+    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const build = jest.fn();
+    const moveTo = jest.fn();
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [busyFullSpawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        return type === FIND_CONSTRUCTION_SITES ? [site] : [];
+      })
+    } as unknown as Room;
+    const creep = {
+      name: 'Builder',
+      memory: {
+        role: 'worker',
+        task: { type: 'build', targetId: 'road-site1' as Id<ConstructionSite> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room,
+      build,
+      moveTo
+    } as unknown as Creep;
+    const getObjectById = jest.fn().mockReturnValue(site);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Builder: creep },
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toBeUndefined();
+    expect(getObjectById).not.toHaveBeenCalled();
+    expect(build).not.toHaveBeenCalled();
+    expect(moveTo).not.toHaveBeenCalled();
+  });
+
   it('keeps controller upgrade work when spawn and extension energy is full', () => {
     const controller = { id: 'controller1', my: true } as StructureController;
     const fullSpawn = {


### PR DESCRIPTION
Closes #312.

## Summary
- Keeps worker resource-delivery tasks focused on productive resource throughput when post-merge economy work is still available.
- Adds worker-runner coverage for productive resource handoff behavior.
- Rebuilds `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 456 tests passed)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Authorship: Codex-authored commit `f84baee` by `lanyusea's bot <lanyusea@gmail.com>`.
