### PR TITLE
feat: keep territory follow-up intents actionable

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1491,6 +1491,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       territoryMemory,
       intents,
       gameTime,
+      roleCounts,
       routeDistanceLookupContext
     )
   );
@@ -1632,13 +1633,13 @@ function getTerritoryIntentActionBodyCost(action) {
 function shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount) {
   return activeCoverageCount < TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET && candidate.intentAction === "reserve" && typeof candidate.renewalTicksToEnd === "number" && candidate.renewalTicksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
 }
-function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
+function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, roleCounts, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget2(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
     const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
@@ -1719,7 +1720,13 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
     if (hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext)) {
       return false;
     }
-    if (target.enabled === false || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime)) {
+    if (target.enabled === false || target.roomName === colonyName) {
+      return true;
+    }
+    if (isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername)) {
+      return false;
+    }
+    if (isTerritoryTargetSuppressed(target, intents, gameTime)) {
       return true;
     }
     if (isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(
@@ -1742,6 +1749,21 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
 }
 function isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, gameTime, colony) {
   return getPersistedTerritoryIntentFollowUp(intents, target.colony, target.roomName, target.action, gameTime) !== null && !isTerritoryIntentActionSpawnReady(colony, target.action);
+}
+function isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) {
+  if (target.action !== "claim") {
+    return false;
+  }
+  const reserveIntent = intents.find(
+    (intent) => intent.colony === target.colony && intent.targetRoom === target.roomName && intent.action === "reserve" && (intent.status === "active" || intent.status === "planned")
+  );
+  if (!reserveIntent) {
+    return false;
+  }
+  if (reserveIntent.followUp === void 0 && getTerritoryCreepCountForTarget(roleCounts, target.roomName, "reserve") <= 0) {
+    return false;
+  }
+  return getVisibleTerritoryTargetState(target.roomName, "reserve", reserveIntent.controllerId, colonyOwnerUsername) !== "unavailable";
 }
 function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, source, orderOffset, routeDistanceLookupContext) {
   const adjacentRooms = getAdjacentRoomNames2(originRoomName);
@@ -2382,6 +2404,9 @@ function sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyO
   let changed = false;
   const sanitizedIntents = intents.map((intent) => {
     if (intent.colony !== colonyName || intent.followUp === void 0 || intent.status === "suppressed") {
+      return intent;
+    }
+    if (intent.status === "active" && intent.action === "reserve") {
       return intent;
     }
     if (!isTerritoryControlAction(intent.action) || isPersistedTerritoryFollowUpStillActionable(intent, intent.action, colonyOwnerUsername)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1760,7 +1760,7 @@ function isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts,
   if (!reserveIntent) {
     return false;
   }
-  if (reserveIntent.followUp === void 0 && getTerritoryCreepCountForTarget(roleCounts, target.roomName, "reserve") <= 0) {
+  if (reserveIntent.followUp === void 0 && getTerritoryCreepCountForTarget(roleCounts, reserveIntent.targetRoom, "reserve") <= 0) {
     return false;
   }
   return getVisibleTerritoryTargetState(target.roomName, "reserve", reserveIntent.controllerId, colonyOwnerUsername) !== "unavailable";

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -564,6 +564,7 @@ function selectTerritoryTarget(
       territoryMemory,
       intents,
       gameTime,
+      roleCounts,
       routeDistanceLookupContext
     )
   );
@@ -769,6 +770,7 @@ function getConfiguredTerritoryCandidates(
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[],
   gameTime: number,
+  roleCounts: RoleCounts,
   routeDistanceLookupContext: RouteDistanceLookupContext
 ): ScoredTerritoryTarget[] {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
@@ -783,6 +785,7 @@ function getConfiguredTerritoryCandidates(
       target.colony !== colonyName ||
       target.roomName === colonyName ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
+      isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) ||
       getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !==
         'available'
     ) {
@@ -904,11 +907,15 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       return false;
     }
 
-    if (
-      target.enabled === false ||
-      target.roomName === colonyName ||
-      isTerritoryTargetSuppressed(target, intents, gameTime)
-    ) {
+    if (target.enabled === false || target.roomName === colonyName) {
+      return true;
+    }
+
+    if (isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername)) {
+      return false;
+    }
+
+    if (isTerritoryTargetSuppressed(target, intents, gameTime)) {
       return true;
     }
 
@@ -948,6 +955,40 @@ function isConfiguredFollowUpTargetBlockedBySpawnReadiness(
   return (
     getPersistedTerritoryIntentFollowUp(intents, target.colony, target.roomName, target.action, gameTime) !== null &&
     !isTerritoryIntentActionSpawnReady(colony, target.action)
+  );
+}
+
+function isClaimTargetDeferredBySameRoomReserveLane(
+  target: TerritoryTargetMemory,
+  intents: TerritoryIntentMemory[],
+  roleCounts: RoleCounts,
+  colonyOwnerUsername: string | null
+): boolean {
+  if (target.action !== 'claim') {
+    return false;
+  }
+
+  const reserveIntent = intents.find(
+    (intent) =>
+      intent.colony === target.colony &&
+      intent.targetRoom === target.roomName &&
+      intent.action === 'reserve' &&
+      (intent.status === 'active' || intent.status === 'planned')
+  );
+  if (!reserveIntent) {
+    return false;
+  }
+
+  if (
+    reserveIntent.followUp === undefined &&
+    getTerritoryCreepCountForTarget(roleCounts, target.roomName, 'reserve') <= 0
+  ) {
+    return false;
+  }
+
+  return (
+    getVisibleTerritoryTargetState(target.roomName, 'reserve', reserveIntent.controllerId, colonyOwnerUsername) !==
+    'unavailable'
   );
 }
 
@@ -1951,6 +1992,10 @@ function sanitizeInvalidPersistedTerritoryFollowUps(
   let changed = false;
   const sanitizedIntents = intents.map((intent) => {
     if (intent.colony !== colonyName || intent.followUp === undefined || intent.status === 'suppressed') {
+      return intent;
+    }
+
+    if (intent.status === 'active' && intent.action === 'reserve') {
       return intent;
     }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -981,7 +981,7 @@ function isClaimTargetDeferredBySameRoomReserveLane(
 
   if (
     reserveIntent.followUp === undefined &&
-    getTerritoryCreepCountForTarget(roleCounts, target.roomName, 'reserve') <= 0
+    getTerritoryCreepCountForTarget(roleCounts, reserveIntent.targetRoom, 'reserve') <= 0
   ) {
     return false;
   }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2888,6 +2888,141 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('keeps a live reserve fallback ahead of retrying the expired claim target', () => {
+    const colony = makeSafeColony();
+    const claimTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'claim' };
+    const reserveTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N1', 'claim');
+    const suppressionTime = 598;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const roleCounts = {
+      worker: 3,
+      claimer: 1,
+      claimersByTargetRoom: { W1N2: 1 },
+      claimersByTargetRoomAction: { reserve: { W1N2: 1 } }
+    };
+    const suppressedClaimIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'claim',
+      status: 'suppressed',
+      updatedAt: suppressionTime,
+      followUp
+    };
+    const activeReserveIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve',
+      status: 'active',
+      updatedAt: suppressionTime + 1,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: makeRecommendationRoom('W1N2')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [claimTarget, reserveTarget],
+        intents: [suppressedClaimIntent, activeReserveIntent]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, roleCounts, 3, retryTime);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve', followUp });
+    expect(shouldSpawnTerritoryControllerCreep(plan!, roleCounts, retryTime)).toBe(false);
+    expect(Memory.territory?.targets).toEqual([claimTarget, reserveTarget]);
+    expect(Memory.territory?.intents).toEqual([
+      suppressedClaimIntent,
+      {
+        ...activeReserveIntent,
+        updatedAt: retryTime
+      }
+    ]);
+  });
+
+  it('extends from a satisfied reserve fallback before retrying the expired claim target', () => {
+    const colony = makeSafeColony();
+    const claimTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'claim' };
+    const reserveTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const fallbackFollowUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N1', 'claim');
+    const adjacentFollowUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const suppressionTime = 599;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === 'W1N1' ? { '1': 'W1N2' } : roomName === 'W1N2' ? { '3': 'W2N2' } : {}
+    );
+    const suppressedClaimIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'claim',
+      status: 'suppressed',
+      updatedAt: suppressionTime,
+      followUp: fallbackFollowUp
+    };
+    const activeReserveIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve',
+      status: 'active',
+      updatedAt: suppressionTime + 1,
+      followUp: fallbackFollowUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: makeRecommendationRoom('W1N2', {
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        }),
+        W2N2: makeRecommendationRoom('W2N2')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [claimTarget, reserveTarget],
+        intents: [suppressedClaimIntent, activeReserveIntent]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N2',
+      action: 'reserve',
+      followUp: adjacentFollowUp
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N2');
+    expect(Memory.territory?.targets).toEqual([
+      claimTarget,
+      reserveTarget,
+      {
+        colony: 'W1N1',
+        roomName: 'W2N2',
+        action: 'reserve'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      suppressedClaimIntent,
+      activeReserveIntent,
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: retryTime,
+        followUp: adjacentFollowUp
+      }
+    ]);
+  });
+
   it('keeps emergency renewal ahead of active-reserve frontier expansion', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };


### PR DESCRIPTION
Closes #322.

## Summary
- Keeps territory follow-up intents actionable when claim/reserve fallback evidence indicates a target should remain active rather than being repeatedly suppressed.
- Adds focused planner coverage for the territory/control follow-up slice.
- Rebuilds `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 458 tests passed)
- `cd prod && npm run build`
- `cd prod && git diff --exit-code -- prod/dist/main.js`

Authorship: Codex-authored commit `fabb73f` by `lanyusea's bot <lanyusea@gmail.com>`.
