### PR TITLE
feat: avoid duplicate spawn energy deliveries

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3269,20 +3269,24 @@ function selectFillableEnergySink(creep) {
 }
 function selectSpawnOrExtensionEnergySink(creep) {
   const energySinks = findFillableEnergySinks(creep).filter(isSpawnOrExtensionEnergySink);
+  if (energySinks.length === 0) {
+    return null;
+  }
+  const loadedWorkers = getSameRoomLoadedWorkers(creep);
   return selectClosestEnergySink(
-    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, creep)),
+    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, creep, loadedWorkers)),
     creep
   );
 }
 function selectPriorityTowerEnergySink(creep) {
   return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink), creep);
 }
-function hasUnreservedEnergySinkCapacity(energySink, creep) {
-  return getReservedEnergyDelivery(energySink, creep) < getFreeStoredEnergyCapacity(energySink);
+function hasUnreservedEnergySinkCapacity(energySink, creep, loadedWorkers) {
+  return getReservedEnergyDelivery(energySink, creep, loadedWorkers) < getFreeStoredEnergyCapacity(energySink);
 }
-function getReservedEnergyDelivery(energySink, creep) {
+function getReservedEnergyDelivery(energySink, creep, loadedWorkers) {
   const energySinkId = String(energySink.id);
-  return getGameCreeps().filter((candidate) => !isSameCreep(candidate, creep) && isSameRoomWorkerWithEnergy(candidate, creep.room)).reduce((reservedEnergy, worker) => {
+  return loadedWorkers.filter((candidate) => !isSameCreep(candidate, creep)).reduce((reservedEnergy, worker) => {
     var _a;
     const task = (_a = worker.memory) == null ? void 0 : _a.task;
     return (task == null ? void 0 : task.type) === "transfer" && String(task.targetId) === energySinkId ? reservedEnergy + getUsedEnergy(worker) : reservedEnergy;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3274,8 +3274,11 @@ function selectSpawnOrExtensionEnergySink(creep) {
   }
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
+  const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   return selectClosestEnergySink(
-    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)),
+    energySinks.filter(
+      (energySink) => isAssignedTransferTarget(energySink, assignedTransferTargetId) || hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
+    ),
     creep
   );
 }
@@ -3304,6 +3307,14 @@ function getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers) {
 function getReservedEnergyDelivery(energySink, reservedEnergyDeliveries) {
   var _a;
   return (_a = reservedEnergyDeliveries.get(String(energySink.id))) != null ? _a : 0;
+}
+function getAssignedTransferTargetId(creep) {
+  var _a;
+  const task = (_a = creep.memory) == null ? void 0 : _a.task;
+  return (task == null ? void 0 : task.type) === "transfer" && typeof task.targetId === "string" ? String(task.targetId) : null;
+}
+function isAssignedTransferTarget(energySink, assignedTransferTargetId) {
+  return assignedTransferTargetId !== null && String(energySink.id) === assignedTransferTargetId;
 }
 function findFillableEnergySinks(creep) {
   const energySinks = creep.room.find(FIND_MY_STRUCTURES, {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3243,10 +3243,25 @@ function selectFillableEnergySink(creep) {
   return (_a = selectSpawnOrExtensionEnergySink(creep)) != null ? _a : selectPriorityTowerEnergySink(creep);
 }
 function selectSpawnOrExtensionEnergySink(creep) {
-  return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isSpawnOrExtensionEnergySink), creep);
+  const energySinks = findFillableEnergySinks(creep).filter(isSpawnOrExtensionEnergySink);
+  return selectClosestEnergySink(
+    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, creep)),
+    creep
+  );
 }
 function selectPriorityTowerEnergySink(creep) {
   return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink), creep);
+}
+function hasUnreservedEnergySinkCapacity(energySink, creep) {
+  return getReservedEnergyDelivery(energySink, creep) < getFreeStoredEnergyCapacity(energySink);
+}
+function getReservedEnergyDelivery(energySink, creep) {
+  const energySinkId = String(energySink.id);
+  return getGameCreeps().filter((candidate) => !isSameCreep(candidate, creep) && isSameRoomWorkerWithEnergy(candidate, creep.room)).reduce((reservedEnergy, worker) => {
+    var _a;
+    const task = (_a = worker.memory) == null ? void 0 : _a.task;
+    return (task == null ? void 0 : task.type) === "transfer" && String(task.targetId) === energySinkId ? reservedEnergy + getUsedEnergy(worker) : reservedEnergy;
+  }, 0);
 }
 function findFillableEnergySinks(creep) {
   const energySinks = creep.room.find(FIND_MY_STRUCTURES, {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3273,24 +3273,37 @@ function selectSpawnOrExtensionEnergySink(creep) {
     return null;
   }
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   return selectClosestEnergySink(
-    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, creep, loadedWorkers)),
+    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)),
     creep
   );
 }
 function selectPriorityTowerEnergySink(creep) {
   return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink), creep);
 }
-function hasUnreservedEnergySinkCapacity(energySink, creep, loadedWorkers) {
-  return getReservedEnergyDelivery(energySink, creep, loadedWorkers) < getFreeStoredEnergyCapacity(energySink);
+function hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries) {
+  return getReservedEnergyDelivery(energySink, reservedEnergyDeliveries) < getFreeStoredEnergyCapacity(energySink);
 }
-function getReservedEnergyDelivery(energySink, creep, loadedWorkers) {
-  const energySinkId = String(energySink.id);
-  return loadedWorkers.filter((candidate) => !isSameCreep(candidate, creep)).reduce((reservedEnergy, worker) => {
-    var _a;
+function getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers) {
+  var _a, _b;
+  const reservedEnergyDeliveries = /* @__PURE__ */ new Map();
+  for (const worker of loadedWorkers) {
+    if (isSameCreep(worker, creep)) {
+      continue;
+    }
     const task = (_a = worker.memory) == null ? void 0 : _a.task;
-    return (task == null ? void 0 : task.type) === "transfer" && String(task.targetId) === energySinkId ? reservedEnergy + getUsedEnergy(worker) : reservedEnergy;
-  }, 0);
+    if ((task == null ? void 0 : task.type) !== "transfer" || typeof task.targetId !== "string") {
+      continue;
+    }
+    const energySinkId = String(task.targetId);
+    reservedEnergyDeliveries.set(energySinkId, ((_b = reservedEnergyDeliveries.get(energySinkId)) != null ? _b : 0) + getUsedEnergy(worker));
+  }
+  return reservedEnergyDeliveries;
+}
+function getReservedEnergyDelivery(energySink, reservedEnergyDeliveries) {
+  var _a;
+  return (_a = reservedEnergyDeliveries.get(String(energySink.id))) != null ? _a : 0;
 }
 function findFillableEnergySinks(creep) {
   const energySinks = creep.room.find(FIND_MY_STRUCTURES, {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -240,8 +240,13 @@ function selectFillableEnergySink(creep: Creep): FillableEnergySink | null {
 
 function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | StructureExtension | null {
   const energySinks = findFillableEnergySinks(creep).filter(isSpawnOrExtensionEnergySink);
+  if (energySinks.length === 0) {
+    return null;
+  }
+
+  const loadedWorkers = getSameRoomLoadedWorkers(creep);
   return selectClosestEnergySink(
-    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, creep)),
+    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, creep, loadedWorkers)),
     creep
   );
 }
@@ -250,14 +255,22 @@ function selectPriorityTowerEnergySink(creep: Creep): StructureTower | null {
   return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink), creep);
 }
 
-function hasUnreservedEnergySinkCapacity(energySink: SpawnExtensionEnergyStructure, creep: Creep): boolean {
-  return getReservedEnergyDelivery(energySink, creep) < getFreeStoredEnergyCapacity(energySink);
+function hasUnreservedEnergySinkCapacity(
+  energySink: SpawnExtensionEnergyStructure,
+  creep: Creep,
+  loadedWorkers: Creep[]
+): boolean {
+  return getReservedEnergyDelivery(energySink, creep, loadedWorkers) < getFreeStoredEnergyCapacity(energySink);
 }
 
-function getReservedEnergyDelivery(energySink: SpawnExtensionEnergyStructure, creep: Creep): number {
+function getReservedEnergyDelivery(
+  energySink: SpawnExtensionEnergyStructure,
+  creep: Creep,
+  loadedWorkers: Creep[]
+): number {
   const energySinkId = String(energySink.id);
-  return getGameCreeps()
-    .filter((candidate) => !isSameCreep(candidate, creep) && isSameRoomWorkerWithEnergy(candidate, creep.room))
+  return loadedWorkers
+    .filter((candidate) => !isSameCreep(candidate, creep))
     .reduce((reservedEnergy, worker) => {
       const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
       return task?.type === 'transfer' && String(task.targetId) === energySinkId

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -245,8 +245,9 @@ function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | Struct
   }
 
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   return selectClosestEnergySink(
-    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, creep, loadedWorkers)),
+    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)),
     creep
   );
 }
@@ -257,26 +258,38 @@ function selectPriorityTowerEnergySink(creep: Creep): StructureTower | null {
 
 function hasUnreservedEnergySinkCapacity(
   energySink: SpawnExtensionEnergyStructure,
+  reservedEnergyDeliveries: Map<string, number>
+): boolean {
+  return getReservedEnergyDelivery(energySink, reservedEnergyDeliveries) < getFreeStoredEnergyCapacity(energySink);
+}
+
+function getReservedEnergyDeliveriesBySinkId(
   creep: Creep,
   loadedWorkers: Creep[]
-): boolean {
-  return getReservedEnergyDelivery(energySink, creep, loadedWorkers) < getFreeStoredEnergyCapacity(energySink);
+): Map<string, number> {
+  const reservedEnergyDeliveries = new Map<string, number>();
+  for (const worker of loadedWorkers) {
+    if (isSameCreep(worker, creep)) {
+      continue;
+    }
+
+    const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+    if (task?.type !== 'transfer' || typeof task.targetId !== 'string') {
+      continue;
+    }
+
+    const energySinkId = String(task.targetId);
+    reservedEnergyDeliveries.set(energySinkId, (reservedEnergyDeliveries.get(energySinkId) ?? 0) + getUsedEnergy(worker));
+  }
+
+  return reservedEnergyDeliveries;
 }
 
 function getReservedEnergyDelivery(
   energySink: SpawnExtensionEnergyStructure,
-  creep: Creep,
-  loadedWorkers: Creep[]
+  reservedEnergyDeliveries: Map<string, number>
 ): number {
-  const energySinkId = String(energySink.id);
-  return loadedWorkers
-    .filter((candidate) => !isSameCreep(candidate, creep))
-    .reduce((reservedEnergy, worker) => {
-      const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
-      return task?.type === 'transfer' && String(task.targetId) === energySinkId
-        ? reservedEnergy + getUsedEnergy(worker)
-        : reservedEnergy;
-    }, 0);
+  return reservedEnergyDeliveries.get(String(energySink.id)) ?? 0;
 }
 
 function findFillableEnergySinks(creep: Creep): FillableEnergySink[] {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -239,11 +239,31 @@ function selectFillableEnergySink(creep: Creep): FillableEnergySink | null {
 }
 
 function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | StructureExtension | null {
-  return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isSpawnOrExtensionEnergySink), creep);
+  const energySinks = findFillableEnergySinks(creep).filter(isSpawnOrExtensionEnergySink);
+  return selectClosestEnergySink(
+    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, creep)),
+    creep
+  );
 }
 
 function selectPriorityTowerEnergySink(creep: Creep): StructureTower | null {
   return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink), creep);
+}
+
+function hasUnreservedEnergySinkCapacity(energySink: SpawnExtensionEnergyStructure, creep: Creep): boolean {
+  return getReservedEnergyDelivery(energySink, creep) < getFreeStoredEnergyCapacity(energySink);
+}
+
+function getReservedEnergyDelivery(energySink: SpawnExtensionEnergyStructure, creep: Creep): number {
+  const energySinkId = String(energySink.id);
+  return getGameCreeps()
+    .filter((candidate) => !isSameCreep(candidate, creep) && isSameRoomWorkerWithEnergy(candidate, creep.room))
+    .reduce((reservedEnergy, worker) => {
+      const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+      return task?.type === 'transfer' && String(task.targetId) === energySinkId
+        ? reservedEnergy + getUsedEnergy(worker)
+        : reservedEnergy;
+    }, 0);
 }
 
 function findFillableEnergySinks(creep: Creep): FillableEnergySink[] {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -246,8 +246,13 @@ function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | Struct
 
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
+  const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   return selectClosestEnergySink(
-    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)),
+    energySinks.filter(
+      (energySink) =>
+        isAssignedTransferTarget(energySink, assignedTransferTargetId) ||
+        hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
+    ),
     creep
   );
 }
@@ -290,6 +295,18 @@ function getReservedEnergyDelivery(
   reservedEnergyDeliveries: Map<string, number>
 ): number {
   return reservedEnergyDeliveries.get(String(energySink.id)) ?? 0;
+}
+
+function getAssignedTransferTargetId(creep: Creep): string | null {
+  const task = creep.memory?.task as Partial<CreepTaskMemory> | undefined;
+  return task?.type === 'transfer' && typeof task.targetId === 'string' ? String(task.targetId) : null;
+}
+
+function isAssignedTransferTarget(
+  energySink: SpawnExtensionEnergyStructure,
+  assignedTransferTargetId: string | null
+): boolean {
+  return assignedTransferTargetId !== null && String(energySink.id) === assignedTransferTargetId;
 }
 
 function findFillableEnergySinks(creep: Creep): FillableEnergySink[] {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1729,7 +1729,14 @@ describe('runWorker', () => {
     const spawn = {
       id: 'spawn1',
       structureType: 'spawn',
-      store: { getFreeCapacity: jest.fn().mockReturnValueOnce(1).mockReturnValueOnce(1).mockReturnValue(0) }
+      store: {
+        getFreeCapacity: jest
+          .fn()
+          .mockReturnValueOnce(1)
+          .mockReturnValueOnce(1)
+          .mockReturnValueOnce(1)
+          .mockReturnValue(0)
+      }
     } as unknown as StructureSpawn;
     const creep = {
       memory: { task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> } },

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1674,7 +1674,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-open' });
   });
 
-  it('keeps primary sink selection available for the worker already carrying the assigned energy', () => {
+  it('keeps the assigned primary sink eligible when other workers cover its remaining capacity', () => {
     const spawn = makeEnergySink('spawn-covered', 'spawn' as StructureConstant, 50);
     const extension = makeEnergySink('extension-open', 'extension' as StructureConstant, 50);
     const structures = [spawn, extension];
@@ -1690,6 +1690,12 @@ describe('selectWorkerTask', () => {
         }
       )
     } as unknown as Room;
+    const otherCarrier = {
+      name: 'OtherCarrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-covered' as Id<AnyStoreStructure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
     const creep = {
       name: 'Carrier',
       memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-covered' as Id<AnyStoreStructure> } },
@@ -1699,7 +1705,7 @@ describe('selectWorkerTask', () => {
       },
       room
     } as unknown as Creep;
-    setGameCreeps({ Carrier: creep });
+    setGameCreeps({ Carrier: creep, OtherCarrier: otherCarrier });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-covered' });
   });

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1590,7 +1590,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-closer' });
   });
 
-  it('filters loaded room workers once while screening primary energy sinks', () => {
+  it('builds loaded worker energy sink reservations once while screening primary energy sinks', () => {
     const spawn = makeEnergySink('spawn-a', 'spawn' as StructureConstant, 300);
     const extension = makeEnergySink('extension-b', 'extension' as StructureConstant, 50);
     const structures = [spawn, extension];
@@ -1605,9 +1605,15 @@ describe('selectWorkerTask', () => {
       })
     } as unknown as Room;
     const workerEnergy = jest.fn().mockReturnValue(50);
-    const idleWorker = {
-      name: 'IdleWorker',
-      memory: { role: 'worker' },
+    const assignedWorkerMemory = { role: 'worker' } as CreepMemory;
+    const assignedWorkerTask = jest.fn().mockReturnValue({
+      type: 'transfer',
+      targetId: 'extension-b' as Id<AnyStoreStructure>
+    });
+    Object.defineProperty(assignedWorkerMemory, 'task', { get: assignedWorkerTask });
+    const assignedWorker = {
+      name: 'AssignedWorker',
+      memory: assignedWorkerMemory,
       store: { getUsedCapacity: workerEnergy },
       room
     } as unknown as Creep;
@@ -1620,10 +1626,11 @@ describe('selectWorkerTask', () => {
       },
       room
     } as unknown as Creep;
-    setGameCreeps({ IdleWorker: idleWorker });
+    setGameCreeps({ AssignedWorker: assignedWorker });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-a' });
-    expect(workerEnergy).toHaveBeenCalledTimes(1);
+    expect(assignedWorkerTask).toHaveBeenCalledTimes(1);
+    expect(workerEnergy).toHaveBeenCalledTimes(2);
   });
 
   it('skips primary energy sinks already covered by other loaded workers', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1590,6 +1590,42 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-closer' });
   });
 
+  it('filters loaded room workers once while screening primary energy sinks', () => {
+    const spawn = makeEnergySink('spawn-a', 'spawn' as StructureConstant, 300);
+    const extension = makeEnergySink('extension-b', 'extension' as StructureConstant, 50);
+    const structures = [spawn, extension];
+    const room = {
+      name: 'W1N1',
+      find: jest.fn((type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type !== FIND_MY_STRUCTURES) {
+          return [];
+        }
+
+        return options?.filter ? structures.filter(options.filter) : structures;
+      })
+    } as unknown as Room;
+    const workerEnergy = jest.fn().mockReturnValue(50);
+    const idleWorker = {
+      name: 'IdleWorker',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: workerEnergy },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'Carrier',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: {
+        getRangeTo: jest.fn((target: TestEnergySink) => (target.id === 'spawn-a' ? 1 : 2))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ IdleWorker: idleWorker });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-a' });
+    expect(workerEnergy).toHaveBeenCalledTimes(1);
+  });
+
   it('skips primary energy sinks already covered by other loaded workers', () => {
     const coveredSpawn = makeEnergySink('spawn-covered', 'spawn' as StructureConstant, 50);
     const openExtension = makeEnergySink('extension-open', 'extension' as StructureConstant, 50);

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1590,6 +1590,77 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-closer' });
   });
 
+  it('skips primary energy sinks already covered by other loaded workers', () => {
+    const coveredSpawn = makeEnergySink('spawn-covered', 'spawn' as StructureConstant, 50);
+    const openExtension = makeEnergySink('extension-open', 'extension' as StructureConstant, 50);
+    const structures = [coveredSpawn, openExtension];
+    const room = {
+      name: 'W1N1',
+      find: jest.fn(
+        (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+          if (type !== FIND_MY_STRUCTURES) {
+            return [];
+          }
+
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+      )
+    } as unknown as Room;
+    const assignedCarrier = {
+      name: 'Carrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-covered' as Id<AnyStoreStructure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const getRangeTo = jest.fn((target: TestEnergySink) => {
+      const ranges: Record<string, number> = {
+        'extension-open': 8,
+        'spawn-covered': 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      name: 'Worker',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Carrier: assignedCarrier, Worker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-open' });
+  });
+
+  it('keeps primary sink selection available for the worker already carrying the assigned energy', () => {
+    const spawn = makeEnergySink('spawn-covered', 'spawn' as StructureConstant, 50);
+    const extension = makeEnergySink('extension-open', 'extension' as StructureConstant, 50);
+    const structures = [spawn, extension];
+    const room = {
+      name: 'W1N1',
+      find: jest.fn(
+        (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+          if (type !== FIND_MY_STRUCTURES) {
+            return [];
+          }
+
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+      )
+    } as unknown as Room;
+    const creep = {
+      name: 'Carrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-covered' as Id<AnyStoreStructure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: {
+        getRangeTo: jest.fn((target: TestEnergySink) => (target.id === 'spawn-covered' ? 1 : 8))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Carrier: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-covered' });
+  });
+
   it('selects fillable extensions before fillable towers', () => {
     const farExtension = makeEnergySink('extension-far', 'extension' as StructureConstant, 50);
     const nearTower = makeEnergySink('tower-near', 'tower' as StructureConstant, 500);


### PR DESCRIPTION
## Summary
- avoid duplicate spawn/extension energy deliveries by accounting for other loaded workers already assigned to the same primary sink
- keep the currently assigned carrier eligible for its own target
- regenerate `prod/dist/main.js`

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 461 tests)
- `cd prod && npm run build`
- `git diff --check`
- `git diff --exit-code -- prod/dist/main.js`

## Scheduler evidence
- Source issue: #324
- Codex-authored implementation commit: `4624b4c`
- Codex-authored merge/reconcile commit after PR #323/main: `54c9a48`
- Worktree: `/root/screeps-worktrees/economy-postdeploy-324`
