### PR TITLE
feat: prioritize actionable territory follow-ups

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1463,6 +1463,15 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
   const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord2();
   let intents = normalizeTerritoryIntents2(territoryMemory == null ? void 0 : territoryMemory.intents);
+  const sanitizedClaimReserveHandoffs = sanitizeSatisfiedClaimReserveHandoffs(
+    territoryMemory,
+    intents,
+    colonyName,
+    colonyOwnerUsername
+  );
+  if (sanitizedClaimReserveHandoffs.changed) {
+    intents = sanitizedClaimReserveHandoffs.intents;
+  }
   const sanitizedFollowUps = sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyOwnerUsername);
   if (sanitizedFollowUps.changed) {
     intents = sanitizedFollowUps.intents;
@@ -2399,6 +2408,47 @@ function upsertTerritoryIntent2(intents, nextIntent) {
     return;
   }
   intents.push(nextIntent);
+}
+function sanitizeSatisfiedClaimReserveHandoffs(territoryMemory, intents, colonyName, colonyOwnerUsername) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return { intents, changed: false };
+  }
+  const satisfiedClaimRooms = getSatisfiedConfiguredClaimRoomNames(
+    territoryMemory.targets,
+    colonyName,
+    colonyOwnerUsername
+  );
+  if (satisfiedClaimRooms.size === 0) {
+    return { intents, changed: false };
+  }
+  const nextTargets = territoryMemory.targets.filter((rawTarget) => {
+    const target = normalizeTerritoryTarget2(rawTarget);
+    return !((target == null ? void 0 : target.colony) === colonyName && target.action === "reserve" && satisfiedClaimRooms.has(target.roomName));
+  });
+  const nextIntents = intents.filter(
+    (intent) => !(intent.colony === colonyName && intent.action === "reserve" && satisfiedClaimRooms.has(intent.targetRoom))
+  );
+  const changed = nextTargets.length !== territoryMemory.targets.length || nextIntents.length !== intents.length;
+  if (!changed) {
+    return { intents, changed: false };
+  }
+  territoryMemory.targets = nextTargets;
+  territoryMemory.intents = nextIntents;
+  for (const targetRoom of satisfiedClaimRooms) {
+    removeTerritoryFollowUpDemand(territoryMemory, colonyName, targetRoom, "reserve");
+    removeTerritoryFollowUpExecutionHint(territoryMemory, colonyName, targetRoom, "reserve");
+  }
+  return { intents: nextIntents, changed: true };
+}
+function getSatisfiedConfiguredClaimRoomNames(rawTargets, colonyName, colonyOwnerUsername) {
+  const satisfiedClaimRooms = /* @__PURE__ */ new Set();
+  for (const rawTarget of rawTargets) {
+    const target = normalizeTerritoryTarget2(rawTarget);
+    if ((target == null ? void 0 : target.colony) === colonyName && target.action === "claim" && getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) === "satisfied") {
+      satisfiedClaimRooms.add(target.roomName);
+    }
+  }
+  return satisfiedClaimRooms;
 }
 function sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyOwnerUsername) {
   let changed = false;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -536,6 +536,15 @@ function selectTerritoryTarget(
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   let intents = normalizeTerritoryIntents(territoryMemory?.intents);
+  const sanitizedClaimReserveHandoffs = sanitizeSatisfiedClaimReserveHandoffs(
+    territoryMemory,
+    intents,
+    colonyName,
+    colonyOwnerUsername
+  );
+  if (sanitizedClaimReserveHandoffs.changed) {
+    intents = sanitizedClaimReserveHandoffs.intents;
+  }
   const sanitizedFollowUps = sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyOwnerUsername);
   if (sanitizedFollowUps.changed) {
     intents = sanitizedFollowUps.intents;
@@ -1982,6 +1991,77 @@ function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: Ter
   }
 
   intents.push(nextIntent);
+}
+
+function sanitizeSatisfiedClaimReserveHandoffs(
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  colonyName: string,
+  colonyOwnerUsername: string | null
+): { intents: TerritoryIntentMemory[]; changed: boolean } {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return { intents, changed: false };
+  }
+
+  const satisfiedClaimRooms = getSatisfiedConfiguredClaimRoomNames(
+    territoryMemory.targets,
+    colonyName,
+    colonyOwnerUsername
+  );
+  if (satisfiedClaimRooms.size === 0) {
+    return { intents, changed: false };
+  }
+
+  const nextTargets = territoryMemory.targets.filter((rawTarget) => {
+    const target = normalizeTerritoryTarget(rawTarget);
+    return !(
+      target?.colony === colonyName &&
+      target.action === 'reserve' &&
+      satisfiedClaimRooms.has(target.roomName)
+    );
+  });
+  const nextIntents = intents.filter(
+    (intent) =>
+      !(
+        intent.colony === colonyName &&
+        intent.action === 'reserve' &&
+        satisfiedClaimRooms.has(intent.targetRoom)
+      )
+  );
+  const changed = nextTargets.length !== territoryMemory.targets.length || nextIntents.length !== intents.length;
+  if (!changed) {
+    return { intents, changed: false };
+  }
+
+  territoryMemory.targets = nextTargets;
+  territoryMemory.intents = nextIntents;
+  for (const targetRoom of satisfiedClaimRooms) {
+    removeTerritoryFollowUpDemand(territoryMemory as TerritoryMemory, colonyName, targetRoom, 'reserve');
+    removeTerritoryFollowUpExecutionHint(territoryMemory as TerritoryMemory, colonyName, targetRoom, 'reserve');
+  }
+
+  return { intents: nextIntents, changed: true };
+}
+
+function getSatisfiedConfiguredClaimRoomNames(
+  rawTargets: unknown[],
+  colonyName: string,
+  colonyOwnerUsername: string | null
+): Set<string> {
+  const satisfiedClaimRooms = new Set<string>();
+  for (const rawTarget of rawTargets) {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (
+      target?.colony === colonyName &&
+      target.action === 'claim' &&
+      getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) ===
+        'satisfied'
+    ) {
+      satisfiedClaimRooms.add(target.roomName);
+    }
+  }
+
+  return satisfiedClaimRooms;
 }
 
 function sanitizeInvalidPersistedTerritoryFollowUps(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3023,6 +3023,97 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('clears stale same-room reserve fallback after the claim target is owned', () => {
+    const colony = makeSafeColony();
+    const claimTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'claim' };
+    const reserveTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const fallbackFollowUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N1', 'claim');
+    const adjacentFollowUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N2', 'claim');
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === 'W1N1' ? { '1': 'W1N2' } : roomName === 'W1N2' ? { '3': 'W2N2' } : {}
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W1N2: makeRecommendationRoom('W1N2', {
+          controller: { my: true, owner: { username: 'me' } } as StructureController
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [claimTarget, reserveTarget],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 600,
+            followUp: fallbackFollowUp
+          }
+        ],
+        demands: [
+          {
+            type: 'followUpPreparation',
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            workerCount: 1,
+            updatedAt: 600,
+            followUp: fallbackFollowUp
+          }
+        ],
+        executionHints: [
+          {
+            type: 'activeFollowUpExecution',
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            reason: 'visibleControlEvidenceStillActionable',
+            updatedAt: 600,
+            followUp: fallbackFollowUp
+          }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 601);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N2',
+      action: 'scout',
+      followUp: adjacentFollowUp
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(describeExits).toHaveBeenCalledWith('W1N2');
+    expect(Memory.territory?.targets).toEqual([claimTarget]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 601,
+        followUp: adjacentFollowUp
+      }
+    ]);
+    expect(Memory.territory?.demands).toBeUndefined();
+    expect(Memory.territory?.executionHints).toEqual([
+      {
+        type: 'activeFollowUpExecution',
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'scout',
+        reason: 'followUpTargetStillUnseen',
+        updatedAt: 601,
+        followUp: adjacentFollowUp
+      }
+    ]);
+  });
+
   it('keeps emergency renewal ahead of active-reserve frontier expansion', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };


### PR DESCRIPTION
## Summary
- Prioritize follow-up territory actions that can be executed immediately instead of deferring behind less actionable targets.
- Add planner coverage for actionable claim/reserve follow-up ordering.
- Regenerate `prod/dist/main.js`.

## Linked issue
Closes #326.

## Roadmap category
Bot capability / gameplay — territory/control.

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 460 tests)
- `cd prod && npm run build`
- `git diff --check`

## Scheduler evidence
- Source issue: #326
- Codex-authored implementation/recovery commit: `04e0d1f`
- Worktree: `/root/screeps-worktrees/territory-post-323-326`
