### PR TITLE
feat: add source2 controller energy lane

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3204,17 +3204,16 @@ function selectWorkerTask(creep) {
         if (spawnRecoveryTask) {
           return spawnRecoveryTask;
         }
-      } else {
+      }
+      const source2ControllerLaneHarvestTask = selectSource2ControllerLaneHarvestTask(creep);
+      if (source2ControllerLaneHarvestTask) {
+        return source2ControllerLaneHarvestTask;
+      }
+      if (!hasPriorityEnergySink) {
         const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
         if (energyAcquisitionTask) {
           return energyAcquisitionTask;
         }
-      }
-    }
-    if (!hasPriorityEnergySink) {
-      const source2ControllerLaneHarvestTask = selectSource2ControllerLaneHarvestTask(creep);
-      if (source2ControllerLaneHarvestTask) {
-        return source2ControllerLaneHarvestTask;
       }
     }
     const source = selectHarvestSource(creep);
@@ -3253,6 +3252,10 @@ function selectWorkerTask(creep) {
   }
   if (territoryControllerTask) {
     return territoryControllerTask;
+  }
+  const source2ControllerLaneLoadedTask = controller ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites) : null;
+  if (source2ControllerLaneLoadedTask) {
+    return source2ControllerLaneLoadedTask;
   }
   if (capacityConstructionSite) {
     return { type: "build", targetId: capacityConstructionSite.id };
@@ -4024,7 +4027,7 @@ function shouldUseSurplusForControllerProgress(creep, controller) {
   if (controller.my === true && controller.level >= 2 && hasRecoverableSurplusEnergy(creep)) {
     return true;
   }
-  return shouldApplySource2ControllerLane(creep, controller);
+  return false;
 }
 function shouldApplySource2ControllerLane(creep, controller) {
   const topology = getSource2ControllerLaneTopology(creep.room, controller);
@@ -4032,6 +4035,13 @@ function shouldApplySource2ControllerLane(creep, controller) {
     return false;
   }
   return !hasOtherSource2ControllerLaneWorker(creep, topology);
+}
+function selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites) {
+  if (!shouldApplySource2ControllerLane(creep, controller)) {
+    return null;
+  }
+  const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller);
+  return productiveEnergySinkTask != null ? productiveEnergySinkTask : { type: "upgrade", targetId: controller.id };
 }
 function selectSource2ControllerLaneHarvestTask(creep) {
   const controller = creep.room.controller;
@@ -4045,7 +4055,7 @@ function selectSource2ControllerLaneHarvestTask(creep) {
   return { type: "harvest", targetId: topology.source.id };
 }
 function getSource2ControllerLaneTopology(room, controller) {
-  if (controller.my !== true || controller.level < 2 || !isHomeRoomName(room, controller) || hasVisibleHostilePresence(room)) {
+  if (controller.my !== true || typeof controller.level !== "number" || controller.level < 2 || getRoomObjectPosition(controller) === null || !isHomeRoomName(room, controller) || hasVisibleHostilePresence(room)) {
     return null;
   }
   const source = getSource2(room);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3181,6 +3181,8 @@ var ENERGY_ACQUISITION_RANGE_COST = 50;
 var ENERGY_ACQUISITION_ACTION_TICKS = 1;
 var HARVEST_ENERGY_PER_WORK_PART = 2;
 var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
+var SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
+var SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 var nearTermSpawnExtensionRefillReserveCache = null;
 function selectWorkerTask(creep) {
   const carriedEnergy = getUsedEnergy(creep);
@@ -3193,9 +3195,11 @@ function selectWorkerTask(creep) {
     if (isTerritoryControlTask(territoryControllerTask)) {
       return territoryControllerTask;
     }
+    let hasPriorityEnergySink = false;
     if (getFreeEnergyCapacity(creep) > 0) {
       const spawnRecoveryEnergySink = selectFillableEnergySink(creep);
       if (spawnRecoveryEnergySink) {
+        hasPriorityEnergySink = true;
         const spawnRecoveryTask = selectSpawnRecoveryEnergyAcquisitionTask(creep, spawnRecoveryEnergySink);
         if (spawnRecoveryTask) {
           return spawnRecoveryTask;
@@ -3205,6 +3209,12 @@ function selectWorkerTask(creep) {
         if (energyAcquisitionTask) {
           return energyAcquisitionTask;
         }
+      }
+    }
+    if (!hasPriorityEnergySink) {
+      const source2ControllerLaneHarvestTask = selectSource2ControllerLaneHarvestTask(creep);
+      if (source2ControllerLaneHarvestTask) {
+        return source2ControllerLaneHarvestTask;
       }
     }
     const source = selectHarvestSource(creep);
@@ -3968,7 +3978,100 @@ function shouldUseSurplusForControllerProgress(creep, controller) {
   if (shouldApplyControllerPressureLane(creep, controller)) {
     return true;
   }
-  return controller.my === true && controller.level >= 2 && hasRecoverableSurplusEnergy(creep);
+  if (controller.my === true && controller.level >= 2 && hasRecoverableSurplusEnergy(creep)) {
+    return true;
+  }
+  return shouldApplySource2ControllerLane(creep, controller);
+}
+function shouldApplySource2ControllerLane(creep, controller) {
+  const topology = getSource2ControllerLaneTopology(creep.room, controller);
+  if (!topology) {
+    return false;
+  }
+  return !hasOtherSource2ControllerLaneWorker(creep, topology);
+}
+function selectSource2ControllerLaneHarvestTask(creep) {
+  const controller = creep.room.controller;
+  if (!controller) {
+    return null;
+  }
+  const topology = getSource2ControllerLaneTopology(creep.room, controller);
+  if (!topology || isSourceDepleted(topology.source) || hasOtherSource2ControllerLaneWorker(creep, topology)) {
+    return null;
+  }
+  return { type: "harvest", targetId: topology.source.id };
+}
+function getSource2ControllerLaneTopology(room, controller) {
+  if (controller.my !== true || controller.level < 2 || !isHomeRoomName(room, controller) || hasVisibleHostilePresence(room)) {
+    return null;
+  }
+  const source = getSource2(room);
+  if (!source) {
+    return null;
+  }
+  const range = getRangeBetweenRoomObjectPositions(source, controller);
+  if (range === null || range > SOURCE2_CONTROLLER_LANE_MAX_RANGE) {
+    return null;
+  }
+  return { controller, source };
+}
+function getSource2(room) {
+  var _a;
+  if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
+    return null;
+  }
+  return (_a = room.find(FIND_SOURCES)[SOURCE2_CONTROLLER_LANE_SOURCE_INDEX]) != null ? _a : null;
+}
+function isHomeRoomName(room, controller) {
+  const roomName = getRoomName(room);
+  const controllerRoomName = getPositionRoomName(controller);
+  return roomName === null || controllerRoomName === null || roomName === controllerRoomName;
+}
+function isSourceDepleted(source) {
+  return typeof source.energy === "number" && source.energy <= 0;
+}
+function hasOtherSource2ControllerLaneWorker(creep, topology) {
+  return getGameCreeps().some(
+    (candidate) => !isSameCreep(candidate, creep) && isSameRoomWorker(candidate, creep.room) && isSource2ControllerLaneTask(candidate, topology)
+  );
+}
+function isSameRoomWorker(creep, room) {
+  var _a;
+  return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom(creep, room);
+}
+function isSource2ControllerLaneTask(creep, topology) {
+  var _a;
+  const task = (_a = creep.memory) == null ? void 0 : _a.task;
+  return (task == null ? void 0 : task.type) === "harvest" && task.targetId === topology.source.id || (task == null ? void 0 : task.type) === "upgrade" && task.targetId === topology.controller.id;
+}
+function getRangeBetweenRoomObjectPositions(left, right) {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  if (!leftPosition || !rightPosition || !isSameRoomPosition2(leftPosition, rightPosition)) {
+    return null;
+  }
+  const rangeFromApi = getRangeBetweenRoomObjects(left, right);
+  if (rangeFromApi !== null) {
+    return rangeFromApi;
+  }
+  return Math.max(Math.abs(leftPosition.x - rightPosition.x), Math.abs(leftPosition.y - rightPosition.y));
+}
+function getRoomObjectPosition(object) {
+  const position = object.pos;
+  return isRoomPosition(position) ? position : null;
+}
+function getPositionRoomName(object) {
+  var _a, _b;
+  return (_b = (_a = getRoomObjectPosition(object)) == null ? void 0 : _a.roomName) != null ? _b : null;
+}
+function isSameRoomPosition2(left, right) {
+  if (typeof left.roomName === "string" && typeof right.roomName === "string") {
+    return left.roomName === right.roomName;
+  }
+  return true;
+}
+function isRoomPosition(value) {
+  return isWorkerTaskRecord(value) && typeof value.x === "number" && typeof value.y === "number" && Number.isFinite(value.x) && Number.isFinite(value.y);
 }
 function hasRecoverableSurplusEnergy(creep) {
   return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null || findDroppedResources(creep.room).some(isUsefulDroppedEnergy);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4114,7 +4114,7 @@ function isSameRoomPosition2(left, right) {
   return true;
 }
 function isRoomPosition(value) {
-  return isWorkerTaskRecord(value) && typeof value.x === "number" && typeof value.y === "number" && Number.isFinite(value.x) && Number.isFinite(value.y);
+  return isWorkerTaskRecord(value) && typeof value.x === "number" && typeof value.y === "number" && typeof value.roomName === "string" && Number.isFinite(value.x) && Number.isFinite(value.y) && value.roomName.length > 0;
 }
 function hasRecoverableSurplusEnergy(creep) {
   return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null || findDroppedResources(creep.room).some(isUsefulDroppedEnergy);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -20,6 +20,8 @@ const ENERGY_ACQUISITION_RANGE_COST = 50;
 const ENERGY_ACQUISITION_ACTION_TICKS = 1;
 const HARVEST_ENERGY_PER_WORK_PART = 2;
 const MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
+const SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
+const SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
@@ -52,6 +54,11 @@ interface NearTermSpawnExtensionRefillReserveCache {
   tick: number;
 }
 
+interface Source2ControllerLaneTopology {
+  controller: StructureController;
+  source: Source;
+}
+
 let nearTermSpawnExtensionRefillReserveCache: NearTermSpawnExtensionRefillReserveCache | null = null;
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
@@ -68,9 +75,11 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
       return territoryControllerTask;
     }
 
+    let hasPriorityEnergySink = false;
     if (getFreeEnergyCapacity(creep) > 0) {
       const spawnRecoveryEnergySink = selectFillableEnergySink(creep);
       if (spawnRecoveryEnergySink) {
+        hasPriorityEnergySink = true;
         const spawnRecoveryTask = selectSpawnRecoveryEnergyAcquisitionTask(creep, spawnRecoveryEnergySink);
         if (spawnRecoveryTask) {
           return spawnRecoveryTask;
@@ -80,6 +89,13 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
         if (energyAcquisitionTask) {
           return energyAcquisitionTask;
         }
+      }
+    }
+
+    if (!hasPriorityEnergySink) {
+      const source2ControllerLaneHarvestTask = selectSource2ControllerLaneHarvestTask(creep);
+      if (source2ControllerLaneHarvestTask) {
+        return source2ControllerLaneHarvestTask;
       }
     }
 
@@ -1270,7 +1286,141 @@ function shouldUseSurplusForControllerProgress(creep: Creep, controller: Structu
     return true;
   }
 
-  return controller.my === true && controller.level >= 2 && hasRecoverableSurplusEnergy(creep);
+  if (controller.my === true && controller.level >= 2 && hasRecoverableSurplusEnergy(creep)) {
+    return true;
+  }
+
+  return shouldApplySource2ControllerLane(creep, controller);
+}
+
+function shouldApplySource2ControllerLane(creep: Creep, controller: StructureController): boolean {
+  const topology = getSource2ControllerLaneTopology(creep.room, controller);
+  if (!topology) {
+    return false;
+  }
+
+  return !hasOtherSource2ControllerLaneWorker(creep, topology);
+}
+
+function selectSource2ControllerLaneHarvestTask(creep: Creep): Extract<CreepTaskMemory, { type: 'harvest' }> | null {
+  const controller = creep.room.controller;
+  if (!controller) {
+    return null;
+  }
+
+  const topology = getSource2ControllerLaneTopology(creep.room, controller);
+  if (!topology || isSourceDepleted(topology.source) || hasOtherSource2ControllerLaneWorker(creep, topology)) {
+    return null;
+  }
+
+  return { type: 'harvest', targetId: topology.source.id };
+}
+
+function getSource2ControllerLaneTopology(
+  room: Room,
+  controller: StructureController
+): Source2ControllerLaneTopology | null {
+  if (
+    controller.my !== true ||
+    controller.level < 2 ||
+    !isHomeRoomName(room, controller) ||
+    hasVisibleHostilePresence(room)
+  ) {
+    return null;
+  }
+
+  const source = getSource2(room);
+  if (!source) {
+    return null;
+  }
+
+  const range = getRangeBetweenRoomObjectPositions(source, controller);
+  if (range === null || range > SOURCE2_CONTROLLER_LANE_MAX_RANGE) {
+    return null;
+  }
+
+  return { controller, source };
+}
+
+function getSource2(room: Room): Source | null {
+  if (typeof FIND_SOURCES !== 'number' || typeof room.find !== 'function') {
+    return null;
+  }
+
+  return room.find(FIND_SOURCES)[SOURCE2_CONTROLLER_LANE_SOURCE_INDEX] ?? null;
+}
+
+function isHomeRoomName(room: Room, controller: StructureController): boolean {
+  const roomName = getRoomName(room);
+  const controllerRoomName = getPositionRoomName(controller);
+  return roomName === null || controllerRoomName === null || roomName === controllerRoomName;
+}
+
+function isSourceDepleted(source: Source): boolean {
+  return typeof source.energy === 'number' && source.energy <= 0;
+}
+
+function hasOtherSource2ControllerLaneWorker(creep: Creep, topology: Source2ControllerLaneTopology): boolean {
+  return getGameCreeps().some(
+    (candidate) =>
+      !isSameCreep(candidate, creep) &&
+      isSameRoomWorker(candidate, creep.room) &&
+      isSource2ControllerLaneTask(candidate, topology)
+  );
+}
+
+function isSameRoomWorker(creep: Creep, room: Room): boolean {
+  return creep.memory?.role === 'worker' && isInRoom(creep, room);
+}
+
+function isSource2ControllerLaneTask(creep: Creep, topology: Source2ControllerLaneTopology): boolean {
+  const task = creep.memory?.task as Partial<CreepTaskMemory> | undefined;
+  return (
+    (task?.type === 'harvest' && task.targetId === topology.source.id) ||
+    (task?.type === 'upgrade' && task.targetId === topology.controller.id)
+  );
+}
+
+function getRangeBetweenRoomObjectPositions(left: RoomObject, right: RoomObject): number | null {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  if (!leftPosition || !rightPosition || !isSameRoomPosition(leftPosition, rightPosition)) {
+    return null;
+  }
+
+  const rangeFromApi = getRangeBetweenRoomObjects(left, right);
+  if (rangeFromApi !== null) {
+    return rangeFromApi;
+  }
+
+  return Math.max(Math.abs(leftPosition.x - rightPosition.x), Math.abs(leftPosition.y - rightPosition.y));
+}
+
+function getRoomObjectPosition(object: RoomObject): RoomPosition | null {
+  const position = (object as RoomObject & { pos?: RoomPosition }).pos;
+  return isRoomPosition(position) ? position : null;
+}
+
+function getPositionRoomName(object: RoomObject): string | null {
+  return getRoomObjectPosition(object)?.roomName ?? null;
+}
+
+function isSameRoomPosition(left: RoomPosition, right: RoomPosition): boolean {
+  if (typeof left.roomName === 'string' && typeof right.roomName === 'string') {
+    return left.roomName === right.roomName;
+  }
+
+  return true;
+}
+
+function isRoomPosition(value: unknown): value is RoomPosition {
+  return (
+    isWorkerTaskRecord(value) &&
+    typeof value.x === 'number' &&
+    typeof value.y === 'number' &&
+    Number.isFinite(value.x) &&
+    Number.isFinite(value.y)
+  );
 }
 
 function hasRecoverableSurplusEnergy(creep: Creep): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1481,8 +1481,10 @@ function isRoomPosition(value: unknown): value is RoomPosition {
     isWorkerTaskRecord(value) &&
     typeof value.x === 'number' &&
     typeof value.y === 'number' &&
+    typeof value.roomName === 'string' &&
     Number.isFinite(value.x) &&
-    Number.isFinite(value.y)
+    Number.isFinite(value.y) &&
+    value.roomName.length > 0
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -84,18 +84,18 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
         if (spawnRecoveryTask) {
           return spawnRecoveryTask;
         }
-      } else {
+      }
+
+      const source2ControllerLaneHarvestTask = selectSource2ControllerLaneHarvestTask(creep);
+      if (source2ControllerLaneHarvestTask) {
+        return source2ControllerLaneHarvestTask;
+      }
+
+      if (!hasPriorityEnergySink) {
         const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
         if (energyAcquisitionTask) {
           return energyAcquisitionTask;
         }
-      }
-    }
-
-    if (!hasPriorityEnergySink) {
-      const source2ControllerLaneHarvestTask = selectSource2ControllerLaneHarvestTask(creep);
-      if (source2ControllerLaneHarvestTask) {
-        return source2ControllerLaneHarvestTask;
       }
     }
 
@@ -143,6 +143,13 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
 
   if (territoryControllerTask) {
     return territoryControllerTask;
+  }
+
+  const source2ControllerLaneLoadedTask = controller
+    ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites)
+    : null;
+  if (source2ControllerLaneLoadedTask) {
+    return source2ControllerLaneLoadedTask;
   }
 
   if (capacityConstructionSite) {
@@ -1353,7 +1360,7 @@ function shouldUseSurplusForControllerProgress(creep: Creep, controller: Structu
     return true;
   }
 
-  return shouldApplySource2ControllerLane(creep, controller);
+  return false;
 }
 
 function shouldApplySource2ControllerLane(creep: Creep, controller: StructureController): boolean {
@@ -1363,6 +1370,19 @@ function shouldApplySource2ControllerLane(creep: Creep, controller: StructureCon
   }
 
   return !hasOtherSource2ControllerLaneWorker(creep, topology);
+}
+
+function selectSource2ControllerLaneLoadedTask(
+  creep: Creep,
+  controller: StructureController,
+  constructionSites: ConstructionSite[]
+): ProductiveEnergySinkTask | Extract<CreepTaskMemory, { type: 'upgrade' }> | null {
+  if (!shouldApplySource2ControllerLane(creep, controller)) {
+    return null;
+  }
+
+  const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller);
+  return productiveEnergySinkTask ?? { type: 'upgrade', targetId: controller.id };
 }
 
 function selectSource2ControllerLaneHarvestTask(creep: Creep): Extract<CreepTaskMemory, { type: 'harvest' }> | null {
@@ -1385,7 +1405,9 @@ function getSource2ControllerLaneTopology(
 ): Source2ControllerLaneTopology | null {
   if (
     controller.my !== true ||
+    typeof controller.level !== 'number' ||
     controller.level < 2 ||
+    getRoomObjectPosition(controller) === null ||
     !isHomeRoomName(room, controller) ||
     hasVisibleHostilePresence(room)
   ) {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4005,6 +4005,13 @@ describe('selectWorkerTask', () => {
 
   it.each([
     ['missing source position', [makeSource('source1', 8, 8), { id: 'source2', energy: 300 } as Source]],
+    [
+      'source position without roomName',
+      [
+        makeSource('source1', 8, 8),
+        { id: 'source2', energy: 300, pos: { x: 24, y: 23 } as RoomPosition } as Source
+      ]
+    ],
     ['far source2/controller topology', [makeSource('source1', 8, 8), makeSource('source2', 40, 40)]]
   ])('falls back to existing worker behavior with %s', (_label, sources) => {
     const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -107,19 +107,37 @@ function makeSalvageEnergySource(
   } as unknown as Tombstone | Ruin;
 }
 
+function makeRoomPosition(x: number, y: number, roomName = 'W1N1'): RoomPosition {
+  return { x, y, roomName } as unknown as RoomPosition;
+}
+
+function makeSource(id: string, x: number, y: number, energy = 300): Source {
+  return {
+    id,
+    energy,
+    pos: makeRoomPosition(x, y)
+  } as unknown as Source;
+}
+
 function makeWorkerTaskRoom({
   constructionSites = [],
   controller = { id: 'controller1', my: true, level: 3 } as StructureController,
   energyAvailable,
   energyCapacityAvailable,
+  hostileCreeps = [],
+  hostileStructures = [],
   myStructures = [],
+  sources = [],
   structures = []
 }: {
   constructionSites?: ConstructionSite[];
   controller?: StructureController;
   energyAvailable?: number;
   energyCapacityAvailable?: number;
+  hostileCreeps?: Creep[];
+  hostileStructures?: AnyStructure[];
   myStructures?: AnyOwnedStructure[];
+  sources?: Source[];
   structures?: AnyStructure[];
 } = {}): Room {
   return {
@@ -132,8 +150,20 @@ function makeWorkerTaskRoom({
         return options?.filter ? myStructures.filter(options.filter) : myStructures;
       }
 
+      if (type === FIND_HOSTILE_CREEPS) {
+        return hostileCreeps;
+      }
+
+      if (type === FIND_HOSTILE_STRUCTURES) {
+        return hostileStructures;
+      }
+
       if (type === FIND_CONSTRUCTION_SITES) {
         return constructionSites;
+      }
+
+      if (type === FIND_SOURCES) {
+        return sources;
       }
 
       if (type === FIND_STRUCTURES) {
@@ -3747,6 +3777,157 @@ describe('selectWorkerTask', () => {
     setGameCreeps({
       Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> })
     });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
+  });
+
+  it('steers an empty worker to source2 when source2 is near the owned controller', () => {
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ controller, sources: [source1, source2] });
+    const creep = {
+      name: 'LaneWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LaneWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
+  });
+
+  it('routes a loaded source2/controller lane worker to upgrade before far generic construction', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ constructionSites: [site], controller, sources: [source1, source2] });
+    const creep = {
+      name: 'LaneWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LaneWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it.each([
+    ['spawn', 'spawn1'],
+    ['extension', 'extension1']
+  ])('keeps %s refill ahead of the source2/controller lane', (structureType, sinkId) => {
+    const energySink = makeEnergySink(sinkId, structureType as StructureConstant, 50);
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [energySink as AnyOwnedStructure],
+        sources: [source1, source2]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: sinkId });
+  });
+
+  it('keeps controller downgrade guard above lane occupancy', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ constructionSites: [site], controller, sources: [source1, source2] });
+    const creep = {
+      name: 'GuardWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> })
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it.each([
+    ['missing source position', [makeSource('source1', 8, 8), { id: 'source2', energy: 300 } as Source]],
+    ['far source2/controller topology', [makeSource('source1', 8, 8), makeSource('source2', 40, 40)]]
+  ])('falls back to existing worker behavior with %s', (_label, sources) => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const creep = {
+      name: 'FallbackWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ constructionSites: [site], controller, sources })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
+  });
+
+  it('falls back to existing worker behavior when the source2/controller lane is unsafe', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const hostile = { id: 'hostile1' } as Creep;
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const creep = {
+      name: 'FallbackWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        hostileCreeps: [hostile],
+        sources: [source1, source2]
+      })
+    } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
   });

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3926,8 +3926,39 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
+  it('keeps an empty source2/controller lane worker on source2 before room-wide stored energy', () => {
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const container = makeStoredEnergyStructure('container-near', 'container' as StructureConstant, 500);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ controller, sources: [source1, source2], structures: [container] });
+    const creep = {
+      name: 'LaneWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LaneWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
+    expect(room.find).not.toHaveBeenCalledWith(FIND_STRUCTURES);
+  });
+
   it('routes a loaded source2/controller lane worker to upgrade before far generic construction', () => {
-    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const site = {
+      id: 'tower-site1',
+      structureType: 'tower',
+      pos: makeRoomPosition(34, 34)
+    } as ConstructionSite;
     const source1 = makeSource('source1', 8, 8);
     const source2 = makeSource('source2', 24, 23);
     const controller = {
@@ -3938,15 +3969,58 @@ describe('selectWorkerTask', () => {
       pos: makeRoomPosition(25, 25)
     } as StructureController;
     const room = makeWorkerTaskRoom({ constructionSites: [site], controller, sources: [source1, source2] });
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'tower-site1': 9,
+        controller1: 1
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
     const creep = {
       name: 'LaneWorker',
       memory: { role: 'worker', colony: 'W1N1' },
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { ...makeRoomPosition(25, 24), getRangeTo } as unknown as RoomPosition,
       room
     } as unknown as Creep;
     setGameCreeps({ LaneWorker: creep });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('uses nearby generic construction before source2/controller lane upgrade', () => {
+    const site = {
+      id: 'tower-site1',
+      structureType: 'tower',
+      pos: makeRoomPosition(26, 24)
+    } as ConstructionSite;
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ constructionSites: [site], controller, sources: [source1, source2] });
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'tower-site1': 1,
+        controller1: 3
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    const creep = {
+      name: 'LaneWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { ...makeRoomPosition(25, 24), getRangeTo } as unknown as RoomPosition,
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LaneWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
   });
 
   it.each([


### PR DESCRIPTION
## Summary
- add a source2-to-controller dedicated energy lane so worker energy spending can favor controller progress when source2 logistics should sustain upgrading
- preserve emergency spawn/refill and controller downgrade priorities ahead of this lane
- add focused worker task tests and regenerate `prod/dist/main.js`

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 468 tests)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

## Scheduler evidence
- Source issue: #328
- Codex-authored implementation commit: `0a9e6620feeae297b33361f044861cad9a8e3d6a`
- Worktree: `/root/screeps-worktrees/source2-controller-lane-328`

Closes #328
