### PR TITLE
feat: prioritize critical road logistics

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4069,18 +4069,38 @@ function selectRepairTarget(creep) {
 }
 function selectCriticalInfrastructureRepairTarget(creep) {
   var _a;
-  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
-    return null;
-  }
   const visibleStructures = findVisibleRoomStructures(creep.room);
   const criticalRoadContext = visibleStructures.some(isCriticalRoadRepairCandidate) ? buildWorkerCriticalRoadLogisticsContext(creep) : null;
+  const canRepairOwnedInfrastructure = ((_a = creep.room.controller) == null ? void 0 : _a.my) === true;
+  const canRepairRemoteCriticalRoads = !canRepairOwnedInfrastructure && criticalRoadContext !== null && canRepairRemoteCriticalRoadInfrastructure(creep);
+  if (!canRepairOwnedInfrastructure && !canRepairRemoteCriticalRoads) {
+    return null;
+  }
   const repairTargets = visibleStructures.filter(
-    (structure) => isCriticalInfrastructureRepairTarget(structure, criticalRoadContext)
+    (structure) => isCriticalInfrastructureRepairTarget(structure, criticalRoadContext, {
+      repairContainers: canRepairOwnedInfrastructure,
+      repairCriticalRoads: canRepairOwnedInfrastructure || canRepairRemoteCriticalRoads
+    })
   );
   if (repairTargets.length === 0) {
     return null;
   }
   return repairTargets.sort(compareRepairTargets)[0];
+}
+function canRepairRemoteCriticalRoadInfrastructure(creep) {
+  var _a;
+  if (!isRemoteTerritoryLogisticsRoom(creep.room) || hasVisibleHostilePresence(creep.room)) {
+    return false;
+  }
+  const controller = creep.room.controller;
+  if (!controller) {
+    return true;
+  }
+  if (controller.owner != null) {
+    return false;
+  }
+  const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
+  return reservationUsername == null || reservationUsername === getCreepOwnerUsername2(creep) || isSelfReservedRoom(creep.room);
 }
 function buildWorkerCriticalRoadLogisticsContext(creep) {
   return buildCriticalRoadLogisticsContext(creep.room, { colonyRoomName: getCreepColonyName(creep) });
@@ -4100,11 +4120,11 @@ function isSafeRepairTarget(structure) {
   }
   return matchesStructureType3(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
 }
-function isCriticalInfrastructureRepairTarget(structure, criticalRoadContext) {
+function isCriticalInfrastructureRepairTarget(structure, criticalRoadContext, options) {
   if (!isSafeRepairTarget(structure) || !isRoadOrContainerRepairTarget(structure) || getHitsRatio(structure) > CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO) {
     return false;
   }
-  return isContainerRepairTarget(structure) || !!criticalRoadContext && isCriticalRoadLogisticsWork(structure, criticalRoadContext);
+  return options.repairContainers && isContainerRepairTarget(structure) || options.repairCriticalRoads && !!criticalRoadContext && isCriticalRoadLogisticsWork(structure, criticalRoadContext);
 }
 function isCriticalRoadRepairCandidate(structure) {
   return isSafeRepairTarget(structure) && isRoadRepairTarget(structure) && getHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3170,9 +3170,11 @@ function isRecord2(value) {
 // src/construction/criticalRoads.ts
 var CRITICAL_ROAD_ROUTE_RANGE = 2;
 function buildCriticalRoadLogisticsContext(room) {
+  const anchorPositions = findOwnedSpawnPositions(room);
+  const targetPositions = findLogisticsTargetPositions(room);
   return {
-    anchorPositions: findOwnedSpawnPositions(room),
-    targetPositions: findLogisticsTargetPositions(room)
+    anchorPositions: anchorPositions.length > 0 ? anchorPositions : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
+    targetPositions
   };
 }
 function isCriticalRoadLogisticsWork(target, context) {
@@ -3195,6 +3197,16 @@ function findLogisticsTargetPositions(room) {
   const controllerPosition = isSameRoomPosition2((_a = room.controller) == null ? void 0 : _a.pos, room.name) ? [room.controller.pos] : [];
   return [...sourcePositions, ...controllerPosition];
 }
+function findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions) {
+  var _a;
+  if (targetPositions.length === 0 || !isRemoteTerritoryLogisticsRoom(room)) {
+    return [];
+  }
+  if (isSameRoomPosition2((_a = room.controller) == null ? void 0 : _a.pos, room.name)) {
+    return [room.controller.pos];
+  }
+  return targetPositions.slice(0, 1);
+}
 function findRoomObjects2(room, constantName) {
   const findConstant = globalThis[constantName];
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
@@ -3209,6 +3221,64 @@ function findRoomObjects2(room, constantName) {
 }
 function isRoadWorkTarget(target) {
   return matchesStructureType2(target.structureType, "STRUCTURE_ROAD", "road");
+}
+function isRemoteTerritoryLogisticsRoom(room) {
+  var _a;
+  return isReferencedRemoteTerritoryRoom(room.name) || ((_a = room.controller) == null ? void 0 : _a.my) !== true && isSelfReservedRoom(room);
+}
+function isReferencedRemoteTerritoryRoom(roomName) {
+  const territoryMemory = getTerritoryMemoryRecord3();
+  if (!territoryMemory) {
+    return false;
+  }
+  return hasRemoteTerritoryReference(territoryMemory.targets, roomName, "roomName") || hasRemoteTerritoryReference(territoryMemory.intents, roomName, "targetRoom") || hasRemoteTerritoryReference(territoryMemory.demands, roomName, "targetRoom") || hasRemoteTerritoryReference(territoryMemory.executionHints, roomName, "targetRoom");
+}
+function hasRemoteTerritoryReference(value, roomName, roomKey) {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((entry) => {
+    if (!isRecord3(entry)) {
+      return false;
+    }
+    return entry[roomKey] === roomName && isNonEmptyString3(entry.colony) && entry.colony !== roomName && isTerritoryControlAction2(entry.action) && entry.status !== "suppressed" && entry.enabled !== false;
+  });
+}
+function isSelfReservedRoom(room) {
+  var _a, _b;
+  const reservationUsername = (_b = (_a = room.controller) == null ? void 0 : _a.reservation) == null ? void 0 : _b.username;
+  return isNonEmptyString3(reservationUsername) && getOwnedUsernames().has(reservationUsername);
+}
+function getTerritoryMemoryRecord3() {
+  const memory = globalThis.Memory;
+  return memory && isRecord3(memory.territory) ? memory.territory : null;
+}
+function getOwnedUsernames() {
+  var _a, _b, _c, _d;
+  const usernames = /* @__PURE__ */ new Set();
+  const game = globalThis.Game;
+  for (const spawn of Object.values((_a = game == null ? void 0 : game.spawns) != null ? _a : {})) {
+    addOwnedUsername(usernames, spawn);
+  }
+  for (const creep of Object.values((_b = game == null ? void 0 : game.creeps) != null ? _b : {})) {
+    addOwnedUsername(usernames, creep);
+  }
+  for (const visibleRoom of Object.values((_c = game == null ? void 0 : game.rooms) != null ? _c : {})) {
+    if (((_d = visibleRoom.controller) == null ? void 0 : _d.my) === true) {
+      addOwnedUsername(usernames, visibleRoom.controller);
+    }
+  }
+  return usernames;
+}
+function addOwnedUsername(usernames, object) {
+  var _a;
+  const username = (_a = object == null ? void 0 : object.owner) == null ? void 0 : _a.username;
+  if (isNonEmptyString3(username)) {
+    usernames.add(username);
+  }
+}
+function isTerritoryControlAction2(action) {
+  return action === "claim" || action === "reserve";
 }
 function isNearLogisticsRoute(position, anchor, destination) {
   if (!isSameRoomPosition2(position, anchor.roomName) || !isSameRoomPosition2(position, destination.roomName)) {
@@ -3238,6 +3308,12 @@ function getSquaredDistance(left, right) {
 }
 function isSameRoomPosition2(position, roomName) {
   return !!position && (!position.roomName || !roomName || position.roomName === roomName);
+}
+function isRecord3(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString3(value) {
+  return typeof value === "string" && value.length > 0;
 }
 function matchesStructureType2(actual, globalName, fallback) {
   var _a;
@@ -4210,7 +4286,7 @@ function isSource2ControllerLaneTask(creep, topology) {
 function getRangeBetweenRoomObjectPositions(left, right) {
   const leftPosition = getRoomObjectPosition(left);
   const rightPosition = getRoomObjectPosition(right);
-  if (!leftPosition || !rightPosition || !isSameRoomPosition2(leftPosition, rightPosition)) {
+  if (!leftPosition || !rightPosition || !isSameRoomPosition3(leftPosition, rightPosition)) {
     return null;
   }
   const rangeFromApi = getRangeBetweenRoomObjects(left, right);
@@ -4227,7 +4303,7 @@ function getPositionRoomName(object) {
   var _a, _b;
   return (_b = (_a = getRoomObjectPosition(object)) == null ? void 0 : _a.roomName) != null ? _b : null;
 }
-function isSameRoomPosition2(left, right) {
+function isSameRoomPosition3(left, right) {
   if (typeof left.roomName === "string" && typeof right.roomName === "string") {
     return left.roomName === right.roomName;
   }
@@ -5695,7 +5771,7 @@ function countTerritoryIntents(roomName) {
   }
   return intents.reduce(
     (counts, intent) => {
-      if (!isRecord3(intent)) {
+      if (!isRecord4(intent)) {
         return counts;
       }
       if (intent.colony !== roomName) {
@@ -5711,7 +5787,7 @@ function countTerritoryIntents(roomName) {
     { active: 0, planned: 0 }
   );
 }
-function isRecord3(value) {
+function isRecord4(value) {
   return typeof value === "object" && value !== null;
 }
 function matchesStructureType4(actual, globalName, fallback) {
@@ -5889,10 +5965,10 @@ function summarizeRoomEventMetrics(room) {
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord4(entry) || typeof entry.event !== "number") {
+    if (!isRecord5(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord4(entry.data) ? entry.data : {};
+    const data = isRecord5(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -5948,7 +6024,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord4(object) || !isRecord4(object.store)) {
+  if (!isRecord5(object) || !isRecord5(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -5962,7 +6038,7 @@ function getEnergyInStore(object) {
 function sumDroppedEnergy(droppedResources) {
   const energyResource = getEnergyResource2();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord4(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord5(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -5983,7 +6059,7 @@ function getEnergyResource2() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord4(value) {
+function isRecord5(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -6056,7 +6132,7 @@ function runTerritoryControllerCreep(creep) {
     }
     return;
   }
-  if (isTerritoryControlAction2(assignment.action) && isCreepKnownToHaveNoActiveClaimParts(creep)) {
+  if (isTerritoryControlAction3(assignment.action) && isCreepKnownToHaveNoActiveClaimParts(creep)) {
     suppressTerritoryAssignment(creep, assignment);
     return;
   }
@@ -6163,7 +6239,7 @@ function getBodyPartConstant3(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function isTerritoryControlAction2(action) {
+function isTerritoryControlAction3(action) {
   return action === "claim" || action === "reserve";
 }
 function isTerritoryAssignment(assignment) {
@@ -6621,7 +6697,7 @@ function parseStrategyEvaluationArtifacts(input) {
   });
 }
 function normalizeStrategyEvaluationArtifact(rawArtifact) {
-  if (!isRecord5(rawArtifact)) {
+  if (!isRecord6(rawArtifact)) {
     return null;
   }
   if (rawArtifact.type === "runtime-summary" || Array.isArray(rawArtifact.rooms)) {
@@ -6630,7 +6706,7 @@ function normalizeStrategyEvaluationArtifact(rawArtifact) {
   if (rawArtifact.artifactType === "runtime-summary") {
     return normalizeRuntimeSummaryArtifact(rawArtifact);
   }
-  if (rawArtifact.artifactType === "room-snapshot" || Array.isArray(rawArtifact.objects) || isRecord5(rawArtifact.objects)) {
+  if (rawArtifact.artifactType === "room-snapshot" || Array.isArray(rawArtifact.objects) || isRecord6(rawArtifact.objects)) {
     return normalizeRoomSnapshotArtifact(rawArtifact);
   }
   return null;
@@ -6714,12 +6790,12 @@ function normalizeRuntimeSummaryArtifact(rawArtifact) {
     artifactType: "runtime-summary",
     ...isFiniteNumber3(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
     rooms,
-    ...isRecord5(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {},
-    ...isRecord5(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {}
+    ...isRecord6(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {},
+    ...isRecord6(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {}
   };
 }
 function normalizeRuntimeSummaryRoom(rawRoom) {
-  if (!isRecord5(rawRoom) || !isNonEmptyString3(rawRoom.roomName)) {
+  if (!isRecord6(rawRoom) || !isNonEmptyString4(rawRoom.roomName)) {
     return null;
   }
   return {
@@ -6728,19 +6804,19 @@ function normalizeRuntimeSummaryRoom(rawRoom) {
     ...isFiniteNumber3(rawRoom.energyCapacity) ? { energyCapacity: rawRoom.energyCapacity } : {},
     ...isFiniteNumber3(rawRoom.workerCount) ? { workerCount: rawRoom.workerCount } : {},
     ...Array.isArray(rawRoom.spawnStatus) ? { spawnStatus: rawRoom.spawnStatus.map(normalizeSpawnStatus) } : {},
-    ...isRecord5(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {},
-    ...isRecord5(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {},
-    ...isRecord5(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {},
-    ...isRecord5(rawRoom.constructionPriority) ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) } : {},
-    ...isRecord5(rawRoom.territoryRecommendation) ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) } : {}
+    ...isRecord6(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {},
+    ...isRecord6(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {},
+    ...isRecord6(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {},
+    ...isRecord6(rawRoom.constructionPriority) ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) } : {},
+    ...isRecord6(rawRoom.territoryRecommendation) ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) } : {}
   };
 }
 function normalizeRoomSnapshotArtifact(rawArtifact) {
-  if (!Array.isArray(rawArtifact.objects) && !isRecord5(rawArtifact.objects)) {
+  if (!Array.isArray(rawArtifact.objects) && !isRecord6(rawArtifact.objects)) {
     return null;
   }
-  const objects = Array.isArray(rawArtifact.objects) ? rawArtifact.objects.flatMap((rawObject) => isRecord5(rawObject) ? [rawObject] : []) : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
-    if (!isRecord5(rawObject)) {
+  const objects = Array.isArray(rawArtifact.objects) ? rawArtifact.objects.flatMap((rawObject) => isRecord6(rawObject) ? [rawObject] : []) : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
+    if (!isRecord6(rawObject)) {
       return [];
     }
     return [{ ...rawObject, id }];
@@ -6748,9 +6824,9 @@ function normalizeRoomSnapshotArtifact(rawArtifact) {
   return {
     artifactType: "room-snapshot",
     ...isFiniteNumber3(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
-    ...isNonEmptyString3(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {},
-    ...isNonEmptyString3(rawArtifact.room) ? { roomName: rawArtifact.room } : {},
-    ...isNonEmptyString3(rawArtifact.owner) ? { owner: rawArtifact.owner } : {},
+    ...isNonEmptyString4(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {},
+    ...isNonEmptyString4(rawArtifact.room) ? { roomName: rawArtifact.room } : {},
+    ...isNonEmptyString4(rawArtifact.owner) ? { owner: rawArtifact.owner } : {},
     objects
   };
 }
@@ -6770,13 +6846,13 @@ function parseJson(text) {
   }
 }
 function normalizeSpawnStatus(rawStatus) {
-  if (!isRecord5(rawStatus)) {
+  if (!isRecord6(rawStatus)) {
     return {};
   }
   return {
-    ...isNonEmptyString3(rawStatus.name) ? { name: rawStatus.name } : {},
-    ...isNonEmptyString3(rawStatus.status) ? { status: rawStatus.status } : {},
-    ...isNonEmptyString3(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {},
+    ...isNonEmptyString4(rawStatus.name) ? { name: rawStatus.name } : {},
+    ...isNonEmptyString4(rawStatus.status) ? { status: rawStatus.status } : {},
+    ...isNonEmptyString4(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {},
     ...isFiniteNumber3(rawStatus.remainingTime) ? { remainingTime: rawStatus.remainingTime } : {}
   };
 }
@@ -6794,7 +6870,7 @@ function normalizeResourceSummary(rawResources) {
     ...isFiniteNumber3(rawResources.workerCarriedEnergy) ? { workerCarriedEnergy: rawResources.workerCarriedEnergy } : {},
     ...isFiniteNumber3(rawResources.droppedEnergy) ? { droppedEnergy: rawResources.droppedEnergy } : {},
     ...isFiniteNumber3(rawResources.sourceCount) ? { sourceCount: rawResources.sourceCount } : {},
-    ...isRecord5(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {}
+    ...isRecord6(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {}
   };
 }
 function normalizeResourceEvents(rawEvents) {
@@ -6807,7 +6883,7 @@ function normalizeCombatSummary(rawCombat) {
   return {
     ...isFiniteNumber3(rawCombat.hostileCreepCount) ? { hostileCreepCount: rawCombat.hostileCreepCount } : {},
     ...isFiniteNumber3(rawCombat.hostileStructureCount) ? { hostileStructureCount: rawCombat.hostileStructureCount } : {},
-    ...isRecord5(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {}
+    ...isRecord6(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {}
   };
 }
 function normalizeCombatEvents(rawEvents) {
@@ -6822,22 +6898,22 @@ function normalizeConstructionPrioritySummary(rawSummary) {
   var _a;
   return {
     ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeConstructionCandidate) } : {},
-    ...rawSummary.nextPrimary === null ? { nextPrimary: null } : isRecord5(rawSummary.nextPrimary) ? { nextPrimary: (_a = normalizeConstructionCandidate(rawSummary.nextPrimary)[0]) != null ? _a : null } : {}
+    ...rawSummary.nextPrimary === null ? { nextPrimary: null } : isRecord6(rawSummary.nextPrimary) ? { nextPrimary: (_a = normalizeConstructionCandidate(rawSummary.nextPrimary)[0]) != null ? _a : null } : {}
   };
 }
 function normalizeConstructionCandidate(rawCandidate) {
-  if (!isRecord5(rawCandidate) || !isNonEmptyString3(rawCandidate.buildItem)) {
+  if (!isRecord6(rawCandidate) || !isNonEmptyString4(rawCandidate.buildItem)) {
     return [];
   }
   return [
     {
       buildItem: rawCandidate.buildItem,
-      ...isNonEmptyString3(rawCandidate.room) ? { room: rawCandidate.room } : {},
+      ...isNonEmptyString4(rawCandidate.room) ? { room: rawCandidate.room } : {},
       ...isFiniteNumber3(rawCandidate.score) ? { score: rawCandidate.score } : {},
-      ...isNonEmptyString3(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {},
-      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString3) } : {},
-      ...Array.isArray(rawCandidate.expectedKpiMovement) ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString3) } : {},
-      ...Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString3) } : {}
+      ...isNonEmptyString4(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString4) } : {},
+      ...Array.isArray(rawCandidate.expectedKpiMovement) ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString4) } : {},
+      ...Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString4) } : {}
     }
   ];
 }
@@ -6845,24 +6921,24 @@ function normalizeTerritoryRecommendationSummary(rawSummary) {
   var _a;
   return {
     ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeTerritoryCandidate) } : {},
-    ...rawSummary.next === null ? { next: null } : isRecord5(rawSummary.next) ? { next: (_a = normalizeTerritoryCandidate(rawSummary.next)[0]) != null ? _a : null } : {},
+    ...rawSummary.next === null ? { next: null } : isRecord6(rawSummary.next) ? { next: (_a = normalizeTerritoryCandidate(rawSummary.next)[0]) != null ? _a : null } : {},
     ...rawSummary.followUpIntent !== void 0 ? { followUpIntent: rawSummary.followUpIntent } : {}
   };
 }
 function normalizeTerritoryCandidate(rawCandidate) {
-  if (!isRecord5(rawCandidate) || !isNonEmptyString3(rawCandidate.roomName)) {
+  if (!isRecord6(rawCandidate) || !isNonEmptyString4(rawCandidate.roomName)) {
     return [];
   }
   return [
     {
       roomName: rawCandidate.roomName,
-      ...isNonEmptyString3(rawCandidate.action) ? { action: rawCandidate.action } : {},
+      ...isNonEmptyString4(rawCandidate.action) ? { action: rawCandidate.action } : {},
       ...isFiniteNumber3(rawCandidate.score) ? { score: rawCandidate.score } : {},
-      ...isNonEmptyString3(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {},
-      ...isNonEmptyString3(rawCandidate.source) ? { source: rawCandidate.source } : {},
-      ...Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString3) } : {},
-      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString3) } : {},
-      ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString3) } : {},
+      ...isNonEmptyString4(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {},
+      ...isNonEmptyString4(rawCandidate.source) ? { source: rawCandidate.source } : {},
+      ...Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString4) } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString4) } : {},
+      ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString4) } : {},
       ...isFiniteNumber3(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {},
       ...isFiniteNumber3(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {},
       ...isFiniteNumber3(rawCandidate.hostileCreepCount) ? { hostileCreepCount: rawCandidate.hostileCreepCount } : {},
@@ -7005,11 +7081,11 @@ function getSnapshotObjectEnergy(object) {
 function getSnapshotObjectOwner(object) {
   var _a;
   const objectUser = object == null ? void 0 : object.user;
-  if (isNonEmptyString3(objectUser)) {
+  if (isNonEmptyString4(objectUser)) {
     return objectUser;
   }
   const ownerUsername = (_a = object == null ? void 0 : object.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString3(ownerUsername) ? ownerUsername : void 0;
+  return isNonEmptyString4(ownerUsername) ? ownerUsername : void 0;
 }
 function isOwnedSnapshotObject(object, owner) {
   var _a;
@@ -7021,13 +7097,13 @@ function isOwnedSnapshotObject(object, owner) {
   }
   return object.user === owner || ((_a = object.owner) == null ? void 0 : _a.username) === owner;
 }
-function isRecord5(value) {
+function isRecord6(value) {
   return typeof value === "object" && value !== null;
 }
 function isFiniteNumber3(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isNonEmptyString3(value) {
+function isNonEmptyString4(value) {
   return typeof value === "string" && value.length > 0;
 }
 

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3167,6 +3167,84 @@ function isRecord2(value) {
   return typeof value === "object" && value !== null;
 }
 
+// src/construction/criticalRoads.ts
+var CRITICAL_ROAD_ROUTE_RANGE = 2;
+function buildCriticalRoadLogisticsContext(room) {
+  return {
+    anchorPositions: findOwnedSpawnPositions(room),
+    targetPositions: findLogisticsTargetPositions(room)
+  };
+}
+function isCriticalRoadLogisticsWork(target, context) {
+  if (!isRoadWorkTarget(target) || !target.pos || context.anchorPositions.length === 0 || context.targetPositions.length === 0) {
+    return false;
+  }
+  const position = target.pos;
+  return context.anchorPositions.some(
+    (anchor) => context.targetPositions.some((destination) => isNearLogisticsRoute(position, anchor, destination))
+  );
+}
+function findOwnedSpawnPositions(room) {
+  return findRoomObjects2(room, "FIND_MY_STRUCTURES").filter(
+    (structure) => matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn")
+  ).map((spawn) => spawn.pos).filter((position) => isSameRoomPosition2(position, room.name));
+}
+function findLogisticsTargetPositions(room) {
+  var _a;
+  const sourcePositions = findRoomObjects2(room, "FIND_SOURCES").map((source) => source.pos).filter((position) => isSameRoomPosition2(position, room.name));
+  const controllerPosition = isSameRoomPosition2((_a = room.controller) == null ? void 0 : _a.pos, room.name) ? [room.controller.pos] : [];
+  return [...sourcePositions, ...controllerPosition];
+}
+function findRoomObjects2(room, constantName) {
+  const findConstant = globalThis[constantName];
+  if (typeof findConstant !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function isRoadWorkTarget(target) {
+  return matchesStructureType2(target.structureType, "STRUCTURE_ROAD", "road");
+}
+function isNearLogisticsRoute(position, anchor, destination) {
+  if (!isSameRoomPosition2(position, anchor.roomName) || !isSameRoomPosition2(position, destination.roomName)) {
+    return false;
+  }
+  return getSquaredDistanceToSegment(position, anchor, destination) <= CRITICAL_ROAD_ROUTE_RANGE ** 2;
+}
+function getSquaredDistanceToSegment(position, start, end) {
+  const deltaX = end.x - start.x;
+  const deltaY = end.y - start.y;
+  const lengthSquared = deltaX * deltaX + deltaY * deltaY;
+  if (lengthSquared === 0) {
+    return getSquaredDistance(position, start);
+  }
+  const projection = ((position.x - start.x) * deltaX + (position.y - start.y) * deltaY) / lengthSquared;
+  const clampedProjection = Math.max(0, Math.min(1, projection));
+  const closestX = start.x + clampedProjection * deltaX;
+  const closestY = start.y + clampedProjection * deltaY;
+  const distanceX = position.x - closestX;
+  const distanceY = position.y - closestY;
+  return distanceX * distanceX + distanceY * distanceY;
+}
+function getSquaredDistance(left, right) {
+  const distanceX = left.x - right.x;
+  const distanceY = left.y - right.y;
+  return distanceX * distanceX + distanceY * distanceY;
+}
+function isSameRoomPosition2(position, roomName) {
+  return !!position && (!position.roomName || !roomName || position.roomName === roomName);
+}
+function matchesStructureType2(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
@@ -3257,13 +3335,13 @@ function selectWorkerTask(creep) {
   if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
     return null;
   }
+  const criticalRoadConstructionSite = selectCriticalRoadConstructionSite(creep, constructionSites);
+  if (criticalRoadConstructionSite) {
+    return { type: "build", targetId: criticalRoadConstructionSite.id };
+  }
   const containerConstructionSite = selectConstructionSite(creep, constructionSites, isContainerConstructionSite);
   if (containerConstructionSite) {
     return { type: "build", targetId: containerConstructionSite.id };
-  }
-  const roadConstructionSite = selectConstructionSite(creep, constructionSites, isRoadConstructionSite2);
-  if (roadConstructionSite) {
-    return { type: "build", targetId: roadConstructionSite.id };
   }
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
     const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller);
@@ -3271,6 +3349,10 @@ function selectWorkerTask(creep) {
       return productiveEnergySinkTask;
     }
     return { type: "upgrade", targetId: controller.id };
+  }
+  const roadConstructionSite = selectConstructionSite(creep, constructionSites, isRoadConstructionSite2);
+  if (roadConstructionSite) {
+    return { type: "build", targetId: roadConstructionSite.id };
   }
   const constructionSite = selectConstructionSite(creep, constructionSites);
   if (constructionSite) {
@@ -3311,7 +3393,7 @@ function isTerritoryControlTask(task) {
   return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
 }
 function isFillableEnergySink(structure) {
-  return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType2(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
+  return (matchesStructureType3(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType3(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType3(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
 function selectFillableEnergySink(creep) {
   var _a;
@@ -3379,14 +3461,14 @@ function findSpawnExtensionEnergyStructures(room) {
   return room.find(FIND_MY_STRUCTURES).filter((structure) => isSpawnExtensionEnergyStructure(structure));
 }
 function isSpawnExtensionEnergyStructure(structure) {
-  return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;
+  return (matchesStructureType3(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType3(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;
 }
 function isSpawnEnergySink(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType3(structure.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isNearTermSpawningSpawn(structure) {
   var _a;
-  if (!matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn")) {
+  if (!matchesStructureType3(structure.structureType, "STRUCTURE_SPAWN", "spawn")) {
     return false;
   }
   const remainingTime = (_a = structure.spawning) == null ? void 0 : _a.remainingTime;
@@ -3396,10 +3478,10 @@ function isSpawnOrExtensionEnergySink(structure) {
   return isSpawnEnergySink(structure) || isExtensionEnergySink(structure);
 }
 function isExtensionEnergySink(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType3(structure.structureType, "STRUCTURE_EXTENSION", "extension");
 }
 function isTowerEnergySink(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_TOWER", "tower");
+  return matchesStructureType3(structure.structureType, "STRUCTURE_TOWER", "tower");
 }
 function isPriorityTowerEnergySink(structure) {
   return isTowerEnergySink(structure) && getStoredEnergy2(structure) < TOWER_REFILL_ENERGY_FLOOR;
@@ -3450,6 +3532,18 @@ function selectConstructionSite(creep, constructionSites, predicate = () => true
 }
 function compareConstructionSiteId(left, right) {
   return String(left.id).localeCompare(String(right.id));
+}
+function selectCriticalRoadConstructionSite(creep, constructionSites) {
+  const roadConstructionSites = constructionSites.filter(isRoadConstructionSite2);
+  if (roadConstructionSites.length === 0) {
+    return null;
+  }
+  const criticalRoadContext = buildCriticalRoadLogisticsContext(creep.room);
+  return selectConstructionSite(
+    creep,
+    roadConstructionSites,
+    (site) => isCriticalRoadLogisticsWork(site, criticalRoadContext)
+  );
 }
 function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller) {
   const controllerRange = getRangeBetweenRoomObjects(creep, controller);
@@ -3510,18 +3604,18 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
   return criticalRepairTarget ? { type: "repair", targetId: criticalRepairTarget.id } : null;
 }
 function isSpawnConstructionSite(site) {
-  return matchesStructureType2(site.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType3(site.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isExtensionConstructionSite(site) {
-  return matchesStructureType2(site.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType3(site.structureType, "STRUCTURE_EXTENSION", "extension");
 }
 function isContainerConstructionSite(site) {
-  return matchesStructureType2(site.structureType, "STRUCTURE_CONTAINER", "container");
+  return matchesStructureType3(site.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isRoadConstructionSite2(site) {
-  return matchesStructureType2(site.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType3(site.structureType, "STRUCTURE_ROAD", "road");
 }
-function matchesStructureType2(actual, globalName, fallback) {
+function matchesStructureType3(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -3569,7 +3663,7 @@ function isSafeStoredEnergySource(structure, context) {
   return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, context);
 }
 function isStoredWorkerEnergySource(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType2(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType2(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
+  return matchesStructureType3(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType3(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType3(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function hasStoredEnergy(structure) {
   return getStoredEnergy2(structure) > 0;
@@ -3583,7 +3677,7 @@ function isFriendlyStoredEnergySource(structure, context) {
   if (((_a = context.room.controller) == null ? void 0 : _a.my) === true) {
     return true;
   }
-  return matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
+  return matchesStructureType3(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
 }
 function isRoomSafeForUnownedContainerWithdrawal(context) {
   var _a;
@@ -3817,7 +3911,11 @@ function selectCriticalInfrastructureRepairTarget(creep) {
   if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
     return null;
   }
-  const repairTargets = findVisibleRoomStructures(creep.room).filter(isCriticalInfrastructureRepairTarget);
+  const visibleStructures = findVisibleRoomStructures(creep.room);
+  const criticalRoadContext = visibleStructures.some(isCriticalRoadRepairCandidate) ? buildCriticalRoadLogisticsContext(creep.room) : null;
+  const repairTargets = visibleStructures.filter(
+    (structure) => isCriticalInfrastructureRepairTarget(structure, criticalRoadContext)
+  );
   if (repairTargets.length === 0) {
     return null;
   }
@@ -3836,19 +3934,31 @@ function isSafeRepairTarget(structure) {
   if (isRoadOrContainerRepairTarget(structure)) {
     return true;
   }
-  return matchesStructureType2(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+  return matchesStructureType3(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
 }
-function isCriticalInfrastructureRepairTarget(structure) {
-  return isSafeRepairTarget(structure) && isRoadOrContainerRepairTarget(structure) && getHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO;
+function isCriticalInfrastructureRepairTarget(structure, criticalRoadContext) {
+  if (!isSafeRepairTarget(structure) || !isRoadOrContainerRepairTarget(structure) || getHitsRatio(structure) > CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO) {
+    return false;
+  }
+  return isContainerRepairTarget(structure) || !!criticalRoadContext && isCriticalRoadLogisticsWork(structure, criticalRoadContext);
+}
+function isCriticalRoadRepairCandidate(structure) {
+  return isSafeRepairTarget(structure) && isRoadRepairTarget(structure) && getHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO;
 }
 function isRoadOrContainerRepairTarget(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container");
+  return isRoadRepairTarget(structure) || isContainerRepairTarget(structure);
+}
+function isRoadRepairTarget(structure) {
+  return matchesStructureType3(structure.structureType, "STRUCTURE_ROAD", "road");
+}
+function isContainerRepairTarget(structure) {
+  return matchesStructureType3(structure.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isWorkerRepairTargetComplete(structure) {
   return structure.hits >= getWorkerRepairHitsCeiling(structure);
 }
 function getWorkerRepairHitsCeiling(structure) {
-  if (matchesStructureType2(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
+  if (matchesStructureType3(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
     return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING);
   }
   return structure.hitsMax;
@@ -3860,10 +3970,10 @@ function compareRepairTargets(left, right) {
   return getRepairPriority(left) - getRepairPriority(right) || getHitsRatio(left) - getHitsRatio(right) || left.hits - right.hits || String(left.id).localeCompare(String(right.id));
 }
 function getRepairPriority(structure) {
-  if (matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road")) {
+  if (matchesStructureType3(structure.structureType, "STRUCTURE_ROAD", "road")) {
     return 0;
   }
-  if (matchesStructureType2(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType3(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
     return 1;
   }
   return 2;
@@ -5136,17 +5246,17 @@ function clampScore(score) {
 function buildRuntimeConstructionPriorityState(colony, creeps) {
   var _a, _b, _c;
   const room = colony.room;
-  const ownedConstructionSites = findRoomObjects2(room, "FIND_MY_CONSTRUCTION_SITES");
-  const ownedStructures = findRoomObjects2(room, "FIND_MY_STRUCTURES");
-  const visibleStructures = findRoomObjects2(room, "FIND_STRUCTURES");
-  const hostileCreeps = findRoomObjects2(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects2(room, "FIND_HOSTILE_STRUCTURES");
-  const sources = findRoomObjects2(room, "FIND_SOURCES");
+  const ownedConstructionSites = findRoomObjects3(room, "FIND_MY_CONSTRUCTION_SITES");
+  const ownedStructures = findRoomObjects3(room, "FIND_MY_STRUCTURES");
+  const visibleStructures = findRoomObjects3(room, "FIND_STRUCTURES");
+  const hostileCreeps = findRoomObjects3(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects3(room, "FIND_HOSTILE_STRUCTURES");
+  const sources = findRoomObjects3(room, "FIND_SOURCES");
   const colonyWorkers = creeps.filter((creep) => {
     var _a2, _b2;
     return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && ((_b2 = creep.memory) == null ? void 0 : _b2.colony) === room.name;
   });
-  const repairSignals = summarizeRepairSignals(visibleStructures);
+  const repairSignals = summarizeRepairSignals(visibleStructures, buildCriticalRoadLogisticsContext(room));
   const territoryIntentCounts = countTerritoryIntents(room.name);
   return {
     roomName: room.name,
@@ -5388,25 +5498,25 @@ function createCandidateForBuildType(buildType, state) {
   }
 }
 function mapStructureTypeToBuildType(structureType) {
-  if (matchesStructureType3(structureType, "STRUCTURE_SPAWN", "spawn")) {
+  if (matchesStructureType4(structureType, "STRUCTURE_SPAWN", "spawn")) {
     return "spawn";
   }
-  if (matchesStructureType3(structureType, "STRUCTURE_EXTENSION", "extension")) {
+  if (matchesStructureType4(structureType, "STRUCTURE_EXTENSION", "extension")) {
     return "extension";
   }
-  if (matchesStructureType3(structureType, "STRUCTURE_TOWER", "tower")) {
+  if (matchesStructureType4(structureType, "STRUCTURE_TOWER", "tower")) {
     return "tower";
   }
-  if (matchesStructureType3(structureType, "STRUCTURE_RAMPART", "rampart")) {
+  if (matchesStructureType4(structureType, "STRUCTURE_RAMPART", "rampart")) {
     return "rampart";
   }
-  if (matchesStructureType3(structureType, "STRUCTURE_ROAD", "road")) {
+  if (matchesStructureType4(structureType, "STRUCTURE_ROAD", "road")) {
     return "road";
   }
-  if (matchesStructureType3(structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType4(structureType, "STRUCTURE_CONTAINER", "container")) {
     return "container";
   }
-  if (matchesStructureType3(structureType, "STRUCTURE_STORAGE", "storage")) {
+  if (matchesStructureType4(structureType, "STRUCTURE_STORAGE", "storage")) {
     return "storage";
   }
   return "observation";
@@ -5417,7 +5527,7 @@ function getConstructionSiteRemainingProgress(site) {
   const progress = typeof site.progress === "number" ? site.progress : 0;
   return Math.max(0, progressTotal - progress);
 }
-function findRoomObjects2(room, constantName) {
+function findRoomObjects3(room, constantName) {
   const findConstant = globalThis[constantName];
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return null;
@@ -5430,15 +5540,18 @@ function findRoomObjects2(room, constantName) {
   }
 }
 function countStructuresByType(structures, globalName, fallback) {
-  return structures == null ? void 0 : structures.filter((structure) => matchesStructureType3(structure.structureType, globalName, fallback)).length;
+  return structures == null ? void 0 : structures.filter((structure) => matchesStructureType4(structure.structureType, globalName, fallback)).length;
 }
-function summarizeRepairSignals(structures) {
+function summarizeRepairSignals(structures, criticalRoadContext) {
   if (structures === null) {
     return null;
   }
   return structures.reduce(
     (summary, structure) => {
       if (!isRepairSignalStructure(structure) || !hasHits(structure)) {
+        return summary;
+      }
+      if (matchesStructureType4(structure.structureType, "STRUCTURE_ROAD", "road") && !isCriticalRoadLogisticsWork(structure, criticalRoadContext)) {
         return summary;
       }
       const hitsRatio = structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
@@ -5453,10 +5566,10 @@ function summarizeRepairSignals(structures) {
   );
 }
 function isRepairSignalStructure(structure) {
-  if (matchesStructureType3(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType3(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType4(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType4(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
     return true;
   }
-  return matchesStructureType3(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true && structure.hits <= IDLE_RAMPART_REPAIR_HITS_CEILING2;
+  return matchesStructureType4(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true && structure.hits <= IDLE_RAMPART_REPAIR_HITS_CEILING2;
 }
 function hasHits(structure) {
   return typeof structure.hits === "number" && typeof structure.hitsMax === "number";
@@ -5488,7 +5601,7 @@ function countTerritoryIntents(roomName) {
 function isRecord3(value) {
   return typeof value === "object" && value !== null;
 }
-function matchesStructureType3(actual, globalName, fallback) {
+function matchesStructureType4(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -5602,9 +5715,9 @@ function buildControllerSummary(room) {
 }
 function summarizeResources(colony, colonyWorkers, events) {
   var _a, _b, _c;
-  const roomStructures = (_a = findRoomObjects3(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const droppedResources = (_b = findRoomObjects3(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _b : [];
-  const sources = (_c = findRoomObjects3(colony.room, "FIND_SOURCES")) != null ? _c : [];
+  const roomStructures = (_a = findRoomObjects4(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const droppedResources = (_b = findRoomObjects4(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _b : [];
+  const sources = (_c = findRoomObjects4(colony.room, "FIND_SOURCES")) != null ? _c : [];
   return {
     storedEnergy: sumEnergyInStores(roomStructures),
     workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
@@ -5615,8 +5728,8 @@ function summarizeResources(colony, colonyWorkers, events) {
 }
 function summarizeCombat(room, events) {
   var _a, _b;
-  const hostileCreeps = (_a = findRoomObjects3(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
-  const hostileStructures = (_b = findRoomObjects3(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
+  const hostileCreeps = (_a = findRoomObjects4(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
+  const hostileStructures = (_b = findRoomObjects4(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
   return {
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -5693,7 +5806,7 @@ function summarizeRoomEventMetrics(room) {
     ...hasCombatEvents ? { combat: combatEvents } : {}
   };
 }
-function findRoomObjects3(room, constantName) {
+function findRoomObjects4(room, constantName) {
   const findConstant = getGlobalNumber2(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3169,11 +3169,15 @@ function isRecord2(value) {
 
 // src/construction/criticalRoads.ts
 var CRITICAL_ROAD_ROUTE_RANGE = 2;
-function buildCriticalRoadLogisticsContext(room) {
+var ROOM_EDGE_MIN3 = 1;
+var ROOM_EDGE_MAX3 = 48;
+var ROOM_CENTER = 25;
+function buildCriticalRoadLogisticsContext(room, options = {}) {
   const anchorPositions = findOwnedSpawnPositions(room);
   const targetPositions = findLogisticsTargetPositions(room);
+  const colonyAnchorPositions = anchorPositions.length === 0 ? findColonyRoomLogisticsAnchorPositions(room, options.colonyRoomName, targetPositions) : [];
   return {
-    anchorPositions: anchorPositions.length > 0 ? anchorPositions : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
+    anchorPositions: anchorPositions.length > 0 ? anchorPositions : colonyAnchorPositions.length > 0 ? colonyAnchorPositions : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
     targetPositions
   };
 }
@@ -3196,6 +3200,74 @@ function findLogisticsTargetPositions(room) {
   const sourcePositions = findRoomObjects2(room, "FIND_SOURCES").map((source) => source.pos).filter((position) => isSameRoomPosition2(position, room.name));
   const controllerPosition = isSameRoomPosition2((_a = room.controller) == null ? void 0 : _a.pos, room.name) ? [room.controller.pos] : [];
   return [...sourcePositions, ...controllerPosition];
+}
+function findColonyRoomLogisticsAnchorPositions(room, colonyRoomName, targetPositions) {
+  if (targetPositions.length === 0 || !isNonEmptyString3(room.name) || !isNonEmptyString3(colonyRoomName) || colonyRoomName === room.name) {
+    return [];
+  }
+  return uniqueRoomPositions(
+    findColonyRoomSpawnPositions(colonyRoomName).map((position) => projectHomeAnchorIntoRoom(position, room.name)).filter((position) => position !== null)
+  );
+}
+function findColonyRoomSpawnPositions(colonyRoomName) {
+  var _a, _b;
+  const game = globalThis.Game;
+  const homeRoom = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[colonyRoomName];
+  const roomSpawnPositions = homeRoom ? findOwnedSpawnPositions(homeRoom) : [];
+  const globalSpawnPositions = Object.values((_b = game == null ? void 0 : game.spawns) != null ? _b : {}).map((spawn) => spawn.pos).filter((position) => isSameRoomPosition2(position, colonyRoomName));
+  return uniqueRoomPositions([...roomSpawnPositions, ...globalSpawnPositions]);
+}
+function projectHomeAnchorIntoRoom(anchor, roomName) {
+  if (!isNonEmptyString3(anchor.roomName) || anchor.roomName === roomName) {
+    return null;
+  }
+  const anchorCoordinates = parseRoomCoordinates(anchor.roomName);
+  const roomCoordinates = parseRoomCoordinates(roomName);
+  if (!anchorCoordinates || !roomCoordinates) {
+    return null;
+  }
+  const deltaX = roomCoordinates.x - anchorCoordinates.x;
+  const deltaY = roomCoordinates.y - anchorCoordinates.y;
+  if (deltaX === 0 && deltaY === 0) {
+    return null;
+  }
+  return {
+    x: deltaX > 0 ? ROOM_EDGE_MIN3 : deltaX < 0 ? ROOM_EDGE_MAX3 : clampRoomCoordinate(anchor.x),
+    y: deltaY > 0 ? ROOM_EDGE_MIN3 : deltaY < 0 ? ROOM_EDGE_MAX3 : clampRoomCoordinate(anchor.y),
+    roomName
+  };
+}
+function parseRoomCoordinates(roomName) {
+  const match = /^([WE])(\d+)([NS])(\d+)$/.exec(roomName);
+  if (!match) {
+    return null;
+  }
+  const horizontalValue = Number(match[2]);
+  const verticalValue = Number(match[4]);
+  if (!Number.isFinite(horizontalValue) || !Number.isFinite(verticalValue)) {
+    return null;
+  }
+  return {
+    x: match[1] === "E" ? horizontalValue : -horizontalValue - 1,
+    y: match[3] === "S" ? verticalValue : -verticalValue - 1
+  };
+}
+function clampRoomCoordinate(value) {
+  if (!Number.isFinite(value)) {
+    return ROOM_CENTER;
+  }
+  return Math.max(ROOM_EDGE_MIN3, Math.min(ROOM_EDGE_MAX3, Math.round(value)));
+}
+function uniqueRoomPositions(positions) {
+  const seen = /* @__PURE__ */ new Set();
+  return positions.filter((position) => {
+    const key = `${position.roomName}:${position.x}:${position.y}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }
 function findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions) {
   var _a;
@@ -3627,7 +3699,7 @@ function selectCriticalRoadConstructionSite(creep, constructionSites) {
   if (roadConstructionSites.length === 0) {
     return null;
   }
-  const criticalRoadContext = buildCriticalRoadLogisticsContext(creep.room);
+  const criticalRoadContext = buildWorkerCriticalRoadLogisticsContext(creep);
   return selectConstructionSite(
     creep,
     roadConstructionSites,
@@ -4001,7 +4073,7 @@ function selectCriticalInfrastructureRepairTarget(creep) {
     return null;
   }
   const visibleStructures = findVisibleRoomStructures(creep.room);
-  const criticalRoadContext = visibleStructures.some(isCriticalRoadRepairCandidate) ? buildCriticalRoadLogisticsContext(creep.room) : null;
+  const criticalRoadContext = visibleStructures.some(isCriticalRoadRepairCandidate) ? buildWorkerCriticalRoadLogisticsContext(creep) : null;
   const repairTargets = visibleStructures.filter(
     (structure) => isCriticalInfrastructureRepairTarget(structure, criticalRoadContext)
   );
@@ -4009,6 +4081,9 @@ function selectCriticalInfrastructureRepairTarget(creep) {
     return null;
   }
   return repairTargets.sort(compareRepairTargets)[0];
+}
+function buildWorkerCriticalRoadLogisticsContext(creep) {
+  return buildCriticalRoadLogisticsContext(creep.room, { colonyRoomName: getCreepColonyName(creep) });
 }
 function findVisibleRoomStructures(room) {
   if (typeof FIND_STRUCTURES !== "number") {

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -1,4 +1,9 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
+import {
+  buildCriticalRoadLogisticsContext,
+  isCriticalRoadLogisticsWork,
+  type CriticalRoadLogisticsContext
+} from './criticalRoads';
 import { getExtensionLimitForRcl } from './extensionPlanner';
 
 export type ConstructionVisionLayer = 'survival' | 'territory' | 'resources' | 'enemyKills';
@@ -716,7 +721,7 @@ function buildRuntimeConstructionPriorityState(
   const hostileStructures = findRoomObjects(room, 'FIND_HOSTILE_STRUCTURES') as Structure[] | null;
   const sources = findRoomObjects(room, 'FIND_SOURCES') as Source[] | null;
   const colonyWorkers = creeps.filter((creep) => creep.memory?.role === 'worker' && creep.memory?.colony === room.name);
-  const repairSignals = summarizeRepairSignals(visibleStructures);
+  const repairSignals = summarizeRepairSignals(visibleStructures, buildCriticalRoadLogisticsContext(room));
   const territoryIntentCounts = countTerritoryIntents(room.name);
 
   return {
@@ -1049,7 +1054,8 @@ function countStructuresByType(
 }
 
 function summarizeRepairSignals(
-  structures: AnyStructure[] | null
+  structures: AnyStructure[] | null,
+  criticalRoadContext: CriticalRoadLogisticsContext
 ): { criticalRepairCount: number; decayingStructureCount: number } | null {
   if (structures === null) {
     return null;
@@ -1058,6 +1064,13 @@ function summarizeRepairSignals(
   return structures.reduce(
     (summary, structure) => {
       if (!isRepairSignalStructure(structure) || !hasHits(structure)) {
+        return summary;
+      }
+
+      if (
+        matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road') &&
+        !isCriticalRoadLogisticsWork(structure, criticalRoadContext)
+      ) {
         return summary;
       }
 

--- a/prod/src/construction/criticalRoads.ts
+++ b/prod/src/construction/criticalRoads.ts
@@ -203,7 +203,7 @@ function isRoadWorkTarget(target: RoadWorkTarget): boolean {
   return matchesStructureType(target.structureType, 'STRUCTURE_ROAD', 'road');
 }
 
-function isRemoteTerritoryLogisticsRoom(room: Room): boolean {
+export function isRemoteTerritoryLogisticsRoom(room: Room): boolean {
   return isReferencedRemoteTerritoryRoom(room.name) || (room.controller?.my !== true && isSelfReservedRoom(room));
 }
 
@@ -242,7 +242,7 @@ function hasRemoteTerritoryReference(value: unknown, roomName: string, roomKey: 
   });
 }
 
-function isSelfReservedRoom(room: Room): boolean {
+export function isSelfReservedRoom(room: Room): boolean {
   const reservationUsername = (room.controller as (StructureController & { reservation?: { username?: string } }) | undefined)
     ?.reservation?.username;
   return isNonEmptyString(reservationUsername) && getOwnedUsernames().has(reservationUsername);

--- a/prod/src/construction/criticalRoads.ts
+++ b/prod/src/construction/criticalRoads.ts
@@ -1,0 +1,123 @@
+export interface CriticalRoadLogisticsContext {
+  anchorPositions: RoomPosition[];
+  targetPositions: RoomPosition[];
+}
+
+interface RoadWorkTarget {
+  pos?: RoomPosition;
+  structureType?: string;
+}
+
+type StructureConstantGlobal = 'STRUCTURE_ROAD' | 'STRUCTURE_SPAWN';
+
+const CRITICAL_ROAD_ROUTE_RANGE = 2;
+
+export function buildCriticalRoadLogisticsContext(room: Room): CriticalRoadLogisticsContext {
+  return {
+    anchorPositions: findOwnedSpawnPositions(room),
+    targetPositions: findLogisticsTargetPositions(room)
+  };
+}
+
+export function isCriticalRoadLogisticsWork(
+  target: RoadWorkTarget,
+  context: CriticalRoadLogisticsContext
+): boolean {
+  if (
+    !isRoadWorkTarget(target) ||
+    !target.pos ||
+    context.anchorPositions.length === 0 ||
+    context.targetPositions.length === 0
+  ) {
+    return false;
+  }
+
+  const position = target.pos;
+  return context.anchorPositions.some((anchor) =>
+    context.targetPositions.some((destination) => isNearLogisticsRoute(position, anchor, destination))
+  );
+}
+
+function findOwnedSpawnPositions(room: Room): RoomPosition[] {
+  return findRoomObjects<AnyOwnedStructure>(room, 'FIND_MY_STRUCTURES')
+    .filter((structure): structure is StructureSpawn =>
+      matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn')
+    )
+    .map((spawn) => spawn.pos)
+    .filter((position): position is RoomPosition => isSameRoomPosition(position, room.name));
+}
+
+function findLogisticsTargetPositions(room: Room): RoomPosition[] {
+  const sourcePositions = findRoomObjects<Source>(room, 'FIND_SOURCES')
+    .map((source) => source.pos)
+    .filter((position): position is RoomPosition => isSameRoomPosition(position, room.name));
+  const controllerPosition = isSameRoomPosition(room.controller?.pos, room.name) ? [room.controller.pos] : [];
+
+  return [...sourcePositions, ...controllerPosition];
+}
+
+function findRoomObjects<T>(room: Room, constantName: FindConstantName): T[] {
+  const findConstant = (globalThis as unknown as Partial<Record<FindConstantName, number>>)[constantName];
+  if (typeof findConstant !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = room.find(findConstant as FindConstant);
+    return Array.isArray(result) ? (result as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function isRoadWorkTarget(target: RoadWorkTarget): boolean {
+  return matchesStructureType(target.structureType, 'STRUCTURE_ROAD', 'road');
+}
+
+function isNearLogisticsRoute(position: RoomPosition, anchor: RoomPosition, destination: RoomPosition): boolean {
+  if (!isSameRoomPosition(position, anchor.roomName) || !isSameRoomPosition(position, destination.roomName)) {
+    return false;
+  }
+
+  return getSquaredDistanceToSegment(position, anchor, destination) <= CRITICAL_ROAD_ROUTE_RANGE ** 2;
+}
+
+function getSquaredDistanceToSegment(position: RoomPosition, start: RoomPosition, end: RoomPosition): number {
+  const deltaX = end.x - start.x;
+  const deltaY = end.y - start.y;
+  const lengthSquared = deltaX * deltaX + deltaY * deltaY;
+
+  if (lengthSquared === 0) {
+    return getSquaredDistance(position, start);
+  }
+
+  const projection = ((position.x - start.x) * deltaX + (position.y - start.y) * deltaY) / lengthSquared;
+  const clampedProjection = Math.max(0, Math.min(1, projection));
+  const closestX = start.x + clampedProjection * deltaX;
+  const closestY = start.y + clampedProjection * deltaY;
+  const distanceX = position.x - closestX;
+  const distanceY = position.y - closestY;
+
+  return distanceX * distanceX + distanceY * distanceY;
+}
+
+function getSquaredDistance(left: RoomPosition, right: RoomPosition): number {
+  const distanceX = left.x - right.x;
+  const distanceY = left.y - right.y;
+  return distanceX * distanceX + distanceY * distanceY;
+}
+
+function isSameRoomPosition(position: RoomPosition | undefined, roomName: string | undefined): position is RoomPosition {
+  return !!position && (!position.roomName || !roomName || position.roomName === roomName);
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: StructureConstantGlobal,
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, string>>;
+  return actual === (constants[globalName] ?? fallback);
+}
+
+type FindConstantName = 'FIND_MY_STRUCTURES' | 'FIND_SOURCES';

--- a/prod/src/construction/criticalRoads.ts
+++ b/prod/src/construction/criticalRoads.ts
@@ -13,9 +13,13 @@ type StructureConstantGlobal = 'STRUCTURE_ROAD' | 'STRUCTURE_SPAWN';
 const CRITICAL_ROAD_ROUTE_RANGE = 2;
 
 export function buildCriticalRoadLogisticsContext(room: Room): CriticalRoadLogisticsContext {
+  const anchorPositions = findOwnedSpawnPositions(room);
+  const targetPositions = findLogisticsTargetPositions(room);
+
   return {
-    anchorPositions: findOwnedSpawnPositions(room),
-    targetPositions: findLogisticsTargetPositions(room)
+    anchorPositions:
+      anchorPositions.length > 0 ? anchorPositions : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
+    targetPositions
   };
 }
 
@@ -56,6 +60,18 @@ function findLogisticsTargetPositions(room: Room): RoomPosition[] {
   return [...sourcePositions, ...controllerPosition];
 }
 
+function findRemoteTerritoryLogisticsAnchorPositions(room: Room, targetPositions: RoomPosition[]): RoomPosition[] {
+  if (targetPositions.length === 0 || !isRemoteTerritoryLogisticsRoom(room)) {
+    return [];
+  }
+
+  if (isSameRoomPosition(room.controller?.pos, room.name)) {
+    return [room.controller.pos];
+  }
+
+  return targetPositions.slice(0, 1);
+}
+
 function findRoomObjects<T>(room: Room, constantName: FindConstantName): T[] {
   const findConstant = (globalThis as unknown as Partial<Record<FindConstantName, number>>)[constantName];
   if (typeof findConstant !== 'number' || typeof room.find !== 'function') {
@@ -72,6 +88,94 @@ function findRoomObjects<T>(room: Room, constantName: FindConstantName): T[] {
 
 function isRoadWorkTarget(target: RoadWorkTarget): boolean {
   return matchesStructureType(target.structureType, 'STRUCTURE_ROAD', 'road');
+}
+
+function isRemoteTerritoryLogisticsRoom(room: Room): boolean {
+  return isReferencedRemoteTerritoryRoom(room.name) || (room.controller?.my !== true && isSelfReservedRoom(room));
+}
+
+function isReferencedRemoteTerritoryRoom(roomName: string): boolean {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return false;
+  }
+
+  return (
+    hasRemoteTerritoryReference(territoryMemory.targets, roomName, 'roomName') ||
+    hasRemoteTerritoryReference(territoryMemory.intents, roomName, 'targetRoom') ||
+    hasRemoteTerritoryReference(territoryMemory.demands, roomName, 'targetRoom') ||
+    hasRemoteTerritoryReference(territoryMemory.executionHints, roomName, 'targetRoom')
+  );
+}
+
+function hasRemoteTerritoryReference(value: unknown, roomName: string, roomKey: 'roomName' | 'targetRoom'): boolean {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+
+  return value.some((entry) => {
+    if (!isRecord(entry)) {
+      return false;
+    }
+
+    return (
+      entry[roomKey] === roomName &&
+      isNonEmptyString(entry.colony) &&
+      entry.colony !== roomName &&
+      isTerritoryControlAction(entry.action) &&
+      entry.status !== 'suppressed' &&
+      entry.enabled !== false
+    );
+  });
+}
+
+function isSelfReservedRoom(room: Room): boolean {
+  const reservationUsername = (room.controller as (StructureController & { reservation?: { username?: string } }) | undefined)
+    ?.reservation?.username;
+  return isNonEmptyString(reservationUsername) && getOwnedUsernames().has(reservationUsername);
+}
+
+function getTerritoryMemoryRecord(): Record<string, unknown> | null {
+  const memory = (globalThis as unknown as { Memory?: Partial<Memory> }).Memory;
+  return memory && isRecord(memory.territory) ? memory.territory : null;
+}
+
+function getOwnedUsernames(): Set<string> {
+  const usernames = new Set<string>();
+  const game = (globalThis as {
+    Game?: {
+      creeps?: Record<string, { owner?: { username?: string } }>;
+      rooms?: Record<string, { controller?: { my?: boolean; owner?: { username?: string } } }>;
+      spawns?: Record<string, { owner?: { username?: string } }>;
+    };
+  }).Game;
+
+  for (const spawn of Object.values(game?.spawns ?? {})) {
+    addOwnedUsername(usernames, spawn);
+  }
+
+  for (const creep of Object.values(game?.creeps ?? {})) {
+    addOwnedUsername(usernames, creep);
+  }
+
+  for (const visibleRoom of Object.values(game?.rooms ?? {})) {
+    if (visibleRoom.controller?.my === true) {
+      addOwnedUsername(usernames, visibleRoom.controller);
+    }
+  }
+
+  return usernames;
+}
+
+function addOwnedUsername(usernames: Set<string>, object: { owner?: { username?: string } } | undefined): void {
+  const username = object?.owner?.username;
+  if (isNonEmptyString(username)) {
+    usernames.add(username);
+  }
+}
+
+function isTerritoryControlAction(action: unknown): action is TerritoryControlAction {
+  return action === 'claim' || action === 'reserve';
 }
 
 function isNearLogisticsRoute(position: RoomPosition, anchor: RoomPosition, destination: RoomPosition): boolean {
@@ -109,6 +213,14 @@ function getSquaredDistance(left: RoomPosition, right: RoomPosition): number {
 
 function isSameRoomPosition(position: RoomPosition | undefined, roomName: string | undefined): position is RoomPosition {
   return !!position && (!position.roomName || !roomName || position.roomName === roomName);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
 }
 
 function matchesStructureType(

--- a/prod/src/construction/criticalRoads.ts
+++ b/prod/src/construction/criticalRoads.ts
@@ -3,6 +3,10 @@ export interface CriticalRoadLogisticsContext {
   targetPositions: RoomPosition[];
 }
 
+export interface CriticalRoadLogisticsContextOptions {
+  colonyRoomName?: string | null;
+}
+
 interface RoadWorkTarget {
   pos?: RoomPosition;
   structureType?: string;
@@ -11,14 +15,28 @@ interface RoadWorkTarget {
 type StructureConstantGlobal = 'STRUCTURE_ROAD' | 'STRUCTURE_SPAWN';
 
 const CRITICAL_ROAD_ROUTE_RANGE = 2;
+const ROOM_EDGE_MIN = 1;
+const ROOM_EDGE_MAX = 48;
+const ROOM_CENTER = 25;
 
-export function buildCriticalRoadLogisticsContext(room: Room): CriticalRoadLogisticsContext {
+export function buildCriticalRoadLogisticsContext(
+  room: Room,
+  options: CriticalRoadLogisticsContextOptions = {}
+): CriticalRoadLogisticsContext {
   const anchorPositions = findOwnedSpawnPositions(room);
   const targetPositions = findLogisticsTargetPositions(room);
+  const colonyAnchorPositions =
+    anchorPositions.length === 0
+      ? findColonyRoomLogisticsAnchorPositions(room, options.colonyRoomName, targetPositions)
+      : [];
 
   return {
     anchorPositions:
-      anchorPositions.length > 0 ? anchorPositions : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
+      anchorPositions.length > 0
+        ? anchorPositions
+        : colonyAnchorPositions.length > 0
+          ? colonyAnchorPositions
+          : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
     targetPositions
   };
 }
@@ -58,6 +76,101 @@ function findLogisticsTargetPositions(room: Room): RoomPosition[] {
   const controllerPosition = isSameRoomPosition(room.controller?.pos, room.name) ? [room.controller.pos] : [];
 
   return [...sourcePositions, ...controllerPosition];
+}
+
+function findColonyRoomLogisticsAnchorPositions(
+  room: Room,
+  colonyRoomName: string | null | undefined,
+  targetPositions: RoomPosition[]
+): RoomPosition[] {
+  if (
+    targetPositions.length === 0 ||
+    !isNonEmptyString(room.name) ||
+    !isNonEmptyString(colonyRoomName) ||
+    colonyRoomName === room.name
+  ) {
+    return [];
+  }
+
+  return uniqueRoomPositions(
+    findColonyRoomSpawnPositions(colonyRoomName)
+      .map((position) => projectHomeAnchorIntoRoom(position, room.name))
+      .filter((position): position is RoomPosition => position !== null)
+  );
+}
+
+function findColonyRoomSpawnPositions(colonyRoomName: string): RoomPosition[] {
+  const game = (globalThis as unknown as { Game?: Partial<Game> }).Game;
+  const homeRoom = game?.rooms?.[colonyRoomName];
+  const roomSpawnPositions = homeRoom ? findOwnedSpawnPositions(homeRoom) : [];
+  const globalSpawnPositions = Object.values(game?.spawns ?? {})
+    .map((spawn) => spawn.pos)
+    .filter((position): position is RoomPosition => isSameRoomPosition(position, colonyRoomName));
+
+  return uniqueRoomPositions([...roomSpawnPositions, ...globalSpawnPositions]);
+}
+
+function projectHomeAnchorIntoRoom(anchor: RoomPosition, roomName: string): RoomPosition | null {
+  if (!isNonEmptyString(anchor.roomName) || anchor.roomName === roomName) {
+    return null;
+  }
+
+  const anchorCoordinates = parseRoomCoordinates(anchor.roomName);
+  const roomCoordinates = parseRoomCoordinates(roomName);
+  if (!anchorCoordinates || !roomCoordinates) {
+    return null;
+  }
+
+  const deltaX = roomCoordinates.x - anchorCoordinates.x;
+  const deltaY = roomCoordinates.y - anchorCoordinates.y;
+  if (deltaX === 0 && deltaY === 0) {
+    return null;
+  }
+
+  return {
+    x: deltaX > 0 ? ROOM_EDGE_MIN : deltaX < 0 ? ROOM_EDGE_MAX : clampRoomCoordinate(anchor.x),
+    y: deltaY > 0 ? ROOM_EDGE_MIN : deltaY < 0 ? ROOM_EDGE_MAX : clampRoomCoordinate(anchor.y),
+    roomName
+  } as RoomPosition;
+}
+
+function parseRoomCoordinates(roomName: string): { x: number; y: number } | null {
+  const match = /^([WE])(\d+)([NS])(\d+)$/.exec(roomName);
+  if (!match) {
+    return null;
+  }
+
+  const horizontalValue = Number(match[2]);
+  const verticalValue = Number(match[4]);
+  if (!Number.isFinite(horizontalValue) || !Number.isFinite(verticalValue)) {
+    return null;
+  }
+
+  return {
+    x: match[1] === 'E' ? horizontalValue : -horizontalValue - 1,
+    y: match[3] === 'S' ? verticalValue : -verticalValue - 1
+  };
+}
+
+function clampRoomCoordinate(value: number): number {
+  if (!Number.isFinite(value)) {
+    return ROOM_CENTER;
+  }
+
+  return Math.max(ROOM_EDGE_MIN, Math.min(ROOM_EDGE_MAX, Math.round(value)));
+}
+
+function uniqueRoomPositions(positions: RoomPosition[]): RoomPosition[] {
+  const seen = new Set<string>();
+  return positions.filter((position) => {
+    const key = `${position.roomName}:${position.x}:${position.y}`;
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
 }
 
 function findRemoteTerritoryLogisticsAnchorPositions(room: Room, targetPositions: RoomPosition[]): RoomPosition[] {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -7,6 +7,8 @@ import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
 import {
   buildCriticalRoadLogisticsContext,
   isCriticalRoadLogisticsWork,
+  isRemoteTerritoryLogisticsRoom,
+  isSelfReservedRoom,
   type CriticalRoadLogisticsContext
 } from '../construction/criticalRoads';
 
@@ -1084,22 +1086,53 @@ function selectRepairTarget(creep: Creep): RepairableWorkerStructure | null {
 }
 
 function selectCriticalInfrastructureRepairTarget(creep: Creep): CriticalInfrastructureRepairTarget | null {
-  if (creep.room.controller?.my !== true) {
-    return null;
-  }
-
   const visibleStructures = findVisibleRoomStructures(creep.room);
   const criticalRoadContext = visibleStructures.some(isCriticalRoadRepairCandidate)
     ? buildWorkerCriticalRoadLogisticsContext(creep)
     : null;
+  const canRepairOwnedInfrastructure = creep.room.controller?.my === true;
+  const canRepairRemoteCriticalRoads =
+    !canRepairOwnedInfrastructure &&
+    criticalRoadContext !== null &&
+    canRepairRemoteCriticalRoadInfrastructure(creep);
+
+  if (!canRepairOwnedInfrastructure && !canRepairRemoteCriticalRoads) {
+    return null;
+  }
+
   const repairTargets = visibleStructures.filter((structure) =>
-    isCriticalInfrastructureRepairTarget(structure, criticalRoadContext)
+    isCriticalInfrastructureRepairTarget(structure, criticalRoadContext, {
+      repairContainers: canRepairOwnedInfrastructure,
+      repairCriticalRoads: canRepairOwnedInfrastructure || canRepairRemoteCriticalRoads
+    })
   );
   if (repairTargets.length === 0) {
     return null;
   }
 
   return repairTargets.sort(compareRepairTargets)[0];
+}
+
+function canRepairRemoteCriticalRoadInfrastructure(creep: Creep): boolean {
+  if (!isRemoteTerritoryLogisticsRoom(creep.room) || hasVisibleHostilePresence(creep.room)) {
+    return false;
+  }
+
+  const controller = creep.room.controller;
+  if (!controller) {
+    return true;
+  }
+
+  if (controller.owner != null) {
+    return false;
+  }
+
+  const reservationUsername = controller.reservation?.username;
+  return (
+    reservationUsername == null ||
+    reservationUsername === getCreepOwnerUsername(creep) ||
+    isSelfReservedRoom(creep.room)
+  );
 }
 
 function buildWorkerCriticalRoadLogisticsContext(creep: Creep): CriticalRoadLogisticsContext {
@@ -1128,7 +1161,8 @@ function isSafeRepairTarget(structure: AnyStructure): structure is RepairableWor
 
 function isCriticalInfrastructureRepairTarget(
   structure: AnyStructure,
-  criticalRoadContext: CriticalRoadLogisticsContext | null
+  criticalRoadContext: CriticalRoadLogisticsContext | null,
+  options: { repairContainers: boolean; repairCriticalRoads: boolean }
 ): structure is CriticalInfrastructureRepairTarget {
   if (
     !isSafeRepairTarget(structure) ||
@@ -1139,8 +1173,10 @@ function isCriticalInfrastructureRepairTarget(
   }
 
   return (
-    isContainerRepairTarget(structure) ||
-    (!!criticalRoadContext && isCriticalRoadLogisticsWork(structure, criticalRoadContext))
+    (options.repairContainers && isContainerRepairTarget(structure)) ||
+    (options.repairCriticalRoads &&
+      !!criticalRoadContext &&
+      isCriticalRoadLogisticsWork(structure, criticalRoadContext))
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -485,7 +485,7 @@ function selectCriticalRoadConstructionSite(
     return null;
   }
 
-  const criticalRoadContext = buildCriticalRoadLogisticsContext(creep.room);
+  const criticalRoadContext = buildWorkerCriticalRoadLogisticsContext(creep);
   return selectConstructionSite(
     creep,
     roadConstructionSites,
@@ -1090,7 +1090,7 @@ function selectCriticalInfrastructureRepairTarget(creep: Creep): CriticalInfrast
 
   const visibleStructures = findVisibleRoomStructures(creep.room);
   const criticalRoadContext = visibleStructures.some(isCriticalRoadRepairCandidate)
-    ? buildCriticalRoadLogisticsContext(creep.room)
+    ? buildWorkerCriticalRoadLogisticsContext(creep)
     : null;
   const repairTargets = visibleStructures.filter((structure) =>
     isCriticalInfrastructureRepairTarget(structure, criticalRoadContext)
@@ -1100,6 +1100,10 @@ function selectCriticalInfrastructureRepairTarget(creep: Creep): CriticalInfrast
   }
 
   return repairTargets.sort(compareRepairTargets)[0];
+}
+
+function buildWorkerCriticalRoadLogisticsContext(creep: Creep): CriticalRoadLogisticsContext {
+  return buildCriticalRoadLogisticsContext(creep.room, { colonyRoomName: getCreepColonyName(creep) });
 }
 
 function findVisibleRoomStructures(room: Room): AnyStructure[] {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -4,6 +4,11 @@ import {
   selectVisibleTerritoryControllerTask
 } from '../territory/territoryPlanner';
 import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
+import {
+  buildCriticalRoadLogisticsContext,
+  isCriticalRoadLogisticsWork,
+  type CriticalRoadLogisticsContext
+} from '../construction/criticalRoads';
 
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
@@ -146,14 +151,14 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return null;
   }
 
+  const criticalRoadConstructionSite = selectCriticalRoadConstructionSite(creep, constructionSites);
+  if (criticalRoadConstructionSite) {
+    return { type: 'build', targetId: criticalRoadConstructionSite.id };
+  }
+
   const containerConstructionSite = selectConstructionSite(creep, constructionSites, isContainerConstructionSite);
   if (containerConstructionSite) {
     return { type: 'build', targetId: containerConstructionSite.id };
-  }
-
-  const roadConstructionSite = selectConstructionSite(creep, constructionSites, isRoadConstructionSite);
-  if (roadConstructionSite) {
-    return { type: 'build', targetId: roadConstructionSite.id };
   }
 
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
@@ -163,6 +168,11 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     }
 
     return { type: 'upgrade', targetId: controller.id };
+  }
+
+  const roadConstructionSite = selectConstructionSite(creep, constructionSites, isRoadConstructionSite);
+  if (roadConstructionSite) {
+    return { type: 'build', targetId: roadConstructionSite.id };
   }
 
   const constructionSite = selectConstructionSite(creep, constructionSites);
@@ -441,6 +451,23 @@ function selectConstructionSite(
 
 function compareConstructionSiteId(left: ConstructionSite, right: ConstructionSite): number {
   return String(left.id).localeCompare(String(right.id));
+}
+
+function selectCriticalRoadConstructionSite(
+  creep: Creep,
+  constructionSites: ConstructionSite[]
+): ConstructionSite | null {
+  const roadConstructionSites = constructionSites.filter(isRoadConstructionSite);
+  if (roadConstructionSites.length === 0) {
+    return null;
+  }
+
+  const criticalRoadContext = buildCriticalRoadLogisticsContext(creep.room);
+  return selectConstructionSite(
+    creep,
+    roadConstructionSites,
+    (site) => isCriticalRoadLogisticsWork(site, criticalRoadContext)
+  );
 }
 
 function selectNearbyProductiveEnergySinkTask(
@@ -1038,7 +1065,13 @@ function selectCriticalInfrastructureRepairTarget(creep: Creep): CriticalInfrast
     return null;
   }
 
-  const repairTargets = findVisibleRoomStructures(creep.room).filter(isCriticalInfrastructureRepairTarget);
+  const visibleStructures = findVisibleRoomStructures(creep.room);
+  const criticalRoadContext = visibleStructures.some(isCriticalRoadRepairCandidate)
+    ? buildCriticalRoadLogisticsContext(creep.room)
+    : null;
+  const repairTargets = visibleStructures.filter((structure) =>
+    isCriticalInfrastructureRepairTarget(structure, criticalRoadContext)
+  );
   if (repairTargets.length === 0) {
     return null;
   }
@@ -1066,19 +1099,42 @@ function isSafeRepairTarget(structure: AnyStructure): structure is RepairableWor
   return matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') && isOwnedRampart(structure);
 }
 
-function isCriticalInfrastructureRepairTarget(structure: AnyStructure): structure is CriticalInfrastructureRepairTarget {
+function isCriticalInfrastructureRepairTarget(
+  structure: AnyStructure,
+  criticalRoadContext: CriticalRoadLogisticsContext | null
+): structure is CriticalInfrastructureRepairTarget {
+  if (
+    !isSafeRepairTarget(structure) ||
+    !isRoadOrContainerRepairTarget(structure) ||
+    getHitsRatio(structure) > CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO
+  ) {
+    return false;
+  }
+
+  return (
+    isContainerRepairTarget(structure) ||
+    (!!criticalRoadContext && isCriticalRoadLogisticsWork(structure, criticalRoadContext))
+  );
+}
+
+function isCriticalRoadRepairCandidate(structure: AnyStructure): structure is StructureRoad {
   return (
     isSafeRepairTarget(structure) &&
-    isRoadOrContainerRepairTarget(structure) &&
+    isRoadRepairTarget(structure) &&
     getHitsRatio(structure) <= CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO
   );
 }
 
 function isRoadOrContainerRepairTarget(structure: AnyStructure): structure is StructureRoad | StructureContainer {
-  return (
-    matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road') ||
-    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')
-  );
+  return isRoadRepairTarget(structure) || isContainerRepairTarget(structure);
+}
+
+function isRoadRepairTarget(structure: AnyStructure): structure is StructureRoad {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road');
+}
+
+function isContainerRepairTarget(structure: AnyStructure): structure is StructureContainer {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container');
 }
 
 export function isWorkerRepairTargetComplete(structure: Structure): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -43,7 +43,7 @@ function makeStructure(
   structureType: StructureConstant,
   hits: number,
   hitsMax: number,
-  extra: Partial<StructureRampart> = {}
+  extra: Record<string, unknown> = {}
 ): AnyStructure {
   return { id, structureType, hits, hitsMax, ...extra } as unknown as AnyStructure;
 }
@@ -51,13 +51,26 @@ function makeStructure(
 function makeEnergySink(
   id: string,
   structureType: StructureConstant,
-  freeCapacity: number
+  freeCapacity: number,
+  extra: Record<string, unknown> = {}
 ): TestEnergySink {
   return {
     id,
     structureType,
-    store: { getFreeCapacity: jest.fn().mockReturnValue(freeCapacity) }
+    store: { getFreeCapacity: jest.fn().mockReturnValue(freeCapacity) },
+    ...extra
   } as unknown as TestEnergySink;
+}
+
+function makeSource(id: string, x: number, y: number, roomName = 'W1N1'): Source {
+  return {
+    id,
+    pos: makeRoomPosition(x, y, roomName)
+  } as unknown as Source;
+}
+
+function makeRoomPosition(x: number, y: number, roomName = 'W1N1'): RoomPosition {
+  return { x, y, roomName } as RoomPosition;
 }
 
 function makeTowerEnergySink(id: string, usedEnergy: number, freeCapacity: number): StructureTower {
@@ -113,6 +126,7 @@ function makeWorkerTaskRoom({
   energyAvailable,
   energyCapacityAvailable,
   myStructures = [],
+  sources = [],
   structures = []
 }: {
   constructionSites?: ConstructionSite[];
@@ -120,6 +134,7 @@ function makeWorkerTaskRoom({
   energyAvailable?: number;
   energyCapacityAvailable?: number;
   myStructures?: AnyOwnedStructure[];
+  sources?: Source[];
   structures?: AnyStructure[];
 } = {}): Room {
   return {
@@ -138,6 +153,10 @@ function makeWorkerTaskRoom({
 
       if (type === FIND_STRUCTURES) {
         return structures;
+      }
+
+      if (type === FIND_SOURCES) {
+        return sources;
       }
 
       return [];
@@ -2578,15 +2597,25 @@ describe('selectWorkerTask', () => {
     ['container', 2_000]
   ])('repairs critical %s damage before generic construction', (structureType, hitsMax) => {
     const site = { id: 'generic-site1', structureType: 'tower' } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
     const repairTarget = makeStructure(
       `${structureType}-critical`,
       structureType as StructureConstant,
       Math.floor(hitsMax * CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO),
-      hitsMax
+      hitsMax,
+      structureType === 'road' ? { pos: makeRoomPosition(12, 10) } : {}
     );
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: makeWorkerTaskRoom({ constructionSites: [site], structures: [repairTarget] })
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        myStructures: structureType === 'road' ? [fullSpawn as AnyOwnedStructure] : [],
+        sources: structureType === 'road' ? [source] : [],
+        structures: [repairTarget]
+      })
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: `${structureType}-critical` });
@@ -2597,11 +2626,16 @@ describe('selectWorkerTask', () => {
     ['container', 2_000]
   ])('repairs critical %s damage before matching construction', (structureType, hitsMax) => {
     const site = { id: `${structureType}-site1`, structureType } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
     const repairTarget = makeStructure(
       `${structureType}-critical`,
       structureType as StructureConstant,
       Math.floor(hitsMax * CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO),
-      hitsMax
+      hitsMax,
+      structureType === 'road' ? { pos: makeRoomPosition(12, 10) } : {}
     );
     const controller = {
       id: 'controller1',
@@ -2609,7 +2643,13 @@ describe('selectWorkerTask', () => {
       level: 3,
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
     } as StructureController;
-    const room = makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [repairTarget] });
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      myStructures: structureType === 'road' ? [fullSpawn as AnyOwnedStructure] : [],
+      sources: structureType === 'road' ? [source] : [],
+      structures: [repairTarget]
+    });
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
       room
@@ -2636,6 +2676,58 @@ describe('selectWorkerTask', () => {
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
       room: makeWorkerTaskRoom({ constructionSites: [site], structures: [road, container] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'generic-site1' });
+  });
+
+  it('keeps off-route road repair behind generic construction even at the critical hit threshold', () => {
+    const site = { id: 'generic-site1', structureType: 'tower' } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
+    const road = makeStructure(
+      'road-off-route',
+      'road' as StructureConstant,
+      Math.floor(5_000 * CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO),
+      5_000,
+      { pos: makeRoomPosition(10, 20) }
+    );
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source],
+        structures: [road]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'generic-site1' });
+  });
+
+  it('keeps route road repair behind generic construction above the critical hit threshold', () => {
+    const site = { id: 'generic-site1', structureType: 'tower' } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
+    const road = makeStructure(
+      'road-worn',
+      'road' as StructureConstant,
+      Math.floor(5_000 * CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO) + 1,
+      5_000,
+      { pos: makeRoomPosition(12, 10) }
+    );
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source],
+        structures: [road]
+      })
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'generic-site1' });
@@ -2733,14 +2825,25 @@ describe('selectWorkerTask', () => {
   });
 
   it('keeps critical road repair before sustained controller progress', () => {
-    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000);
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000, {
+      pos: makeRoomPosition(12, 10)
+    });
     const controller = {
       id: 'controller1',
       my: true,
       level: 3,
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
     } as StructureController;
-    const room = makeWorkerTaskRoom({ controller, structures: [road] });
+    const room = makeWorkerTaskRoom({
+      controller,
+      myStructures: [fullSpawn as AnyOwnedStructure],
+      sources: [source],
+      structures: [road]
+    });
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
       room
@@ -2828,18 +2931,27 @@ describe('selectWorkerTask', () => {
     ['road', 'road-site1'],
     ['container', 'container-site1']
   ])('builds %s construction before sustained controller progress when another loaded worker can build', (structureType, id) => {
-    const site = { id, structureType } as ConstructionSite;
+    const site = {
+      id,
+      structureType,
+      ...(structureType === 'road' ? { pos: makeRoomPosition(12, 10) } : {})
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
     const controller = {
       id: 'controller1',
       my: true,
       level: 2,
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
     } as StructureController;
-    const room = {
-      name: 'W1N1',
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
       controller,
-      find: jest.fn((type) => (type === 2 ? [site] : []))
-    } as unknown as Room;
+      myStructures: structureType === 'road' ? [fullSpawn as AnyOwnedStructure] : [],
+      sources: structureType === 'road' ? [source] : []
+    });
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
       room
@@ -2920,6 +3032,36 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'container-site1' });
+  });
+
+  it('builds critical route road construction before container construction', () => {
+    const roadSite = {
+      id: 'road-critical-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(12, 10)
+    } as ConstructionSite;
+    const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [containerSite, roadSite],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-critical-site1' });
   });
 
   it('builds the closest same-priority construction site after spawn refill is satisfied', () => {
@@ -3336,7 +3478,13 @@ describe('selectWorkerTask', () => {
   });
 
   it('repairs follow-up-ready critical infrastructure before fallback territory upgrading', () => {
-    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000);
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10, 'W2N1')
+    });
+    const source = makeSource('source1', 20, 10, 'W2N1');
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000, {
+      pos: makeRoomPosition(12, 10, 'W2N1')
+    });
     const controller = {
       id: 'controller2',
       my: true,
@@ -3360,6 +3508,8 @@ describe('selectWorkerTask', () => {
         controller,
         energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
         energyCapacityAvailable: 800,
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source],
         structures: [road]
       })
     } as unknown as Creep;
@@ -3772,25 +3922,12 @@ describe('selectWorkerTask', () => {
     const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
       my: true
     });
-    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000);
-    const controller = {
-      id: 'controller1',
-      my: true,
-      level: 3,
-      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
-    } as StructureController;
-    const creep = {
-      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: makeWorkerTaskRoom({ controller, structures: [storage, road] })
-    } as unknown as Creep;
-
-    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-critical' });
-  });
-
-  it('keeps road construction before stored-surplus controller upgrading', () => {
-    const site = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
-    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
-      my: true
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000, {
+      pos: makeRoomPosition(12, 10)
     });
     const controller = {
       id: 'controller1',
@@ -3800,10 +3937,81 @@ describe('selectWorkerTask', () => {
     } as StructureController;
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
-      room: makeWorkerTaskRoom({ constructionSites: [site], controller, structures: [storage] })
+      room: makeWorkerTaskRoom({
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source],
+        structures: [storage, road]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-critical' });
+  });
+
+  it('keeps critical road construction before stored-surplus controller upgrading', () => {
+    const site = {
+      id: 'road-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(12, 10)
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source],
+        structures: [storage]
+      })
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('keeps stored-surplus controller upgrading before off-route road construction', () => {
+    const site = {
+      id: 'road-off-route',
+      structureType: 'road',
+      pos: makeRoomPosition(10, 20)
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 20, 10);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source],
+        structures: [storage]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
   it('does not treat unsafe stored energy as controller upgrade surplus', () => {
@@ -4061,7 +4269,7 @@ describe('selectWorkerTask', () => {
     const hostileRampart = makeStructure('rampart-hostile', 'rampart' as StructureConstant, 100, 1_000, {
       my: false
     });
-    const damagedContainer = makeStructure('container-damaged', 'container' as StructureConstant, 100, 2_000);
+    const damagedContainer = makeStructure('container-damaged', 'container' as StructureConstant, 1_100, 2_000);
     const roadB = makeStructure('road-b', 'road' as StructureConstant, 2_500, 5_000);
     const roadA = makeStructure('road-a', 'road' as StructureConstant, 2_500, 5_000);
     const creep = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -38,6 +38,11 @@ function setGameCreeps(creeps: Record<string, Creep>): void {
   (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps };
 }
 
+function setGameSpawns(spawns: Record<string, StructureSpawn>): void {
+  const globalScope = globalThis as unknown as { Game?: Partial<Game> };
+  globalScope.Game = { ...(globalScope.Game ?? {}), spawns };
+}
+
 function makeStructure(
   id: string,
   structureType: StructureConstant,
@@ -64,6 +69,17 @@ function makeEnergySink(
 
 function makeRoomPosition(x: number, y: number, roomName = 'W1N1'): RoomPosition {
   return { x, y, roomName } as RoomPosition;
+}
+
+function makeSpawn(id: string, x: number, y: number, roomName = 'W1N1'): StructureSpawn {
+  return {
+    id,
+    name: id,
+    structureType: 'spawn',
+    owner: { username: 'Self' },
+    pos: makeRoomPosition(x, y, roomName),
+    store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
+  } as unknown as StructureSpawn;
 }
 
 function makeTowerEnergySink(id: string, usedEnergy: number, freeCapacity: number): StructureTower {
@@ -2873,6 +2889,36 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-critical' });
   });
 
+  it('repairs colony-anchored remote critical roads before generic construction without a local spawn', () => {
+    const site = { id: 'generic-site1', structureType: 'tower' } as ConstructionSite;
+    const source = makeSource('source1', 40, 10, 'W2N1');
+    const road = makeStructure('remote-road-critical', 'road' as StructureConstant, 1_000, 5_000, {
+      pos: makeRoomPosition(46, 10, 'W2N1')
+    });
+    const controller = {
+      id: 'controller2',
+      my: true,
+      level: 3,
+      pos: makeRoomPosition(10, 40, 'W2N1'),
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    setGameSpawns({ Spawn1: makeSpawn('Spawn1', 10, 10, 'W1N1') });
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      sources: [source],
+      structures: [road]
+    });
+    (room as Room & { name: string }).name = 'W2N1';
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'remote-road-critical' });
+  });
+
   it('selects RCL1 controller upgrade before non-spawn construction when downgrade is safe', () => {
     const fullSpawn = {
       id: 'spawn1',
@@ -3116,6 +3162,41 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'remote-road-critical-site1' });
+  });
+
+  it('builds colony-anchored remote critical route road construction before containers without a local spawn', () => {
+    const roadSite = {
+      id: 'remote-road-colony-critical-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(46, 10, 'W2N1')
+    } as ConstructionSite;
+    const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;
+    const source = makeSource('source1', 40, 10, 'W2N1');
+    const controller = {
+      id: 'controller2',
+      my: false,
+      pos: makeRoomPosition(10, 40, 'W2N1'),
+      reservation: { username: 'Self', ticksToEnd: 1_000 }
+    } as StructureController;
+    setGameSpawns({ Spawn1: makeSpawn('Spawn1', 10, 10, 'W1N1') });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+    const room = makeWorkerTaskRoom({
+      constructionSites: [containerSite, roadSite],
+      controller,
+      sources: [source]
+    });
+    (room as Room & { name: string }).name = 'W2N1';
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'remote-road-colony-critical-site1' });
   });
 
   it('builds the closest same-priority construction site after spawn refill is satisfied', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -62,13 +62,6 @@ function makeEnergySink(
   } as unknown as TestEnergySink;
 }
 
-function makeSource(id: string, x: number, y: number, roomName = 'W1N1'): Source {
-  return {
-    id,
-    pos: makeRoomPosition(x, y, roomName)
-  } as unknown as Source;
-}
-
 function makeRoomPosition(x: number, y: number, roomName = 'W1N1'): RoomPosition {
   return { x, y, roomName } as RoomPosition;
 }
@@ -120,15 +113,14 @@ function makeSalvageEnergySource(
   } as unknown as Tombstone | Ruin;
 }
 
-function makeRoomPosition(x: number, y: number, roomName = 'W1N1'): RoomPosition {
-  return { x, y, roomName } as unknown as RoomPosition;
-}
+function makeSource(id: string, x: number, y: number, energyOrRoomName: number | string = 300): Source {
+  const energy = typeof energyOrRoomName === 'number' ? energyOrRoomName : 300;
+  const roomName = typeof energyOrRoomName === 'string' ? energyOrRoomName : 'W1N1';
 
-function makeSource(id: string, x: number, y: number, energy = 300): Source {
   return {
     id,
     energy,
-    pos: makeRoomPosition(x, y)
+    pos: makeRoomPosition(x, y, roomName)
   } as unknown as Source;
 }
 
@@ -3090,6 +3082,40 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-critical-site1' });
+  });
+
+  it('builds reserved-room critical route road construction before container construction without a local spawn', () => {
+    const roadSite = {
+      id: 'remote-road-critical-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(12, 10, 'W2N1')
+    } as ConstructionSite;
+    const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;
+    const source = makeSource('source1', 20, 10, 'W2N1');
+    const controller = {
+      id: 'controller2',
+      my: false,
+      pos: makeRoomPosition(10, 10, 'W2N1'),
+      reservation: { username: 'Self', ticksToEnd: 1_000 }
+    } as StructureController;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+    const room = makeWorkerTaskRoom({
+      constructionSites: [containerSite, roadSite],
+      controller,
+      sources: [source]
+    });
+    (room as Room & { name: string }).name = 'W2N1';
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'remote-road-critical-site1' });
   });
 
   it('builds the closest same-priority construction site after spawn refill is satisfied', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3130,6 +3130,41 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-critical-site1' });
   });
 
+  it('repairs reserved-room critical route roads before container construction without a local spawn', () => {
+    const road = makeStructure('remote-road-critical', 'road' as StructureConstant, 1_000, 5_000, {
+      pos: makeRoomPosition(12, 10, 'W2N1')
+    });
+    const containerSite = { id: 'container-site1', structureType: 'container' } as ConstructionSite;
+    const source = makeSource('source1', 20, 10, 'W2N1');
+    const controller = {
+      id: 'controller2',
+      my: false,
+      pos: makeRoomPosition(10, 10, 'W2N1'),
+      reservation: { username: 'Self', ticksToEnd: 1_000 }
+    } as StructureController;
+    setGameSpawns({ Spawn1: makeSpawn('Spawn1', 10, 10, 'W1N1') });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+    const room = makeWorkerTaskRoom({
+      constructionSites: [containerSite],
+      controller,
+      sources: [source],
+      structures: [road]
+    });
+    (room as Room & { name: string }).name = 'W2N1';
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      owner: { username: 'Self' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'remote-road-critical' });
+  });
+
   it('builds reserved-room critical route road construction before container construction without a local spawn', () => {
     const roadSite = {
       id: 'remote-road-critical-site1',


### PR DESCRIPTION
## Summary
- prioritizes critical road construction/repair routes as logistics infrastructure
- adds critical-road route detection helper and worker-task policy coverage
- keeps generated Screeps bundle synchronized

Closes #331.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 467 tests)
- `cd prod && npm run build`
- post-commit `npm run build` plus `git diff --exit-code -- prod/dist/main.js`

## Scheduler evidence
Recovered dirty Codex worktree `/root/screeps-worktrees/road-first-logistics-331-run2`, controller-verified it, then used a narrow Codex commit-only recovery to preserve author `lanyusea's bot <lanyusea@gmail.com>` at commit `fa9643429b12e0aa1fb8d2721b0a60724e58e4cd`.