### PR TITLE
feat: record worker efficiency telemetry

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6174,7 +6174,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord4(value)) {
+  if (!isRecord5(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3415,6 +3415,7 @@ var SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 var SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 var nearTermSpawnExtensionRefillReserveCache = null;
 function selectWorkerTask(creep) {
+  clearWorkerEfficiencyTelemetry(creep);
   const carriedEnergy = getUsedEnergy(creep);
   const urgentReservationRenewalTask = selectUrgentVisibleReservationRenewalTask(creep);
   const territoryControllerTask = selectVisibleTerritoryControllerTask(creep);
@@ -3601,6 +3602,12 @@ function getLowLoadWorkerEnergyContext(creep) {
     Math.max(1, Math.floor(capacity * LOW_LOAD_WORKER_ENERGY_RATIO))
   );
   return carriedEnergy <= lowLoadEnergyLimit ? { carriedEnergy, freeCapacity } : null;
+}
+function clearWorkerEfficiencyTelemetry(creep) {
+  const memory = creep.memory;
+  if (memory) {
+    delete memory.workerEfficiency;
+  }
 }
 function recordNearbyEnergyChoiceTelemetry(creep, candidate) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3172,7 +3172,11 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
+var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 var NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
+var LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
+var LOW_LOAD_WORKER_ENERGY_CEILING = 25;
+var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -3231,7 +3235,26 @@ function selectWorkerTask(creep) {
   }
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   if (spawnOrExtensionEnergySink) {
-    return { type: "transfer", targetId: spawnOrExtensionEnergySink.id };
+    const spawnOrExtensionRefillTask = {
+      type: "transfer",
+      targetId: spawnOrExtensionEnergySink.id
+    };
+    if (shouldPrioritizeSpawnOrExtensionRefill(creep)) {
+      recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, "urgentSpawnExtensionRefill");
+      return spawnOrExtensionRefillTask;
+    }
+    const lowLoadEnergyAcquisitionCandidate2 = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
+    if (lowLoadEnergyAcquisitionCandidate2) {
+      recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate2);
+      return lowLoadEnergyAcquisitionCandidate2.task;
+    }
+    recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, "noNearbyEnergy");
+    return spawnOrExtensionRefillTask;
+  }
+  const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
+  if (lowLoadEnergyAcquisitionCandidate) {
+    recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate);
+    return lowLoadEnergyAcquisitionCandidate.task;
   }
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
   const capacityConstructionSite = selectCapacityEnablingConstructionSite(creep, constructionSites, controller);
@@ -3322,6 +3345,67 @@ function estimateNearTermSpawnCompletionRefillReserve(room, spawnExtensionEnergy
 }
 function isTerritoryControlTask(task) {
   return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
+}
+function shouldPrioritizeSpawnOrExtensionRefill(creep) {
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  if (energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD) {
+    return true;
+  }
+  if (hasReservedTerritoryFollowUpRefillCapacity(creep) && !hasReadyTerritoryFollowUpEnergy(creep)) {
+    return true;
+  }
+  return hasNearTermSpawnCompletionRefillDemand(creep.room);
+}
+function hasNearTermSpawnCompletionRefillDemand(room) {
+  return findSpawnExtensionEnergyStructures(room).some(isNearTermSpawningSpawn);
+}
+function getLowLoadWorkerEnergyContext(creep) {
+  const carriedEnergy = getUsedEnergy(creep);
+  const freeCapacity = getFreeEnergyCapacity(creep);
+  if (carriedEnergy <= 0 || freeCapacity <= 0) {
+    return null;
+  }
+  const capacity = carriedEnergy + freeCapacity;
+  const lowLoadEnergyLimit = Math.min(
+    LOW_LOAD_WORKER_ENERGY_CEILING,
+    Math.max(1, Math.floor(capacity * LOW_LOAD_WORKER_ENERGY_RATIO))
+  );
+  return carriedEnergy <= lowLoadEnergyLimit ? { carriedEnergy, freeCapacity } : null;
+}
+function recordNearbyEnergyChoiceTelemetry(creep, candidate) {
+  var _a;
+  const context = getLowLoadWorkerEnergyContext(creep);
+  const memory = creep.memory;
+  if (!context || !memory) {
+    return;
+  }
+  memory.workerEfficiency = {
+    type: "nearbyEnergyChoice",
+    tick: (_a = getGameTick()) != null ? _a : 0,
+    carriedEnergy: context.carriedEnergy,
+    freeCapacity: context.freeCapacity,
+    selectedTask: candidate.task.type,
+    targetId: String(candidate.task.targetId),
+    energy: Math.max(0, Math.floor(candidate.energy)),
+    ...candidate.range === null ? {} : { range: candidate.range }
+  };
+}
+function recordLowLoadReturnTelemetry(creep, task, reason) {
+  var _a;
+  const context = getLowLoadWorkerEnergyContext(creep);
+  const memory = creep.memory;
+  if (!context || !memory) {
+    return;
+  }
+  memory.workerEfficiency = {
+    type: "lowLoadReturn",
+    tick: (_a = getGameTick()) != null ? _a : 0,
+    carriedEnergy: context.carriedEnergy,
+    freeCapacity: context.freeCapacity,
+    selectedTask: task.type,
+    targetId: String(task.targetId),
+    reason
+  };
 }
 function isFillableEnergySink(structure) {
   return (matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType2(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType2(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
@@ -3623,6 +3707,60 @@ function selectWorkerEnergyAcquisitionTask(creep) {
   }
   return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
 }
+function selectLowLoadWorkerEnergyAcquisitionCandidate(creep) {
+  if (!shouldKeepLowLoadWorkerAcquiringEnergy(creep)) {
+    return null;
+  }
+  const nearbyCandidates = findLowLoadWorkerEnergyAcquisitionCandidates(creep).filter(
+    (candidate) => candidate.range !== null && candidate.range <= LOW_LOAD_NEARBY_ENERGY_RANGE
+  );
+  if (nearbyCandidates.length === 0) {
+    return null;
+  }
+  return nearbyCandidates.sort(compareLowLoadWorkerEnergyAcquisitionCandidates)[0];
+}
+function shouldKeepLowLoadWorkerAcquiringEnergy(creep) {
+  return getLowLoadWorkerEnergyContext(creep) !== null && !hasVisibleHostilePresence(creep.room);
+}
+function findLowLoadWorkerEnergyAcquisitionCandidates(creep) {
+  return [
+    ...findWorkerEnergyAcquisitionCandidates(creep).map(toLowLoadWorkerEnergyAcquisitionCandidate),
+    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
+  ];
+}
+function toLowLoadWorkerEnergyAcquisitionCandidate(candidate) {
+  return candidate;
+}
+function findLowLoadHarvestEnergyAcquisitionCandidates(creep) {
+  const source = selectHarvestSource(creep);
+  if (!source || isSourceDepleted(source)) {
+    return [];
+  }
+  return [
+    createLowLoadWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getHarvestCandidateEnergy(creep, source),
+      { type: "harvest", targetId: source.id }
+    )
+  ];
+}
+function getHarvestCandidateEnergy(creep, source) {
+  return typeof source.energy === "number" && Number.isFinite(source.energy) ? source.energy : getFreeEnergyCapacity(creep);
+}
+function createLowLoadWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
+  const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
+  return {
+    energy,
+    range,
+    score: range === null ? energy : energy - range * ENERGY_ACQUISITION_RANGE_COST,
+    source,
+    task
+  };
+}
+function compareLowLoadWorkerEnergyAcquisitionCandidates(left, right) {
+  return compareOptionalRanges(left.range, right.range) || right.score - left.score || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
+}
 function selectSpawnRecoveryEnergyAcquisitionTask(creep, energySink) {
   const harvestEta = estimateHarvestDeliveryEta(creep, energySink);
   const candidates = findWorkerEnergyAcquisitionCandidates(creep).map((candidate) => createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink)).filter((candidate) => candidate !== null).filter((candidate) => harvestEta === null || candidate.deliveryEta <= harvestEta);
@@ -3737,6 +3875,9 @@ function getRangeBetweenRoomObjects(left, right) {
   return Number.isFinite(range) ? Math.max(0, range) : null;
 }
 function getRangeToWorkerEnergyAcquisitionSource(creep, source) {
+  return getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
+}
+function getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source) {
   const position = creep.pos;
   if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
     return null;
@@ -4342,6 +4483,8 @@ function runWorker(creep) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
@@ -4500,6 +4643,17 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, 
   }
   return isUrgentEnergySpendingTask(selectedTask);
 }
+function shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, task, selectedTask) {
+  var _a;
+  if (!isEnergyAcquisitionTask(task) || !selectedTask || !isEnergyAcquisitionTask(selectedTask)) {
+    return false;
+  }
+  if (isSameTask(task, selectedTask)) {
+    return false;
+  }
+  const sample = (_a = creep.memory) == null ? void 0 : _a.workerEfficiency;
+  return (sample == null ? void 0 : sample.type) === "nearbyEnergyChoice" && sample.selectedTask === selectedTask.type && sample.targetId === String(selectedTask.targetId) && isCurrentWorkerEfficiencySample(sample);
+}
 function shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectedTask) {
   var _a, _b;
   if (task.type !== "transfer") {
@@ -4577,6 +4731,11 @@ function isEnergyAcquisitionTask(task) {
 }
 function isRecoverableEnergyTask(task) {
   return (task == null ? void 0 : task.type) === "pickup" || (task == null ? void 0 : task.type) === "withdraw";
+}
+function isCurrentWorkerEfficiencySample(sample) {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime !== "number" || sample.tick === gameTime;
 }
 function isTerritoryControlTask2(task) {
   return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
@@ -5611,6 +5770,8 @@ function matchesStructureType3(actual, globalName, fallback) {
 var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
 var MAX_REPORTED_EVENTS = 10;
+var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "upgrade"];
 function emitRuntimeSummary(colonies, creeps, events = []) {
   if (colonies.length === 0 && events.length === 0) {
@@ -5646,6 +5807,7 @@ function summarizeRoom(colony, creeps) {
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime3()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -5693,6 +5855,52 @@ function countWorkerTasks(workers) {
 }
 function isWorkerTaskType(taskType) {
   return WORKER_TASK_TYPES.includes(taskType);
+}
+function summarizeWorkerEfficiency(workers, tick) {
+  const samples = workers.map((worker) => ({ creepName: getCreepName(worker), sample: worker.memory.workerEfficiency })).filter(
+    (entry) => isWorkerEfficiencySample(entry.sample) && isRecentWorkerEfficiencySample(entry.sample, tick)
+  ).sort(compareWorkerEfficiencySampleEntries);
+  if (samples.length === 0) {
+    return {};
+  }
+  const reportedSamples = samples.slice(0, MAX_WORKER_EFFICIENCY_SAMPLES).map(toRuntimeWorkerEfficiencySample);
+  return {
+    workerEfficiency: {
+      lowLoadReturnCount: samples.filter((entry) => entry.sample.type === "lowLoadReturn").length,
+      nearbyEnergyChoiceCount: samples.filter((entry) => entry.sample.type === "nearbyEnergyChoice").length,
+      samples: reportedSamples,
+      ...samples.length > MAX_WORKER_EFFICIENCY_SAMPLES ? { omittedSampleCount: samples.length - MAX_WORKER_EFFICIENCY_SAMPLES } : {}
+    }
+  };
+}
+function compareWorkerEfficiencySampleEntries(left, right) {
+  var _a, _b;
+  return right.sample.tick - left.sample.tick || ((_a = left.creepName) != null ? _a : "").localeCompare((_b = right.creepName) != null ? _b : "") || left.sample.targetId.localeCompare(right.sample.targetId);
+}
+function toRuntimeWorkerEfficiencySample(entry) {
+  return {
+    ...entry.creepName ? { creepName: entry.creepName } : {},
+    ...entry.sample
+  };
+}
+function isRecentWorkerEfficiencySample(sample, tick) {
+  if (tick <= 0) {
+    return true;
+  }
+  return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
+}
+function isWorkerEfficiencySample(value) {
+  if (!isRecord4(value)) {
+    return false;
+  }
+  return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
+}
+function isWorkerEfficiencyTaskType(value) {
+  return value === "harvest" || value === "pickup" || value === "withdraw" || value === "transfer" || value === "build" || value === "repair" || value === "claim" || value === "reserve" || value === "upgrade";
+}
+function getCreepName(creep) {
+  const name = creep.name;
+  return typeof name === "string" && name.length > 0 ? name : void 0;
 }
 function buildControllerSummary(room) {
   const controller = room.controller;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4010,7 +4010,7 @@ function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep) {
   );
 }
 function findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep) {
-  return findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).map(
+  return findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).filter((source) => isReachable(creep, source)).map(
     (source) => toLowLoadWorkerEnergyAcquisitionCandidate(
       createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
         type: "pickup",
@@ -4027,6 +4027,9 @@ function toLowLoadWorkerEnergyAcquisitionCandidate(candidate) {
   return candidate;
 }
 function findLowLoadHarvestEnergyAcquisitionCandidates(creep) {
+  if (getActiveWorkParts(creep) <= 0) {
+    return [];
+  }
   const source = selectHarvestSource(creep);
   if (!source || isSourceDepleted(source)) {
     return [];

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3966,9 +3966,50 @@ function shouldKeepLowLoadWorkerAcquiringEnergy(creep) {
 }
 function findLowLoadWorkerEnergyAcquisitionCandidates(creep) {
   return [
-    ...findWorkerEnergyAcquisitionCandidates(creep).map(toLowLoadWorkerEnergyAcquisitionCandidate),
+    ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep),
+    ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep),
+    ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep),
     ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
   ];
+}
+function findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep) {
+  const context = {
+    creepOwnerUsername: getCreepOwnerUsername2(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  return findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).map(
+    (source) => toLowLoadWorkerEnergyAcquisitionCandidate(
+      createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
+        type: "withdraw",
+        targetId: source.id
+      })
+    )
+  );
+}
+function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep) {
+  return [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).map(
+    (source) => toLowLoadWorkerEnergyAcquisitionCandidate(
+      createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
+        type: "withdraw",
+        targetId: source.id
+      })
+    )
+  );
+}
+function findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep) {
+  return findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).map(
+    (source) => toLowLoadWorkerEnergyAcquisitionCandidate(
+      createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
+        type: "pickup",
+        targetId: source.id
+      })
+    )
+  );
+}
+function isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source) {
+  const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
+  return range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE;
 }
 function toLowLoadWorkerEnergyAcquisitionCandidate(candidate) {
   return candidate;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -25,6 +25,8 @@ export function runWorker(creep: Creep): void {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
@@ -249,6 +251,28 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(
   return isUrgentEnergySpendingTask(selectedTask);
 }
 
+function shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (!isEnergyAcquisitionTask(task) || !selectedTask || !isEnergyAcquisitionTask(selectedTask)) {
+    return false;
+  }
+
+  if (isSameTask(task, selectedTask)) {
+    return false;
+  }
+
+  const sample = creep.memory?.workerEfficiency;
+  return (
+    sample?.type === 'nearbyEnergyChoice' &&
+    sample.selectedTask === selectedTask.type &&
+    sample.targetId === String(selectedTask.targetId) &&
+    isCurrentWorkerEfficiencySample(sample)
+  );
+}
+
 function shouldPreemptTransferTaskForBetterEnergySink(
   creep: Creep,
   task: CreepTaskMemory,
@@ -377,6 +401,11 @@ function isRecoverableEnergyTask(
   task: CreepTaskMemory | null
 ): task is Extract<CreepTaskMemory, { type: 'pickup' | 'withdraw' }> {
   return task?.type === 'pickup' || task?.type === 'withdraw';
+}
+
+function isCurrentWorkerEfficiencySample(sample: WorkerEfficiencySampleMemory): boolean {
+  const gameTime = (globalThis as unknown as { Game?: Partial<Game> }).Game?.time;
+  return typeof gameTime !== 'number' || sample.tick === gameTime;
 }
 
 function isTerritoryControlTask(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -976,6 +976,7 @@ function findNearbyLowLoadDroppedEnergyAcquisitionCandidates(
   return findDroppedResources(creep.room)
     .filter(isUsefulDroppedEnergy)
     .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
+    .filter((source) => isReachable(creep, source))
     .map((source) =>
       toLowLoadWorkerEnergyAcquisitionCandidate(
         createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
@@ -1001,6 +1002,10 @@ function toLowLoadWorkerEnergyAcquisitionCandidate(
 }
 
 function findLowLoadHarvestEnergyAcquisitionCandidates(creep: Creep): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  if (getActiveWorkParts(creep) <= 0) {
+    return [];
+  }
+
   const source = selectHarvestSource(creep);
   if (!source || isSourceDepleted(source)) {
     return [];

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -12,6 +12,9 @@ export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 export const TOWER_REFILL_ENERGY_FLOOR = 500;
 export const URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 export const NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
+export const LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
+export const LOW_LOAD_WORKER_ENERGY_CEILING = 25;
+export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -34,6 +37,8 @@ type WorkerEnergyAcquisitionSource =
   | SalvageableWorkerEnergySource
   | Resource<ResourceConstant>;
 type WorkerEnergyAcquisitionTask = Extract<CreepTaskMemory, { type: 'pickup' | 'withdraw' }>;
+type LowLoadWorkerEnergyAcquisitionSource = WorkerEnergyAcquisitionSource | Source;
+type LowLoadWorkerEnergyAcquisitionTask = Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }>;
 type ProductiveEnergySinkTask = Extract<CreepTaskMemory, { type: 'build' | 'repair' }>;
 
 interface StoredEnergySourceContext {
@@ -118,7 +123,29 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
 
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   if (spawnOrExtensionEnergySink) {
-    return { type: 'transfer', targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure> };
+    const spawnOrExtensionRefillTask: Extract<CreepTaskMemory, { type: 'transfer' }> = {
+      type: 'transfer',
+      targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure>
+    };
+    if (shouldPrioritizeSpawnOrExtensionRefill(creep)) {
+      recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, 'urgentSpawnExtensionRefill');
+      return spawnOrExtensionRefillTask;
+    }
+
+    const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
+    if (lowLoadEnergyAcquisitionCandidate) {
+      recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate);
+      return lowLoadEnergyAcquisitionCandidate.task;
+    }
+
+    recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, 'noNearbyEnergy');
+    return spawnOrExtensionRefillTask;
+  }
+
+  const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
+  if (lowLoadEnergyAcquisitionCandidate) {
+    recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate);
+    return lowLoadEnergyAcquisitionCandidate.task;
   }
 
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
@@ -245,6 +272,87 @@ function estimateNearTermSpawnCompletionRefillReserve(
 
 function isTerritoryControlTask(task: CreepTaskMemory | null): task is Extract<CreepTaskMemory, { type: 'claim' | 'reserve' }> {
   return task?.type === 'claim' || task?.type === 'reserve';
+}
+
+function shouldPrioritizeSpawnOrExtensionRefill(creep: Creep): boolean {
+  const energyAvailable = getRoomEnergyAvailable(creep.room);
+  if (energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD) {
+    return true;
+  }
+
+  if (hasReservedTerritoryFollowUpRefillCapacity(creep) && !hasReadyTerritoryFollowUpEnergy(creep)) {
+    return true;
+  }
+
+  return hasNearTermSpawnCompletionRefillDemand(creep.room);
+}
+
+function hasNearTermSpawnCompletionRefillDemand(room: Room): boolean {
+  return findSpawnExtensionEnergyStructures(room).some(isNearTermSpawningSpawn);
+}
+
+interface LowLoadWorkerEnergyContext {
+  carriedEnergy: number;
+  freeCapacity: number;
+}
+
+function getLowLoadWorkerEnergyContext(creep: Creep): LowLoadWorkerEnergyContext | null {
+  const carriedEnergy = getUsedEnergy(creep);
+  const freeCapacity = getFreeEnergyCapacity(creep);
+  if (carriedEnergy <= 0 || freeCapacity <= 0) {
+    return null;
+  }
+
+  const capacity = carriedEnergy + freeCapacity;
+  const lowLoadEnergyLimit = Math.min(
+    LOW_LOAD_WORKER_ENERGY_CEILING,
+    Math.max(1, Math.floor(capacity * LOW_LOAD_WORKER_ENERGY_RATIO))
+  );
+  return carriedEnergy <= lowLoadEnergyLimit ? { carriedEnergy, freeCapacity } : null;
+}
+
+function recordNearbyEnergyChoiceTelemetry(
+  creep: Creep,
+  candidate: LowLoadWorkerEnergyAcquisitionCandidate
+): void {
+  const context = getLowLoadWorkerEnergyContext(creep);
+  const memory = creep.memory;
+  if (!context || !memory) {
+    return;
+  }
+
+  memory.workerEfficiency = {
+    type: 'nearbyEnergyChoice',
+    tick: getGameTick() ?? 0,
+    carriedEnergy: context.carriedEnergy,
+    freeCapacity: context.freeCapacity,
+    selectedTask: candidate.task.type,
+    targetId: String(candidate.task.targetId),
+    energy: Math.max(0, Math.floor(candidate.energy)),
+    ...(candidate.range === null ? {} : { range: candidate.range })
+  };
+}
+
+function recordLowLoadReturnTelemetry(
+  creep: Creep,
+  task: Extract<CreepTaskMemory, { type: 'transfer' }>,
+  reason: WorkerEfficiencyLowLoadReturnReason
+): void {
+  const context = getLowLoadWorkerEnergyContext(creep);
+  const memory = creep.memory;
+  if (!context || !memory) {
+    return;
+  }
+
+  memory.workerEfficiency = {
+    type: 'lowLoadReturn',
+    tick: getGameTick() ?? 0,
+    carriedEnergy: context.carriedEnergy,
+    freeCapacity: context.freeCapacity,
+    selectedTask: task.type,
+    targetId: String(task.targetId),
+    reason
+  };
 }
 
 function isFillableEnergySink(structure: AnyOwnedStructure): structure is FillableEnergySink {
@@ -722,6 +830,14 @@ interface WorkerEnergyAcquisitionCandidate {
   task: WorkerEnergyAcquisitionTask;
 }
 
+interface LowLoadWorkerEnergyAcquisitionCandidate {
+  energy: number;
+  range: number | null;
+  score: number;
+  source: LowLoadWorkerEnergyAcquisitionSource;
+  task: LowLoadWorkerEnergyAcquisitionTask;
+}
+
 interface SpawnRecoveryEnergyAcquisitionCandidate extends WorkerEnergyAcquisitionCandidate {
   deliveryEta: number;
 }
@@ -739,6 +855,92 @@ function selectWorkerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitio
   }
 
   return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+
+function selectLowLoadWorkerEnergyAcquisitionCandidate(
+  creep: Creep
+): LowLoadWorkerEnergyAcquisitionCandidate | null {
+  if (!shouldKeepLowLoadWorkerAcquiringEnergy(creep)) {
+    return null;
+  }
+
+  const nearbyCandidates = findLowLoadWorkerEnergyAcquisitionCandidates(creep).filter(
+    (candidate) => candidate.range !== null && candidate.range <= LOW_LOAD_NEARBY_ENERGY_RANGE
+  );
+  if (nearbyCandidates.length === 0) {
+    return null;
+  }
+
+  return nearbyCandidates.sort(compareLowLoadWorkerEnergyAcquisitionCandidates)[0];
+}
+
+function shouldKeepLowLoadWorkerAcquiringEnergy(creep: Creep): boolean {
+  return getLowLoadWorkerEnergyContext(creep) !== null && !hasVisibleHostilePresence(creep.room);
+}
+
+function findLowLoadWorkerEnergyAcquisitionCandidates(creep: Creep): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  return [
+    ...findWorkerEnergyAcquisitionCandidates(creep).map(toLowLoadWorkerEnergyAcquisitionCandidate),
+    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
+  ];
+}
+
+function toLowLoadWorkerEnergyAcquisitionCandidate(
+  candidate: WorkerEnergyAcquisitionCandidate
+): LowLoadWorkerEnergyAcquisitionCandidate {
+  return candidate;
+}
+
+function findLowLoadHarvestEnergyAcquisitionCandidates(creep: Creep): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  const source = selectHarvestSource(creep);
+  if (!source || isSourceDepleted(source)) {
+    return [];
+  }
+
+  return [
+    createLowLoadWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getHarvestCandidateEnergy(creep, source),
+      { type: 'harvest', targetId: source.id }
+    )
+  ];
+}
+
+function getHarvestCandidateEnergy(creep: Creep, source: Source): number {
+  return typeof source.energy === 'number' && Number.isFinite(source.energy)
+    ? source.energy
+    : getFreeEnergyCapacity(creep);
+}
+
+function createLowLoadWorkerEnergyAcquisitionCandidate(
+  creep: Creep,
+  source: LowLoadWorkerEnergyAcquisitionSource,
+  energy: number,
+  task: LowLoadWorkerEnergyAcquisitionTask
+): LowLoadWorkerEnergyAcquisitionCandidate {
+  const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
+
+  return {
+    energy,
+    range,
+    score: range === null ? energy : energy - range * ENERGY_ACQUISITION_RANGE_COST,
+    source,
+    task
+  };
+}
+
+function compareLowLoadWorkerEnergyAcquisitionCandidates(
+  left: LowLoadWorkerEnergyAcquisitionCandidate,
+  right: LowLoadWorkerEnergyAcquisitionCandidate
+): number {
+  return (
+    compareOptionalRanges(left.range, right.range) ||
+    right.score - left.score ||
+    right.energy - left.energy ||
+    String(left.source.id).localeCompare(String(right.source.id)) ||
+    left.task.type.localeCompare(right.task.type)
+  );
 }
 
 function selectSpawnRecoveryEnergyAcquisitionTask(
@@ -910,9 +1112,16 @@ function getRangeToWorkerEnergyAcquisitionSource(
   creep: Creep,
   source: WorkerEnergyAcquisitionSource
 ): number | null {
+  return getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
+}
+
+function getRangeToLowLoadWorkerEnergyAcquisitionSource(
+  creep: Creep,
+  source: LowLoadWorkerEnergyAcquisitionSource
+): number | null {
   const position = (creep as Creep & {
     pos?: {
-      getRangeTo?: (target: WorkerEnergyAcquisitionSource) => number;
+      getRangeTo?: (target: LowLoadWorkerEnergyAcquisitionSource) => number;
     };
   }).pos;
   if (typeof position?.getRangeTo !== 'function') {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -909,9 +909,73 @@ function shouldKeepLowLoadWorkerAcquiringEnergy(creep: Creep): boolean {
 
 function findLowLoadWorkerEnergyAcquisitionCandidates(creep: Creep): LowLoadWorkerEnergyAcquisitionCandidate[] {
   return [
-    ...findWorkerEnergyAcquisitionCandidates(creep).map(toLowLoadWorkerEnergyAcquisitionCandidate),
+    ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep),
+    ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep),
+    ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep),
     ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
   ];
+}
+
+function findNearbyLowLoadStoredEnergyAcquisitionCandidates(
+  creep: Creep
+): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  const context: StoredEnergySourceContext = {
+    creepOwnerUsername: getCreepOwnerUsername(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+
+  return findVisibleRoomStructures(creep.room)
+    .filter((structure): structure is StoredWorkerEnergySource => isSafeStoredEnergySource(structure, context))
+    .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
+    .map((source) =>
+      toLowLoadWorkerEnergyAcquisitionCandidate(
+        createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+          type: 'withdraw',
+          targetId: source.id as Id<AnyStoreStructure>
+        })
+      )
+    );
+}
+
+function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(
+  creep: Creep
+): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  return [...findTombstones(creep.room), ...findRuins(creep.room)]
+    .filter(hasSalvageableEnergy)
+    .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
+    .map((source) =>
+      toLowLoadWorkerEnergyAcquisitionCandidate(
+        createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+          type: 'withdraw',
+          targetId: source.id as unknown as Id<AnyStoreStructure>
+        })
+      )
+    );
+}
+
+function findNearbyLowLoadDroppedEnergyAcquisitionCandidates(
+  creep: Creep
+): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  return findDroppedResources(creep.room)
+    .filter(isUsefulDroppedEnergy)
+    .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
+    .map((source) =>
+      toLowLoadWorkerEnergyAcquisitionCandidate(
+        createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
+          type: 'pickup',
+          targetId: source.id
+        })
+      )
+    );
+}
+
+function isNearbyLowLoadWorkerEnergyAcquisitionSource(
+  creep: Creep,
+  source: LowLoadWorkerEnergyAcquisitionSource
+): boolean {
+  const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
+  return range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE;
 }
 
 function toLowLoadWorkerEnergyAcquisitionCandidate(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -74,6 +74,8 @@ interface Source2ControllerLaneTopology {
 let nearTermSpawnExtensionRefillReserveCache: NearTermSpawnExtensionRefillReserveCache | null = null;
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
+  clearWorkerEfficiencyTelemetry(creep);
+
   const carriedEnergy = getUsedEnergy(creep);
   const urgentReservationRenewalTask = selectUrgentVisibleReservationRenewalTask(creep);
   const territoryControllerTask = selectVisibleTerritoryControllerTask(creep);
@@ -321,6 +323,13 @@ function getLowLoadWorkerEnergyContext(creep: Creep): LowLoadWorkerEnergyContext
     Math.max(1, Math.floor(capacity * LOW_LOAD_WORKER_ENERGY_RATIO))
   );
   return carriedEnergy <= lowLoadEnergyLimit ? { carriedEnergy, freeCapacity } : null;
+}
+
+function clearWorkerEfficiencyTelemetry(creep: Creep): void {
+  const memory = creep.memory;
+  if (memory) {
+    delete memory.workerEfficiency;
+  }
 }
 
 function recordNearbyEnergyChoiceTelemetry(

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -10,6 +10,8 @@ import { getActiveTerritoryFollowUpExecutionHints } from '../territory/territory
 export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
 const MAX_REPORTED_EVENTS = 10;
+const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+const WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 
 const WORKER_TASK_TYPES = ['harvest', 'transfer', 'build', 'upgrade'] as const;
 
@@ -42,6 +44,7 @@ interface RuntimeRoomSummary {
   workerCount: number;
   spawnStatus: RuntimeSpawnStatus[];
   taskCounts: WorkerTaskCounts;
+  workerEfficiency?: RuntimeWorkerEfficiencySummary;
   controller?: RuntimeControllerSummary;
   resources: RuntimeResourceSummary;
   combat: RuntimeCombatSummary;
@@ -68,6 +71,22 @@ interface RuntimeResourceSummary {
   droppedEnergy: number;
   sourceCount: number;
   events?: RuntimeResourceEventSummary;
+}
+
+interface RuntimeWorkerEfficiencySummary {
+  lowLoadReturnCount: number;
+  nearbyEnergyChoiceCount: number;
+  samples: RuntimeWorkerEfficiencySampleSummary[];
+  omittedSampleCount?: number;
+}
+
+interface RuntimeWorkerEfficiencySampleSummary extends WorkerEfficiencySampleMemory {
+  creepName?: string;
+}
+
+interface RuntimeWorkerEfficiencySampleEntry {
+  creepName: string | undefined;
+  sample: WorkerEfficiencySampleMemory;
 }
 
 interface RuntimeCombatEventSummary {
@@ -157,6 +176,7 @@ function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSumm
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -212,6 +232,102 @@ function countWorkerTasks(workers: Creep[]): WorkerTaskCounts {
 
 function isWorkerTaskType(taskType: string | undefined): taskType is WorkerTaskType {
   return WORKER_TASK_TYPES.includes(taskType as WorkerTaskType);
+}
+
+function summarizeWorkerEfficiency(
+  workers: Creep[],
+  tick: number
+): { workerEfficiency?: RuntimeWorkerEfficiencySummary } {
+  const samples = workers
+    .map((worker) => ({ creepName: getCreepName(worker), sample: worker.memory.workerEfficiency }))
+    .filter(
+      (entry): entry is RuntimeWorkerEfficiencySampleEntry =>
+        isWorkerEfficiencySample(entry.sample) && isRecentWorkerEfficiencySample(entry.sample, tick)
+    )
+    .sort(compareWorkerEfficiencySampleEntries);
+
+  if (samples.length === 0) {
+    return {};
+  }
+
+  const reportedSamples = samples.slice(0, MAX_WORKER_EFFICIENCY_SAMPLES).map(toRuntimeWorkerEfficiencySample);
+
+  return {
+    workerEfficiency: {
+      lowLoadReturnCount: samples.filter((entry) => entry.sample.type === 'lowLoadReturn').length,
+      nearbyEnergyChoiceCount: samples.filter((entry) => entry.sample.type === 'nearbyEnergyChoice').length,
+      samples: reportedSamples,
+      ...(samples.length > MAX_WORKER_EFFICIENCY_SAMPLES
+        ? { omittedSampleCount: samples.length - MAX_WORKER_EFFICIENCY_SAMPLES }
+        : {})
+    }
+  };
+}
+
+function compareWorkerEfficiencySampleEntries(
+  left: RuntimeWorkerEfficiencySampleEntry,
+  right: RuntimeWorkerEfficiencySampleEntry
+): number {
+  return (
+    right.sample.tick - left.sample.tick ||
+    (left.creepName ?? '').localeCompare(right.creepName ?? '') ||
+    left.sample.targetId.localeCompare(right.sample.targetId)
+  );
+}
+
+function toRuntimeWorkerEfficiencySample(entry: {
+  creepName: string | undefined;
+  sample: WorkerEfficiencySampleMemory;
+}): RuntimeWorkerEfficiencySampleSummary {
+  return {
+    ...(entry.creepName ? { creepName: entry.creepName } : {}),
+    ...entry.sample
+  };
+}
+
+function isRecentWorkerEfficiencySample(sample: WorkerEfficiencySampleMemory, tick: number): boolean {
+  if (tick <= 0) {
+    return true;
+  }
+
+  return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
+}
+
+function isWorkerEfficiencySample(value: unknown): value is WorkerEfficiencySampleMemory {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    (value.type === 'lowLoadReturn' || value.type === 'nearbyEnergyChoice') &&
+    typeof value.tick === 'number' &&
+    Number.isFinite(value.tick) &&
+    typeof value.carriedEnergy === 'number' &&
+    Number.isFinite(value.carriedEnergy) &&
+    typeof value.freeCapacity === 'number' &&
+    Number.isFinite(value.freeCapacity) &&
+    isWorkerEfficiencyTaskType(value.selectedTask) &&
+    typeof value.targetId === 'string'
+  );
+}
+
+function isWorkerEfficiencyTaskType(value: unknown): value is CreepTaskMemory['type'] {
+  return (
+    value === 'harvest' ||
+    value === 'pickup' ||
+    value === 'withdraw' ||
+    value === 'transfer' ||
+    value === 'build' ||
+    value === 'repair' ||
+    value === 'claim' ||
+    value === 'reserve' ||
+    value === 'upgrade'
+  );
+}
+
+function getCreepName(creep: Creep): string | undefined {
+  const name = (creep as Creep & { name?: unknown }).name;
+  return typeof name === 'string' && name.length > 0 ? name : undefined;
 }
 
 function buildControllerSummary(room: Room): { controller?: RuntimeControllerSummary } {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -13,6 +13,7 @@ declare global {
     colony?: string;
     task?: CreepTaskMemory;
     territory?: CreepTerritoryMemory;
+    workerEfficiency?: WorkerEfficiencySampleMemory;
   }
 
   type TerritoryControlAction = 'claim' | 'reserve';
@@ -83,6 +84,21 @@ declare global {
     action: TerritoryIntentAction;
     controllerId?: Id<StructureController>;
     followUp?: TerritoryFollowUpMemory;
+  }
+
+  type WorkerEfficiencySampleType = 'lowLoadReturn' | 'nearbyEnergyChoice';
+  type WorkerEfficiencyLowLoadReturnReason = 'urgentSpawnExtensionRefill' | 'noNearbyEnergy';
+
+  interface WorkerEfficiencySampleMemory {
+    type: WorkerEfficiencySampleType;
+    tick: number;
+    carriedEnergy: number;
+    freeCapacity: number;
+    selectedTask: CreepTaskMemory['type'];
+    targetId: string;
+    energy?: number;
+    range?: number;
+    reason?: WorkerEfficiencyLowLoadReturnReason;
   }
 
   type CreepTaskMemory =

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -211,6 +211,123 @@ describe('runtime telemetry summaries', () => {
     expect(payload.omittedEventCount).toBe(2);
   });
 
+  it('reports bounded room-level worker efficiency samples', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const recentWorkers = Array.from({ length: 7 }, (_, index) =>
+      makeWorker(
+        {
+          role: 'worker',
+          colony: 'W1N1',
+          workerEfficiency:
+            index % 2 === 0
+              ? {
+                  type: 'nearbyEnergyChoice',
+                  tick: RUNTIME_SUMMARY_INTERVAL,
+                  carriedEnergy: 5 + index,
+                  freeCapacity: 45,
+                  selectedTask: 'pickup',
+                  targetId: `drop-${index}`,
+                  energy: 50,
+                  range: 1
+                }
+              : {
+                  type: 'lowLoadReturn',
+                  tick: RUNTIME_SUMMARY_INTERVAL,
+                  carriedEnergy: 5 + index,
+                  freeCapacity: 45,
+                  selectedTask: 'transfer',
+                  targetId: `spawn-${index}`,
+                  reason: 'noNearbyEnergy'
+                }
+        },
+        5,
+        `Worker${index}`
+      )
+    );
+    const staleWorker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        workerEfficiency: {
+          type: 'lowLoadReturn',
+          tick: 0,
+          carriedEnergy: 5,
+          freeCapacity: 45,
+          selectedTask: 'transfer',
+          targetId: 'spawn-stale',
+          reason: 'urgentSpawnExtensionRefill'
+        }
+      },
+      5,
+      'WorkerStale'
+    );
+
+    emitRuntimeSummary([colony], [...recentWorkers, staleWorker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.workerEfficiency).toEqual({
+      lowLoadReturnCount: 3,
+      nearbyEnergyChoiceCount: 4,
+      samples: [
+        {
+          creepName: 'Worker0',
+          type: 'nearbyEnergyChoice',
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          carriedEnergy: 5,
+          freeCapacity: 45,
+          selectedTask: 'pickup',
+          targetId: 'drop-0',
+          energy: 50,
+          range: 1
+        },
+        {
+          creepName: 'Worker1',
+          type: 'lowLoadReturn',
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          carriedEnergy: 6,
+          freeCapacity: 45,
+          selectedTask: 'transfer',
+          targetId: 'spawn-1',
+          reason: 'noNearbyEnergy'
+        },
+        {
+          creepName: 'Worker2',
+          type: 'nearbyEnergyChoice',
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          carriedEnergy: 7,
+          freeCapacity: 45,
+          selectedTask: 'pickup',
+          targetId: 'drop-2',
+          energy: 50,
+          range: 1
+        },
+        {
+          creepName: 'Worker3',
+          type: 'lowLoadReturn',
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          carriedEnergy: 8,
+          freeCapacity: 45,
+          selectedTask: 'transfer',
+          targetId: 'spawn-3',
+          reason: 'noNearbyEnergy'
+        },
+        {
+          creepName: 'Worker4',
+          type: 'nearbyEnergyChoice',
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          carriedEnergy: 9,
+          freeCapacity: 45,
+          selectedTask: 'pickup',
+          targetId: 'drop-4',
+          energy: 50,
+          range: 1
+        }
+      ],
+      omittedSampleCount: 2
+    });
+  });
+
   it('keeps KPI summaries safe when optional Screeps APIs and constants are absent', () => {
     const colony = makeColony({
       time: RUNTIME_SUMMARY_INTERVAL,
@@ -468,8 +585,9 @@ function makeColony(options: {
   };
 }
 
-function makeWorker(memory: CreepMemory, energy = 0): Creep {
+function makeWorker(memory: CreepMemory, energy = 0, name?: string): Creep {
   return {
+    ...(name ? { name } : {}),
     memory,
     store: makeEnergyStore(energy)
   } as unknown as Creep;

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1494,6 +1494,79 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts a low-load harvest return for nearby energy when refill is not urgent', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const droppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'drop-near': 1,
+        source1: 3
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [spawn];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            if (type === FIND_DROPPED_RESOURCES) {
+              return [droppedEnergy];
+            }
+
+            if (type === FIND_SOURCES) {
+              return [source];
+            }
+
+            return [];
+          }
+        )
+      },
+      harvest: jest.fn(),
+      pickup: jest.fn().mockReturnValue(0),
+      transfer: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker: creep },
+      time: 777,
+      getObjectById: jest.fn((id: string) => (id === 'drop-near' ? droppedEnergy : source))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'pickup', targetId: 'drop-near' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 777,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'pickup',
+      targetId: 'drop-near',
+      energy: 50,
+      range: 1
+    });
+    expect(creep.pickup).toHaveBeenCalledWith(droppedEnergy);
+    expect(creep.transfer).not.toHaveBeenCalled();
+    expect(creep.harvest).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('spends partially picked-up energy on extension construction before lower-value tower refill', () => {
     const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 100 } as Resource<ResourceConstant>;
     const extensionSite = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1552,6 +1552,122 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
   });
 
+  it('keeps a low-load worker on nearby dropped energy before non-urgent spawn refill', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const droppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'drop-near': 1,
+        source1: 3
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [droppedEnergy];
+        }
+
+        if (
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 321 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 321,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'pickup',
+      targetId: 'drop-near',
+      energy: 50,
+      range: 1
+    });
+  });
+
+  it('keeps urgent spawn refill before low-load nearby energy acquisition', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const droppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
+    const getRangeTo = jest.fn((target: { id: string }) => (target.id === 'drop-near' ? 1 : 99));
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [droppedEnergy];
+        }
+
+        if (
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 322 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 322,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'transfer',
+      targetId: 'spawn1',
+      reason: 'urgentSpawnExtensionRefill'
+    });
+  });
+
   it('selects the closest spawn or extension before fillable towers', () => {
     const farSpawn = makeEnergySink('spawn-far', 'spawn' as StructureConstant, 300);
     const fullExtension = makeEnergySink('extension-full', 'extension' as StructureConstant, 0);

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1673,6 +1673,186 @@ describe('selectWorkerTask', () => {
     expect(findPathTo).not.toHaveBeenCalled();
   });
 
+  it('ignores unreachable nearby dropped energy for low-load workers', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const blockedDroppedEnergy = {
+      id: 'drop-blocked',
+      resourceType: 'energy',
+      amount: 500
+    } as Resource<ResourceConstant>;
+    const getRangeTo = jest.fn((target: { id: string }) => (target.id === 'drop-blocked' ? 2 : 99));
+    const findPathTo = jest.fn().mockReturnValue([]);
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [blockedDroppedEnergy];
+        }
+
+        if (
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo, findPathTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 324 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 324,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'transfer',
+      targetId: 'spawn1',
+      reason: 'noNearbyEnergy'
+    });
+    expect(findPathTo).toHaveBeenCalledWith(blockedDroppedEnergy, { ignoreCreeps: true });
+  });
+
+  it('returns to refill instead of low-load harvesting without active work parts', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => (target.id === 'source1' ? 1 : 99));
+    const getActiveBodyparts = jest.fn().mockReturnValue(0);
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      getActiveBodyparts,
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 326 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 326,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'transfer',
+      targetId: 'spawn1',
+      reason: 'noNearbyEnergy'
+    });
+    expect(getActiveBodyparts).toHaveBeenCalledWith('work');
+  });
+
+  it('keeps reachable nearby dropped energy selectable for low-load workers', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const droppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
+    const farDroppedEnergy = { id: 'drop-far', resourceType: 'energy', amount: 500 } as Resource<ResourceConstant>;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'drop-far': 10,
+        'drop-near': 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const findPathTo = jest.fn((target: { id: string }) => (target.id === 'drop-near' ? [{ x: 1, y: 1 }] : []));
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [farDroppedEnergy, droppedEnergy];
+        }
+
+        if (
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo, findPathTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 325 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 325,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'pickup',
+      targetId: 'drop-near',
+      energy: 50,
+      range: 2
+    });
+    expect(findPathTo).toHaveBeenCalledTimes(1);
+    expect(findPathTo).toHaveBeenCalledWith(droppedEnergy, { ignoreCreeps: true });
+    expect(findPathTo).not.toHaveBeenCalledWith(farDroppedEnergy, { ignoreCreeps: true });
+  });
+
   it('keeps a low-load worker on nearby container energy', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const container = makeStoredEnergyStructure('container-near', 'container' as StructureConstant, 80);

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1577,17 +1577,20 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
   });
 
-  it('keeps a low-load worker on nearby dropped energy before non-urgent spawn refill', () => {
+  it('keeps a low-load worker on nearby dropped energy without pathing to distant drops', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const droppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
+    const farDroppedEnergy = { id: 'drop-far', resourceType: 'energy', amount: 500 } as Resource<ResourceConstant>;
     const source = { id: 'source1', energy: 300 } as Source;
     const getRangeTo = jest.fn((target: { id: string }) => {
       const ranges: Record<string, number> = {
+        'drop-far': 10,
         'drop-near': 1,
         source1: 3
       };
       return ranges[String(target.id)] ?? 99;
     });
+    const findPathTo = jest.fn().mockReturnValue([]);
     const roomFind = jest.fn(
       (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
         if (type === FIND_MY_STRUCTURES) {
@@ -1596,7 +1599,7 @@ describe('selectWorkerTask', () => {
         }
 
         if (type === FIND_DROPPED_RESOURCES) {
-          return [droppedEnergy];
+          return [farDroppedEnergy, droppedEnergy];
         }
 
         if (
@@ -1618,7 +1621,7 @@ describe('selectWorkerTask', () => {
         getUsedCapacity: jest.fn().mockReturnValue(10),
         getFreeCapacity: jest.fn().mockReturnValue(40)
       },
-      pos: { getRangeTo },
+      pos: { getRangeTo, findPathTo },
       room: {
         energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
         find: roomFind
@@ -1637,6 +1640,74 @@ describe('selectWorkerTask', () => {
       energy: 50,
       range: 1
     });
+    expect(findPathTo).not.toHaveBeenCalled();
+  });
+
+  it('keeps a low-load worker on nearby container energy', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const container = makeStoredEnergyStructure('container-near', 'container' as StructureConstant, 80);
+    const farDroppedEnergy = { id: 'drop-far', resourceType: 'energy', amount: 500 } as Resource<ResourceConstant>;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'container-near': 2,
+        'drop-far': 10
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const findPathTo = jest.fn().mockReturnValue([]);
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [container];
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [farDroppedEnergy];
+        }
+
+        if (
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo, findPathTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 323 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-near' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 323,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'withdraw',
+      targetId: 'container-near',
+      energy: 80,
+      range: 2
+    });
+    expect(findPathTo).not.toHaveBeenCalled();
   });
 
   it('keeps urgent spawn refill before low-load nearby energy acquisition', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1577,6 +1577,36 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
   });
 
+  it('clears stale worker efficiency telemetry when selecting a normal refill task', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const creep = {
+      memory: {
+        role: 'worker',
+        workerEfficiency: {
+          type: 'nearbyEnergyChoice',
+          tick: 300,
+          carriedEnergy: 10,
+          freeCapacity: 40,
+          selectedTask: 'pickup',
+          targetId: 'drop-stale',
+          energy: 50,
+          range: 1
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(150)
+      },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: jest.fn((type) => (type === FIND_MY_STRUCTURES ? [spawn] : []))
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toBeUndefined();
+  });
+
   it('keeps a low-load worker on nearby dropped energy without pathing to distant drops', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const droppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;


### PR DESCRIPTION
## Summary
- Adds bounded worker-efficiency telemetry for load factor, acquisition choice, task churn, idle/no-task, and productive energy signals.
- Records worker movement/task events in the runner/task selection paths and exposes room-level aggregates plus inefficient-worker samples in runtime summary output.
- Adds focused Jest coverage for worker task telemetry, runner updates, and runtime summary aggregation.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 478 tests)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #329
