### PR TITLE
feat: build critical roads for territory follow-ups

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3471,7 +3471,8 @@ function selectWorkerTask(creep) {
   const readyFollowUpProductiveEnergySinkTask = selectReadyFollowUpProductiveEnergySinkTask(
     creep,
     capacityConstructionSite,
-    controller
+    controller,
+    constructionSites
   );
   if (readyFollowUpProductiveEnergySinkTask) {
     return readyFollowUpProductiveEnergySinkTask;
@@ -3751,7 +3752,7 @@ function selectCapacityEnablingConstructionSite(creep, constructionSites, contro
   }
   return selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
 }
-function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstructionSite, controller) {
+function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstructionSite, controller, constructionSites) {
   if (!hasReadyTerritoryFollowUpEnergy(creep)) {
     return null;
   }
@@ -3762,7 +3763,11 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
     return null;
   }
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
-  return criticalRepairTarget ? { type: "repair", targetId: criticalRepairTarget.id } : null;
+  if (criticalRepairTarget) {
+    return { type: "repair", targetId: criticalRepairTarget.id };
+  }
+  const criticalRoadConstructionSite = selectCriticalRoadConstructionSite(creep, constructionSites);
+  return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
 }
 function isSpawnConstructionSite(site) {
   return matchesStructureType3(site.structureType, "STRUCTURE_SPAWN", "spawn");

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -142,7 +142,8 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const readyFollowUpProductiveEnergySinkTask = selectReadyFollowUpProductiveEnergySinkTask(
     creep,
     capacityConstructionSite,
-    controller
+    controller,
+    constructionSites
   );
   if (readyFollowUpProductiveEnergySinkTask) {
     return readyFollowUpProductiveEnergySinkTask;
@@ -576,7 +577,8 @@ function selectCapacityEnablingConstructionSite(
 function selectReadyFollowUpProductiveEnergySinkTask(
   creep: Creep,
   capacityConstructionSite: ConstructionSite | null,
-  controller: StructureController | undefined
+  controller: StructureController | undefined,
+  constructionSites: ConstructionSite[]
 ): ProductiveEnergySinkTask | null {
   if (!hasReadyTerritoryFollowUpEnergy(creep)) {
     return null;
@@ -591,7 +593,12 @@ function selectReadyFollowUpProductiveEnergySinkTask(
   }
 
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
-  return criticalRepairTarget ? { type: 'repair', targetId: criticalRepairTarget.id as Id<Structure> } : null;
+  if (criticalRepairTarget) {
+    return { type: 'repair', targetId: criticalRepairTarget.id as Id<Structure> };
+  }
+
+  const criticalRoadConstructionSite = selectCriticalRoadConstructionSite(creep, constructionSites);
+  return criticalRoadConstructionSite ? { type: 'build', targetId: criticalRoadConstructionSite.id } : null;
 }
 
 function isSpawnConstructionSite(site: ConstructionSite): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3688,6 +3688,48 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-critical' });
   });
 
+  it('builds follow-up-ready critical road logistics before fallback territory upgrading', () => {
+    const homeSpawn = makeSpawn('Spawn1', 25, 25, 'W1N1');
+    const source = makeSource('source1', 24, 25, 'W2N1');
+    const site = {
+      id: 'road-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(40, 25, 'W2N1')
+    } as ConstructionSite;
+    const controller = {
+      id: 'controller2',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25, 'W2N1')
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      spawns: { Spawn1: homeSpawn },
+      time: 517
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        demands: [makeFollowUpDemand(517, 'W1N1', 'W2N1')],
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 517 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+        energyCapacityAvailable: 800,
+        sources: [source]
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
   it('keeps emergency refill before productive follow-up spending', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const site = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;


### PR DESCRIPTION
## Summary
- let ready territory follow-up workers build critical road construction sites after critical repairs
- preserve existing priority for capacity-enabling construction and critical repairs
- add focused worker task coverage and regenerate `prod/dist/main.js`

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 483 tests)
- `cd prod && npm run build`
- `git diff --check`

Closes #336.
