### PR TITLE
feat: sustain controller pressure with loaded workers

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3409,6 +3409,8 @@ var HARVEST_ENERGY_PER_WORK_PART = 2;
 var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 var SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 var SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
+var MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
+var MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS = 2;
 var nearTermSpawnExtensionRefillReserveCache = null;
 function selectWorkerTask(creep) {
   const carriedEnergy = getUsedEnergy(creep);
@@ -4304,7 +4306,15 @@ function shouldApplyControllerPressureLane(creep, controller) {
     return false;
   }
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
-  return (loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS || loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasActiveTerritoryPressure(creep)) && !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller));
+  const hasTerritoryPressure = hasActiveTerritoryPressure(creep);
+  if (loadedWorkers.length < MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS && !(loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasTerritoryPressure)) {
+    return false;
+  }
+  const controllerProgressWorkers = loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS && !hasTerritoryPressure ? MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS : 1;
+  const otherControllerUpgraders = loadedWorkers.filter(
+    (worker) => !isSameCreep(worker, creep) && isUpgradingController(worker, controller)
+  ).length;
+  return otherControllerUpgraders < controllerProgressWorkers;
 }
 function shouldUseSurplusForControllerProgress(creep, controller) {
   if (shouldApplyControllerPressureLane(creep, controller)) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -29,6 +29,8 @@ const HARVEST_ENERGY_PER_WORK_PART = 2;
 const MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 const SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 const SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
+const MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
+const MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS = 2;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
@@ -1447,11 +1449,22 @@ function shouldApplyControllerPressureLane(creep: Creep, controller: StructureCo
   }
 
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
-  return (
-    (loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS ||
-      (loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasActiveTerritoryPressure(creep))) &&
-    !loadedWorkers.some((worker) => worker !== creep && isUpgradingController(worker, controller))
-  );
+  const hasTerritoryPressure = hasActiveTerritoryPressure(creep);
+  if (
+    loadedWorkers.length < MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS &&
+    !(loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasTerritoryPressure)
+  ) {
+    return false;
+  }
+
+  const controllerProgressWorkers =
+    loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS && !hasTerritoryPressure
+      ? MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS
+      : 1;
+  const otherControllerUpgraders = loadedWorkers.filter(
+    (worker) => !isSameCreep(worker, creep) && isUpgradingController(worker, controller)
+  ).length;
+  return otherControllerUpgraders < controllerProgressWorkers;
 }
 
 function shouldUseSurplusForControllerProgress(creep: Creep, controller: StructureController): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4291,6 +4291,58 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
   });
 
+  it('allows a second RCL3 controller pressure upgrader when several loaded workers can cover construction', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type) => (type === 2 ? [site] : []))
+    } as unknown as Room;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      BuilderA: makeLoadedWorker(room),
+      BuilderB: makeLoadedWorker(room)
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('bounds RCL3 controller pressure once two loaded workers are already upgrading', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn((type) => (type === 2 ? [site] : []))
+    } as unknown as Room;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      UpgraderA: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      UpgraderB: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      Builder: makeLoadedWorker(room)
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
+  });
+
   it('steers an empty worker to source2 when source2 is near the owned controller', () => {
     const source1 = makeSource('source1', 8, 8);
     const source2 = makeSource('source2', 24, 23);


### PR DESCRIPTION
## Summary
- Allows a bounded second controller-pressure upgrader when several loaded workers are available to keep construction covered.
- Preserves the existing one-upgrader cap under territory pressure or when too few loaded workers are available.
- Adds focused Jest coverage for the two-upgrader cap and build fallback.

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 485 tests)
- `cd prod && npm run build`
- `git diff --check`

Closes #324
