### PR TITLE
feat: improve territory control recommendations

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -789,8 +789,18 @@ function scoreOccupationCandidate(input, candidate) {
     evidenceStatus = "unavailable";
   } else {
     evidence.push("room visible", "controller visible");
+    const controllerPressureEvidence = getControllerPressureEvidence(input, candidate);
     const unavailableReason = getControllerUnavailableReason(input, candidate.controller);
-    if (unavailableReason) {
+    if (controllerPressureEvidence) {
+      evidence.push(controllerPressureEvidence);
+      action = "reserve";
+      if (candidate.sourceCount === void 0) {
+        risks.push("source count evidence missing");
+        evidenceStatus = "insufficient-evidence";
+      } else {
+        evidence.push(`${candidate.sourceCount} sources visible`);
+      }
+    } else if (unavailableReason) {
       risks.push(unavailableReason);
       evidenceStatus = "unavailable";
       action = candidate.actionHint === "claim" ? "occupy" : "reserve";
@@ -856,9 +866,16 @@ function calculateOccupationScore(input, candidate, action, evidenceStatus) {
   const adjacencyScore = candidate.adjacent ? 25 : 0;
   const readinessScore = Math.min(input.workerCount, MIN_READY_WORKERS) * 12 + (input.energyCapacityAvailable >= TERRITORY_BODY_ENERGY_CAPACITY ? 30 : 0) + (((_c = input.controllerLevel) != null ? _c : 0) >= 2 ? 30 : 0) + (input.ticksToDowngrade === void 0 || input.ticksToDowngrade > DOWNGRADE_GUARD_TICKS ? 20 : 0);
   const riskPenalty = ((_d = candidate.hostileCreepCount) != null ? _d : 0) * 160 + ((_e = candidate.hostileStructureCount) != null ? _e : 0) * 120;
+  const controllerPressurePenalty = candidate.controller && isForeignReservation(input, candidate.controller) ? 180 : 0;
   const evidencePenalty = evidenceStatus === "insufficient-evidence" ? 260 : 0;
   const unavailablePenalty = evidenceStatus === "unavailable" ? 2e3 : 0;
-  return ACTION_SCORE[action] + sourcePriorityScore + adjacencyScore + distanceScore + sourceScore + supportScore + readinessScore - riskPenalty - evidencePenalty - unavailablePenalty;
+  return ACTION_SCORE[action] + sourcePriorityScore + adjacencyScore + distanceScore + sourceScore + supportScore + readinessScore - riskPenalty - controllerPressurePenalty - evidencePenalty - unavailablePenalty;
+}
+function getControllerPressureEvidence(input, candidate) {
+  if (candidate.source !== "configured" || candidate.actionHint !== "reserve" || !candidate.controller || !isForeignReservation(input, candidate.controller)) {
+    return null;
+  }
+  return "foreign reservation can be pressured";
 }
 function getColonyReadinessPreconditions(input) {
   var _a;
@@ -897,6 +914,9 @@ function isOwnReservationDueForRenewal(input, controller) {
 }
 function isOwnReservation(input, controller) {
   return input.colonyOwnerUsername !== void 0 && controller.reservationUsername === input.colonyOwnerUsername;
+}
+function isForeignReservation(input, controller) {
+  return input.colonyOwnerUsername !== void 0 && controller.my !== true && controller.ownerUsername === void 0 && controller.reservationUsername !== void 0 && controller.reservationUsername !== input.colonyOwnerUsername;
 }
 function isControllerOwnedByColony(input, controller) {
   return controller.my === true || !!controller.ownerUsername && controller.ownerUsername === input.colonyOwnerUsername;
@@ -1217,12 +1237,12 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
   if (plan.action === "scout" && isVisibleRoomKnown(plan.targetRoom)) {
     return false;
   }
-  if (getVisibleTerritoryTargetState(
+  if (!isVisibleTerritoryIntentActionable(
     plan.targetRoom,
     plan.action,
     plan.controllerId,
     getVisibleColonyOwnerUsername(plan.colony)
-  ) !== "available") {
+  )) {
     return false;
   }
   const activeCoverageCount = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action);
@@ -1236,12 +1256,12 @@ function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTim
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
     return 0;
   }
-  if (getVisibleTerritoryTargetState(
+  if (!isVisibleTerritoryIntentActionable(
     plan.targetRoom,
     plan.action,
     plan.controllerId,
     getVisibleColonyOwnerUsername(plan.colony)
-  ) !== "available") {
+  )) {
     return 0;
   }
   const demand = getCurrentTerritoryFollowUpDemand(plan, gameTime);
@@ -1318,6 +1338,9 @@ function canCreepReserveTerritoryController(creep, controller, colony) {
   const reservationTicksToEnd = reservation.ticksToEnd;
   return reservationTicksToEnd <= TERRITORY_RESERVATION_COMFORT_TICKS && canRenewReservation(activeClaimParts, reservationTicksToEnd);
 }
+function canCreepPressureTerritoryController(creep, controller, colony) {
+  return getActiveControllerClaimPartCount(creep) > 0 && isForeignReservedController(controller, getTerritoryActorUsername(creep, colony));
+}
 function selectUrgentVisibleReservationRenewalTask(creep) {
   const intent = selectVisibleTerritoryControllerIntent(creep);
   if (!intent || intent.action !== "reserve") {
@@ -1365,7 +1388,7 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   }
   const actorUsername = getTerritoryActorUsername(creep, colony);
   const targetState = getTerritoryControllerTargetState(controller, assignment.action, actorUsername);
-  return targetState === "available" || assignment.action === "reserve" && targetState === "satisfied";
+  return targetState === "available" || assignment.action === "reserve" && targetState === "satisfied" || assignment.action === "reserve" && isForeignReservedController(controller, actorUsername);
 }
 function isVisibleTerritoryAssignmentComplete(assignment, creep) {
   if (assignment.action !== "claim" || !isNonEmptyString2(assignment.targetRoom)) {
@@ -1648,7 +1671,7 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget2(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) || !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)) {
       return [];
     }
     const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
@@ -1685,7 +1708,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
   const configuredTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return intents.flatMap((intent, order) => {
     const recoveredFollowUp = isRecoveredTerritoryFollowUpIntent(intent, gameTime);
-    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || getVisibleTerritoryTargetState(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername) !== "available") {
+    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)) {
       return [];
     }
     const intentKey = `${intent.targetRoom}:${intent.action}`;
@@ -2474,7 +2497,7 @@ function isPersistedTerritoryFollowUpStillActionable(intent, action, colonyOwner
     intent.controllerId,
     colonyOwnerUsername
   );
-  return controllerState === null || controllerState === "available";
+  return controllerState === null || controllerState === "available" || isVisibleTerritoryReservePressureAvailable(intent.targetRoom, action, intent.controllerId, colonyOwnerUsername);
 }
 function getVisibleTerritoryControllerEvidenceState(targetRoom, action, controllerId, colonyOwnerUsername) {
   if (isVisibleRoomMissingController(targetRoom)) {
@@ -2664,7 +2687,7 @@ function buildTerritoryFollowUpExecutionHint(plan, gameTime) {
   };
 }
 function getTerritoryFollowUpExecutionHintReason(targetRoom, action, controllerId, colonyOwnerUsername) {
-  if (getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) !== "available") {
+  if (!isVisibleTerritoryIntentActionable(targetRoom, action, controllerId, colonyOwnerUsername)) {
     return null;
   }
   if (action === "scout") {
@@ -3027,6 +3050,16 @@ function getVisibleTerritoryTargetState(targetRoom, action, controllerId, colony
   }
   return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername != null ? colonyOwnerUsername : null);
 }
+function isVisibleTerritoryIntentActionable(targetRoom, action, controllerId, colonyOwnerUsername) {
+  return getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) === "available" || isVisibleTerritoryReservePressureAvailable(targetRoom, action, controllerId, colonyOwnerUsername);
+}
+function isVisibleTerritoryReservePressureAvailable(targetRoom, action, controllerId, colonyOwnerUsername) {
+  if (action !== "reserve" || isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
+    return false;
+  }
+  const controller = getVisibleController(targetRoom, controllerId);
+  return controller !== null && isForeignReservedController(controller, colonyOwnerUsername);
+}
 function isVisibleRoomKnown(targetRoom) {
   var _a;
   const game = globalThis.Game;
@@ -3057,6 +3090,13 @@ function getReserveControllerTargetState(controller, colonyOwnerUsername) {
     return "unavailable";
   }
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) === null ? "satisfied" : "available";
+}
+function isForeignReservedController(controller, actorUsername) {
+  if (isControllerOwned(controller) || !isNonEmptyString2(actorUsername)) {
+    return false;
+  }
+  const reservation = controller.reservation;
+  return isNonEmptyString2(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
 }
 function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
   if (target.action !== "reserve" || colonyOwnerUsername === null) {
@@ -6504,6 +6544,16 @@ function runTerritoryControllerCreep(creep) {
   if (isTerritoryControlAction3(assignment.action) && isCreepKnownToHaveNoActiveClaimParts(creep)) {
     suppressTerritoryAssignment(creep, assignment);
     return;
+  }
+  if (assignment.action === "reserve" && typeof creep.attackController === "function" && canCreepPressureTerritoryController(creep, controller, creep.memory.colony)) {
+    const pressureResult = executeControllerAction(creep, controller, "attackController");
+    if (pressureResult === ERR_NOT_IN_RANGE_CODE2 && typeof creep.moveTo === "function") {
+      creep.moveTo(controller);
+      return;
+    }
+    if (pressureResult !== ERR_INVALID_TARGET_CODE) {
+      return;
+    }
   }
   if (assignment.action === "reserve" && !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2566,15 +2566,34 @@ function upsertTerritoryIntent2(intents, nextIntent) {
   if (existingIndex >= 0) {
     const existingIntent = intents[existingIndex];
     const controllerId = (_a = nextIntent.controllerId) != null ? _a : existingIntent.controllerId;
-    const preserveControllerPressure = !nextIntent.requiresControllerPressure && shouldPreservePersistedTerritoryIntentPressureRequirement2(existingIntent, controllerId);
+    const requiresControllerPressure2 = shouldRecordTerritoryIntentControllerPressure(
+      nextIntent,
+      controllerId,
+      existingIntent
+    );
     intents[existingIndex] = {
       ...nextIntent,
-      ...preserveControllerPressure ? { requiresControllerPressure: true } : {},
+      ...requiresControllerPressure2 ? { requiresControllerPressure: true } : {},
       ...!nextIntent.followUp && existingIntent.followUp ? { followUp: existingIntent.followUp } : {}
     };
     return;
   }
-  intents.push(nextIntent);
+  const requiresControllerPressure = shouldRecordTerritoryIntentControllerPressure(
+    nextIntent,
+    nextIntent.controllerId
+  );
+  intents.push({
+    ...nextIntent,
+    ...requiresControllerPressure ? { requiresControllerPressure: true } : {}
+  });
+}
+function shouldRecordTerritoryIntentControllerPressure(nextIntent, controllerId, existingIntent) {
+  return nextIntent.requiresControllerPressure === true || isVisibleTerritoryReservePressureAvailable(
+    nextIntent.targetRoom,
+    nextIntent.action,
+    controllerId,
+    getVisibleColonyOwnerUsername(nextIntent.colony)
+  ) || existingIntent !== void 0 && shouldPreservePersistedTerritoryIntentPressureRequirement2(existingIntent, controllerId);
 }
 function sanitizeSatisfiedClaimReserveHandoffs(territoryMemory, intents, colonyName, colonyOwnerUsername) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1458,7 +1458,8 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
     intents,
     colony,
     assignment.targetRoom,
-    assignment.action
+    assignment.action,
+    assignment.controllerId
   );
   const suppressedIntent = {
     colony,
@@ -1489,7 +1490,8 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
     intents,
     colony,
     assignment.targetRoom,
-    "reserve"
+    "reserve",
+    assignment.controllerId
   );
   const plan = {
     colony,
@@ -1750,12 +1752,19 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
       target.colony,
       target.roomName,
       target.action,
-      gameTime
+      gameTime,
+      target.controllerId
     );
     if (persistedFollowUp == null ? void 0 : persistedFollowUp.coolingDown) {
       return [];
     }
-    const requiresControllerPressure = (persistedFollowUp == null ? void 0 : persistedFollowUp.requiresControllerPressure) === true || getPersistedTerritoryIntentPressureRequirement(intents, target.colony, target.roomName, target.action);
+    const requiresControllerPressure = (persistedFollowUp == null ? void 0 : persistedFollowUp.requiresControllerPressure) === true || getPersistedTerritoryIntentPressureRequirement(
+      intents,
+      target.colony,
+      target.roomName,
+      target.action,
+      target.controllerId
+    );
     const candidate = scoreTerritoryCandidate(
       {
         target,
@@ -1795,12 +1804,13 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
       action: intent.action,
       ...intent.controllerId ? { controllerId: intent.controllerId } : {}
     };
+    const requiresControllerPressure = shouldPreservePersistedTerritoryIntentPressureRequirement(intent);
     const candidate = scoreTerritoryCandidate(
       {
         target,
         intentAction: intent.action,
         commitTarget: false,
-        ...intent.requiresControllerPressure ? { requiresControllerPressure: true } : {},
+        ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
         ...intent.followUp ? { followUp: intent.followUp } : {},
         ...intent.followUp ? { persistedFollowUp: true } : {},
         ...recoveredFollowUp ? { recoveredFollowUp: true, recoveredFollowUpSuppressedAt: intent.updatedAt } : {}
@@ -1862,7 +1872,8 @@ function isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, game
     target.colony,
     target.roomName,
     target.action,
-    gameTime
+    gameTime,
+    target.controllerId
   );
   return persistedFollowUp !== null && !isTerritoryIntentActionSpawnReady(
     colony,
@@ -2522,14 +2533,17 @@ function normalizeTerritoryIntents2(rawIntents) {
   }) : [];
 }
 function upsertTerritoryIntent2(intents, nextIntent) {
+  var _a;
   const existingIndex = intents.findIndex(
     (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action
   );
   if (existingIndex >= 0) {
     const existingIntent = intents[existingIndex];
+    const controllerId = (_a = nextIntent.controllerId) != null ? _a : existingIntent.controllerId;
+    const preserveControllerPressure = !nextIntent.requiresControllerPressure && shouldPreservePersistedTerritoryIntentPressureRequirement(existingIntent, controllerId);
     intents[existingIndex] = {
       ...nextIntent,
-      ...!nextIntent.requiresControllerPressure && existingIntent.requiresControllerPressure ? { requiresControllerPressure: true } : {},
+      ...preserveControllerPressure ? { requiresControllerPressure: true } : {},
       ...!nextIntent.followUp && existingIntent.followUp ? { followUp: existingIntent.followUp } : {}
     };
     return;
@@ -2620,16 +2634,25 @@ function omitTerritoryIntentFollowUp(intent) {
     action: intent.action,
     status: intent.status,
     updatedAt: intent.updatedAt,
-    ...intent.requiresControllerPressure ? { requiresControllerPressure: true } : {},
+    ...shouldPreservePersistedTerritoryIntentPressureRequirement(intent) ? { requiresControllerPressure: true } : {},
     ...intent.controllerId ? { controllerId: intent.controllerId } : {}
   };
 }
-function getPersistedTerritoryIntentPressureRequirement(intents, colony, targetRoom, action) {
+function shouldPreservePersistedTerritoryIntentPressureRequirement(intent, controllerId = intent.controllerId) {
+  return intent.requiresControllerPressure === true && isTerritoryControllerPressureVisibilityMissing(intent.targetRoom, intent.action, controllerId);
+}
+function isTerritoryControllerPressureVisibilityMissing(targetRoom, action, controllerId) {
+  return action === "reserve" && getVisibleController(targetRoom, controllerId) === null;
+}
+function getPersistedTerritoryIntentPressureRequirement(intents, colony, targetRoom, action, controllerId) {
+  if (!isTerritoryControllerPressureVisibilityMissing(targetRoom, action, controllerId)) {
+    return false;
+  }
   return intents.some(
     (intent) => intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action && intent.requiresControllerPressure === true
   );
 }
-function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action, gameTime) {
+function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action, gameTime, controllerId) {
   let selectedIntent = null;
   for (const intent of intents) {
     if (intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action && intent.followUp && (!selectedIntent || intent.updatedAt > selectedIntent.updatedAt)) {
@@ -2644,7 +2667,7 @@ function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action
     recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime),
     coolingDown: isRecoveredTerritoryFollowUpAttemptCoolingDown2(selectedIntent, gameTime),
     ...selectedIntent.status === "suppressed" ? { suppressedAt: selectedIntent.updatedAt } : {},
-    ...selectedIntent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
+    ...shouldPreservePersistedTerritoryIntentPressureRequirement(selectedIntent, controllerId) ? { requiresControllerPressure: true } : {}
   };
 }
 function recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -576,6 +576,12 @@ var WORKER_LOGISTICS_PAIR = ["carry", "move"];
 var WORKER_LOGISTICS_PAIR_COST = 100;
 var TERRITORY_CONTROLLER_BODY = ["claim", "move"];
 var TERRITORY_CONTROLLER_BODY_COST = 650;
+var TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS = 5;
+var TERRITORY_CONTROLLER_PRESSURE_BODY = Array.from(
+  { length: TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS },
+  () => TERRITORY_CONTROLLER_BODY
+).flat();
+var TERRITORY_CONTROLLER_PRESSURE_BODY_COST = TERRITORY_CONTROLLER_BODY_COST * TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS;
 var MAX_CREEP_PARTS = 50;
 var MAX_WORKER_PATTERN_COUNT = 4;
 var BODY_PART_COSTS = {
@@ -616,6 +622,12 @@ function buildTerritoryControllerBody(energyAvailable) {
     return [];
   }
   return [...TERRITORY_CONTROLLER_BODY];
+}
+function buildTerritoryControllerPressureBody(energyAvailable) {
+  if (energyAvailable < TERRITORY_CONTROLLER_PRESSURE_BODY_COST) {
+    return [];
+  }
+  return [...TERRITORY_CONTROLLER_PRESSURE_BODY];
 }
 function getBodyCost(body) {
   return body.reduce((cost, part) => cost + BODY_PART_COSTS[part], 0);
@@ -1245,8 +1257,27 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
   )) {
     return false;
   }
+  if (!isTerritoryIntentPlanSpawnCapable(plan)) {
+    return false;
+  }
   const activeCoverageCount = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action);
   return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount);
+}
+function requiresTerritoryControllerPressure(plan) {
+  return isVisibleTerritoryReservePressureAvailable(
+    plan.targetRoom,
+    plan.action,
+    plan.controllerId,
+    getVisibleColonyOwnerUsername(plan.colony)
+  );
+}
+function isTerritoryIntentPlanSpawnCapable(plan) {
+  var _a;
+  if (!requiresTerritoryControllerPressure(plan)) {
+    return true;
+  }
+  const energyCapacityAvailable = (_a = getVisibleRoom(plan.colony)) == null ? void 0 : _a.energyCapacityAvailable;
+  return typeof energyCapacityAvailable !== "number" || energyCapacityAvailable >= TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
 }
 function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime2()) {
   var _a;
@@ -1339,7 +1370,7 @@ function canCreepReserveTerritoryController(creep, controller, colony) {
   return reservationTicksToEnd <= TERRITORY_RESERVATION_COMFORT_TICKS && canRenewReservation(activeClaimParts, reservationTicksToEnd);
 }
 function canCreepPressureTerritoryController(creep, controller, colony) {
-  return getActiveControllerClaimPartCount(creep) > 0 && isForeignReservedController(controller, getTerritoryActorUsername(creep, colony));
+  return getActiveControllerClaimPartCount(creep) >= TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS && isForeignReservedController(controller, getTerritoryActorUsername(creep, colony));
 }
 function selectUrgentVisibleReservationRenewalTask(creep) {
   const intent = selectVisibleTerritoryControllerIntent(creep);
@@ -1388,7 +1419,8 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   }
   const actorUsername = getTerritoryActorUsername(creep, colony);
   const targetState = getTerritoryControllerTargetState(controller, assignment.action, actorUsername);
-  return targetState === "available" || assignment.action === "reserve" && targetState === "satisfied" || assignment.action === "reserve" && isForeignReservedController(controller, actorUsername);
+  const isPressureTarget = assignment.action === "reserve" && isForeignReservedController(controller, actorUsername);
+  return targetState === "available" || assignment.action === "reserve" && targetState === "satisfied" || isPressureTarget && (creep === void 0 || canCreepPressureTerritoryController(creep, controller, colony));
 }
 function isVisibleTerritoryAssignmentComplete(assignment, creep) {
   if (assignment.action !== "claim" || !isNonEmptyString2(assignment.targetRoom)) {
@@ -1535,7 +1567,10 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
     gameTime,
     routeDistanceLookupContext
   );
-  const primaryCandidates = [...persistedIntentCandidates, ...configuredCandidates];
+  const primaryCandidates = getSpawnCapableTerritoryCandidates(
+    [...persistedIntentCandidates, ...configuredCandidates],
+    colony
+  );
   const bestReadyPrimaryCandidate = selectBestScoredTerritoryCandidate(
     getReadyTerritoryCandidates(primaryCandidates, roleCounts, colony)
   );
@@ -1593,7 +1628,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
       routeDistanceLookupContext
     )
   ]);
-  const candidates = [...primaryCandidates, ...adjacentCandidates];
+  const candidates = getSpawnCapableTerritoryCandidates([...primaryCandidates, ...adjacentCandidates], colony);
   return toSelectedTerritoryTarget(
     (_c = (_b = selectBestScoredTerritoryCandidate(getReadyTerritoryCandidates(candidates, roleCounts, colony))) != null ? _b : selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony))) != null ? _c : selectBestScoredTerritoryCandidate(candidates)
   );
@@ -1630,6 +1665,9 @@ function getActionableTerritoryCandidates(candidates, roleCounts, colony) {
     (candidate) => !isTerritoryCandidateSpawnRequired(candidate, roleCounts) || isTerritoryCandidateSpawnReady(candidate, colony)
   );
 }
+function getSpawnCapableTerritoryCandidates(candidates, colony) {
+  return candidates.filter((candidate) => isTerritoryCandidateSpawnCapable(candidate, colony));
+}
 function withImmediateControllerFollowUpState(candidates, roleCounts) {
   return candidates.map((candidate) => {
     if (!isImmediateControllerFollowUpCandidate(candidate, roleCounts)) {
@@ -1653,11 +1691,26 @@ function isTerritoryCandidateSpawnRequired(candidate, roleCounts) {
   return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount);
 }
 function isTerritoryCandidateSpawnReady(candidate, colony) {
-  return isTerritoryIntentActionSpawnReady(colony, candidate.intentAction);
+  const bodyCost = getTerritoryCandidateBodyCost(candidate, colony);
+  return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
 }
 function isTerritoryIntentActionSpawnReady(colony, action) {
   const bodyCost = getTerritoryIntentActionBodyCost(action);
   return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
+}
+function isTerritoryCandidateSpawnCapable(candidate, colony) {
+  return colony.energyCapacityAvailable >= getTerritoryCandidateBodyCost(candidate, colony);
+}
+function getTerritoryCandidateBodyCost(candidate, colony) {
+  return isTerritoryReservePressureCandidate(candidate, getControllerOwnerUsername2(colony.room.controller)) ? TERRITORY_CONTROLLER_PRESSURE_BODY_COST : getTerritoryIntentActionBodyCost(candidate.intentAction);
+}
+function isTerritoryReservePressureCandidate(candidate, colonyOwnerUsername) {
+  return isVisibleTerritoryReservePressureAvailable(
+    candidate.target.roomName,
+    candidate.intentAction,
+    candidate.target.controllerId,
+    colonyOwnerUsername
+  );
 }
 function getTerritoryIntentActionBodyCost(action) {
   return action === "scout" ? TERRITORY_SCOUT_BODY_COST : TERRITORY_CONTROLLER_BODY_COST;
@@ -1774,6 +1827,9 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
       return false;
     }
     if (isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, gameTime, colony)) {
+      return false;
+    }
+    if (isVisibleTerritoryReservePressureAvailable(target.roomName, target.action, target.controllerId, colonyOwnerUsername) && colony.energyCapacityAvailable < TERRITORY_CONTROLLER_PRESSURE_BODY_COST) {
       return false;
     }
     return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
@@ -5276,7 +5332,7 @@ function planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, optio
   if (!spawn) {
     return null;
   }
-  const body = buildTerritorySpawnBody(colony.energyAvailable, territoryIntent.action);
+  const body = buildTerritorySpawnBody(colony.energyAvailable, territoryIntent);
   if (body.length === 0) {
     return null;
   }
@@ -5324,9 +5380,12 @@ function selectWorkerBody(colony, roleCounts) {
 function canAffordBody(body, energyAvailable) {
   return body.length > 0 && getBodyCost(body) <= energyAvailable;
 }
-function buildTerritorySpawnBody(energyAvailable, action) {
-  if (action === "scout") {
+function buildTerritorySpawnBody(energyAvailable, intent) {
+  if (intent.action === "scout") {
     return energyAvailable >= TERRITORY_SCOUT_BODY_COST2 ? [...TERRITORY_SCOUT_BODY] : [];
+  }
+  if (requiresTerritoryControllerPressure(intent)) {
+    return buildTerritoryControllerPressureBody(energyAvailable);
   }
   return buildTerritoryControllerBody(energyAvailable);
 }
@@ -6500,13 +6559,16 @@ function getGameTime3() {
 // src/territory/territoryRunner.ts
 var ERR_NOT_IN_RANGE_CODE2 = -9;
 var ERR_INVALID_TARGET_CODE = -7;
+var ERR_NO_BODYPART_CODE = -12;
 var ERR_GCL_NOT_ENOUGH_CODE = -15;
 var OK_CODE2 = 0;
 var CLAIM_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([
   ERR_INVALID_TARGET_CODE,
+  ERR_NO_BODYPART_CODE,
   ERR_GCL_NOT_ENOUGH_CODE
 ]);
-var RESERVE_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([ERR_INVALID_TARGET_CODE]);
+var RESERVE_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([ERR_INVALID_TARGET_CODE, ERR_NO_BODYPART_CODE]);
+var PRESSURE_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([ERR_NO_BODYPART_CODE]);
 function runTerritoryControllerCreep(creep) {
   var _a;
   const assignment = creep.memory.territory;
@@ -6556,6 +6618,10 @@ function runTerritoryControllerCreep(creep) {
     const pressureResult = executeControllerAction(creep, controller, "attackController");
     if (pressureResult === ERR_NOT_IN_RANGE_CODE2 && typeof creep.moveTo === "function") {
       creep.moveTo(controller);
+      return;
+    }
+    if (PRESSURE_FATAL_RESULT_CODES.has(pressureResult)) {
+      suppressTerritoryAssignment(creep, assignment);
       return;
     }
     if (pressureResult !== ERR_INVALID_TARGET_CODE) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -673,6 +673,7 @@ function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGam
     return null;
   }
   const controllerId = (_a = followUpIntent.controllerId) != null ? _a : existingIntent == null ? void 0 : existingIntent.controllerId;
+  const requiresControllerPressure = followUpIntent.requiresControllerPressure === true || (existingIntent == null ? void 0 : existingIntent.requiresControllerPressure) === true;
   const followUp = (_b = normalizeTerritoryFollowUp(followUpIntent.followUp)) != null ? _b : existingIntent == null ? void 0 : existingIntent.followUp;
   const nextIntent = {
     colony: followUpIntent.colony,
@@ -681,6 +682,7 @@ function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGam
     status: (existingIntent == null ? void 0 : existingIntent.status) === "active" ? "active" : "planned",
     updatedAt: gameTime,
     ...controllerId ? { controllerId } : {},
+    ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...followUp ? { followUp } : {}
   };
   upsertTerritoryIntent(intents, nextIntent);
@@ -1081,6 +1083,7 @@ function normalizeTerritoryIntent(rawIntent) {
     updatedAt: rawIntent.updatedAt,
     ...followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
     ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
+    ...rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
     ...followUp ? { followUp } : {}
   };
 }
@@ -1104,7 +1107,11 @@ function getTerritoryFollowUpOriginAction(source) {
 function upsertTerritoryIntent(intents, nextIntent) {
   const existingIndex = intents.findIndex((intent) => isSameTerritoryIntent(intent, nextIntent));
   if (existingIndex >= 0) {
-    intents[existingIndex] = nextIntent;
+    const existingIntent = intents[existingIndex];
+    intents[existingIndex] = {
+      ...nextIntent,
+      ...!nextIntent.requiresControllerPressure && existingIntent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
+    };
     return;
   }
   intents.push(nextIntent);
@@ -1202,6 +1209,7 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
     targetRoom: target.roomName,
     action: selection.intentAction,
     ...target.controllerId ? { controllerId: target.controllerId } : {},
+    ...selection.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...selection.followUp ? { followUp: selection.followUp } : {}
   };
   if (selection.recoveredFollowUp === true && typeof selection.recoveredFollowUpSuppressedAt === "number") {
@@ -1237,7 +1245,8 @@ function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameT
     status: "suppressed",
     updatedAt: recoveredFollowUpMetadata.suppressedAt,
     followUp: plan.followUp,
-    lastAttemptAt: gameTime
+    lastAttemptAt: gameTime,
+    ...plan.requiresControllerPressure ? { requiresControllerPressure: true } : {}
   };
   removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, plan.colony, plan.targetRoom, plan.action);
@@ -1264,12 +1273,7 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
   return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount);
 }
 function requiresTerritoryControllerPressure(plan) {
-  return isVisibleTerritoryReservePressureAvailable(
-    plan.targetRoom,
-    plan.action,
-    plan.controllerId,
-    getVisibleColonyOwnerUsername(plan.colony)
-  );
+  return plan.action === "reserve" && plan.requiresControllerPressure === true;
 }
 function isTerritoryIntentPlanSpawnCapable(plan) {
   var _a;
@@ -1450,6 +1454,12 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
   const intents = normalizeTerritoryIntents2(territoryMemory.intents);
   territoryMemory.intents = intents;
   const followUp = normalizeTerritoryFollowUp2(assignment.followUp);
+  const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
+    intents,
+    colony,
+    assignment.targetRoom,
+    assignment.action
+  );
   const suppressedIntent = {
     colony,
     targetRoom: assignment.targetRoom,
@@ -1457,6 +1467,7 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
     status: "suppressed",
     updatedAt: gameTime,
     ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
+    ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...followUp ? { followUp } : {}
   };
   upsertTerritoryIntent2(intents, suppressedIntent);
@@ -1472,11 +1483,20 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
     return;
   }
   const followUp = normalizeTerritoryFollowUp2(assignment.followUp);
+  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
+    intents,
+    colony,
+    assignment.targetRoom,
+    "reserve"
+  );
   const plan = {
     colony,
     targetRoom: assignment.targetRoom,
     action: "reserve",
     ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
+    ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...followUp ? { followUp } : {}
   };
   appendTerritoryTargetIfMissing(territoryMemory, {
@@ -1485,8 +1505,6 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
     action: "reserve",
     ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
   });
-  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
-  territoryMemory.intents = intents;
   upsertTerritoryIntent2(intents, {
     colony: plan.colony,
     targetRoom: plan.targetRoom,
@@ -1494,6 +1512,7 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
     status: "active",
     updatedAt: gameTime,
     ...plan.controllerId ? { controllerId: plan.controllerId } : {},
+    ...plan.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...plan.followUp ? { followUp: plan.followUp } : {}
   });
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
@@ -1647,6 +1666,7 @@ function toSelectedTerritoryTarget(candidate) {
     target: candidate.target,
     intentAction: candidate.intentAction,
     commitTarget: candidate.commitTarget,
+    ...candidate.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...candidate.followUp ? { followUp: candidate.followUp } : {},
     ...candidate.recoveredFollowUp ? { recoveredFollowUp: true } : {},
     ...typeof candidate.recoveredFollowUpSuppressedAt === "number" ? { recoveredFollowUpSuppressedAt: candidate.recoveredFollowUpSuppressedAt } : {}
@@ -1691,28 +1711,26 @@ function isTerritoryCandidateSpawnRequired(candidate, roleCounts) {
   return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount);
 }
 function isTerritoryCandidateSpawnReady(candidate, colony) {
-  const bodyCost = getTerritoryCandidateBodyCost(candidate, colony);
+  const bodyCost = getTerritoryCandidateBodyCost(candidate);
   return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
 }
-function isTerritoryIntentActionSpawnReady(colony, action) {
-  const bodyCost = getTerritoryIntentActionBodyCost(action);
+function isTerritoryIntentActionSpawnReady(colony, action, requiresControllerPressure = false) {
+  const bodyCost = getTerritoryIntentActionBodyCost(action, requiresControllerPressure);
   return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
 }
 function isTerritoryCandidateSpawnCapable(candidate, colony) {
-  return colony.energyCapacityAvailable >= getTerritoryCandidateBodyCost(candidate, colony);
+  return colony.energyCapacityAvailable >= getTerritoryCandidateBodyCost(candidate);
 }
-function getTerritoryCandidateBodyCost(candidate, colony) {
-  return isTerritoryReservePressureCandidate(candidate, getControllerOwnerUsername2(colony.room.controller)) ? TERRITORY_CONTROLLER_PRESSURE_BODY_COST : getTerritoryIntentActionBodyCost(candidate.intentAction);
-}
-function isTerritoryReservePressureCandidate(candidate, colonyOwnerUsername) {
-  return isVisibleTerritoryReservePressureAvailable(
-    candidate.target.roomName,
+function getTerritoryCandidateBodyCost(candidate) {
+  return getTerritoryIntentActionBodyCost(
     candidate.intentAction,
-    candidate.target.controllerId,
-    colonyOwnerUsername
+    candidate.requiresControllerPressure === true
   );
 }
-function getTerritoryIntentActionBodyCost(action) {
+function getTerritoryIntentActionBodyCost(action, requiresControllerPressure = false) {
+  if (action === "reserve" && requiresControllerPressure) {
+    return TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
+  }
   return action === "scout" ? TERRITORY_SCOUT_BODY_COST : TERRITORY_CONTROLLER_BODY_COST;
 }
 function shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount) {
@@ -1737,11 +1755,13 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
     if (persistedFollowUp == null ? void 0 : persistedFollowUp.coolingDown) {
       return [];
     }
+    const requiresControllerPressure = (persistedFollowUp == null ? void 0 : persistedFollowUp.requiresControllerPressure) === true || getPersistedTerritoryIntentPressureRequirement(intents, target.colony, target.roomName, target.action);
     const candidate = scoreTerritoryCandidate(
       {
         target,
         intentAction: target.action,
         commitTarget: false,
+        ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
         ...persistedFollowUp ? { followUp: persistedFollowUp.followUp } : {},
         ...persistedFollowUp ? { persistedFollowUp: true } : {},
         ...(persistedFollowUp == null ? void 0 : persistedFollowUp.recovered) ? { recoveredFollowUp: true } : {},
@@ -1780,6 +1800,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
         target,
         intentAction: intent.action,
         commitTarget: false,
+        ...intent.requiresControllerPressure ? { requiresControllerPressure: true } : {},
         ...intent.followUp ? { followUp: intent.followUp } : {},
         ...intent.followUp ? { persistedFollowUp: true } : {},
         ...recoveredFollowUp ? { recoveredFollowUp: true, recoveredFollowUpSuppressedAt: intent.updatedAt } : {}
@@ -1836,7 +1857,18 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
   });
 }
 function isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, gameTime, colony) {
-  return getPersistedTerritoryIntentFollowUp(intents, target.colony, target.roomName, target.action, gameTime) !== null && !isTerritoryIntentActionSpawnReady(colony, target.action);
+  const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
+    intents,
+    target.colony,
+    target.roomName,
+    target.action,
+    gameTime
+  );
+  return persistedFollowUp !== null && !isTerritoryIntentActionSpawnReady(
+    colony,
+    target.action,
+    persistedFollowUp.requiresControllerPressure === true
+  );
 }
 function isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) {
   if (target.action !== "claim") {
@@ -2057,11 +2089,18 @@ function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwn
   }
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
   const occupationActionableTicks = source === "occupationIntent" ? getOccupationIntentActionableTicks(selection, colonyOwnerUsername) : void 0;
+  const requiresControllerPressure = selection.requiresControllerPressure === true || isVisibleTerritoryReservePressureAvailable(
+    selection.target.roomName,
+    selection.intentAction,
+    selection.target.controllerId,
+    colonyOwnerUsername
+  );
   return {
     ...selection,
     source,
     order,
     priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
+    ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...routeDistance !== void 0 ? { routeDistance } : {},
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {},
     ...occupationActionableTicks !== void 0 ? { occupationActionableTicks } : {}
@@ -2090,25 +2129,32 @@ function applyOccupationRecommendationScores(colony, roleCounts, candidates) {
 function applyOccupationRecommendationScore(candidate, recommendation, roleCounts) {
   var _a;
   const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const requiresControllerPressure = intentAction === "reserve" && candidate.requiresControllerPressure === true;
   const nextSelection = {
     target: candidate.target,
     intentAction,
     commitTarget: recommendation.evidenceStatus === "sufficient" && intentAction !== "scout" && candidate.commitTarget,
+    ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...candidate.followUp ? { followUp: candidate.followUp } : {}
   };
   const renewalTicksToEnd = intentAction === "reserve" ? (_a = candidate.renewalTicksToEnd) != null ? _a : null : null;
+  const { requiresControllerPressure: _requiresControllerPressure, ...candidateWithoutPressure } = candidate;
   return {
-    ...candidate,
+    ...candidateWithoutPressure,
     intentAction,
     commitTarget: nextSelection.commitTarget,
     priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
     recommendationScore: recommendation.score,
     recommendationEvidenceStatus: recommendation.evidenceStatus,
+    ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
   };
 }
 function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts) {
   if (recommendation.evidenceStatus === "insufficient-evidence") {
+    if (candidate.intentAction === "reserve" && candidate.requiresControllerPressure === true) {
+      return candidate.intentAction;
+    }
     if (candidate.source === "configured" && getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.target.action) > 0) {
       return candidate.intentAction;
     }
@@ -2462,6 +2508,7 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null) {
     status,
     updatedAt: gameTime,
     ...plan.controllerId ? { controllerId: plan.controllerId } : {},
+    ...plan.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...plan.followUp ? { followUp: plan.followUp } : {}
   };
   upsertTerritoryIntent2(intents, nextIntent);
@@ -2482,6 +2529,7 @@ function upsertTerritoryIntent2(intents, nextIntent) {
     const existingIntent = intents[existingIndex];
     intents[existingIndex] = {
       ...nextIntent,
+      ...!nextIntent.requiresControllerPressure && existingIntent.requiresControllerPressure ? { requiresControllerPressure: true } : {},
       ...!nextIntent.followUp && existingIntent.followUp ? { followUp: existingIntent.followUp } : {}
     };
     return;
@@ -2572,8 +2620,14 @@ function omitTerritoryIntentFollowUp(intent) {
     action: intent.action,
     status: intent.status,
     updatedAt: intent.updatedAt,
+    ...intent.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...intent.controllerId ? { controllerId: intent.controllerId } : {}
   };
+}
+function getPersistedTerritoryIntentPressureRequirement(intents, colony, targetRoom, action) {
+  return intents.some(
+    (intent) => intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action && intent.requiresControllerPressure === true
+  );
 }
 function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action, gameTime) {
   let selectedIntent = null;
@@ -2589,7 +2643,8 @@ function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action
     followUp: selectedIntent.followUp,
     recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime),
     coolingDown: isRecoveredTerritoryFollowUpAttemptCoolingDown2(selectedIntent, gameTime),
-    ...selectedIntent.status === "suppressed" ? { suppressedAt: selectedIntent.updatedAt } : {}
+    ...selectedIntent.status === "suppressed" ? { suppressedAt: selectedIntent.updatedAt } : {},
+    ...selectedIntent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
   };
 }
 function recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime) {
@@ -2825,6 +2880,7 @@ function normalizeTerritoryIntent2(rawIntent) {
     updatedAt: rawIntent.updatedAt,
     ...followUp && isFiniteNumber2(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
     ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
+    ...rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
     ...followUp ? { followUp } : {}
   };
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -673,7 +673,7 @@ function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGam
     return null;
   }
   const controllerId = (_a = followUpIntent.controllerId) != null ? _a : existingIntent == null ? void 0 : existingIntent.controllerId;
-  const requiresControllerPressure = followUpIntent.requiresControllerPressure === true || (existingIntent == null ? void 0 : existingIntent.requiresControllerPressure) === true;
+  const requiresControllerPressure = followUpIntent.requiresControllerPressure === true || (existingIntent ? shouldPreservePersistedTerritoryIntentPressureRequirement(existingIntent, controllerId) : false);
   const followUp = (_b = normalizeTerritoryFollowUp(followUpIntent.followUp)) != null ? _b : existingIntent == null ? void 0 : existingIntent.followUp;
   const nextIntent = {
     colony: followUpIntent.colony,
@@ -790,6 +790,7 @@ function scoreOccupationCandidate(input, candidate) {
   const routeDistance = typeof candidate.routeDistance === "number" ? candidate.routeDistance : void 0;
   let action = "scout";
   let evidenceStatus = "sufficient";
+  let requiresControllerPressure = false;
   if (candidate.routeDistance === null) {
     risks.push("no known route from colony");
     evidenceStatus = "unavailable";
@@ -808,6 +809,7 @@ function scoreOccupationCandidate(input, candidate) {
     if (controllerPressureEvidence) {
       evidence.push(controllerPressureEvidence);
       action = "reserve";
+      requiresControllerPressure = true;
       if (candidate.sourceCount === void 0) {
         risks.push("source count evidence missing");
         evidenceStatus = "insufficient-evidence";
@@ -852,6 +854,7 @@ function scoreOccupationCandidate(input, candidate) {
     risks,
     ...routeDistance !== void 0 ? { routeDistance } : {},
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {},
+    ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...candidate.sourceCount !== void 0 ? { sourceCount: candidate.sourceCount } : {},
     ...candidate.hostileCreepCount !== void 0 ? { hostileCreepCount: candidate.hostileCreepCount } : {},
     ...candidate.hostileStructureCount !== void 0 ? { hostileStructureCount: candidate.hostileStructureCount } : {}
@@ -865,7 +868,8 @@ function buildOccupationRecommendationFollowUpIntent(input, next) {
     colony: input.colonyName,
     targetRoom: next.roomName,
     action: getTerritoryIntentAction(next.action),
-    ...next.controllerId ? { controllerId: next.controllerId } : {}
+    ...next.controllerId ? { controllerId: next.controllerId } : {},
+    ...next.requiresControllerPressure ? { requiresControllerPressure: true } : {}
   };
 }
 function getTerritoryIntentAction(action) {
@@ -1105,16 +1109,38 @@ function getTerritoryFollowUpOriginAction(source) {
   return source === "satisfiedClaimAdjacent" ? "claim" : "reserve";
 }
 function upsertTerritoryIntent(intents, nextIntent) {
+  var _a;
   const existingIndex = intents.findIndex((intent) => isSameTerritoryIntent(intent, nextIntent));
   if (existingIndex >= 0) {
     const existingIntent = intents[existingIndex];
+    const controllerId = (_a = nextIntent.controllerId) != null ? _a : existingIntent.controllerId;
+    const preserveControllerPressure = !nextIntent.requiresControllerPressure && shouldPreservePersistedTerritoryIntentPressureRequirement(existingIntent, controllerId);
     intents[existingIndex] = {
       ...nextIntent,
-      ...!nextIntent.requiresControllerPressure && existingIntent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
+      ...preserveControllerPressure ? { requiresControllerPressure: true } : {}
     };
     return;
   }
   intents.push(nextIntent);
+}
+function shouldPreservePersistedTerritoryIntentPressureRequirement(intent, controllerId = intent.controllerId) {
+  return intent.requiresControllerPressure === true && isTerritoryControllerPressureVisibilityMissing(intent.targetRoom, intent.action, controllerId);
+}
+function isTerritoryControllerPressureVisibilityMissing(targetRoom, action, controllerId) {
+  return action === "reserve" && getVisibleController(targetRoom, controllerId) === null;
+}
+function getVisibleController(targetRoom, controllerId) {
+  var _a, _b;
+  const game = globalThis.Game;
+  const roomController = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom]) == null ? void 0 : _b.controller;
+  if (roomController) {
+    return roomController;
+  }
+  const getObjectById = game == null ? void 0 : game.getObjectById;
+  if (controllerId && typeof getObjectById === "function") {
+    return getObjectById.call(game, controllerId);
+  }
+  return null;
 }
 function isSameTerritoryIntent(intent, followUpIntent) {
   return intent.colony === followUpIntent.colony && intent.targetRoom === followUpIntent.targetRoom && intent.action === followUpIntent.action;
@@ -1347,7 +1373,7 @@ function selectVisibleTerritoryControllerTask(creep) {
     return null;
   }
   if (intent.action === "reserve") {
-    return canCreepReserveTerritoryController(creep, controller, intent.colony) ? { type: "reserve", targetId: controller.id } : null;
+    return canCreepActOnVisibleReserveController(creep, controller, intent.colony) ? { type: "reserve", targetId: controller.id } : null;
   }
   if (controller.my === true) {
     return getStoredEnergy(creep) > 0 ? { type: "upgrade", targetId: controller.id } : null;
@@ -1804,7 +1830,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
       action: intent.action,
       ...intent.controllerId ? { controllerId: intent.controllerId } : {}
     };
-    const requiresControllerPressure = shouldPreservePersistedTerritoryIntentPressureRequirement(intent);
+    const requiresControllerPressure = shouldPreservePersistedTerritoryIntentPressureRequirement2(intent);
     const candidate = scoreTerritoryCandidate(
       {
         target,
@@ -2190,7 +2216,7 @@ function buildOccupationRecommendationCandidate(candidate) {
   };
 }
 function buildVisibleOccupationRecommendationEvidence(room, controllerId) {
-  const controller = getVisibleController(room.name, controllerId);
+  const controller = getVisibleController2(room.name, controllerId);
   return {
     ...controller ? { controller: summarizeOccupationController(controller) } : {},
     sourceCount: countVisibleRoomObjects(room, getFindConstant("FIND_SOURCES")),
@@ -2226,7 +2252,7 @@ function getOccupationIntentActionableTicks(selection, colonyOwnerUsername) {
   if (!isTerritoryControlAction(selection.intentAction)) {
     return void 0;
   }
-  const controller = getVisibleController(selection.target.roomName, selection.target.controllerId);
+  const controller = getVisibleController2(selection.target.roomName, selection.target.controllerId);
   if (!controller) {
     return void 0;
   }
@@ -2373,7 +2399,7 @@ function getTerritoryFollowUpOriginAction2(source) {
   return source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent" ? "reserve" : null;
 }
 function isTerritoryTargetVisible(target) {
-  return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;
+  return isVisibleRoomKnown(target.roomName) || getVisibleController2(target.roomName, target.controllerId) !== null;
 }
 function createRouteDistanceLookupContext() {
   return { revalidatedNoRouteCacheKeys: /* @__PURE__ */ new Set() };
@@ -2439,7 +2465,7 @@ function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
   if (isVisibleRoomMissingController(targetRoom)) {
     return "unavailable";
   }
-  const controller = getVisibleController(targetRoom);
+  const controller = getVisibleController2(targetRoom);
   if (!controller) {
     return "unknown";
   }
@@ -2540,7 +2566,7 @@ function upsertTerritoryIntent2(intents, nextIntent) {
   if (existingIndex >= 0) {
     const existingIntent = intents[existingIndex];
     const controllerId = (_a = nextIntent.controllerId) != null ? _a : existingIntent.controllerId;
-    const preserveControllerPressure = !nextIntent.requiresControllerPressure && shouldPreservePersistedTerritoryIntentPressureRequirement(existingIntent, controllerId);
+    const preserveControllerPressure = !nextIntent.requiresControllerPressure && shouldPreservePersistedTerritoryIntentPressureRequirement2(existingIntent, controllerId);
     intents[existingIndex] = {
       ...nextIntent,
       ...preserveControllerPressure ? { requiresControllerPressure: true } : {},
@@ -2621,7 +2647,7 @@ function getVisibleTerritoryControllerEvidenceState(targetRoom, action, controll
   if (isVisibleRoomMissingController(targetRoom)) {
     return "unavailable";
   }
-  const controller = getVisibleController(targetRoom, controllerId);
+  const controller = getVisibleController2(targetRoom, controllerId);
   if (!controller) {
     return null;
   }
@@ -2634,18 +2660,18 @@ function omitTerritoryIntentFollowUp(intent) {
     action: intent.action,
     status: intent.status,
     updatedAt: intent.updatedAt,
-    ...shouldPreservePersistedTerritoryIntentPressureRequirement(intent) ? { requiresControllerPressure: true } : {},
+    ...shouldPreservePersistedTerritoryIntentPressureRequirement2(intent) ? { requiresControllerPressure: true } : {},
     ...intent.controllerId ? { controllerId: intent.controllerId } : {}
   };
 }
-function shouldPreservePersistedTerritoryIntentPressureRequirement(intent, controllerId = intent.controllerId) {
-  return intent.requiresControllerPressure === true && isTerritoryControllerPressureVisibilityMissing(intent.targetRoom, intent.action, controllerId);
+function shouldPreservePersistedTerritoryIntentPressureRequirement2(intent, controllerId = intent.controllerId) {
+  return intent.requiresControllerPressure === true && isTerritoryControllerPressureVisibilityMissing2(intent.targetRoom, intent.action, controllerId);
 }
-function isTerritoryControllerPressureVisibilityMissing(targetRoom, action, controllerId) {
-  return action === "reserve" && getVisibleController(targetRoom, controllerId) === null;
+function isTerritoryControllerPressureVisibilityMissing2(targetRoom, action, controllerId) {
+  return action === "reserve" && getVisibleController2(targetRoom, controllerId) === null;
 }
 function getPersistedTerritoryIntentPressureRequirement(intents, colony, targetRoom, action, controllerId) {
-  if (!isTerritoryControllerPressureVisibilityMissing(targetRoom, action, controllerId)) {
+  if (!isTerritoryControllerPressureVisibilityMissing2(targetRoom, action, controllerId)) {
     return false;
   }
   return intents.some(
@@ -2667,7 +2693,7 @@ function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action
     recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime),
     coolingDown: isRecoveredTerritoryFollowUpAttemptCoolingDown2(selectedIntent, gameTime),
     ...selectedIntent.status === "suppressed" ? { suppressedAt: selectedIntent.updatedAt } : {},
-    ...shouldPreservePersistedTerritoryIntentPressureRequirement(selectedIntent, controllerId) ? { requiresControllerPressure: true } : {}
+    ...shouldPreservePersistedTerritoryIntentPressureRequirement2(selectedIntent, controllerId) ? { requiresControllerPressure: true } : {}
   };
 }
 function recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime) {
@@ -3065,13 +3091,16 @@ function isCreepVisibleTerritoryIntentActionable(creep, intent) {
     return true;
   }
   if (intent.action === "reserve") {
-    return canCreepReserveTerritoryController(creep, controller, intent.colony);
+    return canCreepActOnVisibleReserveController(creep, controller, intent.colony);
   }
   return getTerritoryControllerTargetState(controller, intent.action, getTerritoryActorUsername(creep, intent.colony)) === "available";
 }
+function canCreepActOnVisibleReserveController(creep, controller, colony) {
+  return canCreepReserveTerritoryController(creep, controller, colony) || canCreepPressureTerritoryController(creep, controller, colony);
+}
 function selectVisibleTerritoryAssignmentController(assignment, creep) {
   var _a;
-  return ((_a = creep == null ? void 0 : creep.room) == null ? void 0 : _a.name) === assignment.targetRoom ? selectCreepRoomController(creep, assignment.controllerId) : getVisibleController(assignment.targetRoom, assignment.controllerId);
+  return ((_a = creep == null ? void 0 : creep.room) == null ? void 0 : _a.name) === assignment.targetRoom ? selectCreepRoomController(creep, assignment.controllerId) : getVisibleController2(assignment.targetRoom, assignment.controllerId);
 }
 function selectCreepRoomController(creep, controllerId) {
   var _a;
@@ -3176,7 +3205,7 @@ function getVisibleTerritoryTargetState(targetRoom, action, controllerId, colony
   if (action === "scout") {
     return isVisibleRoomKnown(targetRoom) ? "unavailable" : "available";
   }
-  const controller = getVisibleController(targetRoom, controllerId);
+  const controller = getVisibleController2(targetRoom, controllerId);
   if (!controller) {
     return "available";
   }
@@ -3192,7 +3221,7 @@ function isVisibleTerritoryReservePressureAvailable(targetRoom, action, controll
   if (action !== "reserve" || isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
     return false;
   }
-  const controller = getVisibleController(targetRoom, controllerId);
+  const controller = getVisibleController2(targetRoom, controllerId);
   return controller !== null && isForeignReservedController(controller, colonyOwnerUsername);
 }
 function isVisibleRoomKnown(targetRoom) {
@@ -3237,7 +3266,7 @@ function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
   if (target.action !== "reserve" || colonyOwnerUsername === null) {
     return null;
   }
-  const controller = getVisibleController(target.roomName, target.controllerId);
+  const controller = getVisibleController2(target.roomName, target.controllerId);
   if (!controller || isControllerOwned(controller)) {
     return null;
   }
@@ -3247,7 +3276,7 @@ function shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount) {
   if (activeCoverageCount >= TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET || plan.action !== "reserve") {
     return false;
   }
-  const controller = getVisibleController(plan.targetRoom, plan.controllerId);
+  const controller = getVisibleController2(plan.targetRoom, plan.controllerId);
   if (!controller || isControllerOwned(controller)) {
     return false;
   }
@@ -3270,7 +3299,7 @@ function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   return reservation.ticksToEnd;
 }
 function getVisibleColonyOwnerUsername(colonyName) {
-  const controller = getVisibleController(colonyName);
+  const controller = getVisibleController2(colonyName);
   return getControllerOwnerUsername2(controller != null ? controller : void 0);
 }
 function getControllerOwnerUsername2(controller) {
@@ -3278,7 +3307,7 @@ function getControllerOwnerUsername2(controller) {
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString2(username) ? username : null;
 }
-function getVisibleController(targetRoom, controllerId) {
+function getVisibleController2(targetRoom, controllerId) {
   var _a, _b;
   const game = globalThis.Game;
   const roomController = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom]) == null ? void 0 : _b.controller;
@@ -5358,6 +5387,9 @@ function executeTask(creep, task, target) {
     case "claim":
       return creep.claimController(target);
     case "reserve":
+      if (typeof creep.attackController === "function" && canCreepPressureTerritoryController(creep, target, creep.memory.colony)) {
+        return creep.attackController(target);
+      }
       return creep.reserveController(target);
     case "upgrade":
       signOccupiedControllerIfNeeded(creep, target);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -5,6 +5,7 @@ import {
   shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill
 } from '../tasks/workerTasks';
 import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
+import { canCreepPressureTerritoryController } from '../territory/territoryPlanner';
 
 type TransferSinkStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION' | 'STRUCTURE_TOWER';
 type CapacityConstructionStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION';
@@ -543,6 +544,13 @@ function executeTask(
     case 'claim':
       return creep.claimController(target as StructureController);
     case 'reserve':
+      if (
+        typeof creep.attackController === 'function' &&
+        canCreepPressureTerritoryController(creep, target as StructureController, creep.memory.colony)
+      ) {
+        return creep.attackController(target as StructureController);
+      }
+
       return creep.reserveController(target as StructureController);
     case 'upgrade':
       signOccupiedControllerIfNeeded(creep, target as StructureController);

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -4,6 +4,13 @@ const WORKER_LOGISTICS_PAIR: BodyPartConstant[] = ['carry', 'move'];
 const WORKER_LOGISTICS_PAIR_COST = 100;
 const TERRITORY_CONTROLLER_BODY: BodyPartConstant[] = ['claim', 'move'];
 export const TERRITORY_CONTROLLER_BODY_COST = 650;
+export const TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS = 5;
+const TERRITORY_CONTROLLER_PRESSURE_BODY: BodyPartConstant[] = Array.from(
+  { length: TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS },
+  () => TERRITORY_CONTROLLER_BODY
+).flat();
+export const TERRITORY_CONTROLLER_PRESSURE_BODY_COST =
+  TERRITORY_CONTROLLER_BODY_COST * TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS;
 const MAX_CREEP_PARTS = 50;
 // General workers cover harvest, haul, build, and upgrade duties. Cap them at
 // four 200-energy patterns (800 energy) so early rooms do not sink capacity into
@@ -66,6 +73,14 @@ export function buildTerritoryControllerBody(energyAvailable: number): BodyPartC
   }
 
   return [...TERRITORY_CONTROLLER_BODY];
+}
+
+export function buildTerritoryControllerPressureBody(energyAvailable: number): BodyPartConstant[] {
+  if (energyAvailable < TERRITORY_CONTROLLER_PRESSURE_BODY_COST) {
+    return [];
+  }
+
+  return [...TERRITORY_CONTROLLER_PRESSURE_BODY];
 }
 
 export function getBodyCost(body: BodyPartConstant[]): number {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -3,6 +3,7 @@ import { getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import {
   buildEmergencyWorkerBody,
   buildTerritoryControllerBody,
+  buildTerritoryControllerPressureBody,
   buildWorkerBody,
   getBodyCost
 } from './bodyBuilder';
@@ -11,6 +12,7 @@ import {
   getTerritoryFollowUpPreparationWorkerDemand,
   planTerritoryIntent,
   recordRecoveredTerritoryFollowUpRetryCooldown,
+  requiresTerritoryControllerPressure,
   shouldSpawnTerritoryControllerCreep,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
   TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND,
@@ -118,7 +120,7 @@ function planTerritorySpawn(
     return null;
   }
 
-  const body = buildTerritorySpawnBody(colony.energyAvailable, territoryIntent.action);
+  const body = buildTerritorySpawnBody(colony.energyAvailable, territoryIntent);
   if (body.length === 0) {
     return null;
   }
@@ -186,9 +188,13 @@ function canAffordBody(body: BodyPartConstant[], energyAvailable: number): boole
   return body.length > 0 && getBodyCost(body) <= energyAvailable;
 }
 
-function buildTerritorySpawnBody(energyAvailable: number, action: TerritoryIntentAction): BodyPartConstant[] {
-  if (action === 'scout') {
+function buildTerritorySpawnBody(energyAvailable: number, intent: TerritoryIntentPlan): BodyPartConstant[] {
+  if (intent.action === 'scout') {
     return energyAvailable >= TERRITORY_SCOUT_BODY_COST ? [...TERRITORY_SCOUT_BODY] : [];
+  }
+
+  if (requiresTerritoryControllerPressure(intent)) {
+    return buildTerritoryControllerPressureBody(energyAvailable);
   }
 
   return buildTerritoryControllerBody(energyAvailable);

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -21,6 +21,7 @@ export interface OccupationRecommendationScore {
   risks: string[];
   routeDistance?: number;
   controllerId?: Id<StructureController>;
+  requiresControllerPressure?: boolean;
   sourceCount?: number;
   hostileCreepCount?: number;
   hostileStructureCount?: number;
@@ -132,7 +133,10 @@ export function persistOccupationRecommendationFollowUpIntent(
 
   const controllerId = followUpIntent.controllerId ?? existingIntent?.controllerId;
   const requiresControllerPressure =
-    followUpIntent.requiresControllerPressure === true || existingIntent?.requiresControllerPressure === true;
+    followUpIntent.requiresControllerPressure === true ||
+    (existingIntent
+      ? shouldPreservePersistedTerritoryIntentPressureRequirement(existingIntent, controllerId)
+      : false);
   const followUp = normalizeTerritoryFollowUp(followUpIntent.followUp) ?? existingIntent?.followUp;
   const nextIntent: TerritoryIntentMemory = {
     colony: followUpIntent.colony,
@@ -273,6 +277,7 @@ function scoreOccupationCandidate(
   const routeDistance = typeof candidate.routeDistance === 'number' ? candidate.routeDistance : undefined;
   let action: OccupationRecommendationAction = 'scout';
   let evidenceStatus: OccupationRecommendationEvidenceStatus = 'sufficient';
+  let requiresControllerPressure = false;
 
   if (candidate.routeDistance === null) {
     risks.push('no known route from colony');
@@ -292,6 +297,7 @@ function scoreOccupationCandidate(
     if (controllerPressureEvidence) {
       evidence.push(controllerPressureEvidence);
       action = 'reserve';
+      requiresControllerPressure = true;
       if (candidate.sourceCount === undefined) {
         risks.push('source count evidence missing');
         evidenceStatus = 'insufficient-evidence';
@@ -338,6 +344,7 @@ function scoreOccupationCandidate(
     risks,
     ...(routeDistance !== undefined ? { routeDistance } : {}),
     ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(candidate.sourceCount !== undefined ? { sourceCount: candidate.sourceCount } : {}),
     ...(candidate.hostileCreepCount !== undefined ? { hostileCreepCount: candidate.hostileCreepCount } : {}),
     ...(candidate.hostileStructureCount !== undefined ? { hostileStructureCount: candidate.hostileStructureCount } : {})
@@ -356,7 +363,8 @@ function buildOccupationRecommendationFollowUpIntent(
     colony: input.colonyName,
     targetRoom: next.roomName,
     action: getTerritoryIntentAction(next.action),
-    ...(next.controllerId ? { controllerId: next.controllerId } : {})
+    ...(next.controllerId ? { controllerId: next.controllerId } : {}),
+    ...(next.requiresControllerPressure ? { requiresControllerPressure: true } : {})
   };
 }
 
@@ -744,16 +752,51 @@ function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: Ter
   const existingIndex = intents.findIndex((intent) => isSameTerritoryIntent(intent, nextIntent));
   if (existingIndex >= 0) {
     const existingIntent = intents[existingIndex];
+    const controllerId = nextIntent.controllerId ?? existingIntent.controllerId;
+    const preserveControllerPressure =
+      !nextIntent.requiresControllerPressure &&
+      shouldPreservePersistedTerritoryIntentPressureRequirement(existingIntent, controllerId);
     intents[existingIndex] = {
       ...nextIntent,
-      ...(!nextIntent.requiresControllerPressure && existingIntent.requiresControllerPressure
-        ? { requiresControllerPressure: true }
-        : {})
+      ...(preserveControllerPressure ? { requiresControllerPressure: true } : {})
     };
     return;
   }
 
   intents.push(nextIntent);
+}
+
+function shouldPreservePersistedTerritoryIntentPressureRequirement(
+  intent: TerritoryIntentMemory,
+  controllerId: Id<StructureController> | undefined = intent.controllerId
+): boolean {
+  return (
+    intent.requiresControllerPressure === true &&
+    isTerritoryControllerPressureVisibilityMissing(intent.targetRoom, intent.action, controllerId)
+  );
+}
+
+function isTerritoryControllerPressureVisibilityMissing(
+  targetRoom: string,
+  action: TerritoryIntentAction,
+  controllerId?: Id<StructureController>
+): boolean {
+  return action === 'reserve' && getVisibleController(targetRoom, controllerId) === null;
+}
+
+function getVisibleController(targetRoom: string, controllerId?: Id<StructureController>): StructureController | null {
+  const game = (globalThis as { Game?: Partial<Game> }).Game;
+  const roomController = game?.rooms?.[targetRoom]?.controller;
+  if (roomController) {
+    return roomController;
+  }
+
+  const getObjectById = game?.getObjectById;
+  if (controllerId && typeof getObjectById === 'function') {
+    return getObjectById.call(game, controllerId) as StructureController | null;
+  }
+
+  return null;
 }
 
 function isSameTerritoryIntent(

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -283,8 +283,18 @@ function scoreOccupationCandidate(
     evidenceStatus = 'unavailable';
   } else {
     evidence.push('room visible', 'controller visible');
+    const controllerPressureEvidence = getControllerPressureEvidence(input, candidate);
     const unavailableReason = getControllerUnavailableReason(input, candidate.controller);
-    if (unavailableReason) {
+    if (controllerPressureEvidence) {
+      evidence.push(controllerPressureEvidence);
+      action = 'reserve';
+      if (candidate.sourceCount === undefined) {
+        risks.push('source count evidence missing');
+        evidenceStatus = 'insufficient-evidence';
+      } else {
+        evidence.push(`${candidate.sourceCount} sources visible`);
+      }
+    } else if (unavailableReason) {
       risks.push(unavailableReason);
       evidenceStatus = 'unavailable';
       action = candidate.actionHint === 'claim' ? 'occupy' : 'reserve';
@@ -370,6 +380,8 @@ function calculateOccupationScore(
     ((input.controllerLevel ?? 0) >= 2 ? 30 : 0) +
     (input.ticksToDowngrade === undefined || input.ticksToDowngrade > DOWNGRADE_GUARD_TICKS ? 20 : 0);
   const riskPenalty = (candidate.hostileCreepCount ?? 0) * 160 + (candidate.hostileStructureCount ?? 0) * 120;
+  const controllerPressurePenalty =
+    candidate.controller && isForeignReservation(input, candidate.controller) ? 180 : 0;
   const evidencePenalty = evidenceStatus === 'insufficient-evidence' ? 260 : 0;
   const unavailablePenalty = evidenceStatus === 'unavailable' ? 2_000 : 0;
 
@@ -382,9 +394,26 @@ function calculateOccupationScore(
     supportScore +
     readinessScore -
     riskPenalty -
+    controllerPressurePenalty -
     evidencePenalty -
     unavailablePenalty
   );
+}
+
+function getControllerPressureEvidence(
+  input: OccupationRecommendationInput,
+  candidate: OccupationRecommendationCandidateInput
+): string | null {
+  if (
+    candidate.source !== 'configured' ||
+    candidate.actionHint !== 'reserve' ||
+    !candidate.controller ||
+    !isForeignReservation(input, candidate.controller)
+  ) {
+    return null;
+  }
+
+  return 'foreign reservation can be pressured';
 }
 
 function getColonyReadinessPreconditions(input: OccupationRecommendationInput): string[] {
@@ -453,6 +482,19 @@ function isOwnReservation(input: OccupationRecommendationInput, controller: Occu
   return (
     input.colonyOwnerUsername !== undefined &&
     controller.reservationUsername === input.colonyOwnerUsername
+  );
+}
+
+function isForeignReservation(
+  input: OccupationRecommendationInput,
+  controller: OccupationControllerEvidence
+): boolean {
+  return (
+    input.colonyOwnerUsername !== undefined &&
+    controller.my !== true &&
+    controller.ownerUsername === undefined &&
+    controller.reservationUsername !== undefined &&
+    controller.reservationUsername !== input.colonyOwnerUsername
   );
 }
 

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -31,6 +31,7 @@ export interface OccupationRecommendationFollowUpIntent {
   targetRoom: string;
   action: TerritoryIntentAction;
   controllerId?: Id<StructureController>;
+  requiresControllerPressure?: boolean;
   followUp?: TerritoryFollowUpMemory;
 }
 
@@ -130,6 +131,8 @@ export function persistOccupationRecommendationFollowUpIntent(
   }
 
   const controllerId = followUpIntent.controllerId ?? existingIntent?.controllerId;
+  const requiresControllerPressure =
+    followUpIntent.requiresControllerPressure === true || existingIntent?.requiresControllerPressure === true;
   const followUp = normalizeTerritoryFollowUp(followUpIntent.followUp) ?? existingIntent?.followUp;
   const nextIntent: TerritoryIntentMemory = {
     colony: followUpIntent.colony,
@@ -138,6 +141,7 @@ export function persistOccupationRecommendationFollowUpIntent(
     status: existingIntent?.status === 'active' ? 'active' : 'planned',
     updatedAt: gameTime,
     ...(controllerId ? { controllerId } : {}),
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(followUp ? { followUp } : {})
   };
 
@@ -710,6 +714,7 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
     ...(typeof rawIntent.controllerId === 'string'
       ? { controllerId: rawIntent.controllerId as Id<StructureController> }
       : {}),
+    ...(rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
     ...(followUp ? { followUp } : {})
   };
 }
@@ -738,7 +743,13 @@ function getTerritoryFollowUpOriginAction(source: TerritoryFollowUpSource): Terr
 function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: TerritoryIntentMemory): void {
   const existingIndex = intents.findIndex((intent) => isSameTerritoryIntent(intent, nextIntent));
   if (existingIndex >= 0) {
-    intents[existingIndex] = nextIntent;
+    const existingIntent = intents[existingIndex];
+    intents[existingIndex] = {
+      ...nextIntent,
+      ...(!nextIntent.requiresControllerPressure && existingIntent.requiresControllerPressure
+        ? { requiresControllerPressure: true }
+        : {})
+    };
     return;
   }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -43,6 +43,7 @@ export interface TerritoryIntentPlan {
   targetRoom: string;
   action: TerritoryIntentAction;
   controllerId?: Id<StructureController>;
+  requiresControllerPressure?: boolean;
   followUp?: TerritoryFollowUpMemory;
 }
 
@@ -54,6 +55,7 @@ interface SelectedTerritoryTarget {
   target: TerritoryTargetMemory;
   intentAction: TerritoryIntentAction;
   commitTarget: boolean;
+  requiresControllerPressure?: boolean;
   followUp?: TerritoryFollowUpMemory;
   persistedFollowUp?: boolean;
   recoveredFollowUp?: boolean;
@@ -91,6 +93,7 @@ interface PersistedTerritoryIntentFollowUp {
   recovered: boolean;
   coolingDown: boolean;
   suppressedAt?: number;
+  requiresControllerPressure?: boolean;
 }
 
 interface RecoveredTerritoryFollowUpRetryMetadata {
@@ -123,6 +126,7 @@ export function planTerritoryIntent(
     targetRoom: target.roomName,
     action: selection.intentAction,
     ...(target.controllerId ? { controllerId: target.controllerId } : {}),
+    ...(selection.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(selection.followUp ? { followUp: selection.followUp } : {})
   };
   if (selection.recoveredFollowUp === true && typeof selection.recoveredFollowUpSuppressedAt === 'number') {
@@ -168,7 +172,8 @@ export function recordRecoveredTerritoryFollowUpRetryCooldown(
     status: 'suppressed',
     updatedAt: recoveredFollowUpMetadata.suppressedAt,
     followUp: plan.followUp,
-    lastAttemptAt: gameTime
+    lastAttemptAt: gameTime,
+    ...(plan.requiresControllerPressure ? { requiresControllerPressure: true } : {})
   };
   removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, plan.colony, plan.targetRoom, plan.action);
@@ -209,12 +214,7 @@ export function shouldSpawnTerritoryControllerCreep(
 }
 
 export function requiresTerritoryControllerPressure(plan: TerritoryIntentPlan): boolean {
-  return isVisibleTerritoryReservePressureAvailable(
-    plan.targetRoom,
-    plan.action,
-    plan.controllerId,
-    getVisibleColonyOwnerUsername(plan.colony)
-  );
+  return plan.action === 'reserve' && plan.requiresControllerPressure === true;
 }
 
 function isTerritoryIntentPlanSpawnCapable(plan: TerritoryIntentPlan): boolean {
@@ -491,6 +491,12 @@ export function suppressTerritoryIntent(
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const followUp = normalizeTerritoryFollowUp(assignment.followUp);
+  const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
+    intents,
+    colony,
+    assignment.targetRoom,
+    assignment.action
+  );
   const suppressedIntent: TerritoryIntentMemory = {
     colony,
     targetRoom: assignment.targetRoom,
@@ -498,6 +504,7 @@ export function suppressTerritoryIntent(
     status: 'suppressed',
     updatedAt: gameTime,
     ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {}),
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(followUp ? { followUp } : {})
   };
 
@@ -521,11 +528,20 @@ export function recordTerritoryReserveFallbackIntent(
   }
 
   const followUp = normalizeTerritoryFollowUp(assignment.followUp);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
+    intents,
+    colony,
+    assignment.targetRoom,
+    'reserve'
+  );
   const plan: TerritoryIntentPlan = {
     colony,
     targetRoom: assignment.targetRoom,
     action: 'reserve',
     ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {}),
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(followUp ? { followUp } : {})
   };
   appendTerritoryTargetIfMissing(territoryMemory, {
@@ -535,8 +551,6 @@ export function recordTerritoryReserveFallbackIntent(
     ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {})
   });
 
-  const intents = normalizeTerritoryIntents(territoryMemory.intents);
-  territoryMemory.intents = intents;
   upsertTerritoryIntent(intents, {
     colony: plan.colony,
     targetRoom: plan.targetRoom,
@@ -544,6 +558,7 @@ export function recordTerritoryReserveFallbackIntent(
     status: 'active',
     updatedAt: gameTime,
     ...(plan.controllerId ? { controllerId: plan.controllerId } : {}),
+    ...(plan.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(plan.followUp ? { followUp: plan.followUp } : {})
   });
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
@@ -721,6 +736,7 @@ function toSelectedTerritoryTarget(candidate: ScoredTerritoryTarget | null): Sel
         target: candidate.target,
         intentAction: candidate.intentAction,
         commitTarget: candidate.commitTarget,
+        ...(candidate.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
         ...(candidate.followUp ? { followUp: candidate.followUp } : {}),
         ...(candidate.recoveredFollowUp ? { recoveredFollowUp: true } : {}),
         ...(typeof candidate.recoveredFollowUpSuppressedAt === 'number'
@@ -802,38 +818,38 @@ function isTerritoryCandidateSpawnRequired(candidate: ScoredTerritoryTarget, rol
 }
 
 function isTerritoryCandidateSpawnReady(candidate: ScoredTerritoryTarget, colony: ColonySnapshot): boolean {
-  const bodyCost = getTerritoryCandidateBodyCost(candidate, colony);
+  const bodyCost = getTerritoryCandidateBodyCost(candidate);
   return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
 }
 
-function isTerritoryIntentActionSpawnReady(colony: ColonySnapshot, action: TerritoryIntentAction): boolean {
-  const bodyCost = getTerritoryIntentActionBodyCost(action);
+function isTerritoryIntentActionSpawnReady(
+  colony: ColonySnapshot,
+  action: TerritoryIntentAction,
+  requiresControllerPressure = false
+): boolean {
+  const bodyCost = getTerritoryIntentActionBodyCost(action, requiresControllerPressure);
   return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
 }
 
 function isTerritoryCandidateSpawnCapable(candidate: ScoredTerritoryTarget, colony: ColonySnapshot): boolean {
-  return colony.energyCapacityAvailable >= getTerritoryCandidateBodyCost(candidate, colony);
+  return colony.energyCapacityAvailable >= getTerritoryCandidateBodyCost(candidate);
 }
 
-function getTerritoryCandidateBodyCost(candidate: ScoredTerritoryTarget, colony: ColonySnapshot): number {
-  return isTerritoryReservePressureCandidate(candidate, getControllerOwnerUsername(colony.room.controller))
-    ? TERRITORY_CONTROLLER_PRESSURE_BODY_COST
-    : getTerritoryIntentActionBodyCost(candidate.intentAction);
-}
-
-function isTerritoryReservePressureCandidate(
-  candidate: Pick<ScoredTerritoryTarget, 'target' | 'intentAction'>,
-  colonyOwnerUsername: string | null
-): boolean {
-  return isVisibleTerritoryReservePressureAvailable(
-    candidate.target.roomName,
+function getTerritoryCandidateBodyCost(candidate: ScoredTerritoryTarget): number {
+  return getTerritoryIntentActionBodyCost(
     candidate.intentAction,
-    candidate.target.controllerId,
-    colonyOwnerUsername
+    candidate.requiresControllerPressure === true
   );
 }
 
-function getTerritoryIntentActionBodyCost(action: TerritoryIntentAction): number {
+function getTerritoryIntentActionBodyCost(
+  action: TerritoryIntentAction,
+  requiresControllerPressure = false
+): number {
+  if (action === 'reserve' && requiresControllerPressure) {
+    return TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
+  }
+
   return action === 'scout' ? TERRITORY_SCOUT_BODY_COST : TERRITORY_CONTROLLER_BODY_COST;
 }
 
@@ -886,12 +902,16 @@ function getConfiguredTerritoryCandidates(
     if (persistedFollowUp?.coolingDown) {
       return [];
     }
+    const requiresControllerPressure =
+      persistedFollowUp?.requiresControllerPressure === true ||
+      getPersistedTerritoryIntentPressureRequirement(intents, target.colony, target.roomName, target.action);
 
     const candidate = scoreTerritoryCandidate(
       {
         target,
         intentAction: target.action,
         commitTarget: false,
+        ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
         ...(persistedFollowUp ? { followUp: persistedFollowUp.followUp } : {}),
         ...(persistedFollowUp ? { persistedFollowUp: true } : {}),
         ...(persistedFollowUp?.recovered ? { recoveredFollowUp: true } : {}),
@@ -951,6 +971,7 @@ function getPersistedTerritoryIntentCandidates(
         target,
         intentAction: intent.action,
         commitTarget: false,
+        ...(intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
         ...(intent.followUp ? { followUp: intent.followUp } : {}),
         ...(intent.followUp ? { persistedFollowUp: true } : {}),
         ...(recoveredFollowUp ? { recoveredFollowUp: true, recoveredFollowUpSuppressedAt: intent.updatedAt } : {})
@@ -1042,9 +1063,20 @@ function isConfiguredFollowUpTargetBlockedBySpawnReadiness(
   gameTime: number,
   colony: ColonySnapshot
 ): boolean {
+  const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
+    intents,
+    target.colony,
+    target.roomName,
+    target.action,
+    gameTime
+  );
   return (
-    getPersistedTerritoryIntentFollowUp(intents, target.colony, target.roomName, target.action, gameTime) !== null &&
-    !isTerritoryIntentActionSpawnReady(colony, target.action)
+    persistedFollowUp !== null &&
+    !isTerritoryIntentActionSpawnReady(
+      colony,
+      target.action,
+      persistedFollowUp.requiresControllerPressure === true
+    )
   );
 }
 
@@ -1421,11 +1453,20 @@ function scoreTerritoryCandidate(
     source === 'occupationIntent'
       ? getOccupationIntentActionableTicks(selection, colonyOwnerUsername)
       : undefined;
+  const requiresControllerPressure =
+    selection.requiresControllerPressure === true ||
+    isVisibleTerritoryReservePressureAvailable(
+      selection.target.roomName,
+      selection.intentAction,
+      selection.target.controllerId,
+      colonyOwnerUsername
+    );
   return {
     ...selection,
     source,
     order,
     priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(routeDistance !== undefined ? { routeDistance } : {}),
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}),
     ...(occupationActionableTicks !== undefined ? { occupationActionableTicks } : {})
@@ -1465,21 +1506,25 @@ function applyOccupationRecommendationScore(
   roleCounts: RoleCounts
 ): ScoredTerritoryTarget {
   const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const requiresControllerPressure = intentAction === 'reserve' && candidate.requiresControllerPressure === true;
   const nextSelection: SelectedTerritoryTarget = {
     target: candidate.target,
     intentAction,
     commitTarget: recommendation.evidenceStatus === 'sufficient' && intentAction !== 'scout' && candidate.commitTarget,
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(candidate.followUp ? { followUp: candidate.followUp } : {})
   };
   const renewalTicksToEnd = intentAction === 'reserve' ? candidate.renewalTicksToEnd ?? null : null;
+  const { requiresControllerPressure: _requiresControllerPressure, ...candidateWithoutPressure } = candidate;
 
   return {
-    ...candidate,
+    ...candidateWithoutPressure,
     intentAction,
     commitTarget: nextSelection.commitTarget,
     priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
     recommendationScore: recommendation.score,
     recommendationEvidenceStatus: recommendation.evidenceStatus,
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
   };
 }
@@ -1490,6 +1535,10 @@ function getRecommendedTerritoryIntentAction(
   roleCounts: RoleCounts
 ): TerritoryIntentAction {
   if (recommendation.evidenceStatus === 'insufficient-evidence') {
+    if (candidate.intentAction === 'reserve' && candidate.requiresControllerPressure === true) {
+      return candidate.intentAction;
+    }
+
     if (
       candidate.source === 'configured' &&
       getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.target.action) > 0
@@ -2037,6 +2086,7 @@ function recordTerritoryIntent(
     status,
     updatedAt: gameTime,
     ...(plan.controllerId ? { controllerId: plan.controllerId } : {}),
+    ...(plan.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(plan.followUp ? { followUp: plan.followUp } : {})
   };
 
@@ -2066,6 +2116,9 @@ function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: Ter
     const existingIntent = intents[existingIndex];
     intents[existingIndex] = {
       ...nextIntent,
+      ...(!nextIntent.requiresControllerPressure && existingIntent.requiresControllerPressure
+        ? { requiresControllerPressure: true }
+        : {}),
       ...(!nextIntent.followUp && existingIntent.followUp ? { followUp: existingIntent.followUp } : {})
     };
     return;
@@ -2217,8 +2270,24 @@ function omitTerritoryIntentFollowUp(intent: TerritoryIntentMemory): TerritoryIn
     action: intent.action,
     status: intent.status,
     updatedAt: intent.updatedAt,
+    ...(intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
   };
+}
+
+function getPersistedTerritoryIntentPressureRequirement(
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  targetRoom: string,
+  action: TerritoryIntentAction
+): boolean {
+  return intents.some(
+    (intent) =>
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      intent.action === action &&
+      intent.requiresControllerPressure === true
+  );
 }
 
 function getPersistedTerritoryIntentFollowUp(
@@ -2249,7 +2318,8 @@ function getPersistedTerritoryIntentFollowUp(
     followUp: selectedIntent.followUp,
     recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime),
     coolingDown: isRecoveredTerritoryFollowUpAttemptCoolingDown(selectedIntent, gameTime),
-    ...(selectedIntent.status === 'suppressed' ? { suppressedAt: selectedIntent.updatedAt } : {})
+    ...(selectedIntent.status === 'suppressed' ? { suppressedAt: selectedIntent.updatedAt } : {}),
+    ...(selectedIntent.requiresControllerPressure ? { requiresControllerPressure: true } : {})
   };
 }
 
@@ -2627,6 +2697,7 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
     ...(typeof rawIntent.controllerId === 'string'
       ? { controllerId: rawIntent.controllerId as Id<StructureController> }
       : {}),
+    ...(rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
     ...(followUp ? { followUp } : {})
   };
 }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -311,7 +311,7 @@ export function selectVisibleTerritoryControllerTask(creep: Creep): CreepTaskMem
   }
 
   if (intent.action === 'reserve') {
-    return canCreepReserveTerritoryController(creep, controller, intent.colony)
+    return canCreepActOnVisibleReserveController(creep, controller, intent.colony)
       ? { type: 'reserve', targetId: controller.id }
       : null;
   }
@@ -3007,12 +3007,23 @@ function isCreepVisibleTerritoryIntentActionable(creep: Creep, intent: Territory
   }
 
   if (intent.action === 'reserve') {
-    return canCreepReserveTerritoryController(creep, controller, intent.colony);
+    return canCreepActOnVisibleReserveController(creep, controller, intent.colony);
   }
 
   return (
     getTerritoryControllerTargetState(controller, intent.action, getTerritoryActorUsername(creep, intent.colony)) ===
     'available'
+  );
+}
+
+function canCreepActOnVisibleReserveController(
+  creep: Creep,
+  controller: StructureController,
+  colony: string | undefined
+): boolean {
+  return (
+    canCreepReserveTerritoryController(creep, controller, colony) ||
+    canCreepPressureTerritoryController(creep, controller, colony)
   );
 }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -184,12 +184,12 @@ export function shouldSpawnTerritoryControllerCreep(
   }
 
   if (
-    getVisibleTerritoryTargetState(
+    !isVisibleTerritoryIntentActionable(
       plan.targetRoom,
       plan.action,
       plan.controllerId,
       getVisibleColonyOwnerUsername(plan.colony)
-    ) !== 'available'
+    )
   ) {
     return false;
   }
@@ -213,12 +213,12 @@ export function getTerritoryFollowUpPreparationWorkerDemand(
   }
 
   if (
-    getVisibleTerritoryTargetState(
+    !isVisibleTerritoryIntentActionable(
       plan.targetRoom,
       plan.action,
       plan.controllerId,
       getVisibleColonyOwnerUsername(plan.colony)
-    ) !== 'available'
+    )
   ) {
     return 0;
   }
@@ -333,6 +333,17 @@ export function canCreepReserveTerritoryController(
   );
 }
 
+export function canCreepPressureTerritoryController(
+  creep: Creep,
+  controller: StructureController,
+  colony: string | undefined
+): boolean {
+  return (
+    getActiveControllerClaimPartCount(creep) > 0 &&
+    isForeignReservedController(controller, getTerritoryActorUsername(creep, colony))
+  );
+}
+
 export function selectUrgentVisibleReservationRenewalTask(creep: Creep): CreepTaskMemory | null {
   const intent = selectVisibleTerritoryControllerIntent(creep);
   if (!intent || intent.action !== 'reserve') {
@@ -396,7 +407,11 @@ export function isVisibleTerritoryAssignmentSafe(
 
   const actorUsername = getTerritoryActorUsername(creep, colony);
   const targetState = getTerritoryControllerTargetState(controller, assignment.action, actorUsername);
-  return targetState === 'available' || (assignment.action === 'reserve' && targetState === 'satisfied');
+  return (
+    targetState === 'available' ||
+    (assignment.action === 'reserve' && targetState === 'satisfied') ||
+    (assignment.action === 'reserve' && isForeignReservedController(controller, actorUsername))
+  );
 }
 
 export function isVisibleTerritoryAssignmentComplete(
@@ -795,8 +810,7 @@ function getConfiguredTerritoryCandidates(
       target.roomName === colonyName ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
       isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) ||
-      getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !==
-        'available'
+      !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)
     ) {
       return [];
     }
@@ -854,8 +868,7 @@ function getPersistedTerritoryIntentCandidates(
       (intent.status !== 'planned' && intent.status !== 'active' && !recoveredFollowUp) ||
       !isTerritoryControlAction(intent.action) ||
       isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) ||
-      getVisibleTerritoryTargetState(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername) !==
-        'available'
+      !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)
     ) {
       return [];
     }
@@ -2104,7 +2117,11 @@ function isPersistedTerritoryFollowUpStillActionable(
     intent.controllerId,
     colonyOwnerUsername
   );
-  return controllerState === null || controllerState === 'available';
+  return (
+    controllerState === null ||
+    controllerState === 'available' ||
+    isVisibleTerritoryReservePressureAvailable(intent.targetRoom, action, intent.controllerId, colonyOwnerUsername)
+  );
 }
 
 function getVisibleTerritoryControllerEvidenceState(
@@ -2409,7 +2426,7 @@ function getTerritoryFollowUpExecutionHintReason(
   controllerId: Id<StructureController> | undefined,
   colonyOwnerUsername: string | null
 ): TerritoryExecutionHintReason | null {
-  if (getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) !== 'available') {
+  if (!isVisibleTerritoryIntentActionable(targetRoom, action, controllerId, colonyOwnerUsername)) {
     return null;
   }
 
@@ -2983,6 +3000,32 @@ function getVisibleTerritoryTargetState(
   return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername ?? null);
 }
 
+function isVisibleTerritoryIntentActionable(
+  targetRoom: string,
+  action: TerritoryIntentAction,
+  controllerId: Id<StructureController> | undefined,
+  colonyOwnerUsername: string | null
+): boolean {
+  return (
+    getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) === 'available' ||
+    isVisibleTerritoryReservePressureAvailable(targetRoom, action, controllerId, colonyOwnerUsername)
+  );
+}
+
+function isVisibleTerritoryReservePressureAvailable(
+  targetRoom: string,
+  action: TerritoryIntentAction,
+  controllerId: Id<StructureController> | undefined,
+  colonyOwnerUsername: string | null
+): boolean {
+  if (action !== 'reserve' || isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
+    return false;
+  }
+
+  const controller = getVisibleController(targetRoom, controllerId);
+  return controller !== null && isForeignReservedController(controller, colonyOwnerUsername);
+}
+
 function isVisibleRoomKnown(targetRoom: string): boolean {
   const game = (globalThis as { Game?: Partial<Game> }).Game;
   return game?.rooms?.[targetRoom] != null;
@@ -3021,6 +3064,18 @@ function getReserveControllerTargetState(
   }
 
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) === null ? 'satisfied' : 'available';
+}
+
+function isForeignReservedController(
+  controller: StructureController,
+  actorUsername: string | null
+): boolean {
+  if (isControllerOwned(controller) || !isNonEmptyString(actorUsername)) {
+    return false;
+  }
+
+  const reservation = controller.reservation;
+  return isNonEmptyString(reservation?.username) && reservation.username !== actorUsername;
 }
 
 function getConfiguredReserveRenewalTicksToEnd(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -495,7 +495,8 @@ export function suppressTerritoryIntent(
     intents,
     colony,
     assignment.targetRoom,
-    assignment.action
+    assignment.action,
+    assignment.controllerId
   );
   const suppressedIntent: TerritoryIntentMemory = {
     colony,
@@ -534,7 +535,8 @@ export function recordTerritoryReserveFallbackIntent(
     intents,
     colony,
     assignment.targetRoom,
-    'reserve'
+    'reserve',
+    assignment.controllerId
   );
   const plan: TerritoryIntentPlan = {
     colony,
@@ -897,14 +899,21 @@ function getConfiguredTerritoryCandidates(
       target.colony,
       target.roomName,
       target.action,
-      gameTime
+      gameTime,
+      target.controllerId
     );
     if (persistedFollowUp?.coolingDown) {
       return [];
     }
     const requiresControllerPressure =
       persistedFollowUp?.requiresControllerPressure === true ||
-      getPersistedTerritoryIntentPressureRequirement(intents, target.colony, target.roomName, target.action);
+      getPersistedTerritoryIntentPressureRequirement(
+        intents,
+        target.colony,
+        target.roomName,
+        target.action,
+        target.controllerId
+      );
 
     const candidate = scoreTerritoryCandidate(
       {
@@ -966,12 +975,13 @@ function getPersistedTerritoryIntentCandidates(
       action: intent.action,
       ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
     };
+    const requiresControllerPressure = shouldPreservePersistedTerritoryIntentPressureRequirement(intent);
     const candidate = scoreTerritoryCandidate(
       {
         target,
         intentAction: intent.action,
         commitTarget: false,
-        ...(intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
+        ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
         ...(intent.followUp ? { followUp: intent.followUp } : {}),
         ...(intent.followUp ? { persistedFollowUp: true } : {}),
         ...(recoveredFollowUp ? { recoveredFollowUp: true, recoveredFollowUpSuppressedAt: intent.updatedAt } : {})
@@ -1068,7 +1078,8 @@ function isConfiguredFollowUpTargetBlockedBySpawnReadiness(
     target.colony,
     target.roomName,
     target.action,
-    gameTime
+    gameTime,
+    target.controllerId
   );
   return (
     persistedFollowUp !== null &&
@@ -2114,11 +2125,13 @@ function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: Ter
 
   if (existingIndex >= 0) {
     const existingIntent = intents[existingIndex];
+    const controllerId = nextIntent.controllerId ?? existingIntent.controllerId;
+    const preserveControllerPressure =
+      !nextIntent.requiresControllerPressure &&
+      shouldPreservePersistedTerritoryIntentPressureRequirement(existingIntent, controllerId);
     intents[existingIndex] = {
       ...nextIntent,
-      ...(!nextIntent.requiresControllerPressure && existingIntent.requiresControllerPressure
-        ? { requiresControllerPressure: true }
-        : {}),
+      ...(preserveControllerPressure ? { requiresControllerPressure: true } : {}),
       ...(!nextIntent.followUp && existingIntent.followUp ? { followUp: existingIntent.followUp } : {})
     };
     return;
@@ -2270,17 +2283,40 @@ function omitTerritoryIntentFollowUp(intent: TerritoryIntentMemory): TerritoryIn
     action: intent.action,
     status: intent.status,
     updatedAt: intent.updatedAt,
-    ...(intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
+    ...(shouldPreservePersistedTerritoryIntentPressureRequirement(intent) ? { requiresControllerPressure: true } : {}),
     ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
   };
+}
+
+function shouldPreservePersistedTerritoryIntentPressureRequirement(
+  intent: TerritoryIntentMemory,
+  controllerId: Id<StructureController> | undefined = intent.controllerId
+): boolean {
+  return (
+    intent.requiresControllerPressure === true &&
+    isTerritoryControllerPressureVisibilityMissing(intent.targetRoom, intent.action, controllerId)
+  );
+}
+
+function isTerritoryControllerPressureVisibilityMissing(
+  targetRoom: string,
+  action: TerritoryIntentAction,
+  controllerId?: Id<StructureController>
+): boolean {
+  return action === 'reserve' && getVisibleController(targetRoom, controllerId) === null;
 }
 
 function getPersistedTerritoryIntentPressureRequirement(
   intents: TerritoryIntentMemory[],
   colony: string,
   targetRoom: string,
-  action: TerritoryIntentAction
+  action: TerritoryIntentAction,
+  controllerId?: Id<StructureController>
 ): boolean {
+  if (!isTerritoryControllerPressureVisibilityMissing(targetRoom, action, controllerId)) {
+    return false;
+  }
+
   return intents.some(
     (intent) =>
       intent.colony === colony &&
@@ -2295,7 +2331,8 @@ function getPersistedTerritoryIntentFollowUp(
   colony: string,
   targetRoom: string,
   action: TerritoryIntentAction,
-  gameTime: number
+  gameTime: number,
+  controllerId?: Id<StructureController>
 ): PersistedTerritoryIntentFollowUp | null {
   let selectedIntent: TerritoryIntentMemory | null = null;
   for (const intent of intents) {
@@ -2319,7 +2356,9 @@ function getPersistedTerritoryIntentFollowUp(
     recovered: isRecoveredTerritoryFollowUpIntent(selectedIntent, gameTime),
     coolingDown: isRecoveredTerritoryFollowUpAttemptCoolingDown(selectedIntent, gameTime),
     ...(selectedIntent.status === 'suppressed' ? { suppressedAt: selectedIntent.updatedAt } : {}),
-    ...(selectedIntent.requiresControllerPressure ? { requiresControllerPressure: true } : {})
+    ...(shouldPreservePersistedTerritoryIntentPressureRequirement(selectedIntent, controllerId)
+      ? { requiresControllerPressure: true }
+      : {})
   };
 }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2126,18 +2126,45 @@ function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: Ter
   if (existingIndex >= 0) {
     const existingIntent = intents[existingIndex];
     const controllerId = nextIntent.controllerId ?? existingIntent.controllerId;
-    const preserveControllerPressure =
-      !nextIntent.requiresControllerPressure &&
-      shouldPreservePersistedTerritoryIntentPressureRequirement(existingIntent, controllerId);
+    const requiresControllerPressure = shouldRecordTerritoryIntentControllerPressure(
+      nextIntent,
+      controllerId,
+      existingIntent
+    );
     intents[existingIndex] = {
       ...nextIntent,
-      ...(preserveControllerPressure ? { requiresControllerPressure: true } : {}),
+      ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
       ...(!nextIntent.followUp && existingIntent.followUp ? { followUp: existingIntent.followUp } : {})
     };
     return;
   }
 
-  intents.push(nextIntent);
+  const requiresControllerPressure = shouldRecordTerritoryIntentControllerPressure(
+    nextIntent,
+    nextIntent.controllerId
+  );
+  intents.push({
+    ...nextIntent,
+    ...(requiresControllerPressure ? { requiresControllerPressure: true } : {})
+  });
+}
+
+function shouldRecordTerritoryIntentControllerPressure(
+  nextIntent: TerritoryIntentMemory,
+  controllerId: Id<StructureController> | undefined,
+  existingIntent?: TerritoryIntentMemory
+): boolean {
+  return (
+    nextIntent.requiresControllerPressure === true ||
+    isVisibleTerritoryReservePressureAvailable(
+      nextIntent.targetRoom,
+      nextIntent.action,
+      controllerId,
+      getVisibleColonyOwnerUsername(nextIntent.colony)
+    ) ||
+    (existingIntent !== undefined &&
+      shouldPreservePersistedTerritoryIntentPressureRequirement(existingIntent, controllerId))
+  );
 }
 
 function sanitizeSatisfiedClaimReserveHandoffs(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1,6 +1,10 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
-import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
+import {
+  TERRITORY_CONTROLLER_BODY_COST,
+  TERRITORY_CONTROLLER_PRESSURE_BODY_COST,
+  TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS
+} from '../spawn/bodyBuilder';
 import {
   scoreOccupationRecommendations,
   type OccupationControllerEvidence,
@@ -194,10 +198,32 @@ export function shouldSpawnTerritoryControllerCreep(
     return false;
   }
 
+  if (!isTerritoryIntentPlanSpawnCapable(plan)) {
+    return false;
+  }
+
   const activeCoverageCount = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action);
   return (
     activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount)
   );
+}
+
+export function requiresTerritoryControllerPressure(plan: TerritoryIntentPlan): boolean {
+  return isVisibleTerritoryReservePressureAvailable(
+    plan.targetRoom,
+    plan.action,
+    plan.controllerId,
+    getVisibleColonyOwnerUsername(plan.colony)
+  );
+}
+
+function isTerritoryIntentPlanSpawnCapable(plan: TerritoryIntentPlan): boolean {
+  if (!requiresTerritoryControllerPressure(plan)) {
+    return true;
+  }
+
+  const energyCapacityAvailable = getVisibleRoom(plan.colony)?.energyCapacityAvailable;
+  return typeof energyCapacityAvailable !== 'number' || energyCapacityAvailable >= TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
 }
 
 export function getTerritoryFollowUpPreparationWorkerDemand(
@@ -339,7 +365,7 @@ export function canCreepPressureTerritoryController(
   colony: string | undefined
 ): boolean {
   return (
-    getActiveControllerClaimPartCount(creep) > 0 &&
+    getActiveControllerClaimPartCount(creep) >= TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS &&
     isForeignReservedController(controller, getTerritoryActorUsername(creep, colony))
   );
 }
@@ -407,10 +433,12 @@ export function isVisibleTerritoryAssignmentSafe(
 
   const actorUsername = getTerritoryActorUsername(creep, colony);
   const targetState = getTerritoryControllerTargetState(controller, assignment.action, actorUsername);
+  const isPressureTarget = assignment.action === 'reserve' && isForeignReservedController(controller, actorUsername);
   return (
     targetState === 'available' ||
     (assignment.action === 'reserve' && targetState === 'satisfied') ||
-    (assignment.action === 'reserve' && isForeignReservedController(controller, actorUsername))
+    (isPressureTarget &&
+      (creep === undefined || canCreepPressureTerritoryController(creep, controller, colony)))
   );
 }
 
@@ -600,7 +628,10 @@ function selectTerritoryTarget(
     gameTime,
     routeDistanceLookupContext
   );
-  const primaryCandidates = [...persistedIntentCandidates, ...configuredCandidates];
+  const primaryCandidates = getSpawnCapableTerritoryCandidates(
+    [...persistedIntentCandidates, ...configuredCandidates],
+    colony
+  );
   const bestReadyPrimaryCandidate = selectBestScoredTerritoryCandidate(
     getReadyTerritoryCandidates(primaryCandidates, roleCounts, colony)
   );
@@ -664,7 +695,7 @@ function selectTerritoryTarget(
       routeDistanceLookupContext
     )
   ]);
-  const candidates = [...primaryCandidates, ...adjacentCandidates];
+  const candidates = getSpawnCapableTerritoryCandidates([...primaryCandidates, ...adjacentCandidates], colony);
 
   return toSelectedTerritoryTarget(
     selectBestScoredTerritoryCandidate(getReadyTerritoryCandidates(candidates, roleCounts, colony)) ??
@@ -727,6 +758,13 @@ function getActionableTerritoryCandidates(
   );
 }
 
+function getSpawnCapableTerritoryCandidates(
+  candidates: ScoredTerritoryTarget[],
+  colony: ColonySnapshot
+): ScoredTerritoryTarget[] {
+  return candidates.filter((candidate) => isTerritoryCandidateSpawnCapable(candidate, colony));
+}
+
 function withImmediateControllerFollowUpState(
   candidates: ScoredTerritoryTarget[],
   roleCounts: RoleCounts
@@ -764,12 +802,35 @@ function isTerritoryCandidateSpawnRequired(candidate: ScoredTerritoryTarget, rol
 }
 
 function isTerritoryCandidateSpawnReady(candidate: ScoredTerritoryTarget, colony: ColonySnapshot): boolean {
-  return isTerritoryIntentActionSpawnReady(colony, candidate.intentAction);
+  const bodyCost = getTerritoryCandidateBodyCost(candidate, colony);
+  return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
 }
 
 function isTerritoryIntentActionSpawnReady(colony: ColonySnapshot, action: TerritoryIntentAction): boolean {
   const bodyCost = getTerritoryIntentActionBodyCost(action);
   return colony.energyCapacityAvailable >= bodyCost && colony.energyAvailable >= bodyCost;
+}
+
+function isTerritoryCandidateSpawnCapable(candidate: ScoredTerritoryTarget, colony: ColonySnapshot): boolean {
+  return colony.energyCapacityAvailable >= getTerritoryCandidateBodyCost(candidate, colony);
+}
+
+function getTerritoryCandidateBodyCost(candidate: ScoredTerritoryTarget, colony: ColonySnapshot): number {
+  return isTerritoryReservePressureCandidate(candidate, getControllerOwnerUsername(colony.room.controller))
+    ? TERRITORY_CONTROLLER_PRESSURE_BODY_COST
+    : getTerritoryIntentActionBodyCost(candidate.intentAction);
+}
+
+function isTerritoryReservePressureCandidate(
+  candidate: Pick<ScoredTerritoryTarget, 'target' | 'intentAction'>,
+  colonyOwnerUsername: string | null
+): boolean {
+  return isVisibleTerritoryReservePressureAvailable(
+    candidate.target.roomName,
+    candidate.intentAction,
+    candidate.target.controllerId,
+    colonyOwnerUsername
+  );
 }
 
 function getTerritoryIntentActionBodyCost(action: TerritoryIntentAction): number {
@@ -958,6 +1019,13 @@ function hasBlockingConfiguredTerritoryTargetForColony(
     }
 
     if (isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, gameTime, colony)) {
+      return false;
+    }
+
+    if (
+      isVisibleTerritoryReservePressureAvailable(target.roomName, target.action, target.controllerId, colonyOwnerUsername) &&
+      colony.energyCapacityAvailable < TERRITORY_CONTROLLER_PRESSURE_BODY_COST
+    ) {
       return false;
     }
 

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -11,13 +11,16 @@ import { signOccupiedControllerIfNeeded } from './controllerSigning';
 
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
+const ERR_NO_BODYPART_CODE = -12 as ScreepsReturnCode;
 const ERR_GCL_NOT_ENOUGH_CODE = -15 as ScreepsReturnCode;
 const OK_CODE = 0 as ScreepsReturnCode;
 const CLAIM_FATAL_RESULT_CODES = new Set<ScreepsReturnCode>([
   ERR_INVALID_TARGET_CODE,
+  ERR_NO_BODYPART_CODE,
   ERR_GCL_NOT_ENOUGH_CODE
 ]);
-const RESERVE_FATAL_RESULT_CODES = new Set<ScreepsReturnCode>([ERR_INVALID_TARGET_CODE]);
+const RESERVE_FATAL_RESULT_CODES = new Set<ScreepsReturnCode>([ERR_INVALID_TARGET_CODE, ERR_NO_BODYPART_CODE]);
+const PRESSURE_FATAL_RESULT_CODES = new Set<ScreepsReturnCode>([ERR_NO_BODYPART_CODE]);
 
 type RoomPositionConstructor = new (x: number, y: number, roomName: string) => RoomPosition;
 
@@ -83,6 +86,11 @@ export function runTerritoryControllerCreep(creep: Creep): void {
     const pressureResult = executeControllerAction(creep, controller, 'attackController');
     if (pressureResult === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {
       creep.moveTo(controller);
+      return;
+    }
+
+    if (PRESSURE_FATAL_RESULT_CODES.has(pressureResult)) {
+      suppressTerritoryAssignment(creep, assignment);
       return;
     }
 

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -1,4 +1,5 @@
 import {
+  canCreepPressureTerritoryController,
   canCreepReserveTerritoryController,
   isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry,
   isVisibleTerritoryAssignmentComplete,
@@ -72,6 +73,22 @@ export function runTerritoryControllerCreep(creep: Creep): void {
   if (isTerritoryControlAction(assignment.action) && isCreepKnownToHaveNoActiveClaimParts(creep)) {
     suppressTerritoryAssignment(creep, assignment);
     return;
+  }
+
+  if (
+    assignment.action === 'reserve' &&
+    typeof creep.attackController === 'function' &&
+    canCreepPressureTerritoryController(creep, controller, creep.memory.colony)
+  ) {
+    const pressureResult = executeControllerAction(creep, controller, 'attackController');
+    if (pressureResult === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {
+      creep.moveTo(controller);
+      return;
+    }
+
+    if (pressureResult !== ERR_INVALID_TARGET_CODE) {
+      return;
+    }
   }
 
   if (
@@ -171,7 +188,7 @@ function selectTargetController(creep: Creep, assignment: CreepTerritoryMemory):
 function executeControllerAction(
   creep: Creep,
   controller: StructureController,
-  action: 'claimController' | 'reserveController'
+  action: 'attackController' | 'claimController' | 'reserveController'
 ): ScreepsReturnCode {
   const controllerAction = creep[action];
   if (typeof controllerAction !== 'function') {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -49,6 +49,7 @@ declare global {
     updatedAt: number;
     lastAttemptAt?: number;
     controllerId?: Id<StructureController>;
+    requiresControllerPressure?: boolean;
     followUp?: TerritoryFollowUpMemory;
   }
 

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -1,6 +1,7 @@
 import {
   buildEmergencyWorkerBody,
   buildTerritoryControllerBody,
+  buildTerritoryControllerPressureBody,
   buildWorkerBody,
   getBodyCost
 } from '../src/spawn/bodyBuilder';
@@ -80,6 +81,27 @@ describe('buildTerritoryControllerBody', () => {
 
   it('builds one claim and move part when affordable', () => {
     expect(buildTerritoryControllerBody(650)).toEqual(['claim', 'move']);
+  });
+});
+
+describe('buildTerritoryControllerPressureBody', () => {
+  it('returns an empty body below five claim/move pairs', () => {
+    expect(buildTerritoryControllerPressureBody(3249)).toEqual([]);
+  });
+
+  it('builds five claim/move pairs when affordable', () => {
+    expect(buildTerritoryControllerPressureBody(3250)).toEqual([
+      'claim',
+      'move',
+      'claim',
+      'move',
+      'claim',
+      'move',
+      'claim',
+      'move',
+      'claim',
+      'move'
+    ]);
   });
 });
 

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -123,9 +123,15 @@ describe('occupation recommendation scoring', () => {
       roomName: 'W2N1',
       action: 'reserve',
       evidenceStatus: 'sufficient',
+      requiresControllerPressure: true,
       evidence: ['room visible', 'controller visible', 'foreign reservation can be pressured', '2 sources visible']
     });
-    expect(report.followUpIntent).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(report.followUpIntent).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      requiresControllerPressure: true
+    });
   });
 
   it('keeps unreserved reserve candidates ahead of foreign reservation pressure', () => {
@@ -386,6 +392,167 @@ describe('occupation recommendation scoring', () => {
         updatedAt: 720,
         controllerId: 'controller2',
         followUp
+      }
+    ]);
+  });
+
+  it('persists pressure-marked recommendation follow-ups before target vision is lost', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = { territory: { intents: [] } };
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          controller: { reservationUsername: 'enemy', reservationTicksToEnd: 3_000 },
+          sourceCount: 2
+        })
+      ])
+    );
+
+    expect(persistOccupationRecommendationFollowUpIntent(report, 730)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 730,
+      requiresControllerPressure: true
+    });
+
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 730,
+        requiresControllerPressure: true
+      }
+    ]);
+  });
+
+  it('clears stale pressure requirements when the target controller is visible again', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: {
+          controller: { my: false } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 730,
+            requiresControllerPressure: true
+          }
+        ]
+      }
+    };
+    const report: OccupationRecommendationReport = {
+      candidates: [],
+      next: null,
+      followUpIntent: { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' }
+    };
+
+    expect(persistOccupationRecommendationFollowUpIntent(report, 731)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 731
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 731
+      }
+    ]);
+  });
+
+  it('preserves stale pressure requirements while target controller visibility is missing', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 730,
+            requiresControllerPressure: true
+          }
+        ]
+      }
+    };
+    const report: OccupationRecommendationReport = {
+      candidates: [],
+      next: null,
+      followUpIntent: { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' }
+    };
+
+    expect(persistOccupationRecommendationFollowUpIntent(report, 731)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 731,
+      requiresControllerPressure: true
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 731,
+        requiresControllerPressure: true
+      }
+    ]);
+  });
+
+  it('clears stale pressure follow-ups when the visible target no longer needs pressure', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: { name: 'W2N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 730,
+            requiresControllerPressure: true
+          }
+        ]
+      }
+    };
+    const report = scoreOccupationRecommendations(makeInput([makeCandidate({ roomName: 'W2N1' })]));
+
+    expect(persistOccupationRecommendationFollowUpIntent(report, 731)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 731
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 731
       }
     ]);
   });

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -108,6 +108,48 @@ describe('occupation recommendation scoring', () => {
     });
   });
 
+  it('treats a configured foreign reservation as reserve controller pressure', () => {
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          controller: { reservationUsername: 'enemy', reservationTicksToEnd: 3_000 },
+          sourceCount: 2
+        })
+      ])
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      action: 'reserve',
+      evidenceStatus: 'sufficient',
+      evidence: ['room visible', 'controller visible', 'foreign reservation can be pressured', '2 sources visible']
+    });
+    expect(report.followUpIntent).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+  });
+
+  it('keeps unreserved reserve candidates ahead of foreign reservation pressure', () => {
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          controller: { reservationUsername: 'enemy', reservationTicksToEnd: 3_000 },
+          sourceCount: 2
+        }),
+        makeCandidate({
+          roomName: 'W3N1',
+          sourceCount: 1
+        })
+      ])
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W3N1',
+      action: 'reserve',
+      evidenceStatus: 'sufficient'
+    });
+  });
+
   it('renews own reservations only when they are near expiry', () => {
     const report = scoreOccupationRecommendations(
       makeInput([

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -328,6 +328,64 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('does not spawn a one-CLAIM reserver for foreign reservation pressure', () => {
+    const { colony } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTerritoryRoom('W2N1', {
+          my: false,
+          reservation: { username: 'enemy', ticksToEnd: 3_000 }
+        } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 143)).toBeNull();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('spawns a pressure-capable claimer for foreign reservation pressure', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 3250,
+      energyCapacityAvailable: 3250,
+      controller: { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTerritoryRoom('W2N1', {
+          my: false,
+          reservation: { username: 'enemy', ticksToEnd: 3_000 }
+        } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 144)).toEqual({
+      spawn,
+      body: ['claim', 'move', 'claim', 'move', 'claim', 'move', 'claim', 'move', 'claim', 'move'],
+      name: 'claimer-W1N1-W2N1-144',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve' }
+      }
+    });
+  });
+
   it('plans a claimer from a persisted occupation claim intent when the target is actionable', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -386,6 +386,55 @@ describe('planSpawn', () => {
     });
   });
 
+  it('does not fall back to a one-CLAIM body for persisted foreign reservation pressure after vision loss', () => {
+    const { colony: visibleColony } = makeColony({
+      energyAvailable: 3250,
+      energyCapacityAvailable: 3250,
+      controller: { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: visibleColony.room,
+        W2N1: makeTerritoryRoom('W2N1', {
+          my: false,
+          reservation: { username: 'enemy', ticksToEnd: 3_000 }
+        } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    expect(planSpawn(visibleColony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 145)).toMatchObject({
+      body: ['claim', 'move', 'claim', 'move', 'claim', 'move', 'claim', 'move', 'claim', 'move']
+    });
+
+    const { colony: darkColony } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 3250,
+      controller: { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: darkColony.room
+      }
+    };
+
+    expect(planSpawn(darkColony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 146)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 146,
+        requiresControllerPressure: true
+      }
+    ]);
+  });
+
   it('plans a claimer from a persisted occupation claim intent when the target is actionable', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3455,7 +3455,7 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.targets).toEqual([healthyReservationTarget, unreservedTarget]);
   });
 
-  it('does not treat hostile or owned reserve targets as renewal candidates', () => {
+  it('keeps own renewal ahead of foreign reservation pressure and owned reserve targets', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {
@@ -3498,7 +3498,7 @@ describe('planTerritoryIntent', () => {
         { colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' },
         { worker: 3, claimer: 0, claimersByTargetRoom: {} }
       )
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldSpawnTerritoryControllerCreep(
         { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
@@ -3537,7 +3537,7 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
-  it('skips visible enemy-reserved reserve targets and plans the next eligible target', () => {
+  it('keeps an unreserved target ahead of enemy-reserved controller pressure', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {
@@ -3569,7 +3569,7 @@ describe('planTerritoryIntent', () => {
         { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
         { worker: 3, claimer: 0, claimersByTargetRoom: {} }
       )
-    ).toBe(false);
+    ).toBe(true);
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
@@ -3668,6 +3668,43 @@ describe('planTerritoryIntent', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: retryTime
+      }
+    ]);
+  });
+
+  it('dispatches a configured reserve target to pressure a foreign reservation', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 542);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 542)
+    ).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 542
       }
     ]);
   });

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3807,6 +3807,42 @@ describe('planTerritoryIntent', () => {
         requiresControllerPressure: true
       }
     ]);
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: lowCapacityColony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: { my: false } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+
+    const clearedPressurePlan = planTerritoryIntent(
+      lowCapacityColony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      545
+    );
+
+    expect(clearedPressurePlan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(clearedPressurePlan).not.toHaveProperty('requiresControllerPressure');
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        clearedPressurePlan!,
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+        545
+      )
+    ).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 545
+      }
+    ]);
   });
 
   it('still requests claimers for visible unowned reserve targets', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3456,7 +3456,7 @@ describe('planTerritoryIntent', () => {
   });
 
   it('keeps own renewal ahead of foreign reservation pressure and owned reserve targets', () => {
-    const colony = makeSafeColony();
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {
         W1N1: colony.room,
@@ -3538,7 +3538,7 @@ describe('planTerritoryIntent', () => {
   });
 
   it('keeps an unreserved target ahead of enemy-reserved controller pressure', () => {
-    const colony = makeSafeColony();
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {
         W1N1: colony.room,
@@ -3579,6 +3579,37 @@ describe('planTerritoryIntent', () => {
         updatedAt: 536
       }
     ]);
+  });
+
+  it('does not dispatch a configured foreign reservation pressure target without pressure body capacity', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 542)).toBeNull();
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+        542
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toBeUndefined();
   });
 
   it('does not renew an explicitly suppressed own reserve target near expiry', () => {
@@ -3673,7 +3704,7 @@ describe('planTerritoryIntent', () => {
   });
 
   it('dispatches a configured reserve target to pressure a foreign reservation', () => {
-    const colony = makeSafeColony();
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {
         W1N1: colony.room,
@@ -3803,22 +3834,26 @@ function makeRecommendationRoom(
 
 function makeSafeColony({
   roomName = 'W1N1',
-  controller = { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 } as StructureController
+  controller = { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 } as StructureController,
+  energyAvailable = 650,
+  energyCapacityAvailable = 650
 }: {
   roomName?: string;
   controller?: StructureController;
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
 } = {}): ColonySnapshot {
   const room = {
     name: roomName,
     controller,
-    energyAvailable: 650,
-    energyCapacityAvailable: 650
+    energyAvailable,
+    energyCapacityAvailable
   } as unknown as Room;
 
   return {
     room,
     spawns: [],
-    energyAvailable: 650,
-    energyCapacityAvailable: 650
+    energyAvailable,
+    energyCapacityAvailable
   };
 }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3,6 +3,7 @@ import {
   buildTerritoryCreepMemory,
   getActiveTerritoryFollowUpExecutionHints,
   planTerritoryIntent,
+  recordTerritoryReserveFallbackIntent,
   recordRecoveredTerritoryFollowUpRetryCooldown,
   shouldSpawnTerritoryControllerCreep,
   suppressTerritoryIntent,
@@ -3742,6 +3743,134 @@ describe('planTerritoryIntent', () => {
         status: 'planned',
         updatedAt: 542,
         requiresControllerPressure: true
+      }
+    ]);
+  });
+
+  it('preserves live pressure when suppressing a visible foreign-reserved reserve intent', () => {
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
+    const target: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const existingIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'active',
+      updatedAt: 543,
+      requiresControllerPressure: true
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [target],
+        intents: [existingIntent]
+      }
+    };
+
+    suppressTerritoryIntent('W1N1', { targetRoom: 'W2N1', action: 'reserve' }, 544);
+
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: 544,
+        requiresControllerPressure: true
+      }
+    ]);
+  });
+
+  it('preserves live pressure when recording a visible foreign-reserved fallback intent', () => {
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
+    const target: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const existingIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'active',
+      updatedAt: 543,
+      requiresControllerPressure: true
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [target],
+        intents: [existingIntent]
+      }
+    };
+
+    recordTerritoryReserveFallbackIntent('W1N1', { targetRoom: 'W2N1', action: 'reserve' }, 544);
+
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 544,
+        requiresControllerPressure: true
+      }
+    ]);
+  });
+
+  it('clears pressure when recording a visible unreserved fallback intent', () => {
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
+    const target: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const existingIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'active',
+      updatedAt: 543,
+      requiresControllerPressure: true
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: { my: false } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [target],
+        intents: [existingIntent]
+      }
+    };
+
+    recordTerritoryReserveFallbackIntent('W1N1', { targetRoom: 'W2N1', action: 'reserve' }, 544);
+
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 544
       }
     ]);
   });

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3495,7 +3495,7 @@ describe('planTerritoryIntent', () => {
     expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
     expect(
       shouldSpawnTerritoryControllerCreep(
-        { colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve' },
+        { colony: 'W1N1', targetRoom: 'W1N2', action: 'reserve', requiresControllerPressure: true },
         { worker: 3, claimer: 0, claimersByTargetRoom: {} }
       )
     ).toBe(true);
@@ -3566,7 +3566,7 @@ describe('planTerritoryIntent', () => {
     expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
     expect(
       shouldSpawnTerritoryControllerCreep(
-        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', requiresControllerPressure: true },
         { worker: 3, claimer: 0, claimersByTargetRoom: {} }
       )
     ).toBe(true);
@@ -3604,7 +3604,7 @@ describe('planTerritoryIntent', () => {
     expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 542)).toBeNull();
     expect(
       shouldSpawnTerritoryControllerCreep(
-        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', requiresControllerPressure: true },
         { worker: 3, claimer: 0, claimersByTargetRoom: {} },
         542
       )
@@ -3725,7 +3725,12 @@ describe('planTerritoryIntent', () => {
 
     const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 542);
 
-    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      requiresControllerPressure: true
+    });
     expect(
       shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 542)
     ).toBe(true);
@@ -3735,7 +3740,71 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'W2N1',
         action: 'reserve',
         status: 'planned',
-        updatedAt: 542
+        updatedAt: 542,
+        requiresControllerPressure: true
+      }
+    ]);
+  });
+
+  it('keeps foreign reservation pressure body requirements after target vision is lost', () => {
+    const visibleColony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: visibleColony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    const pressurePlan = planTerritoryIntent(
+      visibleColony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      543
+    );
+
+    expect(pressurePlan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      requiresControllerPressure: true
+    });
+
+    const lowCapacityColony = makeSafeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: lowCapacityColony.room
+      }
+    };
+
+    expect(
+      planTerritoryIntent(lowCapacityColony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 544)
+    ).toBeNull();
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', requiresControllerPressure: true },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+        544
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 543,
+        requiresControllerPressure: true
       }
     ]);
   });

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -804,7 +804,7 @@ describe('runTerritoryControllerCreep', () => {
       owner: { username: 'me' },
       memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
       room: { name: 'W1N2', controller },
-      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      getActiveBodyparts: jest.fn().mockReturnValue(5),
       attackController: jest.fn().mockReturnValue(0),
       reserveController: jest.fn(),
       moveTo: jest.fn()
@@ -823,6 +823,106 @@ describe('runTerritoryControllerCreep', () => {
         action: 'reserve',
         status: 'active',
         updatedAt: 515
+      }
+    ]);
+  });
+
+  it('suppresses foreign reservation pressure when the claimer lacks five CLAIM parts', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 517,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 516
+          }
+        ]
+      }
+    };
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'enemy', ticksToEnd: 3_000 }
+    } as StructureController;
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      attackController: jest.fn(),
+      reserveController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.attackController).not.toHaveBeenCalled();
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: 517
+      }
+    ]);
+  });
+
+  it('suppresses foreign reservation pressure when attackController reports no CLAIM body parts', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 518,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 517
+          }
+        ]
+      }
+    };
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'enemy', ticksToEnd: 3_000 }
+    } as StructureController;
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(5),
+      attackController: jest.fn().mockReturnValue(-12),
+      reserveController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.attackController).toHaveBeenCalledWith(controller);
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: 518
       }
     ]);
   });

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -777,6 +777,56 @@ describe('runTerritoryControllerCreep', () => {
     ]);
   });
 
+  it('pressures a foreign reservation before trying to reserve the controller', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 516,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 515
+          }
+        ]
+      }
+    };
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'enemy', ticksToEnd: 3_000 }
+    } as StructureController;
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      attackController: jest.fn().mockReturnValue(0),
+      reserveController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.attackController).toHaveBeenCalledWith(controller);
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve' });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 515
+      }
+    ]);
+  });
+
   it('suppresses an enemy-owned reserve target without issuing the impossible reserve call', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 504,

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1317,6 +1317,63 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('executes pressure reservation tasks with attackController against foreign reservations', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'enemy', ticksToEnd: 3_000 }
+    } as StructureController;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 202,
+            requiresControllerPressure: true
+          }
+        ]
+      }
+    };
+    const room = {
+      name: 'W2N1',
+      controller,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const creep = {
+      owner: { username: 'me' },
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'reserve', targetId: 'controller2' as Id<StructureController> }
+      },
+      getActiveBodyparts: jest.fn().mockReturnValue(5),
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      attackController: jest.fn().mockReturnValue(0),
+      reserveController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const getObjectById = jest.fn().mockReturnValue(controller);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(getObjectById).toHaveBeenCalledWith('controller2');
+    expect(creep.memory.task).toEqual({ type: 'reserve', targetId: 'controller2' });
+    expect(creep.attackController).toHaveBeenCalledWith(controller);
+    expect(creep.reserveController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('clears completed repair targets and reassigns without repairing the stale target', () => {
     const fullRoad = { id: 'road-full', structureType: 'road', hits: 5_000, hitsMax: 5_000 } as StructureRoad;
     const damagedRoad = { id: 'road-damaged', structureType: 'road', hits: 1_000, hitsMax: 5_000 } as StructureRoad;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2615,6 +2615,42 @@ describe('selectWorkerTask', () => {
     expect(room.find).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
+  it('selects pressure reserve intents for five-CLAIM creeps against foreign reservations', () => {
+    const controller = {
+      id: 'controller2',
+      my: false,
+      reservation: { username: 'enemy', ticksToEnd: 3_000 }
+    } as StructureController;
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    const room = makeWorkerTaskRoom({ constructionSites: [site], controller });
+    (room as Room & { name: string }).name = 'W2N1';
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 101,
+            requiresControllerPressure: true
+          }
+        ]
+      }
+    };
+    const makeCreep = (claimParts: number): Creep =>
+      ({
+        owner: { username: 'me' },
+        memory: { role: 'worker', colony: 'W1N1' },
+        getActiveBodyparts: jest.fn().mockReturnValue(claimParts),
+        store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+        room
+      }) as unknown as Creep;
+
+    expect(selectWorkerTask(makeCreep(1))).toEqual({ type: 'build', targetId: 'site1' });
+    expect(selectWorkerTask(makeCreep(5))).toEqual({ type: 'reserve', targetId: 'controller2' });
+  });
+
   it('keeps a visible reserve target before spawn refill under concurrent energy pressure', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const controller = { id: 'controller2', my: false } as StructureController;


### PR DESCRIPTION
## Summary
- Allows configured reserve targets with foreign reservations to remain actionable as pressure opportunities.
- Teaches territory controller creeps to attack/pressure foreign reservations before attempting reserve renewal.
- Adds occupation, planner, and runner Jest coverage; regenerates `prod/dist/main.js`.

Closes #339

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 498 tests passed)
- `cd prod && npm run build`
- `git diff --check`

## Scheduler evidence
- Base/deployed main: `69863e5d59b3211ed620439ea1fda645b3a95f82`
- Commit: `b4e12f1` by `lanyusea's bot <lanyusea@gmail.com>`
- Worktree: `/root/screeps-worktrees/territory-post338-339`
