### PR TITLE
feat: reserve worker energy for higher value sinks

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5137,6 +5137,9 @@ function matchesCapacityConstructionStructureType(actual, globalName, fallback) 
 }
 function shouldReplaceTarget(task, target) {
   var _a;
+  if (task.type === "harvest" && isDepletedHarvestSource(target)) {
+    return true;
+  }
   if (task.type === "transfer" && "store" in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
     return true;
   }
@@ -5144,6 +5147,10 @@ function shouldReplaceTarget(task, target) {
     return true;
   }
   return task.type === "repair" && "hits" in target && isWorkerRepairTargetComplete(target);
+}
+function isDepletedHarvestSource(target) {
+  const energy = target == null ? void 0 : target.energy;
+  return typeof energy === "number" && energy <= 0;
 }
 function executeTask(creep, task, target) {
   switch (task.type) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -490,6 +490,10 @@ function shouldReplaceTarget(
   task: CreepTaskMemory,
   target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController | Structure
 ): boolean {
+  if (task.type === 'harvest' && isDepletedHarvestSource(target)) {
+    return true;
+  }
+
   if (task.type === 'transfer' && 'store' in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
     return true;
   }
@@ -499,6 +503,11 @@ function shouldReplaceTarget(
   }
 
   return task.type === 'repair' && 'hits' in target && isWorkerRepairTargetComplete(target);
+}
+
+function isDepletedHarvestSource(target: unknown): target is Source {
+  const energy = (target as Partial<Source> | null)?.energy;
+  return typeof energy === 'number' && energy <= 0;
 }
 
 function executeTask(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -145,6 +145,41 @@ describe('runWorker', () => {
     expect(creep.moveTo).toHaveBeenCalledWith(source);
   });
 
+  it('switches from a depleted harvest target to a viable source in the same tick', () => {
+    const depletedSource = { id: 'source1', energy: 0 } as Source;
+    const viableSource = { id: 'source2', energy: 100 } as Source;
+    const harvest = jest.fn().mockReturnValue(0);
+    const creep = {
+      memory: { task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: {
+        name: 'W1N1',
+        find: jest.fn((type) => (type === FIND_SOURCES ? [depletedSource, viableSource] : []))
+      },
+      harvest,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    const getObjectById = jest.fn((id: string) =>
+      id === 'source1' ? depletedSource : id === 'source2' ? viableSource : null
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source2' });
+    expect(getObjectById).toHaveBeenCalledWith('source1');
+    expect(getObjectById).toHaveBeenCalledWith('source2');
+    expect(harvest).toHaveBeenCalledWith(viableSource);
+    expect(harvest).not.toHaveBeenCalledWith(depletedSource);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('picks up dropped energy and moves when not in range', () => {
     const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
     const creep = {


### PR DESCRIPTION
## Summary
- Makes workers abandon a depleted harvest source before spending a tick on it.
- Re-selects a viable source in the same tick when one is available.
- Adds focused worker-runner Jest coverage and regenerates `prod/dist/main.js`.

Closes #340

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 495 tests passed)
- `cd prod && npm run build`
- `git diff --check`

## Scheduler evidence
- Base/deployed main: `69863e5d59b3211ed620439ea1fda645b3a95f82`
- Commit: `902d002` by `lanyusea's bot <lanyusea@gmail.com>`
- Worktree: `/root/screeps-worktrees/economy-post338-340`
