### PR TITLE
feat: retry depleted worker energy targets

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4877,7 +4877,7 @@ function executeAssignedTask(creep, selectedTask, immediateReselectExecutions = 
     }
   }
   const result = executeTask(creep, task, target);
-  if (task.type === "transfer" && result === ERR_FULL) {
+  if (shouldImmediatelyReselectAfterTaskResult(task, result)) {
     delete creep.memory.task;
     const nextTask = assignNextTask(creep);
     if (nextTask && !isSameTask(task, nextTask) && immediateReselectExecutions < MAX_IMMEDIATE_RESELECT_EXECUTIONS) {
@@ -4888,6 +4888,15 @@ function executeAssignedTask(creep, selectedTask, immediateReselectExecutions = 
   if (result === ERR_NOT_IN_RANGE) {
     creep.moveTo(target);
   }
+}
+function shouldImmediatelyReselectAfterTaskResult(task, result) {
+  if (task.type === "transfer") {
+    return result === ERR_FULL;
+  }
+  return isEnergyAcquisitionTask(task) && isUnavailableEnergyAcquisitionResult(result);
+}
+function isUnavailableEnergyAcquisitionResult(result) {
+  return result === ERR_NOT_ENOUGH_RESOURCES || result === ERR_INVALID_TARGET;
 }
 function assignSelectedTask(creep, selectedTask, previousTask) {
   if (!selectedTask || previousTask && isSameTask(previousTask, selectedTask)) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -84,7 +84,7 @@ function executeAssignedTask(
   }
 
   const result = executeTask(creep, task, target);
-  if (task.type === 'transfer' && result === ERR_FULL) {
+  if (shouldImmediatelyReselectAfterTaskResult(task, result)) {
     delete creep.memory.task;
     const nextTask = assignNextTask(creep);
     if (
@@ -100,6 +100,18 @@ function executeAssignedTask(
   if (result === ERR_NOT_IN_RANGE) {
     creep.moveTo(target as RoomObject);
   }
+}
+
+function shouldImmediatelyReselectAfterTaskResult(task: CreepTaskMemory, result: ScreepsReturnCode): boolean {
+  if (task.type === 'transfer') {
+    return result === ERR_FULL;
+  }
+
+  return isEnergyAcquisitionTask(task) && isUnavailableEnergyAcquisitionResult(result);
+}
+
+function isUnavailableEnergyAcquisitionResult(result: ScreepsReturnCode): boolean {
+  return result === ERR_NOT_ENOUGH_RESOURCES || result === ERR_INVALID_TARGET;
 }
 
 function assignSelectedTask(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -18,8 +18,10 @@ function withRangeTo<T extends { id: string }>(object: T, rangesByTargetId: Reco
 
 describe('runWorker', () => {
   beforeEach(() => {
-    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).ERR_NOT_IN_RANGE = -9;
+    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; ERR_NOT_ENOUGH_RESOURCES: number; ERR_INVALID_TARGET: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).ERR_NOT_IN_RANGE = -9;
     (globalThis as unknown as { ERR_FULL: number }).ERR_FULL = -8;
+    (globalThis as unknown as { ERR_NOT_ENOUGH_RESOURCES: number }).ERR_NOT_ENOUGH_RESOURCES = -6;
+    (globalThis as unknown as { ERR_INVALID_TARGET: number }).ERR_INVALID_TARGET = -7;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
@@ -240,6 +242,40 @@ describe('runWorker', () => {
 
     expect(creep.withdraw).toHaveBeenCalledWith(container, 'energy');
     expect(creep.moveTo).toHaveBeenCalledWith(container);
+  });
+
+  it('reselects and executes when a withdraw target is drained before action', () => {
+    const drainedContainer = {
+      id: 'container-drained',
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) }
+    } as unknown as StructureContainer;
+    const source = { id: 'source1', energy: 300 } as Source;
+    const withdraw = jest.fn().mockReturnValue(ERR_NOT_ENOUGH_RESOURCES);
+    const harvest = jest.fn().mockReturnValue(0);
+    const creep = {
+      memory: { task: { type: 'withdraw', targetId: 'container-drained' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: {
+        name: 'W1N1',
+        find: jest.fn((type) => (type === FIND_SOURCES ? [source] : []))
+      },
+      withdraw,
+      harvest,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : drainedContainer))
+    };
+
+    runWorker(creep);
+
+    expect(withdraw).toHaveBeenCalledWith(drainedContainer, 'energy');
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(harvest).toHaveBeenCalledWith(source);
+    expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
   it('builds an existing build target and moves when not in range', () => {


### PR DESCRIPTION
## Summary
- Retries worker energy acquisition in the same tick when a selected energy target is depleted.
- Falls back to a viable source without wasting movement/tick time on an empty target.
- Adds focused Jest coverage and rebuilds `prod/dist/main.js`.

Fixes #345

## Verification
- `cd prod && npm run typecheck` — passed
- `cd prod && npm test -- --runInBand` — passed (22 suites / 496 tests)
- `cd prod && npm run build` — passed
- `git diff --check` — passed

## Scheduler evidence
- Worktree: `/root/screeps-worktrees/economy-post344-345`
- Branch: `feat/economy-post344-345`
- Commit: `2c07cdd feat: retry depleted worker energy targets`
- Author: `lanyusea's bot <lanyusea@gmail.com>`
