### PR TITLE
feat: continue worker energy retry throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4777,12 +4777,17 @@ function selectHarvestSource(creep) {
   let selectedCount = (_a = assignmentCounts.get(selectedSource.id)) != null ? _a : 0;
   for (const source of viableSources.slice(1)) {
     const count = (_b = assignmentCounts.get(source.id)) != null ? _b : 0;
-    if (count < selectedCount) {
+    if (count < selectedCount || count === selectedCount && isCloserHarvestSource(creep, source, selectedSource)) {
       selectedSource = source;
       selectedCount = count;
     }
   }
   return selectedSource;
+}
+function isCloserHarvestSource(creep, candidate, selected) {
+  const candidateRange = getRangeBetweenRoomObjects(creep, candidate);
+  const selectedRange = getRangeBetweenRoomObjects(creep, selected);
+  return candidateRange !== null && selectedRange !== null && candidateRange < selectedRange;
 }
 function selectViableHarvestSources(sources) {
   const sourcesWithEnergy = sources.filter((source) => typeof source.energy === "number" && source.energy > 0);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2131,16 +2131,21 @@ function selectHarvestSource(creep: Creep): Source | null {
   let selectedSource = viableSources[0];
   let selectedCount = assignmentCounts.get(selectedSource.id) ?? 0;
 
-  // Ties intentionally keep room.find(FIND_SOURCES) order stable.
   for (const source of viableSources.slice(1)) {
     const count = assignmentCounts.get(source.id) ?? 0;
-    if (count < selectedCount) {
+    if (count < selectedCount || (count === selectedCount && isCloserHarvestSource(creep, source, selectedSource))) {
       selectedSource = source;
       selectedCount = count;
     }
   }
 
   return selectedSource;
+}
+
+function isCloserHarvestSource(creep: Creep, candidate: Source, selected: Source): boolean {
+  const candidateRange = getRangeBetweenRoomObjects(creep, candidate);
+  const selectedRange = getRangeBetweenRoomObjects(creep, selected);
+  return candidateRange !== null && selectedRange !== null && candidateRange < selectedRange;
 }
 
 function selectViableHarvestSources(sources: Source[]): Source[] {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1503,15 +1503,17 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-full' });
   });
 
-  it('keeps room.find source order as the stable tie-breaker for viable sources', () => {
+  it('selects the closer harvest source when viable source assignments tie', () => {
     const source2 = { id: 'source2', energy: 100 } as Source;
     const source1 = { id: 'source1', energy: 100 } as Source;
+    const getRangeTo = jest.fn((target: Source) => (target.id === 'source1' ? 2 : 9));
     const creep = {
       store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      pos: { getRangeTo },
       room: { name: 'W1N1', find: jest.fn().mockReturnValue([source2, source1]) }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
   it('falls back deterministically when all sources are empty', () => {


### PR DESCRIPTION
## Summary
- Continue issue #347 economy throughput work by retrying depleted worker energy targets more productively.
- Keeps the built Screeps bundle synchronized in `prod/dist/main.js`.

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 496 tests passed)
- `cd prod && npm run build`

Closes #347.
