### PR TITLE
feat: improve worker energy source selection

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4766,23 +4766,87 @@ function findClosestByRange(creep, objects) {
   return typeof (position == null ? void 0 : position.findClosestByRange) === "function" ? position.findClosestByRange(objects) : null;
 }
 function selectHarvestSource(creep) {
-  var _a, _b;
   const sources = creep.room.find(FIND_SOURCES);
   if (sources.length === 0) {
     return null;
   }
   const viableSources = selectViableHarvestSources(sources);
   const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
-  let selectedSource = viableSources[0];
-  let selectedCount = (_a = assignmentCounts.get(selectedSource.id)) != null ? _a : 0;
-  for (const source of viableSources.slice(1)) {
-    const count = (_b = assignmentCounts.get(source.id)) != null ? _b : 0;
-    if (count < selectedCount || count === selectedCount && isCloserHarvestSource(creep, source, selectedSource)) {
-      selectedSource = source;
-      selectedCount = count;
+  const sourceLoads = viableSources.map((source) => {
+    var _a;
+    return {
+      assignmentCount: (_a = assignmentCounts.get(source.id)) != null ? _a : 0,
+      capacity: getHarvestSourceCapacity(source),
+      source
+    };
+  });
+  let selectedLoad = sourceLoads[0];
+  for (const sourceLoad of sourceLoads.slice(1)) {
+    if (compareHarvestSourceLoads(creep, sourceLoad, selectedLoad) < 0) {
+      selectedLoad = sourceLoad;
     }
   }
-  return selectedSource;
+  return selectedLoad.source;
+}
+function compareHarvestSourceLoads(creep, left, right) {
+  const loadRatioComparison = compareHarvestSourceLoadRatio(left, right);
+  if (loadRatioComparison !== 0) {
+    return loadRatioComparison;
+  }
+  const assignmentComparison = left.assignmentCount - right.assignmentCount;
+  if (assignmentComparison !== 0) {
+    return assignmentComparison;
+  }
+  if (isCloserHarvestSource(creep, left.source, right.source)) {
+    return -1;
+  }
+  if (isCloserHarvestSource(creep, right.source, left.source)) {
+    return 1;
+  }
+  return 0;
+}
+function compareHarvestSourceLoadRatio(left, right) {
+  return left.assignmentCount * right.capacity - right.assignmentCount * left.capacity;
+}
+function getHarvestSourceCapacity(source) {
+  const position = getRoomObjectPosition(source);
+  if (!position) {
+    return 1;
+  }
+  const terrain = getRoomTerrain2(position.roomName);
+  if (!terrain) {
+    return 1;
+  }
+  const wallMask = getTerrainWallMask3();
+  let capacity = 0;
+  for (let dx = -1; dx <= 1; dx += 1) {
+    for (let dy = -1; dy <= 1; dy += 1) {
+      if (dx === 0 && dy === 0) {
+        continue;
+      }
+      const x = position.x + dx;
+      const y = position.y + dy;
+      if (x < 0 || x > 49 || y < 0 || y > 49) {
+        continue;
+      }
+      if ((terrain.get(x, y) & wallMask) === 0) {
+        capacity += 1;
+      }
+    }
+  }
+  return Math.max(1, capacity);
+}
+function getRoomTerrain2(roomName) {
+  var _a;
+  const map = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (map == null ? void 0 : map.getRoomTerrain) !== "function") {
+    return null;
+  }
+  return map.getRoomTerrain(roomName);
+}
+function getTerrainWallMask3() {
+  const terrainWallMask = globalThis.TERRAIN_MASK_WALL;
+  return typeof terrainWallMask === "number" ? terrainWallMask : 1;
 }
 function isCloserHarvestSource(creep, candidate, selected) {
   const candidateRange = getRangeBetweenRoomObjects(creep, candidate);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -73,6 +73,12 @@ interface Source2ControllerLaneTopology {
   source: Source;
 }
 
+interface HarvestSourceLoad {
+  assignmentCount: number;
+  capacity: number;
+  source: Source;
+}
+
 let nearTermSpawnExtensionRefillReserveCache: NearTermSpawnExtensionRefillReserveCache | null = null;
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
@@ -2128,18 +2134,94 @@ function selectHarvestSource(creep: Creep): Source | null {
 
   const viableSources = selectViableHarvestSources(sources);
   const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
-  let selectedSource = viableSources[0];
-  let selectedCount = assignmentCounts.get(selectedSource.id) ?? 0;
+  const sourceLoads = viableSources.map((source) => ({
+    assignmentCount: assignmentCounts.get(source.id) ?? 0,
+    capacity: getHarvestSourceCapacity(source),
+    source
+  }));
+  let selectedLoad = sourceLoads[0];
 
-  for (const source of viableSources.slice(1)) {
-    const count = assignmentCounts.get(source.id) ?? 0;
-    if (count < selectedCount || (count === selectedCount && isCloserHarvestSource(creep, source, selectedSource))) {
-      selectedSource = source;
-      selectedCount = count;
+  for (const sourceLoad of sourceLoads.slice(1)) {
+    if (compareHarvestSourceLoads(creep, sourceLoad, selectedLoad) < 0) {
+      selectedLoad = sourceLoad;
     }
   }
 
-  return selectedSource;
+  return selectedLoad.source;
+}
+
+function compareHarvestSourceLoads(creep: Creep, left: HarvestSourceLoad, right: HarvestSourceLoad): number {
+  const loadRatioComparison = compareHarvestSourceLoadRatio(left, right);
+  if (loadRatioComparison !== 0) {
+    return loadRatioComparison;
+  }
+
+  const assignmentComparison = left.assignmentCount - right.assignmentCount;
+  if (assignmentComparison !== 0) {
+    return assignmentComparison;
+  }
+
+  if (isCloserHarvestSource(creep, left.source, right.source)) {
+    return -1;
+  }
+
+  if (isCloserHarvestSource(creep, right.source, left.source)) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function compareHarvestSourceLoadRatio(left: HarvestSourceLoad, right: HarvestSourceLoad): number {
+  return left.assignmentCount * right.capacity - right.assignmentCount * left.capacity;
+}
+
+function getHarvestSourceCapacity(source: Source): number {
+  const position = getRoomObjectPosition(source);
+  if (!position) {
+    return 1;
+  }
+
+  const terrain = getRoomTerrain(position.roomName);
+  if (!terrain) {
+    return 1;
+  }
+
+  const wallMask = getTerrainWallMask();
+  let capacity = 0;
+  for (let dx = -1; dx <= 1; dx += 1) {
+    for (let dy = -1; dy <= 1; dy += 1) {
+      if (dx === 0 && dy === 0) {
+        continue;
+      }
+
+      const x = position.x + dx;
+      const y = position.y + dy;
+      if (x < 0 || x > 49 || y < 0 || y > 49) {
+        continue;
+      }
+
+      if ((terrain.get(x, y) & wallMask) === 0) {
+        capacity += 1;
+      }
+    }
+  }
+
+  return Math.max(1, capacity);
+}
+
+function getRoomTerrain(roomName: string): RoomTerrain | null {
+  const map = (globalThis as unknown as { Game?: Partial<Pick<Game, 'map'>> }).Game?.map;
+  if (typeof map?.getRoomTerrain !== 'function') {
+    return null;
+  }
+
+  return map.getRoomTerrain(roomName);
+}
+
+function getTerrainWallMask(): number {
+  const terrainWallMask = (globalThis as unknown as { TERRAIN_MASK_WALL?: number }).TERRAIN_MASK_WALL;
+  return typeof terrainWallMask === 'number' ? terrainWallMask : 1;
 }
 
 function isCloserHarvestSource(creep: Creep, candidate: Source, selected: Source): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1482,6 +1482,42 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
+  it('uses source access capacity before closeness when harvest assignments tie', () => {
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    const tightSource = makeSource('source-tight', 10, 10);
+    const openSource = makeSource('source-open', 20, 20);
+    const openHarvestTiles = new Set(['10,9', '19,20', '20,19', '21,20']);
+    const room = {
+      name: 'W1N1',
+      find: jest.fn().mockReturnValue([tightSource, openSource])
+    } as unknown as Room;
+    const getRangeTo = jest.fn((target: Source) => (target.id === 'source-tight' ? 1 : 8));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        TightHarvester: {
+          memory: { role: 'worker', task: { type: 'harvest', targetId: 'source-tight' as Id<Source> } },
+          room
+        } as unknown as Creep,
+        OpenHarvester: {
+          memory: { role: 'worker', task: { type: 'harvest', targetId: 'source-open' as Id<Source> } },
+          room
+        } as unknown as Creep
+      },
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({
+          get: jest.fn((x: number, y: number) => (openHarvestTiles.has(`${x},${y}`) ? 0 : TERRAIN_MASK_WALL))
+        })
+      } as unknown as GameMap
+    };
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-open' });
+  });
+
   it('avoids depleted harvest sources when another source has energy', () => {
     const depletedSource = { id: 'source-empty', energy: 0 } as Source;
     const viableSource = { id: 'source-full', energy: 300 } as Source;


### PR DESCRIPTION
## Summary
- Improves worker energy source selection for resource throughput after PR #348.
- Keeps tests focused on worker task source choice and regenerates `prod/dist/main.js`.

Linked issue: Closes #349
Roadmap category: Bot capability / resources-economy gameplay

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 497 tests passed)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`
- `git diff --check`

## Scheduler evidence
- Base/main: `a8deeff032fd50d0884ec900c40cd40811d6cc65`
- Commit: `e10f5bb` by `lanyusea's bot <lanyusea@gmail.com>`
- Worktree: `/root/screeps-worktrees/economy-post348-349`
