### PR TITLE
feat: improve tower refill reservations

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3670,7 +3670,19 @@ function selectSpawnOrExtensionEnergySink(creep) {
   );
 }
 function selectPriorityTowerEnergySink(creep) {
-  return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink), creep);
+  const priorityTowerEnergySinks = findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink);
+  if (priorityTowerEnergySinks.length === 0) {
+    return null;
+  }
+  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
+  const assignedTransferTargetId = getAssignedTransferTargetId(creep);
+  return selectClosestEnergySink(
+    priorityTowerEnergySinks.filter(
+      (energySink) => isAssignedTransferTarget(energySink, assignedTransferTargetId) || hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
+    ),
+    creep
+  );
 }
 function hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries) {
   return getReservedEnergyDelivery(energySink, reservedEnergyDeliveries) < getFreeStoredEnergyCapacity(energySink);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -419,11 +419,26 @@ function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | Struct
 }
 
 function selectPriorityTowerEnergySink(creep: Creep): StructureTower | null {
-  return selectClosestEnergySink(findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink), creep);
+  const priorityTowerEnergySinks = findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink);
+  if (priorityTowerEnergySinks.length === 0) {
+    return null;
+  }
+
+  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
+  const assignedTransferTargetId = getAssignedTransferTargetId(creep);
+  return selectClosestEnergySink(
+    priorityTowerEnergySinks.filter(
+      (energySink) =>
+        isAssignedTransferTarget(energySink, assignedTransferTargetId) ||
+        hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
+    ),
+    creep
+  );
 }
 
 function hasUnreservedEnergySinkCapacity(
-  energySink: SpawnExtensionEnergyStructure,
+  energySink: FillableEnergySink,
   reservedEnergyDeliveries: Map<string, number>
 ): boolean {
   return getReservedEnergyDelivery(energySink, reservedEnergyDeliveries) < getFreeStoredEnergyCapacity(energySink);
@@ -452,7 +467,7 @@ function getReservedEnergyDeliveriesBySinkId(
 }
 
 function getReservedEnergyDelivery(
-  energySink: SpawnExtensionEnergyStructure,
+  energySink: FillableEnergySink,
   reservedEnergyDeliveries: Map<string, number>
 ): number {
   return reservedEnergyDeliveries.get(String(energySink.id)) ?? 0;
@@ -464,7 +479,7 @@ function getAssignedTransferTargetId(creep: Creep): string | null {
 }
 
 function isAssignedTransferTarget(
-  energySink: SpawnExtensionEnergyStructure,
+  energySink: FillableEnergySink,
   assignedTransferTargetId: string | null
 ): boolean {
   return assignedTransferTargetId !== null && String(energySink.id) === assignedTransferTargetId;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2276,6 +2276,31 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
   });
 
+  it('spends carried energy productively when another worker covers the low tower refill', () => {
+    const lowTower = makeTowerEnergySink('tower-covered', TOWER_REFILL_ENERGY_FLOOR - 1, 50);
+    const site = { id: 'site1', structureType: 'road' } as ConstructionSite;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      myStructures: [lowTower as AnyOwnedStructure]
+    });
+    const assignedCarrier = {
+      name: 'TowerCarrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'tower-covered' as Id<AnyStoreStructure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo: jest.fn((target: { id: string }) => (target.id === 'site1' ? 1 : 5)) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ TowerCarrier: assignedCarrier, Builder: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
+  });
+
   it.each([
     ['spawn', 'spawn-site1'],
     ['extension', 'extension-site1']


### PR DESCRIPTION
## Summary
- Improves worker energy spending by treating low-priority tower refills as reserved when another assigned worker already covers the tower's remaining capacity.
- Keeps excess carried energy moving to productive construction/upgrade work instead of over-routing multiple workers to an already-covered tower.
- Adds focused worker task coverage and regenerates `prod/dist/main.js`.

Closes #351

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 498 tests passed)
- `cd prod && npm run build`
- `git diff --check`

## Scheduler evidence
- Base/main: `b474a697e2a2c5666308646b427e5ce5d3ea4d76`
- Commit: `dd15a84` by `lanyusea's bot <lanyusea@gmail.com>`
- Worktree: `/root/screeps-worktrees/economy-post350-351`
