### PR TITLE
feat: improve reserved refill fallback throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3991,47 +3991,65 @@ function shouldKeepLowLoadWorkerAcquiringEnergy(creep) {
   return getLowLoadWorkerEnergyContext(creep) !== null && !hasVisibleHostilePresence(creep.room);
 }
 function findLowLoadWorkerEnergyAcquisitionCandidates(creep) {
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
   return [
-    ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep),
-    ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep),
-    ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep),
+    ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationContext),
+    ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationContext),
+    ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep, reservationContext),
     ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
   ];
 }
-function findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep) {
+function findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationContext) {
   const context = {
     creepOwnerUsername: getCreepOwnerUsername2(creep),
     hasHostilePresence: hasVisibleHostilePresence(creep.room),
     room: creep.room
   };
-  return findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).map(
-    (source) => toLowLoadWorkerEnergyAcquisitionCandidate(
-      createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
+  return findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getStoredEnergy2(source),
+      {
         type: "withdraw",
         targetId: source.id
-      })
-    )
-  );
+      },
+      reservationContext
+    );
+    return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
+  });
 }
-function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep) {
-  return [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).map(
-    (source) => toLowLoadWorkerEnergyAcquisitionCandidate(
-      createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
+function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationContext) {
+  return [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getStoredEnergy2(source),
+      {
         type: "withdraw",
         targetId: source.id
-      })
-    )
-  );
+      },
+      reservationContext,
+      MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT
+    );
+    return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
+  });
 }
-function findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep) {
-  return findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).filter((source) => isReachable(creep, source)).map(
-    (source) => toLowLoadWorkerEnergyAcquisitionCandidate(
-      createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
+function findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep, reservationContext) {
+  return findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      source.amount,
+      {
         type: "pickup",
         targetId: source.id
-      })
-    )
-  );
+      },
+      reservationContext,
+      MIN_DROPPED_ENERGY_PICKUP_AMOUNT
+    );
+    return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
+  }).filter((candidate) => isReachable(creep, candidate.source));
 }
 function isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source) {
   const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
@@ -4087,28 +4105,59 @@ function findWorkerEnergyAcquisitionCandidates(creep) {
     hasHostilePresence: hasVisibleHostilePresence(creep.room),
     room: creep.room
   };
-  const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).map(
-    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
-      type: "withdraw",
-      targetId: source.id
-    })
-  );
-  const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).map(
-    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy2(source), {
-      type: "withdraw",
-      targetId: source.id
-    })
-  );
-  const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep);
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+  const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getStoredEnergy2(source),
+      {
+        type: "withdraw",
+        targetId: source.id
+      },
+      reservationContext
+    );
+    return candidate ? [candidate] : [];
+  });
+  const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getStoredEnergy2(source),
+      {
+        type: "withdraw",
+        targetId: source.id
+      },
+      reservationContext,
+      MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT
+    );
+    return candidate ? [candidate] : [];
+  });
+  const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext);
   return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
 }
-function findDroppedEnergyAcquisitionCandidates(creep) {
-  return findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).map(
-    (source) => createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
-      type: "pickup",
-      targetId: source.id
-    })
-  ).sort(compareDroppedEnergyReachabilityPriority).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
+function findDroppedEnergyAcquisitionCandidates(creep, reservationContext) {
+  return findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      source.amount,
+      {
+        type: "pickup",
+        targetId: source.id
+      },
+      reservationContext,
+      MIN_DROPPED_ENERGY_PICKUP_AMOUNT
+    );
+    return candidate ? [candidate] : [];
+  }).sort(compareDroppedEnergyReachabilityPriority).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
+}
+function createUnreservedWorkerEnergyAcquisitionCandidate(creep, source, energy, task, reservationContext, minimumEnergy = 1) {
+  const unreservedEnergy = getUnreservedWorkerEnergyAcquisitionAmount(source, energy, reservationContext);
+  if (unreservedEnergy < minimumEnergy) {
+    return null;
+  }
+  return createWorkerEnergyAcquisitionCandidate(creep, source, unreservedEnergy, task);
 }
 function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
@@ -4119,6 +4168,38 @@ function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
     source,
     task
   };
+}
+function createWorkerEnergyAcquisitionReservationContext(creep) {
+  return {
+    reservedEnergyBySourceId: getReservedWorkerEnergyAcquisitionsBySourceId(creep)
+  };
+}
+function getReservedWorkerEnergyAcquisitionsBySourceId(creep) {
+  var _a, _b;
+  const reservedEnergyBySourceId = /* @__PURE__ */ new Map();
+  for (const worker of getGameCreeps()) {
+    if (isSameCreep(worker, creep) || !isSameRoomWorker(worker, creep.room)) {
+      continue;
+    }
+    const task = (_a = worker.memory) == null ? void 0 : _a.task;
+    if (!isWorkerEnergyAcquisitionReservationTask(task)) {
+      continue;
+    }
+    const freeCapacity = getFreeEnergyCapacity(worker);
+    if (freeCapacity <= 0) {
+      continue;
+    }
+    const sourceId = String(task.targetId);
+    reservedEnergyBySourceId.set(sourceId, ((_b = reservedEnergyBySourceId.get(sourceId)) != null ? _b : 0) + freeCapacity);
+  }
+  return reservedEnergyBySourceId;
+}
+function isWorkerEnergyAcquisitionReservationTask(task) {
+  return ((task == null ? void 0 : task.type) === "pickup" || (task == null ? void 0 : task.type) === "withdraw") && typeof task.targetId === "string" && task.targetId.length > 0;
+}
+function getUnreservedWorkerEnergyAcquisitionAmount(source, energy, reservationContext) {
+  var _a;
+  return Math.max(0, energy - ((_a = reservationContext.reservedEnergyBySourceId.get(String(source.id))) != null ? _a : 0));
 }
 function createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink) {
   if (candidate.range === null) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -916,6 +916,10 @@ interface ProductiveEnergySinkCandidate {
   taskPriority: number;
 }
 
+interface WorkerEnergyAcquisitionReservationContext {
+  reservedEnergyBySourceId: Map<string, number>;
+}
+
 function selectWorkerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitionTask | null {
   const candidates = findWorkerEnergyAcquisitionCandidates(creep);
   if (candidates.length === 0) {
@@ -947,16 +951,19 @@ function shouldKeepLowLoadWorkerAcquiringEnergy(creep: Creep): boolean {
 }
 
 function findLowLoadWorkerEnergyAcquisitionCandidates(creep: Creep): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+
   return [
-    ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep),
-    ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep),
-    ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep),
+    ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationContext),
+    ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationContext),
+    ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep, reservationContext),
     ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
   ];
 }
 
 function findNearbyLowLoadStoredEnergyAcquisitionCandidates(
-  creep: Creep
+  creep: Creep,
+  reservationContext: WorkerEnergyAcquisitionReservationContext
 ): LowLoadWorkerEnergyAcquisitionCandidate[] {
   const context: StoredEnergySourceContext = {
     creepOwnerUsername: getCreepOwnerUsername(creep),
@@ -967,47 +974,69 @@ function findNearbyLowLoadStoredEnergyAcquisitionCandidates(
   return findVisibleRoomStructures(creep.room)
     .filter((structure): structure is StoredWorkerEnergySource => isSafeStoredEnergySource(structure, context))
     .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
-    .map((source) =>
-      toLowLoadWorkerEnergyAcquisitionCandidate(
-        createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        getStoredEnergy(source),
+        {
           type: 'withdraw',
           targetId: source.id as Id<AnyStoreStructure>
-        })
-      )
-    );
+        },
+        reservationContext
+      );
+
+      return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
+    });
 }
 
 function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(
-  creep: Creep
+  creep: Creep,
+  reservationContext: WorkerEnergyAcquisitionReservationContext
 ): LowLoadWorkerEnergyAcquisitionCandidate[] {
   return [...findTombstones(creep.room), ...findRuins(creep.room)]
     .filter(hasSalvageableEnergy)
     .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
-    .map((source) =>
-      toLowLoadWorkerEnergyAcquisitionCandidate(
-        createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        getStoredEnergy(source),
+        {
           type: 'withdraw',
           targetId: source.id as unknown as Id<AnyStoreStructure>
-        })
-      )
-    );
+        },
+        reservationContext,
+        MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT
+      );
+
+      return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
+    });
 }
 
 function findNearbyLowLoadDroppedEnergyAcquisitionCandidates(
-  creep: Creep
+  creep: Creep,
+  reservationContext: WorkerEnergyAcquisitionReservationContext
 ): LowLoadWorkerEnergyAcquisitionCandidate[] {
   return findDroppedResources(creep.room)
     .filter(isUsefulDroppedEnergy)
     .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
-    .filter((source) => isReachable(creep, source))
-    .map((source) =>
-      toLowLoadWorkerEnergyAcquisitionCandidate(
-        createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        source.amount,
+        {
           type: 'pickup',
           targetId: source.id
-        })
-      )
-    );
+        },
+        reservationContext,
+        MIN_DROPPED_ENERGY_PICKUP_AMOUNT
+      );
+
+      return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
+    })
+    .filter((candidate) => isReachable(creep, candidate.source));
 }
 
 function isNearbyLowLoadWorkerEnergyAcquisitionSource(
@@ -1103,39 +1132,85 @@ function findWorkerEnergyAcquisitionCandidates(creep: Creep): WorkerEnergyAcquis
     hasHostilePresence: hasVisibleHostilePresence(creep.room),
     room: creep.room
   };
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
   const storedEnergyCandidates = findVisibleRoomStructures(creep.room)
     .filter((structure): structure is StoredWorkerEnergySource => isSafeStoredEnergySource(structure, context))
-    .map((source) =>
-      createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
-        type: 'withdraw',
-        targetId: source.id as Id<AnyStoreStructure>
-      })
-    );
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        getStoredEnergy(source),
+        {
+          type: 'withdraw',
+          targetId: source.id as Id<AnyStoreStructure>
+        },
+        reservationContext
+      );
+
+      return candidate ? [candidate] : [];
+    });
   const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)]
     .filter(hasSalvageableEnergy)
-    .map((source) =>
-      createWorkerEnergyAcquisitionCandidate(creep, source, getStoredEnergy(source), {
-        type: 'withdraw',
-        targetId: source.id as unknown as Id<AnyStoreStructure>
-      })
-    );
-  const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep);
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        getStoredEnergy(source),
+        {
+          type: 'withdraw',
+          targetId: source.id as unknown as Id<AnyStoreStructure>
+        },
+        reservationContext,
+        MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT
+      );
+
+      return candidate ? [candidate] : [];
+    });
+  const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext);
 
   return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
 }
 
-function findDroppedEnergyAcquisitionCandidates(creep: Creep): WorkerEnergyAcquisitionCandidate[] {
+function findDroppedEnergyAcquisitionCandidates(
+  creep: Creep,
+  reservationContext: WorkerEnergyAcquisitionReservationContext
+): WorkerEnergyAcquisitionCandidate[] {
   return findDroppedResources(creep.room)
     .filter(isUsefulDroppedEnergy)
-    .map((source) =>
-      createWorkerEnergyAcquisitionCandidate(creep, source, source.amount, {
-        type: 'pickup',
-        targetId: source.id
-      })
-    )
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        source.amount,
+        {
+          type: 'pickup',
+          targetId: source.id
+        },
+        reservationContext,
+        MIN_DROPPED_ENERGY_PICKUP_AMOUNT
+      );
+
+      return candidate ? [candidate] : [];
+    })
     .sort(compareDroppedEnergyReachabilityPriority)
     .slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS)
     .filter((candidate) => isReachable(creep, candidate.source));
+}
+
+function createUnreservedWorkerEnergyAcquisitionCandidate(
+  creep: Creep,
+  source: WorkerEnergyAcquisitionSource,
+  energy: number,
+  task: WorkerEnergyAcquisitionTask,
+  reservationContext: WorkerEnergyAcquisitionReservationContext,
+  minimumEnergy = 1
+): WorkerEnergyAcquisitionCandidate | null {
+  const unreservedEnergy = getUnreservedWorkerEnergyAcquisitionAmount(source, energy, reservationContext);
+  if (unreservedEnergy < minimumEnergy) {
+    return null;
+  }
+
+  return createWorkerEnergyAcquisitionCandidate(creep, source, unreservedEnergy, task);
 }
 
 function createWorkerEnergyAcquisitionCandidate(
@@ -1153,6 +1228,54 @@ function createWorkerEnergyAcquisitionCandidate(
     source,
     task
   };
+}
+
+function createWorkerEnergyAcquisitionReservationContext(creep: Creep): WorkerEnergyAcquisitionReservationContext {
+  return {
+    reservedEnergyBySourceId: getReservedWorkerEnergyAcquisitionsBySourceId(creep)
+  };
+}
+
+function getReservedWorkerEnergyAcquisitionsBySourceId(creep: Creep): Map<string, number> {
+  const reservedEnergyBySourceId = new Map<string, number>();
+  for (const worker of getGameCreeps()) {
+    if (isSameCreep(worker, creep) || !isSameRoomWorker(worker, creep.room)) {
+      continue;
+    }
+
+    const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+    if (!isWorkerEnergyAcquisitionReservationTask(task)) {
+      continue;
+    }
+
+    const freeCapacity = getFreeEnergyCapacity(worker);
+    if (freeCapacity <= 0) {
+      continue;
+    }
+
+    const sourceId = String(task.targetId);
+    reservedEnergyBySourceId.set(sourceId, (reservedEnergyBySourceId.get(sourceId) ?? 0) + freeCapacity);
+  }
+
+  return reservedEnergyBySourceId;
+}
+
+function isWorkerEnergyAcquisitionReservationTask(
+  task: Partial<CreepTaskMemory> | undefined
+): task is WorkerEnergyAcquisitionTask {
+  return (
+    (task?.type === 'pickup' || task?.type === 'withdraw') &&
+    typeof task.targetId === 'string' &&
+    task.targetId.length > 0
+  );
+}
+
+function getUnreservedWorkerEnergyAcquisitionAmount(
+  source: WorkerEnergyAcquisitionSource,
+  energy: number,
+  reservationContext: WorkerEnergyAcquisitionReservationContext
+): number {
+  return Math.max(0, energy - (reservationContext.reservedEnergyBySourceId.get(String(source.id)) ?? 0));
 }
 
 function createSpawnRecoveryEnergyAcquisitionCandidate(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1245,6 +1245,124 @@ describe('selectWorkerTask', () => {
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
+  it('skips dropped energy already covered by another worker once refill delivery is reserved', () => {
+    const spawn = makeEnergySink('spawn-covered', 'spawn' as StructureConstant, 50);
+    const coveredDroppedEnergy = {
+      id: 'drop-covered',
+      resourceType: 'energy',
+      amount: 25
+    } as Resource<ResourceConstant>;
+    const openDroppedEnergy = {
+      id: 'drop-open',
+      resourceType: 'energy',
+      amount: 25
+    } as Resource<ResourceConstant>;
+    const source = { id: 'source1' } as Source;
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn as AnyOwnedStructure];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [coveredDroppedEnergy, openDroppedEnergy];
+        }
+
+        if (
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const room = { name: 'W1N1', find: roomFind } as unknown as Room;
+    const refillCarrier = makeLoadedWorker(room, {
+      type: 'transfer',
+      targetId: 'spawn-covered' as Id<AnyStoreStructure>
+    });
+    const assignedPickupWorker = {
+      name: 'AssignedPickupWorker',
+      memory: { role: 'worker', task: { type: 'pickup', targetId: 'drop-covered' as Id<Resource> } },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'drop-covered': 1,
+        'drop-open': 3
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      name: 'Worker',
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ AssignedPickupWorker: assignedPickupWorker, RefillCarrier: refillCarrier, Worker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-open' });
+  });
+
+  it('scores stored energy by unreserved amount when another worker is already withdrawing', () => {
+    const reservedContainer = makeStoredEnergyStructure('container-reserved', 'container' as StructureConstant, 120);
+    const openContainer = makeStoredEnergyStructure('container-open', 'container' as StructureConstant, 75);
+    const source = { id: 'source1' } as Source;
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES || type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [reservedContainer, openContainer];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const room = { name: 'W1N1', controller: { my: true }, find: roomFind } as unknown as Room;
+    const assignedWithdrawWorker = {
+      name: 'AssignedWithdrawWorker',
+      memory: {
+        role: 'worker',
+        task: { type: 'withdraw', targetId: 'container-reserved' as Id<AnyStoreStructure> }
+      },
+      store: { getFreeCapacity: jest.fn().mockReturnValue(100) },
+      room
+    } as unknown as Creep;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'container-open': 1,
+        'container-reserved': 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      name: 'Worker',
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ AssignedWithdrawWorker: assignedWithdrawWorker, Worker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-open' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
   it('uses stable amount and id fallback when range helpers are unavailable', () => {
     const droppedEnergy = { id: 'm-drop', resourceType: 'energy', amount: 100 } as Resource<ResourceConstant>;
     const container = makeStoredEnergyStructure('z-container', 'container' as StructureConstant, 100);


### PR DESCRIPTION
## Summary
- Improves worker fallback throughput when high-priority spawn/extension/tower refills are already reserved.
- Adds reservation-aware scoring/skip behavior to reduce duplicate low-value assignments and keep workers moving toward productive construction/controller work.
- Adds focused Jest coverage and regenerates `prod/dist/main.js`.

Closes #353

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 500 tests passed)
- `cd prod && npm run build`
- `git diff --check`

## Scheduler evidence
- Base/deployed main: `affae238e9f57518e5d4f322582585e32e698c31`
- Commit: `1f5f61a` by `lanyusea's bot <lanyusea@gmail.com>`
- Worktree: `/root/screeps-worktrees/economy-post352-353`
