### PR TITLE
feat: improve territory execution readiness

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1299,7 +1299,12 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
   return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount);
 }
 function requiresTerritoryControllerPressure(plan) {
-  return plan.action === "reserve" && plan.requiresControllerPressure === true;
+  return plan.action === "reserve" && (plan.requiresControllerPressure === true || isVisibleTerritoryReservePressureAvailable(
+    plan.targetRoom,
+    plan.action,
+    plan.controllerId,
+    getVisibleColonyOwnerUsername(plan.colony)
+  ));
 }
 function isTerritoryIntentPlanSpawnCapable(plan) {
   var _a;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -214,7 +214,16 @@ export function shouldSpawnTerritoryControllerCreep(
 }
 
 export function requiresTerritoryControllerPressure(plan: TerritoryIntentPlan): boolean {
-  return plan.action === 'reserve' && plan.requiresControllerPressure === true;
+  return (
+    plan.action === 'reserve' &&
+    (plan.requiresControllerPressure === true ||
+      isVisibleTerritoryReservePressureAvailable(
+        plan.targetRoom,
+        plan.action,
+        plan.controllerId,
+        getVisibleColonyOwnerUsername(plan.colony)
+      ))
+  );
 }
 
 function isTerritoryIntentPlanSpawnCapable(plan: TerritoryIntentPlan): boolean {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -5,6 +5,7 @@ import {
   planTerritoryIntent,
   recordTerritoryReserveFallbackIntent,
   recordRecoveredTerritoryFollowUpRetryCooldown,
+  requiresTerritoryControllerPressure,
   shouldSpawnTerritoryControllerCreep,
   suppressTerritoryIntent,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
@@ -3611,6 +3612,31 @@ describe('planTerritoryIntent', () => {
       )
     ).toBe(false);
     expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('infers visible foreign reservation pressure before spawning stale reserve intents', () => {
+    const colony = makeSafeColony();
+    const stalePlan = { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' } as const;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController
+        })
+      }
+    };
+
+    expect(requiresTerritoryControllerPressure(stalePlan)).toBe(true);
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        stalePlan,
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+        542
+      )
+    ).toBe(false);
   });
 
   it('does not renew an explicitly suppressed own reserve target near expiry', () => {


### PR DESCRIPTION
## Summary
- Improves territory/control execution readiness after PR #343.
- Adds territory planner coverage for the new behavior.
- Regenerates `prod/dist/main.js`.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (22 suites / 523 tests)
- `cd prod && npm run build`

Closes #355
