### PR TITLE
feat: continue safe controller progress

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1207,6 +1207,7 @@ var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 
 var TERRITORY_SUPPRESSION_RETRY_TICKS2 = 1500;
 var TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS2 = 50;
 var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
+var TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 1;
 var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
 var ERR_NO_PATH_CODE = -2;
@@ -1225,7 +1226,7 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
   }
-  const selection = selectTerritoryTarget(colony, roleCounts, gameTime);
+  const selection = selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime);
   if (!selection) {
     return null;
   }
@@ -1564,7 +1565,7 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   }
   return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
 }
-function selectTerritoryTarget(colony, roleCounts, gameTime) {
+function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
   var _a, _b, _c;
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
@@ -1601,6 +1602,7 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
   const configuredCandidates = applyOccupationRecommendationScores(
     colony,
     roleCounts,
+    workerTarget,
     getConfiguredTerritoryCandidates(
       colonyName,
       colonyOwnerUsername,
@@ -1627,36 +1629,54 @@ function selectTerritoryTarget(colony, roleCounts, gameTime) {
     getReadyTerritoryCandidates(primaryCandidates, roleCounts, colony)
   );
   if (bestReadyPrimaryCandidate && bestReadyPrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY) {
-    if (!shouldEvaluateVisibleAdjacentFollowUpPreference(bestReadyPrimaryCandidate)) {
-      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
-    }
-    const visibleAdjacentFollowUpCandidates = applyOccupationRecommendationScores(
+    const shouldEvaluateAdjacentControllerProgress = shouldEvaluateVisibleAdjacentControllerProgressPreference(
+      bestReadyPrimaryCandidate,
       colony,
       roleCounts,
-      getVisibleAdjacentFollowUpReserveCandidates(
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        roleCounts,
-        routeDistanceLookupContext
-      )
+      workerTarget
     );
-    if (visibleAdjacentFollowUpCandidates.length === 0) {
+    const shouldEvaluateAdjacentFollowUp = shouldEvaluateVisibleAdjacentFollowUpPreference(bestReadyPrimaryCandidate);
+    if (!shouldEvaluateAdjacentControllerProgress && !shouldEvaluateAdjacentFollowUp) {
+      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
+    }
+    const visibleAdjacentControllerProgressCandidates = applyOccupationRecommendationScores(
+      colony,
+      roleCounts,
+      workerTarget,
+      [
+        ...shouldEvaluateAdjacentControllerProgress ? getVisibleAdjacentReserveCandidates(
+          colonyName,
+          colonyOwnerUsername,
+          territoryMemory,
+          intents,
+          gameTime,
+          routeDistanceLookupContext
+        ) : [],
+        ...shouldEvaluateAdjacentFollowUp ? getVisibleAdjacentFollowUpReserveCandidates(
+          colonyName,
+          colonyOwnerUsername,
+          territoryMemory,
+          intents,
+          gameTime,
+          roleCounts,
+          routeDistanceLookupContext
+        ) : []
+      ]
+    );
+    if (visibleAdjacentControllerProgressCandidates.length === 0) {
       return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
     }
     return toSelectedTerritoryTarget(
       (_a = selectBestScoredTerritoryCandidate(
         getReadyTerritoryCandidates(
-          [...primaryCandidates, ...visibleAdjacentFollowUpCandidates],
+          [...primaryCandidates, ...visibleAdjacentControllerProgressCandidates],
           roleCounts,
           colony
         )
       )) != null ? _a : bestReadyPrimaryCandidate
     );
   }
-  const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, [
+  const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, workerTarget, [
     ...getAdjacentReserveCandidates(
       colonyName,
       colonyName,
@@ -1705,8 +1725,14 @@ function toSelectedTerritoryTarget(candidate) {
     ...typeof candidate.recoveredFollowUpSuppressedAt === "number" ? { recoveredFollowUpSuppressedAt: candidate.recoveredFollowUpSuppressedAt } : {}
   } : null;
 }
+function shouldEvaluateVisibleAdjacentControllerProgressPreference(candidate, colony, roleCounts, workerTarget) {
+  return candidate.priority === TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE && candidate.target.action === "reserve" && isPrimaryTerritoryCandidateSource(candidate.source) && typeof candidate.routeDistance === "number" && candidate.routeDistance > 1 && isTerritoryHomeReadyForAdjacentControllerProgress(colony, roleCounts, workerTarget);
+}
 function shouldEvaluateVisibleAdjacentFollowUpPreference(candidate) {
   return candidate.priority === TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE && candidate.target.action === "reserve";
+}
+function isTerritoryHomeReadyForAdjacentControllerProgress(colony, roleCounts, workerTarget) {
+  return getWorkerCapacity(roleCounts) >= workerTarget + TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS && colony.energyAvailable >= TERRITORY_CONTROLLER_BODY_COST && colony.energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST && colony.spawns.some((spawn) => spawn.spawning == null);
 }
 function getReadyTerritoryCandidates(candidates, roleCounts, colony) {
   return withImmediateControllerFollowUpState(candidates, roleCounts).filter(
@@ -1974,6 +2000,20 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
     return [];
   });
 }
+function getVisibleAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
+  return getAdjacentReserveCandidates(
+    colonyName,
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    false,
+    "adjacent",
+    0,
+    routeDistanceLookupContext
+  );
+}
 function getVisibleAdjacentFollowUpReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, roleCounts, routeDistanceLookupContext) {
   return getAdjacentFollowUpReserveCandidates(
     colonyName,
@@ -2125,10 +2165,11 @@ function getSatisfiedConfiguredTargets(colonyName, colonyOwnerUsername, territor
   });
 }
 function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwnerUsername, routeDistanceLookupContext) {
-  const routeDistance = getKnownRouteLength(colonyName, selection.target.roomName, routeDistanceLookupContext);
-  if (routeDistance === null) {
+  const knownRouteDistance = getKnownRouteLength(colonyName, selection.target.roomName, routeDistanceLookupContext);
+  if (knownRouteDistance === null) {
     return null;
   }
+  const routeDistance = knownRouteDistance != null ? knownRouteDistance : getInferredTerritoryRouteDistance(source);
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
   const occupationActionableTicks = source === "occupationIntent" ? getOccupationIntentActionableTicks(selection, colonyOwnerUsername) : void 0;
   const requiresControllerPressure = selection.requiresControllerPressure === true || isVisibleTerritoryReservePressureAvailable(
@@ -2148,9 +2189,17 @@ function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwn
     ...occupationActionableTicks !== void 0 ? { occupationActionableTicks } : {}
   };
 }
-function applyOccupationRecommendationScores(colony, roleCounts, candidates) {
+function getInferredTerritoryRouteDistance(source) {
+  return source === "adjacent" ? 1 : void 0;
+}
+function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, candidates) {
   var _a;
   const colonyOwnerUsername = (_a = getControllerOwnerUsername2(colony.room.controller)) != null ? _a : void 0;
+  const adjacentControllerProgressReady = isTerritoryHomeReadyForAdjacentControllerProgress(
+    colony,
+    roleCounts,
+    workerTarget
+  );
   return candidates.flatMap((candidate) => {
     var _a2, _b;
     const recommendation = scoreOccupationRecommendations({
@@ -2165,10 +2214,17 @@ function applyOccupationRecommendationScores(colony, roleCounts, candidates) {
     if (!recommendation || recommendation.evidenceStatus === "unavailable") {
       return [];
     }
-    return [applyOccupationRecommendationScore(candidate, recommendation, roleCounts)];
+    return [
+      applyOccupationRecommendationScore(
+        candidate,
+        recommendation,
+        roleCounts,
+        adjacentControllerProgressReady
+      )
+    ];
   });
 }
-function applyOccupationRecommendationScore(candidate, recommendation, roleCounts) {
+function applyOccupationRecommendationScore(candidate, recommendation, roleCounts, adjacentControllerProgressReady) {
   var _a;
   const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
   const requiresControllerPressure = intentAction === "reserve" && candidate.requiresControllerPressure === true;
@@ -2181,6 +2237,12 @@ function applyOccupationRecommendationScore(candidate, recommendation, roleCount
   };
   const renewalTicksToEnd = intentAction === "reserve" ? (_a = candidate.renewalTicksToEnd) != null ? _a : null : null;
   const { requiresControllerPressure: _requiresControllerPressure, ...candidateWithoutPressure } = candidate;
+  const safeAdjacentControllerProgress = isSafeAdjacentControllerProgressCandidate(
+    candidate,
+    recommendation,
+    intentAction,
+    adjacentControllerProgressReady
+  );
   return {
     ...candidateWithoutPressure,
     intentAction,
@@ -2189,8 +2251,12 @@ function applyOccupationRecommendationScore(candidate, recommendation, roleCount
     recommendationScore: recommendation.score,
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
+    ...safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {},
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
   };
+}
+function isSafeAdjacentControllerProgressCandidate(candidate, recommendation, intentAction, adjacentControllerProgressReady) {
+  return adjacentControllerProgressReady && candidate.source === "adjacent" && candidate.target.action === "reserve" && intentAction === "reserve" && candidate.commitTarget === true && candidate.routeDistance === 1 && recommendation.evidenceStatus === "sufficient" && isTerritoryTargetVisible(candidate.target);
 }
 function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts) {
   if (recommendation.evidenceStatus === "insufficient-evidence") {
@@ -2309,7 +2375,7 @@ function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
 }
 function compareTerritoryCandidates(left, right) {
-  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || compareImmediateControllerFollowUpPreference(left, right) || comparePersistedControllerFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || compareRecoveredFollowUpPreference(left, right) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+  return left.priority - right.priority || compareOptionalNumbers2(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || compareSafeAdjacentControllerProgressPreference(left, right) || compareImmediateControllerFollowUpPreference(left, right) || comparePersistedControllerFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers2(left.occupationActionableTicks, right.occupationActionableTicks) || compareRecoveredFollowUpPreference(left, right) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
 }
 function compareImmediateControllerFollowUpPreference(left, right) {
   const leftImmediate = left.immediateControllerFollowUp === true;
@@ -2341,6 +2407,15 @@ function compareVisibleAdjacentFollowUpPreference(left, right) {
     return -1;
   }
   return shouldPreferVisibleAdjacentFollowUp(right, left) ? 1 : 0;
+}
+function compareSafeAdjacentControllerProgressPreference(left, right) {
+  if (shouldPreferSafeAdjacentControllerProgress(left, right)) {
+    return -1;
+  }
+  return shouldPreferSafeAdjacentControllerProgress(right, left) ? 1 : 0;
+}
+function shouldPreferSafeAdjacentControllerProgress(candidate, other) {
+  return candidate.safeAdjacentControllerProgress === true && isLowerConfidenceDistantSameActionCandidate(other, candidate);
 }
 function shouldPreferVisibleAdjacentFollowUp(candidate, other) {
   return isVisibleAdjacentControllerFollowUpCandidate(candidate) && isLowerConfidenceDistantSameActionCandidate(other, candidate);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -23,6 +23,7 @@ export const TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL
 export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 export const TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 export const TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
+export const TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 1;
 
 const EXIT_DIRECTION_ORDER: ExitKey[] = ['1', '3', '5', '7'];
 const MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
@@ -80,6 +81,7 @@ interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   renewalTicksToEnd?: number;
   immediateControllerFollowUp?: boolean;
   occupationActionableTicks?: number;
+  safeAdjacentControllerProgress?: boolean;
 }
 
 type TerritoryTargetVisibilityState = 'available' | 'satisfied' | 'unavailable';
@@ -115,7 +117,7 @@ export function planTerritoryIntent(
     return null;
   }
 
-  const selection = selectTerritoryTarget(colony, roleCounts, gameTime);
+  const selection = selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime);
   if (!selection) {
     return null;
   }
@@ -599,6 +601,7 @@ export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCoun
 function selectTerritoryTarget(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
+  workerTarget: number,
   gameTime: number
 ): SelectedTerritoryTarget | null {
   const colonyName = colony.room.name;
@@ -636,6 +639,7 @@ function selectTerritoryTarget(
   const configuredCandidates = applyOccupationRecommendationScores(
     colony,
     roleCounts,
+    workerTarget,
     getConfiguredTerritoryCandidates(
       colonyName,
       colonyOwnerUsername,
@@ -665,31 +669,53 @@ function selectTerritoryTarget(
     bestReadyPrimaryCandidate &&
     bestReadyPrimaryCandidate.priority <= MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY
   ) {
-    if (!shouldEvaluateVisibleAdjacentFollowUpPreference(bestReadyPrimaryCandidate)) {
+    const shouldEvaluateAdjacentControllerProgress = shouldEvaluateVisibleAdjacentControllerProgressPreference(
+      bestReadyPrimaryCandidate,
+      colony,
+      roleCounts,
+      workerTarget
+    );
+    const shouldEvaluateAdjacentFollowUp = shouldEvaluateVisibleAdjacentFollowUpPreference(bestReadyPrimaryCandidate);
+    if (!shouldEvaluateAdjacentControllerProgress && !shouldEvaluateAdjacentFollowUp) {
       return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
     }
 
-    const visibleAdjacentFollowUpCandidates = applyOccupationRecommendationScores(
+    const visibleAdjacentControllerProgressCandidates = applyOccupationRecommendationScores(
       colony,
       roleCounts,
-      getVisibleAdjacentFollowUpReserveCandidates(
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        roleCounts,
-        routeDistanceLookupContext
-      )
+      workerTarget,
+      [
+        ...(shouldEvaluateAdjacentControllerProgress
+          ? getVisibleAdjacentReserveCandidates(
+              colonyName,
+              colonyOwnerUsername,
+              territoryMemory,
+              intents,
+              gameTime,
+              routeDistanceLookupContext
+            )
+          : []),
+        ...(shouldEvaluateAdjacentFollowUp
+          ? getVisibleAdjacentFollowUpReserveCandidates(
+              colonyName,
+              colonyOwnerUsername,
+              territoryMemory,
+              intents,
+              gameTime,
+              roleCounts,
+              routeDistanceLookupContext
+            )
+          : [])
+      ]
     );
-    if (visibleAdjacentFollowUpCandidates.length === 0) {
+    if (visibleAdjacentControllerProgressCandidates.length === 0) {
       return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
     }
 
     return toSelectedTerritoryTarget(
       selectBestScoredTerritoryCandidate(
         getReadyTerritoryCandidates(
-          [...primaryCandidates, ...visibleAdjacentFollowUpCandidates],
+          [...primaryCandidates, ...visibleAdjacentControllerProgressCandidates],
           roleCounts,
           colony
         )
@@ -697,7 +723,7 @@ function selectTerritoryTarget(
     );
   }
 
-  const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, [
+  const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, workerTarget, [
     ...getAdjacentReserveCandidates(
       colonyName,
       colonyName,
@@ -757,8 +783,37 @@ function toSelectedTerritoryTarget(candidate: ScoredTerritoryTarget | null): Sel
     : null;
 }
 
+function shouldEvaluateVisibleAdjacentControllerProgressPreference(
+  candidate: ScoredTerritoryTarget,
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  workerTarget: number
+): boolean {
+  return (
+    candidate.priority === TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE &&
+    candidate.target.action === 'reserve' &&
+    isPrimaryTerritoryCandidateSource(candidate.source) &&
+    typeof candidate.routeDistance === 'number' &&
+    candidate.routeDistance > 1 &&
+    isTerritoryHomeReadyForAdjacentControllerProgress(colony, roleCounts, workerTarget)
+  );
+}
+
 function shouldEvaluateVisibleAdjacentFollowUpPreference(candidate: ScoredTerritoryTarget): boolean {
   return candidate.priority === TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE && candidate.target.action === 'reserve';
+}
+
+function isTerritoryHomeReadyForAdjacentControllerProgress(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  workerTarget: number
+): boolean {
+  return (
+    getWorkerCapacity(roleCounts) >= workerTarget + TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS &&
+    colony.energyAvailable >= TERRITORY_CONTROLLER_BODY_COST &&
+    colony.energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST &&
+    colony.spawns.some((spawn) => spawn.spawning == null)
+  );
 }
 
 function getReadyTerritoryCandidates(
@@ -1206,6 +1261,28 @@ function getAdjacentReserveCandidates(
   });
 }
 
+function getVisibleAdjacentReserveCandidates(
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  gameTime: number,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): ScoredTerritoryTarget[] {
+  return getAdjacentReserveCandidates(
+    colonyName,
+    colonyName,
+    colonyOwnerUsername,
+    territoryMemory,
+    intents,
+    gameTime,
+    false,
+    'adjacent',
+    0,
+    routeDistanceLookupContext
+  );
+}
+
 function getVisibleAdjacentFollowUpReserveCandidates(
   colonyName: string,
   colonyOwnerUsername: string | null,
@@ -1463,10 +1540,11 @@ function scoreTerritoryCandidate(
   colonyOwnerUsername: string | null,
   routeDistanceLookupContext: RouteDistanceLookupContext
 ): ScoredTerritoryTarget | null {
-  const routeDistance = getKnownRouteLength(colonyName, selection.target.roomName, routeDistanceLookupContext);
-  if (routeDistance === null) {
+  const knownRouteDistance = getKnownRouteLength(colonyName, selection.target.roomName, routeDistanceLookupContext);
+  if (knownRouteDistance === null) {
     return null;
   }
+  const routeDistance = knownRouteDistance ?? getInferredTerritoryRouteDistance(source);
 
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
   const occupationActionableTicks =
@@ -1493,12 +1571,22 @@ function scoreTerritoryCandidate(
   };
 }
 
+function getInferredTerritoryRouteDistance(source: TerritoryCandidateSource): number | undefined {
+  return source === 'adjacent' ? 1 : undefined;
+}
+
 function applyOccupationRecommendationScores(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
+  workerTarget: number,
   candidates: ScoredTerritoryTarget[]
 ): ScoredTerritoryTarget[] {
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller) ?? undefined;
+  const adjacentControllerProgressReady = isTerritoryHomeReadyForAdjacentControllerProgress(
+    colony,
+    roleCounts,
+    workerTarget
+  );
   return candidates.flatMap((candidate) => {
     const recommendation = scoreOccupationRecommendations({
       colonyName: colony.room.name,
@@ -1516,14 +1604,22 @@ function applyOccupationRecommendationScores(
       return [];
     }
 
-    return [applyOccupationRecommendationScore(candidate, recommendation, roleCounts)];
+    return [
+      applyOccupationRecommendationScore(
+        candidate,
+        recommendation,
+        roleCounts,
+        adjacentControllerProgressReady
+      )
+    ];
   });
 }
 
 function applyOccupationRecommendationScore(
   candidate: ScoredTerritoryTarget,
   recommendation: OccupationRecommendationScore,
-  roleCounts: RoleCounts
+  roleCounts: RoleCounts,
+  adjacentControllerProgressReady: boolean
 ): ScoredTerritoryTarget {
   const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
   const requiresControllerPressure = intentAction === 'reserve' && candidate.requiresControllerPressure === true;
@@ -1536,6 +1632,12 @@ function applyOccupationRecommendationScore(
   };
   const renewalTicksToEnd = intentAction === 'reserve' ? candidate.renewalTicksToEnd ?? null : null;
   const { requiresControllerPressure: _requiresControllerPressure, ...candidateWithoutPressure } = candidate;
+  const safeAdjacentControllerProgress = isSafeAdjacentControllerProgressCandidate(
+    candidate,
+    recommendation,
+    intentAction,
+    adjacentControllerProgressReady
+  );
 
   return {
     ...candidateWithoutPressure,
@@ -1545,8 +1647,27 @@ function applyOccupationRecommendationScore(
     recommendationScore: recommendation.score,
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
+    ...(safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {}),
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
   };
+}
+
+function isSafeAdjacentControllerProgressCandidate(
+  candidate: ScoredTerritoryTarget,
+  recommendation: OccupationRecommendationScore,
+  intentAction: TerritoryIntentAction,
+  adjacentControllerProgressReady: boolean
+): boolean {
+  return (
+    adjacentControllerProgressReady &&
+    candidate.source === 'adjacent' &&
+    candidate.target.action === 'reserve' &&
+    intentAction === 'reserve' &&
+    candidate.commitTarget === true &&
+    candidate.routeDistance === 1 &&
+    recommendation.evidenceStatus === 'sufficient' &&
+    isTerritoryTargetVisible(candidate.target)
+  );
 }
 
 function getRecommendedTerritoryIntentAction(
@@ -1723,6 +1844,7 @@ function compareTerritoryCandidates(left: ScoredTerritoryTarget, right: ScoredTe
     left.priority - right.priority ||
     compareOptionalNumbers(left.renewalTicksToEnd, right.renewalTicksToEnd) ||
     compareVisibleAdjacentFollowUpPreference(left, right) ||
+    compareSafeAdjacentControllerProgressPreference(left, right) ||
     compareImmediateControllerFollowUpPreference(left, right) ||
     comparePersistedControllerFollowUpPreference(left, right) ||
     getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) ||
@@ -1786,6 +1908,27 @@ function compareVisibleAdjacentFollowUpPreference(
   }
 
   return shouldPreferVisibleAdjacentFollowUp(right, left) ? 1 : 0;
+}
+
+function compareSafeAdjacentControllerProgressPreference(
+  left: ScoredTerritoryTarget,
+  right: ScoredTerritoryTarget
+): number {
+  if (shouldPreferSafeAdjacentControllerProgress(left, right)) {
+    return -1;
+  }
+
+  return shouldPreferSafeAdjacentControllerProgress(right, left) ? 1 : 0;
+}
+
+function shouldPreferSafeAdjacentControllerProgress(
+  candidate: ScoredTerritoryTarget,
+  other: ScoredTerritoryTarget
+): boolean {
+  return (
+    candidate.safeAdjacentControllerProgress === true &&
+    isLowerConfidenceDistantSameActionCandidate(other, candidate)
+  );
 }
 
 function shouldPreferVisibleAdjacentFollowUp(

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -69,11 +69,17 @@ describe('planSpawn', () => {
     return { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController;
   }
 
-  function makeTerritoryRoom(roomName: string, controller: StructureController): Room {
+  function makeTerritoryRoom(roomName: string, controller: StructureController, sourceCount = 0): Room {
     return {
       name: roomName,
       controller,
-      find: jest.fn().mockReturnValue([])
+      find: jest.fn((type: number) => {
+        if (type === FIND_SOURCES) {
+          return Array.from({ length: sourceCount }, (_, index) => ({ id: `${roomName}-source${index}` }));
+        }
+
+        return [];
+      })
     } as unknown as Room;
   }
 
@@ -1267,6 +1273,79 @@ describe('planSpawn', () => {
         status: 'planned',
         updatedAt: 150
       }
+    ]);
+  });
+
+  it('keeps a farther configured reserve before adjacent progress at the baseline worker floor', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    const describeExits = jest.fn(() => ({ '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W4N1: makeTerritoryRoom('W4N1', { my: false } as StructureController, 1),
+        W2N1: makeTerritoryRoom('W2N1', { my: false } as StructureController, 2)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W4N1', action: 'reserve' }],
+        routeDistances: { 'W1N1>W4N1': 3 }
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 160)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W4N1-160',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W4N1', action: 'reserve' }
+      }
+    });
+    expect(describeExits).not.toHaveBeenCalled();
+    expect(Memory.territory?.targets).toEqual([{ colony: 'W1N1', roomName: 'W4N1', action: 'reserve' }]);
+  });
+
+  it('prefers safe visible adjacent reserve progress over a farther configured reserve with worker surplus', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    const describeExits = jest.fn(() => ({ '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap,
+      rooms: {
+        W4N1: makeTerritoryRoom('W4N1', { my: false } as StructureController, 1),
+        W2N1: makeTerritoryRoom('W2N1', { my: false } as StructureController, 2)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W4N1', action: 'reserve' }],
+        routeDistances: { 'W1N1>W4N1': 3 }
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 4, claimer: 0, claimersByTargetRoom: {} }, 161)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N1-161',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve' }
+      }
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.targets).toEqual([
+      { colony: 'W1N1', roomName: 'W4N1', action: 'reserve' },
+      { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }
     ]);
   });
 


### PR DESCRIPTION
## Summary
- continues safe controller progress after the post-PR358 deploy by tightening territory planner controller-pressure selection
- adds spawn-planner coverage for controller-progress intent under the new safe-progress heuristics
- refreshes `prod/dist/main.js` from `npm run build`

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm test -- --runInBand` (22 suites / 527 tests)
- `npm run build`

Closes #365
