### PR TITLE
feat: prefer recovery refill capacity for loaded workers

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4240,9 +4240,7 @@ function selectSpawnOrExtensionEnergySink(creep) {
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   const unreservedEnergySink = selectSpawnExtensionRecoveryEnergySink(
-    energySinks.filter(
-      (energySink) => isAssignedTransferTarget(energySink, assignedTransferTargetId) || hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
-    ),
+    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)),
     creep,
     reservedEnergyDeliveries,
     assignedTransferTargetId
@@ -4265,17 +4263,9 @@ function selectSpawnExtensionRecoveryEnergySink(energySinks, creep, reservedEner
 }
 function compareSpawnExtensionRecoveryEnergySinks(left, right, creep, reservedEnergyDeliveries, assignedTransferTargetId) {
   const carriedEnergy = getUsedEnergy(creep);
-  const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(
-    left,
-    reservedEnergyDeliveries,
-    assignedTransferTargetId
-  );
-  const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(
-    right,
-    reservedEnergyDeliveries,
-    assignedTransferTargetId
-  );
-  return compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareEnergySinkId(left, right);
+  const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(left, reservedEnergyDeliveries);
+  const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(right, reservedEnergyDeliveries);
+  return compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareAssignedTransferTarget(left, right, assignedTransferTargetId) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareEnergySinkId(left, right);
 }
 function compareAcceptedDeliveryEnergy(leftCapacity, rightCapacity, carriedEnergy) {
   if (carriedEnergy <= 0) {
@@ -4285,14 +4275,19 @@ function compareAcceptedDeliveryEnergy(leftCapacity, rightCapacity, carriedEnerg
   const rightAcceptedEnergy = Math.min(rightCapacity, carriedEnergy);
   return rightAcceptedEnergy - leftAcceptedEnergy;
 }
-function getUnreservedEnergySinkDeliveryCapacity(energySink, reservedEnergyDeliveries, assignedTransferTargetId) {
-  if (isAssignedTransferTarget(energySink, assignedTransferTargetId)) {
-    return getFreeStoredEnergyCapacity(energySink);
-  }
+function getUnreservedEnergySinkDeliveryCapacity(energySink, reservedEnergyDeliveries) {
   return Math.max(
     0,
     getFreeStoredEnergyCapacity(energySink) - getReservedEnergyDelivery(energySink, reservedEnergyDeliveries)
   );
+}
+function compareAssignedTransferTarget(left, right, assignedTransferTargetId) {
+  const leftAssigned = isAssignedTransferTarget(left, assignedTransferTargetId);
+  const rightAssigned = isAssignedTransferTarget(right, assignedTransferTargetId);
+  if (leftAssigned === rightAssigned) {
+    return 0;
+  }
+  return leftAssigned ? -1 : 1;
 }
 function selectPriorityTowerEnergySink(creep) {
   const priorityTowerEnergySinks = findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink);
@@ -4301,10 +4296,9 @@ function selectPriorityTowerEnergySink(creep) {
   }
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
-  const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   return selectClosestEnergySink(
     priorityTowerEnergySinks.filter(
-      (energySink) => isAssignedTransferTarget(energySink, assignedTransferTargetId) || hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
+      (energySink) => hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
     ),
     creep
   );

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3965,13 +3965,60 @@ function selectSpawnOrExtensionEnergySink(creep) {
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   const assignedTransferTargetId = getAssignedTransferTargetId(creep);
-  const unreservedEnergySink = selectClosestEnergySink(
+  const unreservedEnergySink = selectSpawnExtensionRecoveryEnergySink(
     energySinks.filter(
       (energySink) => isAssignedTransferTarget(energySink, assignedTransferTargetId) || hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
     ),
-    creep
+    creep,
+    reservedEnergyDeliveries,
+    assignedTransferTargetId
   );
   return unreservedEnergySink != null ? unreservedEnergySink : selectCloserReservedEnergySinkFallback(energySinks, creep, loadedWorkers, reservedEnergyDeliveries);
+}
+function selectSpawnExtensionRecoveryEnergySink(energySinks, creep, reservedEnergyDeliveries, assignedTransferTargetId) {
+  if (energySinks.length === 0) {
+    return null;
+  }
+  return [...energySinks].sort(
+    (left, right) => compareSpawnExtensionRecoveryEnergySinks(
+      left,
+      right,
+      creep,
+      reservedEnergyDeliveries,
+      assignedTransferTargetId
+    )
+  )[0];
+}
+function compareSpawnExtensionRecoveryEnergySinks(left, right, creep, reservedEnergyDeliveries, assignedTransferTargetId) {
+  const carriedEnergy = getUsedEnergy(creep);
+  const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(
+    left,
+    reservedEnergyDeliveries,
+    assignedTransferTargetId
+  );
+  const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(
+    right,
+    reservedEnergyDeliveries,
+    assignedTransferTargetId
+  );
+  return compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareEnergySinkId(left, right);
+}
+function compareAcceptedDeliveryEnergy(leftCapacity, rightCapacity, carriedEnergy) {
+  if (carriedEnergy <= 0) {
+    return 0;
+  }
+  const leftAcceptedEnergy = Math.min(leftCapacity, carriedEnergy);
+  const rightAcceptedEnergy = Math.min(rightCapacity, carriedEnergy);
+  return rightAcceptedEnergy - leftAcceptedEnergy;
+}
+function getUnreservedEnergySinkDeliveryCapacity(energySink, reservedEnergyDeliveries, assignedTransferTargetId) {
+  if (isAssignedTransferTarget(energySink, assignedTransferTargetId)) {
+    return getFreeStoredEnergyCapacity(energySink);
+  }
+  return Math.max(
+    0,
+    getFreeStoredEnergyCapacity(energySink) - getReservedEnergyDelivery(energySink, reservedEnergyDeliveries)
+  );
 }
 function selectPriorityTowerEnergySink(creep) {
   const priorityTowerEnergySinks = findFillableEnergySinks(creep).filter(isPriorityTowerEnergySink);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -408,17 +408,91 @@ function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | Struct
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   const assignedTransferTargetId = getAssignedTransferTargetId(creep);
-  const unreservedEnergySink = selectClosestEnergySink(
+  const unreservedEnergySink = selectSpawnExtensionRecoveryEnergySink(
     energySinks.filter(
       (energySink) =>
         isAssignedTransferTarget(energySink, assignedTransferTargetId) ||
         hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
     ),
-    creep
+    creep,
+    reservedEnergyDeliveries,
+    assignedTransferTargetId
   );
   return (
     unreservedEnergySink ??
     selectCloserReservedEnergySinkFallback(energySinks, creep, loadedWorkers, reservedEnergyDeliveries)
+  );
+}
+
+function selectSpawnExtensionRecoveryEnergySink<T extends StructureSpawn | StructureExtension>(
+  energySinks: T[],
+  creep: Creep,
+  reservedEnergyDeliveries: Map<string, number>,
+  assignedTransferTargetId: string | null
+): T | null {
+  if (energySinks.length === 0) {
+    return null;
+  }
+
+  return [...energySinks].sort((left, right) =>
+    compareSpawnExtensionRecoveryEnergySinks(
+      left,
+      right,
+      creep,
+      reservedEnergyDeliveries,
+      assignedTransferTargetId
+    )
+  )[0];
+}
+
+function compareSpawnExtensionRecoveryEnergySinks(
+  left: StructureSpawn | StructureExtension,
+  right: StructureSpawn | StructureExtension,
+  creep: Creep,
+  reservedEnergyDeliveries: Map<string, number>,
+  assignedTransferTargetId: string | null
+): number {
+  const carriedEnergy = getUsedEnergy(creep);
+  const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(
+    left,
+    reservedEnergyDeliveries,
+    assignedTransferTargetId
+  );
+  const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(
+    right,
+    reservedEnergyDeliveries,
+    assignedTransferTargetId
+  );
+
+  return (
+    compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) ||
+    compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) ||
+    compareEnergySinkId(left, right)
+  );
+}
+
+function compareAcceptedDeliveryEnergy(leftCapacity: number, rightCapacity: number, carriedEnergy: number): number {
+  if (carriedEnergy <= 0) {
+    return 0;
+  }
+
+  const leftAcceptedEnergy = Math.min(leftCapacity, carriedEnergy);
+  const rightAcceptedEnergy = Math.min(rightCapacity, carriedEnergy);
+  return rightAcceptedEnergy - leftAcceptedEnergy;
+}
+
+function getUnreservedEnergySinkDeliveryCapacity(
+  energySink: FillableEnergySink,
+  reservedEnergyDeliveries: Map<string, number>,
+  assignedTransferTargetId: string | null
+): number {
+  if (isAssignedTransferTarget(energySink, assignedTransferTargetId)) {
+    return getFreeStoredEnergyCapacity(energySink);
+  }
+
+  return Math.max(
+    0,
+    getFreeStoredEnergyCapacity(energySink) - getReservedEnergyDelivery(energySink, reservedEnergyDeliveries)
   );
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -524,11 +524,7 @@ function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | Struct
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   const unreservedEnergySink = selectSpawnExtensionRecoveryEnergySink(
-    energySinks.filter(
-      (energySink) =>
-        isAssignedTransferTarget(energySink, assignedTransferTargetId) ||
-        hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
-    ),
+    energySinks.filter((energySink) => hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)),
     creep,
     reservedEnergyDeliveries,
     assignedTransferTargetId
@@ -568,19 +564,12 @@ function compareSpawnExtensionRecoveryEnergySinks(
   assignedTransferTargetId: string | null
 ): number {
   const carriedEnergy = getUsedEnergy(creep);
-  const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(
-    left,
-    reservedEnergyDeliveries,
-    assignedTransferTargetId
-  );
-  const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(
-    right,
-    reservedEnergyDeliveries,
-    assignedTransferTargetId
-  );
+  const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(left, reservedEnergyDeliveries);
+  const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(right, reservedEnergyDeliveries);
 
   return (
     compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) ||
+    compareAssignedTransferTarget(left, right, assignedTransferTargetId) ||
     compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) ||
     compareEnergySinkId(left, right)
   );
@@ -598,17 +587,26 @@ function compareAcceptedDeliveryEnergy(leftCapacity: number, rightCapacity: numb
 
 function getUnreservedEnergySinkDeliveryCapacity(
   energySink: FillableEnergySink,
-  reservedEnergyDeliveries: Map<string, number>,
-  assignedTransferTargetId: string | null
+  reservedEnergyDeliveries: Map<string, number>
 ): number {
-  if (isAssignedTransferTarget(energySink, assignedTransferTargetId)) {
-    return getFreeStoredEnergyCapacity(energySink);
-  }
-
   return Math.max(
     0,
     getFreeStoredEnergyCapacity(energySink) - getReservedEnergyDelivery(energySink, reservedEnergyDeliveries)
   );
+}
+
+function compareAssignedTransferTarget(
+  left: FillableEnergySink,
+  right: FillableEnergySink,
+  assignedTransferTargetId: string | null
+): number {
+  const leftAssigned = isAssignedTransferTarget(left, assignedTransferTargetId);
+  const rightAssigned = isAssignedTransferTarget(right, assignedTransferTargetId);
+  if (leftAssigned === rightAssigned) {
+    return 0;
+  }
+
+  return leftAssigned ? -1 : 1;
 }
 
 function selectPriorityTowerEnergySink(creep: Creep): StructureTower | null {
@@ -619,12 +617,9 @@ function selectPriorityTowerEnergySink(creep: Creep): StructureTower | null {
 
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
-  const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   return selectClosestEnergySink(
-    priorityTowerEnergySinks.filter(
-      (energySink) =>
-        isAssignedTransferTarget(energySink, assignedTransferTargetId) ||
-        hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
+    priorityTowerEnergySinks.filter((energySink) =>
+      hasUnreservedEnergySinkCapacity(energySink, reservedEnergyDeliveries)
     ),
     creep
   );

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2430,7 +2430,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'site1' });
   });
 
-  it('keeps the assigned primary sink eligible when other workers cover its remaining capacity', () => {
+  it('skips an assigned primary sink when other workers cover its remaining capacity', () => {
     const spawn = makeEnergySink('spawn-covered', 'spawn' as StructureConstant, 50);
     const extension = makeEnergySink('extension-open', 'extension' as StructureConstant, 50);
     const structures = [spawn, extension];
@@ -2463,7 +2463,79 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
     setGameCreeps({ Carrier: creep, OtherCarrier: otherCarrier });
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-covered' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-open' });
+  });
+
+  it('prefers larger unreserved recovery capacity over an assigned primary sink', () => {
+    const spawn = makeEnergySink('spawn-assigned', 'spawn' as StructureConstant, 60);
+    const extension = makeEnergySink('extension-open', 'extension' as StructureConstant, 50);
+    const structures = [spawn, extension];
+    const room = {
+      name: 'W1N1',
+      find: jest.fn(
+        (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+          if (type !== FIND_MY_STRUCTURES) {
+            return [];
+          }
+
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+      )
+    } as unknown as Room;
+    const otherCarrier = {
+      name: 'OtherCarrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-assigned' as Id<AnyStoreStructure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'Carrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-assigned' as Id<AnyStoreStructure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: {
+        getRangeTo: jest.fn((target: TestEnergySink) => (target.id === 'spawn-assigned' ? 1 : 8))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Carrier: creep, OtherCarrier: otherCarrier });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-open' });
+  });
+
+  it('uses assignment only as a tie-breaker among unreserved primary sinks', () => {
+    const spawn = makeEnergySink('spawn-assigned', 'spawn' as StructureConstant, 100);
+    const extension = makeEnergySink('extension-open', 'extension' as StructureConstant, 50);
+    const structures = [spawn, extension];
+    const room = {
+      name: 'W1N1',
+      find: jest.fn(
+        (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+          if (type !== FIND_MY_STRUCTURES) {
+            return [];
+          }
+
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+      )
+    } as unknown as Room;
+    const otherCarrier = {
+      name: 'OtherCarrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-assigned' as Id<AnyStoreStructure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'Carrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-assigned' as Id<AnyStoreStructure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: {
+        getRangeTo: jest.fn((target: TestEnergySink) => (target.id === 'spawn-assigned' ? 8 : 1))
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ Carrier: creep, OtherCarrier: otherCarrier });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-assigned' });
   });
 
   it('selects fillable extensions before fillable towers', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2198,6 +2198,36 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-closer' });
   });
 
+  it('prefers a recovery sink that can accept the full carried load over a closer partial top-off', () => {
+    const recoverySpawn = makeEnergySink('spawn-recovery', 'spawn' as StructureConstant, 300);
+    const partialExtension = makeEnergySink('extension-partial', 'extension' as StructureConstant, 10);
+    const structures = [partialExtension, recoverySpawn];
+    const getRangeTo = jest.fn((target: TestEnergySink) => {
+      const ranges: Record<string, number> = {
+        'extension-partial': 1,
+        'spawn-recovery': 5
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(100) },
+      pos: { getRangeTo },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-recovery' });
+  });
+
   it('builds loaded worker energy sink reservations once while screening primary energy sinks', () => {
     const spawn = makeEnergySink('spawn-a', 'spawn' as StructureConstant, 300);
     const extension = makeEnergySink('extension-b', 'extension' as StructureConstant, 50);


### PR DESCRIPTION
## Summary
- prefers spawn/extension refill targets that can accept the loaded worker's carried energy before falling back to range/id tie-breakers
- keeps reservation accounting intact so assigned targets and already-reserved sinks still behave safely
- adds focused worker-task coverage for choosing a recovery spawn over a closer partial extension top-off

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` (22 suites, 528 tests)
- `npm run build`
- `git diff --check`

Fixes #367
