### PR TITLE
feat: restore territory work after bootstrap survival

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5331,15 +5331,18 @@ function hasRecoverableSurplusEnergy(creep) {
   return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null || findDroppedResources(creep.room).some(isUsefulDroppedEnergy);
 }
 function hasActiveTerritoryPressure(creep) {
-  var _a;
+  var _a, _b;
   const colonyName = getCreepColonyName(creep);
   if (!colonyName) {
     return false;
   }
+  if (((_a = getRecordedColonySurvivalAssessment(colonyName)) == null ? void 0 : _a.mode) === "TERRITORY_READY") {
+    return true;
+  }
   if (hasReadyTerritoryFollowUpEnergy(creep)) {
     return true;
   }
-  const territoryMemory = (_a = globalThis.Memory) == null ? void 0 : _a.territory;
+  const territoryMemory = (_b = globalThis.Memory) == null ? void 0 : _b.territory;
   if (!territoryMemory || !Array.isArray(territoryMemory.intents)) {
     return false;
   }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2254,6 +2254,10 @@ function hasActiveTerritoryPressure(creep: Creep): boolean {
     return false;
   }
 
+  if (getRecordedColonySurvivalAssessment(colonyName)?.mode === 'TERRITORY_READY') {
+    return true;
+  }
+
   if (hasReadyTerritoryFollowUpEnergy(creep)) {
     return true;
   }

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3142,6 +3142,29 @@ describe('selectWorkerTask', () => {
     expect(spawn.store.getFreeCapacity).not.toHaveBeenCalled();
   });
 
+  it('routes carried energy to controller progress when survival gates are territory-ready', () => {
+    recordSurvivalMode('TERRITORY_READY');
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0);
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it('suppresses non-critical construction and routine upgrading during bootstrap', () => {
     recordSurvivalMode('BOOTSTRAP');
     const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
@@ -3260,6 +3283,34 @@ describe('selectWorkerTask', () => {
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
     } as StructureController;
     const room = makeWorkerTaskRoom({ controller });
+    (room as Room & { name: string }).name = 'W2N1';
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toBeNull();
+  });
+
+  it('suppresses claimed remote controller progress during defense', () => {
+    recordSurvivalMode('DEFENSE');
+    const controller = {
+      id: 'controller2',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 900 }]
+      }
+    };
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller
+    });
     (room as Room & { name: string }).name = 'W2N1';
     const creep = {
       memory: { role: 'worker', colony: 'W1N1' },


### PR DESCRIPTION
Closes #369.

## Summary
- Restores territory/control pressure once bootstrap survival mode reports `TERRITORY_READY`.
- Keeps defense/bootstrap suppression intact so controller progress does not steal energy during live recovery modes.
- Updates worker-task tests and generated `prod/dist/main.js`.

## Verification
- `git diff --check` — PASS
- `cd prod && npm run typecheck` — PASS
- `cd prod && npm test -- --runInBand` — PASS (23 suites / 549 tests)
- `cd prod && npm run build` — PASS

Authorship: recovered/committed by Codex as `lanyusea's bot <lanyusea@gmail.com>`.
