### PR TITLE
feat: expose adjacent controller progress intent

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1554,6 +1554,35 @@ function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
     intents
   ).filter((hint) => !isNonEmptyString3(colony) || hint.colony === colony);
 }
+function getTerritoryIntentProgressSummaries(colony, roleCounts) {
+  if (!isNonEmptyString3(colony)) {
+    return [];
+  }
+  const territoryMemory = getTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return [];
+  }
+  return normalizeTerritoryIntents2(territoryMemory.intents).filter(
+    (intent) => isTerritoryIntentProgressVisibleForColony(intent, colony)
+  ).map((intent) => {
+    const activeCreepCount = getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action);
+    return {
+      colony: intent.colony,
+      targetRoom: intent.targetRoom,
+      action: intent.action,
+      status: intent.status,
+      updatedAt: intent.updatedAt,
+      activeCreepCount,
+      adjacentToColony: isRoomAdjacentToColony(intent.colony, intent.targetRoom),
+      ...intent.controllerId ? { controllerId: intent.controllerId } : {},
+      ...intent.requiresControllerPressure ? { requiresControllerPressure: true } : {},
+      ...intent.followUp ? { followUp: intent.followUp } : {}
+    };
+  }).sort(compareTerritoryIntentProgressSummaries);
+}
+function isTerritoryIntentProgressVisibleForColony(intent, colony) {
+  return intent.colony === colony && (intent.status === "planned" || intent.status === "active");
+}
 function buildTerritoryCreepMemory(plan) {
   return {
     role: plan.action === "scout" ? TERRITORY_SCOUT_ROLE : TERRITORY_CLAIMER_ROLE,
@@ -2790,6 +2819,9 @@ function getAdjacentRoomNames2(roomName) {
     return isNonEmptyString3(exitRoom) ? [exitRoom] : [];
   });
 }
+function isRoomAdjacentToColony(colonyName, targetRoom) {
+  return getAdjacentRoomNames2(colonyName).includes(targetRoom);
+}
 function normalizeTerritoryTarget2(rawTarget) {
   if (!isRecord2(rawTarget)) {
     return null;
@@ -3365,6 +3397,9 @@ function isActiveVisibleControllerIntentForCreep(intent, roomName, creepColony) 
 }
 function compareVisibleControllerIntents(left, right) {
   return getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) || getIntentActionPriority(left.action) - getIntentActionPriority(right.action) || right.updatedAt - left.updatedAt || left.colony.localeCompare(right.colony);
+}
+function compareTerritoryIntentProgressSummaries(left, right) {
+  return getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) || right.activeCreepCount - left.activeCreepCount || getIntentActionPriority(left.action) - getIntentActionPriority(right.action) || right.updatedAt - left.updatedAt || left.targetRoom.localeCompare(right.targetRoom);
 }
 function getIntentStatusPriority(status) {
   return status === "active" ? 0 : 1;
@@ -7034,6 +7069,7 @@ var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
 var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+var MAX_TERRITORY_INTENT_SUMMARIES = 5;
 var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "upgrade"];
 function emitRuntimeSummary(colonies, creeps, events = []) {
@@ -7060,6 +7096,7 @@ function shouldEmitRuntimeSummary(tick, events) {
 }
 function summarizeRoom(colony, creeps) {
   const colonyWorkers = creeps.filter((creep) => creep.memory.role === "worker" && creep.memory.colony === colony.room.name);
+  const roleCounts = countCreepsByRole(creeps, colony.room.name);
   const eventMetrics = summarizeRoomEventMetrics(colony.room);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime4());
@@ -7075,9 +7112,21 @@ function summarizeRoom(colony, creeps) {
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
     constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
-    survival: summarizeSurvival(colony, creeps),
+    survival: summarizeSurvival(colony, roleCounts),
     territoryRecommendation,
+    ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
     ...buildTerritoryExecutionHintSummary(colony.room.name)
+  };
+}
+function buildTerritoryIntentSummary(colonyName, roleCounts) {
+  const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
+  if (territoryIntents.length === 0) {
+    return {};
+  }
+  const reportedIntents = territoryIntents.slice(0, MAX_TERRITORY_INTENT_SUMMARIES);
+  return {
+    territoryIntents: reportedIntents,
+    ...territoryIntents.length > MAX_TERRITORY_INTENT_SUMMARIES ? { omittedTerritoryIntentCount: territoryIntents.length - MAX_TERRITORY_INTENT_SUMMARIES } : {}
   };
 }
 function buildTerritoryExecutionHintSummary(colonyName) {
@@ -7215,8 +7264,8 @@ function summarizeConstructionPriority(colony, colonyWorkers) {
     nextPrimary: report.nextPrimary ? toRuntimeConstructionPriorityCandidateSummary(report.nextPrimary) : null
   };
 }
-function summarizeSurvival(colony, creeps) {
-  const assessment = assessColonySnapshotSurvival(colony, countCreepsByRole(creeps, colony.room.name));
+function summarizeSurvival(colony, roleCounts) {
+  const assessment = assessColonySnapshotSurvival(colony, roleCounts);
   return {
     mode: assessment.mode,
     workerCapacity: assessment.workerCapacity,

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -5,18 +5,23 @@ import {
   type ColonySuppressionReason
 } from '../colony/survivalMode';
 import { buildRuntimeConstructionPriorityReport, type ConstructionPriorityScore } from '../construction/constructionPriority';
-import { countCreepsByRole } from '../creeps/roleCounts';
+import { countCreepsByRole, type RoleCounts } from '../creeps/roleCounts';
 import {
   buildRuntimeOccupationRecommendationReport,
   persistOccupationRecommendationFollowUpIntent,
   type OccupationRecommendationReport
 } from '../territory/occupationRecommendation';
-import { getActiveTerritoryFollowUpExecutionHints } from '../territory/territoryPlanner';
+import {
+  getActiveTerritoryFollowUpExecutionHints,
+  getTerritoryIntentProgressSummaries,
+  type TerritoryIntentProgressSummary
+} from '../territory/territoryPlanner';
 
 export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
 const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+const MAX_TERRITORY_INTENT_SUMMARIES = 5;
 const WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 
 const WORKER_TASK_TYPES = ['harvest', 'transfer', 'build', 'upgrade'] as const;
@@ -57,6 +62,8 @@ interface RuntimeRoomSummary {
   constructionPriority: RuntimeConstructionPrioritySummary;
   survival: RuntimeSurvivalSummary;
   territoryRecommendation: OccupationRecommendationReport;
+  territoryIntents?: TerritoryIntentProgressSummary[];
+  omittedTerritoryIntentCount?: number;
   territoryExecutionHints?: TerritoryExecutionHintMemory[];
 }
 
@@ -180,6 +187,7 @@ export function shouldEmitRuntimeSummary(tick: number, events: RuntimeTelemetryE
 
 function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSummary {
   const colonyWorkers = creeps.filter((creep) => creep.memory.role === 'worker' && creep.memory.colony === colony.room.name);
+  const roleCounts = countCreepsByRole(creeps, colony.room.name);
   const eventMetrics = summarizeRoomEventMetrics(colony.room);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime());
@@ -196,9 +204,28 @@ function summarizeRoom(colony: ColonySnapshot, creeps: Creep[]): RuntimeRoomSumm
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
     constructionPriority: summarizeConstructionPriority(colony, colonyWorkers),
-    survival: summarizeSurvival(colony, creeps),
+    survival: summarizeSurvival(colony, roleCounts),
     territoryRecommendation,
+    ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
     ...buildTerritoryExecutionHintSummary(colony.room.name)
+  };
+}
+
+function buildTerritoryIntentSummary(
+  colonyName: string,
+  roleCounts: RoleCounts
+): { territoryIntents?: TerritoryIntentProgressSummary[]; omittedTerritoryIntentCount?: number } {
+  const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
+  if (territoryIntents.length === 0) {
+    return {};
+  }
+
+  const reportedIntents = territoryIntents.slice(0, MAX_TERRITORY_INTENT_SUMMARIES);
+  return {
+    territoryIntents: reportedIntents,
+    ...(territoryIntents.length > MAX_TERRITORY_INTENT_SUMMARIES
+      ? { omittedTerritoryIntentCount: territoryIntents.length - MAX_TERRITORY_INTENT_SUMMARIES }
+      : {})
   };
 }
 
@@ -412,8 +439,8 @@ function summarizeConstructionPriority(
   };
 }
 
-function summarizeSurvival(colony: ColonySnapshot, creeps: Creep[]): RuntimeSurvivalSummary {
-  const assessment = assessColonySnapshotSurvival(colony, countCreepsByRole(creeps, colony.room.name));
+function summarizeSurvival(colony: ColonySnapshot, roleCounts: RoleCounts): RuntimeSurvivalSummary {
+  const assessment = assessColonySnapshotSurvival(colony, roleCounts);
 
   return {
     mode: assessment.mode,

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -49,6 +49,19 @@ export interface TerritoryIntentPlan {
   followUp?: TerritoryFollowUpMemory;
 }
 
+export interface TerritoryIntentProgressSummary {
+  colony: string;
+  targetRoom: string;
+  action: TerritoryIntentAction;
+  status: 'planned' | 'active';
+  updatedAt: number;
+  activeCreepCount: number;
+  adjacentToColony: boolean;
+  controllerId?: Id<StructureController>;
+  requiresControllerPressure?: boolean;
+  followUp?: TerritoryFollowUpMemory;
+}
+
 interface MemoryRecord {
   territory?: unknown;
 }
@@ -296,6 +309,48 @@ export function getActiveTerritoryFollowUpExecutionHints(
     normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
     intents
   ).filter((hint) => !isNonEmptyString(colony) || hint.colony === colony);
+}
+
+export function getTerritoryIntentProgressSummaries(
+  colony: string | null | undefined,
+  roleCounts: RoleCounts
+): TerritoryIntentProgressSummary[] {
+  if (!isNonEmptyString(colony)) {
+    return [];
+  }
+
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return [];
+  }
+
+  return normalizeTerritoryIntents(territoryMemory.intents)
+    .filter((intent): intent is TerritoryIntentMemory & { status: 'planned' | 'active' } =>
+      isTerritoryIntentProgressVisibleForColony(intent, colony)
+    )
+    .map((intent): TerritoryIntentProgressSummary => {
+      const activeCreepCount = getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action);
+      return {
+        colony: intent.colony,
+        targetRoom: intent.targetRoom,
+        action: intent.action,
+        status: intent.status,
+        updatedAt: intent.updatedAt,
+        activeCreepCount,
+        adjacentToColony: isRoomAdjacentToColony(intent.colony, intent.targetRoom),
+        ...(intent.controllerId ? { controllerId: intent.controllerId } : {}),
+        ...(intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
+        ...(intent.followUp ? { followUp: intent.followUp } : {})
+      };
+    })
+    .sort(compareTerritoryIntentProgressSummaries);
+}
+
+function isTerritoryIntentProgressVisibleForColony(
+  intent: TerritoryIntentMemory,
+  colony: string
+): intent is TerritoryIntentMemory & { status: 'planned' | 'active' } {
+  return intent.colony === colony && (intent.status === 'planned' || intent.status === 'active');
 }
 
 export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemory {
@@ -2202,6 +2257,10 @@ function getAdjacentRoomNames(roomName: string): string[] {
   });
 }
 
+function isRoomAdjacentToColony(colonyName: string, targetRoom: string): boolean {
+  return getAdjacentRoomNames(colonyName).includes(targetRoom);
+}
+
 function normalizeTerritoryTarget(rawTarget: unknown): TerritoryTargetMemory | null {
   if (!isRecord(rawTarget)) {
     return null;
@@ -3157,6 +3216,19 @@ function compareVisibleControllerIntents(left: TerritoryIntentMemory, right: Ter
     getIntentActionPriority(left.action) - getIntentActionPriority(right.action) ||
     right.updatedAt - left.updatedAt ||
     left.colony.localeCompare(right.colony)
+  );
+}
+
+function compareTerritoryIntentProgressSummaries(
+  left: TerritoryIntentProgressSummary,
+  right: TerritoryIntentProgressSummary
+): number {
+  return (
+    getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) ||
+    right.activeCreepCount - left.activeCreepCount ||
+    getIntentActionPriority(left.action) - getIntentActionPriority(right.action) ||
+    right.updatedAt - left.updatedAt ||
+    left.targetRoom.localeCompare(right.targetRoom)
   );
 }
 

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -460,6 +460,56 @@ describe('runtime telemetry summaries', () => {
     expect(room.territoryExecutionHints).toEqual([executionHint]);
   });
 
+  it('emits adjacent territory controller-progress intent coverage in room telemetry', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const describeExits = jest.fn(() => ({ '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game.map = {
+      describeExits
+    } as unknown as GameMap;
+    (Game.rooms as Record<string, Room>).W2N1 = makeRemoteRoom('W2N1', {
+      controller: { my: false } as StructureController,
+      sourceCount: 2
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 1
+          }
+        ]
+      }
+    };
+
+    emitRuntimeSummary(
+      [colony],
+      [
+        makeWorker({ role: 'worker', colony: 'W1N1' }),
+        makeWorker({ role: 'worker', colony: 'W1N1' }),
+        makeWorker({ role: 'worker', colony: 'W1N1' }),
+        makeTerritoryClaimer({ targetRoom: 'W2N1', action: 'reserve' }, 'claimer-W1N1-W2N1')
+      ]
+    );
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.territoryIntents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: RUNTIME_SUMMARY_INTERVAL,
+        activeCreepCount: 1,
+        adjacentToColony: true
+      }
+    ]);
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+  });
+
   it('keeps emission gating deterministic', () => {
     expect(shouldEmitRuntimeSummary(1, [])).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [])).toBe(true);
@@ -597,6 +647,23 @@ function makeWorker(memory: CreepMemory, energy = 0, name?: string): Creep {
     ...(name ? { name } : {}),
     memory,
     store: makeEnergyStore(energy)
+  } as unknown as Creep;
+}
+
+function makeTerritoryClaimer(
+  territory: CreepTerritoryMemory,
+  name: string,
+  colony = 'W1N1'
+): Creep {
+  return {
+    name,
+    memory: {
+      role: 'claimer',
+      colony,
+      territory
+    },
+    body: [{ type: 'claim', hits: 100 }],
+    ticksToLive: 1_200
   } as unknown as Creep;
 }
 


### PR DESCRIPTION
## Summary
- Exposes adjacent-controller progress intent in territory/runtime telemetry after PR #373.
- Keeps bootstrap/recovery safety intact and avoids economy worker-task changes while #376 runs separately.
- Regenerates the Screeps bundle.

Linked issue: Fixes #375
Roadmap category: Bot capability / territory-control gameplay

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (23 suites, 556 tests)
- [x] `cd prod && npm run build`
- [x] `git diff --exit-code -- prod/dist/main.js` after build

## Scheduler evidence
Codex implementation left verified dirty edits in `/root/screeps-worktrees/territory-post373-375` after the original process exited without a real commit. Commit-only recovery was performed by Codex with author `lanyusea's bot <lanyusea@gmail.com>`, then the branch was rebased onto current `origin/main` after PR #374 merged/deployed. Final commit: `80cf155347fbfe4ae8dedf4d901041dd28b68dfa`.
