### PR TITLE
feat: expose productive energy telemetry

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7035,7 +7035,9 @@ var RUNTIME_SUMMARY_INTERVAL = 20;
 var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
-var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "upgrade"];
+var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 1e5;
+var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
+var PRODUCTIVE_WORKER_TASK_TYPES = ["build", "repair", "upgrade"];
 function emitRuntimeSummary(colonies, creeps, events = []) {
   if (colonies.length === 0 && events.length === 0) {
     return;
@@ -7104,6 +7106,7 @@ function countWorkerTasks(workers) {
     harvest: 0,
     transfer: 0,
     build: 0,
+    repair: 0,
     upgrade: 0,
     none: 0
   };
@@ -7186,17 +7189,105 @@ function buildControllerSummary(room) {
   return { controller: summary };
 }
 function summarizeResources(colony, colonyWorkers, events) {
-  var _a, _b, _c;
+  var _a, _b, _c, _d;
   const roomStructures = (_a = findRoomObjects4(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const droppedResources = (_b = findRoomObjects4(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _b : [];
-  const sources = (_c = findRoomObjects4(colony.room, "FIND_SOURCES")) != null ? _c : [];
+  const constructionSites = (_b = findRoomObjects4(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
+  const droppedResources = (_c = findRoomObjects4(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
+  const sources = (_d = findRoomObjects4(colony.room, "FIND_SOURCES")) != null ? _d : [];
   return {
     storedEnergy: sumEnergyInStores(roomStructures),
     workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
     droppedEnergy: sumDroppedEnergy(droppedResources),
     sourceCount: sources.length,
+    productiveEnergy: summarizeProductiveEnergy(colony.room, colonyWorkers, constructionSites, roomStructures),
     ...events ? { events } : {}
   };
+}
+function summarizeProductiveEnergy(room, colonyWorkers, constructionSites, roomStructures) {
+  const productiveAssignments = summarizeProductiveWorkerAssignments(colonyWorkers);
+  return {
+    ...productiveAssignments,
+    pendingBuildProgress: sumPendingBuildProgress(constructionSites),
+    repairBacklogHits: sumRepairBacklogHits(roomStructures),
+    ...buildControllerProgressRemaining(room)
+  };
+}
+function summarizeProductiveWorkerAssignments(colonyWorkers) {
+  var _a;
+  const summary = {
+    assignedWorkerCount: 0,
+    assignedCarriedEnergy: 0,
+    buildCarriedEnergy: 0,
+    repairCarriedEnergy: 0,
+    upgradeCarriedEnergy: 0
+  };
+  for (const worker of colonyWorkers) {
+    const taskType = (_a = worker.memory.task) == null ? void 0 : _a.type;
+    if (!isProductiveWorkerTaskType(taskType)) {
+      continue;
+    }
+    const carriedEnergy = getEnergyInStore(worker);
+    summary.assignedWorkerCount += 1;
+    summary.assignedCarriedEnergy += carriedEnergy;
+    if (taskType === "build") {
+      summary.buildCarriedEnergy += carriedEnergy;
+    } else if (taskType === "repair") {
+      summary.repairCarriedEnergy += carriedEnergy;
+    } else {
+      summary.upgradeCarriedEnergy += carriedEnergy;
+    }
+  }
+  return summary;
+}
+function isProductiveWorkerTaskType(taskType) {
+  return PRODUCTIVE_WORKER_TASK_TYPES.includes(taskType);
+}
+function sumPendingBuildProgress(constructionSites) {
+  return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
+}
+function getPendingBuildProgress(constructionSite) {
+  if (!isRecord5(constructionSite)) {
+    return 0;
+  }
+  const progress = getFiniteNumber(constructionSite.progress);
+  const progressTotal = getFiniteNumber(constructionSite.progressTotal);
+  if (progress === null || progressTotal === null) {
+    return 0;
+  }
+  return Math.max(0, Math.ceil(progressTotal - progress));
+}
+function sumRepairBacklogHits(roomStructures) {
+  return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
+}
+function getRepairBacklogHits(structure) {
+  if (!isRecord5(structure) || !isObservableRepairBacklogStructure(structure)) {
+    return 0;
+  }
+  const hits = getFiniteNumber(structure.hits);
+  const hitsMax = getFiniteNumber(structure.hitsMax);
+  if (hits === null || hitsMax === null || hitsMax <= 0) {
+    return 0;
+  }
+  const repairCeiling = isObservedOwnedRampart(structure) ? Math.min(hitsMax, OBSERVED_RAMPART_REPAIR_HITS_CEILING) : hitsMax;
+  return Math.max(0, Math.ceil(repairCeiling - hits));
+}
+function isObservableRepairBacklogStructure(structure) {
+  return matchesStructureType5(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType5(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
+}
+function isObservedOwnedRampart(structure) {
+  return matchesStructureType5(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
+}
+function buildControllerProgressRemaining(room) {
+  const controller = room.controller;
+  if ((controller == null ? void 0 : controller.my) !== true) {
+    return {};
+  }
+  const progress = getFiniteNumber(controller.progress);
+  const progressTotal = getFiniteNumber(controller.progressTotal);
+  if (progress === null || progressTotal === null) {
+    return {};
+  }
+  return { controllerProgressRemaining: Math.max(0, Math.ceil(progressTotal - progress)) };
 }
 function summarizeCombat(room, events) {
   var _a, _b;
@@ -7243,11 +7334,17 @@ function summarizeRoomEventMetrics(room) {
   }
   const harvestEvent = getGlobalNumber3("EVENT_HARVEST");
   const transferEvent = getGlobalNumber3("EVENT_TRANSFER");
+  const buildEvent = getGlobalNumber3("EVENT_BUILD");
+  const repairEvent = getGlobalNumber3("EVENT_REPAIR");
+  const upgradeControllerEvent = getGlobalNumber3("EVENT_UPGRADE_CONTROLLER");
   const attackEvent = getGlobalNumber3("EVENT_ATTACK");
   const objectDestroyedEvent = getGlobalNumber3("EVENT_OBJECT_DESTROYED");
   const resourceEvents = {
     harvestedEnergy: 0,
-    transferredEnergy: 0
+    transferredEnergy: 0,
+    builtProgress: 0,
+    repairedHits: 0,
+    upgradedControllerProgress: 0
   };
   const combatEvents = {
     attackCount: 0,
@@ -7268,6 +7365,18 @@ function summarizeRoomEventMetrics(room) {
     }
     if (entry.event === transferEvent && isEnergyEventData(data)) {
       resourceEvents.transferredEnergy += getNumericEventData(data, "amount");
+      hasResourceEvents = true;
+    }
+    if (entry.event === buildEvent) {
+      resourceEvents.builtProgress += getNumericEventData(data, "amount");
+      hasResourceEvents = true;
+    }
+    if (entry.event === repairEvent) {
+      resourceEvents.repairedHits += getNumericEventData(data, "amount");
+      hasResourceEvents = true;
+    }
+    if (entry.event === upgradeControllerEvent) {
+      resourceEvents.upgradedControllerProgress += getNumericEventData(data, "amount");
       hasResourceEvents = true;
     }
     if (entry.event === attackEvent) {
@@ -7347,6 +7456,14 @@ function getNumericEventData(data, key) {
 function getGlobalNumber3(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
+}
+function matchesStructureType5(value, globalName, fallback) {
+  var _a;
+  const expectedValue = (_a = globalThis[globalName]) != null ? _a : fallback;
+  return value === expectedValue;
+}
+function getFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 function getEnergyResource2() {
   const value = globalThis.RESOURCE_ENERGY;

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -18,10 +18,13 @@ export const RUNTIME_SUMMARY_INTERVAL = 20;
 const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 const WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
+const OBSERVED_RAMPART_REPAIR_HITS_CEILING = 100_000;
 
-const WORKER_TASK_TYPES = ['harvest', 'transfer', 'build', 'upgrade'] as const;
+const WORKER_TASK_TYPES = ['harvest', 'transfer', 'build', 'repair', 'upgrade'] as const;
+const PRODUCTIVE_WORKER_TASK_TYPES = ['build', 'repair', 'upgrade'] as const;
 
 type WorkerTaskType = (typeof WORKER_TASK_TYPES)[number];
+type ProductiveWorkerTaskType = (typeof PRODUCTIVE_WORKER_TASK_TYPES)[number];
 
 interface WorkerTaskCounts extends Record<WorkerTaskType, number> {
   none: number;
@@ -70,6 +73,9 @@ interface RuntimeControllerSummary {
 interface RuntimeResourceEventSummary {
   harvestedEnergy: number;
   transferredEnergy: number;
+  builtProgress: number;
+  repairedHits: number;
+  upgradedControllerProgress: number;
 }
 
 interface RuntimeResourceSummary {
@@ -77,7 +83,19 @@ interface RuntimeResourceSummary {
   workerCarriedEnergy: number;
   droppedEnergy: number;
   sourceCount: number;
+  productiveEnergy: RuntimeProductiveEnergySummary;
   events?: RuntimeResourceEventSummary;
+}
+
+interface RuntimeProductiveEnergySummary {
+  assignedWorkerCount: number;
+  assignedCarriedEnergy: number;
+  buildCarriedEnergy: number;
+  repairCarriedEnergy: number;
+  upgradeCarriedEnergy: number;
+  pendingBuildProgress: number;
+  repairBacklogHits: number;
+  controllerProgressRemaining?: number;
 }
 
 interface RuntimeWorkerEfficiencySummary {
@@ -230,6 +248,7 @@ function countWorkerTasks(workers: Creep[]): WorkerTaskCounts {
     harvest: 0,
     transfer: 0,
     build: 0,
+    repair: 0,
     upgrade: 0,
     none: 0
   };
@@ -377,6 +396,7 @@ function summarizeResources(
   events: RuntimeResourceEventSummary | undefined
 ): RuntimeResourceSummary {
   const roomStructures = findRoomObjects(colony.room, 'FIND_STRUCTURES') ?? colony.spawns;
+  const constructionSites = findRoomObjects(colony.room, 'FIND_MY_CONSTRUCTION_SITES') ?? [];
   const droppedResources = findRoomObjects(colony.room, 'FIND_DROPPED_RESOURCES') ?? [];
   const sources = findRoomObjects(colony.room, 'FIND_SOURCES') ?? [];
 
@@ -385,8 +405,134 @@ function summarizeResources(
     workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
     droppedEnergy: sumDroppedEnergy(droppedResources),
     sourceCount: sources.length,
+    productiveEnergy: summarizeProductiveEnergy(colony.room, colonyWorkers, constructionSites, roomStructures),
     ...(events ? { events } : {})
   };
+}
+
+function summarizeProductiveEnergy(
+  room: Room,
+  colonyWorkers: Creep[],
+  constructionSites: unknown[],
+  roomStructures: unknown[]
+): RuntimeProductiveEnergySummary {
+  const productiveAssignments = summarizeProductiveWorkerAssignments(colonyWorkers);
+
+  return {
+    ...productiveAssignments,
+    pendingBuildProgress: sumPendingBuildProgress(constructionSites),
+    repairBacklogHits: sumRepairBacklogHits(roomStructures),
+    ...buildControllerProgressRemaining(room)
+  };
+}
+
+function summarizeProductiveWorkerAssignments(
+  colonyWorkers: Creep[]
+): Pick<
+  RuntimeProductiveEnergySummary,
+  | 'assignedWorkerCount'
+  | 'assignedCarriedEnergy'
+  | 'buildCarriedEnergy'
+  | 'repairCarriedEnergy'
+  | 'upgradeCarriedEnergy'
+> {
+  const summary = {
+    assignedWorkerCount: 0,
+    assignedCarriedEnergy: 0,
+    buildCarriedEnergy: 0,
+    repairCarriedEnergy: 0,
+    upgradeCarriedEnergy: 0
+  };
+
+  for (const worker of colonyWorkers) {
+    const taskType = worker.memory.task?.type;
+    if (!isProductiveWorkerTaskType(taskType)) {
+      continue;
+    }
+
+    const carriedEnergy = getEnergyInStore(worker);
+    summary.assignedWorkerCount += 1;
+    summary.assignedCarriedEnergy += carriedEnergy;
+    if (taskType === 'build') {
+      summary.buildCarriedEnergy += carriedEnergy;
+    } else if (taskType === 'repair') {
+      summary.repairCarriedEnergy += carriedEnergy;
+    } else {
+      summary.upgradeCarriedEnergy += carriedEnergy;
+    }
+  }
+
+  return summary;
+}
+
+function isProductiveWorkerTaskType(taskType: string | undefined): taskType is ProductiveWorkerTaskType {
+  return PRODUCTIVE_WORKER_TASK_TYPES.includes(taskType as ProductiveWorkerTaskType);
+}
+
+function sumPendingBuildProgress(constructionSites: unknown[]): number {
+  return constructionSites.reduce<number>((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
+}
+
+function getPendingBuildProgress(constructionSite: unknown): number {
+  if (!isRecord(constructionSite)) {
+    return 0;
+  }
+
+  const progress = getFiniteNumber(constructionSite.progress);
+  const progressTotal = getFiniteNumber(constructionSite.progressTotal);
+  if (progress === null || progressTotal === null) {
+    return 0;
+  }
+
+  return Math.max(0, Math.ceil(progressTotal - progress));
+}
+
+function sumRepairBacklogHits(roomStructures: unknown[]): number {
+  return roomStructures.reduce<number>((total, structure) => total + getRepairBacklogHits(structure), 0);
+}
+
+function getRepairBacklogHits(structure: unknown): number {
+  if (!isRecord(structure) || !isObservableRepairBacklogStructure(structure)) {
+    return 0;
+  }
+
+  const hits = getFiniteNumber(structure.hits);
+  const hitsMax = getFiniteNumber(structure.hitsMax);
+  if (hits === null || hitsMax === null || hitsMax <= 0) {
+    return 0;
+  }
+
+  const repairCeiling = isObservedOwnedRampart(structure)
+    ? Math.min(hitsMax, OBSERVED_RAMPART_REPAIR_HITS_CEILING)
+    : hitsMax;
+  return Math.max(0, Math.ceil(repairCeiling - hits));
+}
+
+function isObservableRepairBacklogStructure(structure: Record<string, unknown>): boolean {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container') ||
+    isObservedOwnedRampart(structure)
+  );
+}
+
+function isObservedOwnedRampart(structure: Record<string, unknown>): boolean {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') && structure.my === true;
+}
+
+function buildControllerProgressRemaining(room: Room): { controllerProgressRemaining?: number } {
+  const controller = room.controller;
+  if (controller?.my !== true) {
+    return {};
+  }
+
+  const progress = getFiniteNumber((controller as StructureController & { progress?: unknown }).progress);
+  const progressTotal = getFiniteNumber((controller as StructureController & { progressTotal?: unknown }).progressTotal);
+  if (progress === null || progressTotal === null) {
+    return {};
+  }
+
+  return { controllerProgressRemaining: Math.max(0, Math.ceil(progressTotal - progress)) };
 }
 
 function summarizeCombat(room: Room, events: RuntimeCombatEventSummary | undefined): RuntimeCombatSummary {
@@ -446,11 +592,17 @@ function summarizeRoomEventMetrics(room: Room): RuntimeRoomEventMetrics {
 
   const harvestEvent = getGlobalNumber('EVENT_HARVEST');
   const transferEvent = getGlobalNumber('EVENT_TRANSFER');
+  const buildEvent = getGlobalNumber('EVENT_BUILD');
+  const repairEvent = getGlobalNumber('EVENT_REPAIR');
+  const upgradeControllerEvent = getGlobalNumber('EVENT_UPGRADE_CONTROLLER');
   const attackEvent = getGlobalNumber('EVENT_ATTACK');
   const objectDestroyedEvent = getGlobalNumber('EVENT_OBJECT_DESTROYED');
   const resourceEvents: RuntimeResourceEventSummary = {
     harvestedEnergy: 0,
-    transferredEnergy: 0
+    transferredEnergy: 0,
+    builtProgress: 0,
+    repairedHits: 0,
+    upgradedControllerProgress: 0
   };
   const combatEvents: RuntimeCombatEventSummary = {
     attackCount: 0,
@@ -474,6 +626,21 @@ function summarizeRoomEventMetrics(room: Room): RuntimeRoomEventMetrics {
 
     if (entry.event === transferEvent && isEnergyEventData(data)) {
       resourceEvents.transferredEnergy += getNumericEventData(data, 'amount');
+      hasResourceEvents = true;
+    }
+
+    if (entry.event === buildEvent) {
+      resourceEvents.builtProgress += getNumericEventData(data, 'amount');
+      hasResourceEvents = true;
+    }
+
+    if (entry.event === repairEvent) {
+      resourceEvents.repairedHits += getNumericEventData(data, 'amount');
+      hasResourceEvents = true;
+    }
+
+    if (entry.event === upgradeControllerEvent) {
+      resourceEvents.upgradedControllerProgress += getNumericEventData(data, 'amount');
       hasResourceEvents = true;
     }
 
@@ -570,6 +737,17 @@ function getNumericEventData(data: Record<string, unknown>, key: string): number
 function getGlobalNumber(name: string): number | undefined {
   const value = (globalThis as Record<string, unknown>)[name];
   return typeof value === 'number' ? value : undefined;
+}
+
+type StructureConstantGlobal = 'STRUCTURE_ROAD' | 'STRUCTURE_CONTAINER' | 'STRUCTURE_RAMPART';
+
+function matchesStructureType(value: unknown, globalName: StructureConstantGlobal, fallback: string): boolean {
+  const expectedValue = (globalThis as Record<string, unknown>)[globalName] ?? fallback;
+  return value === expectedValue;
+}
+
+function getFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
 function getEnergyResource(): ResourceConstant {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -17,8 +17,11 @@ const TEST_GLOBALS = {
   FIND_MY_CONSTRUCTION_SITES: 107,
   EVENT_HARVEST: 201,
   EVENT_TRANSFER: 202,
-  EVENT_ATTACK: 203,
-  EVENT_OBJECT_DESTROYED: 204,
+  EVENT_BUILD: 203,
+  EVENT_REPAIR: 204,
+  EVENT_UPGRADE_CONTROLLER: 205,
+  EVENT_ATTACK: 206,
+  EVENT_OBJECT_DESTROYED: 207,
   RESOURCE_ENERGY: 'energy',
   STRUCTURE_EXTENSION: 'extension',
   STRUCTURE_TOWER: 'tower',
@@ -82,6 +85,7 @@ describe('runtime telemetry summaries', () => {
             harvest: 1,
             transfer: 0,
             build: 0,
+            repair: 0,
             upgrade: 0
           },
           controller: {
@@ -95,9 +99,22 @@ describe('runtime telemetry summaries', () => {
             workerCarriedEnergy: 60,
             droppedEnergy: 25,
             sourceCount: 2,
+            productiveEnergy: {
+              assignedWorkerCount: 0,
+              assignedCarriedEnergy: 0,
+              buildCarriedEnergy: 0,
+              repairCarriedEnergy: 0,
+              upgradeCarriedEnergy: 0,
+              pendingBuildProgress: 0,
+              repairBacklogHits: 0,
+              controllerProgressRemaining: 43766
+            },
             events: {
               harvestedEnergy: 10,
-              transferredEnergy: 5
+              transferredEnergy: 5,
+              builtProgress: 25,
+              repairedHits: 100,
+              upgradedControllerProgress: 7
             }
           },
           combat: {
@@ -216,6 +233,77 @@ describe('runtime telemetry summaries', () => {
       result: 0
     });
     expect(payload.omittedEventCount).toBe(2);
+  });
+
+  it('reports productive worker energy and local action backlog in room telemetry', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false,
+      constructionSites: [
+        { id: 'road-site', structureType: TEST_GLOBALS.STRUCTURE_ROAD, progress: 30, progressTotal: 100 },
+        { id: 'extension-site', structureType: TEST_GLOBALS.STRUCTURE_EXTENSION, progress: 25.5, progressTotal: 50 }
+      ],
+      structures: [
+        { id: 'road-damaged', structureType: TEST_GLOBALS.STRUCTURE_ROAD, hits: 1_000, hitsMax: 5_000 },
+        { id: 'container-damaged', structureType: TEST_GLOBALS.STRUCTURE_CONTAINER, hits: 900, hitsMax: 1_000 },
+        {
+          id: 'rampart-damaged',
+          structureType: TEST_GLOBALS.STRUCTURE_RAMPART,
+          my: true,
+          hits: 90_000,
+          hitsMax: 300_000
+        },
+        {
+          id: 'enemy-rampart',
+          structureType: TEST_GLOBALS.STRUCTURE_RAMPART,
+          my: false,
+          hits: 1,
+          hitsMax: 300_000
+        }
+      ]
+    });
+    const creeps = [
+      makeWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'build', targetId: 'road-site' as Id<ConstructionSite> } },
+        40,
+        'Builder'
+      ),
+      makeWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'repair', targetId: 'road-damaged' as Id<Structure> } },
+        20,
+        'Repairer'
+      ),
+      makeWorker(
+        {
+          role: 'worker',
+          colony: 'W1N1',
+          task: { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }
+        },
+        10,
+        'Upgrader'
+      ),
+      makeWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> } },
+        50,
+        'Carrier'
+      )
+    ];
+
+    emitRuntimeSummary([colony], creeps);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.taskCounts).toMatchObject({ build: 1, repair: 1, upgrade: 1, transfer: 1, none: 0 });
+    expect((room.resources as Record<string, unknown>).productiveEnergy).toEqual({
+      assignedWorkerCount: 3,
+      assignedCarriedEnergy: 70,
+      buildCarriedEnergy: 40,
+      repairCarriedEnergy: 20,
+      upgradeCarriedEnergy: 10,
+      pendingBuildProgress: 95,
+      repairBacklogHits: 14100,
+      controllerProgressRemaining: 43766
+    });
   });
 
   it('reports bounded room-level worker efficiency samples', () => {
@@ -509,9 +597,11 @@ function makeColony(options: {
     name: string;
     spawning: { name: string; remainingTime: number } | null;
   };
+  constructionSites?: unknown[];
   installGlobals?: boolean;
   includeRoomFind?: boolean;
   includeEventLog?: boolean;
+  structures?: unknown[];
 }): ColonySnapshot {
   if (options.installGlobals !== false) {
     installRuntimeTelemetryGlobals();
@@ -535,7 +625,8 @@ function makeColony(options: {
     spawning: options.spawn?.spawning ?? null,
     store: makeEnergyStore(50)
   } as unknown as StructureSpawn;
-  const structures = [spawn, { store: makeEnergyStore(125) }];
+  const structures = options.structures ?? [spawn, { store: makeEnergyStore(125) }];
+  const constructionSites = options.constructionSites ?? [];
 
   if (options.includeRoomFind !== false) {
     (room as unknown as { find?: jest.Mock }).find = jest.fn((findType: number): unknown[] => {
@@ -545,7 +636,7 @@ function makeColony(options: {
         case TEST_GLOBALS.FIND_MY_STRUCTURES:
           return structures;
         case TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES:
-          return [];
+          return constructionSites;
         case TEST_GLOBALS.FIND_DROPPED_RESOURCES:
           return [
             { resourceType: TEST_GLOBALS.RESOURCE_ENERGY, amount: 25 },
@@ -568,6 +659,9 @@ function makeColony(options: {
       { event: TEST_GLOBALS.EVENT_HARVEST, data: { amount: 10, resourceType: TEST_GLOBALS.RESOURCE_ENERGY } },
       { event: TEST_GLOBALS.EVENT_TRANSFER, data: { amount: 5, resourceType: TEST_GLOBALS.RESOURCE_ENERGY } },
       { event: TEST_GLOBALS.EVENT_TRANSFER, data: { amount: 99, resourceType: 'power' } },
+      { event: TEST_GLOBALS.EVENT_BUILD, data: { amount: 25 } },
+      { event: TEST_GLOBALS.EVENT_REPAIR, data: { amount: 100 } },
+      { event: TEST_GLOBALS.EVENT_UPGRADE_CONTROLLER, data: { amount: 7 } },
       { event: TEST_GLOBALS.EVENT_ATTACK, data: { damage: 30 } },
       { event: TEST_GLOBALS.EVENT_OBJECT_DESTROYED, data: { type: 'creep' } }
     ]);


### PR DESCRIPTION
## Summary
- Exposes productive energy telemetry so post-PR #374 resource/economy behavior is easier to verify in runtime summaries.
- Adds Jest coverage for the new telemetry shape while preserving bootstrap/recovery safety.
- Regenerates the Screeps bundle.

Linked issue: Fixes #376
Roadmap category: Bot capability / resources-economy gameplay

## Verification
- [x] `git diff --check`
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand` (23 suites, 556 tests)
- [x] `cd prod && npm run build`
- [x] `git diff --exit-code -- prod/dist/main.js` after build

## Scheduler evidence
Codex implementation left verified dirty edits in `/root/screeps-worktrees/economy-post374-376` after the original process disappeared without a real commit. Controller-side verification passed, then commit-only recovery was performed by Codex with author `lanyusea's bot <lanyusea@gmail.com>`. Final commit: `bd7cde6d80f7a09e39019a5b84838b45a9c62e52`.
