### PR TITLE
feat: execute adjacent controller progress follow-up

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1806,12 +1806,15 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
   if (sanitizedClaimReserveHandoffs.changed) {
     intents = sanitizedClaimReserveHandoffs.intents;
   }
-  const sanitizedFollowUps = sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyOwnerUsername);
-  if (sanitizedFollowUps.changed) {
-    intents = sanitizedFollowUps.intents;
-    if (territoryMemory) {
-      territoryMemory.intents = intents;
-    }
+  const sanitizedStaleProgress = sanitizeStaleTerritoryProgressIntents(
+    territoryMemory,
+    intents,
+    colonyName,
+    colonyOwnerUsername,
+    roleCounts
+  );
+  if (sanitizedStaleProgress.changed) {
+    intents = sanitizedStaleProgress.intents;
   }
   refreshTerritoryFollowUpExecutionHints(territoryMemory, intents);
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
@@ -2945,31 +2948,52 @@ function getSatisfiedConfiguredClaimRoomNames(rawTargets, colonyName, colonyOwne
   }
   return satisfiedClaimRooms;
 }
-function sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyOwnerUsername) {
-  let changed = false;
-  const sanitizedIntents = intents.map((intent) => {
-    if (intent.colony !== colonyName || intent.followUp === void 0 || intent.status === "suppressed") {
-      return intent;
+function sanitizeStaleTerritoryProgressIntents(territoryMemory, intents, colonyName, colonyOwnerUsername, roleCounts) {
+  const staleIntents = [];
+  const sanitizedIntents = intents.filter((intent) => {
+    if (!isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername, roleCounts)) {
+      return true;
     }
-    if (intent.status === "active" && intent.action === "reserve") {
-      return intent;
-    }
-    if (!isTerritoryControlAction(intent.action) || isPersistedTerritoryFollowUpStillActionable(intent, intent.action, colonyOwnerUsername)) {
-      return intent;
-    }
-    changed = true;
-    return omitTerritoryIntentFollowUp(intent);
+    staleIntents.push(intent);
+    return false;
   });
-  return { intents: sanitizedIntents, changed };
+  if (staleIntents.length === 0) {
+    return { intents, changed: false };
+  }
+  if (territoryMemory) {
+    setTerritoryIntents(territoryMemory, sanitizedIntents);
+    for (const staleIntent of staleIntents) {
+      removeStaleTerritoryProgressIntentState(territoryMemory, staleIntent);
+    }
+  }
+  return { intents: sanitizedIntents, changed: true };
 }
-function isPersistedTerritoryFollowUpStillActionable(intent, action, colonyOwnerUsername) {
+function isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername, roleCounts) {
+  if (intent.colony !== colonyName) {
+    return false;
+  }
+  if (intent.action === "scout") {
+    return isVisibleRoomKnown(intent.targetRoom);
+  }
+  if (intent.followUp === void 0 || !isTerritoryControlAction(intent.action) || intent.status === "suppressed") {
+    return false;
+  }
+  if (intent.status === "active" && getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action) > 0) {
+    return false;
+  }
   const controllerState = getVisibleTerritoryControllerEvidenceState(
     intent.targetRoom,
-    action,
+    intent.action,
     intent.controllerId,
     colonyOwnerUsername
   );
-  return controllerState === null || controllerState === "available" || isVisibleTerritoryReservePressureAvailable(intent.targetRoom, action, intent.controllerId, colonyOwnerUsername);
+  const stillActionable = controllerState === null || controllerState === "available" || isVisibleTerritoryReservePressureAvailable(
+    intent.targetRoom,
+    intent.action,
+    intent.controllerId,
+    colonyOwnerUsername
+  );
+  return !stillActionable;
 }
 function getVisibleTerritoryControllerEvidenceState(targetRoom, action, controllerId, colonyOwnerUsername) {
   if (isVisibleRoomMissingController(targetRoom)) {
@@ -2981,16 +3005,18 @@ function getVisibleTerritoryControllerEvidenceState(targetRoom, action, controll
   }
   return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername);
 }
-function omitTerritoryIntentFollowUp(intent) {
-  return {
-    colony: intent.colony,
-    targetRoom: intent.targetRoom,
-    action: intent.action,
-    status: intent.status,
-    updatedAt: intent.updatedAt,
-    ...shouldPreservePersistedTerritoryIntentPressureRequirement2(intent) ? { requiresControllerPressure: true } : {},
-    ...intent.controllerId ? { controllerId: intent.controllerId } : {}
-  };
+function removeStaleTerritoryProgressIntentState(territoryMemory, intent) {
+  if (isTerritoryControlAction(intent.action)) {
+    removeTerritoryFollowUpDemand(territoryMemory, intent.colony, intent.targetRoom, intent.action);
+  }
+  removeTerritoryFollowUpExecutionHint(territoryMemory, intent.colony, intent.targetRoom, intent.action);
+}
+function setTerritoryIntents(territoryMemory, intents) {
+  if (intents.length > 0) {
+    territoryMemory.intents = intents;
+  } else {
+    delete territoryMemory.intents;
+  }
 }
 function shouldPreservePersistedTerritoryIntentPressureRequirement2(intent, controllerId = intent.controllerId) {
   return intent.requiresControllerPressure === true && isTerritoryControllerPressureVisibilityMissing2(intent.targetRoom, intent.action, controllerId);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -673,12 +673,15 @@ function selectTerritoryTarget(
   if (sanitizedClaimReserveHandoffs.changed) {
     intents = sanitizedClaimReserveHandoffs.intents;
   }
-  const sanitizedFollowUps = sanitizeInvalidPersistedTerritoryFollowUps(intents, colonyName, colonyOwnerUsername);
-  if (sanitizedFollowUps.changed) {
-    intents = sanitizedFollowUps.intents;
-    if (territoryMemory) {
-      territoryMemory.intents = intents;
-    }
+  const sanitizedStaleProgress = sanitizeStaleTerritoryProgressIntents(
+    territoryMemory,
+    intents,
+    colonyName,
+    colonyOwnerUsername,
+    roleCounts
+  );
+  if (sanitizedStaleProgress.changed) {
+    intents = sanitizedStaleProgress.intents;
   }
   refreshTerritoryFollowUpExecutionHints(territoryMemory, intents);
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
@@ -2450,51 +2453,82 @@ function getSatisfiedConfiguredClaimRoomNames(
   return satisfiedClaimRooms;
 }
 
-function sanitizeInvalidPersistedTerritoryFollowUps(
+function sanitizeStaleTerritoryProgressIntents(
+  territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[],
   colonyName: string,
-  colonyOwnerUsername: string | null
+  colonyOwnerUsername: string | null,
+  roleCounts: RoleCounts
 ): { intents: TerritoryIntentMemory[]; changed: boolean } {
-  let changed = false;
-  const sanitizedIntents = intents.map((intent) => {
-    if (intent.colony !== colonyName || intent.followUp === undefined || intent.status === 'suppressed') {
-      return intent;
+  const staleIntents: TerritoryIntentMemory[] = [];
+  const sanitizedIntents = intents.filter((intent) => {
+    if (!isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername, roleCounts)) {
+      return true;
     }
 
-    if (intent.status === 'active' && intent.action === 'reserve') {
-      return intent;
-    }
-
-    if (
-      !isTerritoryControlAction(intent.action) ||
-      isPersistedTerritoryFollowUpStillActionable(intent, intent.action, colonyOwnerUsername)
-    ) {
-      return intent;
-    }
-
-    changed = true;
-    return omitTerritoryIntentFollowUp(intent);
+    staleIntents.push(intent);
+    return false;
   });
 
-  return { intents: sanitizedIntents, changed };
+  if (staleIntents.length === 0) {
+    return { intents, changed: false };
+  }
+
+  if (territoryMemory) {
+    setTerritoryIntents(territoryMemory, sanitizedIntents);
+    for (const staleIntent of staleIntents) {
+      removeStaleTerritoryProgressIntentState(territoryMemory as TerritoryMemory, staleIntent);
+    }
+  }
+
+  return { intents: sanitizedIntents, changed: true };
 }
 
-function isPersistedTerritoryFollowUpStillActionable(
+function isStaleTerritoryProgressIntent(
   intent: TerritoryIntentMemory,
-  action: TerritoryControlAction,
-  colonyOwnerUsername: string | null
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  roleCounts: RoleCounts
 ): boolean {
+  if (intent.colony !== colonyName) {
+    return false;
+  }
+
+  if (intent.action === 'scout') {
+    return isVisibleRoomKnown(intent.targetRoom);
+  }
+
+  if (
+    intent.followUp === undefined ||
+    !isTerritoryControlAction(intent.action) ||
+    intent.status === 'suppressed'
+  ) {
+    return false;
+  }
+
+  if (
+    intent.status === 'active' &&
+    getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action) > 0
+  ) {
+    return false;
+  }
+
   const controllerState = getVisibleTerritoryControllerEvidenceState(
     intent.targetRoom,
-    action,
+    intent.action,
     intent.controllerId,
     colonyOwnerUsername
   );
-  return (
+  const stillActionable =
     controllerState === null ||
     controllerState === 'available' ||
-    isVisibleTerritoryReservePressureAvailable(intent.targetRoom, action, intent.controllerId, colonyOwnerUsername)
-  );
+    isVisibleTerritoryReservePressureAvailable(
+      intent.targetRoom,
+      intent.action,
+      intent.controllerId,
+      colonyOwnerUsername
+    );
+  return !stillActionable;
 }
 
 function getVisibleTerritoryControllerEvidenceState(
@@ -2515,16 +2549,26 @@ function getVisibleTerritoryControllerEvidenceState(
   return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername);
 }
 
-function omitTerritoryIntentFollowUp(intent: TerritoryIntentMemory): TerritoryIntentMemory {
-  return {
-    colony: intent.colony,
-    targetRoom: intent.targetRoom,
-    action: intent.action,
-    status: intent.status,
-    updatedAt: intent.updatedAt,
-    ...(shouldPreservePersistedTerritoryIntentPressureRequirement(intent) ? { requiresControllerPressure: true } : {}),
-    ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
-  };
+function removeStaleTerritoryProgressIntentState(
+  territoryMemory: TerritoryMemory,
+  intent: TerritoryIntentMemory
+): void {
+  if (isTerritoryControlAction(intent.action)) {
+    removeTerritoryFollowUpDemand(territoryMemory, intent.colony, intent.targetRoom, intent.action);
+  }
+
+  removeTerritoryFollowUpExecutionHint(territoryMemory, intent.colony, intent.targetRoom, intent.action);
+}
+
+function setTerritoryIntents(
+  territoryMemory: TerritoryMemory | Record<string, unknown>,
+  intents: TerritoryIntentMemory[]
+): void {
+  if (intents.length > 0) {
+    territoryMemory.intents = intents;
+  } else {
+    delete territoryMemory.intents;
+  }
 }
 
 function shouldPreservePersistedTerritoryIntentPressureRequirement(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -202,13 +202,6 @@ describe('planTerritoryIntent', () => {
       {
         colony: 'W1N1',
         targetRoom: 'W1N2',
-        action: 'scout',
-        status: 'planned',
-        updatedAt: 527
-      },
-      {
-        colony: 'W1N1',
-        targetRoom: 'W1N2',
         action: 'reserve',
         status: 'planned',
         updatedAt: 528
@@ -254,7 +247,6 @@ describe('planTerritoryIntent', () => {
       }
     ]);
     expect(Memory.territory?.intents).toEqual([
-      suppressedScout,
       {
         colony: 'W1N1',
         targetRoom: 'W1N2',
@@ -2637,7 +2629,7 @@ describe('planTerritoryIntent', () => {
     expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([existingHint]);
   });
 
-  it('drops persisted follow-up metadata after visible controller evidence satisfies the target', () => {
+  it('clears stale follow-up controller intent after visible evidence satisfies the target', () => {
     const colony = makeSafeColony();
     const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
     const staleFollowUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
@@ -2688,13 +2680,6 @@ describe('planTerritoryIntent', () => {
       action: 'reserve'
     });
     expect(Memory.territory?.intents).toEqual([
-      {
-        colony: 'W1N1',
-        targetRoom: 'W3N1',
-        action: 'reserve',
-        status: 'planned',
-        updatedAt: 590
-      },
       {
         colony: 'W1N1',
         targetRoom: 'W2N1',
@@ -3013,7 +2998,6 @@ describe('planTerritoryIntent', () => {
     ]);
     expect(Memory.territory?.intents).toEqual([
       suppressedClaimIntent,
-      activeReserveIntent,
       {
         colony: 'W1N1',
         targetRoom: 'W2N2',


### PR DESCRIPTION
## Summary
- Executes the post-PR377 adjacent controller progress follow-up from issue #381.
- Keeps the territory/control gameplay lane focused on bot behavior under `prod/`.
- Includes regenerated `prod/dist/main.js` from the verified build.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

## Scheduler evidence
- Source issue: #381
- Worktree: `/root/screeps-worktrees/territory-post377-381`
- Commit: `3331f8f` authored by `lanyusea's bot <lanyusea@gmail.com>`

Closes #381
