### PR TITLE
feat: prioritize adjacent controller progress follow-up

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1440,7 +1440,13 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
     recoveredTerritoryFollowUpRetryMetadata.set(plan, { suppressedAt: selection.recoveredFollowUpSuppressedAt });
   }
   const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? "active" : "planned";
-  recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
+  recordTerritoryIntent(
+    plan,
+    status,
+    gameTime,
+    selection.commitTarget ? target : null,
+    selection.routeDistanceLookupContext
+  );
   return plan;
 }
 function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime3()) {
@@ -1816,8 +1822,8 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
   if (sanitizedStaleProgress.changed) {
     intents = sanitizedStaleProgress.intents;
   }
-  refreshTerritoryFollowUpExecutionHints(territoryMemory, intents);
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
+  refreshTerritoryFollowUpExecutionHints(territoryMemory, intents, routeDistanceLookupContext);
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     colony,
     territoryMemory,
@@ -1866,7 +1872,7 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
     );
     const shouldEvaluateAdjacentFollowUp = shouldEvaluateVisibleAdjacentFollowUpPreference(bestReadyPrimaryCandidate);
     if (!shouldEvaluateAdjacentControllerProgress && !shouldEvaluateAdjacentFollowUp) {
-      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
+      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate, routeDistanceLookupContext);
     }
     const visibleAdjacentControllerProgressCandidates = applyOccupationRecommendationScores(
       colony,
@@ -1893,7 +1899,7 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
       ]
     );
     if (visibleAdjacentControllerProgressCandidates.length === 0) {
-      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
+      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate, routeDistanceLookupContext);
     }
     return toSelectedTerritoryTarget(
       (_a = selectBestScoredTerritoryCandidate(
@@ -1902,7 +1908,8 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
           roleCounts,
           colony
         )
-      )) != null ? _a : bestReadyPrimaryCandidate
+      )) != null ? _a : bestReadyPrimaryCandidate,
+      routeDistanceLookupContext
     );
   }
   const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, workerTarget, [
@@ -1931,7 +1938,8 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
   ]);
   const candidates = getSpawnCapableTerritoryCandidates([...primaryCandidates, ...adjacentCandidates], colony);
   return toSelectedTerritoryTarget(
-    (_c = (_b = selectBestScoredTerritoryCandidate(getReadyTerritoryCandidates(candidates, roleCounts, colony))) != null ? _b : selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony))) != null ? _c : selectBestScoredTerritoryCandidate(candidates)
+    (_c = (_b = selectBestScoredTerritoryCandidate(getReadyTerritoryCandidates(candidates, roleCounts, colony))) != null ? _b : selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony))) != null ? _c : selectBestScoredTerritoryCandidate(candidates),
+    routeDistanceLookupContext
   );
 }
 function selectBestScoredTerritoryCandidate(candidates) {
@@ -1943,7 +1951,7 @@ function selectBestScoredTerritoryCandidate(candidates) {
   }
   return bestCandidate;
 }
-function toSelectedTerritoryTarget(candidate) {
+function toSelectedTerritoryTarget(candidate, routeDistanceLookupContext) {
   return candidate ? {
     target: candidate.target,
     intentAction: candidate.intentAction,
@@ -1951,7 +1959,8 @@ function toSelectedTerritoryTarget(candidate) {
     ...candidate.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...candidate.followUp ? { followUp: candidate.followUp } : {},
     ...candidate.recoveredFollowUp ? { recoveredFollowUp: true } : {},
-    ...typeof candidate.recoveredFollowUpSuppressedAt === "number" ? { recoveredFollowUpSuppressedAt: candidate.recoveredFollowUpSuppressedAt } : {}
+    ...typeof candidate.recoveredFollowUpSuppressedAt === "number" ? { recoveredFollowUpSuppressedAt: candidate.recoveredFollowUpSuppressedAt } : {},
+    ...routeDistanceLookupContext ? { routeDistanceLookupContext } : {}
   } : null;
 }
 function shouldEvaluateVisibleAdjacentControllerProgressPreference(candidate, colony, roleCounts, workerTarget) {
@@ -2840,7 +2849,7 @@ function normalizeTerritoryTarget2(rawTarget) {
     ...rawTarget.enabled === false ? { enabled: false } : {}
   };
 }
-function recordTerritoryIntent(plan, status, gameTime, seededTarget = null) {
+function recordTerritoryIntent(plan, status, gameTime, seededTarget = null, routeDistanceLookupContext = createRouteDistanceLookupContext()) {
   const territoryMemory = getWritableTerritoryMemoryRecord2();
   if (!territoryMemory) {
     return;
@@ -2862,7 +2871,7 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null) {
   };
   upsertTerritoryIntent2(intents, nextIntent);
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
-  recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
+  recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime, routeDistanceLookupContext);
 }
 function normalizeTerritoryIntents2(rawIntents) {
   return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
@@ -3110,11 +3119,12 @@ function getCurrentTerritoryFollowUpDemand(plan, gameTime) {
     (demand) => demand.updatedAt === gameTime && demand.colony === plan.colony && demand.targetRoom === plan.targetRoom && demand.action === plan.action
   )) != null ? _a : null;
 }
-function recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime) {
+function recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime, routeDistanceLookupContext = createRouteDistanceLookupContext()) {
   const intents = normalizeTerritoryIntents2(territoryMemory.intents);
   const currentHints = getBoundedActiveTerritoryFollowUpExecutionHints(
     normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
-    intents
+    intents,
+    routeDistanceLookupContext
   );
   const nextHint = buildTerritoryFollowUpExecutionHint(plan, gameTime);
   if (!nextHint) {
@@ -3127,7 +3137,7 @@ function recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime) {
   upsertTerritoryFollowUpExecutionHint(currentHints, nextHint);
   setTerritoryFollowUpExecutionHints(territoryMemory, currentHints);
 }
-function refreshTerritoryFollowUpExecutionHints(territoryMemory, intents) {
+function refreshTerritoryFollowUpExecutionHints(territoryMemory, intents, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.executionHints)) {
     return;
   }
@@ -3135,14 +3145,15 @@ function refreshTerritoryFollowUpExecutionHints(territoryMemory, intents) {
     territoryMemory,
     getBoundedActiveTerritoryFollowUpExecutionHints(
       normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
-      intents
+      intents,
+      routeDistanceLookupContext
     )
   );
 }
-function getBoundedActiveTerritoryFollowUpExecutionHints(hints, intents) {
+function getBoundedActiveTerritoryFollowUpExecutionHints(hints, intents, routeDistanceLookupContext = createRouteDistanceLookupContext()) {
   const latestHintByColony = /* @__PURE__ */ new Map();
   for (const hint of hints) {
-    if (!isTerritoryFollowUpExecutionHintStillActive(hint, intents)) {
+    if (!isTerritoryFollowUpExecutionHintStillActive(hint, intents, routeDistanceLookupContext)) {
       continue;
     }
     const existingHint = latestHintByColony.get(hint.colony);
@@ -3152,8 +3163,8 @@ function getBoundedActiveTerritoryFollowUpExecutionHints(hints, intents) {
   }
   return Array.from(latestHintByColony.values()).sort((left, right) => left.colony.localeCompare(right.colony));
 }
-function isTerritoryFollowUpExecutionHintStillActive(hint, intents) {
-  if (isTerritoryFollowUpExecutionHintKnownUnreachable(hint)) {
+function isTerritoryFollowUpExecutionHintStillActive(hint, intents, routeDistanceLookupContext) {
+  if (isTerritoryFollowUpExecutionHintKnownUnreachable(hint, routeDistanceLookupContext)) {
     return false;
   }
   const matchingIntent = findMatchingActiveTerritoryFollowUpIntent(hint, intents);
@@ -3168,13 +3179,8 @@ function isTerritoryFollowUpExecutionHintStillActive(hint, intents) {
   );
   return currentReason === hint.reason;
 }
-function isTerritoryFollowUpExecutionHintKnownUnreachable(hint) {
-  var _a;
-  const routeDistances = (_a = getTerritoryMemoryRecord2()) == null ? void 0 : _a.routeDistances;
-  if (!isRecord2(routeDistances)) {
-    return false;
-  }
-  return routeDistances[getTerritoryRouteDistanceCacheKey(hint.colony, hint.targetRoom)] === null;
+function isTerritoryFollowUpExecutionHintKnownUnreachable(hint, routeDistanceLookupContext) {
+  return hasKnownNoRoute(hint.colony, hint.targetRoom, routeDistanceLookupContext);
 }
 function findMatchingActiveTerritoryFollowUpIntent(hint, intents) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3153,16 +3153,28 @@ function getBoundedActiveTerritoryFollowUpExecutionHints(hints, intents) {
   return Array.from(latestHintByColony.values()).sort((left, right) => left.colony.localeCompare(right.colony));
 }
 function isTerritoryFollowUpExecutionHintStillActive(hint, intents) {
+  if (isTerritoryFollowUpExecutionHintKnownUnreachable(hint)) {
+    return false;
+  }
   const matchingIntent = findMatchingActiveTerritoryFollowUpIntent(hint, intents);
   if (!(matchingIntent == null ? void 0 : matchingIntent.followUp) || !isSameTerritoryFollowUp(hint.followUp, matchingIntent.followUp)) {
     return false;
   }
-  return getTerritoryFollowUpExecutionHintReason(
+  const currentReason = getTerritoryFollowUpExecutionHintReason(
     matchingIntent.targetRoom,
     matchingIntent.action,
     matchingIntent.controllerId,
     getVisibleColonyOwnerUsername(matchingIntent.colony)
-  ) !== null;
+  );
+  return currentReason === hint.reason;
+}
+function isTerritoryFollowUpExecutionHintKnownUnreachable(hint) {
+  var _a;
+  const routeDistances = (_a = getTerritoryMemoryRecord2()) == null ? void 0 : _a.routeDistances;
+  if (!isRecord2(routeDistances)) {
+    return false;
+  }
+  return routeDistances[getTerritoryRouteDistanceCacheKey(hint.colony, hint.targetRoom)] === null;
 }
 function findMatchingActiveTerritoryFollowUpIntent(hint, intents) {
   var _a;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -75,6 +75,7 @@ interface SelectedTerritoryTarget {
   persistedFollowUp?: boolean;
   recoveredFollowUp?: boolean;
   recoveredFollowUpSuppressedAt?: number;
+  routeDistanceLookupContext?: RouteDistanceLookupContext;
 }
 
 type TerritoryCandidateSource =
@@ -149,7 +150,13 @@ export function planTerritoryIntent(
     recoveredTerritoryFollowUpRetryMetadata.set(plan, { suppressedAt: selection.recoveredFollowUpSuppressedAt });
   }
   const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? 'active' : 'planned';
-  recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
+  recordTerritoryIntent(
+    plan,
+    status,
+    gameTime,
+    selection.commitTarget ? target : null,
+    selection.routeDistanceLookupContext
+  );
 
   return plan;
 }
@@ -683,8 +690,8 @@ function selectTerritoryTarget(
   if (sanitizedStaleProgress.changed) {
     intents = sanitizedStaleProgress.intents;
   }
-  refreshTerritoryFollowUpExecutionHints(territoryMemory, intents);
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
+  refreshTerritoryFollowUpExecutionHints(territoryMemory, intents, routeDistanceLookupContext);
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     colony,
     territoryMemory,
@@ -736,7 +743,7 @@ function selectTerritoryTarget(
     );
     const shouldEvaluateAdjacentFollowUp = shouldEvaluateVisibleAdjacentFollowUpPreference(bestReadyPrimaryCandidate);
     if (!shouldEvaluateAdjacentControllerProgress && !shouldEvaluateAdjacentFollowUp) {
-      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
+      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate, routeDistanceLookupContext);
     }
 
     const visibleAdjacentControllerProgressCandidates = applyOccupationRecommendationScores(
@@ -768,7 +775,7 @@ function selectTerritoryTarget(
       ]
     );
     if (visibleAdjacentControllerProgressCandidates.length === 0) {
-      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate);
+      return toSelectedTerritoryTarget(bestReadyPrimaryCandidate, routeDistanceLookupContext);
     }
 
     return toSelectedTerritoryTarget(
@@ -778,7 +785,8 @@ function selectTerritoryTarget(
           roleCounts,
           colony
         )
-      ) ?? bestReadyPrimaryCandidate
+      ) ?? bestReadyPrimaryCandidate,
+      routeDistanceLookupContext
     );
   }
 
@@ -811,7 +819,8 @@ function selectTerritoryTarget(
   return toSelectedTerritoryTarget(
     selectBestScoredTerritoryCandidate(getReadyTerritoryCandidates(candidates, roleCounts, colony)) ??
       selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony)) ??
-      selectBestScoredTerritoryCandidate(candidates)
+      selectBestScoredTerritoryCandidate(candidates),
+    routeDistanceLookupContext
   );
 }
 
@@ -826,7 +835,10 @@ function selectBestScoredTerritoryCandidate(candidates: ScoredTerritoryTarget[])
   return bestCandidate;
 }
 
-function toSelectedTerritoryTarget(candidate: ScoredTerritoryTarget | null): SelectedTerritoryTarget | null {
+function toSelectedTerritoryTarget(
+  candidate: ScoredTerritoryTarget | null,
+  routeDistanceLookupContext?: RouteDistanceLookupContext
+): SelectedTerritoryTarget | null {
   return candidate
     ? {
         target: candidate.target,
@@ -837,7 +849,8 @@ function toSelectedTerritoryTarget(candidate: ScoredTerritoryTarget | null): Sel
         ...(candidate.recoveredFollowUp ? { recoveredFollowUp: true } : {}),
         ...(typeof candidate.recoveredFollowUpSuppressedAt === 'number'
           ? { recoveredFollowUpSuppressedAt: candidate.recoveredFollowUpSuppressedAt }
-          : {})
+          : {}),
+        ...(routeDistanceLookupContext ? { routeDistanceLookupContext } : {})
       }
     : null;
 }
@@ -2292,7 +2305,8 @@ function recordTerritoryIntent(
   plan: TerritoryIntentPlan,
   status: TerritoryIntentMemory['status'],
   gameTime: number,
-  seededTarget: TerritoryTargetMemory | null = null
+  seededTarget: TerritoryTargetMemory | null = null,
+  routeDistanceLookupContext: RouteDistanceLookupContext = createRouteDistanceLookupContext()
 ): void {
   const territoryMemory = getWritableTerritoryMemoryRecord();
   if (!territoryMemory) {
@@ -2318,7 +2332,7 @@ function recordTerritoryIntent(
 
   upsertTerritoryIntent(intents, nextIntent);
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
-  recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
+  recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime, routeDistanceLookupContext);
 }
 
 function normalizeTerritoryIntents(rawIntents: TerritoryMemory['intents'] | unknown): TerritoryIntentMemory[] {
@@ -2746,12 +2760,14 @@ function getCurrentTerritoryFollowUpDemand(
 function recordTerritoryFollowUpExecutionHint(
   territoryMemory: TerritoryMemory,
   plan: TerritoryIntentPlan,
-  gameTime: number
+  gameTime: number,
+  routeDistanceLookupContext: RouteDistanceLookupContext = createRouteDistanceLookupContext()
 ): void {
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   const currentHints = getBoundedActiveTerritoryFollowUpExecutionHints(
     normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
-    intents
+    intents,
+    routeDistanceLookupContext
   );
   const nextHint = buildTerritoryFollowUpExecutionHint(plan, gameTime);
   if (!nextHint) {
@@ -2770,7 +2786,8 @@ function recordTerritoryFollowUpExecutionHint(
 
 function refreshTerritoryFollowUpExecutionHints(
   territoryMemory: Record<string, unknown> | null,
-  intents: TerritoryIntentMemory[]
+  intents: TerritoryIntentMemory[],
+  routeDistanceLookupContext: RouteDistanceLookupContext
 ): void {
   if (!territoryMemory || !Array.isArray(territoryMemory.executionHints)) {
     return;
@@ -2780,18 +2797,20 @@ function refreshTerritoryFollowUpExecutionHints(
     territoryMemory,
     getBoundedActiveTerritoryFollowUpExecutionHints(
       normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
-      intents
+      intents,
+      routeDistanceLookupContext
     )
   );
 }
 
 function getBoundedActiveTerritoryFollowUpExecutionHints(
   hints: TerritoryExecutionHintMemory[],
-  intents: TerritoryIntentMemory[]
+  intents: TerritoryIntentMemory[],
+  routeDistanceLookupContext: RouteDistanceLookupContext = createRouteDistanceLookupContext()
 ): TerritoryExecutionHintMemory[] {
   const latestHintByColony = new Map<string, TerritoryExecutionHintMemory>();
   for (const hint of hints) {
-    if (!isTerritoryFollowUpExecutionHintStillActive(hint, intents)) {
+    if (!isTerritoryFollowUpExecutionHintStillActive(hint, intents, routeDistanceLookupContext)) {
       continue;
     }
 
@@ -2810,9 +2829,10 @@ function getBoundedActiveTerritoryFollowUpExecutionHints(
 
 function isTerritoryFollowUpExecutionHintStillActive(
   hint: TerritoryExecutionHintMemory,
-  intents: TerritoryIntentMemory[]
+  intents: TerritoryIntentMemory[],
+  routeDistanceLookupContext: RouteDistanceLookupContext
 ): boolean {
-  if (isTerritoryFollowUpExecutionHintKnownUnreachable(hint)) {
+  if (isTerritoryFollowUpExecutionHintKnownUnreachable(hint, routeDistanceLookupContext)) {
     return false;
   }
 
@@ -2831,13 +2851,11 @@ function isTerritoryFollowUpExecutionHintStillActive(
   return currentReason === hint.reason;
 }
 
-function isTerritoryFollowUpExecutionHintKnownUnreachable(hint: TerritoryExecutionHintMemory): boolean {
-  const routeDistances = getTerritoryMemoryRecord()?.routeDistances;
-  if (!isRecord(routeDistances)) {
-    return false;
-  }
-
-  return routeDistances[getTerritoryRouteDistanceCacheKey(hint.colony, hint.targetRoom)] === null;
+function isTerritoryFollowUpExecutionHintKnownUnreachable(
+  hint: TerritoryExecutionHintMemory,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): boolean {
+  return hasKnownNoRoute(hint.colony, hint.targetRoom, routeDistanceLookupContext);
 }
 
 function findMatchingActiveTerritoryFollowUpIntent(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2812,19 +2812,32 @@ function isTerritoryFollowUpExecutionHintStillActive(
   hint: TerritoryExecutionHintMemory,
   intents: TerritoryIntentMemory[]
 ): boolean {
+  if (isTerritoryFollowUpExecutionHintKnownUnreachable(hint)) {
+    return false;
+  }
+
   const matchingIntent = findMatchingActiveTerritoryFollowUpIntent(hint, intents);
   if (!matchingIntent?.followUp || !isSameTerritoryFollowUp(hint.followUp, matchingIntent.followUp)) {
     return false;
   }
 
-  return (
-    getTerritoryFollowUpExecutionHintReason(
-      matchingIntent.targetRoom,
-      matchingIntent.action,
-      matchingIntent.controllerId,
-      getVisibleColonyOwnerUsername(matchingIntent.colony)
-    ) !== null
+  const currentReason = getTerritoryFollowUpExecutionHintReason(
+    matchingIntent.targetRoom,
+    matchingIntent.action,
+    matchingIntent.controllerId,
+    getVisibleColonyOwnerUsername(matchingIntent.colony)
   );
+
+  return currentReason === hint.reason;
+}
+
+function isTerritoryFollowUpExecutionHintKnownUnreachable(hint: TerritoryExecutionHintMemory): boolean {
+  const routeDistances = getTerritoryMemoryRecord()?.routeDistances;
+  if (!isRecord(routeDistances)) {
+    return false;
+  }
+
+  return routeDistances[getTerritoryRouteDistanceCacheKey(hint.colony, hint.targetRoom)] === null;
 }
 
 function findMatchingActiveTerritoryFollowUpIntent(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2727,6 +2727,58 @@ describe('planTerritoryIntent', () => {
     expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([existingHint]);
   });
 
+  it('revalidates a stale no-route execution hint before preserving a live follow-up behind a scout plan', () => {
+    const colony = makeSafeColony();
+    colony.energyAvailable = 50;
+    (colony.room as Room & { energyAvailable: number }).energyAvailable = 50;
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const followUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const followUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 596,
+      followUp
+    };
+    const existingHint: TerritoryExecutionHintMemory = {
+      type: 'activeFollowUpExecution',
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      reason: 'visibleControlEvidenceStillActionable',
+      updatedAt: 596,
+      followUp
+    };
+    const findRoute = jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 3, room: toRoom }]);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W3N1: makeRecommendationRoom('W3N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, followUpTarget],
+        intents: [followUpIntent],
+        executionHints: [existingHint],
+        routeDistances: { 'W1N1>W3N1': null }
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 597)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'scout'
+    });
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W3N1');
+    expect(Memory.territory?.routeDistances?.['W1N1>W3N1']).toBe(1);
+    expect(Memory.territory?.executionHints).toEqual([existingHint]);
+    expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([existingHint]);
+  });
+
   it('clears stale follow-up controller intent after visible evidence satisfies the target', () => {
     const colony = makeSafeColony();
     const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2582,6 +2582,104 @@ describe('planTerritoryIntent', () => {
     expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([]);
   });
 
+  it('clears a visible execution hint after follow-up target visibility is lost', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const followUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const followUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 596,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, followUpTarget],
+        intents: [followUpIntent],
+        executionHints: [
+          {
+            type: 'activeFollowUpExecution',
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            reason: 'visibleControlEvidenceStillActionable',
+            updatedAt: 596,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 597)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.executionHints).toBeUndefined();
+    expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([]);
+  });
+
+  it('clears an execution hint after route lookup proves the follow-up target is unreachable', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const followUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const followUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 598,
+      followUp
+    };
+    const findRoute = jest.fn((_fromRoom: string, toRoom: string) =>
+      toRoom === 'W3N1' ? -2 : [{ exit: 3, room: toRoom }]
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1'),
+        W3N1: makeRecommendationRoom('W3N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, followUpTarget],
+        intents: [followUpIntent],
+        executionHints: [
+          {
+            type: 'activeFollowUpExecution',
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            reason: 'visibleControlEvidenceStillActionable',
+            updatedAt: 598,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 599)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.routeDistances?.['W1N1>W3N1']).toBeNull();
+    expect(Memory.territory?.executionHints).toBeUndefined();
+    expect(getActiveTerritoryFollowUpExecutionHints('W1N1')).toEqual([]);
+  });
+
   it('preserves an active execution hint when a live follow-up intent remains behind a scout plan', () => {
     const colony = makeSafeColony();
     colony.energyAvailable = 50;


### PR DESCRIPTION
## Summary
- prioritize visible adjacent controller progress follow-up planning when the room needs actionable territory pressure
- keep reservation/cooldown/suppression gates intact while making adjacent controller opportunities executable
- add territory planner coverage and rebuild `prod/dist/main.js`

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --check`

Closes #383.
