### PR TITLE
feat: prefer productive worker energy throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4647,14 +4647,14 @@ function compareProductiveEnergySinkCandidates(left, right) {
   return left.range - right.range || left.taskPriority - right.taskPriority || String(left.task.targetId).localeCompare(String(right.task.targetId));
 }
 function selectCapacityEnablingConstructionSite(creep, constructionSites, controller) {
-  const spawnConstructionSite = selectConstructionSite(creep, constructionSites, isSpawnConstructionSite);
+  const spawnConstructionSite = selectUnreservedConstructionSite(creep, constructionSites, isSpawnConstructionSite);
   if (spawnConstructionSite) {
     return spawnConstructionSite;
   }
   if (controller && shouldRushRcl1Controller(controller)) {
     return null;
   }
-  return selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
+  return selectUnreservedConstructionSite(creep, constructionSites, isExtensionConstructionSite);
 }
 function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstructionSite, controller, constructionSites) {
   if (!hasReadyTerritoryFollowUpEnergy(creep)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4064,7 +4064,13 @@ function selectWorkerTask(creep) {
     return null;
   }
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
-  const capacityConstructionSite = selectCapacityEnablingConstructionSite(creep, constructionSites, controller);
+  const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
+  const capacityConstructionSite = selectCapacityEnablingConstructionSite(
+    creep,
+    constructionSites,
+    controller,
+    constructionReservationContext
+  );
   if (capacityConstructionSite && !territoryControllerTask) {
     return { type: "build", targetId: capacityConstructionSite.id };
   }
@@ -4087,7 +4093,7 @@ function selectWorkerTask(creep) {
   if (territoryControllerTask) {
     return territoryControllerTask;
   }
-  const source2ControllerLaneLoadedTask = controller ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites) : null;
+  const source2ControllerLaneLoadedTask = controller ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites, constructionReservationContext) : null;
   if (source2ControllerLaneLoadedTask) {
     return source2ControllerLaneLoadedTask;
   }
@@ -4113,17 +4119,31 @@ function selectWorkerTask(creep) {
     return { type: "build", targetId: containerConstructionSite.id };
   }
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
-    const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller);
+    const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
+      creep,
+      constructionSites,
+      controller,
+      constructionReservationContext
+    );
     if (productiveEnergySinkTask) {
       return productiveEnergySinkTask;
     }
     return { type: "upgrade", targetId: controller.id };
   }
-  const roadConstructionSite = selectUnreservedConstructionSite(creep, constructionSites, isRoadConstructionSite2);
+  const roadConstructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    isRoadConstructionSite2
+  );
   if (roadConstructionSite) {
     return { type: "build", targetId: roadConstructionSite.id };
   }
-  const constructionSite = selectUnreservedConstructionSite(creep, constructionSites);
+  const constructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
   if (constructionSite) {
     return { type: "build", targetId: constructionSite.id };
   }
@@ -4519,14 +4539,14 @@ function selectConstructionSite(creep, constructionSites, predicate = () => true
   }
   return candidates[0];
 }
-function selectUnreservedConstructionSite(creep, constructionSites, predicate = () => true) {
+function selectUnreservedConstructionSite(creep, constructionSites, constructionReservationContext, predicate = () => true) {
   return selectConstructionSite(
     creep,
     constructionSites,
-    (site) => predicate(site) && hasUnreservedConstructionProgress(creep, site)
+    (site) => predicate(site) && hasUnreservedConstructionProgress(creep, site, constructionReservationContext)
   );
 }
-function hasUnreservedConstructionProgress(creep, site) {
+function hasUnreservedConstructionProgress(creep, site, constructionReservationContext) {
   if (isWorkerAssignedToConstructionSite(creep, site)) {
     return true;
   }
@@ -4534,15 +4554,33 @@ function hasUnreservedConstructionProgress(creep, site) {
   if (!Number.isFinite(remainingProgress)) {
     return true;
   }
-  return remainingProgress > getReservedConstructionProgress(creep, site);
+  return remainingProgress > getReservedConstructionProgress(site, constructionReservationContext);
 }
-function getReservedConstructionProgress(creep, site) {
-  return getRoomOwnedCreeps(creep.room).reduce((total, worker) => {
-    if (isSameCreep(worker, creep) || !isSameRoomWorker(worker, creep.room) || !isWorkerAssignedToConstructionSite(worker, site)) {
-      return total;
+function getReservedConstructionProgress(site, constructionReservationContext) {
+  var _a;
+  return (_a = constructionReservationContext.reservedProgressBySiteId.get(String(site.id))) != null ? _a : 0;
+}
+function createEmptyConstructionReservationContext() {
+  return { reservedProgressBySiteId: /* @__PURE__ */ new Map() };
+}
+function createConstructionReservationContext(room) {
+  var _a, _b;
+  const reservedProgressBySiteId = /* @__PURE__ */ new Map();
+  for (const worker of getRoomOwnedCreeps(room)) {
+    if (!isSameRoomWorker(worker, room)) {
+      continue;
     }
-    return total + getUsedEnergy(worker) * getBuildPower();
-  }, 0);
+    const task = (_a = worker.memory) == null ? void 0 : _a.task;
+    if ((task == null ? void 0 : task.type) !== "build" || task.targetId === void 0) {
+      continue;
+    }
+    const siteId = String(task.targetId);
+    reservedProgressBySiteId.set(
+      siteId,
+      ((_b = reservedProgressBySiteId.get(siteId)) != null ? _b : 0) + getUsedEnergy(worker) * getBuildPower()
+    );
+  }
+  return { reservedProgressBySiteId };
 }
 function getRoomOwnedCreeps(room) {
   var _a;
@@ -4611,13 +4649,13 @@ function selectCriticalRoadConstructionSite(creep, constructionSites) {
     (site) => isCriticalRoadLogisticsWork(site, criticalRoadContext)
   );
 }
-function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller) {
+function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller, constructionReservationContext) {
   const controllerRange = getRangeBetweenRoomObjects(creep, controller);
   if (controllerRange === null) {
     return null;
   }
   const candidates = [
-    ...constructionSites.filter((site) => hasUnreservedConstructionProgress(creep, site)).map(
+    ...constructionSites.filter((site) => hasUnreservedConstructionProgress(creep, site, constructionReservationContext)).map(
       (site) => createProductiveEnergySinkCandidate(creep, site, { type: "build", targetId: site.id }, 0)
     ),
     ...findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget).map(
@@ -4646,15 +4684,25 @@ function createProductiveEnergySinkCandidate(creep, target, task, taskPriority) 
 function compareProductiveEnergySinkCandidates(left, right) {
   return left.range - right.range || left.taskPriority - right.taskPriority || String(left.task.targetId).localeCompare(String(right.task.targetId));
 }
-function selectCapacityEnablingConstructionSite(creep, constructionSites, controller) {
-  const spawnConstructionSite = selectUnreservedConstructionSite(creep, constructionSites, isSpawnConstructionSite);
+function selectCapacityEnablingConstructionSite(creep, constructionSites, controller, constructionReservationContext) {
+  const spawnConstructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    isSpawnConstructionSite
+  );
   if (spawnConstructionSite) {
     return spawnConstructionSite;
   }
   if (controller && shouldRushRcl1Controller(controller)) {
     return null;
   }
-  return selectUnreservedConstructionSite(creep, constructionSites, isExtensionConstructionSite);
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    isExtensionConstructionSite
+  );
 }
 function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstructionSite, controller, constructionSites) {
   if (!hasReadyTerritoryFollowUpEnergy(creep)) {
@@ -5416,11 +5464,16 @@ function shouldApplySource2ControllerLane(creep, controller) {
   }
   return !hasOtherSource2ControllerLaneWorker(creep, topology);
 }
-function selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites) {
+function selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites, constructionReservationContext) {
   if (!shouldApplySource2ControllerLane(creep, controller)) {
     return null;
   }
-  const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller);
+  const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
+    creep,
+    constructionSites,
+    controller,
+    constructionReservationContext
+  );
   return productiveEnergySinkTask != null ? productiveEnergySinkTask : { type: "upgrade", targetId: controller.id };
 }
 function selectSource2ControllerLaneHarvestTask(creep) {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1083,7 +1083,7 @@ function selectCapacityEnablingConstructionSite(
   constructionSites: ConstructionSite[],
   controller: StructureController | undefined
 ): ConstructionSite | null {
-  const spawnConstructionSite = selectConstructionSite(creep, constructionSites, isSpawnConstructionSite);
+  const spawnConstructionSite = selectUnreservedConstructionSite(creep, constructionSites, isSpawnConstructionSite);
   if (spawnConstructionSite) {
     return spawnConstructionSite;
   }
@@ -1092,7 +1092,7 @@ function selectCapacityEnablingConstructionSite(
     return null;
   }
 
-  return selectConstructionSite(creep, constructionSites, isExtensionConstructionSite);
+  return selectUnreservedConstructionSite(creep, constructionSites, isExtensionConstructionSite);
 }
 
 function selectReadyFollowUpProductiveEnergySinkTask(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -75,6 +75,10 @@ interface NearTermSpawnExtensionRefillReserveCache {
   tick: number;
 }
 
+interface ConstructionReservationContext {
+  reservedProgressBySiteId: Map<string, number>;
+}
+
 interface Source2ControllerLaneTopology {
   controller: StructureController;
   source: Source;
@@ -194,7 +198,16 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
-  const capacityConstructionSite = selectCapacityEnablingConstructionSite(creep, constructionSites, controller);
+  const constructionReservationContext =
+    constructionSites.length > 0
+      ? createConstructionReservationContext(creep.room)
+      : createEmptyConstructionReservationContext();
+  const capacityConstructionSite = selectCapacityEnablingConstructionSite(
+    creep,
+    constructionSites,
+    controller,
+    constructionReservationContext
+  );
   if (capacityConstructionSite && !territoryControllerTask) {
     return { type: 'build', targetId: capacityConstructionSite.id };
   }
@@ -223,7 +236,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const source2ControllerLaneLoadedTask = controller
-    ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites)
+    ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites, constructionReservationContext)
     : null;
   if (source2ControllerLaneLoadedTask) {
     return source2ControllerLaneLoadedTask;
@@ -257,7 +270,12 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
-    const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller);
+    const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
+      creep,
+      constructionSites,
+      controller,
+      constructionReservationContext
+    );
     if (productiveEnergySinkTask) {
       return productiveEnergySinkTask;
     }
@@ -265,12 +283,21 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return { type: 'upgrade', targetId: controller.id };
   }
 
-  const roadConstructionSite = selectUnreservedConstructionSite(creep, constructionSites, isRoadConstructionSite);
+  const roadConstructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    isRoadConstructionSite
+  );
   if (roadConstructionSite) {
     return { type: 'build', targetId: roadConstructionSite.id };
   }
 
-  const constructionSite = selectUnreservedConstructionSite(creep, constructionSites);
+  const constructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext
+  );
   if (constructionSite) {
     return { type: 'build', targetId: constructionSite.id };
   }
@@ -869,16 +896,21 @@ function selectConstructionSite(
 function selectUnreservedConstructionSite(
   creep: Creep,
   constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext,
   predicate: (site: ConstructionSite) => boolean = () => true
 ): ConstructionSite | null {
   return selectConstructionSite(
     creep,
     constructionSites,
-    (site) => predicate(site) && hasUnreservedConstructionProgress(creep, site)
+    (site) => predicate(site) && hasUnreservedConstructionProgress(creep, site, constructionReservationContext)
   );
 }
 
-function hasUnreservedConstructionProgress(creep: Creep, site: ConstructionSite): boolean {
+function hasUnreservedConstructionProgress(
+  creep: Creep,
+  site: ConstructionSite,
+  constructionReservationContext: ConstructionReservationContext
+): boolean {
   if (isWorkerAssignedToConstructionSite(creep, site)) {
     return true;
   }
@@ -888,21 +920,40 @@ function hasUnreservedConstructionProgress(creep: Creep, site: ConstructionSite)
     return true;
   }
 
-  return remainingProgress > getReservedConstructionProgress(creep, site);
+  return remainingProgress > getReservedConstructionProgress(site, constructionReservationContext);
 }
 
-function getReservedConstructionProgress(creep: Creep, site: ConstructionSite): number {
-  return getRoomOwnedCreeps(creep.room).reduce((total, worker) => {
-    if (
-      isSameCreep(worker, creep) ||
-      !isSameRoomWorker(worker, creep.room) ||
-      !isWorkerAssignedToConstructionSite(worker, site)
-    ) {
-      return total;
+function getReservedConstructionProgress(
+  site: ConstructionSite,
+  constructionReservationContext: ConstructionReservationContext
+): number {
+  return constructionReservationContext.reservedProgressBySiteId.get(String(site.id)) ?? 0;
+}
+
+function createEmptyConstructionReservationContext(): ConstructionReservationContext {
+  return { reservedProgressBySiteId: new Map<string, number>() };
+}
+
+function createConstructionReservationContext(room: Room): ConstructionReservationContext {
+  const reservedProgressBySiteId = new Map<string, number>();
+  for (const worker of getRoomOwnedCreeps(room)) {
+    if (!isSameRoomWorker(worker, room)) {
+      continue;
     }
 
-    return total + getUsedEnergy(worker) * getBuildPower();
-  }, 0);
+    const task = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+    if (task?.type !== 'build' || task.targetId === undefined) {
+      continue;
+    }
+
+    const siteId = String(task.targetId);
+    reservedProgressBySiteId.set(
+      siteId,
+      (reservedProgressBySiteId.get(siteId) ?? 0) + getUsedEnergy(worker) * getBuildPower()
+    );
+  }
+
+  return { reservedProgressBySiteId };
 }
 
 function getRoomOwnedCreeps(room: Room): Creep[] {
@@ -1018,7 +1069,8 @@ function selectCriticalRoadConstructionSite(
 function selectNearbyProductiveEnergySinkTask(
   creep: Creep,
   constructionSites: ConstructionSite[],
-  controller: StructureController
+  controller: StructureController,
+  constructionReservationContext: ConstructionReservationContext
 ): ProductiveEnergySinkTask | null {
   const controllerRange = getRangeBetweenRoomObjects(creep, controller);
   if (controllerRange === null) {
@@ -1027,7 +1079,7 @@ function selectNearbyProductiveEnergySinkTask(
 
   const candidates = [
     ...constructionSites
-      .filter((site) => hasUnreservedConstructionProgress(creep, site))
+      .filter((site) => hasUnreservedConstructionProgress(creep, site, constructionReservationContext))
       .map((site) =>
         createProductiveEnergySinkCandidate(creep, site, { type: 'build', targetId: site.id }, 0)
       ),
@@ -1081,9 +1133,15 @@ function compareProductiveEnergySinkCandidates(
 function selectCapacityEnablingConstructionSite(
   creep: Creep,
   constructionSites: ConstructionSite[],
-  controller: StructureController | undefined
+  controller: StructureController | undefined,
+  constructionReservationContext: ConstructionReservationContext
 ): ConstructionSite | null {
-  const spawnConstructionSite = selectUnreservedConstructionSite(creep, constructionSites, isSpawnConstructionSite);
+  const spawnConstructionSite = selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    isSpawnConstructionSite
+  );
   if (spawnConstructionSite) {
     return spawnConstructionSite;
   }
@@ -1092,7 +1150,12 @@ function selectCapacityEnablingConstructionSite(
     return null;
   }
 
-  return selectUnreservedConstructionSite(creep, constructionSites, isExtensionConstructionSite);
+  return selectUnreservedConstructionSite(
+    creep,
+    constructionSites,
+    constructionReservationContext,
+    isExtensionConstructionSite
+  );
 }
 
 function selectReadyFollowUpProductiveEnergySinkTask(
@@ -2303,13 +2366,19 @@ function shouldApplySource2ControllerLane(creep: Creep, controller: StructureCon
 function selectSource2ControllerLaneLoadedTask(
   creep: Creep,
   controller: StructureController,
-  constructionSites: ConstructionSite[]
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
 ): ProductiveEnergySinkTask | Extract<CreepTaskMemory, { type: 'upgrade' }> | null {
   if (!shouldApplySource2ControllerLane(creep, controller)) {
     return null;
   }
 
-  const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller);
+  const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
+    creep,
+    constructionSites,
+    controller,
+    constructionReservationContext
+  );
   return productiveEnergySinkTask ?? { type: 'upgrade', targetId: controller.id };
 }
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4140,6 +4140,56 @@ describe('selectWorkerTask', () => {
     expect(room.find).toHaveBeenCalledWith(10);
   });
 
+  it('caches room construction reservations across construction candidate checks', () => {
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 10;
+    (globalThis as unknown as { BUILD_POWER: number }).BUILD_POWER = 5;
+    const coveredSite = {
+      id: 'generic-site-a',
+      structureType: 'tower',
+      progress: 0,
+      progressTotal: 100
+    } as ConstructionSite;
+    const openSite = {
+      id: 'generic-site-b',
+      structureType: 'tower',
+      progress: 0,
+      progressTotal: 100
+    } as ConstructionSite;
+    const secondOpenSite = {
+      id: 'generic-site-c',
+      structureType: 'tower',
+      progress: 0,
+      progressTotal: 150
+    } as ConstructionSite;
+    const myCreeps: Creep[] = [];
+    const room = makeWorkerTaskRoom({
+      constructionSites: [coveredSite, openSite, secondOpenSite],
+      controller: undefined,
+      myCreeps
+    });
+    const assignedBuilder = {
+      name: 'AssignedBuilder',
+      memory: { role: 'worker', task: { type: 'build', targetId: 'generic-site-a' as Id<ConstructionSite> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(20) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    myCreeps.push(assignedBuilder, creep);
+    setGameCreeps({});
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'generic-site-b' });
+    expect(
+      (room.find as jest.Mock).mock.calls.filter(
+        ([type]: [number]) => type === (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS
+      )
+    ).toHaveLength(1);
+  });
+
   it('keeps off-route road repair behind generic construction even at the critical hit threshold', () => {
     const site = { id: 'generic-site1', structureType: 'tower' } as ConstructionSite;
     const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4018,6 +4018,81 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'generic-site1' });
   });
 
+  it('skips capacity construction when another worker already covers its remaining progress', () => {
+    (globalThis as unknown as { BUILD_POWER: number }).BUILD_POWER = 5;
+    const extensionSite = {
+      id: 'extension-site1',
+      structureType: 'extension',
+      progress: 0,
+      progressTotal: 100
+    } as ConstructionSite;
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ constructionSites: [roadSite, extensionSite], controller });
+    const assignedBuilder = {
+      name: 'AssignedBuilder',
+      memory: { role: 'worker', task: { type: 'build', targetId: 'extension-site1' as Id<ConstructionSite> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(20) },
+      room
+    } as unknown as Creep;
+    const getRangeTo = jest.fn((target: { id?: string }) => {
+      const ranges: Record<string, number> = {
+        controller1: 5,
+        'extension-site1': 1,
+        'road-site1': 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ AssignedBuilder: assignedBuilder, Builder: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('keeps a worker on its assigned capacity construction site', () => {
+    (globalThis as unknown as { BUILD_POWER: number }).BUILD_POWER = 5;
+    const extensionSite = {
+      id: 'extension-site1',
+      structureType: 'extension',
+      progress: 0,
+      progressTotal: 100
+    } as ConstructionSite;
+    const roadSite = { id: 'road-site1', structureType: 'road' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 2,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ constructionSites: [roadSite, extensionSite], controller });
+    const otherBuilder = {
+      name: 'OtherBuilder',
+      memory: { role: 'worker', task: { type: 'build', targetId: 'extension-site1' as Id<ConstructionSite> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(20) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'AssignedBuilder',
+      memory: { role: 'worker', task: { type: 'build', targetId: 'extension-site1' as Id<ConstructionSite> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ OtherBuilder: otherBuilder, AssignedBuilder: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'extension-site1' });
+  });
+
   it('ignores off-room global builders when room-local construction reservations are available', () => {
     (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 10;
     const site = {


### PR DESCRIPTION
## Summary
- make capacity-enabling construction picks respect existing worker construction reservations
- keep an assigned worker on its reserved extension/spawn site while other workers choose alternative productive sinks
- add worker task coverage and rebuild `prod/dist/main.js`

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --check`

Closes #384.
