### PR TITLE
feat: prefer finishing low-progress economy sinks

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4656,7 +4656,13 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
   }
   const candidates = [
     ...constructionSites.filter((site) => hasUnreservedConstructionProgress(creep, site, constructionReservationContext)).map(
-      (site) => createProductiveEnergySinkCandidate(creep, site, { type: "build", targetId: site.id }, 0)
+      (site) => createProductiveEnergySinkCandidate(
+        creep,
+        site,
+        { type: "build", targetId: site.id },
+        0,
+        canCompleteConstructionSiteWithCarriedEnergy(creep, site)
+      )
     ),
     ...findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget).map(
       (structure) => createProductiveEnergySinkCandidate(
@@ -4674,15 +4680,21 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
   }
   return candidates.sort(compareProductiveEnergySinkCandidates)[0].task;
 }
-function createProductiveEnergySinkCandidate(creep, target, task, taskPriority) {
+function createProductiveEnergySinkCandidate(creep, target, task, taskPriority, canCompleteConstruction = false) {
   const range = getRangeBetweenRoomObjects(creep, target);
   if (range === null) {
     return null;
   }
-  return { range, task, taskPriority };
+  return { canCompleteConstruction, range, task, taskPriority };
 }
 function compareProductiveEnergySinkCandidates(left, right) {
-  return left.range - right.range || left.taskPriority - right.taskPriority || String(left.task.targetId).localeCompare(String(right.task.targetId));
+  return compareProductiveEnergySinkCompletion(left, right) || left.range - right.range || left.taskPriority - right.taskPriority || String(left.task.targetId).localeCompare(String(right.task.targetId));
+}
+function compareProductiveEnergySinkCompletion(left, right) {
+  if (left.canCompleteConstruction === right.canCompleteConstruction) {
+    return 0;
+  }
+  return left.canCompleteConstruction ? -1 : 1;
 }
 function selectCapacityEnablingConstructionSite(creep, constructionSites, controller, constructionReservationContext) {
   const spawnConstructionSite = selectUnreservedConstructionSite(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1081,7 +1081,13 @@ function selectNearbyProductiveEnergySinkTask(
     ...constructionSites
       .filter((site) => hasUnreservedConstructionProgress(creep, site, constructionReservationContext))
       .map((site) =>
-        createProductiveEnergySinkCandidate(creep, site, { type: 'build', targetId: site.id }, 0)
+        createProductiveEnergySinkCandidate(
+          creep,
+          site,
+          { type: 'build', targetId: site.id },
+          0,
+          canCompleteConstructionSiteWithCarriedEnergy(creep, site)
+        )
       ),
     ...findVisibleRoomStructures(creep.room)
       .filter(isSafeRepairTarget)
@@ -1109,14 +1115,15 @@ function createProductiveEnergySinkCandidate(
   creep: Creep,
   target: ConstructionSite | RepairableWorkerStructure,
   task: ProductiveEnergySinkTask,
-  taskPriority: number
+  taskPriority: number,
+  canCompleteConstruction = false
 ): ProductiveEnergySinkCandidate | null {
   const range = getRangeBetweenRoomObjects(creep, target);
   if (range === null) {
     return null;
   }
 
-  return { range, task, taskPriority };
+  return { canCompleteConstruction, range, task, taskPriority };
 }
 
 function compareProductiveEnergySinkCandidates(
@@ -1124,10 +1131,22 @@ function compareProductiveEnergySinkCandidates(
   right: ProductiveEnergySinkCandidate
 ): number {
   return (
+    compareProductiveEnergySinkCompletion(left, right) ||
     left.range - right.range ||
     left.taskPriority - right.taskPriority ||
     String(left.task.targetId).localeCompare(String(right.task.targetId))
   );
+}
+
+function compareProductiveEnergySinkCompletion(
+  left: ProductiveEnergySinkCandidate,
+  right: ProductiveEnergySinkCandidate
+): number {
+  if (left.canCompleteConstruction === right.canCompleteConstruction) {
+    return 0;
+  }
+
+  return left.canCompleteConstruction ? -1 : 1;
 }
 
 function selectCapacityEnablingConstructionSite(
@@ -1355,6 +1374,7 @@ interface SpawnRecoveryEnergyAcquisitionCandidate extends WorkerEnergyAcquisitio
 }
 
 interface ProductiveEnergySinkCandidate {
+  canCompleteConstruction: boolean;
   range: number;
   task: ProductiveEnergySinkTask;
   taskPriority: number;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -6042,6 +6042,56 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
   });
 
+  it('finishes source2/controller lane construction before a closer unfinished build target', () => {
+    (globalThis as unknown as { BUILD_POWER: number }).BUILD_POWER = 5;
+    const unfinishedSite = {
+      id: 'tower-unfinished',
+      structureType: 'tower',
+      progress: 0,
+      progressTotal: 1_000,
+      pos: makeRoomPosition(26, 24)
+    } as ConstructionSite;
+    const finishableSite = {
+      id: 'tower-finishable',
+      structureType: 'tower',
+      progress: 250,
+      progressTotal: 500,
+      pos: makeRoomPosition(27, 24)
+    } as ConstructionSite;
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [unfinishedSite, finishableSite],
+      controller,
+      sources: [source1, source2]
+    });
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        controller1: 4,
+        'tower-finishable': 3,
+        'tower-unfinished': 1
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    const creep = {
+      name: 'LaneWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { ...makeRoomPosition(25, 24), getRangeTo } as unknown as RoomPosition,
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LaneWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-finishable' });
+  });
+
   it.each([
     ['spawn', 'spawn1'],
     ['extension', 'extension1']


### PR DESCRIPTION
## Summary
- prefer low-progress construction sites that a loaded worker can finish when selecting productive economy sinks
- preserve emergency refill / downgrade guard priorities while improving carried-energy throughput
- add focused worker task tests and regenerate `prod/dist/main.js`

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `cd prod && git diff --check`

Closes #387.
