### PR TITLE
feat: carry territory execution hints into runner tasks

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1741,15 +1741,15 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
 }
 function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
   if (!isNonEmptyString3(colony) || !isNonEmptyString3(assignment.targetRoom) || assignment.action !== "reserve") {
-    return;
+    return null;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord2();
   if (!territoryMemory) {
-    return;
+    return null;
   }
-  const followUp = normalizeTerritoryFollowUp2(assignment.followUp);
   const intents = normalizeTerritoryIntents2(territoryMemory.intents);
   territoryMemory.intents = intents;
+  const followUp = getTerritoryReserveFallbackFollowUp(assignment, intents, colony, gameTime);
   const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
     intents,
     colony,
@@ -1757,6 +1757,12 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
     "reserve",
     assignment.controllerId
   );
+  const reserveAssignment = {
+    targetRoom: assignment.targetRoom,
+    action: "reserve",
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
+    ...followUp ? { followUp } : {}
+  };
   const plan = {
     colony,
     targetRoom: assignment.targetRoom,
@@ -1783,6 +1789,7 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
   });
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
   recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
+  return reserveAssignment;
 }
 function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   if (getWorkerCapacity(roleCounts) < workerTarget) {
@@ -3058,6 +3065,32 @@ function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action
     ...selectedIntent.status === "suppressed" ? { suppressedAt: selectedIntent.updatedAt } : {},
     ...shouldPreservePersistedTerritoryIntentPressureRequirement2(selectedIntent, controllerId) ? { requiresControllerPressure: true } : {}
   };
+}
+function getTerritoryReserveFallbackFollowUp(assignment, intents, colony, gameTime) {
+  var _a, _b, _c;
+  const assignmentFollowUp = normalizeTerritoryFollowUp2(assignment.followUp);
+  if (assignmentFollowUp) {
+    return assignmentFollowUp;
+  }
+  const persistedReserveFollowUp = (_a = getPersistedTerritoryIntentFollowUp(
+    intents,
+    colony,
+    assignment.targetRoom,
+    "reserve",
+    gameTime,
+    assignment.controllerId
+  )) == null ? void 0 : _a.followUp;
+  if (persistedReserveFollowUp) {
+    return persistedReserveFollowUp;
+  }
+  return (_c = (_b = getPersistedTerritoryIntentFollowUp(
+    intents,
+    colony,
+    assignment.targetRoom,
+    "claim",
+    gameTime,
+    assignment.controllerId
+  )) == null ? void 0 : _b.followUp) != null ? _c : null;
 }
 function recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime) {
   const demands = pruneCurrentTerritoryFollowUpDemands(territoryMemory, gameTime);
@@ -7784,6 +7817,7 @@ function runTerritoryControllerCreep(creep) {
   }
 }
 function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
+  var _a;
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
@@ -7795,8 +7829,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
     ...assignment.followUp ? { followUp: assignment.followUp } : {}
   };
   suppressTerritoryIntent(creep.memory.colony, assignment, gameTime);
-  recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, gameTime);
-  creep.memory.territory = reserveAssignment;
+  creep.memory.territory = (_a = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, gameTime)) != null ? _a : reserveAssignment;
   const reserveResult = executeControllerAction(creep, controller, "reserveController");
   if (reserveResult === ERR_NOT_IN_RANGE_CODE2 && typeof creep.moveTo === "function") {
     creep.moveTo(controller);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -592,19 +592,19 @@ export function recordTerritoryReserveFallbackIntent(
   colony: string | undefined,
   assignment: CreepTerritoryMemory,
   gameTime: number
-): void {
+): CreepTerritoryMemory | null {
   if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || assignment.action !== 'reserve') {
-    return;
+    return null;
   }
 
   const territoryMemory = getWritableTerritoryMemoryRecord();
   if (!territoryMemory) {
-    return;
+    return null;
   }
 
-  const followUp = normalizeTerritoryFollowUp(assignment.followUp);
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
+  const followUp = getTerritoryReserveFallbackFollowUp(assignment, intents, colony, gameTime);
   const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
     intents,
     colony,
@@ -612,6 +612,12 @@ export function recordTerritoryReserveFallbackIntent(
     'reserve',
     assignment.controllerId
   );
+  const reserveAssignment: CreepTerritoryMemory = {
+    targetRoom: assignment.targetRoom,
+    action: 'reserve',
+    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {}),
+    ...(followUp ? { followUp } : {})
+  };
   const plan: TerritoryIntentPlan = {
     colony,
     targetRoom: assignment.targetRoom,
@@ -639,6 +645,7 @@ export function recordTerritoryReserveFallbackIntent(
   });
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
   recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
+  return reserveAssignment;
 }
 
 export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {
@@ -2657,6 +2664,41 @@ function getPersistedTerritoryIntentFollowUp(
       ? { requiresControllerPressure: true }
       : {})
   };
+}
+
+function getTerritoryReserveFallbackFollowUp(
+  assignment: CreepTerritoryMemory,
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  gameTime: number
+): TerritoryFollowUpMemory | null {
+  const assignmentFollowUp = normalizeTerritoryFollowUp(assignment.followUp);
+  if (assignmentFollowUp) {
+    return assignmentFollowUp;
+  }
+
+  const persistedReserveFollowUp = getPersistedTerritoryIntentFollowUp(
+    intents,
+    colony,
+    assignment.targetRoom,
+    'reserve',
+    gameTime,
+    assignment.controllerId
+  )?.followUp;
+  if (persistedReserveFollowUp) {
+    return persistedReserveFollowUp;
+  }
+
+  return (
+    getPersistedTerritoryIntentFollowUp(
+      intents,
+      colony,
+      assignment.targetRoom,
+      'claim',
+      gameTime,
+      assignment.controllerId
+    )?.followUp ?? null
+  );
 }
 
 function recordTerritoryFollowUpDemand(

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -153,8 +153,8 @@ function tryFallbackClaimAssignmentToReserve(
   };
 
   suppressTerritoryIntent(creep.memory.colony, assignment, gameTime);
-  recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, gameTime);
-  creep.memory.territory = reserveAssignment;
+  creep.memory.territory =
+    recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, gameTime) ?? reserveAssignment;
 
   const reserveResult = executeControllerAction(creep, controller, 'reserveController');
   if (reserveResult === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -777,6 +777,89 @@ describe('runTerritoryControllerCreep', () => {
     ]);
   });
 
+  it('recovers persisted follow-up metadata when an older claim assignment falls back to reserve', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'satisfiedClaimAdjacent',
+      originRoom: 'W1N1',
+      originAction: 'claim'
+    };
+    const claimTarget: TerritoryTargetMemory = {
+      colony: 'W1N1',
+      roomName: 'W1N2',
+      action: 'claim'
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 516,
+      rooms: {
+        W1N2: {
+          name: 'W1N2',
+          controller: { id: 'controller1', my: false } as StructureController,
+          find: jest.fn().mockReturnValue([])
+        } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [claimTarget],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W1N2',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 515,
+            followUp
+          }
+        ]
+      }
+    };
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim' } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      claimController: jest.fn().mockReturnValue(-15),
+      reserveController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'reserve', followUp });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 516,
+        followUp
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 516,
+        followUp
+      }
+    ]);
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: 516,
+        followUp
+      }
+    ]);
+  });
+
   it('pressures a foreign reservation before trying to reserve the controller', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       time: 516,


### PR DESCRIPTION
## Summary
- carry territory execution hints into runner task metadata
- improve territory/control execution reliability while preserving emergency renewal and route-cache semantics
- add focused territory runner coverage and regenerate `prod/dist/main.js`

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `cd prod && git diff --check`

Closes #388.
