### PR TITLE
feat: improve post-PR389 economy throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4537,7 +4537,7 @@ function selectClosestEnergySink(energySinks, creep) {
 function compareEnergySinkId(left, right) {
   return String(left.id).localeCompare(String(right.id));
 }
-function selectConstructionSite(creep, constructionSites, predicate = () => true) {
+function selectConstructionSite(creep, constructionSites, predicate = () => true, constructionReservationContext = createEmptyConstructionReservationContext()) {
   var _a;
   const candidates = constructionSites.filter(predicate);
   if (candidates.length === 0) {
@@ -4545,9 +4545,15 @@ function selectConstructionSite(creep, constructionSites, predicate = () => true
   }
   const position = creep.pos;
   if (typeof (position == null ? void 0 : position.getRangeTo) === "function") {
-    return [...candidates].sort((left, right) => compareConstructionSiteCandidates(creep, left, right))[0];
+    return [...candidates].sort(
+      (left, right) => compareConstructionSiteCandidates(creep, left, right, constructionReservationContext)
+    )[0];
   }
-  const completableConstructionSite = selectNearTermCompletableConstructionSite(creep, candidates);
+  const completableConstructionSite = selectNearTermCompletableConstructionSite(
+    creep,
+    candidates,
+    constructionReservationContext
+  );
   if (completableConstructionSite) {
     return completableConstructionSite;
   }
@@ -4561,7 +4567,8 @@ function selectUnreservedConstructionSite(creep, constructionSites, construction
   return selectConstructionSite(
     creep,
     constructionSites,
-    (site) => predicate(site) && hasUnreservedConstructionProgress(creep, site, constructionReservationContext)
+    (site) => predicate(site) && hasUnreservedConstructionProgress(creep, site, constructionReservationContext),
+    constructionReservationContext
   );
 }
 function hasUnreservedConstructionProgress(creep, site, constructionReservationContext) {
@@ -4616,19 +4623,29 @@ function isWorkerAssignedToConstructionSite(worker, site) {
   const task = (_a = worker.memory) == null ? void 0 : _a.task;
   return (task == null ? void 0 : task.type) === "build" && String(task.targetId) === String(site.id);
 }
-function selectNearTermCompletableConstructionSite(creep, constructionSites) {
-  const candidates = constructionSites.filter((site) => canCompleteConstructionSiteWithCarriedEnergy(creep, site));
+function selectNearTermCompletableConstructionSite(creep, constructionSites, constructionReservationContext) {
+  const candidates = constructionSites.filter(
+    (site) => canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionReservationContext)
+  );
   if (candidates.length === 0) {
     return null;
   }
   return candidates.sort(compareNearTermCompletableConstructionSites)[0];
 }
-function compareConstructionSiteCandidates(creep, left, right) {
-  return compareConstructionSiteCompletion(creep, left, right) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareConstructionSiteId(left, right);
+function compareConstructionSiteCandidates(creep, left, right, constructionReservationContext) {
+  return compareConstructionSiteCompletion(creep, left, right, constructionReservationContext) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareConstructionSiteId(left, right);
 }
-function compareConstructionSiteCompletion(creep, left, right) {
-  const leftCompletable = canCompleteConstructionSiteWithCarriedEnergy(creep, left);
-  const rightCompletable = canCompleteConstructionSiteWithCarriedEnergy(creep, right);
+function compareConstructionSiteCompletion(creep, left, right, constructionReservationContext) {
+  const leftCompletable = canCompleteConstructionSiteWithCarriedEnergy(
+    creep,
+    left,
+    constructionReservationContext
+  );
+  const rightCompletable = canCompleteConstructionSiteWithCarriedEnergy(
+    creep,
+    right,
+    constructionReservationContext
+  );
   if (leftCompletable !== rightCompletable) {
     return leftCompletable ? -1 : 1;
   }
@@ -4637,9 +4654,22 @@ function compareConstructionSiteCompletion(creep, left, right) {
 function compareNearTermCompletableConstructionSites(left, right) {
   return getConstructionSiteRemainingProgress(left) - getConstructionSiteRemainingProgress(right) || compareConstructionSiteId(left, right);
 }
-function canCompleteConstructionSiteWithCarriedEnergy(creep, site) {
-  const remainingProgress = getConstructionSiteRemainingProgress(site);
+function canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionReservationContext = createEmptyConstructionReservationContext()) {
+  const remainingProgress = getUnreservedConstructionProgressForWorker(
+    creep,
+    site,
+    constructionReservationContext
+  );
   return remainingProgress > 0 && remainingProgress <= getUsedEnergy(creep) * getBuildPower();
+}
+function getUnreservedConstructionProgressForWorker(creep, site, constructionReservationContext) {
+  const remainingProgress = getConstructionSiteRemainingProgress(site);
+  if (!Number.isFinite(remainingProgress)) {
+    return remainingProgress;
+  }
+  const reservedProgress = getReservedConstructionProgress(site, constructionReservationContext);
+  const workerReservedProgress = isWorkerAssignedToConstructionSite(creep, site) ? getUsedEnergy(creep) * getBuildPower() : 0;
+  return Math.max(0, remainingProgress - Math.max(0, reservedProgress - workerReservedProgress));
 }
 function getConstructionSiteRemainingProgress(site) {
   const progress = site.progress;
@@ -4679,7 +4709,7 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
         site,
         { type: "build", targetId: site.id },
         0,
-        canCompleteConstructionSiteWithCarriedEnergy(creep, site)
+        canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionReservationContext)
       )
     ),
     ...findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget).map(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -862,7 +862,8 @@ function compareEnergySinkId(left: FillableEnergySink, right: FillableEnergySink
 function selectConstructionSite(
   creep: Creep,
   constructionSites: ConstructionSite[],
-  predicate: (site: ConstructionSite) => boolean = () => true
+  predicate: (site: ConstructionSite) => boolean = () => true,
+  constructionReservationContext: ConstructionReservationContext = createEmptyConstructionReservationContext()
 ): ConstructionSite | null {
   const candidates = constructionSites.filter(predicate);
   if (candidates.length === 0) {
@@ -877,10 +878,16 @@ function selectConstructionSite(
   }).pos;
 
   if (typeof position?.getRangeTo === 'function') {
-    return [...candidates].sort((left, right) => compareConstructionSiteCandidates(creep, left, right))[0];
+    return [...candidates].sort((left, right) =>
+      compareConstructionSiteCandidates(creep, left, right, constructionReservationContext)
+    )[0];
   }
 
-  const completableConstructionSite = selectNearTermCompletableConstructionSite(creep, candidates);
+  const completableConstructionSite = selectNearTermCompletableConstructionSite(
+    creep,
+    candidates,
+    constructionReservationContext
+  );
   if (completableConstructionSite) {
     return completableConstructionSite;
   }
@@ -902,7 +909,8 @@ function selectUnreservedConstructionSite(
   return selectConstructionSite(
     creep,
     constructionSites,
-    (site) => predicate(site) && hasUnreservedConstructionProgress(creep, site, constructionReservationContext)
+    (site) => predicate(site) && hasUnreservedConstructionProgress(creep, site, constructionReservationContext),
+    constructionReservationContext
   );
 }
 
@@ -975,9 +983,12 @@ function isWorkerAssignedToConstructionSite(worker: Creep, site: ConstructionSit
 
 function selectNearTermCompletableConstructionSite(
   creep: Creep,
-  constructionSites: ConstructionSite[]
+  constructionSites: ConstructionSite[],
+  constructionReservationContext: ConstructionReservationContext
 ): ConstructionSite | null {
-  const candidates = constructionSites.filter((site) => canCompleteConstructionSiteWithCarriedEnergy(creep, site));
+  const candidates = constructionSites.filter((site) =>
+    canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionReservationContext)
+  );
   if (candidates.length === 0) {
     return null;
   }
@@ -988,10 +999,11 @@ function selectNearTermCompletableConstructionSite(
 function compareConstructionSiteCandidates(
   creep: Creep,
   left: ConstructionSite,
-  right: ConstructionSite
+  right: ConstructionSite,
+  constructionReservationContext: ConstructionReservationContext
 ): number {
   return (
-    compareConstructionSiteCompletion(creep, left, right) ||
+    compareConstructionSiteCompletion(creep, left, right, constructionReservationContext) ||
     compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) ||
     compareConstructionSiteId(left, right)
   );
@@ -1000,10 +1012,19 @@ function compareConstructionSiteCandidates(
 function compareConstructionSiteCompletion(
   creep: Creep,
   left: ConstructionSite,
-  right: ConstructionSite
+  right: ConstructionSite,
+  constructionReservationContext: ConstructionReservationContext
 ): number {
-  const leftCompletable = canCompleteConstructionSiteWithCarriedEnergy(creep, left);
-  const rightCompletable = canCompleteConstructionSiteWithCarriedEnergy(creep, right);
+  const leftCompletable = canCompleteConstructionSiteWithCarriedEnergy(
+    creep,
+    left,
+    constructionReservationContext
+  );
+  const rightCompletable = canCompleteConstructionSiteWithCarriedEnergy(
+    creep,
+    right,
+    constructionReservationContext
+  );
   if (leftCompletable !== rightCompletable) {
     return leftCompletable ? -1 : 1;
   }
@@ -1019,9 +1040,35 @@ function compareNearTermCompletableConstructionSites(left: ConstructionSite, rig
   );
 }
 
-function canCompleteConstructionSiteWithCarriedEnergy(creep: Creep, site: ConstructionSite): boolean {
-  const remainingProgress = getConstructionSiteRemainingProgress(site);
+function canCompleteConstructionSiteWithCarriedEnergy(
+  creep: Creep,
+  site: ConstructionSite,
+  constructionReservationContext: ConstructionReservationContext = createEmptyConstructionReservationContext()
+): boolean {
+  const remainingProgress = getUnreservedConstructionProgressForWorker(
+    creep,
+    site,
+    constructionReservationContext
+  );
   return remainingProgress > 0 && remainingProgress <= getUsedEnergy(creep) * getBuildPower();
+}
+
+function getUnreservedConstructionProgressForWorker(
+  creep: Creep,
+  site: ConstructionSite,
+  constructionReservationContext: ConstructionReservationContext
+): number {
+  const remainingProgress = getConstructionSiteRemainingProgress(site);
+  if (!Number.isFinite(remainingProgress)) {
+    return remainingProgress;
+  }
+
+  const reservedProgress = getReservedConstructionProgress(site, constructionReservationContext);
+  const workerReservedProgress = isWorkerAssignedToConstructionSite(creep, site)
+    ? getUsedEnergy(creep) * getBuildPower()
+    : 0;
+
+  return Math.max(0, remainingProgress - Math.max(0, reservedProgress - workerReservedProgress));
 }
 
 function getConstructionSiteRemainingProgress(site: ConstructionSite): number {
@@ -1086,7 +1133,7 @@ function selectNearbyProductiveEnergySinkTask(
           site,
           { type: 'build', targetId: site.id },
           0,
-          canCompleteConstructionSiteWithCarriedEnergy(creep, site)
+          canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionReservationContext)
         )
       ),
     ...findVisibleRoomStructures(creep.room)

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4061,6 +4061,7 @@ describe('selectWorkerTask', () => {
   });
 
   it('finishes construction whose remaining unreserved progress fits carried energy', () => {
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 10;
     (globalThis as unknown as { BUILD_POWER: number }).BUILD_POWER = 5;
     const nearUnfinishedSite = {
       id: 'tower-near-unfinished',
@@ -4074,9 +4075,11 @@ describe('selectWorkerTask', () => {
       progress: 250,
       progressTotal: 500
     } as ConstructionSite;
+    const myCreeps: Creep[] = [];
     const room = makeWorkerTaskRoom({
       constructionSites: [nearUnfinishedSite, reservedFinishableSite],
-      controller: undefined
+      controller: undefined,
+      myCreeps
     });
     const assignedBuilder = {
       name: 'AssignedBuilder',
@@ -4101,9 +4104,11 @@ describe('selectWorkerTask', () => {
       pos: { getRangeTo },
       room
     } as unknown as Creep;
+    myCreeps.push(assignedBuilder, creep);
     setGameCreeps({ AssignedBuilder: assignedBuilder, Builder: creep });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-reserved-finishable' });
+    expect(room.find).toHaveBeenCalledWith(10);
   });
 
   it('keeps a worker on its assigned capacity construction site', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4060,6 +4060,52 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
   });
 
+  it('finishes construction whose remaining unreserved progress fits carried energy', () => {
+    (globalThis as unknown as { BUILD_POWER: number }).BUILD_POWER = 5;
+    const nearUnfinishedSite = {
+      id: 'tower-near-unfinished',
+      structureType: 'tower',
+      progress: 0,
+      progressTotal: 1_000
+    } as ConstructionSite;
+    const reservedFinishableSite = {
+      id: 'tower-reserved-finishable',
+      structureType: 'tower',
+      progress: 250,
+      progressTotal: 500
+    } as ConstructionSite;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [nearUnfinishedSite, reservedFinishableSite],
+      controller: undefined
+    });
+    const assignedBuilder = {
+      name: 'AssignedBuilder',
+      memory: {
+        role: 'worker',
+        task: { type: 'build', targetId: 'tower-reserved-finishable' as Id<ConstructionSite> }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(40) },
+      room
+    } as unknown as Creep;
+    const getRangeTo = jest.fn((target: { id?: string }) => {
+      const ranges: Record<string, number> = {
+        'tower-near-unfinished': 1,
+        'tower-reserved-finishable': 8
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      name: 'Builder',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(10) },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ AssignedBuilder: assignedBuilder, Builder: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-reserved-finishable' });
+  });
+
   it('keeps a worker on its assigned capacity construction site', () => {
     (globalThis as unknown as { BUILD_POWER: number }).BUILD_POWER = 5;
     const extensionSite = {


### PR DESCRIPTION
## Summary
- improve worker economy throughput after #389 by prioritizing finishing low-progress economy sinks when safe
- add tests covering finishable sink selection and priority preservation
- regenerate `prod/dist/main.js`

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --check`

Closes #391.

Scheduler evidence: recovered verified Codex edits into real commit `772f4fe` authored by `lanyusea's bot <lanyusea@gmail.com>`; untracked `prod/node_modules` was not staged.