### PR TITLE
feat: improve post-PR390 territory control

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7772,7 +7772,7 @@ function runTerritoryControllerCreep(creep) {
     return;
   }
   if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
-    moveTowardTargetRoom(creep, assignment.targetRoom);
+    moveTowardTargetRoom(creep, assignment);
     return;
   }
   if (assignment.action === "scout") {
@@ -7880,12 +7880,34 @@ function executeControllerAction(creep, controller, action) {
   }
   return controllerAction.call(creep, controller);
 }
-function moveTowardTargetRoom(creep, targetRoom) {
-  const RoomPositionCtor = globalThis.RoomPosition;
-  if (typeof RoomPositionCtor !== "function" || typeof creep.moveTo !== "function") {
+function moveTowardTargetRoom(creep, assignment) {
+  if (typeof creep.moveTo !== "function") {
     return;
   }
-  creep.moveTo(new RoomPositionCtor(25, 25, targetRoom));
+  const visibleController = selectVisibleTargetRoomController(assignment);
+  if (visibleController) {
+    creep.moveTo(visibleController);
+    return;
+  }
+  const RoomPositionCtor = globalThis.RoomPosition;
+  if (typeof RoomPositionCtor !== "function") {
+    return;
+  }
+  creep.moveTo(new RoomPositionCtor(25, 25, assignment.targetRoom));
+}
+function selectVisibleTargetRoomController(assignment) {
+  var _a, _b, _c;
+  if (!isTerritoryControlAction3(assignment.action)) {
+    return null;
+  }
+  const game = globalThis.Game;
+  if (assignment.controllerId && typeof (game == null ? void 0 : game.getObjectById) === "function") {
+    const controller = game.getObjectById.call(game, assignment.controllerId);
+    if (controller) {
+      return controller;
+    }
+  }
+  return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
 function getGameTime5() {
   var _a;

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -45,7 +45,7 @@ export function runTerritoryControllerCreep(creep: Creep): void {
   }
 
   if (creep.room?.name !== assignment.targetRoom) {
-    moveTowardTargetRoom(creep, assignment.targetRoom);
+    moveTowardTargetRoom(creep, assignment);
     return;
   }
 
@@ -206,13 +206,39 @@ function executeControllerAction(
   return controllerAction.call(creep, controller);
 }
 
-function moveTowardTargetRoom(creep: Creep, targetRoom: string): void {
-  const RoomPositionCtor = (globalThis as { RoomPosition?: RoomPositionConstructor }).RoomPosition;
-  if (typeof RoomPositionCtor !== 'function' || typeof creep.moveTo !== 'function') {
+function moveTowardTargetRoom(creep: Creep, assignment: CreepTerritoryMemory): void {
+  if (typeof creep.moveTo !== 'function') {
     return;
   }
 
-  creep.moveTo(new RoomPositionCtor(25, 25, targetRoom));
+  const visibleController = selectVisibleTargetRoomController(assignment);
+  if (visibleController) {
+    creep.moveTo(visibleController);
+    return;
+  }
+
+  const RoomPositionCtor = (globalThis as { RoomPosition?: RoomPositionConstructor }).RoomPosition;
+  if (typeof RoomPositionCtor !== 'function') {
+    return;
+  }
+
+  creep.moveTo(new RoomPositionCtor(25, 25, assignment.targetRoom));
+}
+
+function selectVisibleTargetRoomController(assignment: CreepTerritoryMemory): StructureController | null {
+  if (!isTerritoryControlAction(assignment.action)) {
+    return null;
+  }
+
+  const game = (globalThis as { Game?: Partial<Game> }).Game;
+  if (assignment.controllerId && typeof game?.getObjectById === 'function') {
+    const controller = game.getObjectById.call(game, assignment.controllerId) as StructureController | null;
+    if (controller) {
+      return controller;
+    }
+  }
+
+  return game?.rooms?.[assignment.targetRoom]?.controller ?? null;
 }
 
 function getGameTime(): number {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -34,6 +34,28 @@ describe('runTerritoryControllerCreep', () => {
     expect(creep.reserveController).not.toHaveBeenCalled();
   });
 
+  it('moves toward a visible target controller before entering the target room', () => {
+    const controller = { id: 'controller1', my: false } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 500,
+      rooms: {
+        W1N2: { name: 'W1N2', controller, find: jest.fn().mockReturnValue([]) } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    const creep = {
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'reserve' } },
+      room: { name: 'W1N1' },
+      moveTo: jest.fn(),
+      reserveController: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(creep.reserveController).not.toHaveBeenCalled();
+  });
+
   it('suppresses and does not move toward a visible hostile target room', () => {
     const hostile = { id: 'enemy1' } as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -408,7 +430,7 @@ describe('runTerritoryControllerCreep', () => {
 
     expect(creep.claimController).not.toHaveBeenCalled();
     expect(creep.signController).not.toHaveBeenCalled();
-    expect(creep.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W1N2' });
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
     expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'claim', followUp });
     expect(Memory.territory).toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- improve post-#390 territory runner behavior by carrying territory-control execution hints into runner task selection
- add tests covering territory runner hint behavior
- regenerate `prod/dist/main.js`

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --check`

Closes #392.

Scheduler evidence: recovered verified Codex edits into real commit `464f766` authored by `lanyusea's bot <lanyusea@gmail.com>`; untracked `prod/node_modules` was not staged.