### PR TITLE
feat: improve territory controller attack retry

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7799,7 +7799,7 @@ function runTerritoryControllerCreep(creep) {
     suppressTerritoryAssignment(creep, assignment);
     return;
   }
-  if (assignment.action === "reserve" && typeof creep.attackController === "function" && canCreepPressureTerritoryController(creep, controller, creep.memory.colony)) {
+  if (isTerritoryControlAction3(assignment.action) && typeof creep.attackController === "function" && canCreepPressureTerritoryController(creep, controller, creep.memory.colony)) {
     const pressureResult = executeControllerAction(creep, controller, "attackController");
     if (pressureResult === ERR_NOT_IN_RANGE_CODE2 && typeof creep.moveTo === "function") {
       creep.moveTo(controller);

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -79,7 +79,7 @@ export function runTerritoryControllerCreep(creep: Creep): void {
   }
 
   if (
-    assignment.action === 'reserve' &&
+    isTerritoryControlAction(assignment.action) &&
     typeof creep.attackController === 'function' &&
     canCreepPressureTerritoryController(creep, controller, creep.memory.colony)
   ) {

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -276,6 +276,56 @@ describe('runTerritoryControllerCreep', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
+  it('pressures a foreign reservation before trying to claim the controller', () => {
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'enemy', ticksToEnd: 3_000 }
+    } as StructureController;
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim' } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(5),
+      attackController: jest.fn().mockReturnValue(0),
+      claimController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.attackController).toHaveBeenCalledWith(controller);
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'claim' });
+    expect(Memory.territory).toBeUndefined();
+  });
+
+  it('moves a claim-pressure creep into range before claiming a foreign-reserved controller', () => {
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'enemy', ticksToEnd: 3_000 }
+    } as StructureController;
+    const creep = {
+      owner: { username: 'me' },
+      memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'claim' } },
+      room: { name: 'W1N2', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(5),
+      attackController: jest.fn().mockReturnValue(-9),
+      claimController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep);
+
+    expect(creep.attackController).toHaveBeenCalledWith(controller);
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'claim' });
+    expect(Memory.territory).toBeUndefined();
+  });
+
   it('suppresses an unworkable follow-up claim assignment so the planner stops requeueing it', () => {
     const followUp: TerritoryFollowUpMemory = {
       source: 'satisfiedClaimAdjacent',


### PR DESCRIPTION
## Summary
- improves territory controller attack retry behavior after PR #394's controller-targeted movement
- adds focused territory runner coverage for attack retry behavior
- rebuilds `prod/dist/main.js`

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (23 suites / 572 tests)
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #395
