### PR TITLE
feat: improve post-PR398 worker throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4021,6 +4021,7 @@ var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 var ENERGY_ACQUISITION_RANGE_COST = 50;
 var ENERGY_ACQUISITION_ACTION_TICKS = 1;
+var WORKER_ENERGY_SURPLUS_SCORE_RATIO = 0.4;
 var HARVEST_ENERGY_PER_WORK_PART = 2;
 var DEFAULT_BUILD_POWER = 5;
 var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
@@ -5125,13 +5126,22 @@ function createUnreservedWorkerEnergyAcquisitionCandidate(creep, source, energy,
 }
 function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
+  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity(creep));
   return {
     energy,
     range,
-    score: range === null ? energy : energy - range * ENERGY_ACQUISITION_RANGE_COST,
+    score: range === null ? energyScore : energyScore - range * ENERGY_ACQUISITION_RANGE_COST,
     source,
     task
   };
+}
+function scoreWorkerEnergyAcquisitionAmount(energy, freeCapacity) {
+  if (freeCapacity <= 0) {
+    return energy;
+  }
+  const immediateTripEnergy = Math.min(energy, freeCapacity);
+  const surplusEnergy = Math.max(0, energy - immediateTripEnergy);
+  return immediateTripEnergy + surplusEnergy * WORKER_ENERGY_SURPLUS_SCORE_RATIO;
 }
 function createWorkerEnergyAcquisitionReservationContext(creep) {
   return {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -34,6 +34,7 @@ const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 const MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
 const ENERGY_ACQUISITION_RANGE_COST = 50;
 const ENERGY_ACQUISITION_ACTION_TICKS = 1;
+const WORKER_ENERGY_SURPLUS_SCORE_RATIO = 0.4;
 const HARVEST_ENERGY_PER_WORK_PART = 2;
 const DEFAULT_BUILD_POWER = 5;
 const MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
@@ -1758,14 +1759,25 @@ function createWorkerEnergyAcquisitionCandidate(
   task: WorkerEnergyAcquisitionTask
 ): WorkerEnergyAcquisitionCandidate {
   const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
+  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity(creep));
 
   return {
     energy,
     range,
-    score: range === null ? energy : energy - range * ENERGY_ACQUISITION_RANGE_COST,
+    score: range === null ? energyScore : energyScore - range * ENERGY_ACQUISITION_RANGE_COST,
     source,
     task
   };
+}
+
+function scoreWorkerEnergyAcquisitionAmount(energy: number, freeCapacity: number): number {
+  if (freeCapacity <= 0) {
+    return energy;
+  }
+
+  const immediateTripEnergy = Math.min(energy, freeCapacity);
+  const surplusEnergy = Math.max(0, energy - immediateTripEnergy);
+  return immediateTripEnergy + surplusEnergy * WORKER_ENERGY_SURPLUS_SCORE_RATIO;
 }
 
 function createWorkerEnergyAcquisitionReservationContext(creep: Creep): WorkerEnergyAcquisitionReservationContext {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -962,6 +962,47 @@ describe('selectWorkerTask', () => {
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
+  it('prefers a nearby full-load pickup over distant surplus stored energy', () => {
+    const nearbyDroppedEnergy = { id: 'drop-full-load', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
+    const farStorage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const source = { id: 'source1' } as Source;
+    const getRangeTo = jest.fn((target: StructureStorage | Resource<ResourceConstant>) => {
+      const ranges: Record<string, number> = {
+        'drop-full-load': 1,
+        'storage-surplus': 10
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [nearbyDroppedEnergy];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [farStorage];
+      }
+
+      if (type === FIND_HOSTILE_CREEPS || type === FIND_HOSTILE_STRUCTURES) {
+        return [];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { controller: { my: true }, find: roomFind }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-full-load' });
+    expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
   it('keeps closest safe stored energy when stored amounts are comparable', () => {
     const nearbyContainer = makeStoredEnergyStructure('container-near', 'container' as StructureConstant, 100);
     const fartherStorage = makeStoredEnergyStructure('storage-far', 'storage' as StructureConstant, 150, { my: true });


### PR DESCRIPTION
## Summary
- Improves worker energy throughput after PR #398 by refining productive energy target selection.
- Adds focused worker task coverage for the new throughput behavior.
- Rebuilds `prod/dist/main.js`.

Closes #401.

## Verification
Controller-side verification before Codex commit-only recovery:
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (23 suites / 576 tests)
- `cd prod && npm run build`
- `git diff --check`

Commit: `f9bafa3 lanyusea's bot <lanyusea@gmail.com> feat: improve post-PR398 worker throughput (#401)`

## Scheduler notes
- Worktree: `/root/screeps-worktrees/economy-post398-401`
- Branch: `feat/economy-post398-401`
- Untracked `prod/node_modules` symlink is dependency infrastructure and is not part of the PR.
