### PR TITLE
fix: reduce low-load worker return churn

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4561,21 +4561,13 @@ function selectWorkerTask(creep) {
       return spawnOrExtensionRefillTask;
     }
     if (!remoteProductiveSpendingSuppressed) {
-      const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
-      if (lowLoadEnergyAcquisitionCandidate) {
-        recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate);
-        return lowLoadEnergyAcquisitionCandidate.task;
+      const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+      if (lowLoadEnergyContinuationTask) {
+        return lowLoadEnergyContinuationTask;
       }
     }
     recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, "noNearbyEnergy");
     return spawnOrExtensionRefillTask;
-  }
-  if (!remoteProductiveSpendingSuppressed) {
-    const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
-    if (lowLoadEnergyAcquisitionCandidate) {
-      recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate);
-      return lowLoadEnergyAcquisitionCandidate.task;
-    }
   }
   if (remoteProductiveSpendingSuppressed) {
     const suppressedRemoteEnergyHandlingTask = selectSuppressedRemoteEnergyHandlingTask(creep);
@@ -4598,6 +4590,13 @@ function selectWorkerTask(creep) {
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
     return { type: "transfer", targetId: priorityTowerEnergySink.id };
+  }
+  if (!remoteProductiveSpendingSuppressed) {
+    const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
+    if (lowLoadEnergyAcquisitionCandidate) {
+      recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate);
+      return lowLoadEnergyAcquisitionCandidate.task;
+    }
   }
   if (bootstrapNonCriticalWorkSuppressed) {
     return selectBootstrapSurvivalSpendingTask(
@@ -4656,6 +4655,10 @@ function selectWorkerTask(creep) {
     return { type: "build", targetId: containerConstructionSite.id };
   }
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
+    const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+    if (lowLoadEnergyContinuationTask) {
+      return lowLoadEnergyContinuationTask;
+    }
     const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
       creep,
       constructionSites,
@@ -4689,6 +4692,10 @@ function selectWorkerTask(creep) {
     return { type: "repair", targetId: repairTarget.id };
   }
   if (controller == null ? void 0 : controller.my) {
+    const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+    if (lowLoadEnergyContinuationTask) {
+      return lowLoadEnergyContinuationTask;
+    }
     return { type: "upgrade", targetId: controller.id };
   }
   return null;
@@ -5421,8 +5428,29 @@ function selectLowLoadWorkerEnergyAcquisitionCandidate(creep) {
   }
   return nearbyCandidates.sort(compareLowLoadWorkerEnergyAcquisitionCandidates)[0];
 }
+function selectLowLoadWorkerEnergyContinuationTask(creep) {
+  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep);
+  if (!candidate) {
+    return null;
+  }
+  recordNearbyEnergyChoiceTelemetry(creep, candidate);
+  return candidate.task;
+}
+function selectLowLoadWorkerEnergyContinuationCandidate(creep) {
+  if (!shouldKeepLowLoadWorkerAcquiringEnergy(creep)) {
+    return null;
+  }
+  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep);
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(compareLowLoadWorkerEnergyAcquisitionCandidates)[0];
+}
 function shouldKeepLowLoadWorkerAcquiringEnergy(creep) {
   return getLowLoadWorkerEnergyContext(creep) !== null && !hasVisibleHostilePresence(creep.room);
+}
+function findLowLoadWorkerEnergyContinuationCandidates(creep) {
+  return findLowLoadWorkerEnergyAcquisitionCandidates(creep);
 }
 function findLowLoadWorkerEnergyAcquisitionCandidates(creep) {
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
@@ -6453,6 +6481,8 @@ function runWorker(creep) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
@@ -6631,6 +6661,17 @@ function shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, task, se
   const sample = (_a = creep.memory) == null ? void 0 : _a.workerEfficiency;
   return (sample == null ? void 0 : sample.type) === "nearbyEnergyChoice" && sample.selectedTask === selectedTask.type && sample.targetId === String(selectedTask.targetId) && isCurrentWorkerEfficiencySample(sample);
 }
+function shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, task, selectedTask) {
+  var _a;
+  if (!isLowLoadReturnTask(task) || !selectedTask || !isEnergyAcquisitionTask(selectedTask)) {
+    return false;
+  }
+  if (isSameTask(task, selectedTask)) {
+    return false;
+  }
+  const sample = (_a = creep.memory) == null ? void 0 : _a.workerEfficiency;
+  return (sample == null ? void 0 : sample.type) === "nearbyEnergyChoice" && sample.selectedTask === selectedTask.type && sample.targetId === String(selectedTask.targetId) && isCurrentWorkerEfficiencySample(sample);
+}
 function shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectedTask) {
   var _a, _b;
   if (task.type !== "transfer") {
@@ -6705,6 +6746,9 @@ function isEnergySpendingTask(task) {
 }
 function isEnergyAcquisitionTask(task) {
   return task.type === "harvest" || task.type === "pickup" || task.type === "withdraw";
+}
+function isLowLoadReturnTask(task) {
+  return task.type === "transfer" || task.type === "upgrade";
 }
 function isRecoverableEnergyTask(task) {
   return (task == null ? void 0 : task.type) === "pickup" || (task == null ? void 0 : task.type) === "withdraw";

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4484,6 +4484,7 @@ var NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
 var LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
 var LOW_LOAD_WORKER_ENERGY_CEILING = 25;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
+var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -5440,7 +5441,9 @@ function selectLowLoadWorkerEnergyContinuationCandidate(creep) {
   if (!shouldKeepLowLoadWorkerAcquiringEnergy(creep)) {
     return null;
   }
-  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep);
+  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep).filter(
+    isLowLoadWorkerEnergyContinuationCandidateInRange
+  );
   if (candidates.length === 0) {
     return null;
   }
@@ -5450,7 +5453,12 @@ function shouldKeepLowLoadWorkerAcquiringEnergy(creep) {
   return getLowLoadWorkerEnergyContext(creep) !== null && !hasVisibleHostilePresence(creep.room);
 }
 function findLowLoadWorkerEnergyContinuationCandidates(creep) {
-  return findLowLoadWorkerEnergyAcquisitionCandidates(creep);
+  return [
+    ...findWorkerEnergyAcquisitionCandidates(creep, {
+      maximumRange: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+    }).map(toLowLoadWorkerEnergyAcquisitionCandidate),
+    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
+  ];
 }
 function findLowLoadWorkerEnergyAcquisitionCandidates(creep) {
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
@@ -5517,6 +5525,9 @@ function isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source) {
   const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
   return range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE;
 }
+function isLowLoadWorkerEnergyContinuationCandidateInRange(candidate) {
+  return candidate.range !== null && candidate.range <= LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE;
+}
 function toLowLoadWorkerEnergyAcquisitionCandidate(candidate) {
   return candidate;
 }
@@ -5561,7 +5572,7 @@ function selectSpawnRecoveryEnergyAcquisitionTask(creep, energySink) {
   }
   return candidates.sort(compareSpawnRecoveryEnergyAcquisitionCandidates)[0].task;
 }
-function findWorkerEnergyAcquisitionCandidates(creep) {
+function findWorkerEnergyAcquisitionCandidates(creep, options = {}) {
   const context = {
     creepOwnerUsername: getCreepOwnerUsername2(creep),
     hasHostilePresence: hasVisibleHostilePresence(creep.room),
@@ -5580,7 +5591,7 @@ function findWorkerEnergyAcquisitionCandidates(creep) {
       reservationContext
     );
     return candidate ? [candidate] : [];
-  });
+  }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
   const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).flatMap((source) => {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
@@ -5594,11 +5605,11 @@ function findWorkerEnergyAcquisitionCandidates(creep) {
       MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT
     );
     return candidate ? [candidate] : [];
-  });
-  const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext);
+  }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
+  const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext, options);
   return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
 }
-function findDroppedEnergyAcquisitionCandidates(creep, reservationContext) {
+function findDroppedEnergyAcquisitionCandidates(creep, reservationContext, options = {}) {
   return findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).flatMap((source) => {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
@@ -5612,7 +5623,10 @@ function findDroppedEnergyAcquisitionCandidates(creep, reservationContext) {
       MIN_DROPPED_ENERGY_PICKUP_AMOUNT
     );
     return candidate ? [candidate] : [];
-  }).sort(compareDroppedEnergyReachabilityPriority).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
+  }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options)).sort(compareDroppedEnergyReachabilityPriority).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
+}
+function isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options) {
+  return options.maximumRange === void 0 || candidate.range !== null && candidate.range <= options.maximumRange;
 }
 function createUnreservedWorkerEnergyAcquisitionCandidate(creep, source, energy, task, reservationContext, minimumEnergy = 1) {
   const unreservedEnergy = getUnreservedWorkerEnergyAcquisitionAmount(source, energy, reservationContext);

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -28,6 +28,8 @@ export function runWorker(creep: Creep): void {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForControllerDowngradeGuard(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptTransferTaskForBetterEnergySink(creep, currentTask, selectedTask)) {
@@ -286,6 +288,28 @@ function shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(
   );
 }
 
+function shouldPreemptLowLoadReturnTaskForEnergyAcquisition(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (!isLowLoadReturnTask(task) || !selectedTask || !isEnergyAcquisitionTask(selectedTask)) {
+    return false;
+  }
+
+  if (isSameTask(task, selectedTask)) {
+    return false;
+  }
+
+  const sample = creep.memory?.workerEfficiency;
+  return (
+    sample?.type === 'nearbyEnergyChoice' &&
+    sample.selectedTask === selectedTask.type &&
+    sample.targetId === String(selectedTask.targetId) &&
+    isCurrentWorkerEfficiencySample(sample)
+  );
+}
+
 function shouldPreemptTransferTaskForBetterEnergySink(
   creep: Creep,
   task: CreepTaskMemory,
@@ -408,6 +432,12 @@ function isEnergyAcquisitionTask(task: CreepTaskMemory): task is Extract<
   { type: 'harvest' | 'pickup' | 'withdraw' }
 > {
   return task.type === 'harvest' || task.type === 'pickup' || task.type === 'withdraw';
+}
+
+function isLowLoadReturnTask(
+  task: CreepTaskMemory
+): task is Extract<CreepTaskMemory, { type: 'transfer' | 'upgrade' }> {
+  return task.type === 'transfer' || task.type === 'upgrade';
 }
 
 function isRecoverableEnergyTask(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -28,6 +28,7 @@ export const NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
 export const LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
 export const LOW_LOAD_WORKER_ENERGY_CEILING = 25;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
+export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -1468,6 +1469,10 @@ interface WorkerEnergyAcquisitionReservationContext {
   reservedEnergyBySourceId: Map<string, number>;
 }
 
+interface WorkerEnergyAcquisitionSearchOptions {
+  maximumRange?: number;
+}
+
 function selectWorkerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitionTask | null {
   const candidates = findWorkerEnergyAcquisitionCandidates(creep);
   if (candidates.length === 0) {
@@ -1511,7 +1516,9 @@ function selectLowLoadWorkerEnergyContinuationCandidate(
     return null;
   }
 
-  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep);
+  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep).filter(
+    isLowLoadWorkerEnergyContinuationCandidateInRange
+  );
   if (candidates.length === 0) {
     return null;
   }
@@ -1526,7 +1533,12 @@ function shouldKeepLowLoadWorkerAcquiringEnergy(creep: Creep): boolean {
 function findLowLoadWorkerEnergyContinuationCandidates(
   creep: Creep
 ): LowLoadWorkerEnergyAcquisitionCandidate[] {
-  return findLowLoadWorkerEnergyAcquisitionCandidates(creep);
+  return [
+    ...findWorkerEnergyAcquisitionCandidates(creep, {
+      maximumRange: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+    }).map(toLowLoadWorkerEnergyAcquisitionCandidate),
+    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
+  ];
 }
 
 function findLowLoadWorkerEnergyAcquisitionCandidates(creep: Creep): LowLoadWorkerEnergyAcquisitionCandidate[] {
@@ -1626,6 +1638,12 @@ function isNearbyLowLoadWorkerEnergyAcquisitionSource(
   return range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE;
 }
 
+function isLowLoadWorkerEnergyContinuationCandidateInRange(
+  candidate: LowLoadWorkerEnergyAcquisitionCandidate
+): boolean {
+  return candidate.range !== null && candidate.range <= LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE;
+}
+
 function toLowLoadWorkerEnergyAcquisitionCandidate(
   candidate: WorkerEnergyAcquisitionCandidate
 ): LowLoadWorkerEnergyAcquisitionCandidate {
@@ -1705,7 +1723,10 @@ function selectSpawnRecoveryEnergyAcquisitionTask(
   return candidates.sort(compareSpawnRecoveryEnergyAcquisitionCandidates)[0].task;
 }
 
-function findWorkerEnergyAcquisitionCandidates(creep: Creep): WorkerEnergyAcquisitionCandidate[] {
+function findWorkerEnergyAcquisitionCandidates(
+  creep: Creep,
+  options: WorkerEnergyAcquisitionSearchOptions = {}
+): WorkerEnergyAcquisitionCandidate[] {
   const context: StoredEnergySourceContext = {
     creepOwnerUsername: getCreepOwnerUsername(creep),
     hasHostilePresence: hasVisibleHostilePresence(creep.room),
@@ -1727,7 +1748,8 @@ function findWorkerEnergyAcquisitionCandidates(creep: Creep): WorkerEnergyAcquis
       );
 
       return candidate ? [candidate] : [];
-    });
+    })
+    .filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
   const salvageEnergyCandidates = [...findTombstones(creep.room), ...findRuins(creep.room)]
     .filter(hasSalvageableEnergy)
     .flatMap((source) => {
@@ -1744,15 +1766,17 @@ function findWorkerEnergyAcquisitionCandidates(creep: Creep): WorkerEnergyAcquis
       );
 
       return candidate ? [candidate] : [];
-    });
-  const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext);
+    })
+    .filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
+  const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext, options);
 
   return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
 }
 
 function findDroppedEnergyAcquisitionCandidates(
   creep: Creep,
-  reservationContext: WorkerEnergyAcquisitionReservationContext
+  reservationContext: WorkerEnergyAcquisitionReservationContext,
+  options: WorkerEnergyAcquisitionSearchOptions = {}
 ): WorkerEnergyAcquisitionCandidate[] {
   return findDroppedResources(creep.room)
     .filter(isUsefulDroppedEnergy)
@@ -1771,9 +1795,17 @@ function findDroppedEnergyAcquisitionCandidates(
 
       return candidate ? [candidate] : [];
     })
+    .filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options))
     .sort(compareDroppedEnergyReachabilityPriority)
     .slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS)
     .filter((candidate) => isReachable(creep, candidate.source));
+}
+
+function isWorkerEnergyAcquisitionCandidateWithinSearchRange(
+  candidate: WorkerEnergyAcquisitionCandidate,
+  options: WorkerEnergyAcquisitionSearchOptions
+): boolean {
+  return options.maximumRange === undefined || (candidate.range !== null && candidate.range <= options.maximumRange);
 }
 
 function createUnreservedWorkerEnergyAcquisitionCandidate(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -170,23 +170,14 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     }
 
     if (!remoteProductiveSpendingSuppressed) {
-      const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
-      if (lowLoadEnergyAcquisitionCandidate) {
-        recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate);
-        return lowLoadEnergyAcquisitionCandidate.task;
+      const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+      if (lowLoadEnergyContinuationTask) {
+        return lowLoadEnergyContinuationTask;
       }
     }
 
     recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, 'noNearbyEnergy');
     return spawnOrExtensionRefillTask;
-  }
-
-  if (!remoteProductiveSpendingSuppressed) {
-    const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
-    if (lowLoadEnergyAcquisitionCandidate) {
-      recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate);
-      return lowLoadEnergyAcquisitionCandidate.task;
-    }
   }
 
   if (remoteProductiveSpendingSuppressed) {
@@ -216,6 +207,14 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
     return { type: 'transfer', targetId: priorityTowerEnergySink.id as Id<AnyStoreStructure> };
+  }
+
+  if (!remoteProductiveSpendingSuppressed) {
+    const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
+    if (lowLoadEnergyAcquisitionCandidate) {
+      recordNearbyEnergyChoiceTelemetry(creep, lowLoadEnergyAcquisitionCandidate);
+      return lowLoadEnergyAcquisitionCandidate.task;
+    }
   }
 
   if (bootstrapNonCriticalWorkSuppressed) {
@@ -287,6 +286,11 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
+    const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+    if (lowLoadEnergyContinuationTask) {
+      return lowLoadEnergyContinuationTask;
+    }
+
     const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
       creep,
       constructionSites,
@@ -325,6 +329,11 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   if (controller?.my) {
+    const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+    if (lowLoadEnergyContinuationTask) {
+      return lowLoadEnergyContinuationTask;
+    }
+
     return { type: 'upgrade', targetId: controller.id };
   }
 
@@ -1485,8 +1494,39 @@ function selectLowLoadWorkerEnergyAcquisitionCandidate(
   return nearbyCandidates.sort(compareLowLoadWorkerEnergyAcquisitionCandidates)[0];
 }
 
+function selectLowLoadWorkerEnergyContinuationTask(creep: Creep): LowLoadWorkerEnergyAcquisitionTask | null {
+  const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep);
+  if (!candidate) {
+    return null;
+  }
+
+  recordNearbyEnergyChoiceTelemetry(creep, candidate);
+  return candidate.task;
+}
+
+function selectLowLoadWorkerEnergyContinuationCandidate(
+  creep: Creep
+): LowLoadWorkerEnergyAcquisitionCandidate | null {
+  if (!shouldKeepLowLoadWorkerAcquiringEnergy(creep)) {
+    return null;
+  }
+
+  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.sort(compareLowLoadWorkerEnergyAcquisitionCandidates)[0];
+}
+
 function shouldKeepLowLoadWorkerAcquiringEnergy(creep: Creep): boolean {
   return getLowLoadWorkerEnergyContext(creep) !== null && !hasVisibleHostilePresence(creep.room);
+}
+
+function findLowLoadWorkerEnergyContinuationCandidates(
+  creep: Creep
+): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  return findLowLoadWorkerEnergyAcquisitionCandidates(creep);
 }
 
 function findLowLoadWorkerEnergyAcquisitionCandidates(creep: Creep): LowLoadWorkerEnergyAcquisitionCandidate[] {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1533,6 +1533,7 @@ function shouldKeepLowLoadWorkerAcquiringEnergy(creep: Creep): boolean {
 function findLowLoadWorkerEnergyContinuationCandidates(
   creep: Creep
 ): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  // Use the normal candidate set so continuation can take close energy beyond the nearby-only fast path.
   return [
     ...findWorkerEnergyAcquisitionCandidates(creep, {
       maximumRange: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1743,6 +1743,77 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts a stale non-urgent refill task when a low-load worker can keep harvesting', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(300) }
+    } as unknown as StructureSpawn;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        source1: 6,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+            if (type === FIND_MY_STRUCTURES) {
+              const structures = [spawn];
+              return options?.filter ? structures.filter(options.filter) : structures;
+            }
+
+            if (
+              type === FIND_DROPPED_RESOURCES ||
+              type === FIND_STRUCTURES ||
+              type === FIND_HOSTILE_CREEPS ||
+              type === FIND_HOSTILE_STRUCTURES
+            ) {
+              return [];
+            }
+
+            return type === FIND_SOURCES ? [source] : [];
+          }
+        )
+      },
+      harvest: jest.fn().mockReturnValue(0),
+      transfer: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker: creep },
+      time: 778,
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : spawn))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 778,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'harvest',
+      targetId: 'source1',
+      energy: 300,
+      range: 6
+    });
+    expect(creep.harvest).toHaveBeenCalledWith(source);
+    expect(creep.transfer).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('spends partially picked-up energy on extension construction before lower-value tower refill', () => {
     const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 100 } as Resource<ResourceConstant>;
     const extensionSite = { id: 'extension-site1', structureType: 'extension' } as ConstructionSite;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2172,6 +2172,69 @@ describe('selectWorkerTask', () => {
     });
   });
 
+  it('continues with close salvage energy outside the nearby-only range before farther harvest', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const salvageEnergy = makeSalvageEnergySource('tombstone-mid', 50);
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        source1: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
+        'tombstone-mid': LOW_LOAD_NEARBY_ENERGY_RANGE + 1,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_TOMBSTONES) {
+          return [salvageEnergy];
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 332 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'tombstone-mid' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 332,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'withdraw',
+      targetId: 'tombstone-mid',
+      energy: 50,
+      range: LOW_LOAD_NEARBY_ENERGY_RANGE + 1
+    });
+  });
+
   it('ignores unreachable nearby dropped energy for low-load workers', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const blockedDroppedEnergy = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2,6 +2,8 @@ import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
   CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
+  LOW_LOAD_NEARBY_ENERGY_RANGE,
+  LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
   TOWER_REFILL_ENERGY_FLOOR,
   URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
   estimateNearTermSpawnExtensionRefillReserve,
@@ -1983,6 +1985,128 @@ describe('selectWorkerTask', () => {
       energy: 300,
       range: 6
     });
+  });
+
+  it('returns to refill instead of taking a far low-load harvest detour', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        source1: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE + 1,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 329 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 329,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'transfer',
+      targetId: 'spawn1',
+      reason: 'noNearbyEnergy'
+    });
+  });
+
+  it('continues with close dropped energy outside the nearby-only range before farther harvest', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const droppedEnergy = { id: 'drop-mid', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'drop-mid': LOW_LOAD_NEARBY_ENERGY_RANGE + 1,
+        source1: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const findPathTo = jest.fn((target: { id: string }) => (target.id === 'drop-mid' ? [{ x: 1, y: 1 }] : []));
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_DROPPED_RESOURCES) {
+          return [droppedEnergy];
+        }
+
+        if (
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo, findPathTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 330 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-mid' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 330,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'pickup',
+      targetId: 'drop-mid',
+      energy: 50,
+      range: LOW_LOAD_NEARBY_ENERGY_RANGE + 1
+    });
+    expect(findPathTo).toHaveBeenCalledWith(droppedEnergy, { ignoreCreeps: true });
   });
 
   it('ignores unreachable nearby dropped energy for low-load workers', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2109,6 +2109,69 @@ describe('selectWorkerTask', () => {
     expect(findPathTo).toHaveBeenCalledWith(droppedEnergy, { ignoreCreeps: true });
   });
 
+  it('continues with close stored energy outside the nearby-only range before farther harvest', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const storedEnergy = makeStoredEnergyStructure('storage-mid', 'storage' as StructureConstant, 50, { my: true });
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'storage-mid': LOW_LOAD_NEARBY_ENERGY_RANGE + 1,
+        source1: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [storedEnergy];
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 331 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage-mid' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 331,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'withdraw',
+      targetId: 'storage-mid',
+      energy: 50,
+      range: LOW_LOAD_NEARBY_ENERGY_RANGE + 1
+    });
+  });
+
   it('ignores unreachable nearby dropped energy for low-load workers', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const blockedDroppedEnergy = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1927,6 +1927,64 @@ describe('selectWorkerTask', () => {
     expect(findPathTo).not.toHaveBeenCalled();
   });
 
+  it('keeps a low-load worker harvesting instead of making a non-urgent primary refill trip', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        source1: 6,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 327 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 327,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'harvest',
+      targetId: 'source1',
+      energy: 300,
+      range: 6
+    });
+  });
+
   it('ignores unreachable nearby dropped energy for low-load workers', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const blockedDroppedEnergy = {
@@ -2225,6 +2283,112 @@ describe('selectWorkerTask', () => {
       selectedTask: 'transfer',
       targetId: 'spawn1',
       reason: 'urgentSpawnExtensionRefill'
+    });
+  });
+
+  it('keeps urgent tower refill allowed for low-load workers that could keep harvesting', () => {
+    const lowTower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        source1: 1,
+        'tower-low': 3
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [lowTower];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room: makeWorkerTaskRoom({
+        myStructures: [lowTower as AnyOwnedStructure],
+        sources: [source]
+      })
+    } as unknown as Creep;
+    creep.room.find = roomFind as unknown as Room['find'];
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
+  });
+
+  it('keeps a low-load worker harvesting instead of making a normal controller upgrade trip', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        controller1: 2,
+        source1: 6
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn((type: number) => {
+      if (
+        type === FIND_DROPPED_RESOURCES ||
+        type === FIND_STRUCTURES ||
+        type === FIND_MY_STRUCTURES ||
+        type === FIND_CONSTRUCTION_SITES ||
+        type === FIND_HOSTILE_CREEPS ||
+        type === FIND_HOSTILE_STRUCTURES ||
+        type === FIND_TOMBSTONES ||
+        type === FIND_RUINS
+      ) {
+        return [];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room: {
+        controller,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 328 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 328,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'harvest',
+      targetId: 'source1',
+      energy: 300,
+      range: 6
     });
   });
 


### PR DESCRIPTION
## Summary
- Reduces low-load worker return/refill churn so workers with tiny carried energy keep acquiring energy for normal/non-urgent work when possible.
- Preserves urgent partial deliveries for survival refill cases and no-acquisition fallback cases.
- Adds deterministic worker task/runner tests covering low-load non-urgent suppression and urgent/fallback allowances.

Closes #411.

## Verification
Controller-side verification after reconciling onto current `origin/main` (`158fe2c`):
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 24 suites / 620 tests passed
- `cd prod && npm run build`

Commit: `52b9756 lanyusea's bot <lanyusea@gmail.com> fix: return worker energy before refilling (#411)`

## Safety
- No destructive API/respawn behavior.
- Generated `prod/dist/main.js` was updated via build.
- `prod/node_modules` remains untracked dependency infrastructure.
