### PR TITLE
feat: generate offline strategy shadow reports

### DIFF
--- a/docs/ops/rl-dataset-pipeline.md
+++ b/docs/ops/rl-dataset-pipeline.md
@@ -44,7 +44,7 @@ Generate bounded offline strategy-shadow reports from saved local runtime artifa
 python3 scripts/screeps_strategy_shadow_report.py --out-dir runtime-artifacts/strategy-shadow
 ```
 
-With no positional paths, the generator scans the same safe local roots as the dataset exporter: `/root/screeps/runtime-artifacts`, `/root/.hermes/cron/output`, and repo-local `runtime-artifacts`. The command wraps `evaluateStrategyShadowReplay` through the built `prod/dist/main.js` export, so run `cd prod && npm run build` first if the production bundle is missing or stale.
+With no positional paths, the generator scans the same safe local roots as the dataset exporter: `/root/screeps/runtime-artifacts`, `/root/.hermes/cron/output`, and repo-local `runtime-artifacts`. The command wraps `evaluateStrategyShadowReplay` through the built `prod/dist/main.js` export, so run `npm --prefix prod run build` first if the production bundle is missing or stale. That build form preserves the repo-root cwd for the following Python command and its default paths.
 
 Reports are written under the gitignored `runtime-artifacts/strategy-shadow/` path. Each report records source path/hash metadata, evaluated artifact count, model families, candidate/incumbent strategy IDs, ranking-diff and changed-top counts, KPI summary fields, generated time, bot commit, and bounded sanitized warnings. Ranking diff bodies are sampled and bounded; raw runtime-summary lines, raw logs, and configured secret values are not copied.
 

--- a/docs/ops/rl-dataset-pipeline.md
+++ b/docs/ops/rl-dataset-pipeline.md
@@ -36,6 +36,20 @@ The exporter does not call live APIs, does not require Screeps or Steam credenti
 
 The output location is gitignored by the repository-level `runtime-artifacts/` ignore rule.
 
+## Strategy-Shadow Report Generation
+
+Generate bounded offline strategy-shadow reports from saved local runtime artifacts:
+
+```bash
+python3 scripts/screeps_strategy_shadow_report.py --out-dir runtime-artifacts/strategy-shadow
+```
+
+With no positional paths, the generator scans the same safe local roots as the dataset exporter: `/root/screeps/runtime-artifacts`, `/root/.hermes/cron/output`, and repo-local `runtime-artifacts`. The command wraps `evaluateStrategyShadowReplay` through the built `prod/dist/main.js` export, so run `cd prod && npm run build` first if the production bundle is missing or stale.
+
+Reports are written under the gitignored `runtime-artifacts/strategy-shadow/` path. Each report records source path/hash metadata, evaluated artifact count, model families, candidate/incumbent strategy IDs, ranking-diff and changed-top counts, KPI summary fields, generated time, bot commit, and bounded sanitized warnings. Ranking diff bodies are sampled and bounded; raw runtime-summary lines, raw logs, and configured secret values are not copied.
+
+Safety contract: the generator only reads saved local artifacts and the local built bundle. It makes no live API calls, performs no official MMO writes, writes no `Memory` or `RawMemory`, and emits `liveEffect: false` plus explicit safety metadata in every report. Generated reports are suitable as offline dataset and historical validation input only.
+
 ## Storage Layout
 
 Each run writes one deterministic directory:

--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -393,6 +393,7 @@ def strategy_shadow_report_metadata(raw: JsonObject, source: SourceFile, line_nu
     candidate_ids: set[str] = set()
     incumbent_ids: set[str] = set()
     ranking_diff_count = 0
+    changed_top_count = 0
     for report in model_reports:
         if not isinstance(report, dict):
             continue
@@ -402,8 +403,13 @@ def strategy_shadow_report_metadata(raw: JsonObject, source: SourceFile, line_nu
             candidate_ids.add(report["candidateStrategyId"])
         if isinstance(report.get("incumbentStrategyId"), str):
             incumbent_ids.add(report["incumbentStrategyId"])
-        if isinstance(report.get("rankingDiffs"), list):
-            ranking_diff_count += len(report["rankingDiffs"])
+        ranking_diffs = report.get("rankingDiffs") if isinstance(report.get("rankingDiffs"), list) else []
+        ranking_diff_count += int(report["rankingDiffCount"]) if is_number(report.get("rankingDiffCount")) else len(ranking_diffs)
+        changed_top_count += (
+            int(report["changedTopCount"])
+            if is_number(report.get("changedTopCount"))
+            else sum(1 for diff in ranking_diffs if isinstance(diff, dict) and diff.get("changedTop") is True)
+        )
 
     return {
         "sourceId": source.source_id,
@@ -413,6 +419,7 @@ def strategy_shadow_report_metadata(raw: JsonObject, source: SourceFile, line_nu
         "artifactCount": number_or_none(raw.get("artifactCount")),
         "modelReportCount": len(model_reports),
         "rankingDiffCount": ranking_diff_count,
+        "changedTopCount": changed_top_count,
         "families": sorted(families),
         "candidateStrategyIds": sorted(candidate_ids),
         "incumbentStrategyIds": sorted(incumbent_ids),

--- a/scripts/screeps_strategy_shadow_report.py
+++ b/scripts/screeps_strategy_shadow_report.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+"""Generate bounded offline strategy-shadow reports from saved Screeps artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence, TextIO
+
+import screeps_rl_dataset_export as dataset_export
+
+
+SCHEMA_VERSION = 1
+REPORT_TYPE = "screeps-strategy-shadow-report"
+GENERATION_SUMMARY_TYPE = "screeps-strategy-shadow-report-generation"
+DEFAULT_OUT_DIR = Path("runtime-artifacts/strategy-shadow")
+DEFAULT_DIST_PATH = Path("prod/dist/main.js")
+DEFAULT_ARTIFACT_LIMIT = 200
+DEFAULT_MAX_RANKING_DIFF_SAMPLES = 25
+DEFAULT_MAX_WARNING_COUNT = 20
+DEFAULT_MAX_WARNING_BYTES = 240
+DEFAULT_NODE_TIMEOUT_SECONDS = 30
+REPORT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+JsonObject = dict[str, Any]
+
+EVALUATOR_RUNNER_JS = r"""
+const fs = require("fs");
+
+const input = JSON.parse(fs.readFileSync(0, "utf8"));
+const evaluatorModule = require(input.distPath);
+if (typeof evaluatorModule.evaluateStrategyShadowReplay !== "function") {
+  throw new Error(`evaluateStrategyShadowReplay export not found in ${input.distPath}`);
+}
+
+const report = evaluatorModule.evaluateStrategyShadowReplay({
+  artifacts: input.artifacts,
+  config: {
+    enabled: true,
+    candidateStrategyIds: input.candidateStrategyIds || []
+  }
+});
+
+process.stdout.write(JSON.stringify(report));
+"""
+
+
+@dataclass(frozen=True)
+class SelectedArtifact:
+    record: dataset_export.ArtifactRecord
+    artifact_hash: str
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def build_strategy_shadow_report(
+    paths: Sequence[str],
+    out_dir: Path = DEFAULT_OUT_DIR,
+    *,
+    dist_path: Path = DEFAULT_DIST_PATH,
+    report_id: str | None = None,
+    generated_at: str | None = None,
+    bot_commit: str | None = None,
+    max_file_bytes: int = dataset_export.DEFAULT_MAX_FILE_BYTES,
+    artifact_limit: int = DEFAULT_ARTIFACT_LIMIT,
+    max_ranking_diff_samples: int = DEFAULT_MAX_RANKING_DIFF_SAMPLES,
+    max_warning_count: int = DEFAULT_MAX_WARNING_COUNT,
+    node_timeout_seconds: int = DEFAULT_NODE_TIMEOUT_SECONDS,
+    candidate_strategy_ids: Sequence[str] = (),
+    repo_root: Path | None = None,
+) -> JsonObject:
+    repo = repo_root or Path.cwd()
+    resolved_out_dir = out_dir.expanduser()
+    resolved_dist_path = resolve_dist_path(dist_path, repo)
+    resolved_bot_commit = bot_commit or dataset_export.git_commit(repo)
+    resolved_generated_at = generated_at or utc_now_iso()
+
+    scan = dataset_export.collect_artifact_records(
+        paths,
+        max_file_bytes=max_file_bytes,
+        excluded_roots=[resolved_out_dir],
+    )
+    selected_records = list(scan.records[:artifact_limit])
+    selected_artifacts = [
+        SelectedArtifact(record=record, artifact_hash=dataset_export.canonical_hash(record.payload))
+        for record in selected_records
+    ]
+    artifacts = [selected.record.payload for selected in selected_artifacts]
+
+    evaluator_report = run_shadow_evaluator(
+        resolved_dist_path,
+        artifacts,
+        candidate_strategy_ids=candidate_strategy_ids,
+        timeout_seconds=node_timeout_seconds,
+    )
+    report = sanitize_report(
+        evaluator_report=evaluator_report,
+        scan=scan,
+        selected_artifacts=selected_artifacts,
+        input_paths=list(paths) if paths else list(dataset_export.DEFAULT_INPUT_PATHS),
+        generated_at=resolved_generated_at,
+        bot_commit=resolved_bot_commit,
+        max_file_bytes=max_file_bytes,
+        artifact_limit=artifact_limit,
+        max_ranking_diff_samples=max_ranking_diff_samples,
+        max_warning_count=max_warning_count,
+        dist_path=resolved_dist_path,
+    )
+    resolved_report_id = report_id or default_report_id(report)
+    validate_report_id(resolved_report_id)
+    report["reportId"] = resolved_report_id
+
+    report_path = resolved_out_dir / f"{resolved_report_id}.json"
+    write_json_atomic(report_path, report)
+
+    return build_generation_summary(report, report_path, scan)
+
+
+def resolve_dist_path(dist_path: Path, repo_root: Path) -> Path:
+    expanded = dist_path.expanduser()
+    resolved = expanded if expanded.is_absolute() else repo_root / expanded
+    resolved = resolved.resolve(strict=False)
+    if not resolved.exists():
+        raise FileNotFoundError(
+            f"{dataset_export.display_path(resolved)} not found; run `cd prod && npm run build` before generating reports"
+        )
+    return resolved
+
+
+def run_shadow_evaluator(
+    dist_path: Path,
+    artifacts: Sequence[JsonObject],
+    *,
+    candidate_strategy_ids: Sequence[str],
+    timeout_seconds: int,
+) -> JsonObject:
+    payload = {
+        "distPath": str(dist_path),
+        "artifacts": list(artifacts),
+        "candidateStrategyIds": list(candidate_strategy_ids),
+    }
+    try:
+        result = subprocess.run(
+            ["node", "-e", EVALUATOR_RUNNER_JS],
+            input=json.dumps(payload, sort_keys=True),
+            text=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as error:
+        raise RuntimeError("node executable not found; install Node and run `cd prod && npm run build`") from error
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(f"strategy shadow evaluator timed out after {timeout_seconds}s") from error
+    except subprocess.CalledProcessError as error:
+        stderr = sanitize_text(error.stderr or "", max_bytes=800)
+        raise RuntimeError(f"strategy shadow evaluator failed: {stderr}") from error
+
+    parsed = dataset_export.parse_json(result.stdout)
+    if not isinstance(parsed, dict):
+        raise RuntimeError("strategy shadow evaluator returned non-object JSON")
+    return parsed
+
+
+def sanitize_report(
+    *,
+    evaluator_report: JsonObject,
+    scan: dataset_export.ScanResult,
+    selected_artifacts: Sequence[SelectedArtifact],
+    input_paths: Sequence[str],
+    generated_at: str,
+    bot_commit: str,
+    max_file_bytes: int,
+    artifact_limit: int,
+    max_ranking_diff_samples: int,
+    max_warning_count: int,
+    dist_path: Path,
+) -> JsonObject:
+    model_reports = sanitize_model_reports(evaluator_report.get("modelReports"), max_ranking_diff_samples)
+    ranking_diff_count = sum(number_or_zero(report.get("rankingDiffCount")) for report in model_reports)
+    changed_top_count = sum(number_or_zero(report.get("changedTopCount")) for report in model_reports)
+    warnings = bounded_warnings(evaluator_report.get("warnings"), max_warning_count)
+
+    if len(scan.records) > len(selected_artifacts):
+        warnings.append(
+            sanitize_text(
+                f"artifact limit applied: evaluated {len(selected_artifacts)} of {len(scan.records)} parsed artifacts",
+                max_bytes=DEFAULT_MAX_WARNING_BYTES,
+            )
+        )
+
+    return {
+        "type": REPORT_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "generatedAt": generated_at,
+        "botCommit": sanitize_text(bot_commit, max_bytes=80),
+        "enabled": evaluator_report.get("enabled") is True,
+        "liveEffect": False,
+        "safety": safety_metadata(dist_path),
+        "source": source_metadata(
+            scan=scan,
+            selected_artifacts=selected_artifacts,
+            input_paths=input_paths,
+            max_file_bytes=max_file_bytes,
+            artifact_limit=artifact_limit,
+        ),
+        "artifactCount": number_or_zero(evaluator_report.get("artifactCount")),
+        "modelReportCount": len(model_reports),
+        "modelFamilies": sorted(
+            {
+                report["family"]
+                for report in model_reports
+                if isinstance(report.get("family"), str) and report.get("family")
+            }
+        ),
+        "candidateStrategyIds": sorted(
+            {
+                report["candidateStrategyId"]
+                for report in model_reports
+                if isinstance(report.get("candidateStrategyId"), str) and report.get("candidateStrategyId")
+            }
+        ),
+        "incumbentStrategyIds": sorted(
+            {
+                report["incumbentStrategyId"]
+                for report in model_reports
+                if isinstance(report.get("incumbentStrategyId"), str) and report.get("incumbentStrategyId")
+            }
+        ),
+        "rankingDiffCount": ranking_diff_count,
+        "changedTopCount": changed_top_count,
+        "kpiSummary": sanitize_kpi_summary(evaluator_report.get("kpi")),
+        "modelReports": model_reports,
+        "warnings": warnings[:max_warning_count],
+    }
+
+
+def safety_metadata(dist_path: Path) -> JsonObject:
+    return {
+        "liveEffect": False,
+        "inputMode": "saved local runtime-summary artifacts only",
+        "evaluator": "evaluateStrategyShadowReplay",
+        "distPath": dataset_export.display_path(dist_path),
+        "networkRequired": False,
+        "liveApiCalls": False,
+        "officialMmoWritesAllowed": False,
+        "memoryWritesAllowed": False,
+        "rawMemoryWritesAllowed": False,
+        "creepSpawnMarketIntentsAllowed": False,
+        "allowedUse": "offline strategy replay, RL dataset indexing, and historical validation input only",
+    }
+
+
+def source_metadata(
+    *,
+    scan: dataset_export.ScanResult,
+    selected_artifacts: Sequence[SelectedArtifact],
+    input_paths: Sequence[str],
+    max_file_bytes: int,
+    artifact_limit: int,
+) -> JsonObject:
+    selected_source_ids = {selected.record.source.source_id for selected in selected_artifacts}
+    source_files = [
+        source_file_metadata(source, selected_artifacts)
+        for source in sorted(scan.source_files.values(), key=lambda item: item.source_id)
+        if source.source_id in selected_source_ids
+    ]
+    artifacts = [
+        {
+            "artifactId": f"artifact-{selected.artifact_hash[:16]}",
+            "sourceId": selected.record.source.source_id,
+            "path": selected.record.source.display_path,
+            "lineNumber": selected.record.line_number,
+            "artifactKind": selected.record.artifact_kind,
+            "sha256": selected.artifact_hash,
+            "tick": number_or_none(selected.record.payload.get("tick")),
+            "roomCount": room_count(selected.record.payload),
+        }
+        for selected in selected_artifacts
+    ]
+    return {
+        "inputPaths": dataset_export.redacted_input_paths(input_paths),
+        "scannedFiles": scan.scanned_files,
+        "sourceCount": len(source_files),
+        "parsedRuntimeArtifactCount": len(scan.records),
+        "evaluatedArtifactCount": len(selected_artifacts),
+        "artifactLimit": artifact_limit,
+        "artifactLimitApplied": len(scan.records) > len(selected_artifacts),
+        "maxFileBytes": max_file_bytes,
+        "skippedFileCount": len(scan.skipped_files),
+        "skippedFiles": sanitize_skipped_files(scan.skipped_files),
+        "sourceFiles": source_files,
+        "artifacts": artifacts,
+    }
+
+
+def source_file_metadata(source: dataset_export.SourceFile, selected_artifacts: Sequence[SelectedArtifact]) -> JsonObject:
+    matching = [selected for selected in selected_artifacts if selected.record.source.source_id == source.source_id]
+    return {
+        "sourceId": source.source_id,
+        "path": source.display_path,
+        "sizeBytes": source.size_bytes,
+        "sha256": source.sha256,
+        "artifactCount": len(matching),
+        "lineNumbers": [
+            selected.record.line_number
+            for selected in matching
+            if isinstance(selected.record.line_number, int)
+        ][:50],
+    }
+
+
+def sanitize_skipped_files(skipped_files: Sequence[JsonObject], limit: int = 20) -> list[JsonObject]:
+    sanitized: list[JsonObject] = []
+    for item in skipped_files[:limit]:
+        sanitized_item: JsonObject = {}
+        for key, value in item.items():
+            if isinstance(value, str):
+                sanitized_item[str(key)] = sanitize_text(value, max_bytes=240)
+            elif isinstance(value, (int, float, bool)) or value is None:
+                sanitized_item[str(key)] = value
+        sanitized.append(sanitized_item)
+    return sanitized
+
+
+def sanitize_model_reports(raw_model_reports: Any, max_ranking_diff_samples: int) -> list[JsonObject]:
+    if not isinstance(raw_model_reports, list):
+        return []
+
+    model_reports: list[JsonObject] = []
+    for raw_report in raw_model_reports:
+        if not isinstance(raw_report, dict):
+            continue
+        raw_diffs = raw_report.get("rankingDiffs") if isinstance(raw_report.get("rankingDiffs"), list) else []
+        diff_samples = [sanitize_ranking_diff(diff) for diff in raw_diffs[:max_ranking_diff_samples] if isinstance(diff, dict)]
+        changed_top_count = sum(1 for diff in raw_diffs if isinstance(diff, dict) and diff.get("changedTop") is True)
+        model_reports.append(
+            {
+                "family": sanitize_text(raw_report.get("family"), max_bytes=80),
+                "incumbentStrategyId": sanitize_text(raw_report.get("incumbentStrategyId"), max_bytes=120),
+                "candidateStrategyId": sanitize_text(raw_report.get("candidateStrategyId"), max_bytes=120),
+                "rankingDiffCount": len(raw_diffs),
+                "changedTopCount": changed_top_count,
+                "rankingDiffsTruncated": len(raw_diffs) > len(diff_samples),
+                "rankingDiffs": diff_samples,
+            }
+        )
+    return model_reports
+
+
+def sanitize_ranking_diff(raw_diff: JsonObject) -> JsonObject:
+    rank_changes = raw_diff.get("rankChanges") if isinstance(raw_diff.get("rankChanges"), list) else []
+    return {
+        "artifactIndex": number_or_none(raw_diff.get("artifactIndex")),
+        "tick": number_or_none(raw_diff.get("tick")),
+        "roomName": sanitize_optional_text(raw_diff.get("roomName"), max_bytes=80),
+        "context": sanitize_text(raw_diff.get("context"), max_bytes=80),
+        "changedTop": raw_diff.get("changedTop") is True,
+        "incumbentTop": sanitize_ranked_item(raw_diff.get("incumbentTop")),
+        "candidateTop": sanitize_ranked_item(raw_diff.get("candidateTop")),
+        "rankChangeCount": len(rank_changes),
+        "rankChangeSamples": [sanitize_rank_change(item) for item in rank_changes[:5] if isinstance(item, dict)],
+    }
+
+
+def sanitize_ranked_item(raw_item: Any) -> JsonObject | None:
+    if not isinstance(raw_item, dict):
+        return None
+    return {
+        "itemId": sanitize_text(raw_item.get("itemId"), max_bytes=160),
+        "label": sanitize_text(raw_item.get("label"), max_bytes=160),
+        "rank": number_or_none(raw_item.get("rank")),
+        "score": number_or_none(raw_item.get("score")),
+        "baseScore": number_or_none(raw_item.get("baseScore")),
+    }
+
+
+def sanitize_rank_change(raw_change: JsonObject) -> JsonObject:
+    return {
+        "itemId": sanitize_text(raw_change.get("itemId"), max_bytes=160),
+        "label": sanitize_text(raw_change.get("label"), max_bytes=160),
+        "incumbentRank": number_or_none(raw_change.get("incumbentRank")),
+        "candidateRank": number_or_none(raw_change.get("candidateRank")),
+        "delta": number_or_none(raw_change.get("delta")),
+    }
+
+
+def sanitize_kpi_summary(raw_kpi: Any) -> JsonObject:
+    if not isinstance(raw_kpi, dict):
+        return {}
+    summary: JsonObject = {}
+    reliability = raw_kpi.get("reliability")
+    if isinstance(reliability, dict):
+        summary["reliability"] = {
+            "passed": reliability.get("passed") is True,
+            "reasons": bounded_warnings(reliability.get("reasons"), DEFAULT_MAX_WARNING_COUNT),
+            "metrics": select_number_map(reliability.get("metrics")),
+        }
+    for dimension in ("territory", "resources", "kills"):
+        raw_dimension = raw_kpi.get(dimension)
+        if isinstance(raw_dimension, dict):
+            summary[dimension] = {
+                "score": number_or_none(raw_dimension.get("score")),
+                "components": select_number_map(raw_dimension.get("components")),
+            }
+    return summary
+
+
+def bounded_warnings(raw_warnings: Any, limit: int) -> list[str]:
+    if not isinstance(raw_warnings, list):
+        return []
+    warnings: list[str] = []
+    for warning in raw_warnings[:limit]:
+        if isinstance(warning, str):
+            warnings.append(sanitize_text(warning, max_bytes=DEFAULT_MAX_WARNING_BYTES))
+    return warnings
+
+
+def build_generation_summary(report: JsonObject, report_path: Path, scan: dataset_export.ScanResult) -> JsonObject:
+    return {
+        "ok": True,
+        "type": GENERATION_SUMMARY_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "reportId": report["reportId"],
+        "reportPath": dataset_export.display_path(report_path),
+        "liveEffect": False,
+        "artifactCount": report["artifactCount"],
+        "parsedRuntimeArtifactCount": len(scan.records),
+        "modelReportCount": report["modelReportCount"],
+        "rankingDiffCount": report["rankingDiffCount"],
+        "changedTopCount": report["changedTopCount"],
+        "candidateStrategyIds": report["candidateStrategyIds"],
+        "incumbentStrategyIds": report["incumbentStrategyIds"],
+        "warnings": report["warnings"],
+    }
+
+
+def default_report_id(report: JsonObject) -> str:
+    generated_at = str(report.get("generatedAt", "unknown")).replace(":", "").replace("+", "").replace("Z", "Z")
+    seed = {
+        "schemaVersion": SCHEMA_VERSION,
+        "generatedAt": report.get("generatedAt"),
+        "botCommit": report.get("botCommit"),
+        "source": report.get("source"),
+        "candidateStrategyIds": report.get("candidateStrategyIds"),
+        "rankingDiffCount": report.get("rankingDiffCount"),
+        "changedTopCount": report.get("changedTopCount"),
+    }
+    return f"strategy-shadow-{generated_at}-{dataset_export.canonical_hash(seed)[:12]}"
+
+
+def validate_report_id(report_id: str) -> None:
+    if not REPORT_ID_RE.fullmatch(report_id) or report_id in {".", ".."}:
+        raise ValueError("report id may contain only letters, numbers, dot, underscore, and hyphen")
+
+
+def write_json_atomic(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
+            temp_fd = -1
+            handle.write(json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True))
+            handle.write("\n")
+        os.replace(temp_path, path)
+    finally:
+        if temp_fd != -1:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def sanitize_text(value: Any, max_bytes: int) -> str:
+    text = value if isinstance(value, str) else ""
+    sanitized = dataset_export.redact_text(text).replace("\r", " ").replace("\n", " ")
+    encoded = sanitized.encode("utf-8")[:max_bytes]
+    return encoded.decode("utf-8", errors="ignore")
+
+
+def sanitize_optional_text(value: Any, max_bytes: int) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return sanitize_text(value, max_bytes=max_bytes)
+
+
+def select_number_map(raw: Any) -> JsonObject:
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): value for key, value in sorted(raw.items()) if dataset_export.is_number(value)}
+
+
+def number_or_none(value: Any) -> int | float | None:
+    return value if dataset_export.is_number(value) else None
+
+
+def number_or_zero(value: Any) -> int:
+    return int(value) if dataset_export.is_number(value) else 0
+
+
+def room_count(payload: JsonObject) -> int:
+    rooms = payload.get("rooms")
+    return len(rooms) if isinstance(rooms, list) else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a bounded offline strategy-shadow report from saved local Screeps runtime-summary artifacts."
+        ),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=(
+            "Files or directories to scan. Defaults to /root/screeps/runtime-artifacts, "
+            "/root/.hermes/cron/output, and repo-local runtime-artifacts."
+        ),
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help=f"Report output directory. Default: {DEFAULT_OUT_DIR}.",
+    )
+    parser.add_argument(
+        "--dist-path",
+        type=Path,
+        default=DEFAULT_DIST_PATH,
+        help=f"Built prod bundle exporting evaluateStrategyShadowReplay. Default: {DEFAULT_DIST_PATH}.",
+    )
+    parser.add_argument(
+        "--report-id",
+        help="Optional report file stem. Defaults to a timestamp plus content hash.",
+    )
+    parser.add_argument(
+        "--bot-commit",
+        help="Bot commit to record. Defaults to git rev-parse HEAD.",
+    )
+    parser.add_argument(
+        "--max-file-bytes",
+        type=positive_int,
+        default=dataset_export.DEFAULT_MAX_FILE_BYTES,
+        help=f"Skip files larger than this many bytes. Default: {dataset_export.DEFAULT_MAX_FILE_BYTES}.",
+    )
+    parser.add_argument(
+        "--artifact-limit",
+        type=positive_int,
+        default=DEFAULT_ARTIFACT_LIMIT,
+        help=f"Maximum parsed runtime artifacts to evaluate. Default: {DEFAULT_ARTIFACT_LIMIT}.",
+    )
+    parser.add_argument(
+        "--max-ranking-diff-samples",
+        type=positive_int,
+        default=DEFAULT_MAX_RANKING_DIFF_SAMPLES,
+        help=f"Maximum ranking diff samples kept per model report. Default: {DEFAULT_MAX_RANKING_DIFF_SAMPLES}.",
+    )
+    parser.add_argument(
+        "--max-warning-count",
+        type=positive_int,
+        default=DEFAULT_MAX_WARNING_COUNT,
+        help=f"Maximum warnings retained in the report. Default: {DEFAULT_MAX_WARNING_COUNT}.",
+    )
+    parser.add_argument(
+        "--candidate-strategy-id",
+        action="append",
+        default=[],
+        help="Candidate strategy ID to evaluate. Repeat to override the registry's shadow candidates.",
+    )
+    parser.add_argument(
+        "--node-timeout-seconds",
+        type=positive_int,
+        default=DEFAULT_NODE_TIMEOUT_SECONDS,
+        help=f"Node evaluator timeout. Default: {DEFAULT_NODE_TIMEOUT_SECONDS}.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout) -> int:
+    args = build_parser().parse_args(argv)
+    summary = build_strategy_shadow_report(
+        args.paths,
+        args.out_dir,
+        dist_path=args.dist_path,
+        report_id=args.report_id,
+        bot_commit=args.bot_commit,
+        max_file_bytes=args.max_file_bytes,
+        artifact_limit=args.artifact_limit,
+        max_ranking_diff_samples=args.max_ranking_diff_samples,
+        max_warning_count=args.max_warning_count,
+        node_timeout_seconds=args.node_timeout_seconds,
+        candidate_strategy_ids=args.candidate_strategy_id,
+    )
+    stdout.write(json.dumps(summary, indent=2, sort_keys=True, ensure_ascii=True))
+    stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/screeps_strategy_shadow_report.py
+++ b/scripts/screeps_strategy_shadow_report.py
@@ -89,14 +89,15 @@ def build_strategy_shadow_report(
     candidate_strategy_ids: Sequence[str] = (),
     repo_root: Path | None = None,
 ) -> JsonObject:
-    repo = repo_root or Path.cwd()
-    resolved_out_dir = out_dir.expanduser()
+    repo = resolve_repo_root(repo_root)
+    resolved_out_dir = resolve_repo_relative_path(out_dir, repo)
     resolved_dist_path = resolve_dist_path(dist_path, repo)
     resolved_bot_commit = bot_commit or dataset_export.git_commit(repo)
     resolved_generated_at = generated_at or utc_now_iso()
+    resolved_input_paths = resolve_input_paths(paths, repo)
 
     scan = dataset_export.collect_artifact_records(
-        paths,
+        resolved_input_paths,
         max_file_bytes=max_file_bytes,
         excluded_roots=[resolved_out_dir],
     )
@@ -117,7 +118,7 @@ def build_strategy_shadow_report(
         evaluator_report=evaluator_report,
         scan=scan,
         selected_artifacts=selected_artifacts,
-        input_paths=list(paths) if paths else list(dataset_export.DEFAULT_INPUT_PATHS),
+        input_paths=resolved_input_paths,
         generated_at=resolved_generated_at,
         bot_commit=resolved_bot_commit,
         max_file_bytes=max_file_bytes,
@@ -136,13 +137,31 @@ def build_strategy_shadow_report(
     return build_generation_summary(report, report_path, scan)
 
 
-def resolve_dist_path(dist_path: Path, repo_root: Path) -> Path:
-    expanded = dist_path.expanduser()
+def default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_repo_root(repo_root: Path | None) -> Path:
+    root = repo_root if repo_root is not None else default_repo_root()
+    return dataset_export.resolve_path(root.expanduser())
+
+
+def resolve_repo_relative_path(path: Path, repo_root: Path) -> Path:
+    expanded = path.expanduser()
     resolved = expanded if expanded.is_absolute() else repo_root / expanded
-    resolved = resolved.resolve(strict=False)
+    return dataset_export.resolve_path(resolved)
+
+
+def resolve_input_paths(paths: Sequence[str], repo_root: Path) -> list[str]:
+    input_paths = list(paths) if paths else list(dataset_export.DEFAULT_INPUT_PATHS)
+    return [str(resolve_repo_relative_path(Path(path), repo_root)) for path in input_paths]
+
+
+def resolve_dist_path(dist_path: Path, repo_root: Path) -> Path:
+    resolved = resolve_repo_relative_path(dist_path, repo_root)
     if not resolved.exists():
         raise FileNotFoundError(
-            f"{dataset_export.display_path(resolved)} not found; run `cd prod && npm run build` before generating reports"
+            f"{dataset_export.display_path(resolved)} not found; run `npm --prefix prod run build` before generating reports"
         )
     return resolved
 
@@ -170,7 +189,7 @@ def run_shadow_evaluator(
             timeout=timeout_seconds,
         )
     except FileNotFoundError as error:
-        raise RuntimeError("node executable not found; install Node and run `cd prod && npm run build`") from error
+        raise RuntimeError("node executable not found; install Node and run `npm --prefix prod run build`") from error
     except subprocess.TimeoutExpired as error:
         raise RuntimeError(f"strategy shadow evaluator timed out after {timeout_seconds}s") from error
     except subprocess.CalledProcessError as error:

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -261,6 +261,7 @@ class RlDatasetExportTest(unittest.TestCase):
         shadow_metadata = run_manifest["strategy"]["shadowReports"][0]
         self.assertEqual(shadow_metadata["families"], ["construction-priority"])
         self.assertEqual(shadow_metadata["rankingDiffCount"], 2)
+        self.assertEqual(shadow_metadata["changedTopCount"], 1)
         self.assertNotIn("warnings", shadow_metadata)
 
     def test_cli_output_and_dataset_do_not_include_configured_secret_or_raw_artifact_line(self) -> None:

--- a/scripts/test_screeps_strategy_shadow_report.py
+++ b/scripts/test_screeps_strategy_shadow_report.py
@@ -200,6 +200,61 @@ class StrategyShadowReportTest(unittest.TestCase):
         self.assertIn("kpiSummary", report)
         self.assertNotIn("#runtime-summary", json.dumps(report, sort_keys=True))
 
+    def test_defaults_are_repo_root_anchored_from_non_repo_cwd_and_exclude_output_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            fake_repo = root / "repo"
+            scheduler_cwd = root / "scheduler"
+            runtime_root = fake_repo / "runtime-artifacts"
+            out_dir = runtime_root / "strategy-shadow"
+            dist_path = fake_repo / "prod" / "dist" / "main.js"
+            scheduler_cwd.mkdir()
+            runtime_root.mkdir(parents=True)
+            out_dir.mkdir()
+            dist_path.parent.mkdir(parents=True)
+            dist_path.write_text("module.exports = {};\n", encoding="utf-8")
+            artifact = runtime_root / "runtime.log"
+            artifact.write_text(runtime_line(replay_payload(300)), encoding="utf-8")
+            prior_output = out_dir / "prior-report.log"
+            prior_output.write_text(runtime_line(replay_payload(999)), encoding="utf-8")
+
+            evaluator_report = {
+                "enabled": True,
+                "artifactCount": 1,
+                "modelReports": [],
+                "warnings": [],
+            }
+            previous_cwd = Path.cwd()
+            try:
+                os.chdir(scheduler_cwd)
+                with (
+                    mock.patch.object(shadow_report, "default_repo_root", return_value=fake_repo),
+                    mock.patch.object(dataset_export, "DEFAULT_INPUT_PATHS", ("runtime-artifacts",)),
+                    mock.patch.object(
+                        shadow_report,
+                        "run_shadow_evaluator",
+                        return_value=evaluator_report,
+                    ) as evaluator,
+                ):
+                    summary = shadow_report.build_strategy_shadow_report(
+                        [],
+                        report_id="default-paths",
+                        generated_at="2026-05-01T00:00:00Z",
+                        bot_commit="d" * 40,
+                    )
+            finally:
+                os.chdir(previous_cwd)
+
+            report = read_json(out_dir / "default-paths.json")
+
+        self.assertTrue(summary["ok"])
+        self.assertFalse((scheduler_cwd / "runtime-artifacts").exists())
+        self.assertEqual(evaluator.call_args.args[0], dist_path.resolve())
+        self.assertEqual([artifact["tick"] for artifact in evaluator.call_args.args[1]], [300])
+        self.assertEqual(report["source"]["parsedRuntimeArtifactCount"], 1)
+        self.assertEqual(report["source"]["sourceCount"], 1)
+        self.assertEqual(report["source"]["artifacts"][0]["tick"], 300)
+
     def test_bounds_diff_samples_and_redacts_configured_secret_values(self) -> None:
         secret = "supersecret123456"
         payloads = [replay_payload(200, secret), replay_payload(201, secret), replay_payload(202, secret)]

--- a/scripts/test_screeps_strategy_shadow_report.py
+++ b/scripts/test_screeps_strategy_shadow_report.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_dataset_export as dataset_export
+import screeps_strategy_shadow_report as shadow_report
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def runtime_line(payload: dict[str, object]) -> str:
+    return f"#runtime-summary {json.dumps(payload, sort_keys=True)}\n"
+
+
+def read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def replay_payload(tick: int = 200, secret_suffix: str = "") -> dict[str, object]:
+    remote_label = "build remote road/container logistics"
+    if secret_suffix:
+        remote_label = f"{remote_label} {secret_suffix}"
+    return {
+        "type": "runtime-summary",
+        "tick": tick,
+        "rooms": [
+            {
+                "roomName": "E26S49",
+                "energyAvailable": 350,
+                "energyCapacity": 550,
+                "workerCount": 4,
+                "spawnStatus": [{"name": "Spawn1", "status": "idle"}],
+                "controller": {
+                    "level": 3,
+                    "progress": 12000,
+                    "progressTotal": 135000,
+                    "ticksToDowngrade": 8000,
+                },
+                "resources": {
+                    "storedEnergy": 420,
+                    "workerCarriedEnergy": 120,
+                    "droppedEnergy": 30,
+                    "sourceCount": 2,
+                    "events": {"harvestedEnergy": 80, "transferredEnergy": 65},
+                },
+                "combat": {
+                    "hostileCreepCount": 0,
+                    "hostileStructureCount": 0,
+                    "events": {
+                        "attackCount": 0,
+                        "attackDamage": 0,
+                        "objectDestroyedCount": 0,
+                        "creepDestroyedCount": 0,
+                    },
+                },
+                "constructionPriority": {
+                    "candidates": [
+                        {
+                            "buildItem": "build extension capacity",
+                            "room": "E26S49",
+                            "score": 70,
+                            "urgency": "high",
+                            "preconditions": [],
+                            "expectedKpiMovement": [
+                                "raises spawn energy capacity",
+                                "unlocks larger workers and faster RCL progress",
+                            ],
+                            "risk": ["adds build backlog before roads/containers if worker capacity is low"],
+                        },
+                        {
+                            "buildItem": remote_label,
+                            "room": "E26S49",
+                            "score": 62,
+                            "urgency": "medium",
+                            "preconditions": [],
+                            "expectedKpiMovement": [
+                                "opens remote territory route",
+                                "supports reserve room economy",
+                                "improves harvest throughput",
+                            ],
+                            "risk": [],
+                        },
+                        {
+                            "buildItem": "build rampart defense",
+                            "room": "E26S49",
+                            "score": 45,
+                            "urgency": "medium",
+                            "preconditions": [],
+                            "expectedKpiMovement": ["improves spawn/controller survivability under pressure"],
+                            "risk": ["decays without sustained repair budget"],
+                        },
+                    ],
+                    "nextPrimary": {
+                        "buildItem": "build extension capacity",
+                        "room": "E26S49",
+                        "score": 70,
+                        "urgency": "high",
+                        "preconditions": [],
+                        "expectedKpiMovement": [
+                            "raises spawn energy capacity",
+                            "unlocks larger workers and faster RCL progress",
+                        ],
+                        "risk": ["adds build backlog before roads/containers if worker capacity is low"],
+                    },
+                },
+                "territoryRecommendation": {
+                    "candidates": [
+                        {
+                            "roomName": "E48S27",
+                            "action": "reserve",
+                            "score": 850,
+                            "evidenceStatus": "sufficient",
+                            "source": "configured",
+                            "evidence": ["room visible", "controller is available", "2 sources visible"],
+                            "preconditions": [],
+                            "risks": [],
+                            "routeDistance": 2,
+                            "sourceCount": 2,
+                        },
+                        {
+                            "roomName": "E49S28",
+                            "action": "occupy",
+                            "score": 820,
+                            "evidenceStatus": "sufficient",
+                            "source": "configured",
+                            "evidence": ["room visible", "controller is available", "1 source visible"],
+                            "preconditions": [],
+                            "risks": [],
+                            "routeDistance": 1,
+                            "sourceCount": 1,
+                        },
+                    ],
+                    "next": {
+                        "roomName": "E48S27",
+                        "action": "reserve",
+                        "score": 850,
+                        "evidenceStatus": "sufficient",
+                        "source": "configured",
+                        "evidence": ["room visible", "controller is available", "2 sources visible"],
+                        "preconditions": [],
+                        "risks": [],
+                        "routeDistance": 2,
+                        "sourceCount": 2,
+                    },
+                },
+            }
+        ],
+        "cpu": {"used": 5.2, "bucket": 9000},
+    }
+
+
+class StrategyShadowReportTest(unittest.TestCase):
+    def test_generates_bounded_offline_report_with_safety_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "runtime.log"
+            artifact.write_text(runtime_line(replay_payload()), encoding="utf-8")
+            out_dir = root / "strategy-shadow"
+
+            summary = shadow_report.build_strategy_shadow_report(
+                [str(artifact)],
+                out_dir,
+                report_id="shadow-test",
+                generated_at="2026-05-01T00:00:00Z",
+                bot_commit="a" * 40,
+                repo_root=REPO_ROOT,
+            )
+            report = read_json(out_dir / "shadow-test.json")
+
+        self.assertTrue(summary["ok"])
+        self.assertFalse(summary["liveEffect"])
+        self.assertEqual(report["type"], "screeps-strategy-shadow-report")
+        self.assertFalse(report["liveEffect"])
+        self.assertFalse(report["safety"]["liveApiCalls"])
+        self.assertFalse(report["safety"]["officialMmoWritesAllowed"])
+        self.assertFalse(report["safety"]["memoryWritesAllowed"])
+        self.assertFalse(report["safety"]["creepSpawnMarketIntentsAllowed"])
+        self.assertEqual(report["artifactCount"], 1)
+        self.assertGreaterEqual(report["rankingDiffCount"], 2)
+        self.assertGreaterEqual(report["changedTopCount"], 2)
+        self.assertEqual(
+            report["candidateStrategyIds"],
+            ["construction-priority.territory-shadow.v1", "expansion-remote.territory-shadow.v1"],
+        )
+        self.assertEqual(report["source"]["sourceCount"], 1)
+        self.assertEqual(report["source"]["evaluatedArtifactCount"], 1)
+        self.assertIn("sha256", report["source"]["sourceFiles"][0])
+        self.assertIn("kpiSummary", report)
+        self.assertNotIn("#runtime-summary", json.dumps(report, sort_keys=True))
+
+    def test_bounds_diff_samples_and_redacts_configured_secret_values(self) -> None:
+        secret = "supersecret123456"
+        payloads = [replay_payload(200, secret), replay_payload(201, secret), replay_payload(202, secret)]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "runtime.log"
+            artifact.write_text("".join(runtime_line(copy.deepcopy(payload)) for payload in payloads), encoding="utf-8")
+            out_dir = root / "strategy-shadow"
+
+            with mock.patch.dict(os.environ, {"SCREEPS_AUTH_TOKEN": secret}):
+                shadow_report.build_strategy_shadow_report(
+                    [str(artifact)],
+                    out_dir,
+                    report_id="shadow-bounds",
+                    generated_at="2026-05-01T00:00:00Z",
+                    bot_commit="b" * 40,
+                    artifact_limit=2,
+                    max_ranking_diff_samples=1,
+                    repo_root=REPO_ROOT,
+                )
+            report_path = out_dir / "shadow-bounds.json"
+            report = read_json(report_path)
+            report_text = report_path.read_text(encoding="utf-8")
+
+        self.assertNotIn(secret, report_text)
+        self.assertNotIn("#runtime-summary", report_text)
+        self.assertEqual(report["source"]["parsedRuntimeArtifactCount"], 3)
+        self.assertEqual(report["source"]["evaluatedArtifactCount"], 2)
+        self.assertTrue(report["source"]["artifactLimitApplied"])
+        self.assertTrue(any("artifact limit applied" in warning for warning in report["warnings"]))
+        for model_report in report["modelReports"]:
+            self.assertLessEqual(len(model_report["rankingDiffs"]), 1)
+            if model_report["rankingDiffCount"] > 1:
+                self.assertTrue(model_report["rankingDiffsTruncated"])
+
+    def test_cli_output_is_compact_and_dataset_export_indexes_generated_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "runtime.log"
+            artifact.write_text(runtime_line(replay_payload()), encoding="utf-8")
+            report_dir = root / "strategy-shadow"
+            stdout = io.StringIO()
+
+            exit_code = shadow_report.main(
+                [
+                    str(artifact),
+                    "--out-dir",
+                    str(report_dir),
+                    "--report-id",
+                    "shadow-cli",
+                    "--bot-commit",
+                    "c" * 40,
+                ],
+                stdout=stdout,
+            )
+            cli_output = stdout.getvalue()
+            dataset_dir = root / "datasets"
+            summary = dataset_export.build_dataset(
+                [str(artifact), str(report_dir / "shadow-cli.json")],
+                dataset_dir,
+                run_id="shadow-dataset",
+                bot_commit="c" * 40,
+                eval_ratio_value=0,
+                repo_root=REPO_ROOT,
+            )
+            run_manifest = read_json(dataset_dir / "shadow-dataset" / "run_manifest.json")
+
+        self.assertEqual(exit_code, 0)
+        self.assertNotIn("#runtime-summary", cli_output)
+        self.assertIn("reportPath", cli_output)
+        self.assertEqual(summary["strategyShadowReportCount"], 1)
+        shadow_metadata = run_manifest["strategy"]["shadowReports"][0]
+        self.assertEqual(shadow_metadata["rankingDiffCount"], 2)
+        self.assertEqual(shadow_metadata["changedTopCount"], 2)
+        self.assertEqual(
+            shadow_metadata["candidateStrategyIds"],
+            ["construction-priority.territory-shadow.v1", "expansion-remote.territory-shadow.v1"],
+        )
+        self.assertNotIn("rankingDiffs", shadow_metadata)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `scripts/screeps_strategy_shadow_report.py`, a cron-compatible offline generator for bounded strategy-shadow report artifacts from saved local runtime summaries.
- Extends the RL dataset exporter to index generated report counters including changed-top counts.
- Adds tests covering report generation, bounded/no-raw-log output, safety metadata, and dataset exporter compatibility.
- Documents the command and safety contract in `docs/ops/rl-dataset-pipeline.md`.

Fixes #432
Refs #409
Refs #417
Refs #430

## Verification

- `git diff --check`
- `python3 -m py_compile scripts/screeps_strategy_shadow_report.py scripts/screeps_rl_dataset_export.py`
- `python3 -m unittest scripts.test_screeps_strategy_shadow_report scripts.test_screeps_rl_dataset_export`

## Safety

- Offline/local artifact reader only.
- No live Screeps API calls.
- No official MMO writes.
- Reports carry `liveEffect: false` safety metadata and are intended for offline/shadow/historical-validation use only.