### PR TITLE
feat: improve low-energy worker throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6794,7 +6794,7 @@ function isCurrentTransferTargetCoveredByOtherLoadedWorkers(creep, task, target)
     return false;
   }
   let reservedEnergy = 0;
-  for (const worker of getGameCreeps2()) {
+  for (const worker of creep.room.find(FIND_MY_CREEPS)) {
     if (isSameCreep2(worker, creep) || !isSameRoomWorkerWithEnergy2(worker, creep.room)) {
       continue;
     }
@@ -6838,11 +6838,6 @@ function getUsedTransferEnergy(creep) {
   var _a, _b;
   const usedCapacity = (_b = (_a = creep.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY);
   return typeof usedCapacity === "number" && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
-}
-function getGameCreeps2() {
-  var _a;
-  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  return creeps ? Object.values(creeps) : [];
 }
 function isSameRoomWorkerWithEnergy2(creep, room) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6708,7 +6708,12 @@ function shouldPreemptTransferTaskForBetterEnergySink(creep, task, selectedTask)
     return true;
   }
   const selectedTarget = Game.getObjectById(selectedTask.targetId);
-  return getTransferSinkPriority(selectedTarget) > getTransferSinkPriority(currentTarget);
+  const selectedPriority = getTransferSinkPriority(selectedTarget);
+  const currentPriority = getTransferSinkPriority(currentTarget);
+  if (selectedPriority > currentPriority) {
+    return true;
+  }
+  return isPrimaryTransferSink(currentTarget) && selectedPriority > 0 && isValidTransferTarget(selectedTarget) && isCurrentTransferTargetCoveredByOtherLoadedWorkers(creep, task, currentTarget);
 }
 function shouldPreemptTransferTaskForControllerDowngradeGuard(creep, task, selectedTask) {
   if (task.type !== "transfer") {
@@ -6778,6 +6783,32 @@ function isTerritoryControlTask2(task) {
 function isValidTransferTarget(target) {
   return getFreeTransferEnergyCapacity(target) > 0;
 }
+function isPrimaryTransferSink(target) {
+  return getTransferSinkPriority(target) >= 2;
+}
+function isCurrentTransferTargetCoveredByOtherLoadedWorkers(creep, task, target) {
+  var _a;
+  const targetId = String(task.targetId);
+  const freeCapacity = getFreeTransferEnergyCapacity(target);
+  if (freeCapacity <= 0) {
+    return false;
+  }
+  let reservedEnergy = 0;
+  for (const worker of getGameCreeps2()) {
+    if (isSameCreep2(worker, creep) || !isSameRoomWorkerWithEnergy2(worker, creep.room)) {
+      continue;
+    }
+    const workerTask = (_a = worker.memory) == null ? void 0 : _a.task;
+    if ((workerTask == null ? void 0 : workerTask.type) !== "transfer" || String(workerTask.targetId) !== targetId) {
+      continue;
+    }
+    reservedEnergy += getUsedTransferEnergy(worker);
+    if (reservedEnergy >= freeCapacity) {
+      return true;
+    }
+  }
+  return false;
+}
 function isUrgentEnergySpendingTask(task) {
   const target = getTaskTarget(task);
   if (task.type === "transfer") {
@@ -6802,6 +6833,42 @@ function getFreeTransferEnergyCapacity(target) {
   const store = target == null ? void 0 : target.store;
   const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, RESOURCE_ENERGY);
   return typeof freeCapacity === "number" ? freeCapacity : 0;
+}
+function getUsedTransferEnergy(creep) {
+  var _a, _b;
+  const usedCapacity = (_b = (_a = creep.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY);
+  return typeof usedCapacity === "number" && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
+}
+function getGameCreeps2() {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  return creeps ? Object.values(creeps) : [];
+}
+function isSameRoomWorkerWithEnergy2(creep, room) {
+  var _a;
+  return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom2(creep, room) && getUsedTransferEnergy(creep) > 0;
+}
+function isInRoom2(creep, room) {
+  var _a;
+  if (typeof room.name === "string" && room.name.length > 0) {
+    return ((_a = creep.room) == null ? void 0 : _a.name) === room.name;
+  }
+  return creep.room === room;
+}
+function isSameCreep2(left, right) {
+  if (left === right) {
+    return true;
+  }
+  const leftKey = getCreepStableKey(left);
+  return leftKey.length > 0 && leftKey === getCreepStableKey(right);
+}
+function getCreepStableKey(creep) {
+  const name = creep.name;
+  if (typeof name === "string" && name.length > 0) {
+    return name;
+  }
+  const id = creep.id;
+  return typeof id === "string" && id.length > 0 ? id : "";
 }
 function getTransferSinkPriority(target) {
   const structureType = target == null ? void 0 : target.structureType;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -488,7 +488,7 @@ function isCurrentTransferTargetCoveredByOtherLoadedWorkers(
   }
 
   let reservedEnergy = 0;
-  for (const worker of getGameCreeps()) {
+  for (const worker of creep.room.find(FIND_MY_CREEPS)) {
     if (isSameCreep(worker, creep) || !isSameRoomWorkerWithEnergy(worker, creep.room)) {
       continue;
     }
@@ -544,11 +544,6 @@ function getFreeTransferEnergyCapacity(target: unknown): number {
 function getUsedTransferEnergy(creep: Creep): number {
   const usedCapacity = creep.store?.getUsedCapacity?.(RESOURCE_ENERGY);
   return typeof usedCapacity === 'number' && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
-}
-
-function getGameCreeps(): Creep[] {
-  const creeps = (globalThis as unknown as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
-  return creeps ? Object.values(creeps) : [];
 }
 
 function isSameRoomWorkerWithEnergy(creep: Creep, room: Room): boolean {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -341,7 +341,18 @@ function shouldPreemptTransferTaskForBetterEnergySink(
   }
 
   const selectedTarget = Game.getObjectById(selectedTask.targetId);
-  return getTransferSinkPriority(selectedTarget) > getTransferSinkPriority(currentTarget);
+  const selectedPriority = getTransferSinkPriority(selectedTarget);
+  const currentPriority = getTransferSinkPriority(currentTarget);
+  if (selectedPriority > currentPriority) {
+    return true;
+  }
+
+  return (
+    isPrimaryTransferSink(currentTarget) &&
+    selectedPriority > 0 &&
+    isValidTransferTarget(selectedTarget) &&
+    isCurrentTransferTargetCoveredByOtherLoadedWorkers(creep, task, currentTarget)
+  );
 }
 
 function shouldPreemptTransferTaskForControllerDowngradeGuard(
@@ -461,6 +472,41 @@ function isValidTransferTarget(target: unknown): target is AnyStoreStructure {
   return getFreeTransferEnergyCapacity(target) > 0;
 }
 
+function isPrimaryTransferSink(target: unknown): target is StructureSpawn | StructureExtension {
+  return getTransferSinkPriority(target) >= 2;
+}
+
+function isCurrentTransferTargetCoveredByOtherLoadedWorkers(
+  creep: Creep,
+  task: Extract<CreepTaskMemory, { type: 'transfer' }>,
+  target: AnyStoreStructure
+): boolean {
+  const targetId = String(task.targetId);
+  const freeCapacity = getFreeTransferEnergyCapacity(target);
+  if (freeCapacity <= 0) {
+    return false;
+  }
+
+  let reservedEnergy = 0;
+  for (const worker of getGameCreeps()) {
+    if (isSameCreep(worker, creep) || !isSameRoomWorkerWithEnergy(worker, creep.room)) {
+      continue;
+    }
+
+    const workerTask = worker.memory?.task as Partial<CreepTaskMemory> | undefined;
+    if (workerTask?.type !== 'transfer' || String(workerTask.targetId) !== targetId) {
+      continue;
+    }
+
+    reservedEnergy += getUsedTransferEnergy(worker);
+    if (reservedEnergy >= freeCapacity) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function isUrgentEnergySpendingTask(task: CreepTaskMemory): boolean {
   const target = getTaskTarget(task);
   if (task.type === 'transfer') {
@@ -493,6 +539,47 @@ function getFreeTransferEnergyCapacity(target: unknown): number {
     ?.store;
   const freeCapacity = store?.getFreeCapacity?.(RESOURCE_ENERGY);
   return typeof freeCapacity === 'number' ? freeCapacity : 0;
+}
+
+function getUsedTransferEnergy(creep: Creep): number {
+  const usedCapacity = creep.store?.getUsedCapacity?.(RESOURCE_ENERGY);
+  return typeof usedCapacity === 'number' && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
+}
+
+function getGameCreeps(): Creep[] {
+  const creeps = (globalThis as unknown as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  return creeps ? Object.values(creeps) : [];
+}
+
+function isSameRoomWorkerWithEnergy(creep: Creep, room: Room): boolean {
+  return creep.memory?.role === 'worker' && isInRoom(creep, room) && getUsedTransferEnergy(creep) > 0;
+}
+
+function isInRoom(creep: Creep, room: Room): boolean {
+  if (typeof room.name === 'string' && room.name.length > 0) {
+    return creep.room?.name === room.name;
+  }
+
+  return creep.room === room;
+}
+
+function isSameCreep(left: Creep, right: Creep): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  const leftKey = getCreepStableKey(left);
+  return leftKey.length > 0 && leftKey === getCreepStableKey(right);
+}
+
+function getCreepStableKey(creep: Creep): string {
+  const name = (creep as Creep & { name?: unknown }).name;
+  if (typeof name === 'string' && name.length > 0) {
+    return name;
+  }
+
+  const id = (creep as Creep & { id?: unknown }).id;
+  return typeof id === 'string' && id.length > 0 ? id : '';
 }
 
 function getTransferSinkPriority(target: unknown): number {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1958,6 +1958,59 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts an over-reserved primary refill target for uncovered spawn-extension demand', () => {
+    const coveredSpawn = {
+      id: 'spawn-covered',
+      structureType: 'spawn',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
+    } as unknown as StructureSpawn;
+    const openExtension = {
+      id: 'extension-open',
+      structureType: 'extension',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
+    } as unknown as StructureExtension;
+    const room = {
+      name: 'W1N1',
+      find: jest.fn(
+        (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
+          if (type !== FIND_MY_STRUCTURES) {
+            return [];
+          }
+
+          const structures = [coveredSpawn, openExtension];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+      )
+    } as unknown as Room;
+    const assignedCarrier = {
+      name: 'AssignedCarrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-covered' as Id<AnyStoreStructure> } },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    const creep = {
+      name: 'Carrier',
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'spawn-covered' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room,
+      transfer: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { AssignedCarrier: assignedCarrier, Carrier: creep },
+      getObjectById: jest.fn((id: string) => (id === 'extension-open' ? openExtension : coveredSpawn))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'extension-open' });
+    expect(creep.transfer).toHaveBeenCalledWith(openExtension, 'energy');
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('preempts tower transfer work for a primary fillable energy sink and executes it immediately', () => {
     const extension = {
       id: 'extension1',

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -26,6 +26,7 @@ describe('runWorker', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 10;
     (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
     (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
@@ -1962,23 +1963,31 @@ describe('runWorker', () => {
     const coveredSpawn = {
       id: 'spawn-covered',
       structureType: 'spawn',
-      store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
+      store: { getFreeCapacity: jest.fn().mockReturnValue(20) }
     } as unknown as StructureSpawn;
     const openExtension = {
       id: 'extension-open',
       structureType: 'extension',
       store: { getFreeCapacity: jest.fn().mockReturnValue(50) }
     } as unknown as StructureExtension;
+    const roomLocalCreeps: Creep[] = [];
     const room = {
       name: 'W1N1',
       find: jest.fn(
-        (type: number, options?: { filter?: (structure: StructureSpawn | StructureExtension) => boolean }) => {
-          if (type !== FIND_MY_STRUCTURES) {
-            return [];
+        (
+          type: number,
+          options?: { filter?: (object: StructureSpawn | StructureExtension | Creep) => boolean }
+        ) => {
+          if (type === FIND_MY_CREEPS) {
+            return options?.filter ? roomLocalCreeps.filter(options.filter) : roomLocalCreeps;
           }
 
-          const structures = [coveredSpawn, openExtension];
-          return options?.filter ? structures.filter(options.filter) : structures;
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [coveredSpawn, openExtension];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          return [];
         }
       )
     } as unknown as Room;
@@ -1999,14 +2008,16 @@ describe('runWorker', () => {
       transfer: jest.fn().mockReturnValue(0),
       moveTo: jest.fn()
     } as unknown as Creep;
+    roomLocalCreeps.push(assignedCarrier, creep);
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
-      creeps: { AssignedCarrier: assignedCarrier, Carrier: creep },
+      creeps: {},
       getObjectById: jest.fn((id: string) => (id === 'extension-open' ? openExtension : coveredSpawn))
     };
 
     runWorker(creep);
 
     expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'extension-open' });
+    expect(room.find).toHaveBeenCalledWith(FIND_MY_CREEPS);
     expect(creep.transfer).toHaveBeenCalledWith(openExtension, 'energy');
     expect(creep.moveTo).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Improves low-energy worker continuation so workers keep using productive nearby energy instead of falling back too early.
- Adds coverage for low-energy throughput behavior in worker runner tests.
- Regenerates `prod/dist/main.js`.

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --check`

Refs #434
