### PR TITLE
feat: spawn workers for territory recommendations

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1275,6 +1275,10 @@ var ACTION_SCORE = {
 function buildRuntimeOccupationRecommendationReport(colony, colonyWorkers) {
   return scoreOccupationRecommendations(buildRuntimeOccupationRecommendationInput(colony, colonyWorkers));
 }
+function clearOccupationRecommendationFollowUpIntent(report) {
+  report.followUpIntent = null;
+  return report;
+}
 function scoreOccupationRecommendations(input) {
   var _a;
   const candidates = input.candidates.filter((candidate) => candidate.roomName !== input.colonyName).map((candidate) => scoreOccupationCandidate(input, candidate)).sort(compareOccupationRecommendationScores);
@@ -8097,7 +8101,7 @@ var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
 var PRODUCTIVE_WORKER_TASK_TYPES = ["build", "repair", "upgrade"];
-function emitRuntimeSummary(colonies, creeps, events = []) {
+function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return;
   }
@@ -8107,13 +8111,16 @@ function emitRuntimeSummary(colonies, creeps, events = []) {
   }
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const creepsByColony = groupCreepsByColony(creeps);
+  const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const summary = {
     type: "runtime-summary",
     tick,
-    rooms: colonies.map((colony) => {
-      var _a;
-      return summarizeRoom(colony, (_a = creepsByColony.get(colony.room.name)) != null ? _a : []);
-    }),
+    rooms: colonies.map(
+      (colony) => {
+        var _a;
+        return summarizeRoom(colony, (_a = creepsByColony.get(colony.room.name)) != null ? _a : [], persistOccupationRecommendations);
+      }
+    ),
     ...reportedEvents.length > 0 ? { events: reportedEvents } : {},
     ...events.length > MAX_REPORTED_EVENTS ? { omittedEventCount: events.length - MAX_REPORTED_EVENTS } : {},
     ...buildCpuSummary()
@@ -8137,12 +8144,14 @@ function groupCreepsByColony(creeps) {
   }
   return creepsByColony;
 }
-function summarizeRoom(colony, colonyCreeps) {
+function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations) {
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
   const eventMetrics = summarizeRoomEventMetrics(colony.room);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
-  persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime5());
+  if (persistOccupationRecommendations) {
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime5());
+  }
   return {
     roomName: colony.room.name,
     energyAvailable: colony.energyAvailable,
@@ -8844,17 +8853,15 @@ function runEconomy(preludeTelemetryEvents = []) {
       runTerritoryControllerCreep(creep);
     }
   }
-  emitRuntimeSummary(colonies, creeps, telemetryEvents);
+  emitRuntimeSummary(colonies, creeps, telemetryEvents, { persistOccupationRecommendations: false });
 }
 function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady) {
-  if (!territoryReady) {
-    return;
-  }
   const colonyWorkers = creeps.filter(
     (creep) => creep.memory.role === "worker" && creep.memory.colony === colony.room.name
   );
+  const report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   persistOccupationRecommendationFollowUpIntent(
-    buildRuntimeOccupationRecommendationReport(colony, colonyWorkers),
+    territoryReady ? report : clearOccupationRecommendationFollowUpIntent(report),
     Game.time
   );
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8752,11 +8752,9 @@ function runEconomy(preludeTelemetryEvents = []) {
       planEarlyRoadConstruction(colony);
     }
     let roleCounts = countCreepsByRole(creeps, colony.room.name);
-    recordColonySurvivalAssessment(
-      colony.room.name,
-      assessColonySnapshotSurvival(colony, roleCounts),
-      Game.time
-    );
+    const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
+    recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
+    refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady);
     let availableEnergy = colony.energyAvailable;
     let successfulSpawnCount = 0;
     const usedSpawns = /* @__PURE__ */ new Set();
@@ -8800,6 +8798,18 @@ function runEconomy(preludeTelemetryEvents = []) {
     }
   }
   emitRuntimeSummary(colonies, creeps, telemetryEvents);
+}
+function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady) {
+  if (!territoryReady) {
+    return;
+  }
+  const colonyWorkers = creeps.filter(
+    (creep) => creep.memory.role === "worker" && creep.memory.colony === colony.room.name
+  );
+  persistOccupationRecommendationFollowUpIntent(
+    buildRuntimeOccupationRecommendationReport(colony, colonyWorkers),
+    Game.time
+  );
 }
 function createSpawnPlanningColony(colony, energyAvailable, usedSpawns) {
   return {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -11,6 +11,10 @@ import { runWorker } from '../creeps/workerRunner';
 import { getBodyCost } from '../spawn/bodyBuilder';
 import { planSpawn, type SpawnPlanningOptions, type SpawnRequest } from '../spawn/spawnPlanner';
 import { emitRuntimeSummary, type RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
+import {
+  buildRuntimeOccupationRecommendationReport,
+  persistOccupationRecommendationFollowUpIntent
+} from '../territory/occupationRecommendation';
 import { TERRITORY_CLAIMER_ROLE, TERRITORY_SCOUT_ROLE } from '../territory/territoryPlanner';
 import { runTerritoryControllerCreep } from '../territory/territoryRunner';
 
@@ -35,11 +39,9 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
     }
 
     let roleCounts = countCreepsByRole(creeps, colony.room.name);
-    recordColonySurvivalAssessment(
-      colony.room.name,
-      assessColonySnapshotSurvival(colony, roleCounts),
-      Game.time
-    );
+    const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
+    recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
+    refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady);
     let availableEnergy = colony.energyAvailable;
     let successfulSpawnCount = 0;
     const usedSpawns = new Set<StructureSpawn>();
@@ -91,6 +93,24 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   }
 
   emitRuntimeSummary(colonies, creeps, telemetryEvents);
+}
+
+function refreshExecutableTerritoryRecommendation(
+  colony: ColonySnapshot,
+  creeps: Creep[],
+  territoryReady: boolean
+): void {
+  if (!territoryReady) {
+    return;
+  }
+
+  const colonyWorkers = creeps.filter(
+    (creep) => creep.memory.role === 'worker' && creep.memory.colony === colony.room.name
+  );
+  persistOccupationRecommendationFollowUpIntent(
+    buildRuntimeOccupationRecommendationReport(colony, colonyWorkers),
+    Game.time
+  );
 }
 
 function createSpawnPlanningColony(

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -13,6 +13,7 @@ import { planSpawn, type SpawnPlanningOptions, type SpawnRequest } from '../spaw
 import { emitRuntimeSummary, type RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 import {
   buildRuntimeOccupationRecommendationReport,
+  clearOccupationRecommendationFollowUpIntent,
   persistOccupationRecommendationFollowUpIntent
 } from '../territory/occupationRecommendation';
 import { TERRITORY_CLAIMER_ROLE, TERRITORY_SCOUT_ROLE } from '../territory/territoryPlanner';
@@ -92,7 +93,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
     }
   }
 
-  emitRuntimeSummary(colonies, creeps, telemetryEvents);
+  emitRuntimeSummary(colonies, creeps, telemetryEvents, { persistOccupationRecommendations: false });
 }
 
 function refreshExecutableTerritoryRecommendation(
@@ -100,15 +101,12 @@ function refreshExecutableTerritoryRecommendation(
   creeps: Creep[],
   territoryReady: boolean
 ): void {
-  if (!territoryReady) {
-    return;
-  }
-
   const colonyWorkers = creeps.filter(
     (creep) => creep.memory.role === 'worker' && creep.memory.colony === colony.room.name
   );
+  const report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   persistOccupationRecommendationFollowUpIntent(
-    buildRuntimeOccupationRecommendationReport(colony, colonyWorkers),
+    territoryReady ? report : clearOccupationRecommendationFollowUpIntent(report),
     Game.time
   );
 }

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -184,7 +184,16 @@ interface RuntimeSummary {
   cpu?: RuntimeCpuSummary;
 }
 
-export function emitRuntimeSummary(colonies: ColonySnapshot[], creeps: Creep[], events: RuntimeTelemetryEvent[] = []): void {
+interface RuntimeSummaryOptions {
+  persistOccupationRecommendations?: boolean;
+}
+
+export function emitRuntimeSummary(
+  colonies: ColonySnapshot[],
+  creeps: Creep[],
+  events: RuntimeTelemetryEvent[] = [],
+  options: RuntimeSummaryOptions = {}
+): void {
   if (colonies.length === 0 && events.length === 0) {
     return;
   }
@@ -196,10 +205,13 @@ export function emitRuntimeSummary(colonies: ColonySnapshot[], creeps: Creep[], 
 
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const creepsByColony = groupCreepsByColony(creeps);
+  const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const summary: RuntimeSummary = {
     type: 'runtime-summary',
     tick,
-    rooms: colonies.map((colony) => summarizeRoom(colony, creepsByColony.get(colony.room.name) ?? [])),
+    rooms: colonies.map((colony) =>
+      summarizeRoom(colony, creepsByColony.get(colony.room.name) ?? [], persistOccupationRecommendations)
+    ),
     ...(reportedEvents.length > 0 ? { events: reportedEvents } : {}),
     ...(events.length > MAX_REPORTED_EVENTS ? { omittedEventCount: events.length - MAX_REPORTED_EVENTS } : {}),
     ...buildCpuSummary()
@@ -229,12 +241,18 @@ function groupCreepsByColony(creeps: Creep[]): Map<string, Creep[]> {
   return creepsByColony;
 }
 
-function summarizeRoom(colony: ColonySnapshot, colonyCreeps: Creep[]): RuntimeRoomSummary {
+function summarizeRoom(
+  colony: ColonySnapshot,
+  colonyCreeps: Creep[],
+  persistOccupationRecommendations: boolean
+): RuntimeRoomSummary {
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === 'worker');
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
   const eventMetrics = summarizeRoomEventMetrics(colony.room);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
-  persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime());
+  if (persistOccupationRecommendations) {
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime());
+  }
 
   return {
     roomName: colony.room.name,

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -96,6 +96,14 @@ export function buildRuntimeOccupationRecommendationReport(
   return scoreOccupationRecommendations(buildRuntimeOccupationRecommendationInput(colony, colonyWorkers));
 }
 
+export function clearOccupationRecommendationFollowUpIntent(
+  report: OccupationRecommendationReport
+): OccupationRecommendationReport {
+  // Mutate so the non-enumerable colonyName marker used by persistence is retained.
+  report.followUpIntent = null;
+  return report;
+}
+
 export function scoreOccupationRecommendations(
   input: OccupationRecommendationInput
 ): OccupationRecommendationReport {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -470,6 +470,91 @@ describe('runEconomy', () => {
 
     expect(creep.reserveController).toHaveBeenCalledWith(controller);
   });
+
+  it('turns a safe occupation recommendation into same-tick territory spawn pressure', () => {
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const room = makeTerritoryReadyEconomyRoom();
+    const targetRoom = makeVisibleReserveRoom('W2N1', 'controller2' as Id<StructureController>);
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 320,
+      rooms: { W1N1: room, W2N1: targetRoom },
+      spawns: { Spawn1: spawn },
+      creeps: workers,
+      getObjectById: jest.fn().mockReturnValue(null),
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' }))
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['claim', 'move'], 'claimer-W1N1-W2N1-320', {
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: {
+          targetRoom: 'W2N1',
+          action: 'reserve',
+          controllerId: 'controller2'
+        }
+      }
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
+  it('keeps unsafe occupation recommendations on worker recovery before territory spawn pressure', () => {
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const room = makeTerritoryReadyEconomyRoom();
+    const targetRoom = makeVisibleReserveRoom('W2N1', 'controller2' as Id<StructureController>);
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 321,
+      rooms: { W1N1: room, W2N1: targetRoom },
+      spawns: { Spawn1: spawn },
+      creeps: { Worker1: makeEconomyWorker(room) },
+      getObjectById: jest.fn().mockReturnValue(null),
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' }))
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(
+      ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      'worker-W1N1-321',
+      {
+        memory: { role: 'worker', colony: 'W1N1' }
+      }
+    );
+    expect(Memory.territory?.targets).toBeUndefined();
+  });
 });
 
 interface LifecycleSpawn extends StructureSpawn {
@@ -516,4 +601,41 @@ function createLifecycleSpawn(room: Room, creeps: Record<string, Creep>, spawnTi
   };
 
   return spawn as unknown as LifecycleSpawn;
+}
+
+function makeTerritoryReadyEconomyRoom(): Room {
+  return {
+    name: 'W1N1',
+    energyAvailable: 650,
+    energyCapacityAvailable: 650,
+    controller: {
+      my: true,
+      owner: { username: 'me' },
+      level: 3,
+      ticksToDowngrade: 10_000
+    } as StructureController,
+    find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: 'home-source' } as Source] : []))
+  } as unknown as Room;
+}
+
+function makeVisibleReserveRoom(
+  roomName: string,
+  controllerId: Id<StructureController>
+): Room {
+  return {
+    name: roomName,
+    controller: { id: controllerId, my: false } as StructureController,
+    find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
+  } as unknown as Room;
+}
+
+function makeEconomyWorker(room: Room): Creep {
+  return {
+    memory: { role: 'worker', colony: room.name },
+    room,
+    store: {
+      getUsedCapacity: jest.fn().mockReturnValue(0),
+      getFreeCapacity: jest.fn().mockReturnValue(50)
+    }
+  } as unknown as Creep;
 }

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -555,6 +555,95 @@ describe('runEconomy', () => {
     );
     expect(Memory.territory?.targets).toBeUndefined();
   });
+
+  it('clears stale recommendation-created territory targets on unsafe hostile ticks', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_HOSTILE_CREEPS: number;
+      FIND_HOSTILE_STRUCTURES: number;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 2;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 3;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            action: 'reserve',
+            createdBy: 'occupationRecommendation',
+            controllerId: 'controller2' as Id<StructureController>
+          },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'claim' },
+          {
+            colony: 'W1N1',
+            roomName: 'W4N1',
+            action: 'reserve',
+            createdBy: 'occupationRecommendation',
+            enabled: false
+          },
+          {
+            colony: 'W9N9',
+            roomName: 'W9N8',
+            action: 'reserve',
+            createdBy: 'occupationRecommendation'
+          }
+        ],
+        routeDistances: { 'W1N1>W3N1': null }
+      }
+    };
+    const hostile = { id: 'hostile1' } as Creep;
+    const room = makeHostileEconomyRoom([hostile]);
+    const targetRoom = makeVisibleReserveRoom('W2N1', 'controller2' as Id<StructureController>);
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 322,
+      rooms: { W1N1: room, W2N1: targetRoom },
+      spawns: { Spawn1: spawn },
+      creeps: workers,
+      getObjectById: jest.fn().mockReturnValue(null),
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' }))
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['tough', 'attack', 'move'], 'defender-W1N1-322', {
+      memory: {
+        role: 'defender',
+        colony: 'W1N1',
+        defense: { homeRoom: 'W1N1' }
+      }
+    });
+    expect(Memory.territory?.targets).toEqual([
+      { colony: 'W1N1', roomName: 'W3N1', action: 'claim' },
+      {
+        colony: 'W1N1',
+        roomName: 'W4N1',
+        action: 'reserve',
+        createdBy: 'occupationRecommendation',
+        enabled: false
+      },
+      {
+        colony: 'W9N9',
+        roomName: 'W9N8',
+        action: 'reserve',
+        createdBy: 'occupationRecommendation'
+      }
+    ]);
+  });
 });
 
 interface LifecycleSpawn extends StructureSpawn {
@@ -626,6 +715,24 @@ function makeVisibleReserveRoom(
     name: roomName,
     controller: { id: controllerId, my: false } as StructureController,
     find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
+  } as unknown as Room;
+}
+
+function makeHostileEconomyRoom(hostileCreeps: Creep[]): Room {
+  const room = makeTerritoryReadyEconomyRoom();
+  return {
+    ...room,
+    find: jest.fn((type: number) => {
+      if (type === FIND_SOURCES) {
+        return [{ id: 'home-source' } as Source];
+      }
+
+      if (type === FIND_HOSTILE_CREEPS) {
+        return hostileCreeps;
+      }
+
+      return [];
+    })
   } as unknown as Room;
 }
 


### PR DESCRIPTION
## Summary
- Turns executable territory recommendations into worker spawn/task pressure from the economy loop.
- Adds focused Jest coverage for safe recommendation-backed spawn pressure and negative cases.
- Rebuilds the Screeps bundle artifact.

## Scope
- Gameplay territory/control lane for #440.
- Runtime impact: allows safe executable reserve/claim recommendations to influence in-game worker spawning/task action while preserving bootstrap safety.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` (24 suites / 640 tests)
- `cd prod && npm run build`

Closes #440.
