### PR TITLE
feat: harden productive worker pressure recovery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -652,6 +652,9 @@ var MIN_WORKER_TARGET = 3;
 var WORKERS_PER_SOURCE = 2;
 var CONSTRUCTION_BACKLOG_WORKER_BONUS = 1;
 var SUBSTANTIAL_CONSTRUCTION_BACKLOG_SITE_COUNT = 5;
+var SPAWN_EXTENSION_REFILL_WORKER_BONUS = 1;
+var MIN_PRODUCTIVE_WORKER_BODY_ENERGY = 200;
+var SPAWN_EXTENSION_REFILL_PRESSURE_RATIO = 0.75;
 var MAX_WORKER_TARGET = 6;
 var BOOTSTRAP_WORKER_FLOOR = 3;
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
@@ -706,11 +709,18 @@ function getWorkerTarget(colony, roleCounts) {
   if (workerCapacity < baseTarget || !isConstructionBonusHomeSafe(colony.room.controller)) {
     return baseTarget;
   }
+  const refillPressureTarget = shouldAddSpawnExtensionRefillWorker(colony) ? Math.min(MAX_WORKER_TARGET, baseTarget + SPAWN_EXTENSION_REFILL_WORKER_BONUS) : baseTarget;
+  if (workerCapacity < refillPressureTarget) {
+    return refillPressureTarget;
+  }
   const constructionBacklogSiteCount = getConstructionBacklogSiteCount(colony.room);
   if (constructionBacklogSiteCount === 0) {
-    return baseTarget;
+    return refillPressureTarget;
   }
-  const firstBonusTarget = Math.min(MAX_WORKER_TARGET, baseTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
+  const firstBonusTarget = Math.min(
+    MAX_WORKER_TARGET,
+    refillPressureTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS
+  );
   if (workerCapacity < firstBonusTarget || constructionBacklogSiteCount < SUBSTANTIAL_CONSTRUCTION_BACKLOG_SITE_COUNT) {
     return firstBonusTarget;
   }
@@ -787,6 +797,9 @@ function getControllerSurvivalState(controller) {
 }
 function isConstructionBonusHomeSafe(controller) {
   return (controller == null ? void 0 : controller.my) === true && (typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > CONTROLLER_DOWNGRADE_GUARD_TICKS);
+}
+function shouldAddSpawnExtensionRefillWorker(colony) {
+  return colony.spawns.length > 0 && colony.energyAvailable >= MIN_PRODUCTIVE_WORKER_BODY_ENERGY && colony.energyAvailable < TERRITORY_CONTROLLER_BODY_COST && colony.energyCapacityAvailable > 0 && colony.energyAvailable < colony.energyCapacityAvailable * SPAWN_EXTENSION_REFILL_PRESSURE_RATIO;
 }
 function getConstructionBacklogSiteCount(room) {
   return countRoomFind(room, "FIND_MY_CONSTRUCTION_SITES");

--- a/prod/src/colony/survivalMode.ts
+++ b/prod/src/colony/survivalMode.ts
@@ -53,6 +53,9 @@ const MIN_WORKER_TARGET = 3;
 const WORKERS_PER_SOURCE = 2;
 const CONSTRUCTION_BACKLOG_WORKER_BONUS = 1;
 const SUBSTANTIAL_CONSTRUCTION_BACKLOG_SITE_COUNT = 5;
+const SPAWN_EXTENSION_REFILL_WORKER_BONUS = 1;
+const MIN_PRODUCTIVE_WORKER_BODY_ENERGY = 200;
+const SPAWN_EXTENSION_REFILL_PRESSURE_RATIO = 0.75;
 const MAX_WORKER_TARGET = 6;
 const BOOTSTRAP_WORKER_FLOOR = 3;
 const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
@@ -121,12 +124,22 @@ export function getWorkerTarget(colony: ColonySnapshot, roleCounts: RoleCounts):
     return baseTarget;
   }
 
-  const constructionBacklogSiteCount = getConstructionBacklogSiteCount(colony.room);
-  if (constructionBacklogSiteCount === 0) {
-    return baseTarget;
+  const refillPressureTarget = shouldAddSpawnExtensionRefillWorker(colony)
+    ? Math.min(MAX_WORKER_TARGET, baseTarget + SPAWN_EXTENSION_REFILL_WORKER_BONUS)
+    : baseTarget;
+  if (workerCapacity < refillPressureTarget) {
+    return refillPressureTarget;
   }
 
-  const firstBonusTarget = Math.min(MAX_WORKER_TARGET, baseTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
+  const constructionBacklogSiteCount = getConstructionBacklogSiteCount(colony.room);
+  if (constructionBacklogSiteCount === 0) {
+    return refillPressureTarget;
+  }
+
+  const firstBonusTarget = Math.min(
+    MAX_WORKER_TARGET,
+    refillPressureTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS
+  );
   if (
     workerCapacity < firstBonusTarget ||
     constructionBacklogSiteCount < SUBSTANTIAL_CONSTRUCTION_BACKLOG_SITE_COUNT
@@ -260,6 +273,16 @@ function isConstructionBonusHomeSafe(controller: StructureController | undefined
     controller?.my === true &&
     (typeof controller.ticksToDowngrade !== 'number' ||
       controller.ticksToDowngrade > CONTROLLER_DOWNGRADE_GUARD_TICKS)
+  );
+}
+
+function shouldAddSpawnExtensionRefillWorker(colony: ColonySnapshot): boolean {
+  return (
+    colony.spawns.length > 0 &&
+    colony.energyAvailable >= MIN_PRODUCTIVE_WORKER_BODY_ENERGY &&
+    colony.energyAvailable < TERRITORY_CONTROLLER_BODY_COST &&
+    colony.energyCapacityAvailable > 0 &&
+    colony.energyAvailable < colony.energyCapacityAvailable * SPAWN_EXTENSION_REFILL_PRESSURE_RATIO
   );
 }
 

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -139,6 +139,66 @@ describe('runEconomy', () => {
     );
   });
 
+  it('keeps spawning a productive worker while baseline workers still leave refill pressure', () => {
+    (globalThis as unknown as {
+      FIND_MY_STRUCTURES: number;
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_SOURCES: number;
+      STRUCTURE_EXTENSION: StructureConstant;
+    }).FIND_MY_STRUCTURES = 1;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 4;
+    (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    const extensions = Array.from(
+      { length: 5 },
+      (_, index) => ({ id: `extension${index}`, structureType: 'extension' }) as StructureExtension
+    );
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 400,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 2, ticksToDowngrade: 10_000 } as StructureController,
+      find: jest.fn((type: number, options?: { filter?: (structure: StructureExtension) => boolean }) => {
+        if (type === FIND_SOURCES) {
+          return [{ id: 'source1' } as Source];
+        }
+
+        if (type === FIND_MY_STRUCTURES) {
+          return options?.filter ? extensions.filter(options.filter) : extensions;
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(0)
+    } as unknown as StructureSpawn;
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 127,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: workers
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(
+      ['work', 'carry', 'move', 'work', 'carry', 'move'],
+      'worker-W1N1-127',
+      {
+        memory: { role: 'worker', colony: 'W1N1' }
+      }
+    );
+  });
+
   it('waits through critical energy without invalid spawn attempts and recovers when an emergency body is affordable', () => {
     const room = {
       name: 'W1N1',

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -217,6 +217,23 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 4 }, 146)).toBeNull();
   });
 
+  it('adds one worker target while spawn-extension refill pressure remains after baseline workers', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N16',
+      energyAvailable: 400,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 146)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move'],
+      name: 'worker-W1N16-146',
+      memory: { role: 'worker', colony: 'W1N16' }
+    });
+    expect(planSpawn(colony, { worker: 4 }, 147)).toBeNull();
+  });
+
   it('adds a second worker target for substantial construction backlog after the first bonus target is safe', () => {
     const { colony, spawn } = makeColony({
       roomName: 'W1N14',


### PR DESCRIPTION
## Summary
- Adds a productive-worker pressure bonus when spawn/extension refill demand remains after baseline workers.
- Keeps the bonus bounded by worker capacity and construction-backlog logic.
- Updates economy/spawn planner coverage and generated Screeps bundle.

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --check`

Refs #445