### PR TITLE
feat: add controller pressure spawn follow-up

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1986,7 +1986,7 @@ var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 var TERRITORY_SCOUT_BODY_COST = 50;
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 = "occupationRecommendation";
 var recoveredTerritoryFollowUpRetryMetadata = /* @__PURE__ */ new WeakMap();
-function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
+function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options = {}) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
   }
@@ -2003,6 +2003,9 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
     ...selection.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...selection.followUp ? { followUp: selection.followUp } : {}
   };
+  if (options.controllerPressureOnly === true && !requiresTerritoryControllerPressure(plan)) {
+    return null;
+  }
   if (selection.recoveredFollowUp === true && typeof selection.recoveredFollowUpSuppressedAt === "number") {
     recoveredTerritoryFollowUpRetryMetadata.set(plan, { suppressedAt: selection.recoveredFollowUpSuppressedAt });
   }
@@ -7191,14 +7194,16 @@ function planDefenseSpawn(context) {
   };
 }
 function planTerritoryRemoteSpawn(context) {
-  if (context.options.workersOnly || context.survival.mode !== "TERRITORY_READY") {
+  if (context.survival.mode !== "TERRITORY_READY" || context.options.workersOnly && context.options.allowTerritoryControllerPressure !== true) {
     return null;
   }
+  const controllerPressureOnly = context.options.workersOnly === true && context.options.allowTerritoryControllerPressure === true;
   const territoryIntent = planTerritoryIntent(
     context.colony,
     context.roleCounts,
     context.workerTarget,
-    context.gameTime
+    context.gameTime,
+    { controllerPressureOnly }
   );
   if (!territoryIntent) {
     return null;
@@ -8833,7 +8838,7 @@ function runEconomy(preludeTelemetryEvents = []) {
       if (!spawnRequest) {
         break;
       }
-      if (successfulSpawnCount > 0 && spawnRequest.memory.role !== "worker") {
+      if (successfulSpawnCount > 0 && !isAllowedPostSpawnRequest(spawnRequest)) {
         break;
       }
       const outcome = attemptSpawnRequest(
@@ -8881,7 +8886,21 @@ function createSpawnPlanningColony(colony, energyAvailable, usedSpawns) {
   };
 }
 function getSpawnPlanningOptions(successfulSpawnCount) {
-  return successfulSpawnCount > 0 ? { nameSuffix: String(successfulSpawnCount + 1), workersOnly: true } : {};
+  return successfulSpawnCount > 0 ? {
+    nameSuffix: String(successfulSpawnCount + 1),
+    workersOnly: true,
+    allowTerritoryControllerPressure: true
+  } : {};
+}
+function isAllowedPostSpawnRequest(spawnRequest) {
+  return spawnRequest.memory.role === "worker" || isTerritoryControllerPressureSpawnRequest(spawnRequest);
+}
+function isTerritoryControllerPressureSpawnRequest(spawnRequest) {
+  const territory = spawnRequest.memory.territory;
+  return spawnRequest.memory.role === TERRITORY_CLAIMER_ROLE && ((territory == null ? void 0 : territory.action) === "claim" || (territory == null ? void 0 : territory.action) === "reserve") && countBodyParts(spawnRequest.body, "claim") >= TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS;
+}
+function countBodyParts(body, bodyPart) {
+  return body.filter((part) => part === bodyPart).length;
 }
 function attemptSpawnRequest(spawnRequest, roomName, telemetryEvents, spawns) {
   let lastOutcome = null;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2003,7 +2003,7 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
   }
-  const selection = selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime);
+  const selection = selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, options);
   if (!selection) {
     return null;
   }
@@ -2016,9 +2016,6 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options
     ...selection.requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...selection.followUp ? { followUp: selection.followUp } : {}
   };
-  if (options.controllerPressureOnly === true && !requiresTerritoryControllerPressure(plan)) {
-    return null;
-  }
   if (selection.recoveredFollowUp === true && typeof selection.recoveredFollowUpSuppressedAt === "number") {
     recoveredTerritoryFollowUpRetryMetadata.set(plan, { suppressedAt: selection.recoveredFollowUpSuppressedAt });
   }
@@ -2390,7 +2387,7 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   }
   return typeof controller.ticksToDowngrade !== "number" || controller.ticksToDowngrade > TERRITORY_DOWNGRADE_GUARD_TICKS;
 }
-function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
+function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, options = {}) {
   var _a, _b, _c;
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
@@ -2427,27 +2424,33 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
     roleCounts,
     routeDistanceLookupContext
   );
-  const configuredCandidates = applyOccupationRecommendationScores(
-    colony,
-    roleCounts,
-    workerTarget,
-    getConfiguredTerritoryCandidates(
+  const configuredCandidates = filterControllerPressureOnlyCandidates(
+    applyOccupationRecommendationScores(
+      colony,
+      roleCounts,
+      workerTarget,
+      getConfiguredTerritoryCandidates(
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        roleCounts,
+        routeDistanceLookupContext
+      )
+    ),
+    options
+  );
+  const persistedIntentCandidates = filterControllerPressureOnlyCandidates(
+    getPersistedTerritoryIntentCandidates(
       colonyName,
       colonyOwnerUsername,
       territoryMemory,
       intents,
       gameTime,
-      roleCounts,
       routeDistanceLookupContext
-    )
-  );
-  const persistedIntentCandidates = getPersistedTerritoryIntentCandidates(
-    colonyName,
-    colonyOwnerUsername,
-    territoryMemory,
-    intents,
-    gameTime,
-    routeDistanceLookupContext
+    ),
+    options
   );
   const primaryCandidates = getSpawnCapableTerritoryCandidates(
     [...persistedIntentCandidates, ...configuredCandidates],
@@ -2467,29 +2470,32 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
     if (!shouldEvaluateAdjacentControllerProgress && !shouldEvaluateAdjacentFollowUp) {
       return toSelectedTerritoryTarget(bestReadyPrimaryCandidate, routeDistanceLookupContext);
     }
-    const visibleAdjacentControllerProgressCandidates = applyOccupationRecommendationScores(
-      colony,
-      roleCounts,
-      workerTarget,
-      [
-        ...shouldEvaluateAdjacentControllerProgress ? getVisibleAdjacentReserveCandidates(
-          colonyName,
-          colonyOwnerUsername,
-          territoryMemory,
-          intents,
-          gameTime,
-          routeDistanceLookupContext
-        ) : [],
-        ...shouldEvaluateAdjacentFollowUp ? getVisibleAdjacentFollowUpReserveCandidates(
-          colonyName,
-          colonyOwnerUsername,
-          territoryMemory,
-          intents,
-          gameTime,
-          roleCounts,
-          routeDistanceLookupContext
-        ) : []
-      ]
+    const visibleAdjacentControllerProgressCandidates = filterControllerPressureOnlyCandidates(
+      applyOccupationRecommendationScores(
+        colony,
+        roleCounts,
+        workerTarget,
+        [
+          ...shouldEvaluateAdjacentControllerProgress ? getVisibleAdjacentReserveCandidates(
+            colonyName,
+            colonyOwnerUsername,
+            territoryMemory,
+            intents,
+            gameTime,
+            routeDistanceLookupContext
+          ) : [],
+          ...shouldEvaluateAdjacentFollowUp ? getVisibleAdjacentFollowUpReserveCandidates(
+            colonyName,
+            colonyOwnerUsername,
+            territoryMemory,
+            intents,
+            gameTime,
+            roleCounts,
+            routeDistanceLookupContext
+          ) : []
+        ]
+      ),
+      options
     );
     if (visibleAdjacentControllerProgressCandidates.length === 0) {
       return toSelectedTerritoryTarget(bestReadyPrimaryCandidate, routeDistanceLookupContext);
@@ -2505,35 +2511,47 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime) {
       routeDistanceLookupContext
     );
   }
-  const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, workerTarget, [
-    ...getAdjacentReserveCandidates(
-      colonyName,
-      colonyName,
-      colonyOwnerUsername,
-      territoryMemory,
-      intents,
-      gameTime,
-      !hasBlockingConfiguredTarget,
-      "adjacent",
-      0,
-      routeDistanceLookupContext
-    ),
-    ...getAdjacentFollowUpReserveCandidates(
-      colonyName,
-      colonyOwnerUsername,
-      territoryMemory,
-      intents,
-      gameTime,
-      roleCounts,
-      !hasBlockingConfiguredTarget,
-      routeDistanceLookupContext
-    )
-  ]);
+  const adjacentCandidates = filterControllerPressureOnlyCandidates(
+    applyOccupationRecommendationScores(colony, roleCounts, workerTarget, [
+      ...getAdjacentReserveCandidates(
+        colonyName,
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        !hasBlockingConfiguredTarget,
+        "adjacent",
+        0,
+        routeDistanceLookupContext
+      ),
+      ...getAdjacentFollowUpReserveCandidates(
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        roleCounts,
+        !hasBlockingConfiguredTarget,
+        routeDistanceLookupContext
+      )
+    ]),
+    options
+  );
   const candidates = getSpawnCapableTerritoryCandidates([...primaryCandidates, ...adjacentCandidates], colony);
   return toSelectedTerritoryTarget(
     (_c = (_b = selectBestScoredTerritoryCandidate(getReadyTerritoryCandidates(candidates, roleCounts, colony))) != null ? _b : selectBestScoredTerritoryCandidate(getActionableTerritoryCandidates(candidates, roleCounts, colony))) != null ? _c : selectBestScoredTerritoryCandidate(candidates),
     routeDistanceLookupContext
   );
+}
+function filterControllerPressureOnlyCandidates(candidates, options) {
+  if (options.controllerPressureOnly !== true) {
+    return candidates;
+  }
+  return candidates.filter(isControllerPressureCandidate);
+}
+function isControllerPressureCandidate(candidate) {
+  return isTerritoryControlAction2(candidate.intentAction) && candidate.requiresControllerPressure === true;
 }
 function selectBestScoredTerritoryCandidate(candidates) {
   let bestCandidate = null;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -8,7 +8,7 @@ import { planExtensionConstruction } from '../construction/extensionPlanner';
 import { planEarlyRoadConstruction } from '../construction/roadPlanner';
 import { countCreepsByRole, getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
-import { getBodyCost } from '../spawn/bodyBuilder';
+import { getBodyCost, TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS } from '../spawn/bodyBuilder';
 import { planSpawn, type SpawnPlanningOptions, type SpawnRequest } from '../spawn/spawnPlanner';
 import { emitRuntimeSummary, type RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 import {
@@ -59,7 +59,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
         break;
       }
 
-      if (successfulSpawnCount > 0 && spawnRequest.memory.role !== 'worker') {
+      if (successfulSpawnCount > 0 && !isAllowedPostSpawnRequest(spawnRequest)) {
         break;
       }
 
@@ -124,7 +124,30 @@ function createSpawnPlanningColony(
 }
 
 function getSpawnPlanningOptions(successfulSpawnCount: number): SpawnPlanningOptions {
-  return successfulSpawnCount > 0 ? { nameSuffix: String(successfulSpawnCount + 1), workersOnly: true } : {};
+  return successfulSpawnCount > 0
+    ? {
+        nameSuffix: String(successfulSpawnCount + 1),
+        workersOnly: true,
+        allowTerritoryControllerPressure: true
+      }
+    : {};
+}
+
+function isAllowedPostSpawnRequest(spawnRequest: SpawnRequest): boolean {
+  return spawnRequest.memory.role === 'worker' || isTerritoryControllerPressureSpawnRequest(spawnRequest);
+}
+
+function isTerritoryControllerPressureSpawnRequest(spawnRequest: SpawnRequest): boolean {
+  const territory = spawnRequest.memory.territory;
+  return (
+    spawnRequest.memory.role === TERRITORY_CLAIMER_ROLE &&
+    (territory?.action === 'claim' || territory?.action === 'reserve') &&
+    countBodyParts(spawnRequest.body, 'claim') >= TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS
+  );
+}
+
+function countBodyParts(body: BodyPartConstant[], bodyPart: BodyPartConstant): number {
+  return body.filter((part) => part === bodyPart).length;
 }
 
 function attemptSpawnRequest(

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -52,6 +52,7 @@ export interface SpawnRequest {
 export interface SpawnPlanningOptions {
   nameSuffix?: string;
   workersOnly?: boolean;
+  allowTerritoryControllerPressure?: boolean;
 }
 
 const TERRITORY_SCOUT_BODY: BodyPartConstant[] = ['move'];
@@ -179,15 +180,21 @@ function planDefenseSpawn(context: SpawnPlanningContext): SpawnRequest | null {
 }
 
 function planTerritoryRemoteSpawn(context: SpawnPlanningContext): SpawnRequest | null {
-  if (context.options.workersOnly || context.survival.mode !== 'TERRITORY_READY') {
+  if (
+    context.survival.mode !== 'TERRITORY_READY' ||
+    (context.options.workersOnly && context.options.allowTerritoryControllerPressure !== true)
+  ) {
     return null;
   }
 
+  const controllerPressureOnly =
+    context.options.workersOnly === true && context.options.allowTerritoryControllerPressure === true;
   const territoryIntent = planTerritoryIntent(
     context.colony,
     context.roleCounts,
     context.workerTarget,
-    context.gameTime
+    context.gameTime,
+    { controllerPressureOnly }
   );
   if (!territoryIntent) {
     return null;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -67,6 +67,10 @@ export interface TerritoryIntentPlanningOptions {
   controllerPressureOnly?: boolean;
 }
 
+interface TerritoryTargetSelectionOptions {
+  controllerPressureOnly?: boolean;
+}
+
 interface MemoryRecord {
   territory?: unknown;
 }
@@ -138,7 +142,7 @@ export function planTerritoryIntent(
     return null;
   }
 
-  const selection = selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime);
+  const selection = selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, options);
   if (!selection) {
     return null;
   }
@@ -152,9 +156,6 @@ export function planTerritoryIntent(
     ...(selection.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(selection.followUp ? { followUp: selection.followUp } : {})
   };
-  if (options.controllerPressureOnly === true && !requiresTerritoryControllerPressure(plan)) {
-    return null;
-  }
 
   if (selection.recoveredFollowUp === true && typeof selection.recoveredFollowUpSuppressedAt === 'number') {
     recoveredTerritoryFollowUpRetryMetadata.set(plan, { suppressedAt: selection.recoveredFollowUpSuppressedAt });
@@ -684,7 +685,8 @@ function selectTerritoryTarget(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
   workerTarget: number,
-  gameTime: number
+  gameTime: number,
+  options: TerritoryTargetSelectionOptions = {}
 ): SelectedTerritoryTarget | null {
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
@@ -721,27 +723,33 @@ function selectTerritoryTarget(
     roleCounts,
     routeDistanceLookupContext
   );
-  const configuredCandidates = applyOccupationRecommendationScores(
-    colony,
-    roleCounts,
-    workerTarget,
-    getConfiguredTerritoryCandidates(
+  const configuredCandidates = filterControllerPressureOnlyCandidates(
+    applyOccupationRecommendationScores(
+      colony,
+      roleCounts,
+      workerTarget,
+      getConfiguredTerritoryCandidates(
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        roleCounts,
+        routeDistanceLookupContext
+      )
+    ),
+    options
+  );
+  const persistedIntentCandidates = filterControllerPressureOnlyCandidates(
+    getPersistedTerritoryIntentCandidates(
       colonyName,
       colonyOwnerUsername,
       territoryMemory,
       intents,
       gameTime,
-      roleCounts,
       routeDistanceLookupContext
-    )
-  );
-  const persistedIntentCandidates = getPersistedTerritoryIntentCandidates(
-    colonyName,
-    colonyOwnerUsername,
-    territoryMemory,
-    intents,
-    gameTime,
-    routeDistanceLookupContext
+    ),
+    options
   );
   const primaryCandidates = getSpawnCapableTerritoryCandidates(
     [...persistedIntentCandidates, ...configuredCandidates],
@@ -765,33 +773,36 @@ function selectTerritoryTarget(
       return toSelectedTerritoryTarget(bestReadyPrimaryCandidate, routeDistanceLookupContext);
     }
 
-    const visibleAdjacentControllerProgressCandidates = applyOccupationRecommendationScores(
-      colony,
-      roleCounts,
-      workerTarget,
-      [
-        ...(shouldEvaluateAdjacentControllerProgress
-          ? getVisibleAdjacentReserveCandidates(
-              colonyName,
-              colonyOwnerUsername,
-              territoryMemory,
-              intents,
-              gameTime,
-              routeDistanceLookupContext
-            )
-          : []),
-        ...(shouldEvaluateAdjacentFollowUp
-          ? getVisibleAdjacentFollowUpReserveCandidates(
-              colonyName,
-              colonyOwnerUsername,
-              territoryMemory,
-              intents,
-              gameTime,
-              roleCounts,
-              routeDistanceLookupContext
-            )
-          : [])
-      ]
+    const visibleAdjacentControllerProgressCandidates = filterControllerPressureOnlyCandidates(
+      applyOccupationRecommendationScores(
+        colony,
+        roleCounts,
+        workerTarget,
+        [
+          ...(shouldEvaluateAdjacentControllerProgress
+            ? getVisibleAdjacentReserveCandidates(
+                colonyName,
+                colonyOwnerUsername,
+                territoryMemory,
+                intents,
+                gameTime,
+                routeDistanceLookupContext
+              )
+            : []),
+          ...(shouldEvaluateAdjacentFollowUp
+            ? getVisibleAdjacentFollowUpReserveCandidates(
+                colonyName,
+                colonyOwnerUsername,
+                territoryMemory,
+                intents,
+                gameTime,
+                roleCounts,
+                routeDistanceLookupContext
+              )
+            : [])
+        ]
+      ),
+      options
     );
     if (visibleAdjacentControllerProgressCandidates.length === 0) {
       return toSelectedTerritoryTarget(bestReadyPrimaryCandidate, routeDistanceLookupContext);
@@ -809,30 +820,33 @@ function selectTerritoryTarget(
     );
   }
 
-  const adjacentCandidates = applyOccupationRecommendationScores(colony, roleCounts, workerTarget, [
-    ...getAdjacentReserveCandidates(
-      colonyName,
-      colonyName,
-      colonyOwnerUsername,
-      territoryMemory,
-      intents,
-      gameTime,
-      !hasBlockingConfiguredTarget,
-      'adjacent',
-      0,
-      routeDistanceLookupContext
-    ),
-    ...getAdjacentFollowUpReserveCandidates(
-      colonyName,
-      colonyOwnerUsername,
-      territoryMemory,
-      intents,
-      gameTime,
-      roleCounts,
-      !hasBlockingConfiguredTarget,
-      routeDistanceLookupContext
-    )
-  ]);
+  const adjacentCandidates = filterControllerPressureOnlyCandidates(
+    applyOccupationRecommendationScores(colony, roleCounts, workerTarget, [
+      ...getAdjacentReserveCandidates(
+        colonyName,
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        !hasBlockingConfiguredTarget,
+        'adjacent',
+        0,
+        routeDistanceLookupContext
+      ),
+      ...getAdjacentFollowUpReserveCandidates(
+        colonyName,
+        colonyOwnerUsername,
+        territoryMemory,
+        intents,
+        gameTime,
+        roleCounts,
+        !hasBlockingConfiguredTarget,
+        routeDistanceLookupContext
+      )
+    ]),
+    options
+  );
   const candidates = getSpawnCapableTerritoryCandidates([...primaryCandidates, ...adjacentCandidates], colony);
 
   return toSelectedTerritoryTarget(
@@ -841,6 +855,21 @@ function selectTerritoryTarget(
       selectBestScoredTerritoryCandidate(candidates),
     routeDistanceLookupContext
   );
+}
+
+function filterControllerPressureOnlyCandidates(
+  candidates: ScoredTerritoryTarget[],
+  options: TerritoryTargetSelectionOptions
+): ScoredTerritoryTarget[] {
+  if (options.controllerPressureOnly !== true) {
+    return candidates;
+  }
+
+  return candidates.filter(isControllerPressureCandidate);
+}
+
+function isControllerPressureCandidate(candidate: ScoredTerritoryTarget): boolean {
+  return isTerritoryControlAction(candidate.intentAction) && candidate.requiresControllerPressure === true;
 }
 
 function selectBestScoredTerritoryCandidate(candidates: ScoredTerritoryTarget[]): ScoredTerritoryTarget | null {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -63,6 +63,10 @@ export interface TerritoryIntentProgressSummary {
   followUp?: TerritoryFollowUpMemory;
 }
 
+export interface TerritoryIntentPlanningOptions {
+  controllerPressureOnly?: boolean;
+}
+
 interface MemoryRecord {
   territory?: unknown;
 }
@@ -127,7 +131,8 @@ export function planTerritoryIntent(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
   workerTarget: number,
-  gameTime: number
+  gameTime: number,
+  options: TerritoryIntentPlanningOptions = {}
 ): TerritoryIntentPlan | null {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
     return null;
@@ -147,6 +152,10 @@ export function planTerritoryIntent(
     ...(selection.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(selection.followUp ? { followUp: selection.followUp } : {})
   };
+  if (options.controllerPressureOnly === true && !requiresTerritoryControllerPressure(plan)) {
+    return null;
+  }
+
   if (selection.recoveredFollowUp === true && typeof selection.recoveredFollowUpSuppressedAt === 'number') {
     recoveredTerritoryFollowUpRetryMetadata.set(plan, { suppressedAt: selection.recoveredFollowUpSuppressedAt });
   }

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -637,6 +637,8 @@ describe('runEconomy', () => {
 
     runEconomy();
 
+    expect(spawn1.spawnCreep).toHaveBeenCalledTimes(1);
+    expect(spawn2.spawnCreep).toHaveBeenCalledTimes(1);
     expect(spawn1.spawnCreep).toHaveBeenCalledWith(
       ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
       'worker-W1N1-323',

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -522,6 +522,109 @@ describe('runEconomy', () => {
     ]);
   });
 
+  it('uses a second idle spawn for controller pressure after spawning follow-up support', () => {
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'activeReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 323,
+            requiresControllerPressure: true,
+            followUp
+          }
+        ]
+      }
+    };
+    const room = makeTerritoryReadyEconomyRoom({
+      energyAvailable: 4_050,
+      energyCapacityAvailable: 4_050
+    });
+    const targetRoom = makeVisibleForeignReservedRoom('W2N1', 'controller2' as Id<StructureController>);
+    const spawn1 = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const spawn2 = {
+      name: 'Spawn2',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 323,
+      rooms: { W1N1: room, W2N1: targetRoom },
+      spawns: { Spawn1: spawn1, Spawn2: spawn2 },
+      creeps: workers,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    runEconomy();
+
+    expect(spawn1.spawnCreep).toHaveBeenCalledWith(
+      ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      'worker-W1N1-323',
+      {
+        memory: { role: 'worker', colony: 'W1N1' }
+      }
+    );
+    expect(spawn2.spawnCreep).toHaveBeenCalledWith(
+      ['claim', 'move', 'claim', 'move', 'claim', 'move', 'claim', 'move', 'claim', 'move'],
+      'claimer-W1N1-W2N1-323-2',
+      {
+        memory: {
+          role: 'claimer',
+          colony: 'W1N1',
+          territory: {
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            controllerId: 'controller2',
+            followUp
+          }
+        }
+      }
+    );
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 323,
+        controllerId: 'controller2',
+        requiresControllerPressure: true,
+        followUp
+      }
+    ]);
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: 323,
+        followUp
+      }
+    ]);
+  });
+
   it('keeps unsafe occupation recommendations on worker recovery before territory spawn pressure', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
@@ -692,11 +795,17 @@ function createLifecycleSpawn(room: Room, creeps: Record<string, Creep>, spawnTi
   return spawn as unknown as LifecycleSpawn;
 }
 
-function makeTerritoryReadyEconomyRoom(): Room {
+function makeTerritoryReadyEconomyRoom({
+  energyAvailable = 650,
+  energyCapacityAvailable = 650
+}: {
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
+} = {}): Room {
   return {
     name: 'W1N1',
-    energyAvailable: 650,
-    energyCapacityAvailable: 650,
+    energyAvailable,
+    energyCapacityAvailable,
     controller: {
       my: true,
       owner: { username: 'me' },
@@ -704,6 +813,21 @@ function makeTerritoryReadyEconomyRoom(): Room {
       ticksToDowngrade: 10_000
     } as StructureController,
     find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: 'home-source' } as Source] : []))
+  } as unknown as Room;
+}
+
+function makeVisibleForeignReservedRoom(
+  roomName: string,
+  controllerId: Id<StructureController>
+): Room {
+  return {
+    name: roomName,
+    controller: {
+      id: controllerId,
+      my: false,
+      reservation: { username: 'enemy', ticksToEnd: 3_000 }
+    } as StructureController,
+    find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
   } as unknown as Room;
 }
 

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1106,6 +1106,92 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('uses controller-pressure-only territory planning for a persisted follow-up pressure spawn', () => {
+    const followUp: TerritoryFollowUpMemory = {
+      source: 'activeReserveAdjacent',
+      originRoom: 'W1N2',
+      originAction: 'reserve'
+    };
+    const { colony, spawn } = makeColony({
+      energyAvailable: 3250,
+      energyCapacityAvailable: 3250,
+      controller: { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTerritoryRoom('W2N1', { my: false } as StructureController, 2),
+        W3N1: makeTerritoryRoom(
+          'W3N1',
+          {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController,
+          2
+        )
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'claim' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 154,
+            requiresControllerPressure: true,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(
+      planSpawn(
+        colony,
+        { worker: 4, claimer: 0, claimersByTargetRoom: {} },
+        155,
+        { workersOnly: true, allowTerritoryControllerPressure: true }
+      )
+    ).toEqual({
+      spawn,
+      body: ['claim', 'move', 'claim', 'move', 'claim', 'move', 'claim', 'move', 'claim', 'move'],
+      name: 'claimer-W1N1-W3N1-155',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W3N1', action: 'reserve', followUp }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 155,
+        requiresControllerPressure: true,
+        followUp
+      }
+    ]);
+    expect(Memory.territory?.demands).toEqual([
+      {
+        type: 'followUpPreparation',
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        workerCount: 1,
+        updatedAt: 155,
+        followUp
+      }
+    ]);
+  });
+
   it('cools down a recovered follow-up when no spawn action is available', () => {
     const followUp: TerritoryFollowUpMemory = {
       source: 'activeReserveAdjacent',

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3984,6 +3984,94 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('selects a lower-priority pressure target when controller pressure is the only allowed territory spawn', () => {
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1'),
+        W3N1: makeRecommendationRoom('W3N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'claim' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(
+      colony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      543,
+      { controllerPressureOnly: true }
+    );
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      requiresControllerPressure: true
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 543,
+        requiresControllerPressure: true
+      }
+    ]);
+  });
+
+  it('keeps normal territory ranking ahead of pressure-only filtering when all territory spawns are allowed', () => {
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1'),
+        W3N1: makeRecommendationRoom('W3N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'claim' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 543);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim' });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 543
+      }
+    ]);
+  });
+
   it('preserves live pressure when suppressing a visible foreign-reserved reserve intent', () => {
     const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
     const target: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };


### PR DESCRIPTION
## Summary
- Allows a second idle spawn to dispatch territory controller-pressure claim/reserve follow-up after a support worker spawn.
- Restricts post-spawn non-worker allowance to controller-pressure territory requests only.
- Adds economy-loop coverage for multi-spawn controller-pressure follow-up and updates the generated Screeps bundle.

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --check`

Refs #446