### PR TITLE
feat: harden worker body scaling for throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -580,6 +580,8 @@ var WORKER_PATTERN = ["work", "carry", "move"];
 var WORKER_PATTERN_COST = 200;
 var WORKER_LOGISTICS_PAIR = ["carry", "move"];
 var WORKER_LOGISTICS_PAIR_COST = 100;
+var WORKER_SURPLUS_MOVE = ["move"];
+var WORKER_SURPLUS_MOVE_COST = 50;
 var EMERGENCY_DEFENDER_BODY = ["tough", "attack", "move"];
 var EMERGENCY_DEFENDER_BODY_COST = 140;
 var TERRITORY_CONTROLLER_BODY = ["claim", "move"];
@@ -613,11 +615,18 @@ function buildWorkerBody(energyAvailable) {
   if (shouldAddWorkerLogisticsPair(energyAvailable, patternCount, body.length)) {
     return [...body, ...WORKER_LOGISTICS_PAIR];
   }
+  if (shouldAddWorkerSurplusMove(energyAvailable, patternCount, body.length)) {
+    return [...body, ...WORKER_SURPLUS_MOVE];
+  }
   return body;
 }
 function shouldAddWorkerLogisticsPair(energyAvailable, patternCount, bodyPartCount) {
   const remainingEnergy = energyAvailable - patternCount * WORKER_PATTERN_COST;
   return patternCount >= 2 && patternCount < MAX_WORKER_PATTERN_COUNT && remainingEnergy >= WORKER_LOGISTICS_PAIR_COST && bodyPartCount + WORKER_LOGISTICS_PAIR.length <= MAX_CREEP_PARTS;
+}
+function shouldAddWorkerSurplusMove(energyAvailable, patternCount, bodyPartCount) {
+  const remainingEnergy = energyAvailable - patternCount * WORKER_PATTERN_COST;
+  return patternCount >= 2 && patternCount < MAX_WORKER_PATTERN_COUNT && remainingEnergy >= WORKER_SURPLUS_MOVE_COST && bodyPartCount + WORKER_SURPLUS_MOVE.length <= MAX_CREEP_PARTS;
 }
 function buildEmergencyWorkerBody(energyAvailable) {
   if (energyAvailable < WORKER_PATTERN_COST) {

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -2,6 +2,8 @@ const WORKER_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move'];
 const WORKER_PATTERN_COST = 200;
 const WORKER_LOGISTICS_PAIR: BodyPartConstant[] = ['carry', 'move'];
 const WORKER_LOGISTICS_PAIR_COST = 100;
+const WORKER_SURPLUS_MOVE: BodyPartConstant[] = ['move'];
+const WORKER_SURPLUS_MOVE_COST = 50;
 const EMERGENCY_DEFENDER_BODY: BodyPartConstant[] = ['tough', 'attack', 'move'];
 const EMERGENCY_DEFENDER_BODY_COST = 140;
 const TERRITORY_CONTROLLER_BODY: BodyPartConstant[] = ['claim', 'move'];
@@ -43,6 +45,10 @@ export function buildWorkerBody(energyAvailable: number): BodyPartConstant[] {
     return [...body, ...WORKER_LOGISTICS_PAIR];
   }
 
+  if (shouldAddWorkerSurplusMove(energyAvailable, patternCount, body.length)) {
+    return [...body, ...WORKER_SURPLUS_MOVE];
+  }
+
   return body;
 }
 
@@ -58,6 +64,21 @@ function shouldAddWorkerLogisticsPair(
     patternCount < MAX_WORKER_PATTERN_COUNT &&
     remainingEnergy >= WORKER_LOGISTICS_PAIR_COST &&
     bodyPartCount + WORKER_LOGISTICS_PAIR.length <= MAX_CREEP_PARTS
+  );
+}
+
+function shouldAddWorkerSurplusMove(
+  energyAvailable: number,
+  patternCount: number,
+  bodyPartCount: number
+): boolean {
+  const remainingEnergy = energyAvailable - patternCount * WORKER_PATTERN_COST;
+
+  return (
+    patternCount >= 2 &&
+    patternCount < MAX_WORKER_PATTERN_COUNT &&
+    remainingEnergy >= WORKER_SURPLUS_MOVE_COST &&
+    bodyPartCount + WORKER_SURPLUS_MOVE.length <= MAX_CREEP_PARTS
   );
 }
 

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -33,9 +33,11 @@ describe('buildWorkerBody', () => {
     expect(buildWorkerBody(600)).toEqual(repeatWorkerPattern(3));
   });
 
-  it('uses mid-capacity remainders for carry and move throughput', () => {
+  it('uses mid-capacity remainders for movement and logistics throughput', () => {
+    expect(buildWorkerBody(450)).toEqual([...repeatWorkerPattern(2), 'move']);
     expect(buildWorkerBody(500)).toEqual([...repeatWorkerPattern(2), 'carry', 'move']);
     expect(buildWorkerBody(550)).toEqual([...repeatWorkerPattern(2), 'carry', 'move']);
+    expect(buildWorkerBody(650)).toEqual([...repeatWorkerPattern(3), 'move']);
     expect(buildWorkerBody(700)).toEqual([...repeatWorkerPattern(3), 'carry', 'move']);
   });
 

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -607,7 +607,7 @@ describe('runEconomy', () => {
     runEconomy();
 
     expect(spawn.spawnCreep).toHaveBeenCalledWith(
-      ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
       'worker-W1N1-321',
       {
         memory: { role: 'worker', colony: 'W1N1' }

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1015,7 +1015,7 @@ describe('planSpawn', () => {
 
     expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 155)).toEqual({
       spawn,
-      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
       name: 'worker-W1N1-155',
       memory: { role: 'worker', colony: 'W1N1' }
     });
@@ -1613,7 +1613,7 @@ describe('planSpawn', () => {
 
     expect(planSpawn(colony, { worker: 1, claimer: 0, claimersByTargetRoom: {} }, 140)).toEqual({
       spawn,
-      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
       name: 'worker-W1N1-140',
       memory: { role: 'worker', colony: 'W1N1' }
     });
@@ -1634,7 +1634,7 @@ describe('planSpawn', () => {
 
     expect(planSpawn(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 141)).toEqual({
       spawn,
-      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
       name: 'worker-W1N1-141',
       memory: { role: 'worker', colony: 'W1N1' }
     });
@@ -1844,7 +1844,7 @@ describe('planSpawn', () => {
 
     expect(planSpawn(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 161)).toEqual({
       spawn,
-      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
       name: 'worker-W1N1-161',
       memory: { role: 'worker', colony: 'W1N1' }
     });
@@ -1881,7 +1881,7 @@ describe('planSpawn', () => {
 
     expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 152)).toEqual({
       spawn,
-      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
       name: 'worker-W1N15-152',
       memory: { role: 'worker', colony: 'W1N15' }
     });


### PR DESCRIPTION
## Summary
- hardens worker body scaling so throughput-oriented worker requests can add useful WORK/CARRY/MOVE sets as energy capacity rises
- updates spawn/economy tests for the adjusted body shapes and worker-throughput expectations
- regenerates the Screeps bundle

## Verification
- [x] `cd prod && npm run typecheck`
- [x] `cd prod && npm test -- --runInBand`
- [x] `cd prod && npm run build`
- [x] `git diff --check`

Linked issue: Refs #449

Domain: Bot capability / resources-economy
Kind: code
