### PR TITLE
fix: add agent metrics to roadmap report

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -483,7 +483,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-05-01 22:23:12 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-05-01 22:58:24 CST</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -649,17 +649,17 @@ main {
           </a>
 
 
-          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/449">
+          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/452">
             <h3>Bot capability</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Ship general gameplay behavior that advances the bot beyond single-slice fixes.</span>
-              <span class="roadmap-label">Next</span><span>Current: #449 In review - Recovered #449 dirty Codex implementation into commit 70b0ddc and P...</span>
+              <span class="roadmap-label">Next</span><span>Current: #452 In progress - P1 Economy: post-450 worker throughput follow-up</span>
             </div>
             <div class="progress-row">
               <span class="progress-value">99%</span>
               <span class="progress-track"><span class="progress-fill" style="width: 99%"></span></span>
             </div>
-            <div class="roadmap-status">186 Project items · 1 active · 185 done</div>
+            <div class="roadmap-status">187 Project items · 1 active · 186 done</div>
           </a>
 
 
@@ -793,10 +793,10 @@ main {
               <span class="column-count">1</span>
             </div>
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/449">
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/452">
               <span class="kanban-priority">P1</span>
-              <h4>#449 P1 Economy: post-447 worker throughput follow-up</h4>
-              <p>In review · Bot capability · Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; contr...</p>
+              <h4>#452 P1 Economy: post-450 worker throughput follow-up</h4>
+              <p>In progress · Bot capability · Bot capability</p>
             </a>
 
           </article>
@@ -880,9 +880,15 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Docs/process</h3>
-              <span class="column-count">0</span>
+              <span class="column-count">1</span>
             </div>
-            <div class="kanban-empty">—</div>
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/pull/451">
+              <span class="kanban-priority">P2</span>
+              <h4>#451 fix: add agent metrics to roadmap report</h4>
+              <p>In review · Docs/process · Docs/process</p>
+            </a>
+
           </article>
 
         </div>
@@ -896,28 +902,28 @@ main {
           <article class="process-card">
             <p class="process-value">1.5B</p>
             <p class="process-label">Agent tokens</p>
-            <p class="process-detail">1,517,772,656 total; latest token_count in 1,028/1,029 sessions</p>
+            <p class="process-detail">1,523,589,512 total; latest token_count in 1,032/1,033 sessions</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">3d 4h</p>
+            <p class="process-value">3d 5h</p>
             <p class="process-label">Codex runtime</p>
-            <p class="process-detail">summed first-to-last JSONL timestamps across 1,029/1,029 sessions</p>
+            <p class="process-detail">summed first-to-last JSONL timestamps across 1,033/1,033 sessions</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">1,029</p>
+            <p class="process-value">1,033</p>
             <p class="process-label">Codex runs</p>
             <p class="process-detail">rollout JSONL files counted as Codex runs</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">2,340</p>
+            <p class="process-value">2,341</p>
             <p class="process-label">Automation runs</p>
-            <p class="process-detail">2,340 cron outputs across 36 jobs</p>
+            <p class="process-detail">2,341 cron outputs across 29 jobs</p>
           </article>
 
 
@@ -931,7 +937,7 @@ main {
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-05-01T14:23:12Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-05-01T14:58:24Z</footer>
   </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -483,7 +483,7 @@ main {
           <p><strong>Project</strong> · Long-running Screeps: World AI and autonomous operations project.</p>
           <p><strong>Links</strong> · <a href="https://github.com/lanyusea/screeps">https://github.com/lanyusea/screeps</a></p>
         </div>
-        <p class="published"><strong>PUBLISHED</strong> · 2026-05-01 16:26:38 CST</p>
+        <p class="published"><strong>PUBLISHED</strong> · 2026-05-01 22:23:12 CST</p>
       </div>
       <div class="hero-art">
         <div class="brand-logo-frame"><img class="brand-logo" src="assets/screeps-community-logo.png" alt="Screeps community logo"></div>
@@ -600,10 +600,10 @@ main {
               <span class="roadmap-label">Next</span><span>Current: #273 Ready - RCA from owner report: #232 was marked Done after scaffold/vision PR, w...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">89%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 89%"></span></span>
+              <span class="progress-value">93%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 93%"></span></span>
             </div>
-            <div class="roadmap-status">27 Project items · 3 active · 24 done</div>
+            <div class="roadmap-status">28 Project items · 2 active · 26 done</div>
           </a>
 
 
@@ -649,31 +649,31 @@ main {
           </a>
 
 
-          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/362">
+          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/449">
             <h3>Bot capability</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Ship general gameplay behavior that advances the bot beyond single-slice fixes.</span>
-              <span class="roadmap-label">Next</span><span>No active item; latest tracked: #362 Done - P0: add Overmind-inspired bootstrap mode and expl...</span>
+              <span class="roadmap-label">Next</span><span>Current: #449 In review - Recovered #449 dirty Codex implementation into commit 70b0ddc and P...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">100%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 100%"></span></span>
+              <span class="progress-value">99%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 99%"></span></span>
             </div>
-            <div class="roadmap-status">183 Project items · 0 active · 183 done</div>
+            <div class="roadmap-status">186 Project items · 1 active · 185 done</div>
           </a>
 
 
-          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/405">
+          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/issues/407">
             <h3>Combat</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Protect survival, hostile response, and defense/combat readiness.</span>
-              <span class="roadmap-label">Next</span><span>Current: #405 In progress - P1 Combat: one-time code review sweep for dead-zone and placehold...</span>
+              <span class="roadmap-label">Next</span><span>Current: #407 Ready - QA requirement added to Hermes Screeps deploy-floor skill: dead-zone/pl...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">0%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 0%"></span></span>
+              <span class="progress-value">67%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 67%"></span></span>
             </div>
-            <div class="roadmap-status">2 Project items · 2 active · 0 done</div>
+            <div class="roadmap-status">3 Project items · 1 active · 2 done</div>
           </a>
 
 
@@ -681,13 +681,13 @@ main {
             <h3>Territory/Economy</h3>
             <div class="roadmap-table">
               <span class="roadmap-label">Goal</span><span>Advance expansion, controller pressure, worker efficiency, and resource throughput.</span>
-              <span class="roadmap-label">Next</span><span>Current: #424 In review - PR #426 updated with Codex-authored review-fix 7f72488; verificatio...</span>
+              <span class="roadmap-label">Next</span><span>No active item; latest tracked: #424 Done - Completed by merged PR #426; merge commit fb44ef4...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">0%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 0%"></span></span>
+              <span class="progress-value">100%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 100%"></span></span>
             </div>
-            <div class="roadmap-status">1 Project item · 1 active · 0 done</div>
+            <div class="roadmap-status">7 Project items · 0 active · 7 done</div>
           </a>
 
 
@@ -712,24 +712,10 @@ main {
               <span class="roadmap-label">Next</span><span>Current: #266 Ready - Owner correction 2026-05-01: all RL/strategy-iteration follow-ups are P...</span>
             </div>
             <div class="progress-row">
-              <span class="progress-value">0%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 0%"></span></span>
+              <span class="progress-value">33%</span>
+              <span class="progress-track"><span class="progress-fill" style="width: 33%"></span></span>
             </div>
-            <div class="roadmap-status">7 Project items · 7 active · 0 done</div>
-          </a>
-
-
-          <a class="roadmap-card" href="https://github.com/lanyusea/screeps/pull/38">
-            <h3>Docs/process</h3>
-            <div class="roadmap-table">
-              <span class="roadmap-label">Goal</span><span>Preserve decisions, rules, and operating context for agent continuity.</span>
-              <span class="roadmap-label">Next</span><span>No active item; latest tracked: #38 Done - PR #38 records PR #37 merge checkpoint; merged 202...</span>
-            </div>
-            <div class="progress-row">
-              <span class="progress-value">100%</span>
-              <span class="progress-track"><span class="progress-fill" style="width: 100%"></span></span>
-            </div>
-            <div class="roadmap-status">15 Project items · 0 active · 15 done</div>
+            <div class="roadmap-status">9 Project items · 6 active · 3 done</div>
           </a>
 
         </div>
@@ -743,7 +729,7 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Agent OS</h3>
-              <span class="column-count">3</span>
+              <span class="column-count">2</span>
             </div>
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/273">
@@ -757,13 +743,6 @@ main {
               <span class="kanban-priority">P1</span>
               <h4>#408 P1 Agent OS: strategy reports must include proactive P0 postmortems</h4>
               <p>Ready · Agent OS · Owner correction: strategy-adjustment reports in 1497586175580311654 must proactively incl...</p>
-            </a>
-
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/427">
-              <span class="kanban-priority">P1</span>
-              <h4>#427 P1 Agent OS: unify rules taxonomy and fix domain display drift</h4>
-              <p>Ready · Agent OS · 2026-05-01 live state audit repaired missing Project item and milestone; added to Project...</p>
             </a>
 
           </article>
@@ -811,24 +790,23 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Bot capability</h3>
-              <span class="column-count">0</span>
+              <span class="column-count">1</span>
             </div>
-            <div class="kanban-empty">—</div>
+
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/449">
+              <span class="kanban-priority">P1</span>
+              <h4>#449 P1 Economy: post-447 worker throughput follow-up</h4>
+              <p>In review · Bot capability · Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; contr...</p>
+            </a>
+
           </article>
 
 
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Combat</h3>
-              <span class="column-count">2</span>
+              <span class="column-count">1</span>
             </div>
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/405">
-              <span class="kanban-priority">P1</span>
-              <h4>#405 P1 Combat: one-time code review sweep for dead-zone and placehol...</h4>
-              <p>In progress · Combat · Combat</p>
-            </a>
-
 
             <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/407">
               <span class="kanban-priority">P1</span>
@@ -842,15 +820,9 @@ main {
           <article class="kanban-column">
             <div class="column-heading">
               <h3>Territory/Economy</h3>
-              <span class="column-count">1</span>
+              <span class="column-count">0</span>
             </div>
-
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/424">
-              <span class="kanban-priority">P1</span>
-              <h4>#424 P1 Territory: make next reserve/claim recommendation executable</h4>
-              <p>In review · Territory/Economy · PR #426 updated with Codex-authored review-fix 7f72488; verification passed l...</p>
-            </a>
-
+            <div class="kanban-empty">—</div>
           </article>
 
 
@@ -896,10 +868,10 @@ main {
             </a>
 
 
-            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/414">
+            <a class="kanban-item" href="https://github.com/lanyusea/screeps/issues/416">
               <span class="kanban-priority">P1</span>
-              <h4>#414 P1: RL Flywheel: build accelerated self-hosted simulator harness...</h4>
-              <p>Ready · RL flywheel · Owner requires self-hosted accelerated parallel simulation targeting ~100x official ser...</p>
+              <h4>#416 P1: RL Flywheel: choose RL training framework and reward tuning...</h4>
+              <p>Ready · RL flywheel · Owner requires RL framework selection and reward tuning workflow; implementation issue...</p>
             </a>
 
           </article>
@@ -918,48 +890,48 @@ main {
 
 
       <section class="section" id="process">
-        <h2 class="section-title">04 Development Process Data</h2>
+        <h2 class="section-title">04 Delivery Metrics</h2>
         <div class="process-grid">
 
           <article class="process-card">
-            <p class="process-value">302</p>
-            <p class="process-label">Total commits</p>
-            <p class="process-detail">repository history</p>
+            <p class="process-value">1.5B</p>
+            <p class="process-label">Agent tokens</p>
+            <p class="process-detail">1,517,772,656 total; latest token_count in 1,028/1,029 sessions</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">229</p>
-            <p class="process-label">Total PRs</p>
-            <p class="process-detail">221 merged</p>
+            <p class="process-value">3d 4h</p>
+            <p class="process-label">Codex runtime</p>
+            <p class="process-detail">summed first-to-last JSONL timestamps across 1,029/1,029 sessions</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">198</p>
-            <p class="process-label">Total issues</p>
-            <p class="process-detail">16 open</p>
+            <p class="process-value">1,029</p>
+            <p class="process-label">Codex runs</p>
+            <p class="process-detail">rollout JSONL files counted as Codex runs</p>
           </article>
 
 
           <article class="process-card">
-            <p class="process-value">5</p>
+            <p class="process-value">2,340</p>
+            <p class="process-label">Automation runs</p>
+            <p class="process-detail">2,340 cron outputs across 36 jobs</p>
+          </article>
+
+
+          <article class="process-card">
+            <p class="process-value">6</p>
             <p class="process-label">Official deploys</p>
             <p class="process-detail">GitHub Project official deploy evidence</p>
-          </article>
-
-
-          <article class="process-card">
-            <p class="process-value">1</p>
-            <p class="process-label">Private smoke tests</p>
-            <p class="process-detail">smoke/report evidence</p>
           </article>
 
         </div>
       </section>
 
     </main>
-    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-05-01T08:26:38Z</footer>
+    <footer class="report-footer">format roadmap-portrait-kpi-kanban-v5 · repo https://github.com/lanyusea/screeps · generated 2026-05-01T14:23:12Z</footer>
   </div>
 </body>
 </html>

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,35 +3,14 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-05-01T08:26:38Z",
-  "generatedAtCst": "2026-05-01 16:26:38 CST",
+  "generatedAt": "2026-05-01T14:23:12Z",
+  "generatedAtCst": "2026-05-01 22:23:12 CST",
   "github": {
     "fetchErrors": [],
     "fetched": true,
     "issues": [
       {
-        "createdAt": "2026-05-01T08:07:41Z",
-        "domain": "Agent OS",
-        "domainSource": "heuristic",
-        "kind": "ops",
-        "labels": [
-          "kind:ops",
-          "priority:p1",
-          "roadmap",
-          "roadmap:p0-agent-ops"
-        ],
-        "milestone": "P0: Agent OS / Discord visibility gate",
-        "number": 427,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1 Agent OS: unify rules taxonomy and fix domain display drift",
-        "type": "Issue",
-        "updatedAt": "2026-05-01T08:18:34Z",
-        "url": "https://github.com/lanyusea/screeps/issues/427"
-      },
-      {
-        "createdAt": "2026-05-01T06:22:06Z",
+        "createdAt": "2026-05-01T13:58:51Z",
         "domain": "Territory/Economy",
         "domainSource": "heuristic",
         "kind": "code",
@@ -42,14 +21,35 @@
           "roadmap:territory-economy"
         ],
         "milestone": "Phase B: Bot capability hardening gate",
-        "number": 424,
+        "number": 449,
         "priority": "P1",
         "state": "OPEN",
         "status": "Ready",
-        "title": "P1 Territory: make next reserve/claim recommendation executable",
+        "title": "P1 Economy: post-447 worker throughput follow-up",
         "type": "Issue",
-        "updatedAt": "2026-05-01T08:24:22Z",
-        "url": "https://github.com/lanyusea/screeps/issues/424"
+        "updatedAt": "2026-05-01T14:22:08Z",
+        "url": "https://github.com/lanyusea/screeps/issues/449"
+      },
+      {
+        "createdAt": "2026-05-01T13:03:13Z",
+        "domain": "Territory/Economy",
+        "domainSource": "heuristic",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "Phase B: Bot capability hardening gate",
+        "number": 446,
+        "priority": "P1",
+        "state": "OPEN",
+        "status": "Ready",
+        "title": "P1 Territory: post-spawn-action controller pressure follow-up",
+        "type": "Issue",
+        "updatedAt": "2026-05-01T13:34:46Z",
+        "url": "https://github.com/lanyusea/screeps/issues/446"
       },
       {
         "createdAt": "2026-05-01T02:31:57Z",
@@ -92,7 +92,7 @@
         "status": "Ready",
         "title": "P1: RL Flywheel: historical MMO replay validation before rollout",
         "type": "Issue",
-        "updatedAt": "2026-05-01T08:24:26Z",
+        "updatedAt": "2026-05-01T08:32:23Z",
         "url": "https://github.com/lanyusea/screeps/issues/417"
       },
       {
@@ -116,28 +116,6 @@
         "type": "Issue",
         "updatedAt": "2026-05-01T08:24:29Z",
         "url": "https://github.com/lanyusea/screeps/issues/416"
-      },
-      {
-        "createdAt": "2026-05-01T02:31:43Z",
-        "domain": "Change-control",
-        "domainSource": "heuristic",
-        "kind": "code",
-        "labels": [
-          "kind:code",
-          "priority:p1",
-          "roadmap",
-          "roadmap:phase-c-telemetry",
-          "roadmap:rl-flywheel"
-        ],
-        "milestone": "P1: RL strategy flywheel gate",
-        "number": 414,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "Ready",
-        "title": "P1: RL Flywheel: build accelerated self-hosted simulator harness target 100x official tick speed",
-        "type": "Issue",
-        "updatedAt": "2026-05-01T08:24:31Z",
-        "url": "https://github.com/lanyusea/screeps/issues/414"
       },
       {
         "createdAt": "2026-05-01T02:31:35Z",
@@ -225,27 +203,6 @@
         "url": "https://github.com/lanyusea/screeps/issues/407"
       },
       {
-        "createdAt": "2026-05-01T02:03:28Z",
-        "domain": "Combat",
-        "domainSource": "heuristic",
-        "kind": "review",
-        "labels": [
-          "kind:review",
-          "priority:p1",
-          "roadmap",
-          "roadmap:combat"
-        ],
-        "milestone": "Combat: Survival / defense gate",
-        "number": 405,
-        "priority": "P1",
-        "state": "OPEN",
-        "status": "In review",
-        "title": "P1 Combat: one-time code review sweep for dead-zone and placeholder logic",
-        "type": "Issue",
-        "updatedAt": "2026-05-01T08:24:48Z",
-        "url": "https://github.com/lanyusea/screeps/issues/405"
-      },
-      {
         "createdAt": "2026-04-29T02:56:34Z",
         "domain": "Agent OS",
         "domainSource": "heuristic",
@@ -307,7 +264,7 @@
         "status": "Ready",
         "title": "P1: Phase E: gameplay release cadence and emergency hotfix gate are not enforced",
         "type": "Issue",
-        "updatedAt": "2026-05-01T08:24:41Z",
+        "updatedAt": "2026-05-01T13:53:19Z",
         "url": "https://github.com/lanyusea/screeps/issues/63"
       },
       {
@@ -350,7 +307,7 @@
         "status": "Ready",
         "title": "P1:Phase C:runtime-summary/runtime-alert \u5b9a\u65f6\u76d1\u63a7\u6295\u9012\u5c1a\u672a\u5b8c\u6210",
         "type": "Issue",
-        "updatedAt": "2026-04-28T09:25:18Z",
+        "updatedAt": "2026-05-01T13:38:47Z",
         "url": "https://github.com/lanyusea/screeps/issues/29"
       }
     ],
@@ -372,24 +329,6 @@
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/408",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "Agent OS",
-          "domainSource": "project",
-          "evidence": "2026-05-01 live state audit repaired missing Project item and milestone; added to Project #3 as Ready/P1/Agent OS/ops.",
-          "kind": "ops",
-          "lane": "Agent OS",
-          "nextAction": "",
-          "number": 427,
-          "priority": "P1",
-          "projectDomain": "Agent OS",
-          "state": "",
-          "status": "Ready",
-          "title": "P1 Agent OS: unify rules taxonomy and fix domain display drift",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/427",
           "visionLayer": "foundation blocker"
         },
         {
@@ -773,6 +712,24 @@
         {
           "domain": "Agent OS",
           "domainSource": "project",
+          "evidence": "Live audit 2026-05-01T16:31+08: PR #428 exists; PR Project item repaired/added. Checks pending; mergeState BEHIND.",
+          "kind": "ops",
+          "lane": "Agent OS",
+          "nextAction": "",
+          "number": 427,
+          "priority": "P1",
+          "projectDomain": "Agent OS",
+          "state": "",
+          "status": "Done",
+          "title": "P1 Agent OS: unify rules taxonomy and fix domain display drift",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/427",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Agent OS",
+          "domainSource": "project",
           "evidence": "Merged PR #162 at c75de59; cron continuation prompt also updated with 24h forced-P2 anti-starvation policy; checks green and CodeRabbit resolved.",
           "kind": "ops",
           "lane": "Agent OS",
@@ -858,6 +815,24 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/219",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Agent OS",
+          "domainSource": "project",
+          "evidence": "PR #428 implements Minimal Rules OS registry, cron/route registry, templates, audit script, Project Domain/Kind options, and Pages domain progress regeneration. Local QA PASS: audit --github; pytest 6 passed.",
+          "kind": "ops",
+          "lane": "Agent OS",
+          "nextAction": "",
+          "number": 428,
+          "priority": "P1",
+          "projectDomain": "Agent OS",
+          "state": "",
+          "status": "Done",
+          "title": "docs: unify Screeps rules taxonomy and domain display",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/428",
           "visionLayer": "foundation blocker"
         },
         {
@@ -1439,7 +1414,7 @@
         {
           "domain": "Runtime monitor",
           "domainSource": "project",
-          "evidence": "Merged PR #423 at 2026-05-01T06:34:31Z; merge commit 0235a3a; final QA/checks/review threads clean.",
+          "evidence": "2026-05-01 shadow cadence audit: evaluator is passive/manual/test-only today; runtime summary/alert jobs generate input artifacts, but no recurring shadow-eval report job yet. #415/#417 comments updated with gap.",
           "kind": "code",
           "lane": "Runtime monitor",
           "nextAction": "",
@@ -1925,6 +1900,42 @@
         {
           "domain": "Bot capability",
           "domainSource": "project",
+          "evidence": "Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; controller verification passed; PR added to Project.",
+          "kind": "code",
+          "lane": "Bot capability",
+          "nextAction": "",
+          "number": 449,
+          "priority": "P1",
+          "projectDomain": "Bot capability",
+          "state": "",
+          "status": "In review",
+          "title": "P1 Economy: post-447 worker throughput follow-up",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/449",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Bot capability",
+          "domainSource": "heuristic",
+          "evidence": "2026-05-01 22:02+08 scheduler: PR #448 review-fix commit 219adc2 pushed after controller verification (typecheck/Jest/build/diff-check) and Codex commit-only recovery. CI/CodeRabbit pending for new head 219adc26390d867be709c4c66de75f7cc7ba9f68.",
+          "kind": "code",
+          "lane": "",
+          "nextAction": "",
+          "number": 448,
+          "priority": "P1",
+          "projectDomain": "",
+          "state": "",
+          "status": "In review",
+          "title": "feat: add controller pressure spawn follow-up",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/448",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Bot capability",
+          "domainSource": "project",
           "evidence": "2026-05-01 13:58 +08: PR #419 recovered by Codex commits 97b9859 + merge 1535c7d; exact-head QA PASS (24 suites/616 tests); threads 0 active/0 unresolved; GitHub checks green/CLEAN.",
           "kind": "code",
           "lane": "Bot capability",
@@ -2155,6 +2166,24 @@
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/30",
           "visionLayer": "resources"
+        },
+        {
+          "domain": "Bot capability",
+          "domainSource": "project",
+          "evidence": "2026-05-01T18:57+08 PR #438 live thread PRRT_kwDOSMSsO85-8-ak fixed/pushed as Codex-authored commit 4fd003d; verification diff-check, typecheck, Jest 24/631, build.",
+          "kind": "code",
+          "lane": "Bot capability",
+          "nextAction": "",
+          "number": 437,
+          "priority": "P1",
+          "projectDomain": "Bot capability",
+          "state": "",
+          "status": "Done",
+          "title": "P1 Economy: continue resource throughput after worker lookup deploy",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/437",
+          "visionLayer": "territory"
         },
         {
           "domain": "Bot capability",
@@ -4498,6 +4527,24 @@
         },
         {
           "domain": "Bot capability",
+          "domainSource": "project",
+          "evidence": "2026-05-01T19:05+08 updated branch to 5c54d5a after #426 merge; prod-ci/CodeRabbit success, no unresolved GraphQL threads; exact-head QA proc_[redacted] pid 1727803 dispatched.",
+          "kind": "code",
+          "lane": "Bot capability",
+          "nextAction": "",
+          "number": 438,
+          "priority": "P1",
+          "projectDomain": "Bot capability",
+          "state": "",
+          "status": "Done",
+          "title": "feat: improve post-lookup resource throughput",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/438",
+          "visionLayer": "resources"
+        },
+        {
+          "domain": "Bot capability",
           "domainSource": "heuristic",
           "evidence": "2026-04-28 18:55 +08: PR #184 merged after prod-ci SUCCESS, CodeRabbit/Gemini no blocking findings, update-branch onto PR #183/main (head c16439c), exact-head QA PASS (295 tests), merge commit c798a32. Local main at c798a32.",
           "kind": "code",
@@ -5795,24 +5842,6 @@
         {
           "domain": "Combat",
           "domainSource": "project",
-          "evidence": "",
-          "kind": "review",
-          "lane": "Combat",
-          "nextAction": "",
-          "number": 405,
-          "priority": "P1",
-          "projectDomain": "Combat",
-          "state": "",
-          "status": "In progress",
-          "title": "P1 Combat: one-time code review sweep for dead-zone and placeholder logic",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/405",
-          "visionLayer": "enemy kills"
-        },
-        {
-          "domain": "Combat",
-          "domainSource": "project",
           "evidence": "QA requirement added to Hermes Screeps deploy-floor skill: dead-zone/placeholders block QA if survival-critical; non-severe findings need Combat issues.",
           "kind": "qa",
           "lane": "Combat",
@@ -5829,22 +5858,58 @@
           "visionLayer": "enemy kills"
         },
         {
-          "domain": "Territory/Economy",
+          "domain": "Combat",
           "domainSource": "project",
-          "evidence": "PR #426 updated with Codex-authored review-fix 7f72488; verification passed locally before push.",
-          "kind": "code",
-          "lane": "Territory/Economy",
+          "evidence": "Authoritative PR #443 updated via REST update-branch to bbf3104; prod-ci/CodeRabbit green at checkpoint; final GraphQL thread requery still needed.",
+          "kind": "review",
+          "lane": "Combat",
           "nextAction": "",
-          "number": 424,
+          "number": 405,
           "priority": "P1",
-          "projectDomain": "Territory/Economy",
+          "projectDomain": "Combat",
           "state": "",
-          "status": "In review",
-          "title": "P1 Territory: make next reserve/claim recommendation executable",
+          "status": "Done",
+          "title": "P1 Combat: one-time code review sweep for dead-zone and placeholder logic",
           "type": "Issue",
           "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/424",
-          "visionLayer": "territory"
+          "url": "https://github.com/lanyusea/screeps/issues/405",
+          "visionLayer": "enemy kills"
+        },
+        {
+          "domain": "Combat",
+          "domainSource": "project",
+          "evidence": "",
+          "kind": "code",
+          "lane": "Combat",
+          "nextAction": "",
+          "number": 443,
+          "priority": "P1",
+          "projectDomain": "Combat",
+          "state": "",
+          "status": "Done",
+          "title": "fix: avoid downgrade guard blocking defender replacement",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/443",
+          "visionLayer": "enemy kills"
+        },
+        {
+          "domain": "Combat",
+          "domainSource": "heuristic",
+          "evidence": "2026-05-01T17:17+08 exact-head QA PASS on PR #429 head 3669691 (proc_[redacted] exit 0): No critical issues found; prod/dist/main.js sync check passed; LFS docs/roadmap-kpi.sqlite noise treated as infrastructure. Outdated thread PRRT_kwDOSMSsO85-8LBw queued for resolution/re-query.",
+          "kind": "code",
+          "lane": "",
+          "nextAction": "",
+          "number": 429,
+          "priority": "P1",
+          "projectDomain": "",
+          "state": "",
+          "status": "Done",
+          "title": "fix: close combat dead-zone placeholder gap",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/429",
+          "visionLayer": "enemy kills"
         },
         {
           "domain": "Territory/Economy",
@@ -5853,15 +5918,123 @@
           "kind": "code",
           "lane": "",
           "nextAction": "",
-          "number": 426,
+          "number": 446,
           "priority": "P1",
           "projectDomain": "",
           "state": "",
           "status": "In review",
-          "title": "feat: make territory recommendations executable",
+          "title": "P1 Territory: post-spawn-action controller pressure follow-up",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/446",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "heuristic",
+          "evidence": "PR #450 opened for #449 at 70b0ddc; controller verification passed (typecheck, Jest, build, diff --check); CI/CodeRabbit pending; exact-head QA required.",
+          "kind": "code",
+          "lane": "",
+          "nextAction": "",
+          "number": 450,
+          "priority": "P1",
+          "projectDomain": "",
+          "state": "",
+          "status": "In review",
+          "title": "feat: harden worker body scaling for throughput",
           "type": "PullRequest",
           "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/426",
+          "url": "https://github.com/lanyusea/screeps/pull/450",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "Done via merged PR #444; merge commit f8fd7a9 after exact-head QA PASS, prod-ci/CodeRabbit green, and GraphQL live threads clear.",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 442,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "P1 Economy: continue early-room resource throughput after spawn recovery deploy",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/442",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "2026-05-01T18:20+08 completed: PR #435 merged at 7d760c6 after green prod-ci/CodeRabbit, no unresolved review threads, exact-head QA proc_[redacted] PASS (typecheck/Jest/build/bundle drift; no critical issues).",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 434,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "P1 Economy: improve low-energy worker throughput after combat deploy",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/434",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "heuristic",
+          "evidence": "2026-05-01 21:50+08 scheduler: completed via PR #447; merged commit fb0d5508 after green CI/bot review and exact-head QA PASS. Deployed in official workflow run 25216817698 with healthy E26S49 sidecars.",
+          "kind": "code",
+          "lane": "",
+          "nextAction": "",
+          "number": 445,
+          "priority": "P1",
+          "projectDomain": "",
+          "state": "",
+          "status": "Done",
+          "title": "P1 Economy: post-deploy productive worker pressure follow-up",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/445",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "Completed by merged PR #426; merge commit fb44ef4 after green prod-ci, CodeRabbit, no unresolved GraphQL threads, exact-head QA PASS proc_[redacted].",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 424,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "P1 Territory: make next reserve/claim recommendation executable",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/424",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "Authoritative PR #441 head 34b00bb includes recovered review-fix for CodeRabbit PRRT_kwDOSMSsO85-9X1Z; local controller verification PASS before commit; prod-ci success and CodeRabbit pending after push.",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 440,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "P1 Territory: turn executable recommendations into spawn/task action",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/440",
           "visionLayer": "territory"
         },
         {
@@ -6533,6 +6706,42 @@
         {
           "domain": "Territory/Economy",
           "domainSource": "heuristic",
+          "evidence": "2026-05-01 scheduler: PR #447/#448 CI green, CodeRabbit success, GraphQL unresolved threads empty, exact-head QA PASS. #447 head 79c4fc5; #448 head 432ca4b.",
+          "kind": "code",
+          "lane": "",
+          "nextAction": "",
+          "number": 447,
+          "priority": "P1",
+          "projectDomain": "",
+          "state": "",
+          "status": "Done",
+          "title": "feat: harden productive worker pressure recovery",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/447",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "Merged 2026-05-01T12:19:46Z as f8fd7a9 after exact-head QA PASS, prod-ci/CodeRabbit green, GraphQL threads clear.",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 444,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "feat: improve early resource throughput",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/444",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "heuristic",
           "evidence": "2026-04-28T20:59+08 exact-head QA PASS on ad5c64f: diff-check, typecheck, Jest 16 suites/303 tests, build, dist drift check. prod-ci/review gate still pending.",
           "kind": "code",
           "lane": "",
@@ -6546,6 +6755,24 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/197",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "2026-05-01T18:20+08 completed: PR #435 merged at 7d760c6 after green prod-ci/CodeRabbit, no unresolved review threads, exact-head QA proc_[redacted] PASS (typecheck/Jest/build/bundle drift; no critical issues).",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 435,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "feat: improve low-energy worker throughput",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/435",
           "visionLayer": "territory"
         },
         {
@@ -6767,6 +6994,24 @@
         {
           "domain": "Territory/Economy",
           "domainSource": "heuristic",
+          "evidence": "Merged at 2026-05-01T10:59Z as fb44ef4 after green prod-ci, CodeRabbit, no unresolved threads, exact-head QA PASS.",
+          "kind": "code",
+          "lane": "",
+          "nextAction": "",
+          "number": 426,
+          "priority": "P1",
+          "projectDomain": "",
+          "state": "",
+          "status": "Done",
+          "title": "feat: make territory recommendations executable",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/426",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
+          "domainSource": "heuristic",
           "evidence": "PR #168 opened for #167 on head a8e964a. Controller verification and independent exact-head QA PASS: diff-check, typecheck, Jest 16 suites/259 tests, build, dist drift check. prod-ci SUCCESS; CodeRabbit pending/UNSTABLE at 16:14+08.",
           "kind": "code",
           "lane": "",
@@ -6928,6 +7173,24 @@
         },
         {
           "domain": "Territory/Economy",
+          "domainSource": "project",
+          "evidence": "",
+          "kind": "code",
+          "lane": "Territory/Economy",
+          "nextAction": "",
+          "number": 441,
+          "priority": "P1",
+          "projectDomain": "Territory/Economy",
+          "state": "",
+          "status": "Done",
+          "title": "feat: spawn workers for territory recommendations",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/441",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
           "domainSource": "heuristic",
           "evidence": "PR #212 opened at 4634f08 after stale Codex lane recovery. Controller verification after merging main: diff-check; typecheck; Jest 16 suites/324 tests; build; dist clean. prod-ci queued; review gate pending.",
           "kind": "code",
@@ -7073,24 +7336,6 @@
         {
           "domain": "RL flywheel",
           "domainSource": "project",
-          "evidence": "Owner requires self-hosted accelerated parallel simulation targeting ~100x official service throughput; implementation issue created.",
-          "kind": "code",
-          "lane": "RL flywheel",
-          "nextAction": "",
-          "number": 414,
-          "priority": "P1",
-          "projectDomain": "RL flywheel",
-          "state": "",
-          "status": "Ready",
-          "title": "P1: RL Flywheel: build accelerated self-hosted simulator harness target 100x official tick speed",
-          "type": "Issue",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/414",
-          "visionLayer": "foundation blocker"
-        },
-        {
-          "domain": "RL flywheel",
-          "domainSource": "project",
           "evidence": "Owner requires RL framework selection and reward tuning workflow; implementation issue created.",
           "kind": "code",
           "lane": "RL flywheel",
@@ -7144,6 +7389,42 @@
         },
         {
           "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-05-01T18:38+08 recovered verified Codex #414 work into commit 1a517ed and opened PR #439. Verification: diff-check, py_compile, unittest 4 OK.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 414,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P1: RL Flywheel: build accelerated self-hosted simulator harness target 100x official tick speed",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/414",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-05-01T17:26+08 PR #433 review-fix pushed as fd51b18 after current-main reconcile; verification passed (diff-check, py_compile, unittest 11).",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 432,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "P1: RL Flywheel: scheduled offline strategy-shadow report generation",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/432",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
           "domainSource": "heuristic",
           "evidence": "PR #420 merged at e81bc3171957078158805252f15a83d138bcafdf after CodeRabbit link-pinning thread cleared. prod-ci and CodeRabbit were green; unresolved review-thread query returned empty. Issue #413 closed.",
           "kind": "code",
@@ -7158,6 +7439,42 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/420",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "heuristic",
+          "evidence": "",
+          "kind": "code",
+          "lane": "",
+          "nextAction": "",
+          "number": 439,
+          "priority": "P1",
+          "projectDomain": "",
+          "state": "",
+          "status": "Done",
+          "title": "feat: add RL simulator harness dry-run slice",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/439",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "RL flywheel",
+          "domainSource": "project",
+          "evidence": "2026-05-01T17:26+08 review-fix for PR #433 pushed as fd51b18 after reconciling onto main 618fc4e; verification passed (diff-check, py_compile, unittest 11 tests). Await fresh checks/bot review.",
+          "kind": "code",
+          "lane": "RL flywheel",
+          "nextAction": "",
+          "number": 433,
+          "priority": "P1",
+          "projectDomain": "RL flywheel",
+          "state": "",
+          "status": "Done",
+          "title": "feat: generate offline strategy shadow reports",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/433",
           "visionLayer": "foundation blocker"
         },
         {
@@ -7230,6 +7547,24 @@
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/216",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Docs/process",
+          "domainSource": "project",
+          "evidence": "2026-05-01T16:59+08:00 #430 in review via PR #431. Gate now CLEAN: head 410c290, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, no active review threads. Awaiting >=15 minute elapsed review gate.",
+          "kind": "docs",
+          "lane": "Docs/process",
+          "nextAction": "",
+          "number": 430,
+          "priority": "P1",
+          "projectDomain": "Docs/process",
+          "state": "",
+          "status": "Done",
+          "title": "P1: RL Domain Refresh: system roadmap for strategy-change flywheel",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/430",
           "visionLayer": "foundation blocker"
         },
         {
@@ -7343,6 +7678,24 @@
         {
           "domain": "Docs/process",
           "domainSource": "project",
+          "evidence": "Merged PR #431 at 2026-05-01T09:08Z, merge commit 9b1421c; prod-ci PASS, CodeRabbit PASS, no review threads. #430 closed/Done.",
+          "kind": "docs",
+          "lane": "Docs/process",
+          "nextAction": "",
+          "number": 431,
+          "priority": "P1",
+          "projectDomain": "Docs/process",
+          "state": "",
+          "status": "Done",
+          "title": "docs: define RL domain roadmap",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/431",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Docs/process",
+          "domainSource": "project",
           "evidence": "PR #66 merged at 2026-04-27T03:29:27Z as 1f41670 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, and empty GraphQL review threads.",
           "kind": "docs",
           "lane": "Docs/process",
@@ -7433,6 +7786,24 @@
         {
           "domain": "Docs/process",
           "domainSource": "project",
+          "evidence": "PR #436 merged at 2026-05-01T10:29:48Z, merge 880d0cc. Main ff verified. Pages live CSS: repeat(5) present, repeat(7) absent. Roadmap cron job 92ca290f7996 run 2026-05-01 18:33 ok, delivered MEDIA image sha256 9c3ac0b264d85a3e6f9a706cd42b253d69d4be7f186354b61f18258f3a35d607; vision QA confirms 5/5 no clipping.",
+          "kind": "code",
+          "lane": "Docs/process",
+          "nextAction": "",
+          "number": 436,
+          "priority": "P1",
+          "projectDomain": "Docs/process",
+          "state": "",
+          "status": "Done",
+          "title": "fix: render domain kanban as five-column rows",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/436",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Docs/process",
+          "domainSource": "project",
           "evidence": "DONE via PR #220 merged 2026-04-28T17:03:10Z, merge commit 7cb8dac. Gates: >=15min, prod-ci success, CodeRabbit success, no active review threads. Verification: check-roadmap-kpi-placeholders PASS, py_compile PASS, local+live browser/vision QA PASS. Live Pages https://lanyusea.github.io/screeps/ contains 9 placeholder lines and 63 placeholder points; charts show axes/date labels, muted placeholder lines, and hollow markers. No sqlite sidecars.",
           "kind": "docs",
           "lane": "Docs/process",
@@ -7494,24 +7865,6 @@
                   "type": "Issue",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/408",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "Agent OS",
-                  "domainSource": "project",
-                  "evidence": "2026-05-01 live state audit repaired missing Project item and milestone; added to Project #3 as Ready/P1/Agent OS/ops.",
-                  "kind": "ops",
-                  "lane": "Agent OS",
-                  "nextAction": "",
-                  "number": 427,
-                  "priority": "P1",
-                  "projectDomain": "Agent OS",
-                  "state": "",
-                  "status": "Ready",
-                  "title": "P1 Agent OS: unify rules taxonomy and fix domain display drift",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/427",
                   "visionLayer": "foundation blocker"
                 },
                 {
@@ -7908,6 +8261,24 @@
                 {
                   "domain": "Agent OS",
                   "domainSource": "project",
+                  "evidence": "Live audit 2026-05-01T16:31+08: PR #428 exists; PR Project item repaired/added. Checks pending; mergeState BEHIND.",
+                  "kind": "ops",
+                  "lane": "Agent OS",
+                  "nextAction": "",
+                  "number": 427,
+                  "priority": "P1",
+                  "projectDomain": "Agent OS",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1 Agent OS: unify rules taxonomy and fix domain display drift",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/427",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Agent OS",
+                  "domainSource": "project",
                   "evidence": "Merged PR #162 at c75de59; cron continuation prompt also updated with 24h forced-P2 anti-starvation policy; checks green and CodeRabbit resolved.",
                   "kind": "ops",
                   "lane": "Agent OS",
@@ -7975,6 +8346,24 @@
                   "type": "PullRequest",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/pull/219",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Agent OS",
+                  "domainSource": "project",
+                  "evidence": "PR #428 implements Minimal Rules OS registry, cron/route registry, templates, audit script, Project Domain/Kind options, and Pages domain progress regeneration. Local QA PASS: audit --github; pytest 6 passed.",
+                  "kind": "ops",
+                  "lane": "Agent OS",
+                  "nextAction": "",
+                  "number": 428,
+                  "priority": "P1",
+                  "projectDomain": "Agent OS",
+                  "state": "",
+                  "status": "Done",
+                  "title": "docs: unify Screeps rules taxonomy and domain display",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/428",
                   "visionLayer": "foundation blocker"
                 }
               ],
@@ -8287,7 +8676,7 @@
                 {
                   "domain": "Runtime monitor",
                   "domainSource": "project",
-                  "evidence": "Merged PR #423 at 2026-05-01T06:34:31Z; merge commit 0235a3a; final QA/checks/review threads clean.",
+                  "evidence": "2026-05-01 shadow cadence audit: evaluator is passive/manual/test-only today; runtime summary/alert jobs generate input artifacts, but no recurring shadow-eval report job yet. #415/#417 comments updated with gap.",
                   "kind": "code",
                   "lane": "Runtime monitor",
                   "nextAction": "",
@@ -8802,7 +9191,26 @@
               "status": "In progress"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "domain": "Bot capability",
+                  "domainSource": "project",
+                  "evidence": "Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; controller verification passed; PR added to Project.",
+                  "kind": "code",
+                  "lane": "Bot capability",
+                  "nextAction": "",
+                  "number": 449,
+                  "priority": "P1",
+                  "projectDomain": "Bot capability",
+                  "state": "",
+                  "status": "In review",
+                  "title": "P1 Economy: post-447 worker throughput follow-up",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/449",
+                  "visionLayer": "territory"
+                }
+              ],
               "status": "In review"
             },
             {
@@ -9040,6 +9448,24 @@
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/30",
                   "visionLayer": "resources"
+                },
+                {
+                  "domain": "Bot capability",
+                  "domainSource": "project",
+                  "evidence": "2026-05-01T18:57+08 PR #438 live thread PRRT_kwDOSMSsO85-8-ak fixed/pushed as Codex-authored commit 4fd003d; verification diff-check, typecheck, Jest 24/631, build.",
+                  "kind": "code",
+                  "lane": "Bot capability",
+                  "nextAction": "",
+                  "number": 437,
+                  "priority": "P1",
+                  "projectDomain": "Bot capability",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1 Economy: continue resource throughput after worker lookup deploy",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/437",
+                  "visionLayer": "territory"
                 },
                 {
                   "domain": "Bot capability",
@@ -11186,6 +11612,24 @@
                 {
                   "domain": "Bot capability",
                   "domainSource": "project",
+                  "evidence": "2026-05-01T19:05+08 updated branch to 5c54d5a after #426 merge; prod-ci/CodeRabbit success, no unresolved GraphQL threads; exact-head QA proc_[redacted] pid 1727803 dispatched.",
+                  "kind": "code",
+                  "lane": "Bot capability",
+                  "nextAction": "",
+                  "number": 438,
+                  "priority": "P1",
+                  "projectDomain": "Bot capability",
+                  "state": "",
+                  "status": "Done",
+                  "title": "feat: improve post-lookup resource throughput",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/438",
+                  "visionLayer": "resources"
+                },
+                {
+                  "domain": "Bot capability",
+                  "domainSource": "project",
                   "evidence": "PR #343 head 428a66d had QA pass, but CodeRabbit posted fresh live blocker at territoryPlanner.ts:2135; review-fix Codex proc_[redacted] dispatched.",
                   "kind": "code",
                   "lane": "Bot capability",
@@ -12138,26 +12582,7 @@
               "status": "Ready"
             },
             {
-              "cards": [
-                {
-                  "domain": "Combat",
-                  "domainSource": "project",
-                  "evidence": "",
-                  "kind": "review",
-                  "lane": "Combat",
-                  "nextAction": "",
-                  "number": 405,
-                  "priority": "P1",
-                  "projectDomain": "Combat",
-                  "state": "",
-                  "status": "In progress",
-                  "title": "P1 Combat: one-time code review sweep for dead-zone and placeholder logic",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/405",
-                  "visionLayer": "enemy kills"
-                }
-              ],
+              "cards": [],
               "status": "In progress"
             },
             {
@@ -12165,7 +12590,44 @@
               "status": "In review"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "domain": "Combat",
+                  "domainSource": "project",
+                  "evidence": "Authoritative PR #443 updated via REST update-branch to bbf3104; prod-ci/CodeRabbit green at checkpoint; final GraphQL thread requery still needed.",
+                  "kind": "review",
+                  "lane": "Combat",
+                  "nextAction": "",
+                  "number": 405,
+                  "priority": "P1",
+                  "projectDomain": "Combat",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1 Combat: one-time code review sweep for dead-zone and placeholder logic",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/405",
+                  "visionLayer": "enemy kills"
+                },
+                {
+                  "domain": "Combat",
+                  "domainSource": "project",
+                  "evidence": "",
+                  "kind": "code",
+                  "lane": "Combat",
+                  "nextAction": "",
+                  "number": 443,
+                  "priority": "P1",
+                  "projectDomain": "Combat",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: avoid downgrade guard blocking defender replacement",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/443",
+                  "visionLayer": "enemy kills"
+                }
+              ],
               "status": "Done"
             }
           ]
@@ -12187,11 +12649,51 @@
               "status": "In progress"
             },
             {
+              "cards": [],
+              "status": "In review"
+            },
+            {
               "cards": [
                 {
                   "domain": "Territory/Economy",
                   "domainSource": "project",
-                  "evidence": "PR #426 updated with Codex-authored review-fix 7f72488; verification passed locally before push.",
+                  "evidence": "Done via merged PR #444; merge commit f8fd7a9 after exact-head QA PASS, prod-ci/CodeRabbit green, and GraphQL live threads clear.",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 442,
+                  "priority": "P1",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1 Economy: continue early-room resource throughput after spawn recovery deploy",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/442",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "2026-05-01T18:20+08 completed: PR #435 merged at 7d760c6 after green prod-ci/CodeRabbit, no unresolved review threads, exact-head QA proc_[redacted] PASS (typecheck/Jest/build/bundle drift; no critical issues).",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 434,
+                  "priority": "P1",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1 Economy: improve low-energy worker throughput after combat deploy",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/434",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "Completed by merged PR #426; merge commit fb44ef4 after green prod-ci, CodeRabbit, no unresolved GraphQL threads, exact-head QA PASS proc_[redacted].",
                   "kind": "code",
                   "lane": "Territory/Economy",
                   "nextAction": "",
@@ -12199,18 +12701,86 @@
                   "priority": "P1",
                   "projectDomain": "Territory/Economy",
                   "state": "",
-                  "status": "In review",
+                  "status": "Done",
                   "title": "P1 Territory: make next reserve/claim recommendation executable",
                   "type": "Issue",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/424",
                   "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "Authoritative PR #441 head 34b00bb includes recovered review-fix for CodeRabbit PRRT_kwDOSMSsO85-9X1Z; local controller verification PASS before commit; prod-ci success and CodeRabbit pending after push.",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 440,
+                  "priority": "P1",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1 Territory: turn executable recommendations into spawn/task action",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/440",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "Merged 2026-05-01T12:19:46Z as f8fd7a9 after exact-head QA PASS, prod-ci/CodeRabbit green, GraphQL threads clear.",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 444,
+                  "priority": "P1",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "feat: improve early resource throughput",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/444",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "2026-05-01T18:20+08 completed: PR #435 merged at 7d760c6 after green prod-ci/CodeRabbit, no unresolved review threads, exact-head QA proc_[redacted] PASS (typecheck/Jest/build/bundle drift; no critical issues).",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 435,
+                  "priority": "P1",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "feat: improve low-energy worker throughput",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/435",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Territory/Economy",
+                  "domainSource": "project",
+                  "evidence": "",
+                  "kind": "code",
+                  "lane": "Territory/Economy",
+                  "nextAction": "",
+                  "number": 441,
+                  "priority": "P1",
+                  "projectDomain": "Territory/Economy",
+                  "state": "",
+                  "status": "Done",
+                  "title": "feat: spawn workers for territory recommendations",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/441",
+                  "visionLayer": "territory"
                 }
               ],
-              "status": "In review"
-            },
-            {
-              "cards": [],
               "status": "Done"
             }
           ]
@@ -12345,24 +12915,6 @@
                 {
                   "domain": "RL flywheel",
                   "domainSource": "project",
-                  "evidence": "Owner requires self-hosted accelerated parallel simulation targeting ~100x official service throughput; implementation issue created.",
-                  "kind": "code",
-                  "lane": "RL flywheel",
-                  "nextAction": "",
-                  "number": 414,
-                  "priority": "P1",
-                  "projectDomain": "RL flywheel",
-                  "state": "",
-                  "status": "Ready",
-                  "title": "P1: RL Flywheel: build accelerated self-hosted simulator harness target 100x official tick speed",
-                  "type": "Issue",
-                  "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/414",
-                  "visionLayer": "foundation blocker"
-                },
-                {
-                  "domain": "RL flywheel",
-                  "domainSource": "project",
                   "evidence": "Owner requires RL framework selection and reward tuning workflow; implementation issue created.",
                   "kind": "code",
                   "lane": "RL flywheel",
@@ -12408,7 +12960,62 @@
               "status": "In review"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-05-01T18:38+08 recovered verified Codex #414 work into commit 1a517ed and opened PR #439. Verification: diff-check, py_compile, unittest 4 OK.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 414,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: RL Flywheel: build accelerated self-hosted simulator harness target 100x official tick speed",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/414",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-05-01T17:26+08 PR #433 review-fix pushed as fd51b18 after current-main reconcile; verification passed (diff-check, py_compile, unittest 11).",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 432,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: RL Flywheel: scheduled offline strategy-shadow report generation",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/432",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "RL flywheel",
+                  "domainSource": "project",
+                  "evidence": "2026-05-01T17:26+08 review-fix for PR #433 pushed as fd51b18 after reconciling onto main 618fc4e; verification passed (diff-check, py_compile, unittest 11 tests). Await fresh checks/bot review.",
+                  "kind": "code",
+                  "lane": "RL flywheel",
+                  "nextAction": "",
+                  "number": 433,
+                  "priority": "P1",
+                  "projectDomain": "RL flywheel",
+                  "state": "",
+                  "status": "Done",
+                  "title": "feat: generate offline strategy shadow reports",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/433",
+                  "visionLayer": "foundation blocker"
+                }
+              ],
               "status": "Done"
             }
           ]
@@ -12505,6 +13112,24 @@
                   "type": "Issue",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/216",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Docs/process",
+                  "domainSource": "project",
+                  "evidence": "2026-05-01T16:59+08:00 #430 in review via PR #431. Gate now CLEAN: head 410c290, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, no active review threads. Awaiting >=15 minute elapsed review gate.",
+                  "kind": "docs",
+                  "lane": "Docs/process",
+                  "nextAction": "",
+                  "number": 430,
+                  "priority": "P1",
+                  "projectDomain": "Docs/process",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1: RL Domain Refresh: system roadmap for strategy-change flywheel",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/430",
                   "visionLayer": "foundation blocker"
                 },
                 {
@@ -12618,6 +13243,24 @@
                 {
                   "domain": "Docs/process",
                   "domainSource": "project",
+                  "evidence": "Merged PR #431 at 2026-05-01T09:08Z, merge commit 9b1421c; prod-ci PASS, CodeRabbit PASS, no review threads. #430 closed/Done.",
+                  "kind": "docs",
+                  "lane": "Docs/process",
+                  "nextAction": "",
+                  "number": 431,
+                  "priority": "P1",
+                  "projectDomain": "Docs/process",
+                  "state": "",
+                  "status": "Done",
+                  "title": "docs: define RL domain roadmap",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/431",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Docs/process",
+                  "domainSource": "project",
                   "evidence": "PR #66 merged at 2026-04-27T03:29:27Z as 1f41670 after >=15m gate, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, and empty GraphQL review threads.",
                   "kind": "docs",
                   "lane": "Docs/process",
@@ -12672,6 +13315,24 @@
                 {
                   "domain": "Docs/process",
                   "domainSource": "project",
+                  "evidence": "PR #436 merged at 2026-05-01T10:29:48Z, merge 880d0cc. Main ff verified. Pages live CSS: repeat(5) present, repeat(7) absent. Roadmap cron job 92ca290f7996 run 2026-05-01 18:33 ok, delivered MEDIA image sha256 9c3ac0b264d85a3e6f9a706cd42b253d69d4be7f186354b61f18258f3a35d607; vision QA confirms 5/5 no clipping.",
+                  "kind": "code",
+                  "lane": "Docs/process",
+                  "nextAction": "",
+                  "number": 436,
+                  "priority": "P1",
+                  "projectDomain": "Docs/process",
+                  "state": "",
+                  "status": "Done",
+                  "title": "fix: render domain kanban as five-column rows",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/436",
+                  "visionLayer": "foundation blocker"
+                },
+                {
+                  "domain": "Docs/process",
+                  "domainSource": "project",
                   "evidence": "DONE via PR #220 merged 2026-04-28T17:03:10Z, merge commit 7cb8dac. Gates: >=15min, prod-ci success, CodeRabbit success, no active review threads. Verification: check-roadmap-kpi-placeholders PASS, py_compile PASS, local+live browser/vision QA PASS. Live Pages https://lanyusea.github.io/screeps/ contains 9 placeholder lines and 63 placeholder points; charts show axes/date labels, muted placeholder lines, and hollow markers. No sqlite sidecars.",
                   "kind": "docs",
                   "lane": "Docs/process",
@@ -12716,12 +13377,12 @@
       {
         "instrumented": true,
         "label": "Open roadmap issues",
-        "value": 16
+        "value": 14
       },
       {
         "instrumented": true,
         "label": "Open PRs",
-        "value": 1
+        "value": 2
       },
       {
         "instrumented": true,
@@ -12731,17 +13392,17 @@
       {
         "instrumented": true,
         "label": "Project cards",
-        "value": 395
+        "value": 418
       },
       {
         "instrumented": true,
         "label": "In progress",
-        "value": 3
+        "value": 2
       },
       {
         "instrumented": true,
         "label": "In review",
-        "value": 2
+        "value": 4
       }
     ],
     "projectItems": [
@@ -12892,7 +13553,7 @@
         "blockedBy": "",
         "domain": "Runtime monitor",
         "domainSource": "project",
-        "evidence": "Scheduler audit 2026-04-28T17:15+08: stale In progress state repaired; no active process/PR currently owns #29. Runtime-summary job is healthy, but KPI/console-evidence work remains.",
+        "evidence": "2026-05-01 21:36+08 scheduler: latest deploy run 25215098606 for main 77b66cbd archived; E26S49 sidecars healthy (owner lanyusea, spawn=1, creeps=4, health ok). Runtime monitor aliases still stale to E48S29 and need repair.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -13585,7 +14246,7 @@
         "blockedBy": "",
         "domain": "Release/deploy",
         "domainSource": "project",
-        "evidence": "2026-05-01 16:20 +08 deployment floor satisfied for main/gameplay commit 0eff7ce via official run 25207811166; deploy ok=true branch/activeWorld matched; postdeploy summary owner lanyusea spawns=1 creeps=4 hostiles=0 tick=364721; alert=false; health ok=true.",
+        "evidence": "2026-05-01 21:53+08 scheduler: PR #447 merged; official deploy run 25216817698 deployed main fb0d5508 to shardX/E26S49. Sidecars healthy: owner lanyusea, spawn=1, creeps=4, hostiles=0, health ok. Runtime summary/alert jobs manually triggered post-deploy.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -20653,7 +21314,7 @@
         "blockedBy": "",
         "domain": "Combat",
         "domainSource": "project",
-        "evidence": "",
+        "evidence": "Authoritative PR #443 updated via REST update-branch to bbf3104; prod-ci/CodeRabbit green at checkpoint; final GraphQL thread requery still needed.",
         "kind": "review",
         "labels": [
           "kind:review",
@@ -20667,7 +21328,7 @@
         "priority": "P1",
         "projectDomain": "Combat",
         "state": "",
-        "status": "In progress",
+        "status": "Done",
         "title": "P1 Combat: one-time code review sweep for dead-zone and placeholder logic",
         "type": "Issue",
         "updatedAt": "",
@@ -20865,7 +21526,7 @@
         "blockedBy": "",
         "domain": "RL flywheel",
         "domainSource": "project",
-        "evidence": "Owner requires self-hosted accelerated parallel simulation targeting ~100x official service throughput; implementation issue created.",
+        "evidence": "2026-05-01T18:38+08 recovered verified Codex #414 work into commit 1a517ed and opened PR #439. Verification: diff-check, py_compile, unittest 4 OK.",
         "kind": "code",
         "labels": [
           "kind:code",
@@ -20880,7 +21541,7 @@
         "priority": "P1",
         "projectDomain": "RL flywheel",
         "state": "",
-        "status": "Ready",
+        "status": "Done",
         "title": "P1: RL Flywheel: build accelerated self-hosted simulator harness target 100x official tick speed",
         "type": "Issue",
         "updatedAt": "",
@@ -20890,7 +21551,7 @@
         "blockedBy": "",
         "domain": "Runtime monitor",
         "domainSource": "project",
-        "evidence": "Merged PR #423 at 2026-05-01T06:34:31Z; merge commit 0235a3a; final QA/checks/review threads clean.",
+        "evidence": "2026-05-01 shadow cadence audit: evaluator is passive/manual/test-only today; runtime summary/alert jobs generate input artifacts, but no recurring shadow-eval report job yet. #415/#417 comments updated with gap.",
         "kind": "code",
         "labels": [
           "kind:code",
@@ -21088,7 +21749,7 @@
         "blockedBy": "",
         "domain": "Territory/Economy",
         "domainSource": "project",
-        "evidence": "PR #426 updated with Codex-authored review-fix 7f72488; verification passed locally before push.",
+        "evidence": "Completed by merged PR #426; merge commit fb44ef4 after green prod-ci, CodeRabbit, no unresolved GraphQL threads, exact-head QA PASS proc_[redacted].",
         "kind": "code",
         "labels": [
           "kind:code",
@@ -21102,7 +21763,7 @@
         "priority": "P1",
         "projectDomain": "Territory/Economy",
         "state": "",
-        "status": "In review",
+        "status": "Done",
         "title": "P1 Territory: make next reserve/claim recommendation executable",
         "type": "Issue",
         "updatedAt": "",
@@ -21131,7 +21792,7 @@
         "blockedBy": "",
         "domain": "Territory/Economy",
         "domainSource": "heuristic",
-        "evidence": "",
+        "evidence": "Merged at 2026-05-01T10:59Z as fb44ef4 after green prod-ci, CodeRabbit, no unresolved threads, exact-head QA PASS.",
         "kind": "code",
         "labels": [],
         "milestone": "",
@@ -21140,7 +21801,7 @@
         "priority": "P1",
         "projectDomain": "",
         "state": "",
-        "status": "In review",
+        "status": "Done",
         "title": "feat: make territory recommendations executable",
         "type": "PullRequest",
         "updatedAt": "",
@@ -21150,7 +21811,7 @@
         "blockedBy": "",
         "domain": "Agent OS",
         "domainSource": "project",
-        "evidence": "2026-05-01 live state audit repaired missing Project item and milestone; added to Project #3 as Ready/P1/Agent OS/ops.",
+        "evidence": "Live audit 2026-05-01T16:31+08: PR #428 exists; PR Project item repaired/added. Checks pending; mergeState BEHIND.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -21164,14 +21825,520 @@
         "priority": "P1",
         "projectDomain": "Agent OS",
         "state": "",
-        "status": "Ready",
+        "status": "Done",
         "title": "P1 Agent OS: unify rules taxonomy and fix domain display drift",
         "type": "Issue",
         "updatedAt": "",
         "url": "https://github.com/lanyusea/screeps/issues/427"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Agent OS",
+        "domainSource": "project",
+        "evidence": "PR #428 implements Minimal Rules OS registry, cron/route registry, templates, audit script, Project Domain/Kind options, and Pages domain progress regeneration. Local QA PASS: audit --github; pytest 6 passed.",
+        "kind": "ops",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 428,
+        "priority": "P1",
+        "projectDomain": "Agent OS",
+        "state": "",
+        "status": "Done",
+        "title": "docs: unify Screeps rules taxonomy and domain display",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/428"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Combat",
+        "domainSource": "heuristic",
+        "evidence": "2026-05-01T17:17+08 exact-head QA PASS on PR #429 head 3669691 (proc_[redacted] exit 0): No critical issues found; prod/dist/main.js sync check passed; LFS docs/roadmap-kpi.sqlite noise treated as infrastructure. Outdated thread PRRT_kwDOSMSsO85-8LBw queued for resolution/re-query.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 429,
+        "priority": "P1",
+        "projectDomain": "",
+        "state": "",
+        "status": "Done",
+        "title": "fix: close combat dead-zone placeholder gap",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/429"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Docs/process",
+        "domainSource": "project",
+        "evidence": "2026-05-01T16:59+08:00 #430 in review via PR #431. Gate now CLEAN: head 410c290, prod-ci SUCCESS, CodeRabbit SUCCESS/no actionable comments, Gemini no feedback, no active review threads. Awaiting >=15 minute elapsed review gate.",
+        "kind": "docs",
+        "labels": [
+          "kind:docs",
+          "priority:p1",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 430,
+        "priority": "P1",
+        "projectDomain": "Docs/process",
+        "state": "",
+        "status": "Done",
+        "title": "P1: RL Domain Refresh: system roadmap for strategy-change flywheel",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/430"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Docs/process",
+        "domainSource": "project",
+        "evidence": "Merged PR #431 at 2026-05-01T09:08Z, merge commit 9b1421c; prod-ci PASS, CodeRabbit PASS, no review threads. #430 closed/Done.",
+        "kind": "docs",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 431,
+        "priority": "P1",
+        "projectDomain": "Docs/process",
+        "state": "",
+        "status": "Done",
+        "title": "docs: define RL domain roadmap",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/431"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-05-01T17:26+08 PR #433 review-fix pushed as fd51b18 after current-main reconcile; verification passed (diff-check, py_compile, unittest 11).",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:rl-flywheel"
+        ],
+        "milestone": "P1: RL strategy flywheel gate",
+        "nextAction": "",
+        "number": 432,
+        "priority": "P1",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "P1: RL Flywheel: scheduled offline strategy-shadow report generation",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/432"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "project",
+        "evidence": "2026-05-01T17:26+08 review-fix for PR #433 pushed as fd51b18 after reconciling onto main 618fc4e; verification passed (diff-check, py_compile, unittest 11 tests). Await fresh checks/bot review.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 433,
+        "priority": "P1",
+        "projectDomain": "RL flywheel",
+        "state": "",
+        "status": "Done",
+        "title": "feat: generate offline strategy shadow reports",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/433"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "2026-05-01T18:20+08 completed: PR #435 merged at 7d760c6 after green prod-ci/CodeRabbit, no unresolved review threads, exact-head QA proc_[redacted] PASS (typecheck/Jest/build/bundle drift; no critical issues).",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "Phase B: Bot capability hardening gate",
+        "nextAction": "",
+        "number": 434,
+        "priority": "P1",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "P1 Economy: improve low-energy worker throughput after combat deploy",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/434"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "2026-05-01T18:20+08 completed: PR #435 merged at 7d760c6 after green prod-ci/CodeRabbit, no unresolved review threads, exact-head QA proc_[redacted] PASS (typecheck/Jest/build/bundle drift; no critical issues).",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 435,
+        "priority": "P1",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "feat: improve low-energy worker throughput",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/435"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Docs/process",
+        "domainSource": "project",
+        "evidence": "PR #436 merged at 2026-05-01T10:29:48Z, merge 880d0cc. Main ff verified. Pages live CSS: repeat(5) present, repeat(7) absent. Roadmap cron job 92ca290f7996 run 2026-05-01 18:33 ok, delivered MEDIA image sha256 9c3ac0b264d85a3e6f9a706cd42b253d69d4be7f186354b61f18258f3a35d607; vision QA confirms 5/5 no clipping.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 436,
+        "priority": "P1",
+        "projectDomain": "Docs/process",
+        "state": "",
+        "status": "Done",
+        "title": "fix: render domain kanban as five-column rows",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/436"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Bot capability",
+        "domainSource": "project",
+        "evidence": "2026-05-01T18:57+08 PR #438 live thread PRRT_kwDOSMSsO85-8-ak fixed/pushed as Codex-authored commit 4fd003d; verification diff-check, typecheck, Jest 24/631, build.",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "Phase B: Bot capability hardening gate",
+        "nextAction": "",
+        "number": 437,
+        "priority": "P1",
+        "projectDomain": "Bot capability",
+        "state": "",
+        "status": "Done",
+        "title": "P1 Economy: continue resource throughput after worker lookup deploy",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/437"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Bot capability",
+        "domainSource": "project",
+        "evidence": "2026-05-01T19:05+08 updated branch to 5c54d5a after #426 merge; prod-ci/CodeRabbit success, no unresolved GraphQL threads; exact-head QA proc_[redacted] pid 1727803 dispatched.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 438,
+        "priority": "P1",
+        "projectDomain": "Bot capability",
+        "state": "",
+        "status": "Done",
+        "title": "feat: improve post-lookup resource throughput",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/438"
+      },
+      {
+        "blockedBy": "",
+        "domain": "RL flywheel",
+        "domainSource": "heuristic",
+        "evidence": "",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 439,
+        "priority": "P1",
+        "projectDomain": "",
+        "state": "",
+        "status": "Done",
+        "title": "feat: add RL simulator harness dry-run slice",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/439"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "Authoritative PR #441 head 34b00bb includes recovered review-fix for CodeRabbit PRRT_kwDOSMSsO85-9X1Z; local controller verification PASS before commit; prod-ci success and CodeRabbit pending after push.",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "Phase B: Bot capability hardening gate",
+        "nextAction": "",
+        "number": 440,
+        "priority": "P1",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "P1 Territory: turn executable recommendations into spawn/task action",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/440"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 441,
+        "priority": "P1",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "feat: spawn workers for territory recommendations",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/441"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "Done via merged PR #444; merge commit f8fd7a9 after exact-head QA PASS, prod-ci/CodeRabbit green, and GraphQL live threads clear.",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "Phase B: Bot capability hardening gate",
+        "nextAction": "",
+        "number": 442,
+        "priority": "P1",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "P1 Economy: continue early-room resource throughput after spawn recovery deploy",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/442"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Combat",
+        "domainSource": "project",
+        "evidence": "",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 443,
+        "priority": "P1",
+        "projectDomain": "Combat",
+        "state": "",
+        "status": "Done",
+        "title": "fix: avoid downgrade guard blocking defender replacement",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/443"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "project",
+        "evidence": "Merged 2026-05-01T12:19:46Z as f8fd7a9 after exact-head QA PASS, prod-ci/CodeRabbit green, GraphQL threads clear.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 444,
+        "priority": "P1",
+        "projectDomain": "Territory/Economy",
+        "state": "",
+        "status": "Done",
+        "title": "feat: improve early resource throughput",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/444"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "heuristic",
+        "evidence": "2026-05-01 21:50+08 scheduler: completed via PR #447; merged commit fb0d5508 after green CI/bot review and exact-head QA PASS. Deployed in official workflow run 25216817698 with healthy E26S49 sidecars.",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "Phase B: Bot capability hardening gate",
+        "nextAction": "",
+        "number": 445,
+        "priority": "P1",
+        "projectDomain": "",
+        "state": "",
+        "status": "Done",
+        "title": "P1 Economy: post-deploy productive worker pressure follow-up",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/445"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "heuristic",
+        "evidence": "",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "Phase B: Bot capability hardening gate",
+        "nextAction": "",
+        "number": 446,
+        "priority": "P1",
+        "projectDomain": "",
+        "state": "",
+        "status": "In review",
+        "title": "P1 Territory: post-spawn-action controller pressure follow-up",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/446"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "heuristic",
+        "evidence": "2026-05-01 scheduler: PR #447/#448 CI green, CodeRabbit success, GraphQL unresolved threads empty, exact-head QA PASS. #447 head 79c4fc5; #448 head 432ca4b.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 447,
+        "priority": "P1",
+        "projectDomain": "",
+        "state": "",
+        "status": "Done",
+        "title": "feat: harden productive worker pressure recovery",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/447"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Bot capability",
+        "domainSource": "heuristic",
+        "evidence": "2026-05-01 22:02+08 scheduler: PR #448 review-fix commit 219adc2 pushed after controller verification (typecheck/Jest/build/diff-check) and Codex commit-only recovery. CI/CodeRabbit pending for new head 219adc26390d867be709c4c66de75f7cc7ba9f68.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 448,
+        "priority": "P1",
+        "projectDomain": "",
+        "state": "",
+        "status": "In review",
+        "title": "feat: add controller pressure spawn follow-up",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/448"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Bot capability",
+        "domainSource": "project",
+        "evidence": "Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; controller verification passed; PR added to Project.",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "Phase B: Bot capability hardening gate",
+        "nextAction": "",
+        "number": 449,
+        "priority": "P1",
+        "projectDomain": "Bot capability",
+        "state": "",
+        "status": "In review",
+        "title": "P1 Economy: post-447 worker throughput follow-up",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/449"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Territory/Economy",
+        "domainSource": "heuristic",
+        "evidence": "PR #450 opened for #449 at 70b0ddc; controller verification passed (typecheck, Jest, build, diff --check); CI/CodeRabbit pending; exact-head QA required.",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 450,
+        "priority": "P1",
+        "projectDomain": "",
+        "state": "",
+        "status": "In review",
+        "title": "feat: harden worker body scaling for throughput",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/450"
       }
     ],
     "pullRequests": [
+      {
+        "checks": {
+          "failure": 0,
+          "pending": 1,
+          "success": 1,
+          "total": 2
+        },
+        "createdAt": "2026-05-01T14:21:04Z",
+        "domain": "Territory/Economy",
+        "domainSource": "heuristic",
+        "isDraft": false,
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "number": 450,
+        "priority": "P1",
+        "reviewDecision": "",
+        "state": "OPEN",
+        "status": "In review",
+        "title": "feat: harden worker body scaling for throughput",
+        "type": "PullRequest",
+        "updatedAt": "2026-05-01T14:23:02Z",
+        "url": "https://github.com/lanyusea/screeps/pull/450"
+      },
       {
         "checks": {
           "failure": 0,
@@ -21179,22 +22346,22 @@
           "success": 2,
           "total": 2
         },
-        "createdAt": "2026-05-01T06:40:16Z",
-        "domain": "Territory/Economy",
+        "createdAt": "2026-05-01T13:33:49Z",
+        "domain": "Bot capability",
         "domainSource": "heuristic",
         "isDraft": false,
         "kind": "code",
         "labels": [],
         "milestone": "",
-        "number": 426,
+        "number": 448,
         "priority": "P1",
         "reviewDecision": "",
         "state": "OPEN",
         "status": "In review",
-        "title": "feat: make territory recommendations executable",
+        "title": "feat: add controller pressure spawn follow-up",
         "type": "PullRequest",
-        "updatedAt": "2026-05-01T08:16:50Z",
-        "url": "https://github.com/lanyusea/screeps/pull/426"
+        "updatedAt": "2026-05-01T14:23:21Z",
+        "url": "https://github.com/lanyusea/screeps/pull/448"
       }
     ],
     "roadmapCards": [
@@ -21487,7 +22654,7 @@
             "categoryLabel": "Territory",
             "description": "Total controller progress movement across the runtime KPI window.",
             "details": {},
-            "formattedValue": "-91196",
+            "formattedValue": "-83866",
             "instrumented": true,
             "key": "controller_progress_delta",
             "label": "Controller progress delta",
@@ -21498,7 +22665,7 @@
             "source": "runtime-summary controller fields",
             "status": "observed",
             "unit": "progress/window",
-            "value": -91196
+            "value": -83866
           }
         ]
       },
@@ -21834,7 +23001,7 @@
             "categoryLabel": "Guardrails / Reliability",
             "description": "Runtime-summary lines found by the persisted artifact feeder.",
             "details": {},
-            "formattedValue": "214",
+            "formattedValue": "253",
             "instrumented": true,
             "key": "runtime_summary_samples",
             "label": "Runtime summary samples",
@@ -21845,14 +23012,14 @@
             "source": "runtime KPI artifact bridge",
             "status": "observed",
             "unit": "samples",
-            "value": 214
+            "value": 253
           },
           {
             "category": "guardrails",
             "categoryLabel": "Guardrails / Reliability",
             "description": "Files matched by the persisted artifact feeder.",
             "details": {},
-            "formattedValue": "214",
+            "formattedValue": "253",
             "instrumented": true,
             "key": "kpi_artifact_files",
             "label": "KPI artifact files",
@@ -21863,7 +23030,7 @@
             "source": "runtime KPI artifact bridge",
             "status": "observed",
             "unit": "files",
-            "value": 214
+            "value": 253
           },
           {
             "category": "guardrails",
@@ -22059,6 +23226,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "alert_false_positives": [
@@ -22087,6 +23268,20 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not instrumented",
           "value": null
         }
@@ -22119,6 +23314,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "not observed",
           "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "not observed",
+          "value": null
         }
       ],
       "attack_damage": [
@@ -22147,6 +23356,20 @@
           "instrumented": true,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not observed",
           "value": null
         }
@@ -22179,6 +23402,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "not observed",
           "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "not observed",
+          "value": null
         }
       ],
       "controller_level_sum": [
@@ -22207,6 +23444,20 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "observed",
+          "value": 2.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 2.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "observed",
           "value": 2.0
         }
@@ -22239,6 +23490,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "observed",
           "value": -91196.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": -83866.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "observed",
+          "value": -83866.0
         }
       ],
       "cpu_bucket": [
@@ -22267,6 +23532,20 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not instrumented",
           "value": null
         }
@@ -22299,6 +23578,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "creeps_destroyed_generic": [
@@ -22327,6 +23620,20 @@
           "instrumented": true,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not observed",
           "value": null
         }
@@ -22359,6 +23666,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "observed",
           "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "enemy_kills": [
@@ -22387,6 +23708,20 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not instrumented",
           "value": null
         }
@@ -22419,6 +23754,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "harvested_energy": [
@@ -22447,6 +23796,20 @@
           "instrumented": true,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not observed",
           "value": null
         }
@@ -22479,6 +23842,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "observed",
           "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "hostile_structures": [
@@ -22507,6 +23884,20 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "observed",
           "value": 0.0
         }
@@ -22539,6 +23930,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "observed",
           "value": 214.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 253.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "observed",
+          "value": 253.0
         }
       ],
       "objects_destroyed": [
@@ -22567,6 +23972,20 @@
           "instrumented": true,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not observed",
           "value": null
         }
@@ -22599,6 +24018,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "owned_room_delta": [
@@ -22627,6 +24060,20 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "observed",
           "value": 0.0
         }
@@ -22659,6 +24106,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "observed",
           "value": 1.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 1.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "observed",
+          "value": 1.0
         }
       ],
       "reserved_remote_rooms": [
@@ -22687,6 +24148,20 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not instrumented",
           "value": null
         }
@@ -22719,6 +24194,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "runtime_summary_samples": [
@@ -22749,6 +24238,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "observed",
           "value": 214.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 253.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "observed",
+          "value": 253.0
         }
       ],
       "source_count": [
@@ -22777,6 +24280,20 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "observed",
+          "value": 2.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 2.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "observed",
           "value": 2.0
         }
@@ -22809,6 +24326,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "spawn_utilization": [
@@ -22837,6 +24368,20 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not instrumented",
           "value": null
         }
@@ -22869,6 +24414,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "observed",
           "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "stored_energy_delta": [
@@ -22897,6 +24456,20 @@
           "instrumented": true,
           "observed": true,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "observed",
           "value": 0.0
         }
@@ -22929,6 +24502,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "not instrumented",
           "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "not instrumented",
+          "value": null
         }
       ],
       "transferred_energy": [
@@ -22957,6 +24544,20 @@
           "instrumented": true,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not observed",
+          "value": null
+        },
+        {
+          "instrumented": true,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not observed",
           "value": null
         }
@@ -22989,6 +24590,20 @@
           "sampledAt": "2026-05-01T08:26:38Z",
           "status": "observed",
           "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "observed",
+          "value": 0.0
+        },
+        {
+          "instrumented": true,
+          "observed": true,
+          "sampledAt": "2026-05-01T14:23:12Z",
+          "status": "observed",
+          "value": 0.0
         }
       ],
       "worker_recovery_state": [
@@ -23017,6 +24632,20 @@
           "instrumented": false,
           "observed": false,
           "sampledAt": "2026-05-01T08:26:38Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:20:44Z",
+          "status": "not instrumented",
+          "value": null
+        },
+        {
+          "instrumented": false,
+          "observed": false,
+          "sampledAt": "2026-05-01T14:23:12Z",
           "status": "not instrumented",
           "value": null
         }
@@ -23064,15 +24693,6 @@
             "status": "Ready",
             "title": "#408 P1 Agent OS: strategy reports must include proactive P0 postmortems",
             "url": "https://github.com/lanyusea/screeps/issues/408"
-          },
-          {
-            "description": "Ready \u00b7 Agent OS \u00b7 2026-05-01 live state audit repaired missing Project item and milestone; added to Project...",
-            "domain": "Agent OS",
-            "number": 427,
-            "priority": "P1",
-            "status": "Ready",
-            "title": "#427 P1 Agent OS: unify rules taxonomy and fix domain display drift",
-            "url": "https://github.com/lanyusea/screeps/issues/427"
           }
         ],
         "title": "Agent OS"
@@ -23110,20 +24730,21 @@
         "title": "Release/deploy"
       },
       {
-        "items": [],
+        "items": [
+          {
+            "description": "In review \u00b7 Bot capability \u00b7 Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; contr...",
+            "domain": "Bot capability",
+            "number": 449,
+            "priority": "P1",
+            "status": "In review",
+            "title": "#449 P1 Economy: post-447 worker throughput follow-up",
+            "url": "https://github.com/lanyusea/screeps/issues/449"
+          }
+        ],
         "title": "Bot capability"
       },
       {
         "items": [
-          {
-            "description": "In progress \u00b7 Combat \u00b7 Combat",
-            "domain": "Combat",
-            "number": 405,
-            "priority": "P1",
-            "status": "In progress",
-            "title": "#405 P1 Combat: one-time code review sweep for dead-zone and placehol...",
-            "url": "https://github.com/lanyusea/screeps/issues/405"
-          },
           {
             "description": "Ready \u00b7 Combat \u00b7 QA requirement added to Hermes Screeps deploy-floor skill: dead-zone/placeholders block QA i...",
             "domain": "Combat",
@@ -23137,17 +24758,7 @@
         "title": "Combat"
       },
       {
-        "items": [
-          {
-            "description": "In review \u00b7 Territory/Economy \u00b7 PR #426 updated with Codex-authored review-fix 7f72488; verification passed l...",
-            "domain": "Territory/Economy",
-            "number": 424,
-            "priority": "P1",
-            "status": "In review",
-            "title": "#424 P1 Territory: make next reserve/claim recommendation executable",
-            "url": "https://github.com/lanyusea/screeps/issues/424"
-          }
-        ],
+        "items": [],
         "title": "Territory/Economy"
       },
       {
@@ -23194,13 +24805,13 @@
             "url": "https://github.com/lanyusea/screeps/issues/412"
           },
           {
-            "description": "Ready \u00b7 RL flywheel \u00b7 Owner requires self-hosted accelerated parallel simulation targeting ~100x official ser...",
+            "description": "Ready \u00b7 RL flywheel \u00b7 Owner requires RL framework selection and reward tuning workflow; implementation issue...",
             "domain": "RL flywheel",
-            "number": 414,
+            "number": 416,
             "priority": "P1",
             "status": "Ready",
-            "title": "#414 P1: RL Flywheel: build accelerated self-hosted simulator harness...",
-            "url": "https://github.com/lanyusea/screeps/issues/414"
+            "title": "#416 P1: RL Flywheel: choose RL training framework and reward tuning...",
+            "url": "https://github.com/lanyusea/screeps/issues/416"
           }
         ],
         "title": "RL flywheel"
@@ -23506,51 +25117,56 @@
     ],
     "processCards": [
       {
-        "delta": "+1",
-        "detail": "repository history",
-        "label": "Total commits",
-        "value": 302
-      },
-      {
-        "delta": "+1",
-        "detail": "221 merged",
-        "label": "Total PRs",
-        "source": "github",
-        "value": 229
+        "delta": "+0",
+        "detail": "1,517,772,656 total; latest token_count in 1,028/1,029 sessions",
+        "label": "Agent tokens",
+        "rawValue": 1517772656,
+        "source": ".codex/sessions/**/rollout-*.jsonl",
+        "value": "1.5B"
       },
       {
         "delta": "+0",
-        "detail": "16 open",
-        "label": "Total issues",
-        "source": "github",
-        "value": 198
+        "detail": "summed first-to-last JSONL timestamps across 1,029/1,029 sessions",
+        "label": "Codex runtime",
+        "rawValueSeconds": 276252,
+        "source": ".codex/sessions/**/rollout-*.jsonl timestamps",
+        "value": "3d 4h"
+      },
+      {
+        "delta": "+0",
+        "detail": "rollout JSONL files counted as Codex runs",
+        "label": "Codex runs",
+        "rawValue": 1029,
+        "source": ".codex/sessions/**/rollout-*.jsonl",
+        "value": "1,029"
+      },
+      {
+        "delta": "+0",
+        "detail": "2,340 cron outputs across 36 jobs",
+        "label": "Automation runs",
+        "rawValue": 2340,
+        "source": ".hermes/cron/output/*/*.md",
+        "value": "2,340"
       },
       {
         "delta": "+0",
         "detail": "GitHub Project official deploy evidence",
         "label": "Official deploys",
         "source": "github project evidence",
-        "value": 5
-      },
-      {
-        "delta": "+0",
-        "detail": "smoke/report evidence",
-        "label": "Private smoke tests",
-        "source": "approved process report count",
-        "value": 1
+        "value": 6
       }
     ],
     "roadmapCards": [
       {
-        "activeItems": 3,
+        "activeItems": 2,
         "domain": "Agent OS",
-        "doneItems": 24,
+        "doneItems": 26,
         "goal": "Keep autonomous scheduling, routing, review, and handoff operations healthy.",
         "next": "Current: #273 Ready - RCA from owner report: #232 was marked Done after scaffold/vision PR, w...",
-        "progress": 89,
-        "status": "27 Project items \u00b7 3 active \u00b7 24 done",
+        "progress": 93,
+        "status": "28 Project items \u00b7 2 active \u00b7 26 done",
         "title": "Agent OS",
-        "totalItems": 27,
+        "totalItems": 28,
         "url": "https://github.com/lanyusea/screeps/issues/273"
       },
       {
@@ -23590,39 +25206,39 @@
         "url": "https://github.com/lanyusea/screeps/issues/63"
       },
       {
-        "activeItems": 0,
+        "activeItems": 1,
         "domain": "Bot capability",
-        "doneItems": 183,
+        "doneItems": 185,
         "goal": "Ship general gameplay behavior that advances the bot beyond single-slice fixes.",
-        "next": "No active item; latest tracked: #362 Done - P0: add Overmind-inspired bootstrap mode and expl...",
-        "progress": 100,
-        "status": "183 Project items \u00b7 0 active \u00b7 183 done",
+        "next": "Current: #449 In review - Recovered #449 dirty Codex implementation into commit 70b0ddc and P...",
+        "progress": 99,
+        "status": "186 Project items \u00b7 1 active \u00b7 185 done",
         "title": "Bot capability",
-        "totalItems": 183,
-        "url": "https://github.com/lanyusea/screeps/issues/362"
-      },
-      {
-        "activeItems": 2,
-        "domain": "Combat",
-        "doneItems": 0,
-        "goal": "Protect survival, hostile response, and defense/combat readiness.",
-        "next": "Current: #405 In progress - P1 Combat: one-time code review sweep for dead-zone and placehold...",
-        "progress": 0,
-        "status": "2 Project items \u00b7 2 active \u00b7 0 done",
-        "title": "Combat",
-        "totalItems": 2,
-        "url": "https://github.com/lanyusea/screeps/issues/405"
+        "totalItems": 186,
+        "url": "https://github.com/lanyusea/screeps/issues/449"
       },
       {
         "activeItems": 1,
+        "domain": "Combat",
+        "doneItems": 2,
+        "goal": "Protect survival, hostile response, and defense/combat readiness.",
+        "next": "Current: #407 Ready - QA requirement added to Hermes Screeps deploy-floor skill: dead-zone/pl...",
+        "progress": 67,
+        "status": "3 Project items \u00b7 1 active \u00b7 2 done",
+        "title": "Combat",
+        "totalItems": 3,
+        "url": "https://github.com/lanyusea/screeps/issues/407"
+      },
+      {
+        "activeItems": 0,
         "domain": "Territory/Economy",
-        "doneItems": 0,
+        "doneItems": 7,
         "goal": "Advance expansion, controller pressure, worker efficiency, and resource throughput.",
-        "next": "Current: #424 In review - PR #426 updated with Codex-authored review-fix 7f72488; verificatio...",
-        "progress": 0,
-        "status": "1 Project item \u00b7 1 active \u00b7 0 done",
+        "next": "No active item; latest tracked: #424 Done - Completed by merged PR #426; merge commit fb44ef4...",
+        "progress": 100,
+        "status": "7 Project items \u00b7 0 active \u00b7 7 done",
         "title": "Territory/Economy",
-        "totalItems": 1,
+        "totalItems": 7,
         "url": "https://github.com/lanyusea/screeps/issues/424"
       },
       {
@@ -23638,28 +25254,16 @@
         "url": "https://github.com/lanyusea/screeps/issues/59"
       },
       {
-        "activeItems": 7,
+        "activeItems": 6,
         "domain": "RL flywheel",
-        "doneItems": 0,
+        "doneItems": 3,
         "goal": "Drive offline/simulator/data/training/validation work for safe strategy self-evolution.",
         "next": "Current: #266 Ready - Owner correction 2026-05-01: all RL/strategy-iteration follow-ups are P...",
-        "progress": 0,
-        "status": "7 Project items \u00b7 7 active \u00b7 0 done",
+        "progress": 33,
+        "status": "9 Project items \u00b7 6 active \u00b7 3 done",
         "title": "RL flywheel",
-        "totalItems": 7,
+        "totalItems": 9,
         "url": "https://github.com/lanyusea/screeps/issues/266"
-      },
-      {
-        "activeItems": 0,
-        "domain": "Docs/process",
-        "doneItems": 15,
-        "goal": "Preserve decisions, rules, and operating context for agent continuity.",
-        "next": "No active item; latest tracked: #38 Done - PR #38 records PR #37 merge checkpoint; merged 202...",
-        "progress": 100,
-        "status": "15 Project items \u00b7 0 active \u00b7 15 done",
-        "title": "Docs/process",
-        "totalItems": 15,
-        "url": "https://github.com/lanyusea/screeps/pull/38"
       }
     ]
   },
@@ -23669,15 +25273,15 @@
         "",
         ""
       ],
-      "matchedFiles": 214,
+      "matchedFiles": 253,
       "reason": "",
-      "runtimeSummaryLines": 214,
-      "scannedFiles": 97685,
-      "skippedFileCount": 2206
+      "runtimeSummaryLines": 253,
+      "scannedFiles": 98044,
+      "skippedFileCount": 2215
     },
     "window": {
       "firstTick": 274256,
-      "latestTick": 364895
+      "latestTick": 368949
     }
   },
   "schemaVersion": 1,

--- a/docs/roadmap-data.json
+++ b/docs/roadmap-data.json
@@ -3,14 +3,14 @@
     "logo": "assets/screeps-community-logo.png"
   },
   "format": "roadmap-portrait-kpi-kanban-v5",
-  "generatedAt": "2026-05-01T14:23:12Z",
-  "generatedAtCst": "2026-05-01 22:23:12 CST",
+  "generatedAt": "2026-05-01T14:58:24Z",
+  "generatedAtCst": "2026-05-01 22:58:24 CST",
   "github": {
     "fetchErrors": [],
     "fetched": true,
     "issues": [
       {
-        "createdAt": "2026-05-01T13:58:51Z",
+        "createdAt": "2026-05-01T14:44:31Z",
         "domain": "Territory/Economy",
         "domainSource": "heuristic",
         "kind": "code",
@@ -21,14 +21,14 @@
           "roadmap:territory-economy"
         ],
         "milestone": "Phase B: Bot capability hardening gate",
-        "number": 449,
+        "number": 452,
         "priority": "P1",
         "state": "OPEN",
         "status": "Ready",
-        "title": "P1 Economy: post-447 worker throughput follow-up",
+        "title": "P1 Economy: post-450 worker throughput follow-up",
         "type": "Issue",
-        "updatedAt": "2026-05-01T14:22:08Z",
-        "url": "https://github.com/lanyusea/screeps/issues/449"
+        "updatedAt": "2026-05-01T14:45:38Z",
+        "url": "https://github.com/lanyusea/screeps/issues/452"
       },
       {
         "createdAt": "2026-05-01T13:03:13Z",
@@ -264,7 +264,7 @@
         "status": "Ready",
         "title": "P1: Phase E: gameplay release cadence and emergency hotfix gate are not enforced",
         "type": "Issue",
-        "updatedAt": "2026-05-01T13:53:19Z",
+        "updatedAt": "2026-05-01T14:44:12Z",
         "url": "https://github.com/lanyusea/screeps/issues/63"
       },
       {
@@ -1900,25 +1900,25 @@
         {
           "domain": "Bot capability",
           "domainSource": "project",
-          "evidence": "Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; controller verification passed; PR added to Project.",
+          "evidence": "",
           "kind": "code",
           "lane": "Bot capability",
           "nextAction": "",
-          "number": 449,
+          "number": 452,
           "priority": "P1",
           "projectDomain": "Bot capability",
           "state": "",
-          "status": "In review",
-          "title": "P1 Economy: post-447 worker throughput follow-up",
+          "status": "In progress",
+          "title": "P1 Economy: post-450 worker throughput follow-up",
           "type": "Issue",
           "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/issues/449",
+          "url": "https://github.com/lanyusea/screeps/issues/452",
           "visionLayer": "territory"
         },
         {
           "domain": "Bot capability",
           "domainSource": "heuristic",
-          "evidence": "2026-05-01 22:02+08 scheduler: PR #448 review-fix commit 219adc2 pushed after controller verification (typecheck/Jest/build/diff-check) and Codex commit-only recovery. CI/CodeRabbit pending for new head 219adc26390d867be709c4c66de75f7cc7ba9f68.",
+          "evidence": "",
           "kind": "code",
           "lane": "",
           "nextAction": "",
@@ -2183,6 +2183,24 @@
           "type": "Issue",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/issues/437",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Bot capability",
+          "domainSource": "project",
+          "evidence": "2026-05-01 22:40+08 scheduler: PR #450 merged as fb4831734bf200e250622440aeb7bb5b227cccd7; official deploy run 25218553175 succeeded for shardX/E26S49; postdeploy healthy owner=lanyusea spawn=1 creeps=5 hostiles=0.",
+          "kind": "code",
+          "lane": "Bot capability",
+          "nextAction": "",
+          "number": 449,
+          "priority": "P1",
+          "projectDomain": "Bot capability",
+          "state": "",
+          "status": "Done",
+          "title": "P1 Economy: post-447 worker throughput follow-up",
+          "type": "Issue",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/issues/449",
           "visionLayer": "territory"
         },
         {
@@ -5931,24 +5949,6 @@
         },
         {
           "domain": "Territory/Economy",
-          "domainSource": "heuristic",
-          "evidence": "PR #450 opened for #449 at 70b0ddc; controller verification passed (typecheck, Jest, build, diff --check); CI/CodeRabbit pending; exact-head QA required.",
-          "kind": "code",
-          "lane": "",
-          "nextAction": "",
-          "number": 450,
-          "priority": "P1",
-          "projectDomain": "",
-          "state": "",
-          "status": "In review",
-          "title": "feat: harden worker body scaling for throughput",
-          "type": "PullRequest",
-          "updatedAt": "",
-          "url": "https://github.com/lanyusea/screeps/pull/450",
-          "visionLayer": "territory"
-        },
-        {
-          "domain": "Territory/Economy",
           "domainSource": "project",
           "evidence": "Done via merged PR #444; merge commit f8fd7a9 after exact-head QA PASS, prod-ci/CodeRabbit green, and GraphQL live threads clear.",
           "kind": "code",
@@ -6723,6 +6723,24 @@
         },
         {
           "domain": "Territory/Economy",
+          "domainSource": "heuristic",
+          "evidence": "2026-05-01 22:40+08 scheduler: PR #450 merged as fb4831734bf200e250622440aeb7bb5b227cccd7; official deploy run 25218553175 succeeded for shardX/E26S49; postdeploy healthy owner=lanyusea spawn=1 creeps=5 hostiles=0.",
+          "kind": "code",
+          "lane": "",
+          "nextAction": "",
+          "number": 450,
+          "priority": "P1",
+          "projectDomain": "",
+          "state": "",
+          "status": "Done",
+          "title": "feat: harden worker body scaling for throughput",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/450",
+          "visionLayer": "territory"
+        },
+        {
+          "domain": "Territory/Economy",
           "domainSource": "project",
           "evidence": "Merged 2026-05-01T12:19:46Z as f8fd7a9 after exact-head QA PASS, prod-ci/CodeRabbit green, GraphQL threads clear.",
           "kind": "code",
@@ -7475,6 +7493,24 @@
           "type": "PullRequest",
           "updatedAt": "",
           "url": "https://github.com/lanyusea/screeps/pull/433",
+          "visionLayer": "foundation blocker"
+        },
+        {
+          "domain": "Docs/process",
+          "domainSource": "project",
+          "evidence": "",
+          "kind": "code",
+          "lane": "Docs/process",
+          "nextAction": "",
+          "number": 451,
+          "priority": "P2",
+          "projectDomain": "Docs/process",
+          "state": "",
+          "status": "In review",
+          "title": "fix: add agent metrics to roadmap report",
+          "type": "PullRequest",
+          "updatedAt": "",
+          "url": "https://github.com/lanyusea/screeps/pull/451",
           "visionLayer": "foundation blocker"
         },
         {
@@ -9187,30 +9223,30 @@
               "status": "Ready"
             },
             {
-              "cards": [],
-              "status": "In progress"
-            },
-            {
               "cards": [
                 {
                   "domain": "Bot capability",
                   "domainSource": "project",
-                  "evidence": "Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; controller verification passed; PR added to Project.",
+                  "evidence": "",
                   "kind": "code",
                   "lane": "Bot capability",
                   "nextAction": "",
-                  "number": 449,
+                  "number": 452,
                   "priority": "P1",
                   "projectDomain": "Bot capability",
                   "state": "",
-                  "status": "In review",
-                  "title": "P1 Economy: post-447 worker throughput follow-up",
+                  "status": "In progress",
+                  "title": "P1 Economy: post-450 worker throughput follow-up",
                   "type": "Issue",
                   "updatedAt": "",
-                  "url": "https://github.com/lanyusea/screeps/issues/449",
+                  "url": "https://github.com/lanyusea/screeps/issues/452",
                   "visionLayer": "territory"
                 }
               ],
+              "status": "In progress"
+            },
+            {
+              "cards": [],
               "status": "In review"
             },
             {
@@ -9465,6 +9501,24 @@
                   "type": "Issue",
                   "updatedAt": "",
                   "url": "https://github.com/lanyusea/screeps/issues/437",
+                  "visionLayer": "territory"
+                },
+                {
+                  "domain": "Bot capability",
+                  "domainSource": "project",
+                  "evidence": "2026-05-01 22:40+08 scheduler: PR #450 merged as fb4831734bf200e250622440aeb7bb5b227cccd7; official deploy run 25218553175 succeeded for shardX/E26S49; postdeploy healthy owner=lanyusea spawn=1 creeps=5 hostiles=0.",
+                  "kind": "code",
+                  "lane": "Bot capability",
+                  "nextAction": "",
+                  "number": 449,
+                  "priority": "P1",
+                  "projectDomain": "Bot capability",
+                  "state": "",
+                  "status": "Done",
+                  "title": "P1 Economy: post-447 worker throughput follow-up",
+                  "type": "Issue",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/issues/449",
                   "visionLayer": "territory"
                 },
                 {
@@ -13037,7 +13091,26 @@
               "status": "In progress"
             },
             {
-              "cards": [],
+              "cards": [
+                {
+                  "domain": "Docs/process",
+                  "domainSource": "project",
+                  "evidence": "",
+                  "kind": "code",
+                  "lane": "Docs/process",
+                  "nextAction": "",
+                  "number": 451,
+                  "priority": "P2",
+                  "projectDomain": "Docs/process",
+                  "state": "",
+                  "status": "In review",
+                  "title": "fix: add agent metrics to roadmap report",
+                  "type": "PullRequest",
+                  "updatedAt": "",
+                  "url": "https://github.com/lanyusea/screeps/pull/451",
+                  "visionLayer": "foundation blocker"
+                }
+              ],
               "status": "In review"
             },
             {
@@ -13392,17 +13465,17 @@
       {
         "instrumented": true,
         "label": "Project cards",
-        "value": 418
+        "value": 420
       },
       {
         "instrumented": true,
         "label": "In progress",
-        "value": 2
+        "value": 3
       },
       {
         "instrumented": true,
         "label": "In review",
-        "value": 4
+        "value": 3
       }
     ],
     "projectItems": [
@@ -14246,7 +14319,7 @@
         "blockedBy": "",
         "domain": "Release/deploy",
         "domainSource": "project",
-        "evidence": "2026-05-01 21:53+08 scheduler: PR #447 merged; official deploy run 25216817698 deployed main fb0d5508 to shardX/E26S49. Sidecars healthy: owner lanyusea, spawn=1, creeps=4, hostiles=0, health ok. Runtime summary/alert jobs manually triggered post-deploy.",
+        "evidence": "2026-05-01 22:41+08 scheduler: PR #450 merged; official deploy run 25218553175 deployed main fb4831734bf200e250622440aeb7bb5b227cccd7 to shardX/E26S49. Sidecars healthy: owner lanyusea, spawn=1, creeps=5, hostiles=0, health ok. Runtime summary/alert jobs manually triggered post-deploy.",
         "kind": "ops",
         "labels": [
           "kind:ops",
@@ -22255,7 +22328,7 @@
         "blockedBy": "",
         "domain": "Bot capability",
         "domainSource": "heuristic",
-        "evidence": "2026-05-01 22:02+08 scheduler: PR #448 review-fix commit 219adc2 pushed after controller verification (typecheck/Jest/build/diff-check) and Codex commit-only recovery. CI/CodeRabbit pending for new head 219adc26390d867be709c4c66de75f7cc7ba9f68.",
+        "evidence": "",
         "kind": "code",
         "labels": [],
         "milestone": "",
@@ -22274,7 +22347,7 @@
         "blockedBy": "",
         "domain": "Bot capability",
         "domainSource": "project",
-        "evidence": "Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; controller verification passed; PR added to Project.",
+        "evidence": "2026-05-01 22:40+08 scheduler: PR #450 merged as fb4831734bf200e250622440aeb7bb5b227cccd7; official deploy run 25218553175 succeeded for shardX/E26S49; postdeploy healthy owner=lanyusea spawn=1 creeps=5 hostiles=0.",
         "kind": "code",
         "labels": [
           "kind:code",
@@ -22288,7 +22361,7 @@
         "priority": "P1",
         "projectDomain": "Bot capability",
         "state": "",
-        "status": "In review",
+        "status": "Done",
         "title": "P1 Economy: post-447 worker throughput follow-up",
         "type": "Issue",
         "updatedAt": "",
@@ -22298,7 +22371,7 @@
         "blockedBy": "",
         "domain": "Territory/Economy",
         "domainSource": "heuristic",
-        "evidence": "PR #450 opened for #449 at 70b0ddc; controller verification passed (typecheck, Jest, build, diff --check); CI/CodeRabbit pending; exact-head QA required.",
+        "evidence": "2026-05-01 22:40+08 scheduler: PR #450 merged as fb4831734bf200e250622440aeb7bb5b227cccd7; official deploy run 25218553175 succeeded for shardX/E26S49; postdeploy healthy owner=lanyusea spawn=1 creeps=5 hostiles=0.",
         "kind": "code",
         "labels": [],
         "milestone": "",
@@ -22307,37 +22380,80 @@
         "priority": "P1",
         "projectDomain": "",
         "state": "",
-        "status": "In review",
+        "status": "Done",
         "title": "feat: harden worker body scaling for throughput",
         "type": "PullRequest",
         "updatedAt": "",
         "url": "https://github.com/lanyusea/screeps/pull/450"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Docs/process",
+        "domainSource": "project",
+        "evidence": "",
+        "kind": "code",
+        "labels": [],
+        "milestone": "",
+        "nextAction": "",
+        "number": 451,
+        "priority": "P2",
+        "projectDomain": "Docs/process",
+        "state": "",
+        "status": "In review",
+        "title": "fix: add agent metrics to roadmap report",
+        "type": "PullRequest",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/pull/451"
+      },
+      {
+        "blockedBy": "",
+        "domain": "Bot capability",
+        "domainSource": "project",
+        "evidence": "",
+        "kind": "code",
+        "labels": [
+          "kind:code",
+          "priority:p1",
+          "roadmap",
+          "roadmap:territory-economy"
+        ],
+        "milestone": "Phase B: Bot capability hardening gate",
+        "nextAction": "",
+        "number": 452,
+        "priority": "P1",
+        "projectDomain": "Bot capability",
+        "state": "",
+        "status": "In progress",
+        "title": "P1 Economy: post-450 worker throughput follow-up",
+        "type": "Issue",
+        "updatedAt": "",
+        "url": "https://github.com/lanyusea/screeps/issues/452"
       }
     ],
     "pullRequests": [
       {
         "checks": {
           "failure": 0,
-          "pending": 1,
-          "success": 1,
+          "pending": 0,
+          "success": 2,
           "total": 2
         },
-        "createdAt": "2026-05-01T14:21:04Z",
-        "domain": "Territory/Economy",
+        "createdAt": "2026-05-01T14:31:45Z",
+        "domain": "Agent OS",
         "domainSource": "heuristic",
         "isDraft": false,
         "kind": "code",
         "labels": [],
         "milestone": "",
-        "number": 450,
+        "number": 451,
         "priority": "P1",
         "reviewDecision": "",
         "state": "OPEN",
         "status": "In review",
-        "title": "feat: harden worker body scaling for throughput",
+        "title": "fix: add agent metrics to roadmap report",
         "type": "PullRequest",
-        "updatedAt": "2026-05-01T14:23:02Z",
-        "url": "https://github.com/lanyusea/screeps/pull/450"
+        "updatedAt": "2026-05-01T14:51:58Z",
+        "url": "https://github.com/lanyusea/screeps/pull/451"
       },
       {
         "checks": {
@@ -22360,7 +22476,7 @@
         "status": "In review",
         "title": "feat: add controller pressure spawn follow-up",
         "type": "PullRequest",
-        "updatedAt": "2026-05-01T14:23:21Z",
+        "updatedAt": "2026-05-01T14:52:58Z",
         "url": "https://github.com/lanyusea/screeps/pull/448"
       }
     ],
@@ -23001,7 +23117,7 @@
             "categoryLabel": "Guardrails / Reliability",
             "description": "Runtime-summary lines found by the persisted artifact feeder.",
             "details": {},
-            "formattedValue": "253",
+            "formattedValue": "259",
             "instrumented": true,
             "key": "runtime_summary_samples",
             "label": "Runtime summary samples",
@@ -23012,14 +23128,14 @@
             "source": "runtime KPI artifact bridge",
             "status": "observed",
             "unit": "samples",
-            "value": 253
+            "value": 259
           },
           {
             "category": "guardrails",
             "categoryLabel": "Guardrails / Reliability",
             "description": "Files matched by the persisted artifact feeder.",
             "details": {},
-            "formattedValue": "253",
+            "formattedValue": "259",
             "instrumented": true,
             "key": "kpi_artifact_files",
             "label": "KPI artifact files",
@@ -23030,7 +23146,7 @@
             "source": "runtime KPI artifact bridge",
             "status": "observed",
             "unit": "files",
-            "value": 253
+            "value": 259
           },
           {
             "category": "guardrails",
@@ -23230,14 +23346,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -23274,14 +23383,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -23318,14 +23420,7 @@
         {
           "instrumented": true,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not observed",
-          "value": null
-        },
-        {
-          "instrumented": true,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not observed",
           "value": null
         }
@@ -23362,14 +23457,7 @@
         {
           "instrumented": true,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not observed",
-          "value": null
-        },
-        {
-          "instrumented": true,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not observed",
           "value": null
         }
@@ -23406,14 +23494,7 @@
         {
           "instrumented": true,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not observed",
-          "value": null
-        },
-        {
-          "instrumented": true,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not observed",
           "value": null
         }
@@ -23450,14 +23531,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 2.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 2.0
         }
@@ -23494,14 +23568,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": -83866.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": -83866.0
         }
@@ -23538,14 +23605,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -23582,14 +23642,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -23626,14 +23679,7 @@
         {
           "instrumented": true,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not observed",
-          "value": null
-        },
-        {
-          "instrumented": true,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not observed",
           "value": null
         }
@@ -23670,14 +23716,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 0.0
         }
@@ -23714,14 +23753,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -23758,14 +23790,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -23802,14 +23827,7 @@
         {
           "instrumented": true,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not observed",
-          "value": null
-        },
-        {
-          "instrumented": true,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not observed",
           "value": null
         }
@@ -23846,14 +23864,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 0.0
         }
@@ -23890,14 +23901,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 0.0
         }
@@ -23934,16 +23938,9 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
-          "value": 253.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
-          "status": "observed",
-          "value": 253.0
+          "value": 259.0
         }
       ],
       "objects_destroyed": [
@@ -23978,14 +23975,7 @@
         {
           "instrumented": true,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not observed",
-          "value": null
-        },
-        {
-          "instrumented": true,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not observed",
           "value": null
         }
@@ -24022,14 +24012,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -24066,14 +24049,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 0.0
         }
@@ -24110,14 +24086,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 1.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 1.0
         }
@@ -24154,14 +24123,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -24198,14 +24160,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -24242,16 +24197,9 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
-          "value": 253.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
-          "status": "observed",
-          "value": 253.0
+          "value": 259.0
         }
       ],
       "source_count": [
@@ -24286,14 +24234,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 2.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 2.0
         }
@@ -24330,14 +24271,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -24374,14 +24308,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -24418,14 +24345,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 0.0
         }
@@ -24462,14 +24382,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 0.0
         }
@@ -24506,14 +24419,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -24550,14 +24456,7 @@
         {
           "instrumented": true,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not observed",
-          "value": null
-        },
-        {
-          "instrumented": true,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not observed",
           "value": null
         }
@@ -24594,14 +24493,7 @@
         {
           "instrumented": true,
           "observed": true,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "observed",
-          "value": 0.0
-        },
-        {
-          "instrumented": true,
-          "observed": true,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "observed",
           "value": 0.0
         }
@@ -24638,14 +24530,7 @@
         {
           "instrumented": false,
           "observed": false,
-          "sampledAt": "2026-05-01T14:20:44Z",
-          "status": "not instrumented",
-          "value": null
-        },
-        {
-          "instrumented": false,
-          "observed": false,
-          "sampledAt": "2026-05-01T14:23:12Z",
+          "sampledAt": "2026-05-01T14:58:24Z",
           "status": "not instrumented",
           "value": null
         }
@@ -24732,13 +24617,13 @@
       {
         "items": [
           {
-            "description": "In review \u00b7 Bot capability \u00b7 Recovered #449 dirty Codex implementation into commit 70b0ddc and PR #450; contr...",
+            "description": "In progress \u00b7 Bot capability \u00b7 Bot capability",
             "domain": "Bot capability",
-            "number": 449,
+            "number": 452,
             "priority": "P1",
-            "status": "In review",
-            "title": "#449 P1 Economy: post-447 worker throughput follow-up",
-            "url": "https://github.com/lanyusea/screeps/issues/449"
+            "status": "In progress",
+            "title": "#452 P1 Economy: post-450 worker throughput follow-up",
+            "url": "https://github.com/lanyusea/screeps/issues/452"
           }
         ],
         "title": "Bot capability"
@@ -24817,7 +24702,17 @@
         "title": "RL flywheel"
       },
       {
-        "items": [],
+        "items": [
+          {
+            "description": "In review \u00b7 Docs/process \u00b7 Docs/process",
+            "domain": "Docs/process",
+            "number": 451,
+            "priority": "P2",
+            "status": "In review",
+            "title": "#451 fix: add agent metrics to roadmap report",
+            "url": "https://github.com/lanyusea/screeps/pull/451"
+          }
+        ],
         "title": "Docs/process"
       }
     ],
@@ -25118,35 +25013,35 @@
     "processCards": [
       {
         "delta": "+0",
-        "detail": "1,517,772,656 total; latest token_count in 1,028/1,029 sessions",
+        "detail": "1,523,589,512 total; latest token_count in 1,032/1,033 sessions",
         "label": "Agent tokens",
-        "rawValue": 1517772656,
-        "source": ".codex/sessions/**/rollout-*.jsonl",
+        "rawValue": 1523589512,
+        "source": "repo-attributed .codex/sessions/**/rollout-*.jsonl",
         "value": "1.5B"
       },
       {
         "delta": "+0",
-        "detail": "summed first-to-last JSONL timestamps across 1,029/1,029 sessions",
+        "detail": "summed first-to-last JSONL timestamps across 1,033/1,033 sessions",
         "label": "Codex runtime",
-        "rawValueSeconds": 276252,
-        "source": ".codex/sessions/**/rollout-*.jsonl timestamps",
-        "value": "3d 4h"
+        "rawValueSeconds": 277282,
+        "source": "repo-attributed .codex/sessions/**/rollout-*.jsonl timestamps",
+        "value": "3d 5h"
       },
       {
         "delta": "+0",
         "detail": "rollout JSONL files counted as Codex runs",
         "label": "Codex runs",
-        "rawValue": 1029,
-        "source": ".codex/sessions/**/rollout-*.jsonl",
-        "value": "1,029"
+        "rawValue": 1033,
+        "source": "repo-attributed .codex/sessions/**/rollout-*.jsonl",
+        "value": "1,033"
       },
       {
         "delta": "+0",
-        "detail": "2,340 cron outputs across 36 jobs",
+        "detail": "2,341 cron outputs across 29 jobs",
         "label": "Automation runs",
-        "rawValue": 2340,
-        "source": ".hermes/cron/output/*/*.md",
-        "value": "2,340"
+        "rawValue": 2341,
+        "source": "repo-attributed .hermes/cron/output/*/*.md",
+        "value": "2,341"
       },
       {
         "delta": "+0",
@@ -25208,14 +25103,14 @@
       {
         "activeItems": 1,
         "domain": "Bot capability",
-        "doneItems": 185,
+        "doneItems": 186,
         "goal": "Ship general gameplay behavior that advances the bot beyond single-slice fixes.",
-        "next": "Current: #449 In review - Recovered #449 dirty Codex implementation into commit 70b0ddc and P...",
+        "next": "Current: #452 In progress - P1 Economy: post-450 worker throughput follow-up",
         "progress": 99,
-        "status": "186 Project items \u00b7 1 active \u00b7 185 done",
+        "status": "187 Project items \u00b7 1 active \u00b7 186 done",
         "title": "Bot capability",
-        "totalItems": 186,
-        "url": "https://github.com/lanyusea/screeps/issues/449"
+        "totalItems": 187,
+        "url": "https://github.com/lanyusea/screeps/issues/452"
       },
       {
         "activeItems": 1,
@@ -25273,11 +25168,11 @@
         "",
         ""
       ],
-      "matchedFiles": 253,
+      "matchedFiles": 259,
       "reason": "",
-      "runtimeSummaryLines": 253,
-      "scannedFiles": 98044,
-      "skippedFileCount": 2215
+      "runtimeSummaryLines": 259,
+      "scannedFiles": 98095,
+      "skippedFileCount": 2217
     },
     "window": {
       "firstTick": 274256,

--- a/scripts/check-roadmap-renderer.js
+++ b/scripts/check-roadmap-renderer.js
@@ -23,6 +23,7 @@ const EXPECTED_PROJECT_DOMAINS = [
   'RL flywheel',
   'Docs/process'
 ];
+const EXPECTED_ROADMAP_DOMAINS = EXPECTED_PROJECT_DOMAINS.filter(domain => domain !== 'Docs/process');
 
 function fail(message) {
   failures.push(message);
@@ -177,7 +178,7 @@ function assertNoOldVisibleFallbacks(text) {
 function assertDomainClassification(report, text) {
   const roadmapTitles = (report.roadmapCards || []).map(card => String(card.title || ''));
   assert(
-    JSON.stringify(roadmapTitles) === JSON.stringify(EXPECTED_PROJECT_DOMAINS),
+    JSON.stringify(roadmapTitles) === JSON.stringify(EXPECTED_ROADMAP_DOMAINS),
     `roadmap cards should be current Project Domain categories; saw ${JSON.stringify(roadmapTitles)}`
   );
 
@@ -192,6 +193,15 @@ function assertDomainClassification(report, text) {
   for (const domain of EXPECTED_PROJECT_DOMAINS) {
     assert(text.includes(domain), `visible report is missing Project Domain category: ${domain}`);
   }
+}
+
+function assertProjectDomainSectionSplit(body) {
+  const roadmapSection = findSectionByHeading(body, '02 Project Domains');
+  const kanbanSection = findSectionByHeading(body, '03 Project Domain Board');
+  assert(Boolean(roadmapSection), 'Project Domains section is missing');
+  assert(Boolean(kanbanSection), 'Project Domain Board section is missing');
+  assert(!tagText(roadmapSection).includes('Docs/process'), 'Project Domains section should exclude Docs/process');
+  assert(tagText(kanbanSection).includes('Docs/process'), 'Project Domain Board should include Docs/process');
 }
 
 function assertKpiCardsMatchPagesData(body, text, cards) {
@@ -337,6 +347,7 @@ if (fs.existsSync(htmlPath)) {
   assertDomainKanbanFiveColumnCss(html);
   assertKpiCardsMatchPagesData(body, text, report.kpiCards || []);
   assertDomainClassification(report, text);
+  assertProjectDomainSectionSplit(body);
   assertRoadmapCardsMatchPagesData(body, report.roadmapCards || []);
   assertKanbanMatchesPagesData(body, report.domainKanban || [], '03 Project Domain Board');
   assertProcessCardsMatchPagesData(body, report.processCards || []);

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -136,6 +136,12 @@ class AutomationRunMetrics:
     available: bool
 
 
+@dataclass(frozen=True)
+class RepoAttribution:
+    path_roots: tuple[Path, ...]
+    text_terms: tuple[str, ...]
+
+
 METRIC_SPECS: tuple[MetricSpec, ...] = (
     MetricSpec(
         "owned_rooms",
@@ -2471,7 +2477,7 @@ def build_report_process_cards(
         official_deploy_source = "unavailable"
 
     return [
-        *build_agent_process_cards(cached_process_cards),
+        *build_agent_process_cards(repo_root, repo, cached_process_cards),
         {
             "value": official_deploy_value,
             "label": "Official deploys",
@@ -2482,27 +2488,32 @@ def build_report_process_cards(
     ]
 
 
-def build_agent_process_cards(cached_process_cards: Sequence[JsonObject]) -> list[JsonObject]:
-    codex_metrics = summarize_codex_sessions(CODEX_SESSION_ROOT)
-    automation_metrics = summarize_automation_runs(HERMES_CRON_OUTPUT_ROOT)
+def build_agent_process_cards(
+    repo_root: Path,
+    repo: JsonObject,
+    cached_process_cards: Sequence[JsonObject],
+) -> list[JsonObject]:
+    attribution = build_repo_attribution(repo_root, repo)
+    codex_metrics = summarize_codex_sessions(CODEX_SESSION_ROOT, attribution)
+    automation_metrics = summarize_automation_runs(HERMES_CRON_OUTPUT_ROOT, attribution)
 
     if codex_metrics.session_count == 0:
         token_card = cached_or_unavailable_process_card(
             cached_process_cards,
             "Agent tokens",
-            "no local Codex rollout JSONL files found",
+            "no repo-attributed local Codex rollout JSONL files found",
             "unavailable",
         )
         runtime_card = cached_or_unavailable_process_card(
             cached_process_cards,
             "Codex runtime",
-            "no local Codex rollout JSONL files found",
+            "no repo-attributed local Codex rollout JSONL files found",
             "unavailable",
         )
         runs_card = cached_or_unavailable_process_card(
             cached_process_cards,
             "Codex runs",
-            "no local Codex rollout JSONL files found",
+            "no repo-attributed local Codex rollout JSONL files found",
             "unavailable",
         )
     else:
@@ -2532,7 +2543,7 @@ def build_agent_process_cards(cached_process_cards: Sequence[JsonObject]) -> lis
             "label": "Agent tokens",
             "detail": token_detail,
             "delta": "+0",
-            "source": ".codex/sessions/**/rollout-*.jsonl",
+            "source": "repo-attributed .codex/sessions/**/rollout-*.jsonl",
         }
         runtime_card = {
             "value": runtime_value,
@@ -2540,7 +2551,7 @@ def build_agent_process_cards(cached_process_cards: Sequence[JsonObject]) -> lis
             "label": "Codex runtime",
             "detail": runtime_detail,
             "delta": "+0",
-            "source": ".codex/sessions/**/rollout-*.jsonl timestamps",
+            "source": "repo-attributed .codex/sessions/**/rollout-*.jsonl timestamps",
         }
         runs_card = {
             "value": format_compact_count(codex_metrics.session_count),
@@ -2548,7 +2559,7 @@ def build_agent_process_cards(cached_process_cards: Sequence[JsonObject]) -> lis
             "label": "Codex runs",
             "detail": "rollout JSONL files counted as Codex runs",
             "delta": "+0",
-            "source": ".codex/sessions/**/rollout-*.jsonl",
+            "source": "repo-attributed .codex/sessions/**/rollout-*.jsonl",
         }
 
     if automation_metrics.available:
@@ -2561,13 +2572,13 @@ def build_agent_process_cards(cached_process_cards: Sequence[JsonObject]) -> lis
                 f"{automation_metrics.job_count:,} jobs"
             ),
             "delta": "+0",
-            "source": ".hermes/cron/output/*/*.md",
+            "source": "repo-attributed .hermes/cron/output/*/*.md",
         }
     else:
         automation_card = cached_or_unavailable_process_card(
             cached_process_cards,
             "Automation runs",
-            "no local Hermes cron markdown outputs found",
+            "no repo-attributed local Hermes cron markdown outputs found",
             "unavailable",
         )
 
@@ -2605,10 +2616,14 @@ def process_cached_detail(cached_card: JsonObject, fallback: str) -> str:
     return f"{cached_detail} · cached"
 
 
-def summarize_codex_sessions(session_root: Path) -> CodexSessionMetrics:
+def summarize_codex_sessions(
+    session_root: Path,
+    attribution: RepoAttribution | None = None,
+) -> CodexSessionMetrics:
     if not session_root.exists():
         return CodexSessionMetrics(0, 0, 0, None, None, 0)
 
+    attribution = attribution or build_repo_attribution(None, None)
     session_count = 0
     token_session_count = 0
     timed_session_count = 0
@@ -2617,6 +2632,8 @@ def summarize_codex_sessions(session_root: Path) -> CodexSessionMetrics:
     elapsed_seconds = 0
     for path in sorted(session_root.glob(f"**/{CODEX_SESSION_PATTERN}")):
         if not path.is_file():
+            continue
+        if not codex_session_is_repo_attributed(path, attribution):
             continue
         session_count += 1
         session = summarize_codex_session_file(path)
@@ -2646,7 +2663,7 @@ def summarize_codex_session_file(path: Path) -> tuple[int | None, int | None] | 
     last_seen: datetime | None = None
     latest_tokens: int | None = None
     try:
-        with path.open("r", encoding="utf-8") as handle:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
             for line in handle:
                 try:
                     record = json.loads(line)
@@ -2683,12 +2700,155 @@ def codex_token_count_from_record(record: Mapping[str, Any]) -> int | None:
     return int(number)
 
 
-def summarize_automation_runs(output_root: Path) -> AutomationRunMetrics:
+def summarize_automation_runs(
+    output_root: Path,
+    attribution: RepoAttribution | None = None,
+) -> AutomationRunMetrics:
     if not output_root.exists():
         return AutomationRunMetrics(0, 0, False)
-    paths = [path for path in output_root.glob("*/*.md") if path.is_file()]
+    attribution = attribution or build_repo_attribution(None, None)
+    paths = []
+    for path in output_root.glob("*/*.md"):
+        if not path.is_file():
+            continue
+        if not text_file_mentions_any(path, attribution.text_terms):
+            continue
+        paths.append(path)
     job_count = len({path.parent for path in paths})
     return AutomationRunMetrics(len(paths), job_count, bool(paths))
+
+
+def build_repo_attribution(repo_root: Path | None, repo: Mapping[str, Any] | None) -> RepoAttribution:
+    path_roots: list[Path] = []
+    text_terms: list[str] = []
+    repo_name = ""
+
+    if repo_root is not None:
+        append_attribution_path(path_roots, text_terms, repo_root)
+    if repo is not None:
+        full_name = str(repo.get("fullName") or "").strip().lower()
+        if full_name:
+            text_terms.extend([full_name, f"github.com/{full_name}"])
+            repo_name = full_name.rsplit("/", 1)[-1]
+        url = str(repo.get("url") or "").strip().lower()
+        if url:
+            text_terms.append(url.removesuffix(".git"))
+
+    if repo_name:
+        append_attribution_path(path_roots, text_terms, Path("/root") / repo_name)
+        append_attribution_path(path_roots, text_terms, Path("/root") / f"{repo_name}-worktrees")
+        append_attribution_path(path_roots, text_terms, Path("/root/worktrees") / repo_name)
+
+    return RepoAttribution(
+        path_roots=tuple(dedupe_paths(path_roots)),
+        text_terms=tuple(dedupe_strings(text_terms)),
+    )
+
+
+def append_attribution_path(path_roots: list[Path], text_terms: list[str], path: Path) -> None:
+    resolved = resolve_path_for_attribution(path)
+    path_roots.append(resolved)
+    text_terms.append(str(resolved).lower())
+
+
+def dedupe_paths(paths: Sequence[Path]) -> list[Path]:
+    deduped: list[Path] = []
+    for path in paths:
+        if path not in deduped:
+            deduped.append(path)
+    return deduped
+
+
+def dedupe_strings(terms: Sequence[str]) -> list[str]:
+    deduped: list[str] = []
+    for term in terms:
+        normalized = term.strip().lower()
+        if normalized and normalized not in deduped:
+            deduped.append(normalized)
+    return deduped
+
+
+def codex_session_is_repo_attributed(path: Path, attribution: RepoAttribution) -> bool:
+    if not attribution.path_roots and not attribution.text_terms:
+        return False
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, Mapping):
+                    continue
+                if codex_record_is_repo_attributed(record, attribution):
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def codex_record_is_repo_attributed(record: Mapping[str, Any], attribution: RepoAttribution) -> bool:
+    payload = record.get("payload")
+    payload_mapping = payload if isinstance(payload, Mapping) else {}
+    for container in (record, payload_mapping):
+        for key in ("cwd", "workdir", "repoRoot", "repo_root"):
+            value = container.get(key)
+            if isinstance(value, str) and path_text_matches_attribution(value, attribution.path_roots):
+                return True
+        git = container.get("git")
+        if isinstance(git, Mapping):
+            for key in ("repository_url", "repositoryUrl", "remote", "url"):
+                value = git.get(key)
+                if isinstance(value, str) and text_matches_attribution(value, attribution.text_terms):
+                    return True
+    return False
+
+
+def path_text_matches_attribution(value: str, roots: Sequence[Path]) -> bool:
+    if not value.strip():
+        return False
+    try:
+        candidate = resolve_path_for_attribution(Path(value).expanduser())
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return any(path_is_relative_to(candidate, root) for root in roots)
+
+
+def resolve_path_for_attribution(path: Path) -> Path:
+    try:
+        return path.expanduser().resolve()
+    except OSError:
+        return path.expanduser().absolute()
+
+
+def path_is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def text_matches_attribution(value: str, terms: Sequence[str]) -> bool:
+    text = value.strip().lower().removesuffix(".git")
+    for term in terms:
+        candidate = term.strip().lower().removesuffix(".git")
+        if not candidate:
+            continue
+        pattern = rf"(?<![a-z0-9_.-]){re.escape(candidate)}(?![a-z0-9_.-])"
+        if re.search(pattern, text):
+            return True
+    return False
+
+
+def text_file_mentions_any(path: Path, terms: Sequence[str], *, max_bytes: int = 2_000_000) -> bool:
+    if not terms:
+        return False
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")[:max_bytes].lower()
+    except OSError:
+        return False
+    return text_matches_attribution(text, terms)
 
 
 def format_compact_count(value: int | float) -> str:

--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -119,6 +119,23 @@ class OfficialDeployEvidenceSummary:
     latest: OfficialDeployEvidenceRecord | None = None
 
 
+@dataclass(frozen=True)
+class CodexSessionMetrics:
+    session_count: int
+    token_session_count: int
+    timed_session_count: int
+    total_tokens: int | None
+    elapsed_seconds: int | None
+    unreadable_count: int
+
+
+@dataclass(frozen=True)
+class AutomationRunMetrics:
+    run_count: int
+    job_count: int
+    available: bool
+
+
 METRIC_SPECS: tuple[MetricSpec, ...] = (
     MetricSpec(
         "owned_rooms",
@@ -487,6 +504,10 @@ PROJECT_DOMAIN_ORDER: tuple[str, ...] = (
     "Docs/process",
 )
 
+REPORT_ROADMAP_DOMAIN_ORDER: tuple[str, ...] = tuple(
+    domain for domain in PROJECT_DOMAIN_ORDER if domain != "Docs/process"
+)
+
 PROJECT_DOMAIN_FIELD_KEYS: tuple[str, ...] = (
     "Project Domain",
     "projectDomain",
@@ -516,6 +537,9 @@ OFFICIAL_DEPLOY_EVIDENCE_PATTERNS: tuple[str, ...] = (
     "official-screeps-deploy.json",
     "official-screeps-deploy-*.json",
 )
+CODEX_SESSION_ROOT = Path("/root/.codex/sessions")
+CODEX_SESSION_PATTERN = "rollout-*.jsonl"
+HERMES_CRON_OUTPUT_ROOT = Path("/root/.hermes/cron/output")
 
 KPI_DATES: tuple[str, ...] = ("4/21", "4/22", "4/23", "4/24", "4/25", "4/26", "4/27")
 
@@ -2105,11 +2129,11 @@ def build_report_roadmap_cards(github_snapshot: JsonObject, repo: JsonObject) ->
             [item for item in items if project_domain(item) == domain],
             key=domain_item_sort_key,
         )
-        for domain in PROJECT_DOMAIN_ORDER
+        for domain in REPORT_ROADMAP_DOMAIN_ORDER
     }
     return [
         build_report_domain_card(domain, items_by_domain[domain], repo, github_snapshot)
-        for domain in PROJECT_DOMAIN_ORDER
+        for domain in REPORT_ROADMAP_DOMAIN_ORDER
     ]
 
 
@@ -2431,28 +2455,7 @@ def build_report_process_cards(
     github_snapshot: JsonObject,
     cached_page_data: JsonObject,
 ) -> list[JsonObject]:
-    commit_count = parse_count(run_text(["git", "rev-list", "--count", "HEAD"], repo_root))
-    prs, pr_error = fetch_all_prs(repo_root, str(repo["fullName"]))
-    issues, issue_error = fetch_all_issues(repo_root, str(repo["fullName"]))
     cached_process_cards = cached_report_process_cards(cached_page_data)
-    cached_pr_card = cached_process_card(cached_process_cards, "Total PRs", "\u603b PR \u6570")
-    cached_issue_card = cached_process_card(cached_process_cards, "Total issues", "\u603b issue \u6570")
-    total_prs: int | str = len(prs) if pr_error is None else INSUFFICIENT_EVIDENCE
-    merged_prs: int | str = (
-        sum(1 for item in prs if str(item.get("state") or "").upper() == "MERGED")
-        if pr_error is None
-        else INSUFFICIENT_EVIDENCE
-    )
-    if pr_error is not None and cached_pr_card:
-        total_prs = cached_pr_card.get("value", INSUFFICIENT_EVIDENCE)
-    total_issues: int | str = len(issues) if issue_error is None else INSUFFICIENT_EVIDENCE
-    open_issues: int | str = (
-        sum(1 for item in issues if str(item.get("state") or "").upper() == "OPEN")
-        if issue_error is None
-        else INSUFFICIENT_EVIDENCE
-    )
-    if issue_error is not None and cached_issue_card:
-        total_issues = cached_issue_card.get("value", INSUFFICIENT_EVIDENCE)
     official_deploy_summary = summarize_official_deploy_evidence(repo_root)
     official_deploy_project_count = count_official_deploy_evidence(repo_root, github_snapshot)
     official_deploy_count = max(official_deploy_summary.count, official_deploy_project_count)
@@ -2466,34 +2469,9 @@ def build_report_process_cards(
     else:
         official_deploy_detail = "evidence unavailable"
         official_deploy_source = "unavailable"
-    private_smoke_count = count_private_smoke_process_reports(repo_root)
 
     return [
-        {"value": commit_count, "label": "Total commits", "detail": "repository history", "delta": "+1"},
-        {
-            "value": total_prs,
-            "label": "Total PRs",
-            "detail": process_detail(
-                pr_error,
-                "gh pr list",
-                f"{merged_prs} merged",
-                cached_pr_card,
-            ),
-            "delta": "+1" if pr_error is None else cached_pr_card.get("delta", "cached") if cached_pr_card else "n/a",
-            "source": "github" if pr_error is None else "cached" if cached_pr_card else "unavailable",
-        },
-        {
-            "value": total_issues,
-            "label": "Total issues",
-            "detail": process_detail(
-                issue_error,
-                "gh issue list",
-                f"{open_issues} open",
-                cached_issue_card,
-            ),
-            "delta": "+0" if issue_error is None else cached_issue_card.get("delta", "cached") if cached_issue_card else "n/a",
-            "source": "github" if issue_error is None else "cached" if cached_issue_card else "unavailable",
-        },
+        *build_agent_process_cards(cached_process_cards),
         {
             "value": official_deploy_value,
             "label": "Official deploys",
@@ -2501,14 +2479,245 @@ def build_report_process_cards(
             "delta": "+0",
             "source": official_deploy_source,
         },
-        {
-            "value": private_smoke_count,
-            "label": "Private smoke tests",
-            "detail": "smoke/report evidence",
-            "delta": "+0",
-            "source": "approved process report count",
-        },
     ]
+
+
+def build_agent_process_cards(cached_process_cards: Sequence[JsonObject]) -> list[JsonObject]:
+    codex_metrics = summarize_codex_sessions(CODEX_SESSION_ROOT)
+    automation_metrics = summarize_automation_runs(HERMES_CRON_OUTPUT_ROOT)
+
+    if codex_metrics.session_count == 0:
+        token_card = cached_or_unavailable_process_card(
+            cached_process_cards,
+            "Agent tokens",
+            "no local Codex rollout JSONL files found",
+            "unavailable",
+        )
+        runtime_card = cached_or_unavailable_process_card(
+            cached_process_cards,
+            "Codex runtime",
+            "no local Codex rollout JSONL files found",
+            "unavailable",
+        )
+        runs_card = cached_or_unavailable_process_card(
+            cached_process_cards,
+            "Codex runs",
+            "no local Codex rollout JSONL files found",
+            "unavailable",
+        )
+    else:
+        token_value: str = "unavailable"
+        token_detail = f"0/{codex_metrics.session_count:,} sessions exposed token_count totals"
+        if codex_metrics.total_tokens is not None:
+            token_value = format_compact_count(codex_metrics.total_tokens)
+            token_detail = (
+                f"{format_integer(codex_metrics.total_tokens)} total; "
+                f"latest token_count in {codex_metrics.token_session_count:,}/{codex_metrics.session_count:,} sessions"
+            )
+        if codex_metrics.unreadable_count:
+            token_detail = f"{token_detail}; {codex_metrics.unreadable_count:,} unreadable"
+
+        runtime_value: str = "unavailable"
+        runtime_detail = f"0/{codex_metrics.session_count:,} sessions exposed timestamps"
+        if codex_metrics.elapsed_seconds is not None:
+            runtime_value = format_duration(codex_metrics.elapsed_seconds)
+            runtime_detail = (
+                "summed first-to-last JSONL timestamps across "
+                f"{codex_metrics.timed_session_count:,}/{codex_metrics.session_count:,} sessions"
+            )
+
+        token_card = {
+            "value": token_value,
+            "rawValue": codex_metrics.total_tokens,
+            "label": "Agent tokens",
+            "detail": token_detail,
+            "delta": "+0",
+            "source": ".codex/sessions/**/rollout-*.jsonl",
+        }
+        runtime_card = {
+            "value": runtime_value,
+            "rawValueSeconds": codex_metrics.elapsed_seconds,
+            "label": "Codex runtime",
+            "detail": runtime_detail,
+            "delta": "+0",
+            "source": ".codex/sessions/**/rollout-*.jsonl timestamps",
+        }
+        runs_card = {
+            "value": format_compact_count(codex_metrics.session_count),
+            "rawValue": codex_metrics.session_count,
+            "label": "Codex runs",
+            "detail": "rollout JSONL files counted as Codex runs",
+            "delta": "+0",
+            "source": ".codex/sessions/**/rollout-*.jsonl",
+        }
+
+    if automation_metrics.available:
+        automation_card = {
+            "value": format_compact_count(automation_metrics.run_count),
+            "rawValue": automation_metrics.run_count,
+            "label": "Automation runs",
+            "detail": (
+                f"{automation_metrics.run_count:,} cron outputs across "
+                f"{automation_metrics.job_count:,} jobs"
+            ),
+            "delta": "+0",
+            "source": ".hermes/cron/output/*/*.md",
+        }
+    else:
+        automation_card = cached_or_unavailable_process_card(
+            cached_process_cards,
+            "Automation runs",
+            "no local Hermes cron markdown outputs found",
+            "unavailable",
+        )
+
+    return [token_card, runtime_card, runs_card, automation_card]
+
+
+def cached_or_unavailable_process_card(
+    cached_process_cards: Sequence[JsonObject],
+    label: str,
+    detail: str,
+    source: str,
+) -> JsonObject:
+    cached_card = cached_process_card(cached_process_cards, label)
+    if cached_card:
+        return {
+            **cached_card,
+            "detail": process_cached_detail(cached_card, detail),
+            "source": "cached",
+            "delta": cached_card.get("delta", "cached"),
+        }
+    return {
+        "value": "unavailable",
+        "label": label,
+        "detail": detail,
+        "delta": "n/a",
+        "source": source,
+    }
+
+
+def process_cached_detail(cached_card: JsonObject, fallback: str) -> str:
+    cached_detail = str(cached_card.get("detail") or "").strip()
+    if not cached_detail:
+        cached_detail = fallback
+    cached_detail = CACHED_SUFFIX_RE.sub("", cached_detail).strip()
+    return f"{cached_detail} · cached"
+
+
+def summarize_codex_sessions(session_root: Path) -> CodexSessionMetrics:
+    if not session_root.exists():
+        return CodexSessionMetrics(0, 0, 0, None, None, 0)
+
+    session_count = 0
+    token_session_count = 0
+    timed_session_count = 0
+    unreadable_count = 0
+    total_tokens = 0
+    elapsed_seconds = 0
+    for path in sorted(session_root.glob(f"**/{CODEX_SESSION_PATTERN}")):
+        if not path.is_file():
+            continue
+        session_count += 1
+        session = summarize_codex_session_file(path)
+        if session is None:
+            unreadable_count += 1
+            continue
+        latest_tokens, elapsed = session
+        if latest_tokens is not None:
+            token_session_count += 1
+            total_tokens += latest_tokens
+        if elapsed is not None:
+            timed_session_count += 1
+            elapsed_seconds += elapsed
+
+    return CodexSessionMetrics(
+        session_count=session_count,
+        token_session_count=token_session_count,
+        timed_session_count=timed_session_count,
+        total_tokens=total_tokens if token_session_count else None,
+        elapsed_seconds=elapsed_seconds if timed_session_count else None,
+        unreadable_count=unreadable_count,
+    )
+
+
+def summarize_codex_session_file(path: Path) -> tuple[int | None, int | None] | None:
+    first_seen: datetime | None = None
+    last_seen: datetime | None = None
+    latest_tokens: int | None = None
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                timestamp = parse_timestamp(str(record.get("timestamp") or ""))
+                if timestamp is not None:
+                    first_seen = timestamp if first_seen is None else min(first_seen, timestamp)
+                    last_seen = timestamp if last_seen is None else max(last_seen, timestamp)
+                token_count = codex_token_count_from_record(record)
+                if token_count is not None:
+                    latest_tokens = token_count
+    except OSError:
+        return None
+
+    elapsed: int | None = None
+    if first_seen is not None and last_seen is not None:
+        elapsed = max(0, int((last_seen - first_seen).total_seconds()))
+    return latest_tokens, elapsed
+
+
+def codex_token_count_from_record(record: Mapping[str, Any]) -> int | None:
+    if record.get("type") != "event_msg":
+        return None
+    payload = record.get("payload")
+    if not isinstance(payload, Mapping) or payload.get("type") != "token_count":
+        return None
+    total = get_path(payload, ("info", "total_token_usage", "total_tokens"))
+    number = as_number(total)
+    if number is None:
+        return None
+    return int(number)
+
+
+def summarize_automation_runs(output_root: Path) -> AutomationRunMetrics:
+    if not output_root.exists():
+        return AutomationRunMetrics(0, 0, False)
+    paths = [path for path in output_root.glob("*/*.md") if path.is_file()]
+    job_count = len({path.parent for path in paths})
+    return AutomationRunMetrics(len(paths), job_count, bool(paths))
+
+
+def format_compact_count(value: int | float) -> str:
+    number = float(value)
+    abs_value = abs(number)
+    for threshold, suffix in ((1_000_000_000, "B"), (1_000_000, "M")):
+        if abs_value >= threshold:
+            compact = number / threshold
+            decimals = 0 if abs(compact) >= 100 or compact.is_integer() else 1
+            return f"{compact:.{decimals}f}{suffix}"
+    return format_integer(int(number))
+
+
+def format_integer(value: int | float) -> str:
+    return f"{int(value):,}"
+
+
+def format_duration(seconds: int | float) -> str:
+    remaining = max(0, int(seconds))
+    days, remaining = divmod(remaining, 86_400)
+    hours, remaining = divmod(remaining, 3_600)
+    minutes, _ = divmod(remaining, 60)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m"
+    return f"{remaining}s"
 
 
 def cached_report_process_cards(cached_page_data: JsonObject) -> list[JsonObject]:
@@ -4280,7 +4489,7 @@ def render_report_process(data: JsonObject) -> str:
     cards = "\n".join(render_process_card(card) for card in data["report"]["processCards"])
     return f"""
       <section class="section" id="process">
-        <h2 class="section-title">04 Development Process Data</h2>
+        <h2 class="section-title">04 Delivery Metrics</h2>
         <div class="process-grid">
           {cards}
         </div>

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -60,6 +60,22 @@ def write_evidence(repo_root: Path, name: str, evidence: dict[str, Any] | str) -
         path.write_text(json.dumps(evidence), encoding="utf-8")
 
 
+def write_codex_session(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+
+
+def token_count_record(timestamp: str, total_tokens: int) -> dict[str, Any]:
+    return {
+        "timestamp": timestamp,
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {"total_token_usage": {"total_tokens": total_tokens}},
+        },
+    }
+
+
 class GenerateRoadmapPageTest(unittest.TestCase):
     def test_screeps_room_target_falls_back_to_current_official_room(self) -> None:
         target = roadmap.build_screeps_room_target({})
@@ -132,6 +148,8 @@ class GenerateRoadmapPageTest(unittest.TestCase):
                 patch.object(roadmap, "fetch_all_prs", return_value=([{"state": "MERGED"}], None)),
                 patch.object(roadmap, "fetch_all_issues", return_value=([{"state": "OPEN"}], None)),
                 patch.object(roadmap, "count_private_smoke_process_reports", return_value=1),
+                patch.object(roadmap, "CODEX_SESSION_ROOT", repo_root / "missing-codex-sessions"),
+                patch.object(roadmap, "HERMES_CRON_OUTPUT_ROOT", repo_root / "missing-cron-output"),
             ):
                 cards = roadmap.build_report_process_cards(repo_root, {"fullName": "lanyusea/screeps"}, {}, {})
 
@@ -140,6 +158,58 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual(release_card["source"], "official deploy evidence JSON")
         self.assertIn("latest commit cccccccccccc", release_card["detail"])
         self.assertIn("run 123456", release_card["detail"])
+
+    def test_report_process_cards_compute_agent_metrics_from_local_fixtures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            codex_root = repo_root / "codex-sessions"
+            cron_root = repo_root / "hermes-cron-output"
+            write_codex_session(
+                codex_root / "2026" / "05" / "01" / "rollout-alpha.jsonl",
+                [
+                    {"timestamp": "2026-05-01T00:00:00Z", "type": "session_meta", "payload": {}},
+                    token_count_record("2026-05-01T00:05:00Z", 100),
+                    token_count_record("2026-05-01T00:10:00Z", 150),
+                ],
+            )
+            write_codex_session(
+                codex_root / "2026" / "05" / "01" / "rollout-beta.jsonl",
+                [
+                    {"timestamp": "2026-05-01T01:00:00Z", "type": "session_meta", "payload": {}},
+                    token_count_record("2026-05-01T01:30:00Z", 75),
+                ],
+            )
+            for relative in ("job-a/one.md", "job-a/two.md", "job-b/three.md"):
+                output = cron_root / relative
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_text("done\n", encoding="utf-8")
+
+            with (
+                patch.object(roadmap, "CODEX_SESSION_ROOT", codex_root),
+                patch.object(roadmap, "HERMES_CRON_OUTPUT_ROOT", cron_root),
+                patch.object(roadmap, "summarize_official_deploy_evidence", return_value=roadmap.OfficialDeployEvidenceSummary(0)),
+                patch.object(roadmap, "count_official_deploy_evidence", return_value=0),
+            ):
+                cards = roadmap.build_report_process_cards(repo_root, {"fullName": "lanyusea/screeps"}, {}, {})
+
+        cards_by_label = {card["label"]: card for card in cards}
+        self.assertEqual([card["label"] for card in cards], [
+            "Agent tokens",
+            "Codex runtime",
+            "Codex runs",
+            "Automation runs",
+            "Official deploys",
+        ])
+        self.assertEqual(cards_by_label["Agent tokens"]["value"], "225")
+        self.assertEqual(cards_by_label["Agent tokens"]["rawValue"], 225)
+        self.assertIn("latest token_count in 2/2 sessions", cards_by_label["Agent tokens"]["detail"])
+        self.assertEqual(cards_by_label["Agent tokens"]["source"], ".codex/sessions/**/rollout-*.jsonl")
+        self.assertEqual(cards_by_label["Codex runtime"]["value"], "40m")
+        self.assertEqual(cards_by_label["Codex runtime"]["rawValueSeconds"], 2400)
+        self.assertIn("first-to-last JSONL timestamps", cards_by_label["Codex runtime"]["detail"])
+        self.assertEqual(cards_by_label["Codex runs"]["value"], "2")
+        self.assertEqual(cards_by_label["Automation runs"]["value"], "3")
+        self.assertIn("3 cron outputs across 2 jobs", cards_by_label["Automation runs"]["detail"])
 
     def test_report_groups_visible_work_by_project_domain(self) -> None:
         repo = {
@@ -228,8 +298,10 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         roadmap_cards = roadmap.build_report_roadmap_cards(github_snapshot, repo)
         domain_board = roadmap.build_report_domain_kanban(github_snapshot)
 
-        self.assertEqual([card["title"] for card in roadmap_cards], list(roadmap.PROJECT_DOMAIN_ORDER))
+        self.assertEqual([card["title"] for card in roadmap_cards], list(roadmap.REPORT_ROADMAP_DOMAIN_ORDER))
+        self.assertNotIn("Docs/process", [card["title"] for card in roadmap_cards])
         self.assertEqual([column["title"] for column in domain_board], list(roadmap.PROJECT_DOMAIN_ORDER))
+        self.assertIn("Docs/process", [column["title"] for column in domain_board])
 
         runtime_column = next(column for column in domain_board if column["title"] == "Runtime monitor")
         gameplay_column = next(column for column in domain_board if column["title"] == "Gameplay Evolution")
@@ -298,7 +370,7 @@ class GenerateRoadmapPageTest(unittest.TestCase):
                         "status": "No Project Domain items observed",
                         "url": "",
                     }
-                    for domain in roadmap.PROJECT_DOMAIN_ORDER
+                    for domain in roadmap.REPORT_ROADMAP_DOMAIN_ORDER
                 ],
                 "domainKanban": [{"title": domain, "items": []} for domain in roadmap.PROJECT_DOMAIN_ORDER],
                 "processCards": [],
@@ -306,9 +378,13 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         }
 
         html = roadmap.render_html(data)
+        roadmap_section = html.split("03 Project Domain Board", 1)[0]
+        kanban_section = html.split("03 Project Domain Board", 1)[1]
 
         self.assertIn("02 Project Domains", html)
         self.assertIn("03 Project Domain Board", html)
+        self.assertNotIn("Docs/process", roadmap_section)
+        self.assertIn("Docs/process", kanban_section)
         self.assertIn(
             ".kanban-grid {\n  display: grid;\n  grid-template-columns: repeat(5, minmax(0, 1fr));",
             html,

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -76,6 +76,14 @@ def token_count_record(timestamp: str, total_tokens: int) -> dict[str, Any]:
     }
 
 
+def session_meta_record(timestamp: str, cwd: Path | str) -> dict[str, Any]:
+    return {
+        "timestamp": timestamp,
+        "type": "session_meta",
+        "payload": {"cwd": str(cwd), "originator": "codex_exec"},
+    }
+
+
 class GenerateRoadmapPageTest(unittest.TestCase):
     def test_screeps_room_target_falls_back_to_current_official_room(self) -> None:
         target = roadmap.build_screeps_room_target({})
@@ -167,7 +175,7 @@ class GenerateRoadmapPageTest(unittest.TestCase):
             write_codex_session(
                 codex_root / "2026" / "05" / "01" / "rollout-alpha.jsonl",
                 [
-                    {"timestamp": "2026-05-01T00:00:00Z", "type": "session_meta", "payload": {}},
+                    session_meta_record("2026-05-01T00:00:00Z", repo_root),
                     token_count_record("2026-05-01T00:05:00Z", 100),
                     token_count_record("2026-05-01T00:10:00Z", 150),
                 ],
@@ -175,14 +183,24 @@ class GenerateRoadmapPageTest(unittest.TestCase):
             write_codex_session(
                 codex_root / "2026" / "05" / "01" / "rollout-beta.jsonl",
                 [
-                    {"timestamp": "2026-05-01T01:00:00Z", "type": "session_meta", "payload": {}},
+                    session_meta_record("2026-05-01T01:00:00Z", "/root/screeps-worktrees/agent-metrics"),
                     token_count_record("2026-05-01T01:30:00Z", 75),
+                ],
+            )
+            write_codex_session(
+                codex_root / "2026" / "05" / "01" / "rollout-unrelated.jsonl",
+                [
+                    session_meta_record("2026-05-01T02:00:00Z", "/tmp/other-repo"),
+                    token_count_record("2026-05-01T02:10:00Z", 999),
                 ],
             )
             for relative in ("job-a/one.md", "job-a/two.md", "job-b/three.md"):
                 output = cron_root / relative
                 output.parent.mkdir(parents=True, exist_ok=True)
-                output.write_text("done\n", encoding="utf-8")
+                output.write_text("screeps roadmap fanout for lanyusea/screeps\n", encoding="utf-8")
+            unrelated = cron_root / "job-c" / "unrelated.md"
+            unrelated.parent.mkdir(parents=True, exist_ok=True)
+            unrelated.write_text("other repository automation\n", encoding="utf-8")
 
             with (
                 patch.object(roadmap, "CODEX_SESSION_ROOT", codex_root),
@@ -203,13 +221,93 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual(cards_by_label["Agent tokens"]["value"], "225")
         self.assertEqual(cards_by_label["Agent tokens"]["rawValue"], 225)
         self.assertIn("latest token_count in 2/2 sessions", cards_by_label["Agent tokens"]["detail"])
-        self.assertEqual(cards_by_label["Agent tokens"]["source"], ".codex/sessions/**/rollout-*.jsonl")
+        self.assertEqual(cards_by_label["Agent tokens"]["source"], "repo-attributed .codex/sessions/**/rollout-*.jsonl")
         self.assertEqual(cards_by_label["Codex runtime"]["value"], "40m")
         self.assertEqual(cards_by_label["Codex runtime"]["rawValueSeconds"], 2400)
         self.assertIn("first-to-last JSONL timestamps", cards_by_label["Codex runtime"]["detail"])
         self.assertEqual(cards_by_label["Codex runs"]["value"], "2")
         self.assertEqual(cards_by_label["Automation runs"]["value"], "3")
         self.assertIn("3 cron outputs across 2 jobs", cards_by_label["Automation runs"]["detail"])
+
+    def test_report_process_cards_ignore_unattributed_host_global_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            codex_root = repo_root / "codex-sessions"
+            cron_root = repo_root / "hermes-cron-output"
+            write_codex_session(
+                codex_root / "2026" / "05" / "01" / "rollout-global.jsonl",
+                [
+                    {"timestamp": "2026-05-01T00:00:00Z", "type": "session_meta", "payload": {}},
+                    {
+                        "timestamp": "2026-05-01T00:01:00Z",
+                        "type": "turn_context",
+                        "payload": {
+                            "cwd": "/tmp/unrelated-repo",
+                            "user_instructions": "Discuss lanyusea/screeps but do not mutate it.",
+                        },
+                    },
+                    token_count_record("2026-05-01T00:10:00Z", 999),
+                ],
+            )
+            output = cron_root / "job-a" / "one.md"
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text("Screeps roadmap fanout completed without repository metadata\n", encoding="utf-8")
+
+            with (
+                patch.object(roadmap, "CODEX_SESSION_ROOT", codex_root),
+                patch.object(roadmap, "HERMES_CRON_OUTPUT_ROOT", cron_root),
+                patch.object(roadmap, "summarize_official_deploy_evidence", return_value=roadmap.OfficialDeployEvidenceSummary(0)),
+                patch.object(roadmap, "count_official_deploy_evidence", return_value=0),
+            ):
+                cards = roadmap.build_report_process_cards(repo_root, {"fullName": "lanyusea/screeps"}, {}, {})
+
+        cards_by_label = {card["label"]: card for card in cards}
+        self.assertEqual(cards_by_label["Agent tokens"]["value"], "unavailable")
+        self.assertEqual(cards_by_label["Codex runs"]["value"], "unavailable")
+        self.assertEqual(cards_by_label["Automation runs"]["value"], "unavailable")
+
+    def test_agent_metrics_skip_bad_or_similarly_named_repo_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp) / "screeps"
+            repo_root.mkdir()
+            codex_root = Path(tmp) / "codex-sessions"
+            cron_root = Path(tmp) / "hermes-cron-output"
+            write_codex_session(
+                codex_root / "2026" / "05" / "01" / "rollout-screeps-tools.jsonl",
+                [
+                    session_meta_record("2026-05-01T00:00:00Z", "/root/screeps-tools"),
+                    token_count_record("2026-05-01T00:01:00Z", 999),
+                ],
+            )
+            bad_path = codex_root / "2026" / "05" / "01" / "rollout-bad.jsonl"
+            bad_path.parent.mkdir(parents=True, exist_ok=True)
+            bad_path.write_bytes(
+                b'{"timestamp":"2026-05-01T00:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/bad'
+                b'\x00'
+                b'path"}}\n\xff\xfe\n'
+            )
+            write_codex_session(
+                codex_root / "2026" / "05" / "01" / "rollout-good.jsonl",
+                [
+                    session_meta_record("2026-05-01T01:00:00Z", repo_root),
+                    token_count_record("2026-05-01T01:03:00Z", 42),
+                ],
+            )
+            unrelated = cron_root / "job-a" / "unrelated.md"
+            unrelated.parent.mkdir(parents=True, exist_ok=True)
+            unrelated.write_text("github.com/lanyusea/screeps-tools\n", encoding="utf-8")
+            related = cron_root / "job-b" / "related.md"
+            related.parent.mkdir(parents=True, exist_ok=True)
+            related.write_text("github.com/lanyusea/screeps\n", encoding="utf-8")
+
+            attribution = roadmap.build_repo_attribution(repo_root, {"fullName": "lanyusea/screeps"})
+            codex_metrics = roadmap.summarize_codex_sessions(codex_root, attribution)
+            automation_metrics = roadmap.summarize_automation_runs(cron_root, attribution)
+
+        self.assertEqual(codex_metrics.session_count, 1)
+        self.assertEqual(codex_metrics.total_tokens, 42)
+        self.assertEqual(automation_metrics.run_count, 1)
+        self.assertEqual(automation_metrics.job_count, 1)
 
     def test_report_groups_visible_work_by_project_domain(self) -> None:
         repo = {


### PR DESCRIPTION
## Summary
- Hide `Docs/process` from the high-level `02 Project Domains` card grid to improve the report composition.
- Keep `Docs/process` in the `03 Project Domain Board` kanban so the board remains a balanced 5×2 layout.
- Replace the bottom delivery/process cards with evidence-based agent work statistics: Agent tokens, Codex runtime, Codex runs, Automation runs, and Official deploys.

## Verification
- `python3 -m py_compile scripts/generate-roadmap-page.py scripts/check-roadmap-kpi-placeholders.py`
- `python3 -B scripts/check-roadmap-kpi-placeholders.py /root/screeps-worktrees/roadmap-agent-metrics`
- `node scripts/check-roadmap-renderer.js /root/screeps-worktrees/roadmap-agent-metrics`
- `python3 scripts/test_generate_roadmap_page.py`
- `node scripts/render-screeps-roadmap.js /root/screeps-worktrees/roadmap-agent-metrics /tmp/screeps-roadmap-agent-metrics-rerun.png`
- `git diff --check`

## Visual QA
- Rendered image: `/tmp/screeps-roadmap-agent-metrics-rerun.png`
- SHA256: `301e028160a186f9a0f672bacd1532c83a8d8ab2aee1107f746551ca181ddf13`
- Vision QA passed: `02 Project Domains` excludes `Docs/process`; `03 Project Domain Board` still includes `Docs/process` with the 5/5 layout; bottom Delivery Metrics includes Agent tokens, Codex runtime, Codex runs, and Automation runs; no obvious clipping/overlap.
