### PR TITLE
feat: balance harvest source work throughput

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4627,6 +4627,8 @@ var WORKER_ENERGY_SURPLUS_SCORE_RATIO = 0.4;
 var HARVEST_ENERGY_PER_WORK_PART = 2;
 var DEFAULT_BUILD_POWER = 5;
 var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
+var DEFAULT_SOURCE_ENERGY_CAPACITY = 3e3;
+var DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
 var SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 var SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 var MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
@@ -5720,30 +5722,28 @@ function selectSpawnRecoveryHarvestCandidate(creep, energySink) {
     return null;
   }
   const viableSources = selectViableHarvestSources(sources);
-  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
+  const assignmentLoads = getSameRoomWorkerHarvestLoads(creep.room.name, viableSources);
   const candidates = viableSources.map(
-    (source) => {
-      var _a;
-      return createSpawnRecoveryHarvestCandidate(creep, source, energySink, (_a = assignmentCounts.get(source.id)) != null ? _a : 0);
-    }
+    (source) => createSpawnRecoveryHarvestCandidate(
+      creep,
+      source,
+      energySink,
+      getHarvestSourceAssignmentLoad(assignmentLoads, source)
+    )
   ).filter((candidate) => candidate !== null);
   if (candidates.length === 0) {
     return null;
   }
   return candidates.sort(compareSpawnRecoveryHarvestCandidates)[0];
 }
-function createSpawnRecoveryHarvestCandidate(creep, source, energySink, assignmentCount) {
+function createSpawnRecoveryHarvestCandidate(creep, source, energySink, assignmentLoad) {
   const deliveryEta = estimateHarvestDeliveryEtaFromSource(creep, source, energySink);
   if (deliveryEta === null || !Number.isFinite(deliveryEta)) {
     return null;
   }
   return {
     deliveryEta,
-    load: {
-      assignmentCount,
-      capacity: getHarvestSourceCapacity(source),
-      source
-    },
+    load: createHarvestSourceLoad(source, assignmentLoad),
     source
   };
 }
@@ -5914,15 +5914,32 @@ function estimateHarvestSourceAvailabilityDelay(source) {
   return Number.isFinite(ticksToRegeneration) && ticksToRegeneration > 0 ? Math.ceil(ticksToRegeneration) : null;
 }
 function getActiveWorkParts(creep) {
-  const workPart = globalThis.WORK;
-  if (typeof workPart !== "string" || typeof creep.getActiveBodyparts !== "function") {
-    return 1;
+  var _a;
+  const workPart = getBodyPartConstant3("WORK", "work");
+  const activeWorkParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, workPart);
+  if (typeof activeWorkParts === "number" && Number.isFinite(activeWorkParts)) {
+    return Math.max(0, Math.floor(activeWorkParts));
   }
-  const activeWorkParts = creep.getActiveBodyparts(workPart);
-  if (activeWorkParts === 0) {
-    return 0;
+  const bodyWorkParts = countActiveBodyParts(creep.body, workPart);
+  return bodyWorkParts != null ? bodyWorkParts : 1;
+}
+function countActiveBodyParts(body, bodyPartType) {
+  if (!Array.isArray(body)) {
+    return null;
   }
-  return Number.isFinite(activeWorkParts) && activeWorkParts > 0 ? activeWorkParts : 1;
+  return body.filter((part) => isActiveBodyPart3(part, bodyPartType)).length;
+}
+function isActiveBodyPart3(part, bodyPartType) {
+  if (typeof part !== "object" || part === null) {
+    return false;
+  }
+  const bodyPart = part;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
+}
+function getBodyPartConstant3(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
 }
 function getRangeBetweenRoomObjects(left, right) {
   const position = left.pos;
@@ -6551,15 +6568,10 @@ function selectHarvestSource(creep) {
     return null;
   }
   const viableSources = selectViableHarvestSources(sources);
-  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
-  const sourceLoads = viableSources.map((source) => {
-    var _a;
-    return {
-      assignmentCount: (_a = assignmentCounts.get(source.id)) != null ? _a : 0,
-      capacity: getHarvestSourceCapacity(source),
-      source
-    };
-  });
+  const assignmentLoads = getSameRoomWorkerHarvestLoads(creep.room.name, viableSources);
+  const sourceLoads = viableSources.map(
+    (source) => createHarvestSourceLoad(source, getHarvestSourceAssignmentLoad(assignmentLoads, source))
+  );
   let selectedLoad = sourceLoads[0];
   for (const sourceLoad of sourceLoads.slice(1)) {
     if (compareHarvestSourceLoads(creep, sourceLoad, selectedLoad) < 0) {
@@ -6569,13 +6581,21 @@ function selectHarvestSource(creep) {
   return selectedLoad.source;
 }
 function compareHarvestSourceLoads(creep, left, right) {
-  const loadRatioComparison = compareHarvestSourceLoadRatio(left, right);
-  if (loadRatioComparison !== 0) {
-    return loadRatioComparison;
+  const workLoadRatioComparison = compareHarvestSourceWorkLoadRatio(left, right);
+  if (workLoadRatioComparison !== 0) {
+    return workLoadRatioComparison;
+  }
+  const accessLoadRatioComparison = compareHarvestSourceAccessLoadRatio(left, right);
+  if (accessLoadRatioComparison !== 0) {
+    return accessLoadRatioComparison;
   }
   const assignmentComparison = left.assignmentCount - right.assignmentCount;
   if (assignmentComparison !== 0) {
     return assignmentComparison;
+  }
+  const assignedWorkComparison = left.assignedWorkParts - right.assignedWorkParts;
+  if (assignedWorkComparison !== 0) {
+    return assignedWorkComparison;
   }
   if (isCloserHarvestSource(creep, left.source, right.source)) {
     return -1;
@@ -6586,9 +6606,30 @@ function compareHarvestSourceLoads(creep, left, right) {
   return 0;
 }
 function compareHarvestSourceLoadRatio(left, right) {
-  return left.assignmentCount * right.capacity - right.assignmentCount * left.capacity;
+  return compareHarvestSourceWorkLoadRatio(left, right) || compareHarvestSourceAccessLoadRatio(left, right);
 }
-function getHarvestSourceCapacity(source) {
+function compareHarvestSourceWorkLoadRatio(left, right) {
+  return left.assignedWorkParts * right.workCapacity - right.assignedWorkParts * left.workCapacity;
+}
+function compareHarvestSourceAccessLoadRatio(left, right) {
+  return left.assignmentCount * right.accessCapacity - right.assignmentCount * left.accessCapacity;
+}
+function createHarvestSourceLoad(source, assignmentLoad) {
+  return {
+    ...assignmentLoad,
+    accessCapacity: getHarvestSourceAccessCapacity(source),
+    workCapacity: getHarvestSourceWorkCapacity(source),
+    source
+  };
+}
+function getHarvestSourceAssignmentLoad(assignmentLoads, source) {
+  var _a;
+  return (_a = assignmentLoads.get(source.id)) != null ? _a : createEmptyHarvestSourceAssignmentLoad();
+}
+function createEmptyHarvestSourceAssignmentLoad() {
+  return { assignedWorkParts: 0, assignmentCount: 0 };
+}
+function getHarvestSourceAccessCapacity(source) {
   const position = getRoomObjectPosition(source);
   if (!position) {
     return 1;
@@ -6616,6 +6657,23 @@ function getHarvestSourceCapacity(source) {
   }
   return Math.max(1, capacity);
 }
+function getHarvestSourceWorkCapacity(source) {
+  const energyCapacity = getHarvestSourceEnergyCapacity(source);
+  const regenTicks = getSourceEnergyRegenTicks();
+  return Math.max(1, Math.ceil(energyCapacity / regenTicks / HARVEST_ENERGY_PER_WORK_PART));
+}
+function getHarvestSourceEnergyCapacity(source) {
+  const sourceEnergyCapacity = source.energyCapacity;
+  if (typeof sourceEnergyCapacity === "number" && Number.isFinite(sourceEnergyCapacity) && sourceEnergyCapacity > 0) {
+    return sourceEnergyCapacity;
+  }
+  const defaultSourceEnergyCapacity = globalThis.SOURCE_ENERGY_CAPACITY;
+  return typeof defaultSourceEnergyCapacity === "number" && Number.isFinite(defaultSourceEnergyCapacity) && defaultSourceEnergyCapacity > 0 ? defaultSourceEnergyCapacity : DEFAULT_SOURCE_ENERGY_CAPACITY;
+}
+function getSourceEnergyRegenTicks() {
+  const regenTicks = globalThis.ENERGY_REGEN_TIME;
+  return typeof regenTicks === "number" && Number.isFinite(regenTicks) && regenTicks > 0 ? regenTicks : DEFAULT_SOURCE_ENERGY_REGEN_TICKS;
+}
 function getRoomTerrain2(roomName) {
   var _a;
   const map = (_a = globalThis.Game) == null ? void 0 : _a.map;
@@ -6637,14 +6695,14 @@ function selectViableHarvestSources(sources) {
   const sourcesWithEnergy = sources.filter((source) => typeof source.energy === "number" && source.energy > 0);
   return sourcesWithEnergy.length > 0 ? sourcesWithEnergy : sources;
 }
-function countSameRoomWorkerHarvestAssignments(roomName, sources) {
+function getSameRoomWorkerHarvestLoads(roomName, sources) {
   var _a, _b, _c, _d;
-  const assignmentCounts = /* @__PURE__ */ new Map();
+  const assignmentLoads = /* @__PURE__ */ new Map();
   for (const source of sources) {
-    assignmentCounts.set(source.id, 0);
+    assignmentLoads.set(source.id, createEmptyHarvestSourceAssignmentLoad());
   }
   if (!roomName) {
-    return assignmentCounts;
+    return assignmentLoads;
   }
   const sourceIds = new Set(sources.map((source) => source.id));
   for (const assignedCreep of getGameCreeps()) {
@@ -6654,9 +6712,13 @@ function countSameRoomWorkerHarvestAssignments(roomName, sources) {
       continue;
     }
     const sourceId = targetId;
-    assignmentCounts.set(sourceId, ((_d = assignmentCounts.get(sourceId)) != null ? _d : 0) + 1);
+    const currentLoad = (_d = assignmentLoads.get(sourceId)) != null ? _d : createEmptyHarvestSourceAssignmentLoad();
+    assignmentLoads.set(sourceId, {
+      assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts(assignedCreep),
+      assignmentCount: currentLoad.assignmentCount + 1
+    });
   }
-  return assignmentCounts;
+  return assignmentLoads;
 }
 function getGameCreeps() {
   var _a;
@@ -8795,7 +8857,7 @@ function getGameTime6() {
 }
 function isCreepKnownToHaveNoActiveClaimParts(creep) {
   var _a;
-  const claimPart = getBodyPartConstant3("CLAIM", "claim");
+  const claimPart = getBodyPartConstant4("CLAIM", "claim");
   const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
   if (typeof activeClaimParts === "number") {
     return activeClaimParts <= 0;
@@ -8803,16 +8865,16 @@ function isCreepKnownToHaveNoActiveClaimParts(creep) {
   if (!Array.isArray(creep.body)) {
     return false;
   }
-  return !creep.body.some((part) => isActiveBodyPart3(part, claimPart));
+  return !creep.body.some((part) => isActiveBodyPart4(part, claimPart));
 }
-function isActiveBodyPart3(part, bodyPartType) {
+function isActiveBodyPart4(part, bodyPartType) {
   if (typeof part !== "object" || part === null) {
     return false;
   }
   const bodyPart = part;
   return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
 }
-function getBodyPartConstant3(globalName, fallback) {
+function getBodyPartConstant4(globalName, fallback) {
   var _a;
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -40,6 +40,8 @@ const WORKER_ENERGY_SURPLUS_SCORE_RATIO = 0.4;
 const HARVEST_ENERGY_PER_WORK_PART = 2;
 const DEFAULT_BUILD_POWER = 5;
 const MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
+const DEFAULT_SOURCE_ENERGY_CAPACITY = 3_000;
+const DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
 const SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 const SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 const MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
@@ -88,9 +90,16 @@ interface Source2ControllerLaneTopology {
 }
 
 interface HarvestSourceLoad {
+  assignedWorkParts: number;
   assignmentCount: number;
-  capacity: number;
+  accessCapacity: number;
+  workCapacity: number;
   source: Source;
+}
+
+interface HarvestSourceAssignmentLoad {
+  assignedWorkParts: number;
+  assignmentCount: number;
 }
 
 let nearTermSpawnExtensionRefillReserveCache: NearTermSpawnExtensionRefillReserveCache | null = null;
@@ -1753,10 +1762,15 @@ function selectSpawnRecoveryHarvestCandidate(
   }
 
   const viableSources = selectViableHarvestSources(sources);
-  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
+  const assignmentLoads = getSameRoomWorkerHarvestLoads(creep.room.name, viableSources);
   const candidates = viableSources
     .map((source) =>
-      createSpawnRecoveryHarvestCandidate(creep, source, energySink, assignmentCounts.get(source.id) ?? 0)
+      createSpawnRecoveryHarvestCandidate(
+        creep,
+        source,
+        energySink,
+        getHarvestSourceAssignmentLoad(assignmentLoads, source)
+      )
     )
     .filter((candidate): candidate is SpawnRecoveryHarvestCandidate => candidate !== null);
 
@@ -1771,7 +1785,7 @@ function createSpawnRecoveryHarvestCandidate(
   creep: Creep,
   source: Source,
   energySink: FillableEnergySink,
-  assignmentCount: number
+  assignmentLoad: HarvestSourceAssignmentLoad
 ): SpawnRecoveryHarvestCandidate | null {
   const deliveryEta = estimateHarvestDeliveryEtaFromSource(creep, source, energySink);
   if (deliveryEta === null || !Number.isFinite(deliveryEta)) {
@@ -1780,11 +1794,7 @@ function createSpawnRecoveryHarvestCandidate(
 
   return {
     deliveryEta,
-    load: {
-      assignmentCount,
-      capacity: getHarvestSourceCapacity(source),
-      source
-    },
+    load: createHarvestSourceLoad(source, assignmentLoad),
     source
   };
 }
@@ -2039,17 +2049,36 @@ function estimateHarvestSourceAvailabilityDelay(source: Source): number | null {
 }
 
 function getActiveWorkParts(creep: Creep): number {
-  const workPart = (globalThis as unknown as { WORK?: BodyPartConstant }).WORK;
-  if (typeof workPart !== 'string' || typeof creep.getActiveBodyparts !== 'function') {
-    return 1;
+  const workPart = getBodyPartConstant('WORK', 'work');
+  const activeWorkParts = creep.getActiveBodyparts?.(workPart);
+  if (typeof activeWorkParts === 'number' && Number.isFinite(activeWorkParts)) {
+    return Math.max(0, Math.floor(activeWorkParts));
   }
 
-  const activeWorkParts = creep.getActiveBodyparts(workPart);
-  if (activeWorkParts === 0) {
-    return 0;
+  const bodyWorkParts = countActiveBodyParts(creep.body, workPart);
+  return bodyWorkParts ?? 1;
+}
+
+function countActiveBodyParts(body: unknown, bodyPartType: BodyPartConstant): number | null {
+  if (!Array.isArray(body)) {
+    return null;
   }
 
-  return Number.isFinite(activeWorkParts) && activeWorkParts > 0 ? activeWorkParts : 1;
+  return body.filter((part) => isActiveBodyPart(part, bodyPartType)).length;
+}
+
+function isActiveBodyPart(part: unknown, bodyPartType: BodyPartConstant): boolean {
+  if (typeof part !== 'object' || part === null) {
+    return false;
+  }
+
+  const bodyPart = part as Partial<BodyPartDefinition>;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === 'number' && bodyPart.hits > 0;
+}
+
+function getBodyPartConstant(globalName: 'WORK', fallback: BodyPartConstant): BodyPartConstant {
+  const constants = globalThis as unknown as Partial<Record<'WORK', BodyPartConstant>>;
+  return constants[globalName] ?? fallback;
 }
 
 function getRangeBetweenRoomObjects(left: RoomObject, right: RoomObject): number | null {
@@ -3004,12 +3033,10 @@ function selectHarvestSource(creep: Creep): Source | null {
   }
 
   const viableSources = selectViableHarvestSources(sources);
-  const assignmentCounts = countSameRoomWorkerHarvestAssignments(creep.room.name, viableSources);
-  const sourceLoads = viableSources.map((source) => ({
-    assignmentCount: assignmentCounts.get(source.id) ?? 0,
-    capacity: getHarvestSourceCapacity(source),
-    source
-  }));
+  const assignmentLoads = getSameRoomWorkerHarvestLoads(creep.room.name, viableSources);
+  const sourceLoads = viableSources.map((source) =>
+    createHarvestSourceLoad(source, getHarvestSourceAssignmentLoad(assignmentLoads, source))
+  );
   let selectedLoad = sourceLoads[0];
 
   for (const sourceLoad of sourceLoads.slice(1)) {
@@ -3022,14 +3049,24 @@ function selectHarvestSource(creep: Creep): Source | null {
 }
 
 function compareHarvestSourceLoads(creep: Creep, left: HarvestSourceLoad, right: HarvestSourceLoad): number {
-  const loadRatioComparison = compareHarvestSourceLoadRatio(left, right);
-  if (loadRatioComparison !== 0) {
-    return loadRatioComparison;
+  const workLoadRatioComparison = compareHarvestSourceWorkLoadRatio(left, right);
+  if (workLoadRatioComparison !== 0) {
+    return workLoadRatioComparison;
+  }
+
+  const accessLoadRatioComparison = compareHarvestSourceAccessLoadRatio(left, right);
+  if (accessLoadRatioComparison !== 0) {
+    return accessLoadRatioComparison;
   }
 
   const assignmentComparison = left.assignmentCount - right.assignmentCount;
   if (assignmentComparison !== 0) {
     return assignmentComparison;
+  }
+
+  const assignedWorkComparison = left.assignedWorkParts - right.assignedWorkParts;
+  if (assignedWorkComparison !== 0) {
+    return assignedWorkComparison;
   }
 
   if (isCloserHarvestSource(creep, left.source, right.source)) {
@@ -3044,10 +3081,41 @@ function compareHarvestSourceLoads(creep: Creep, left: HarvestSourceLoad, right:
 }
 
 function compareHarvestSourceLoadRatio(left: HarvestSourceLoad, right: HarvestSourceLoad): number {
-  return left.assignmentCount * right.capacity - right.assignmentCount * left.capacity;
+  return compareHarvestSourceWorkLoadRatio(left, right) || compareHarvestSourceAccessLoadRatio(left, right);
 }
 
-function getHarvestSourceCapacity(source: Source): number {
+function compareHarvestSourceWorkLoadRatio(left: HarvestSourceLoad, right: HarvestSourceLoad): number {
+  return left.assignedWorkParts * right.workCapacity - right.assignedWorkParts * left.workCapacity;
+}
+
+function compareHarvestSourceAccessLoadRatio(left: HarvestSourceLoad, right: HarvestSourceLoad): number {
+  return left.assignmentCount * right.accessCapacity - right.assignmentCount * left.accessCapacity;
+}
+
+function createHarvestSourceLoad(
+  source: Source,
+  assignmentLoad: HarvestSourceAssignmentLoad
+): HarvestSourceLoad {
+  return {
+    ...assignmentLoad,
+    accessCapacity: getHarvestSourceAccessCapacity(source),
+    workCapacity: getHarvestSourceWorkCapacity(source),
+    source
+  };
+}
+
+function getHarvestSourceAssignmentLoad(
+  assignmentLoads: Map<Id<Source>, HarvestSourceAssignmentLoad>,
+  source: Source
+): HarvestSourceAssignmentLoad {
+  return assignmentLoads.get(source.id) ?? createEmptyHarvestSourceAssignmentLoad();
+}
+
+function createEmptyHarvestSourceAssignmentLoad(): HarvestSourceAssignmentLoad {
+  return { assignedWorkParts: 0, assignmentCount: 0 };
+}
+
+function getHarvestSourceAccessCapacity(source: Source): number {
   const position = getRoomObjectPosition(source);
   if (!position) {
     return 1;
@@ -3081,6 +3149,34 @@ function getHarvestSourceCapacity(source: Source): number {
   return Math.max(1, capacity);
 }
 
+function getHarvestSourceWorkCapacity(source: Source): number {
+  const energyCapacity = getHarvestSourceEnergyCapacity(source);
+  const regenTicks = getSourceEnergyRegenTicks();
+  return Math.max(1, Math.ceil(energyCapacity / regenTicks / HARVEST_ENERGY_PER_WORK_PART));
+}
+
+function getHarvestSourceEnergyCapacity(source: Source): number {
+  const sourceEnergyCapacity = source.energyCapacity;
+  if (typeof sourceEnergyCapacity === 'number' && Number.isFinite(sourceEnergyCapacity) && sourceEnergyCapacity > 0) {
+    return sourceEnergyCapacity;
+  }
+
+  const defaultSourceEnergyCapacity = (globalThis as unknown as { SOURCE_ENERGY_CAPACITY?: number })
+    .SOURCE_ENERGY_CAPACITY;
+  return typeof defaultSourceEnergyCapacity === 'number' &&
+    Number.isFinite(defaultSourceEnergyCapacity) &&
+    defaultSourceEnergyCapacity > 0
+    ? defaultSourceEnergyCapacity
+    : DEFAULT_SOURCE_ENERGY_CAPACITY;
+}
+
+function getSourceEnergyRegenTicks(): number {
+  const regenTicks = (globalThis as unknown as { ENERGY_REGEN_TIME?: number }).ENERGY_REGEN_TIME;
+  return typeof regenTicks === 'number' && Number.isFinite(regenTicks) && regenTicks > 0
+    ? regenTicks
+    : DEFAULT_SOURCE_ENERGY_REGEN_TICKS;
+}
+
 function getRoomTerrain(roomName: string): RoomTerrain | null {
   const map = (globalThis as unknown as { Game?: Partial<Pick<Game, 'map'>> }).Game?.map;
   if (typeof map?.getRoomTerrain !== 'function') {
@@ -3106,14 +3202,17 @@ function selectViableHarvestSources(sources: Source[]): Source[] {
   return sourcesWithEnergy.length > 0 ? sourcesWithEnergy : sources;
 }
 
-function countSameRoomWorkerHarvestAssignments(roomName: string | undefined, sources: Source[]): Map<Id<Source>, number> {
-  const assignmentCounts = new Map<Id<Source>, number>();
+function getSameRoomWorkerHarvestLoads(
+  roomName: string | undefined,
+  sources: Source[]
+): Map<Id<Source>, HarvestSourceAssignmentLoad> {
+  const assignmentLoads = new Map<Id<Source>, HarvestSourceAssignmentLoad>();
   for (const source of sources) {
-    assignmentCounts.set(source.id, 0);
+    assignmentLoads.set(source.id, createEmptyHarvestSourceAssignmentLoad());
   }
 
   if (!roomName) {
-    return assignmentCounts;
+    return assignmentLoads;
   }
 
   const sourceIds = new Set(sources.map((source) => source.id as string));
@@ -3132,10 +3231,14 @@ function countSameRoomWorkerHarvestAssignments(roomName: string | undefined, sou
     }
 
     const sourceId = targetId as Id<Source>;
-    assignmentCounts.set(sourceId, (assignmentCounts.get(sourceId) ?? 0) + 1);
+    const currentLoad = assignmentLoads.get(sourceId) ?? createEmptyHarvestSourceAssignmentLoad();
+    assignmentLoads.set(sourceId, {
+      assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts(assignedCreep),
+      assignmentCount: currentLoad.assignmentCount + 1
+    });
   }
 
-  return assignmentCounts;
+  return assignmentLoads;
 }
 
 function getGameCreeps(): Creep[] {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -6777,6 +6777,49 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-underloaded' });
   });
 
+  it('balances spawn recovery harvest by assigned worker work parts', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const heavySource = withRangeTo(makeSource('source-heavy', 11, 10), { spawn1: 1 }) as unknown as Source;
+    const lightSource = withRangeTo(makeSource('source-light', 12, 10), { spawn1: 1 }) as unknown as Source;
+    const room = makeWorkerTaskRoom({
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [heavySource, lightSource]
+    });
+    const creep = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'source-heavy': 1,
+            'source-light': 2
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({
+      HeavyHarvester: {
+        getActiveBodyparts: jest.fn().mockReturnValue(4),
+        memory: { role: 'worker', task: { type: 'harvest', targetId: heavySource.id } },
+        room
+      } as unknown as Creep,
+      LightHarvester: {
+        getActiveBodyparts: jest.fn().mockReturnValue(1),
+        memory: { role: 'worker', task: { type: 'harvest', targetId: lightSource.id } },
+        room
+      } as unknown as Creep,
+      RecoveryWorker: creep
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-light' });
+  });
+
   it('keeps spawn recovery harvest selection deterministic by source id when load and eta tie', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const laterSource = withRangeTo(makeSource('source-b', 11, 10), { spawn1: 1 }) as unknown as Source;


### PR DESCRIPTION
## Summary
- Balances harvest source selection by assigned WORK throughput as well as access-slot count.
- Adds active WORK-part fallback counting for worker harvest load decisions.
- Adds regression coverage for assigning stronger workers to under-served sources and updates the generated Screeps bundle.

## Verification
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand`
- `cd prod && npm run build`
- `git diff --check`

Refs #452

Domain: Bot capability / resource economy
Kind: code/test
Runtime impact: gameplay-affecting worker harvest distribution and source throughput behavior.