### PR TITLE
feat: prioritize urgent refill delivery

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4655,6 +4655,7 @@ var LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
 var LOW_LOAD_WORKER_ENERGY_CEILING = 25;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
+var SPAWN_RECOVERY_REFILL_PRESSURE_RATIO = 0.75;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -4975,10 +4976,21 @@ function shouldPrioritizeSpawnOrExtensionRefill(creep) {
   if (energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD) {
     return true;
   }
+  if (hasSpawnRecoveryRefillPressure(creep, energyAvailable)) {
+    return true;
+  }
   if (hasReservedTerritoryFollowUpRefillCapacity(creep) && !hasReadyTerritoryFollowUpEnergy(creep)) {
     return true;
   }
   return hasNearTermSpawnCompletionRefillDemand(creep.room);
+}
+function hasSpawnRecoveryRefillPressure(creep, energyAvailable) {
+  const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
+  if (!survivalAssessment || survivalAssessment.workerCapacity >= survivalAssessment.workerTarget) {
+    return false;
+  }
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
+  return energyCapacityAvailable !== null && energyCapacityAvailable > 0 && energyAvailable < energyCapacityAvailable * SPAWN_RECOVERY_REFILL_PRESSURE_RATIO;
 }
 function hasNearTermSpawnCompletionRefillDemand(room) {
   return findSpawnExtensionEnergyStructures(room).some(isNearTermSpawningSpawn);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -29,6 +29,7 @@ export const LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
 export const LOW_LOAD_WORKER_ENERGY_CEILING = 25;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
+const SPAWN_RECOVERY_REFILL_PRESSURE_RATIO = 0.75;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -497,11 +498,29 @@ function shouldPrioritizeSpawnOrExtensionRefill(creep: Creep): boolean {
     return true;
   }
 
+  if (hasSpawnRecoveryRefillPressure(creep, energyAvailable)) {
+    return true;
+  }
+
   if (hasReservedTerritoryFollowUpRefillCapacity(creep) && !hasReadyTerritoryFollowUpEnergy(creep)) {
     return true;
   }
 
   return hasNearTermSpawnCompletionRefillDemand(creep.room);
+}
+
+function hasSpawnRecoveryRefillPressure(creep: Creep, energyAvailable: number): boolean {
+  const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
+  if (!survivalAssessment || survivalAssessment.workerCapacity >= survivalAssessment.workerTarget) {
+    return false;
+  }
+
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
+  return (
+    energyCapacityAvailable !== null &&
+    energyCapacityAvailable > 0 &&
+    energyAvailable < energyCapacityAvailable * SPAWN_RECOVERY_REFILL_PRESSURE_RATIO
+  );
 }
 
 function hasNearTermSpawnCompletionRefillDemand(room: Room): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2092,6 +2092,93 @@ describe('selectWorkerTask', () => {
     });
   });
 
+  it.each([
+    ['spawn', 'spawn1'],
+    ['extension', 'extension1']
+  ])('prioritizes urgent %s refill over low-load harvest continuation during spawn recovery', (structureType, id) => {
+    const energySink = makeEnergySink(id, structureType as StructureConstant, 300);
+    const lowEnergySource = makeSource('source-low', 8, 8, 10);
+    const loadReadySource = makeSource('source-ready', 20, 20, 300);
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        [id]: 2,
+        'source-low': 1,
+        'source-ready': LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const room = makeWorkerTaskRoom({
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+      energyCapacityAvailable: 400,
+      myStructures: [energySink as AnyOwnedStructure],
+      sources: [lowEnergySource, loadReadySource]
+    });
+    const creep = {
+      name: 'RecoveryCarrier',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RecoveryCarrier: creep });
+    recordSurvivalMode('LOCAL_STABLE', 333);
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 333,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'transfer',
+      targetId: id,
+      reason: 'urgentSpawnExtensionRefill'
+    });
+  });
+
+  it('keeps the load-ready harvest preference during spawn recovery when no refill target exists', () => {
+    const lowEnergySource = makeSource('source-low', 8, 8, 10);
+    const loadReadySource = makeSource('source-ready', 20, 20, 300);
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'source-low': 1,
+        'source-ready': LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const room = makeWorkerTaskRoom({
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+      energyCapacityAvailable: 400,
+      sources: [lowEnergySource, loadReadySource]
+    });
+    const creep = {
+      name: 'RecoveryCarrier',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RecoveryCarrier: creep });
+    recordSurvivalMode('LOCAL_STABLE', 334);
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-ready' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 334,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'harvest',
+      targetId: 'source-ready',
+      energy: 300,
+      range: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+    });
+  });
+
   it('returns to refill instead of taking a far low-load harvest detour', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const source = { id: 'source1', energy: 300 } as Source;


### PR DESCRIPTION
## Summary
- Prioritizes urgent spawn/extension refill delivery for carrying workers during spawn-recovery pressure.
- Preserves #458's load-ready harvest preference when the worker is empty or no urgent refill target exists.
- Adds worker task regression coverage and updates the generated Screeps bundle.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 24 suites / 666 tests
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #459

Domain: Bot capability / resources-economy gameplay
Kind: code/test
Runtime impact: gameplay-affecting worker refill and spawn recovery behavior.

Scheduler evidence: recovered useful Codex-authored dirty worktree after OS process was absent, fast-forwarded onto current `origin/main` (`3244635`), controller-verified, committed as `f4632668939563152c0de959e526acb0ddc40af2`, and pushed from `feat/economy-post458-459`.
