### PR TITLE
feat: recover stale territory follow-ups (#460)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2147,7 +2147,12 @@ function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGam
     return false;
   }
   return normalizeTerritoryIntents2(territoryMemory.intents).some(
-    (intent) => intent.colony === colony && intent.followUp !== void 0 && isTerritoryControlAction2(intent.action) && (intent.status === "planned" || isRecoveredTerritoryFollowUpIntent(intent, gameTime) || intent.status === "active" && getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action) === 0)
+    (intent) => intent.colony === colony && intent.followUp !== void 0 && isTerritoryControlAction2(intent.action) && isVisibleTerritoryIntentActionable(
+      intent.targetRoom,
+      intent.action,
+      intent.controllerId,
+      getVisibleColonyOwnerUsername2(intent.colony)
+    ) && (intent.status === "planned" || isRecoveredTerritoryFollowUpIntent(intent, gameTime) || intent.status === "active" && getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action) === 0)
   );
 }
 function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
@@ -3629,19 +3634,12 @@ function isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername,
   if (intent.status === "active" && getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action) > 0) {
     return false;
   }
-  const controllerState = getVisibleTerritoryControllerEvidenceState(
+  return !isVisibleTerritoryIntentActionable(
     intent.targetRoom,
     intent.action,
     intent.controllerId,
     colonyOwnerUsername
   );
-  const stillActionable = controllerState === null || controllerState === "available" || isVisibleTerritoryReservePressureAvailable(
-    intent.targetRoom,
-    intent.action,
-    intent.controllerId,
-    colonyOwnerUsername
-  );
-  return !stillActionable;
 }
 function getVisibleTerritoryControllerEvidenceState(targetRoom, action, controllerId, colonyOwnerUsername) {
   if (isVisibleRoomMissingController(targetRoom)) {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -335,6 +335,12 @@ export function hasPendingTerritoryFollowUpIntent(
       intent.colony === colony &&
       intent.followUp !== undefined &&
       isTerritoryControlAction(intent.action) &&
+      isVisibleTerritoryIntentActionable(
+        intent.targetRoom,
+        intent.action,
+        intent.controllerId,
+        getVisibleColonyOwnerUsername(intent.colony)
+      ) &&
       (intent.status === 'planned' ||
         isRecoveredTerritoryFollowUpIntent(intent, gameTime) ||
         (intent.status === 'active' &&
@@ -2615,22 +2621,12 @@ function isStaleTerritoryProgressIntent(
     return false;
   }
 
-  const controllerState = getVisibleTerritoryControllerEvidenceState(
+  return !isVisibleTerritoryIntentActionable(
     intent.targetRoom,
     intent.action,
     intent.controllerId,
     colonyOwnerUsername
   );
-  const stillActionable =
-    controllerState === null ||
-    controllerState === 'available' ||
-    isVisibleTerritoryReservePressureAvailable(
-      intent.targetRoom,
-      intent.action,
-      intent.controllerId,
-      colonyOwnerUsername
-    );
-  return !stillActionable;
 }
 
 function getVisibleTerritoryControllerEvidenceState(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2,6 +2,7 @@ import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   buildTerritoryCreepMemory,
   getActiveTerritoryFollowUpExecutionHints,
+  hasPendingTerritoryFollowUpIntent,
   planTerritoryIntent,
   recordTerritoryReserveFallbackIntent,
   recordRecoveredTerritoryFollowUpRetryCooldown,
@@ -2917,6 +2918,163 @@ describe('planTerritoryIntent', () => {
     ]);
     expect(Memory.territory?.demands).toBeUndefined();
     expect(Memory.territory?.executionHints).toBeUndefined();
+  });
+
+  it('clears stale follow-up controller intent after visible target becomes unsafe', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
+    const staleFollowUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const staleFollowUpIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 591,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1'),
+        W3N1: makeRecommendationRoom('W3N1', { hostileCreepCount: 1 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, staleFollowUpTarget],
+        intents: [staleFollowUpIntent],
+        demands: [
+          {
+            type: 'followUpPreparation',
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            workerCount: 1,
+            updatedAt: 591,
+            followUp
+          }
+        ],
+        executionHints: [
+          {
+            type: 'activeFollowUpExecution',
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            reason: 'visibleControlEvidenceStillActionable',
+            updatedAt: 591,
+            followUp
+          }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 592);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 592
+      }
+    ]);
+    expect(Memory.territory?.demands).toBeUndefined();
+    expect(Memory.territory?.executionHints).toBeUndefined();
+  });
+
+  it('does not report unsafe stale follow-up intent as pending demand', () => {
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W3N1: makeRecommendationRoom('W3N1', { hostileCreepCount: 1 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 592,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(
+      hasPendingTerritoryFollowUpIntent('W1N1', { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 593)
+    ).toBe(false);
+  });
+
+  it('keeps controller pressure ahead of stale follow-up fallback cleanup', () => {
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', { hostileCreepCount: 1 }),
+        W3N1: makeRecommendationRoom('W3N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController,
+          sourceCount: 2
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 592,
+            followUp
+          }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(
+      colony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      593,
+      { controllerPressureOnly: true, followUpOnly: true }
+    );
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      requiresControllerPressure: true
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 593,
+        requiresControllerPressure: true
+      }
+    ]);
   });
 
   it('scouts an alternate adjacent room while a recovered follow-up target is cooling down', () => {


### PR DESCRIPTION
## Summary
- Filters pending territory follow-up demand through visible controller/actionability evidence so unsafe or already-stale follow-up intents stop advertising pending spawn demand.
- Reuses the existing visible actionability predicate for stale follow-up cleanup.
- Adds territory planner regression coverage for stale/unsafe follow-up cleanup and pressure-first fallback preservation.

## Verification
- `git diff --check`
- `cd prod && npm run typecheck`
- `cd prod && npm test -- --runInBand` — 24 suites / 666 tests
- `cd prod && npm run build`
- `git diff --exit-code -- prod/dist/main.js`

Closes #460

Domain: Bot capability / territory-control gameplay
Kind: code/test
Runtime impact: gameplay-affecting territory follow-up recovery and spawn planning behavior.

Scheduler evidence: dispatched Codex session `proc_4fd047bd113a`, controller-verified commit `b4fdecbf2b4cb58527c1c40bb736786eaba55631`, and pushed from `feat/territory-post456-460`.
