### PR TITLE
feat: territory recovered intent spawn priority (#464)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2465,13 +2465,18 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
       routeDistanceLookupContext
     )
   );
-  const persistedIntentCandidates = getPersistedTerritoryIntentCandidates(
-    colonyName,
-    colonyOwnerUsername,
-    territoryMemory,
-    intents,
-    gameTime,
-    routeDistanceLookupContext
+  const persistedIntentCandidates = applyOccupationRecommendationScores(
+    colony,
+    roleCounts,
+    workerTarget,
+    getPersistedTerritoryIntentCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      routeDistanceLookupContext
+    )
   );
   const primaryCandidates = getSpawnCapableTerritoryCandidates(
     filterTerritoryCandidatesForPlanningOptions(
@@ -3144,6 +3149,9 @@ function isSafeAdjacentControllerProgressCandidate(candidate, recommendation, in
   return adjacentControllerProgressReady && candidate.source === "adjacent" && candidate.target.action === "reserve" && intentAction === "reserve" && candidate.commitTarget === true && candidate.routeDistance === 1 && recommendation.evidenceStatus === "sufficient" && isTerritoryTargetVisible(candidate.target);
 }
 function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts) {
+  if (candidate.source === "occupationIntent" && isPersistedControllerFollowUpCandidate(candidate)) {
+    return candidate.intentAction;
+  }
   if (recommendation.evidenceStatus === "insufficient-evidence") {
     if (isRecoveredTerritoryFollowUpControlCandidate(candidate)) {
       return candidate.intentAction;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1991,6 +1991,7 @@ var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWA
 var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 var TERRITORY_SUPPRESSION_RETRY_TICKS2 = 1500;
 var TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS2 = 50;
+var TERRITORY_RECOVERED_INTENT_SPAWN_PRIORITY = 1e3;
 var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 var TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 0;
 var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
@@ -3129,18 +3130,24 @@ function applyOccupationRecommendationScore(candidate, recommendation, roleCount
     intentAction,
     commitTarget: nextSelection.commitTarget,
     priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
-    recommendationScore: recommendation.score,
+    recommendationScore: getTerritoryCandidateRecommendationScore(candidate, recommendation),
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {},
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
   };
 }
+function getTerritoryCandidateRecommendationScore(candidate, recommendation) {
+  return recommendation.score + (candidate.recoveredFollowUp === true ? TERRITORY_RECOVERED_INTENT_SPAWN_PRIORITY : 0);
+}
 function isSafeAdjacentControllerProgressCandidate(candidate, recommendation, intentAction, adjacentControllerProgressReady) {
   return adjacentControllerProgressReady && candidate.source === "adjacent" && candidate.target.action === "reserve" && intentAction === "reserve" && candidate.commitTarget === true && candidate.routeDistance === 1 && recommendation.evidenceStatus === "sufficient" && isTerritoryTargetVisible(candidate.target);
 }
 function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts) {
   if (recommendation.evidenceStatus === "insufficient-evidence") {
+    if (isRecoveredTerritoryFollowUpControlCandidate(candidate)) {
+      return candidate.intentAction;
+    }
     if (isTerritoryControlAction2(candidate.intentAction) && candidate.requiresControllerPressure === true) {
       return candidate.intentAction;
     }
@@ -3153,6 +3160,9 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
     return "claim";
   }
   return recommendation.action === "reserve" ? "reserve" : candidate.intentAction;
+}
+function isRecoveredTerritoryFollowUpControlCandidate(candidate) {
+  return candidate.recoveredFollowUp === true && candidate.followUp !== void 0 && isTerritoryControlAction2(candidate.intentAction);
 }
 function buildOccupationRecommendationCandidate(candidate) {
   const room = getVisibleRoom(candidate.target.roomName);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -772,13 +772,18 @@ function selectTerritoryTarget(
       routeDistanceLookupContext
     )
   );
-  const persistedIntentCandidates = getPersistedTerritoryIntentCandidates(
-    colonyName,
-    colonyOwnerUsername,
-    territoryMemory,
-    intents,
-    gameTime,
-    routeDistanceLookupContext
+  const persistedIntentCandidates = applyOccupationRecommendationScores(
+    colony,
+    roleCounts,
+    workerTarget,
+    getPersistedTerritoryIntentCandidates(
+      colonyName,
+      colonyOwnerUsername,
+      territoryMemory,
+      intents,
+      gameTime,
+      routeDistanceLookupContext
+    )
   );
   const primaryCandidates = getSpawnCapableTerritoryCandidates(
     filterTerritoryCandidatesForPlanningOptions(
@@ -1849,6 +1854,10 @@ function getRecommendedTerritoryIntentAction(
   recommendation: OccupationRecommendationScore,
   roleCounts: RoleCounts
 ): TerritoryIntentAction {
+  if (candidate.source === 'occupationIntent' && isPersistedControllerFollowUpCandidate(candidate)) {
+    return candidate.intentAction;
+  }
+
   if (recommendation.evidenceStatus === 'insufficient-evidence') {
     if (isRecoveredTerritoryFollowUpControlCandidate(candidate)) {
       return candidate.intentAction;

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -22,6 +22,7 @@ export const TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATI
 export const TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 export const TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
+export const TERRITORY_RECOVERED_INTENT_SPAWN_PRIORITY = 1_000;
 export const TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 // TERRITORY_READY already proves local worker recovery; use that floor for adjacent visible controller progress.
 export const TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 0;
@@ -1807,12 +1808,22 @@ function applyOccupationRecommendationScore(
     intentAction,
     commitTarget: nextSelection.commitTarget,
     priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
-    recommendationScore: recommendation.score,
+    recommendationScore: getTerritoryCandidateRecommendationScore(candidate, recommendation),
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {}),
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
   };
+}
+
+function getTerritoryCandidateRecommendationScore(
+  candidate: ScoredTerritoryTarget,
+  recommendation: OccupationRecommendationScore
+): number {
+  return (
+    recommendation.score +
+    (candidate.recoveredFollowUp === true ? TERRITORY_RECOVERED_INTENT_SPAWN_PRIORITY : 0)
+  );
 }
 
 function isSafeAdjacentControllerProgressCandidate(
@@ -1839,6 +1850,10 @@ function getRecommendedTerritoryIntentAction(
   roleCounts: RoleCounts
 ): TerritoryIntentAction {
   if (recommendation.evidenceStatus === 'insufficient-evidence') {
+    if (isRecoveredTerritoryFollowUpControlCandidate(candidate)) {
+      return candidate.intentAction;
+    }
+
     if (isTerritoryControlAction(candidate.intentAction) && candidate.requiresControllerPressure === true) {
       return candidate.intentAction;
     }
@@ -1858,6 +1873,14 @@ function getRecommendedTerritoryIntentAction(
   }
 
   return recommendation.action === 'reserve' ? 'reserve' : candidate.intentAction;
+}
+
+function isRecoveredTerritoryFollowUpControlCandidate(candidate: ScoredTerritoryTarget): boolean {
+  return (
+    candidate.recoveredFollowUp === true &&
+    candidate.followUp !== undefined &&
+    isTerritoryControlAction(candidate.intentAction)
+  );
 }
 
 function buildOccupationRecommendationCandidate(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2320,6 +2320,161 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('spawns a recovered claim intent even below the normal claim score', () => {
+    const colony = makeSafeColony();
+    const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'claim' };
+    const recoveredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'claim' };
+    const followUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N2', 'claim');
+    const suppressionTime = 602;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1', { sourceCount: 2 }),
+        W3N1: makeRecommendationRoom('W3N1', { sourceCount: 0 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [genericTarget, recoveredTarget],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'claim',
+            status: 'suppressed',
+            updatedAt: suppressionTime,
+            followUp
+          }
+        ]
+      }
+    };
+
+    const roleCounts = { worker: 3, claimer: 0, claimersByTargetRoom: {} };
+    const plan = planTerritoryIntent(colony, roleCounts, 3, retryTime);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      followUp
+    });
+    expect(shouldSpawnTerritoryControllerCreep(plan!, roleCounts, retryTime)).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: retryTime,
+        followUp
+      }
+    ]);
+  });
+
+  it('keeps recovered intent priority below the home controller downgrade guard', () => {
+    const colony = makeSafeColony({
+      controller: {
+        my: true,
+        owner: { username: 'me' },
+        level: 3,
+        ticksToDowngrade: TERRITORY_DOWNGRADE_GUARD_TICKS
+      } as StructureController
+    });
+    const followUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N2', 'claim');
+    const suppressionTime = 603;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    const roleCounts = { worker: 3, claimer: 0, claimersByTargetRoom: {} };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W3N1: makeRecommendationRoom('W3N1', { sourceCount: 0 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'claim',
+            status: 'suppressed',
+            updatedAt: suppressionTime,
+            followUp
+          }
+        ]
+      }
+    };
+
+    expect(hasPendingTerritoryFollowUpIntent('W1N1', roleCounts, retryTime)).toBe(true);
+    expect(planTerritoryIntent(colony, roleCounts, 3, retryTime)).toBeNull();
+  });
+
+  it('keeps multiple recovered intents bounded to one spawn candidate', () => {
+    const colony = makeSafeColony();
+    const firstFollowUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N2', 'claim');
+    const secondFollowUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N3', 'claim');
+    const suppressionTime = 604;
+    const retryTime = suppressionTime + TERRITORY_SUPPRESSION_RETRY_TICKS + 1;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W3N1: makeRecommendationRoom('W3N1', { sourceCount: 1 }),
+        W4N1: makeRecommendationRoom('W4N1', { sourceCount: 2 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'claim',
+            status: 'suppressed',
+            updatedAt: suppressionTime,
+            followUp: firstFollowUp
+          },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W4N1',
+            action: 'claim',
+            status: 'suppressed',
+            updatedAt: suppressionTime,
+            followUp: secondFollowUp
+          }
+        ]
+      }
+    };
+
+    const roleCounts = { worker: 3, claimer: 0, claimersByTargetRoom: {} };
+    const plan = planTerritoryIntent(colony, roleCounts, 3, retryTime);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      followUp: firstFollowUp
+    });
+    expect(shouldSpawnTerritoryControllerCreep(plan!, roleCounts, retryTime)).toBe(true);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: retryTime,
+        followUp: firstFollowUp
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W4N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: suppressionTime,
+        followUp: secondFollowUp
+      }
+    ]);
+    expect(Memory.territory?.intents?.filter((intent) => intent.status === 'planned')).toHaveLength(1);
+  });
+
   it('cools down recovered follow-up attempts before retrying them again', () => {
     const colony = makeSafeColony();
     const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -2409,7 +2409,7 @@ describe('planTerritoryIntent', () => {
     expect(planTerritoryIntent(colony, roleCounts, 3, retryTime)).toBeNull();
   });
 
-  it('keeps multiple recovered intents bounded to one spawn candidate', () => {
+  it('keeps multiple recovered intents bounded to one recommendation-scored spawn candidate', () => {
     const colony = makeSafeColony();
     const firstFollowUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N2', 'claim');
     const secondFollowUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N3', 'claim');
@@ -2449,9 +2449,9 @@ describe('planTerritoryIntent', () => {
 
     expect(plan).toEqual({
       colony: 'W1N1',
-      targetRoom: 'W3N1',
+      targetRoom: 'W4N1',
       action: 'claim',
-      followUp: firstFollowUp
+      followUp: secondFollowUp
     });
     expect(shouldSpawnTerritoryControllerCreep(plan!, roleCounts, retryTime)).toBe(true);
     expect(Memory.territory?.intents).toEqual([
@@ -2459,16 +2459,16 @@ describe('planTerritoryIntent', () => {
         colony: 'W1N1',
         targetRoom: 'W3N1',
         action: 'claim',
-        status: 'planned',
-        updatedAt: retryTime,
+        status: 'suppressed',
+        updatedAt: suppressionTime,
         followUp: firstFollowUp
       },
       {
         colony: 'W1N1',
         targetRoom: 'W4N1',
         action: 'claim',
-        status: 'suppressed',
-        updatedAt: suppressionTime,
+        status: 'planned',
+        updatedAt: retryTime,
         followUp: secondFollowUp
       }
     ]);


### PR DESCRIPTION
## Summary
Implements territory recovered intent spawning priority (#464).

Adds `TERRITORY_RECOVERED_INTENT_SPAWN_PRIORITY` constant that gives recovered territory follow-up intents elevated spawn priority — above normal background claim scoring but below emergency controller-downgrade defense.

## Changes
- `prod/src/territory/territoryPlanner.ts`: Hook recovered intents into spawn decisions with score bonus
- `prod/test/territoryPlanner.test.ts`: Tests for recovered intent spawn, downgrade guard priority, and queue overflow
- `prod/dist/main.js`: Regenerated bundle

## Verification
- Typecheck: PASS
- 672 tests: all PASS
- Build: PASS

## Commit
`3cbe537 lanyusea's bot <lanyusea@gmail.com> feat: territory recovered intent spawn priority (#464)`

Refs #464