### PR TITLE
feat: refill minimum load and throughput telemetry (#463)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8296,13 +8296,13 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
     return;
   }
   const tick = getGameTime5();
+  if (!shouldEmitRuntimeSummary(tick, events)) {
+    return;
+  }
   const creepsByColony = groupCreepsByColony(creeps);
   const refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
   const eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
   refreshRefillTelemetry(colonies, creepsByColony, refillTargetIdsByRoom, eventMetricsByRoom, tick);
-  if (!shouldEmitRuntimeSummary(tick, events)) {
-    return;
-  }
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const summary = {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4653,7 +4653,9 @@ var LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
 var LOW_LOAD_WORKER_ENERGY_CEILING = 25;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
+var REFILL_DELIVERY_MIN_LOAD = 20;
 var SPAWN_RECOVERY_REFILL_PRESSURE_RATIO = 0.75;
+var REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED = 50;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -4739,6 +4741,13 @@ function selectWorkerTask(creep) {
       targetId: spawnOrExtensionEnergySink.id
     };
     if (shouldPrioritizeSpawnOrExtensionRefill(creep)) {
+      const refillMinLoadContinuationTask = selectUrgentRefillMinLoadContinuationTask(
+        creep,
+        spawnOrExtensionEnergySink
+      );
+      if (refillMinLoadContinuationTask) {
+        return refillMinLoadContinuationTask;
+      }
       recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, "urgentSpawnExtensionRefill");
       return spawnOrExtensionRefillTask;
     }
@@ -4981,6 +4990,15 @@ function shouldPrioritizeSpawnOrExtensionRefill(creep) {
     return true;
   }
   return hasNearTermSpawnCompletionRefillDemand(creep.room);
+}
+function selectUrgentRefillMinLoadContinuationTask(creep, energySink) {
+  if (getUsedEnergy(creep) >= REFILL_DELIVERY_MIN_LOAD) {
+    return null;
+  }
+  if (getFreeStoredEnergyCapacity(energySink) <= REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED) {
+    return null;
+  }
+  return selectLowLoadWorkerEnergyContinuationTask(creep);
 }
 function hasSpawnRecoveryRefillPressure(creep, energyAvailable) {
   const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
@@ -8266,8 +8284,10 @@ var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
 var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+var MAX_REFILL_DELIVERY_SAMPLES = 5;
 var MAX_TERRITORY_INTENT_SUMMARIES = 5;
 var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
+var REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
 var PRODUCTIVE_WORKER_TASK_TYPES = ["build", "repair", "upgrade"];
@@ -8276,19 +8296,27 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
     return;
   }
   const tick = getGameTime5();
+  const creepsByColony = groupCreepsByColony(creeps);
+  const refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
+  const eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
+  refreshRefillTelemetry(colonies, creepsByColony, refillTargetIdsByRoom, eventMetricsByRoom, tick);
   if (!shouldEmitRuntimeSummary(tick, events)) {
     return;
   }
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
-  const creepsByColony = groupCreepsByColony(creeps);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const summary = {
     type: "runtime-summary",
     tick,
     rooms: colonies.map(
       (colony) => {
-        var _a;
-        return summarizeRoom(colony, (_a = creepsByColony.get(colony.room.name)) != null ? _a : [], persistOccupationRecommendations);
+        var _a, _b;
+        return summarizeRoom(
+          colony,
+          (_a = creepsByColony.get(colony.room.name)) != null ? _a : [],
+          persistOccupationRecommendations,
+          (_b = eventMetricsByRoom.get(colony.room.name)) != null ? _b : {}
+        );
       }
     ),
     ...reportedEvents.length > 0 ? { events: reportedEvents } : {},
@@ -8314,10 +8342,27 @@ function groupCreepsByColony(creeps) {
   }
   return creepsByColony;
 }
-function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations) {
+function buildRefillTargetIdsByRoom(colonies) {
+  const refillTargetIdsByRoom = /* @__PURE__ */ new Map();
+  for (const colony of colonies) {
+    refillTargetIdsByRoom.set(colony.room.name, getSpawnExtensionEnergyStructureIds(colony.room));
+  }
+  return refillTargetIdsByRoom;
+}
+function buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom) {
+  var _a;
+  const eventMetricsByRoom = /* @__PURE__ */ new Map();
+  for (const colony of colonies) {
+    eventMetricsByRoom.set(
+      colony.room.name,
+      summarizeRoomEventMetrics(colony.room, (_a = refillTargetIdsByRoom.get(colony.room.name)) != null ? _a : /* @__PURE__ */ new Set())
+    );
+  }
+  return eventMetricsByRoom;
+}
+function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics) {
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
-  const eventMetrics = summarizeRoomEventMetrics(colony.room);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   if (persistOccupationRecommendations) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime5());
@@ -8330,6 +8375,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations) {
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
     ...summarizeWorkerEfficiency(colonyWorkers, getGameTime5()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime5()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -8418,6 +8464,102 @@ function toRuntimeWorkerEfficiencySample(entry) {
     ...entry.creepName ? { creepName: entry.creepName } : {},
     ...entry.sample
   };
+}
+function summarizeRefillTelemetry(workers, tick) {
+  return {
+    ...summarizeRefillDeliveryTicks(workers, tick),
+    ...summarizeRefillWorkerUtilization(workers)
+  };
+}
+function summarizeRefillDeliveryTicks(workers, tick) {
+  const samples = workers.flatMap(
+    (worker) => {
+      var _a, _b;
+      return ((_b = (_a = worker.memory.refillTelemetry) == null ? void 0 : _a.recentDeliveries) != null ? _b : []).map((sample) => ({
+        creepName: getCreepName2(worker),
+        sample
+      }));
+    }
+  ).filter(
+    (entry) => isRecentRefillDeliverySample(entry.sample, tick)
+  ).sort(compareRefillDeliverySampleEntries);
+  if (samples.length === 0) {
+    return {};
+  }
+  const reportedSamples = samples.slice(0, MAX_REFILL_DELIVERY_SAMPLES).map(toRuntimeRefillDeliverySample);
+  const deliveryTicks = samples.map((entry) => entry.sample.deliveryTicks);
+  const completedCount = deliveryTicks.length;
+  return {
+    refillDeliveryTicks: {
+      completedCount,
+      averageTicks: roundRatio(deliveryTicks.reduce((total, value) => total + value, 0), completedCount),
+      maxTicks: Math.max(...deliveryTicks),
+      samples: reportedSamples,
+      ...samples.length > MAX_REFILL_DELIVERY_SAMPLES ? { omittedSampleCount: samples.length - MAX_REFILL_DELIVERY_SAMPLES } : {}
+    }
+  };
+}
+function summarizeRefillWorkerUtilization(workers) {
+  const workerSummaries = workers.map((worker) => {
+    var _a, _b;
+    const telemetry = worker.memory.refillTelemetry;
+    if (!telemetry) {
+      return null;
+    }
+    const refillActiveTicks2 = Math.max(0, Math.floor((_a = telemetry.refillActiveTicks) != null ? _a : 0));
+    const idleOrOtherTaskTicks2 = Math.max(0, Math.floor((_b = telemetry.idleOrOtherTaskTicks) != null ? _b : 0));
+    const totalTicks2 = refillActiveTicks2 + idleOrOtherTaskTicks2;
+    if (totalTicks2 <= 0) {
+      return null;
+    }
+    return {
+      ...getCreepName2(worker) ? { creepName: getCreepName2(worker) } : {},
+      refillActiveTicks: refillActiveTicks2,
+      idleOrOtherTaskTicks: idleOrOtherTaskTicks2,
+      ratio: roundRatio(refillActiveTicks2, totalTicks2)
+    };
+  }).filter((summary) => summary !== null).sort(compareRefillWorkerUtilizationSummaries);
+  if (workerSummaries.length === 0) {
+    return {};
+  }
+  const refillActiveTicks = workerSummaries.reduce((total, worker) => total + worker.refillActiveTicks, 0);
+  const idleOrOtherTaskTicks = workerSummaries.reduce((total, worker) => total + worker.idleOrOtherTaskTicks, 0);
+  const totalTicks = refillActiveTicks + idleOrOtherTaskTicks;
+  return {
+    refillWorkerUtilization: {
+      assignedWorkerCount: workerSummaries.length,
+      refillActiveTicks,
+      idleOrOtherTaskTicks,
+      ratio: roundRatio(refillActiveTicks, totalTicks),
+      workers: workerSummaries
+    }
+  };
+}
+function compareRefillDeliverySampleEntries(left, right) {
+  var _a, _b;
+  return right.sample.tick - left.sample.tick || ((_a = left.creepName) != null ? _a : "").localeCompare((_b = right.creepName) != null ? _b : "") || left.sample.targetId.localeCompare(right.sample.targetId);
+}
+function toRuntimeRefillDeliverySample(entry) {
+  return {
+    ...entry.creepName ? { creepName: entry.creepName } : {},
+    ...entry.sample
+  };
+}
+function compareRefillWorkerUtilizationSummaries(left, right) {
+  var _a, _b;
+  return right.refillActiveTicks + right.idleOrOtherTaskTicks - (left.refillActiveTicks + left.idleOrOtherTaskTicks) || ((_a = left.creepName) != null ? _a : "").localeCompare((_b = right.creepName) != null ? _b : "");
+}
+function isRecentRefillDeliverySample(sample, tick) {
+  return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
+}
+function isRefillDeliverySample(value) {
+  return isRecord5(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+}
+function roundRatio(numerator, denominator) {
+  if (denominator <= 0) {
+    return 0;
+  }
+  return Math.round(numerator / denominator * 1e3) / 1e3;
 }
 function isRecentWorkerEfficiencySample(sample, tick) {
   if (tick <= 0) {
@@ -8596,7 +8738,133 @@ function toRuntimeConstructionPriorityCandidateSummary(score) {
     risk: score.risk
   };
 }
-function summarizeRoomEventMetrics(room) {
+function refreshRefillTelemetry(colonies, creepsByColony, refillTargetIdsByRoom, eventMetricsByRoom, tick) {
+  var _a, _b, _c, _d;
+  for (const colony of colonies) {
+    const roomName = colony.room.name;
+    const refillTargetIds = (_a = refillTargetIdsByRoom.get(roomName)) != null ? _a : /* @__PURE__ */ new Set();
+    const refillTransfers = (_c = (_b = eventMetricsByRoom.get(roomName)) == null ? void 0 : _b.refillTransfers) != null ? _c : [];
+    const workers = ((_d = creepsByColony.get(roomName)) != null ? _d : []).filter((creep) => creep.memory.role === "worker");
+    for (const worker of workers) {
+      refreshWorkerRefillTelemetry(worker, refillTargetIds, refillTransfers, tick);
+    }
+  }
+}
+function refreshWorkerRefillTelemetry(worker, refillTargetIds, refillTransfers, tick) {
+  var _a;
+  const refillTargetId = getAssignedRefillTargetId(worker, refillTargetIds);
+  let telemetry = worker.memory.refillTelemetry;
+  if (refillTargetId) {
+    telemetry = ensureWorkerRefillTelemetry(worker);
+    if (!telemetry.current || telemetry.current.targetId !== refillTargetId) {
+      telemetry.current = {
+        targetId: refillTargetId,
+        startedAt: tick,
+        activeTicks: 0,
+        idleOrOtherTaskTicks: 0
+      };
+    }
+    recordWorkerRefillTelemetryTick(telemetry, true, tick);
+  } else if (telemetry && (telemetry.current || hasRecentWorkerRefillDelivery(telemetry, tick))) {
+    recordWorkerRefillTelemetryTick(telemetry, false, tick);
+  }
+  if (!(telemetry == null ? void 0 : telemetry.current)) {
+    pruneWorkerRefillTelemetry(worker, tick);
+    return;
+  }
+  const current = telemetry.current;
+  const deliveryEvents = refillTransfers.filter(
+    (event) => isWorkerRefillTransferEvent(worker, current.targetId, event)
+  );
+  if (deliveryEvents.length === 0) {
+    pruneWorkerRefillTelemetry(worker, tick);
+    return;
+  }
+  const energyDelivered = deliveryEvents.reduce((total, event) => total + event.amount, 0);
+  const sample = {
+    tick,
+    targetId: current.targetId,
+    deliveryTicks: Math.max(1, tick - current.startedAt + 1),
+    activeTicks: current.activeTicks,
+    idleOrOtherTaskTicks: current.idleOrOtherTaskTicks,
+    energyDelivered
+  };
+  telemetry.recentDeliveries = [sample, ...(_a = telemetry.recentDeliveries) != null ? _a : []].filter(
+    (recentSample) => isRecentRefillDeliverySample(recentSample, tick)
+  );
+  delete telemetry.current;
+  pruneWorkerRefillTelemetry(worker, tick);
+}
+function ensureWorkerRefillTelemetry(worker) {
+  if (!worker.memory.refillTelemetry) {
+    worker.memory.refillTelemetry = {};
+  }
+  return worker.memory.refillTelemetry;
+}
+function recordWorkerRefillTelemetryTick(telemetry, isRefillActive, tick) {
+  var _a, _b;
+  if (telemetry.lastUpdatedAt === tick) {
+    return;
+  }
+  if (isRefillActive) {
+    telemetry.refillActiveTicks = ((_a = telemetry.refillActiveTicks) != null ? _a : 0) + 1;
+    if (telemetry.current) {
+      telemetry.current.activeTicks += 1;
+    }
+  } else {
+    telemetry.idleOrOtherTaskTicks = ((_b = telemetry.idleOrOtherTaskTicks) != null ? _b : 0) + 1;
+    if (telemetry.current) {
+      telemetry.current.idleOrOtherTaskTicks += 1;
+    }
+  }
+  telemetry.lastUpdatedAt = tick;
+}
+function pruneWorkerRefillTelemetry(worker, tick) {
+  const telemetry = worker.memory.refillTelemetry;
+  if (!telemetry) {
+    return;
+  }
+  if (telemetry.recentDeliveries) {
+    telemetry.recentDeliveries = telemetry.recentDeliveries.filter(
+      (sample) => isRecentRefillDeliverySample(sample, tick)
+    );
+    if (telemetry.recentDeliveries.length === 0) {
+      delete telemetry.recentDeliveries;
+    }
+  }
+  if (!telemetry.current && !telemetry.recentDeliveries && (telemetry.lastUpdatedAt === void 0 || telemetry.lastUpdatedAt <= tick - REFILL_DELIVERY_SAMPLE_TTL)) {
+    delete worker.memory.refillTelemetry;
+  }
+}
+function hasRecentWorkerRefillDelivery(telemetry, tick) {
+  var _a;
+  return ((_a = telemetry.recentDeliveries) != null ? _a : []).some((sample) => isRecentRefillDeliverySample(sample, tick));
+}
+function getAssignedRefillTargetId(worker, refillTargetIds) {
+  const task = worker.memory.task;
+  if ((task == null ? void 0 : task.type) !== "transfer") {
+    return null;
+  }
+  const targetId = String(task.targetId);
+  return refillTargetIds.has(targetId) ? targetId : null;
+}
+function isWorkerRefillTransferEvent(worker, targetId, event) {
+  return event.targetId === targetId && getWorkerEventIds(worker).some((workerId) => workerId === event.objectId);
+}
+function getWorkerEventIds(worker) {
+  const ids = [];
+  const id = worker.id;
+  const name = worker.name;
+  if (typeof id === "string" && id.length > 0) {
+    ids.push(id);
+  }
+  if (typeof name === "string" && name.length > 0) {
+    ids.push(name);
+  }
+  return ids;
+}
+function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEnergyStructureIds(room)) {
+  var _a;
   const eventLog = getRoomEventLog(room);
   if (!eventLog) {
     return {};
@@ -8621,6 +8889,7 @@ function summarizeRoomEventMetrics(room) {
     objectDestroyedCount: 0,
     creepDestroyedCount: 0
   };
+  const refillTransfers = [];
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
@@ -8633,7 +8902,17 @@ function summarizeRoomEventMetrics(room) {
       hasResourceEvents = true;
     }
     if (entry.event === transferEvent && isEnergyEventData(data)) {
-      resourceEvents.transferredEnergy += getNumericEventData(data, "amount");
+      const amount = getNumericEventData(data, "amount");
+      resourceEvents.transferredEnergy += amount;
+      const targetId = getEventTargetId(data);
+      if (targetId && refillTargetIds.has(targetId)) {
+        resourceEvents.refillEnergyDelivered = ((_a = resourceEvents.refillEnergyDelivered) != null ? _a : 0) + amount;
+        refillTransfers.push({
+          ...buildEventObjectId(entry),
+          targetId,
+          amount
+        });
+      }
       hasResourceEvents = true;
     }
     if (entry.event === buildEvent) {
@@ -8663,8 +8942,36 @@ function summarizeRoomEventMetrics(room) {
   }
   return {
     ...hasResourceEvents ? { resources: resourceEvents } : {},
-    ...hasCombatEvents ? { combat: combatEvents } : {}
+    ...hasCombatEvents ? { combat: combatEvents } : {},
+    ...refillTransfers.length > 0 ? { refillTransfers } : {}
   };
+}
+function getSpawnExtensionEnergyStructureIds(room) {
+  var _a, _b;
+  const structures = (_b = (_a = findRoomObjects5(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects5(room, "FIND_STRUCTURES")) != null ? _b : [];
+  const ids = /* @__PURE__ */ new Set();
+  for (const structure of structures) {
+    if (!isSpawnExtensionEnergyStructure2(structure)) {
+      continue;
+    }
+    const id = getObjectId2(structure);
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}
+function isSpawnExtensionEnergyStructure2(structure) {
+  return isRecord5(structure) && (matchesStructureType6(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType6(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+}
+function getEventTargetId(data) {
+  return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
+}
+function buildEventObjectId(entry) {
+  return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
+}
+function getObjectId2(value) {
+  return isRecord5(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects5(room, constantName) {
   const findConstant = getGlobalNumber4(constantName);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8291,18 +8291,37 @@ var REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
 var PRODUCTIVE_WORKER_TASK_TYPES = ["build", "repair", "upgrade"];
+var cachedRefillTargetIdsByRoom = /* @__PURE__ */ new Map();
+var cachedEventMetricsByRoom = /* @__PURE__ */ new Map();
+var cachedEventMetricsTick;
 function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return;
   }
   const tick = getGameTime5();
-  if (!shouldEmitRuntimeSummary(tick, events)) {
+  resetCachedRefillTelemetryIfTickRewound(tick);
+  const emitsSummary = shouldEmitRuntimeSummary(tick, events);
+  const creepsByColony = groupCreepsByColony(creeps);
+  let refillTargetIdsByRoom = cachedRefillTargetIdsByRoom;
+  let eventMetricsByRoom = cachedEventMetricsByRoom;
+  if (emitsSummary) {
+    refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
+    eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
+    cachedRefillTargetIdsByRoom = refillTargetIdsByRoom;
+    cachedEventMetricsByRoom = eventMetricsByRoom;
+    cachedEventMetricsTick = tick;
+  }
+  refreshRefillTelemetry(
+    colonies,
+    creepsByColony,
+    refillTargetIdsByRoom,
+    eventMetricsByRoom,
+    tick,
+    cachedEventMetricsTick
+  );
+  if (!emitsSummary) {
     return;
   }
-  const creepsByColony = groupCreepsByColony(creeps);
-  const refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
-  const eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
-  refreshRefillTelemetry(colonies, creepsByColony, refillTargetIdsByRoom, eventMetricsByRoom, tick);
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const summary = {
@@ -8327,6 +8346,14 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
 }
 function shouldEmitRuntimeSummary(tick, events) {
   return events.length > 0 || tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
+}
+function resetCachedRefillTelemetryIfTickRewound(tick) {
+  if (cachedEventMetricsTick === void 0 || tick >= cachedEventMetricsTick) {
+    return;
+  }
+  cachedRefillTargetIdsByRoom = /* @__PURE__ */ new Map();
+  cachedEventMetricsByRoom = /* @__PURE__ */ new Map();
+  cachedEventMetricsTick = void 0;
 }
 function groupCreepsByColony(creeps) {
   var _a;
@@ -8738,12 +8765,12 @@ function toRuntimeConstructionPriorityCandidateSummary(score) {
     risk: score.risk
   };
 }
-function refreshRefillTelemetry(colonies, creepsByColony, refillTargetIdsByRoom, eventMetricsByRoom, tick) {
+function refreshRefillTelemetry(colonies, creepsByColony, refillTargetIdsByRoom, eventMetricsByRoom, tick, eventMetricsTick) {
   var _a, _b, _c, _d;
   for (const colony of colonies) {
     const roomName = colony.room.name;
     const refillTargetIds = (_a = refillTargetIdsByRoom.get(roomName)) != null ? _a : /* @__PURE__ */ new Set();
-    const refillTransfers = (_c = (_b = eventMetricsByRoom.get(roomName)) == null ? void 0 : _b.refillTransfers) != null ? _c : [];
+    const refillTransfers = eventMetricsTick === tick ? (_c = (_b = eventMetricsByRoom.get(roomName)) == null ? void 0 : _b.refillTransfers) != null ? _c : [] : [];
     const workers = ((_d = creepsByColony.get(roomName)) != null ? _d : []).filter((creep) => creep.memory.role === "worker");
     for (const worker of workers) {
       refreshWorkerRefillTelemetry(worker, refillTargetIds, refillTransfers, tick);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -29,7 +29,9 @@ export const LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
 export const LOW_LOAD_WORKER_ENERGY_CEILING = 25;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
+export const REFILL_DELIVERY_MIN_LOAD = 20;
 const SPAWN_RECOVERY_REFILL_PRESSURE_RATIO = 0.75;
+const REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED = 50;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -186,6 +188,14 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
       targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure>
     };
     if (shouldPrioritizeSpawnOrExtensionRefill(creep)) {
+      const refillMinLoadContinuationTask = selectUrgentRefillMinLoadContinuationTask(
+        creep,
+        spawnOrExtensionEnergySink
+      );
+      if (refillMinLoadContinuationTask) {
+        return refillMinLoadContinuationTask;
+      }
+
       recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, 'urgentSpawnExtensionRefill');
       return spawnOrExtensionRefillTask;
     }
@@ -507,6 +517,21 @@ function shouldPrioritizeSpawnOrExtensionRefill(creep: Creep): boolean {
   }
 
   return hasNearTermSpawnCompletionRefillDemand(creep.room);
+}
+
+function selectUrgentRefillMinLoadContinuationTask(
+  creep: Creep,
+  energySink: SpawnExtensionEnergyStructure
+): LowLoadWorkerEnergyAcquisitionTask | null {
+  if (getUsedEnergy(creep) >= REFILL_DELIVERY_MIN_LOAD) {
+    return null;
+  }
+
+  if (getFreeStoredEnergyCapacity(energySink) <= REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED) {
+    return null;
+  }
+
+  return selectLowLoadWorkerEnergyContinuationTask(creep);
 }
 
 function hasSpawnRecoveryRefillPressure(creep: Creep, energyAvailable: number): boolean {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -21,8 +21,10 @@ export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
 const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+const MAX_REFILL_DELIVERY_SAMPLES = 5;
 const MAX_TERRITORY_INTENT_SUMMARIES = 5;
 const WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
+const REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const OBSERVED_RAMPART_REPAIR_HITS_CEILING = 100_000;
 
 const WORKER_TASK_TYPES = ['harvest', 'transfer', 'build', 'repair', 'upgrade'] as const;
@@ -67,6 +69,8 @@ interface RuntimeRoomSummary {
   spawnStatus: RuntimeSpawnStatus[];
   taskCounts: WorkerTaskCounts;
   workerEfficiency?: RuntimeWorkerEfficiencySummary;
+  refillDeliveryTicks?: RuntimeRefillDeliveryTicksSummary;
+  refillWorkerUtilization?: RuntimeRefillWorkerUtilizationSummary;
   controller?: RuntimeControllerSummary;
   resources: RuntimeResourceSummary;
   combat: RuntimeCombatSummary;
@@ -88,6 +92,7 @@ interface RuntimeControllerSummary {
 interface RuntimeResourceEventSummary {
   harvestedEnergy: number;
   transferredEnergy: number;
+  refillEnergyDelivered?: number;
   builtProgress: number;
   repairedHits: number;
   upgradedControllerProgress: number;
@@ -129,6 +134,38 @@ interface RuntimeWorkerEfficiencySampleEntry {
   sample: WorkerEfficiencySampleMemory;
 }
 
+interface RuntimeRefillDeliveryTicksSummary {
+  completedCount: number;
+  averageTicks: number;
+  maxTicks: number;
+  samples: RuntimeRefillDeliverySampleSummary[];
+  omittedSampleCount?: number;
+}
+
+interface RuntimeRefillDeliverySampleSummary extends WorkerRefillDeliverySampleMemory {
+  creepName?: string;
+}
+
+interface RuntimeRefillDeliverySampleEntry {
+  creepName: string | undefined;
+  sample: WorkerRefillDeliverySampleMemory;
+}
+
+interface RuntimeRefillWorkerUtilizationSummary {
+  assignedWorkerCount: number;
+  refillActiveTicks: number;
+  idleOrOtherTaskTicks: number;
+  ratio: number;
+  workers: RuntimeRefillWorkerUtilizationWorkerSummary[];
+}
+
+interface RuntimeRefillWorkerUtilizationWorkerSummary {
+  creepName?: string;
+  refillActiveTicks: number;
+  idleOrOtherTaskTicks: number;
+  ratio: number;
+}
+
 interface RuntimeCombatEventSummary {
   attackCount: number;
   attackDamage: number;
@@ -168,6 +205,13 @@ interface RuntimeSurvivalSummary {
 interface RuntimeRoomEventMetrics {
   resources?: RuntimeResourceEventSummary;
   combat?: RuntimeCombatEventSummary;
+  refillTransfers?: RuntimeRefillTransferEvent[];
+}
+
+interface RuntimeRefillTransferEvent {
+  objectId?: string;
+  targetId: string;
+  amount: number;
 }
 
 interface RuntimeCpuSummary {
@@ -199,18 +243,26 @@ export function emitRuntimeSummary(
   }
 
   const tick = getGameTime();
+  const creepsByColony = groupCreepsByColony(creeps);
+  const refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
+  const eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
+  refreshRefillTelemetry(colonies, creepsByColony, refillTargetIdsByRoom, eventMetricsByRoom, tick);
   if (!shouldEmitRuntimeSummary(tick, events)) {
     return;
   }
 
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
-  const creepsByColony = groupCreepsByColony(creeps);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
   const summary: RuntimeSummary = {
     type: 'runtime-summary',
     tick,
     rooms: colonies.map((colony) =>
-      summarizeRoom(colony, creepsByColony.get(colony.room.name) ?? [], persistOccupationRecommendations)
+      summarizeRoom(
+        colony,
+        creepsByColony.get(colony.room.name) ?? [],
+        persistOccupationRecommendations,
+        eventMetricsByRoom.get(colony.room.name) ?? {}
+      )
     ),
     ...(reportedEvents.length > 0 ? { events: reportedEvents } : {}),
     ...(events.length > MAX_REPORTED_EVENTS ? { omittedEventCount: events.length - MAX_REPORTED_EVENTS } : {}),
@@ -241,14 +293,38 @@ function groupCreepsByColony(creeps: Creep[]): Map<string, Creep[]> {
   return creepsByColony;
 }
 
+function buildRefillTargetIdsByRoom(colonies: ColonySnapshot[]): Map<string, Set<string>> {
+  const refillTargetIdsByRoom = new Map<string, Set<string>>();
+  for (const colony of colonies) {
+    refillTargetIdsByRoom.set(colony.room.name, getSpawnExtensionEnergyStructureIds(colony.room));
+  }
+
+  return refillTargetIdsByRoom;
+}
+
+function buildRoomEventMetricsByRoom(
+  colonies: ColonySnapshot[],
+  refillTargetIdsByRoom: Map<string, Set<string>>
+): Map<string, RuntimeRoomEventMetrics> {
+  const eventMetricsByRoom = new Map<string, RuntimeRoomEventMetrics>();
+  for (const colony of colonies) {
+    eventMetricsByRoom.set(
+      colony.room.name,
+      summarizeRoomEventMetrics(colony.room, refillTargetIdsByRoom.get(colony.room.name) ?? new Set<string>())
+    );
+  }
+
+  return eventMetricsByRoom;
+}
+
 function summarizeRoom(
   colony: ColonySnapshot,
   colonyCreeps: Creep[],
-  persistOccupationRecommendations: boolean
+  persistOccupationRecommendations: boolean,
+  eventMetrics: RuntimeRoomEventMetrics
 ): RuntimeRoomSummary {
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === 'worker');
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
-  const eventMetrics = summarizeRoomEventMetrics(colony.room);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   if (persistOccupationRecommendations) {
     persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime());
@@ -262,6 +338,7 @@ function summarizeRoom(
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
     ...summarizeWorkerEfficiency(colonyWorkers, getGameTime()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -389,6 +466,164 @@ function toRuntimeWorkerEfficiencySample(entry: {
     ...(entry.creepName ? { creepName: entry.creepName } : {}),
     ...entry.sample
   };
+}
+
+function summarizeRefillTelemetry(
+  workers: Creep[],
+  tick: number
+): {
+  refillDeliveryTicks?: RuntimeRefillDeliveryTicksSummary;
+  refillWorkerUtilization?: RuntimeRefillWorkerUtilizationSummary;
+} {
+  return {
+    ...summarizeRefillDeliveryTicks(workers, tick),
+    ...summarizeRefillWorkerUtilization(workers)
+  };
+}
+
+function summarizeRefillDeliveryTicks(
+  workers: Creep[],
+  tick: number
+): { refillDeliveryTicks?: RuntimeRefillDeliveryTicksSummary } {
+  const samples = workers
+    .flatMap((worker) =>
+      (worker.memory.refillTelemetry?.recentDeliveries ?? []).map((sample) => ({
+        creepName: getCreepName(worker),
+        sample
+      }))
+    )
+    .filter((entry): entry is RuntimeRefillDeliverySampleEntry =>
+      isRecentRefillDeliverySample(entry.sample, tick)
+    )
+    .sort(compareRefillDeliverySampleEntries);
+
+  if (samples.length === 0) {
+    return {};
+  }
+
+  const reportedSamples = samples.slice(0, MAX_REFILL_DELIVERY_SAMPLES).map(toRuntimeRefillDeliverySample);
+  const deliveryTicks = samples.map((entry) => entry.sample.deliveryTicks);
+  const completedCount = deliveryTicks.length;
+
+  return {
+    refillDeliveryTicks: {
+      completedCount,
+      averageTicks: roundRatio(deliveryTicks.reduce((total, value) => total + value, 0), completedCount),
+      maxTicks: Math.max(...deliveryTicks),
+      samples: reportedSamples,
+      ...(samples.length > MAX_REFILL_DELIVERY_SAMPLES
+        ? { omittedSampleCount: samples.length - MAX_REFILL_DELIVERY_SAMPLES }
+        : {})
+    }
+  };
+}
+
+function summarizeRefillWorkerUtilization(
+  workers: Creep[]
+): { refillWorkerUtilization?: RuntimeRefillWorkerUtilizationSummary } {
+  const workerSummaries = workers
+    .map((worker): RuntimeRefillWorkerUtilizationWorkerSummary | null => {
+      const telemetry = worker.memory.refillTelemetry;
+      if (!telemetry) {
+        return null;
+      }
+
+      const refillActiveTicks = Math.max(0, Math.floor(telemetry.refillActiveTicks ?? 0));
+      const idleOrOtherTaskTicks = Math.max(0, Math.floor(telemetry.idleOrOtherTaskTicks ?? 0));
+      const totalTicks = refillActiveTicks + idleOrOtherTaskTicks;
+      if (totalTicks <= 0) {
+        return null;
+      }
+
+      return {
+        ...(getCreepName(worker) ? { creepName: getCreepName(worker) } : {}),
+        refillActiveTicks,
+        idleOrOtherTaskTicks,
+        ratio: roundRatio(refillActiveTicks, totalTicks)
+      };
+    })
+    .filter((summary): summary is RuntimeRefillWorkerUtilizationWorkerSummary => summary !== null)
+    .sort(compareRefillWorkerUtilizationSummaries);
+
+  if (workerSummaries.length === 0) {
+    return {};
+  }
+
+  const refillActiveTicks = workerSummaries.reduce((total, worker) => total + worker.refillActiveTicks, 0);
+  const idleOrOtherTaskTicks = workerSummaries.reduce((total, worker) => total + worker.idleOrOtherTaskTicks, 0);
+  const totalTicks = refillActiveTicks + idleOrOtherTaskTicks;
+
+  return {
+    refillWorkerUtilization: {
+      assignedWorkerCount: workerSummaries.length,
+      refillActiveTicks,
+      idleOrOtherTaskTicks,
+      ratio: roundRatio(refillActiveTicks, totalTicks),
+      workers: workerSummaries
+    }
+  };
+}
+
+function compareRefillDeliverySampleEntries(
+  left: RuntimeRefillDeliverySampleEntry,
+  right: RuntimeRefillDeliverySampleEntry
+): number {
+  return (
+    right.sample.tick - left.sample.tick ||
+    (left.creepName ?? '').localeCompare(right.creepName ?? '') ||
+    left.sample.targetId.localeCompare(right.sample.targetId)
+  );
+}
+
+function toRuntimeRefillDeliverySample(
+  entry: RuntimeRefillDeliverySampleEntry
+): RuntimeRefillDeliverySampleSummary {
+  return {
+    ...(entry.creepName ? { creepName: entry.creepName } : {}),
+    ...entry.sample
+  };
+}
+
+function compareRefillWorkerUtilizationSummaries(
+  left: RuntimeRefillWorkerUtilizationWorkerSummary,
+  right: RuntimeRefillWorkerUtilizationWorkerSummary
+): number {
+  return (
+    right.refillActiveTicks + right.idleOrOtherTaskTicks - (left.refillActiveTicks + left.idleOrOtherTaskTicks) ||
+    (left.creepName ?? '').localeCompare(right.creepName ?? '')
+  );
+}
+
+function isRecentRefillDeliverySample(sample: WorkerRefillDeliverySampleMemory, tick: number): boolean {
+  return (
+    isRefillDeliverySample(sample) &&
+    (tick <= 0 || (sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL))
+  );
+}
+
+function isRefillDeliverySample(value: unknown): value is WorkerRefillDeliverySampleMemory {
+  return (
+    isRecord(value) &&
+    typeof value.tick === 'number' &&
+    Number.isFinite(value.tick) &&
+    typeof value.targetId === 'string' &&
+    typeof value.deliveryTicks === 'number' &&
+    Number.isFinite(value.deliveryTicks) &&
+    typeof value.activeTicks === 'number' &&
+    Number.isFinite(value.activeTicks) &&
+    typeof value.idleOrOtherTaskTicks === 'number' &&
+    Number.isFinite(value.idleOrOtherTaskTicks) &&
+    typeof value.energyDelivered === 'number' &&
+    Number.isFinite(value.energyDelivered)
+  );
+}
+
+function roundRatio(numerator: number, denominator: number): number {
+  if (denominator <= 0) {
+    return 0;
+  }
+
+  return Math.round((numerator / denominator) * 1_000) / 1_000;
 }
 
 function isRecentWorkerEfficiencySample(sample: WorkerEfficiencySampleMemory, tick: number): boolean {
@@ -655,7 +890,176 @@ function toRuntimeConstructionPriorityCandidateSummary(
   };
 }
 
-function summarizeRoomEventMetrics(room: Room): RuntimeRoomEventMetrics {
+function refreshRefillTelemetry(
+  colonies: ColonySnapshot[],
+  creepsByColony: Map<string, Creep[]>,
+  refillTargetIdsByRoom: Map<string, Set<string>>,
+  eventMetricsByRoom: Map<string, RuntimeRoomEventMetrics>,
+  tick: number
+): void {
+  for (const colony of colonies) {
+    const roomName = colony.room.name;
+    const refillTargetIds = refillTargetIdsByRoom.get(roomName) ?? new Set<string>();
+    const refillTransfers = eventMetricsByRoom.get(roomName)?.refillTransfers ?? [];
+    const workers = (creepsByColony.get(roomName) ?? []).filter((creep) => creep.memory.role === 'worker');
+    for (const worker of workers) {
+      refreshWorkerRefillTelemetry(worker, refillTargetIds, refillTransfers, tick);
+    }
+  }
+}
+
+function refreshWorkerRefillTelemetry(
+  worker: Creep,
+  refillTargetIds: Set<string>,
+  refillTransfers: RuntimeRefillTransferEvent[],
+  tick: number
+): void {
+  const refillTargetId = getAssignedRefillTargetId(worker, refillTargetIds);
+  let telemetry = worker.memory.refillTelemetry;
+
+  if (refillTargetId) {
+    telemetry = ensureWorkerRefillTelemetry(worker);
+    if (!telemetry.current || telemetry.current.targetId !== refillTargetId) {
+      telemetry.current = {
+        targetId: refillTargetId,
+        startedAt: tick,
+        activeTicks: 0,
+        idleOrOtherTaskTicks: 0
+      };
+    }
+
+    recordWorkerRefillTelemetryTick(telemetry, true, tick);
+  } else if (telemetry && (telemetry.current || hasRecentWorkerRefillDelivery(telemetry, tick))) {
+    recordWorkerRefillTelemetryTick(telemetry, false, tick);
+  }
+
+  if (!telemetry?.current) {
+    pruneWorkerRefillTelemetry(worker, tick);
+    return;
+  }
+
+  const current = telemetry.current;
+  const deliveryEvents = refillTransfers.filter((event) =>
+    isWorkerRefillTransferEvent(worker, current.targetId, event)
+  );
+  if (deliveryEvents.length === 0) {
+    pruneWorkerRefillTelemetry(worker, tick);
+    return;
+  }
+
+  const energyDelivered = deliveryEvents.reduce((total, event) => total + event.amount, 0);
+  const sample: WorkerRefillDeliverySampleMemory = {
+    tick,
+    targetId: current.targetId,
+    deliveryTicks: Math.max(1, tick - current.startedAt + 1),
+    activeTicks: current.activeTicks,
+    idleOrOtherTaskTicks: current.idleOrOtherTaskTicks,
+    energyDelivered
+  };
+  telemetry.recentDeliveries = [sample, ...(telemetry.recentDeliveries ?? [])].filter((recentSample) =>
+    isRecentRefillDeliverySample(recentSample, tick)
+  );
+  delete telemetry.current;
+  pruneWorkerRefillTelemetry(worker, tick);
+}
+
+function ensureWorkerRefillTelemetry(worker: Creep): WorkerRefillTelemetryMemory {
+  if (!worker.memory.refillTelemetry) {
+    worker.memory.refillTelemetry = {};
+  }
+
+  return worker.memory.refillTelemetry;
+}
+
+function recordWorkerRefillTelemetryTick(
+  telemetry: WorkerRefillTelemetryMemory,
+  isRefillActive: boolean,
+  tick: number
+): void {
+  if (telemetry.lastUpdatedAt === tick) {
+    return;
+  }
+
+  if (isRefillActive) {
+    telemetry.refillActiveTicks = (telemetry.refillActiveTicks ?? 0) + 1;
+    if (telemetry.current) {
+      telemetry.current.activeTicks += 1;
+    }
+  } else {
+    telemetry.idleOrOtherTaskTicks = (telemetry.idleOrOtherTaskTicks ?? 0) + 1;
+    if (telemetry.current) {
+      telemetry.current.idleOrOtherTaskTicks += 1;
+    }
+  }
+
+  telemetry.lastUpdatedAt = tick;
+}
+
+function pruneWorkerRefillTelemetry(worker: Creep, tick: number): void {
+  const telemetry = worker.memory.refillTelemetry;
+  if (!telemetry) {
+    return;
+  }
+
+  if (telemetry.recentDeliveries) {
+    telemetry.recentDeliveries = telemetry.recentDeliveries.filter((sample) =>
+      isRecentRefillDeliverySample(sample, tick)
+    );
+    if (telemetry.recentDeliveries.length === 0) {
+      delete telemetry.recentDeliveries;
+    }
+  }
+
+  if (
+    !telemetry.current &&
+    !telemetry.recentDeliveries &&
+    (telemetry.lastUpdatedAt === undefined || telemetry.lastUpdatedAt <= tick - REFILL_DELIVERY_SAMPLE_TTL)
+  ) {
+    delete worker.memory.refillTelemetry;
+  }
+}
+
+function hasRecentWorkerRefillDelivery(telemetry: WorkerRefillTelemetryMemory, tick: number): boolean {
+  return (telemetry.recentDeliveries ?? []).some((sample) => isRecentRefillDeliverySample(sample, tick));
+}
+
+function getAssignedRefillTargetId(worker: Creep, refillTargetIds: Set<string>): string | null {
+  const task = worker.memory.task;
+  if (task?.type !== 'transfer') {
+    return null;
+  }
+
+  const targetId = String(task.targetId);
+  return refillTargetIds.has(targetId) ? targetId : null;
+}
+
+function isWorkerRefillTransferEvent(
+  worker: Creep,
+  targetId: string,
+  event: RuntimeRefillTransferEvent
+): boolean {
+  return event.targetId === targetId && getWorkerEventIds(worker).some((workerId) => workerId === event.objectId);
+}
+
+function getWorkerEventIds(worker: Creep): string[] {
+  const ids: string[] = [];
+  const id = (worker as Creep & { id?: unknown }).id;
+  const name = (worker as Creep & { name?: unknown }).name;
+  if (typeof id === 'string' && id.length > 0) {
+    ids.push(id);
+  }
+
+  if (typeof name === 'string' && name.length > 0) {
+    ids.push(name);
+  }
+
+  return ids;
+}
+
+function summarizeRoomEventMetrics(
+  room: Room,
+  refillTargetIds: Set<string> = getSpawnExtensionEnergyStructureIds(room)
+): RuntimeRoomEventMetrics {
   const eventLog = getRoomEventLog(room);
   if (!eventLog) {
     return {};
@@ -681,6 +1085,7 @@ function summarizeRoomEventMetrics(room: Room): RuntimeRoomEventMetrics {
     objectDestroyedCount: 0,
     creepDestroyedCount: 0
   };
+  const refillTransfers: RuntimeRefillTransferEvent[] = [];
   let hasResourceEvents = false;
   let hasCombatEvents = false;
 
@@ -696,7 +1101,17 @@ function summarizeRoomEventMetrics(room: Room): RuntimeRoomEventMetrics {
     }
 
     if (entry.event === transferEvent && isEnergyEventData(data)) {
-      resourceEvents.transferredEnergy += getNumericEventData(data, 'amount');
+      const amount = getNumericEventData(data, 'amount');
+      resourceEvents.transferredEnergy += amount;
+      const targetId = getEventTargetId(data);
+      if (targetId && refillTargetIds.has(targetId)) {
+        resourceEvents.refillEnergyDelivered = (resourceEvents.refillEnergyDelivered ?? 0) + amount;
+        refillTransfers.push({
+          ...buildEventObjectId(entry),
+          targetId,
+          amount
+        });
+      }
       hasResourceEvents = true;
     }
 
@@ -732,8 +1147,47 @@ function summarizeRoomEventMetrics(room: Room): RuntimeRoomEventMetrics {
 
   return {
     ...(hasResourceEvents ? { resources: resourceEvents } : {}),
-    ...(hasCombatEvents ? { combat: combatEvents } : {})
+    ...(hasCombatEvents ? { combat: combatEvents } : {}),
+    ...(refillTransfers.length > 0 ? { refillTransfers } : {})
   };
+}
+
+function getSpawnExtensionEnergyStructureIds(room: Room): Set<string> {
+  const structures = findRoomObjects(room, 'FIND_MY_STRUCTURES') ?? findRoomObjects(room, 'FIND_STRUCTURES') ?? [];
+  const ids = new Set<string>();
+
+  for (const structure of structures) {
+    if (!isSpawnExtensionEnergyStructure(structure)) {
+      continue;
+    }
+
+    const id = getObjectId(structure);
+    if (id) {
+      ids.add(id);
+    }
+  }
+
+  return ids;
+}
+
+function isSpawnExtensionEnergyStructure(structure: unknown): boolean {
+  return (
+    isRecord(structure) &&
+    (matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+      matchesStructureType(structure.structureType, 'STRUCTURE_EXTENSION', 'extension'))
+  );
+}
+
+function getEventTargetId(data: Record<string, unknown>): string | null {
+  return typeof data.targetId === 'string' && data.targetId.length > 0 ? data.targetId : null;
+}
+
+function buildEventObjectId(entry: Record<string, unknown>): { objectId?: string } {
+  return typeof entry.objectId === 'string' && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
+}
+
+function getObjectId(value: unknown): string | null {
+  return isRecord(value) && typeof value.id === 'string' && value.id.length > 0 ? value.id : null;
 }
 
 function findRoomObjects(room: Room, constantName: string): unknown[] | undefined {
@@ -810,7 +1264,12 @@ function getGlobalNumber(name: string): number | undefined {
   return typeof value === 'number' ? value : undefined;
 }
 
-type StructureConstantGlobal = 'STRUCTURE_ROAD' | 'STRUCTURE_CONTAINER' | 'STRUCTURE_RAMPART';
+type StructureConstantGlobal =
+  | 'STRUCTURE_ROAD'
+  | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_RAMPART'
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_EXTENSION';
 
 function matchesStructureType(value: unknown, globalName: StructureConstantGlobal, fallback: string): boolean {
   const expectedValue = (globalThis as Record<string, unknown>)[globalName] ?? fallback;

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -243,13 +243,14 @@ export function emitRuntimeSummary(
   }
 
   const tick = getGameTime();
+  if (!shouldEmitRuntimeSummary(tick, events)) {
+    return;
+  }
+
   const creepsByColony = groupCreepsByColony(creeps);
   const refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
   const eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
   refreshRefillTelemetry(colonies, creepsByColony, refillTargetIdsByRoom, eventMetricsByRoom, tick);
-  if (!shouldEmitRuntimeSummary(tick, events)) {
-    return;
-  }
 
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -232,6 +232,10 @@ interface RuntimeSummaryOptions {
   persistOccupationRecommendations?: boolean;
 }
 
+let cachedRefillTargetIdsByRoom = new Map<string, Set<string>>();
+let cachedEventMetricsByRoom = new Map<string, RuntimeRoomEventMetrics>();
+let cachedEventMetricsTick: number | undefined;
+
 export function emitRuntimeSummary(
   colonies: ColonySnapshot[],
   creeps: Creep[],
@@ -243,14 +247,31 @@ export function emitRuntimeSummary(
   }
 
   const tick = getGameTime();
-  if (!shouldEmitRuntimeSummary(tick, events)) {
-    return;
+  resetCachedRefillTelemetryIfTickRewound(tick);
+  const emitsSummary = shouldEmitRuntimeSummary(tick, events);
+  const creepsByColony = groupCreepsByColony(creeps);
+  let refillTargetIdsByRoom = cachedRefillTargetIdsByRoom;
+  let eventMetricsByRoom = cachedEventMetricsByRoom;
+
+  if (emitsSummary) {
+    refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
+    eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
+    cachedRefillTargetIdsByRoom = refillTargetIdsByRoom;
+    cachedEventMetricsByRoom = eventMetricsByRoom;
+    cachedEventMetricsTick = tick;
   }
 
-  const creepsByColony = groupCreepsByColony(creeps);
-  const refillTargetIdsByRoom = buildRefillTargetIdsByRoom(colonies);
-  const eventMetricsByRoom = buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom);
-  refreshRefillTelemetry(colonies, creepsByColony, refillTargetIdsByRoom, eventMetricsByRoom, tick);
+  refreshRefillTelemetry(
+    colonies,
+    creepsByColony,
+    refillTargetIdsByRoom,
+    eventMetricsByRoom,
+    tick,
+    cachedEventMetricsTick
+  );
+  if (!emitsSummary) {
+    return;
+  }
 
   const reportedEvents = events.slice(0, MAX_REPORTED_EVENTS);
   const persistOccupationRecommendations = options.persistOccupationRecommendations !== false;
@@ -275,6 +296,16 @@ export function emitRuntimeSummary(
 
 export function shouldEmitRuntimeSummary(tick: number, events: RuntimeTelemetryEvent[]): boolean {
   return events.length > 0 || (tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0);
+}
+
+function resetCachedRefillTelemetryIfTickRewound(tick: number): void {
+  if (cachedEventMetricsTick === undefined || tick >= cachedEventMetricsTick) {
+    return;
+  }
+
+  cachedRefillTargetIdsByRoom = new Map<string, Set<string>>();
+  cachedEventMetricsByRoom = new Map<string, RuntimeRoomEventMetrics>();
+  cachedEventMetricsTick = undefined;
 }
 
 function groupCreepsByColony(creeps: Creep[]): Map<string, Creep[]> {
@@ -896,12 +927,14 @@ function refreshRefillTelemetry(
   creepsByColony: Map<string, Creep[]>,
   refillTargetIdsByRoom: Map<string, Set<string>>,
   eventMetricsByRoom: Map<string, RuntimeRoomEventMetrics>,
-  tick: number
+  tick: number,
+  eventMetricsTick: number | undefined
 ): void {
   for (const colony of colonies) {
     const roomName = colony.room.name;
     const refillTargetIds = refillTargetIdsByRoom.get(roomName) ?? new Set<string>();
-    const refillTransfers = eventMetricsByRoom.get(roomName)?.refillTransfers ?? [];
+    // Room event logs are tick-scoped; cached refill transfer events must not be replayed on later ticks.
+    const refillTransfers = eventMetricsTick === tick ? eventMetricsByRoom.get(roomName)?.refillTransfers ?? [] : [];
     const workers = (creepsByColony.get(roomName) ?? []).filter((creep) => creep.memory.role === 'worker');
     for (const worker of workers) {
       refreshWorkerRefillTelemetry(worker, refillTargetIds, refillTransfers, tick);

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -16,6 +16,7 @@ declare global {
     defense?: CreepDefenseMemory;
     territory?: CreepTerritoryMemory;
     workerEfficiency?: WorkerEfficiencySampleMemory;
+    refillTelemetry?: WorkerRefillTelemetryMemory;
   }
 
   type DefenseActionType =
@@ -134,6 +135,30 @@ declare global {
     energy?: number;
     range?: number;
     reason?: WorkerEfficiencyLowLoadReturnReason;
+  }
+
+  interface WorkerRefillTelemetryMemory {
+    current?: WorkerRefillDeliveryMemory;
+    recentDeliveries?: WorkerRefillDeliverySampleMemory[];
+    refillActiveTicks?: number;
+    idleOrOtherTaskTicks?: number;
+    lastUpdatedAt?: number;
+  }
+
+  interface WorkerRefillDeliveryMemory {
+    targetId: string;
+    startedAt: number;
+    activeTicks: number;
+    idleOrOtherTaskTicks: number;
+  }
+
+  interface WorkerRefillDeliverySampleMemory {
+    tick: number;
+    targetId: string;
+    deliveryTicks: number;
+    activeTicks: number;
+    idleOrOtherTaskTicks: number;
+    energyDelivered: number;
   }
 
   type CreepTaskMemory =

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -208,6 +208,107 @@ describe('runtime telemetry summaries', () => {
     expect(logSpy).not.toHaveBeenCalled();
   });
 
+  it('refreshes refill telemetry on non-cadence ticks from cached room data without rescanning', () => {
+    const refillTarget = {
+      id: 'extension1',
+      structureType: TEST_GLOBALS.STRUCTURE_EXTENSION,
+      store: makeEnergyStore(0)
+    };
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      structures: [refillTarget]
+    });
+    const roomFind = (colony.room as unknown as { find: jest.Mock }).find;
+    const getEventLog = jest.fn(() =>
+      Game.time === RUNTIME_SUMMARY_INTERVAL * 2
+        ? [
+            {
+              event: TEST_GLOBALS.EVENT_TRANSFER,
+              objectId: 'worker1',
+              data: {
+                targetId: 'extension1',
+                amount: 25,
+                resourceType: TEST_GLOBALS.RESOURCE_ENERGY
+              }
+            }
+          ]
+        : []
+    );
+    (colony.room as unknown as { getEventLog: jest.Mock }).getEventLog = getEventLog;
+    const worker = {
+      id: 'worker1',
+      name: 'RefillWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'transfer', targetId: 'extension1' as Id<AnyStoreStructure> }
+      },
+      store: makeEnergyStore(25)
+    } as unknown as Creep;
+
+    emitRuntimeSummary([colony], [], [], { persistOccupationRecommendations: false });
+    logSpy.mockClear();
+    roomFind.mockClear();
+    getEventLog.mockClear();
+
+    for (let tick = RUNTIME_SUMMARY_INTERVAL + 1; tick < RUNTIME_SUMMARY_INTERVAL * 2; tick += 1) {
+      (globalThis as unknown as { Game: Partial<Game> }).Game.time = tick;
+      emitRuntimeSummary([colony], [worker], [], { persistOccupationRecommendations: false });
+    }
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(roomFind).not.toHaveBeenCalled();
+    expect(getEventLog).not.toHaveBeenCalled();
+    expect(worker.memory.refillTelemetry).toMatchObject({
+      current: {
+        targetId: 'extension1',
+        startedAt: RUNTIME_SUMMARY_INTERVAL + 1,
+        activeTicks: RUNTIME_SUMMARY_INTERVAL - 1,
+        idleOrOtherTaskTicks: 0
+      },
+      refillActiveTicks: RUNTIME_SUMMARY_INTERVAL - 1,
+      lastUpdatedAt: RUNTIME_SUMMARY_INTERVAL * 2 - 1
+    });
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game.time = RUNTIME_SUMMARY_INTERVAL * 2;
+    emitRuntimeSummary([colony], [worker], [], { persistOccupationRecommendations: false });
+
+    expect(roomFind).toHaveBeenCalled();
+    expect(getEventLog).toHaveBeenCalledTimes(1);
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.refillDeliveryTicks).toEqual({
+      completedCount: 1,
+      averageTicks: RUNTIME_SUMMARY_INTERVAL,
+      maxTicks: RUNTIME_SUMMARY_INTERVAL,
+      samples: [
+        {
+          creepName: 'RefillWorker',
+          tick: RUNTIME_SUMMARY_INTERVAL * 2,
+          targetId: 'extension1',
+          deliveryTicks: RUNTIME_SUMMARY_INTERVAL,
+          activeTicks: RUNTIME_SUMMARY_INTERVAL,
+          idleOrOtherTaskTicks: 0,
+          energyDelivered: 25
+        }
+      ]
+    });
+    expect(room.refillWorkerUtilization).toEqual({
+      assignedWorkerCount: 1,
+      refillActiveTicks: RUNTIME_SUMMARY_INTERVAL,
+      idleOrOtherTaskTicks: 0,
+      ratio: 1,
+      workers: [
+        {
+          creepName: 'RefillWorker',
+          refillActiveTicks: RUNTIME_SUMMARY_INTERVAL,
+          idleOrOtherTaskTicks: 0,
+          ratio: 1
+        }
+      ]
+    });
+  });
+
   it('emits non-cadence summaries for spawn events and bounds event payload size', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL + 1 });
     const events = Array.from({ length: 12 }, (_, index): RuntimeTelemetryEvent => ({

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4,11 +4,18 @@ import {
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   LOW_LOAD_NEARBY_ENERGY_RANGE,
   LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
+  REFILL_DELIVERY_MIN_LOAD,
   TOWER_REFILL_ENERGY_FLOOR,
   URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
   estimateNearTermSpawnExtensionRefillReserve,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import {
+  emitRuntimeSummary,
+  RUNTIME_SUMMARY_INTERVAL,
+  RUNTIME_SUMMARY_PREFIX
+} from '../src/telemetry/runtimeSummary';
 import {
   assessColonySurvival,
   clearColonySurvivalAssessmentCache,
@@ -2095,7 +2102,7 @@ describe('selectWorkerTask', () => {
   it.each([
     ['spawn', 'spawn1'],
     ['extension', 'extension1']
-  ])('prioritizes urgent %s refill over low-load harvest continuation during spawn recovery', (structureType, id) => {
+  ])('keeps urgent %s refill worker acquiring energy until the min delivery load during spawn recovery', (structureType, id) => {
     const energySink = makeEnergySink(id, structureType as StructureConstant, 300);
     const lowEnergySource = makeSource('source-low', 8, 8, 10);
     const loadReadySource = makeSource('source-ready', 20, 20, 300);
@@ -2126,16 +2133,157 @@ describe('selectWorkerTask', () => {
     setGameCreeps({ RecoveryCarrier: creep });
     recordSurvivalMode('LOCAL_STABLE', 333);
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: id });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-ready' });
     expect(creep.memory.workerEfficiency).toEqual({
-      type: 'lowLoadReturn',
+      type: 'nearbyEnergyChoice',
       tick: 333,
       carriedEnergy: 2,
       freeCapacity: 48,
+      selectedTask: 'harvest',
+      targetId: 'source-ready',
+      energy: 300,
+      range: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+    });
+  });
+
+  it('returns early for urgent refill when the only visible source is depleted', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const depletedSource = makeSource('source-empty', 8, 8, 0);
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'source-empty': 1,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const room = makeWorkerTaskRoom({
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      energyCapacityAvailable: 400,
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [depletedSource]
+    });
+    const creep = {
+      name: 'RecoveryCarrier',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(REFILL_DELIVERY_MIN_LOAD - 1),
+        getFreeCapacity: jest.fn().mockReturnValue(81)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ RecoveryCarrier: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 0,
+      carriedEnergy: REFILL_DELIVERY_MIN_LOAD - 1,
+      freeCapacity: 81,
       selectedTask: 'transfer',
-      targetId: id,
+      targetId: 'spawn1',
       reason: 'urgentSpawnExtensionRefill'
     });
+  });
+
+  it('records refill delivery ticks and delivered energy in runtime summary telemetry', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300, {
+      name: 'Spawn1'
+    }) as StructureSpawn;
+    const room = makeWorkerTaskRoom({
+      energyAvailable: 100,
+      energyCapacityAvailable: 300,
+      myStructures: [spawn as AnyOwnedStructure],
+      structures: [spawn]
+    });
+    const worker = {
+      id: 'worker1',
+      name: 'RefillWorker',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> },
+        refillTelemetry: {
+          current: {
+            targetId: 'spawn1',
+            startedAt: RUNTIME_SUMMARY_INTERVAL - 2,
+            activeTicks: 2,
+            idleOrOtherTaskTicks: 1
+          },
+          refillActiveTicks: 2,
+          idleOrOtherTaskTicks: 1,
+          lastUpdatedAt: RUNTIME_SUMMARY_INTERVAL - 1
+        }
+      },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(15) }
+    } as unknown as Creep;
+    const colony: ColonySnapshot = {
+      room,
+      spawns: [spawn],
+      energyAvailable: 100,
+      energyCapacityAvailable: 300
+    };
+    (room as unknown as { getEventLog: jest.Mock }).getEventLog = jest.fn(() => [
+      {
+        event: 10,
+        objectId: 'worker1',
+        data: { targetId: 'spawn1', amount: 15, resourceType: RESOURCE_ENERGY }
+      }
+    ]);
+    (globalThis as unknown as { EVENT_TRANSFER: number }).EVENT_TRANSFER = 10;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { RefillWorker: worker },
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      time: RUNTIME_SUMMARY_INTERVAL
+    };
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    try {
+      emitRuntimeSummary([colony], [worker], [], { persistOccupationRecommendations: false });
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const [message] = logSpy.mock.calls[0];
+      expect(typeof message).toBe('string');
+      const payload = JSON.parse((message as string).slice(RUNTIME_SUMMARY_PREFIX.length)) as {
+        rooms: Array<Record<string, unknown>>;
+      };
+      const [roomSummary] = payload.rooms;
+      expect((roomSummary.resources as Record<string, Record<string, number>>).events.refillEnergyDelivered).toBe(15);
+      expect(roomSummary.refillDeliveryTicks).toEqual({
+        completedCount: 1,
+        averageTicks: 3,
+        maxTicks: 3,
+        samples: [
+          {
+            creepName: 'RefillWorker',
+            tick: RUNTIME_SUMMARY_INTERVAL,
+            targetId: 'spawn1',
+            deliveryTicks: 3,
+            activeTicks: 3,
+            idleOrOtherTaskTicks: 1,
+            energyDelivered: 15
+          }
+        ]
+      });
+      expect(roomSummary.refillWorkerUtilization).toEqual({
+        assignedWorkerCount: 1,
+        refillActiveTicks: 3,
+        idleOrOtherTaskTicks: 1,
+        ratio: 0.75,
+        workers: [
+          {
+            creepName: 'RefillWorker',
+            refillActiveTicks: 3,
+            idleOrOtherTaskTicks: 1,
+            ratio: 0.75
+          }
+        ]
+      });
+    } finally {
+      logSpy.mockRestore();
+      delete (globalThis as unknown as { EVENT_TRANSFER?: number }).EVENT_TRANSFER;
+    }
   });
 
   it('keeps the load-ready harvest preference during spawn recovery when no refill target exists', () => {
@@ -2674,7 +2822,7 @@ describe('selectWorkerTask', () => {
     expect(findPathTo).not.toHaveBeenCalled();
   });
 
-  it('keeps urgent spawn refill before low-load nearby energy acquisition', () => {
+  it('keeps urgent spawn refill worker acquiring nearby energy while below the min delivery load', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const droppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
     const getRangeTo = jest.fn((target: { id: string }) => (target.id === 'drop-near' ? 1 : 99));
@@ -2716,15 +2864,16 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 322 };
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
     expect(creep.memory.workerEfficiency).toEqual({
-      type: 'lowLoadReturn',
+      type: 'nearbyEnergyChoice',
       tick: 322,
       carriedEnergy: 10,
       freeCapacity: 40,
-      selectedTask: 'transfer',
-      targetId: 'spawn1',
-      reason: 'urgentSpawnExtensionRefill'
+      selectedTask: 'pickup',
+      targetId: 'drop-near',
+      energy: 50,
+      range: 1
     });
   });
 


### PR DESCRIPTION
## Summary
Follow-up to #461: hardens refill throughput with minimum load guard and telemetry.

## Changes
- `workerTasks.ts`: Added `REFILL_DELIVERY_MIN_LOAD` (20 energy) so workers on urgent refill continue acquisition instead of returning with tiny loads
- `runtimeSummary.ts`: Added refill throughput telemetry — `refillDeliveryTicks`, `refillWorkerUtilization`, `refillEnergyDelivered`
- `types.d.ts`: Type definitions for new refill telemetry fields
- `workerTasks.test.ts`: Tests for minimum load behavior and refill telemetry

## Verification
- Typecheck: PASS
- Jest tests: 671/671 PASS
- Build: PASS
- git diff --check: clean

Refs #463