### PR TITLE
feat: distance-aware expansion candidate scoring (#467)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1289,6 +1289,8 @@ var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
 var TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR = ">";
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR = "occupationRecommendation";
+var ROAD_DISTANCE_BASE_SCORE = 100;
+var ROAD_DISTANCE_ROOM_COST_SCORE = 20;
 var ACTION_SCORE = {
   occupy: 1e3,
   reserve: 800,
@@ -1470,20 +1472,23 @@ function buildRuntimeOccupationCandidates(colonyName) {
         visible: false,
         actionHint: target.action,
         ...target.controllerId ? { controllerId: target.controllerId } : {},
-        routeDistance: getCachedRouteDistance(colonyName, target.roomName)
+        routeDistance: getCachedRouteDistance(colonyName, target.roomName),
+        roadDistance: getCachedNearestOwnedRoomRouteDistance(colonyName, target.roomName)
       });
       order += 1;
     }
   }
   for (const roomName of getAdjacentRoomNames(colonyName)) {
     const cachedRouteDistance = getCachedRouteDistance(colonyName, roomName);
+    const routeDistance = cachedRouteDistance === void 0 ? 1 : cachedRouteDistance;
     upsertOccupationCandidate(candidatesByRoom, {
       roomName,
       source: "adjacent",
       order,
       adjacent: true,
       visible: false,
-      routeDistance: cachedRouteDistance === void 0 ? 1 : cachedRouteDistance
+      routeDistance,
+      ...typeof routeDistance === "number" ? { roadDistance: routeDistance } : {}
     });
     order += 1;
   }
@@ -1509,6 +1514,9 @@ function upsertOccupationCandidate(candidatesByRoom, candidate) {
   }
   if (existing.routeDistance === void 0 && candidate.routeDistance !== void 0) {
     existing.routeDistance = candidate.routeDistance;
+  }
+  if (existing.roadDistance === void 0 && candidate.roadDistance !== void 0) {
+    existing.roadDistance = candidate.roadDistance;
   }
 }
 function enrichVisibleOccupationCandidate(candidate) {
@@ -1606,6 +1614,7 @@ function scoreOccupationCandidate(input, candidate) {
     preconditions,
     risks,
     ...routeDistance !== void 0 ? { routeDistance } : {},
+    ...candidate.roadDistance !== void 0 ? { roadDistance: candidate.roadDistance } : {},
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {},
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...candidate.sourceCount !== void 0 ? { sourceCount: candidate.sourceCount } : {},
@@ -1630,7 +1639,8 @@ function getTerritoryIntentAction(action) {
 }
 function calculateOccupationScore(input, candidate, action, evidenceStatus) {
   var _a, _b, _c, _d, _e;
-  const distanceScore = typeof candidate.routeDistance === "number" ? Math.max(0, 80 - candidate.routeDistance * 15) : 0;
+  const roadDistance = getCandidateRoadDistance(candidate);
+  const roadDistanceScore = typeof roadDistance === "number" ? ROAD_DISTANCE_BASE_SCORE - roadDistance * ROAD_DISTANCE_ROOM_COST_SCORE : 0;
   const sourceScore = typeof candidate.sourceCount === "number" ? Math.min(candidate.sourceCount, 2) * 70 : 0;
   const supportScore = Math.min((_a = candidate.ownedStructureCount) != null ? _a : 0, 3) * 8 + Math.min((_b = candidate.constructionSiteCount) != null ? _b : 0, 3) * 5;
   const sourcePriorityScore = candidate.source === "configured" ? 50 : 25;
@@ -1640,7 +1650,11 @@ function calculateOccupationScore(input, candidate, action, evidenceStatus) {
   const controllerPressurePenalty = candidate.controller && isForeignReservation(input, candidate.controller) ? 180 : 0;
   const evidencePenalty = evidenceStatus === "insufficient-evidence" ? 260 : 0;
   const unavailablePenalty = evidenceStatus === "unavailable" ? 2e3 : 0;
-  return ACTION_SCORE[action] + sourcePriorityScore + adjacencyScore + distanceScore + sourceScore + supportScore + readinessScore - riskPenalty - controllerPressurePenalty - evidencePenalty - unavailablePenalty;
+  return ACTION_SCORE[action] + sourcePriorityScore + adjacencyScore + roadDistanceScore + sourceScore + supportScore + readinessScore - riskPenalty - controllerPressurePenalty - evidencePenalty - unavailablePenalty;
+}
+function getCandidateRoadDistance(candidate) {
+  var _a;
+  return (_a = candidate.roadDistance) != null ? _a : typeof candidate.routeDistance === "number" ? candidate.routeDistance : void 0;
 }
 function getControllerPressureEvidence(input, candidate) {
   if (candidate.source !== "configured" || !isTerritoryControlAction(candidate.actionHint) || !candidate.controller || !isForeignReservation(input, candidate.controller)) {
@@ -1767,6 +1781,32 @@ function getCachedRouteDistance(fromRoom, targetRoom) {
   }
   const distance = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`];
   return typeof distance === "number" || distance === null ? distance : void 0;
+}
+function getCachedNearestOwnedRoomRouteDistance(fromRoom, targetRoom) {
+  const ownedRoomNames = getVisibleOwnedRoomNames(fromRoom);
+  let nearestDistance;
+  for (const ownedRoomName of ownedRoomNames) {
+    const distance = ownedRoomName === fromRoom ? getCachedRouteDistance(fromRoom, targetRoom) : getCachedRouteDistance(ownedRoomName, targetRoom);
+    if (typeof distance !== "number") {
+      continue;
+    }
+    nearestDistance = nearestDistance === void 0 ? distance : Math.min(nearestDistance, distance);
+  }
+  return nearestDistance;
+}
+function getVisibleOwnedRoomNames(fallbackRoomName) {
+  var _a;
+  const roomNames = /* @__PURE__ */ new Set([fallbackRoomName]);
+  const rooms = getGameRooms();
+  if (!rooms) {
+    return Array.from(roomNames);
+  }
+  for (const room of Object.values(rooms)) {
+    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && typeof room.name === "string" && room.name.length > 0) {
+      roomNames.add(room.name);
+    }
+  }
+  return Array.from(roomNames);
 }
 function findRoomObjects2(room, constantName) {
   const findConstant = getGlobalNumber3(constantName);
@@ -3057,6 +3097,12 @@ function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwn
     return null;
   }
   const routeDistance = knownRouteDistance != null ? knownRouteDistance : getInferredTerritoryRouteDistance(source);
+  const roadDistance = getNearestOwnedRoomRouteDistance(
+    colonyName,
+    selection.target.roomName,
+    routeDistance,
+    routeDistanceLookupContext
+  );
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
   const occupationActionableTicks = source === "occupationIntent" ? getOccupationIntentActionableTicks(selection, colonyOwnerUsername) : void 0;
   const requiresControllerPressure = selection.requiresControllerPressure === true || isVisibleTerritoryReservePressureAvailable(
@@ -3072,6 +3118,7 @@ function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwn
     priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...routeDistance !== void 0 ? { routeDistance } : {},
+    ...roadDistance !== void 0 ? { roadDistance } : {},
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {},
     ...occupationActionableTicks !== void 0 ? { occupationActionableTicks } : {}
   };
@@ -3182,6 +3229,7 @@ function buildOccupationRecommendationCandidate(candidate) {
     visible: room != null,
     actionHint: candidate.target.action,
     ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
+    ...candidate.roadDistance !== void 0 ? { roadDistance: candidate.roadDistance } : {},
     ...room ? buildVisibleOccupationRecommendationEvidence(room, candidate.target.controllerId) : {}
   };
 }
@@ -3385,6 +3433,31 @@ function createRouteDistanceLookupContext() {
 }
 function hasKnownNoRoute(fromRoom, targetRoom, routeDistanceLookupContext) {
   return getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) === null;
+}
+function getNearestOwnedRoomRouteDistance(colonyName, targetRoom, fallbackRouteDistance, routeDistanceLookupContext) {
+  let nearestDistance = fallbackRouteDistance;
+  for (const ownedRoomName of getVisibleOwnedRoomNames2(colonyName)) {
+    const routeDistance = ownedRoomName === colonyName ? fallbackRouteDistance : getKnownRouteLength(ownedRoomName, targetRoom, routeDistanceLookupContext);
+    if (typeof routeDistance !== "number") {
+      continue;
+    }
+    nearestDistance = nearestDistance === void 0 ? routeDistance : Math.min(nearestDistance, routeDistance);
+  }
+  return nearestDistance;
+}
+function getVisibleOwnedRoomNames2(fallbackRoomName) {
+  var _a, _b;
+  const roomNames = /* @__PURE__ */ new Set([fallbackRoomName]);
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return Array.from(roomNames);
+  }
+  for (const room of Object.values(rooms)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString3(room.name)) {
+      roomNames.add(room.name);
+    }
+  }
+  return Array.from(roomNames);
 }
 function getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) {
   var _a;
@@ -10130,6 +10203,7 @@ function normalizeTerritoryCandidate(rawCandidate) {
       ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString5) } : {},
       ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString5) } : {},
       ...isFiniteNumber3(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {},
+      ...isFiniteNumber3(rawCandidate.roadDistance) ? { roadDistance: rawCandidate.roadDistance } : {},
       ...isFiniteNumber3(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {},
       ...isFiniteNumber3(rawCandidate.hostileCreepCount) ? { hostileCreepCount: rawCandidate.hostileCreepCount } : {},
       ...isFiniteNumber3(rawCandidate.hostileStructureCount) ? { hostileStructureCount: rawCandidate.hostileStructureCount } : {}
@@ -10469,7 +10543,7 @@ function buildConstructionRankingItem(room, candidate, artifactIndex, tick) {
   };
 }
 function buildTerritoryRankingItem(room, candidate, artifactIndex, tick) {
-  var _a, _b, _c, _d, _e, _f, _g, _h, _i;
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j;
   const actionTerritorySignal = candidate.action === "occupy" ? 8 : candidate.action === "reserve" ? 6 : 2;
   const hostileRisk = ((_a = candidate.hostileCreepCount) != null ? _a : 0) * 5 + ((_b = candidate.hostileStructureCount) != null ? _b : 0) * 4;
   const evidenceRisk = candidate.evidenceStatus === "unavailable" ? 12 : candidate.evidenceStatus === "insufficient-evidence" ? 5 : 0;
@@ -10486,7 +10560,7 @@ function buildTerritoryRankingItem(room, candidate, artifactIndex, tick) {
       resources: Math.min((_f = candidate.sourceCount) != null ? _f : 0, 3) * 2,
       kills: hostileRisk > 0 ? 1 : 0,
       reliability: candidate.evidenceStatus === "sufficient" ? 1 : 0,
-      risk: hostileRisk + evidenceRisk + ((_h = (_g = candidate.risks) == null ? void 0 : _g.length) != null ? _h : 0) + Math.max(0, ((_i = candidate.routeDistance) != null ? _i : 1) - 1)
+      risk: hostileRisk + evidenceRisk + ((_h = (_g = candidate.risks) == null ? void 0 : _g.length) != null ? _h : 0) + Math.max(0, ((_j = (_i = candidate.roadDistance) != null ? _i : candidate.routeDistance) != null ? _j : 1) - 1)
     }
   };
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1288,6 +1288,7 @@ var RESERVATION_RENEWAL_TICKS = 1e3;
 var TERRITORY_SUPPRESSION_RETRY_TICKS = 1500;
 var TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR = ">";
+var ERR_NO_PATH_CODE = -2;
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR = "occupationRecommendation";
 var ROAD_DISTANCE_BASE_SCORE = 100;
 var ROAD_DISTANCE_ROOM_COST_SCORE = 20;
@@ -1786,13 +1787,37 @@ function getCachedNearestOwnedRoomRouteDistance(fromRoom, targetRoom) {
   const ownedRoomNames = getVisibleOwnedRoomNames(fromRoom);
   let nearestDistance;
   for (const ownedRoomName of ownedRoomNames) {
-    const distance = ownedRoomName === fromRoom ? getCachedRouteDistance(fromRoom, targetRoom) : getCachedRouteDistance(ownedRoomName, targetRoom);
+    const cachedDistance = ownedRoomName === fromRoom ? getCachedRouteDistance(fromRoom, targetRoom) : getCachedRouteDistance(ownedRoomName, targetRoom);
+    const distance = cachedDistance === void 0 ? findUncachedRouteDistance(ownedRoomName, targetRoom) : cachedDistance;
     if (typeof distance !== "number") {
       continue;
     }
     nearestDistance = nearestDistance === void 0 ? distance : Math.min(nearestDistance, distance);
   }
   return nearestDistance;
+}
+function findUncachedRouteDistance(fromRoom, targetRoom) {
+  var _a;
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
+    return void 0;
+  }
+  try {
+    const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom);
+    if (route === getNoPathResultCode()) {
+      return void 0;
+    }
+    return Array.isArray(route) ? route.length : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function getNoPathResultCode() {
+  const noPathCode = globalThis.ERR_NO_PATH;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE;
 }
 function getVisibleOwnedRoomNames(fallbackRoomName) {
   var _a;
@@ -2036,7 +2061,7 @@ var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 var TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 0;
 var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
-var ERR_NO_PATH_CODE = -2;
+var ERR_NO_PATH_CODE2 = -2;
 var TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL = 0;
 var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM = 1;
 var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE = 2;
@@ -3478,7 +3503,7 @@ function getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) {
     return void 0;
   }
   const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom);
-  if (route === getNoPathResultCode()) {
+  if (route === getNoPathResultCode2()) {
     if (cache) {
       cache[cacheKey] = null;
     }
@@ -3506,9 +3531,9 @@ function getTerritoryRouteDistanceCache() {
 function getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom) {
   return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR2}${targetRoom}`;
 }
-function getNoPathResultCode() {
+function getNoPathResultCode2() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE2;
 }
 function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
   if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {

--- a/prod/src/strategy/kpiEvaluator.ts
+++ b/prod/src/strategy/kpiEvaluator.ts
@@ -94,6 +94,7 @@ export interface StrategyRuntimeTerritoryCandidate {
   preconditions?: string[];
   risks?: string[];
   routeDistance?: number;
+  roadDistance?: number;
   sourceCount?: number;
   hostileCreepCount?: number;
   hostileStructureCount?: number;
@@ -585,6 +586,7 @@ function normalizeTerritoryCandidate(rawCandidate: unknown): StrategyRuntimeTerr
         : {}),
       ...(Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString) } : {}),
       ...(isFiniteNumber(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {}),
+      ...(isFiniteNumber(rawCandidate.roadDistance) ? { roadDistance: rawCandidate.roadDistance } : {}),
       ...(isFiniteNumber(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {}),
       ...(isFiniteNumber(rawCandidate.hostileCreepCount)
         ? { hostileCreepCount: rawCandidate.hostileCreepCount }

--- a/prod/src/strategy/shadowEvaluator.ts
+++ b/prod/src/strategy/shadowEvaluator.ts
@@ -340,7 +340,11 @@ function buildTerritoryRankingItem(
       resources: Math.min(candidate.sourceCount ?? 0, 3) * 2,
       kills: hostileRisk > 0 ? 1 : 0,
       reliability: candidate.evidenceStatus === 'sufficient' ? 1 : 0,
-      risk: hostileRisk + evidenceRisk + (candidate.risks?.length ?? 0) + Math.max(0, (candidate.routeDistance ?? 1) - 1)
+      risk:
+        hostileRisk +
+        evidenceRisk +
+        (candidate.risks?.length ?? 0) +
+        Math.max(0, (candidate.roadDistance ?? candidate.routeDistance ?? 1) - 1)
     }
   };
 }

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -21,6 +21,7 @@ export interface OccupationRecommendationScore {
   preconditions: string[];
   risks: string[];
   routeDistance?: number;
+  roadDistance?: number;
   controllerId?: Id<StructureController>;
   requiresControllerPressure?: boolean;
   sourceCount?: number;
@@ -56,6 +57,7 @@ export interface OccupationRecommendationCandidateInput {
   actionHint?: TerritoryControlAction;
   controllerId?: Id<StructureController>;
   routeDistance?: number | null;
+  roadDistance?: number;
   controller?: OccupationControllerEvidence;
   sourceCount?: number;
   hostileCreepCount?: number;
@@ -80,6 +82,8 @@ const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 const TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
 const OCCUPATION_RECOMMENDATION_TARGET_CREATOR: TerritoryTargetMemory['createdBy'] = 'occupationRecommendation';
+const ROAD_DISTANCE_BASE_SCORE = 100;
+const ROAD_DISTANCE_ROOM_COST_SCORE = 20;
 type OccupationRecommendationControlTargetKey = Pick<TerritoryTargetMemory, 'roomName' | 'action'>;
 
 // Project vision ordering: territory action dominates resource value; combat/risk only gates or deprioritizes.
@@ -365,7 +369,8 @@ function buildRuntimeOccupationCandidates(colonyName: string): OccupationRecomme
         visible: false,
         actionHint: target.action,
         ...(target.controllerId ? { controllerId: target.controllerId } : {}),
-        routeDistance: getCachedRouteDistance(colonyName, target.roomName)
+        routeDistance: getCachedRouteDistance(colonyName, target.roomName),
+        roadDistance: getCachedNearestOwnedRoomRouteDistance(colonyName, target.roomName)
       });
       order += 1;
     }
@@ -373,13 +378,15 @@ function buildRuntimeOccupationCandidates(colonyName: string): OccupationRecomme
 
   for (const roomName of getAdjacentRoomNames(colonyName)) {
     const cachedRouteDistance = getCachedRouteDistance(colonyName, roomName);
+    const routeDistance = cachedRouteDistance === undefined ? 1 : cachedRouteDistance;
     upsertOccupationCandidate(candidatesByRoom, {
       roomName,
       source: 'adjacent',
       order,
       adjacent: true,
       visible: false,
-      routeDistance: cachedRouteDistance === undefined ? 1 : cachedRouteDistance
+      routeDistance,
+      ...(typeof routeDistance === 'number' ? { roadDistance: routeDistance } : {})
     });
     order += 1;
   }
@@ -412,6 +419,9 @@ function upsertOccupationCandidate(
   }
   if (existing.routeDistance === undefined && candidate.routeDistance !== undefined) {
     existing.routeDistance = candidate.routeDistance;
+  }
+  if (existing.roadDistance === undefined && candidate.roadDistance !== undefined) {
+    existing.roadDistance = candidate.roadDistance;
   }
 }
 
@@ -519,6 +529,7 @@ function scoreOccupationCandidate(
     preconditions,
     risks,
     ...(routeDistance !== undefined ? { routeDistance } : {}),
+    ...(candidate.roadDistance !== undefined ? { roadDistance: candidate.roadDistance } : {}),
     ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(candidate.sourceCount !== undefined ? { sourceCount: candidate.sourceCount } : {}),
@@ -554,8 +565,11 @@ function calculateOccupationScore(
   action: OccupationRecommendationAction,
   evidenceStatus: OccupationRecommendationEvidenceStatus
 ): number {
-  const distanceScore =
-    typeof candidate.routeDistance === 'number' ? Math.max(0, 80 - candidate.routeDistance * 15) : 0;
+  const roadDistance = getCandidateRoadDistance(candidate);
+  const roadDistanceScore =
+    typeof roadDistance === 'number'
+      ? ROAD_DISTANCE_BASE_SCORE - roadDistance * ROAD_DISTANCE_ROOM_COST_SCORE
+      : 0;
   const sourceScore = typeof candidate.sourceCount === 'number' ? Math.min(candidate.sourceCount, 2) * 70 : 0;
   const supportScore =
     Math.min(candidate.ownedStructureCount ?? 0, 3) * 8 +
@@ -577,7 +591,7 @@ function calculateOccupationScore(
     ACTION_SCORE[action] +
     sourcePriorityScore +
     adjacencyScore +
-    distanceScore +
+    roadDistanceScore +
     sourceScore +
     supportScore +
     readinessScore -
@@ -586,6 +600,10 @@ function calculateOccupationScore(
     evidencePenalty -
     unavailablePenalty
   );
+}
+
+function getCandidateRoadDistance(candidate: OccupationRecommendationCandidateInput): number | undefined {
+  return candidate.roadDistance ?? (typeof candidate.routeDistance === 'number' ? candidate.routeDistance : undefined);
 }
 
 function getControllerPressureEvidence(
@@ -810,6 +828,40 @@ function getCachedRouteDistance(fromRoom: string, targetRoom: string): number | 
 
   const distance = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`];
   return typeof distance === 'number' || distance === null ? distance : undefined;
+}
+
+function getCachedNearestOwnedRoomRouteDistance(fromRoom: string, targetRoom: string): number | undefined {
+  const ownedRoomNames = getVisibleOwnedRoomNames(fromRoom);
+  let nearestDistance: number | undefined;
+  for (const ownedRoomName of ownedRoomNames) {
+    const distance =
+      ownedRoomName === fromRoom
+        ? getCachedRouteDistance(fromRoom, targetRoom)
+        : getCachedRouteDistance(ownedRoomName, targetRoom);
+    if (typeof distance !== 'number') {
+      continue;
+    }
+
+    nearestDistance = nearestDistance === undefined ? distance : Math.min(nearestDistance, distance);
+  }
+
+  return nearestDistance;
+}
+
+function getVisibleOwnedRoomNames(fallbackRoomName: string): string[] {
+  const roomNames = new Set<string>([fallbackRoomName]);
+  const rooms = getGameRooms();
+  if (!rooms) {
+    return Array.from(roomNames);
+  }
+
+  for (const room of Object.values(rooms)) {
+    if (room?.controller?.my === true && typeof room.name === 'string' && room.name.length > 0) {
+      roomNames.add(room.name);
+    }
+  }
+
+  return Array.from(roomNames);
 }
 
 function findRoomObjects(room: Room, constantName: string): unknown[] | undefined {

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -81,6 +81,7 @@ const RESERVATION_RENEWAL_TICKS = 1_000;
 const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 const TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const OCCUPATION_RECOMMENDATION_TARGET_CREATOR: TerritoryTargetMemory['createdBy'] = 'occupationRecommendation';
 const ROAD_DISTANCE_BASE_SCORE = 100;
 const ROAD_DISTANCE_ROOM_COST_SCORE = 20;
@@ -834,10 +835,14 @@ function getCachedNearestOwnedRoomRouteDistance(fromRoom: string, targetRoom: st
   const ownedRoomNames = getVisibleOwnedRoomNames(fromRoom);
   let nearestDistance: number | undefined;
   for (const ownedRoomName of ownedRoomNames) {
-    const distance =
+    const cachedDistance =
       ownedRoomName === fromRoom
         ? getCachedRouteDistance(fromRoom, targetRoom)
         : getCachedRouteDistance(ownedRoomName, targetRoom);
+    const distance =
+      cachedDistance === undefined
+        ? findUncachedRouteDistance(ownedRoomName, targetRoom)
+        : cachedDistance;
     if (typeof distance !== 'number') {
       continue;
     }
@@ -846,6 +851,37 @@ function getCachedNearestOwnedRoomRouteDistance(fromRoom: string, targetRoom: st
   }
 
   return nearestDistance;
+}
+
+function findUncachedRouteDistance(fromRoom: string, targetRoom: string): number | undefined {
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map as
+    | (Partial<GameMap> & {
+        findRoute?: (fromRoom: string, toRoom: string) => unknown;
+      })
+    | undefined;
+  if (typeof gameMap?.findRoute !== 'function') {
+    return undefined;
+  }
+
+  try {
+    const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom);
+    if (route === getNoPathResultCode()) {
+      return undefined;
+    }
+
+    return Array.isArray(route) ? route.length : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getNoPathResultCode(): ScreepsReturnCode {
+  const noPathCode = (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
+  return typeof noPathCode === 'number' ? noPathCode : ERR_NO_PATH_CODE;
 }
 
 function getVisibleOwnedRoomNames(fallbackRoomName: string): string[] {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -105,6 +105,7 @@ interface ScoredTerritoryTarget extends SelectedTerritoryTarget {
   recommendationScore?: number;
   recommendationEvidenceStatus?: OccupationRecommendationEvidenceStatus;
   routeDistance?: number;
+  roadDistance?: number;
   renewalTicksToEnd?: number;
   immediateControllerFollowUp?: boolean;
   occupationActionableTicks?: number;
@@ -1713,6 +1714,12 @@ function scoreTerritoryCandidate(
     return null;
   }
   const routeDistance = knownRouteDistance ?? getInferredTerritoryRouteDistance(source);
+  const roadDistance = getNearestOwnedRoomRouteDistance(
+    colonyName,
+    selection.target.roomName,
+    routeDistance,
+    routeDistanceLookupContext
+  );
 
   const renewalTicksToEnd = getConfiguredReserveRenewalTicksToEnd(selection.target, colonyOwnerUsername);
   const occupationActionableTicks =
@@ -1734,6 +1741,7 @@ function scoreTerritoryCandidate(
     priority: getTerritoryCandidatePriority(selection, renewalTicksToEnd),
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(routeDistance !== undefined ? { routeDistance } : {}),
+    ...(roadDistance !== undefined ? { roadDistance } : {}),
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}),
     ...(occupationActionableTicks !== undefined ? { occupationActionableTicks } : {})
   };
@@ -1904,6 +1912,7 @@ function buildOccupationRecommendationCandidate(
     visible: room != null,
     actionHint: candidate.target.action,
     ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
+    ...(candidate.roadDistance !== undefined ? { roadDistance: candidate.roadDistance } : {}),
     ...(room ? buildVisibleOccupationRecommendationEvidence(room, candidate.target.controllerId) : {})
   };
 }
@@ -2243,6 +2252,44 @@ function hasKnownNoRoute(
   routeDistanceLookupContext: RouteDistanceLookupContext
 ): boolean {
   return getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) === null;
+}
+
+function getNearestOwnedRoomRouteDistance(
+  colonyName: string,
+  targetRoom: string,
+  fallbackRouteDistance: number | undefined,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): number | undefined {
+  let nearestDistance = fallbackRouteDistance;
+  for (const ownedRoomName of getVisibleOwnedRoomNames(colonyName)) {
+    const routeDistance =
+      ownedRoomName === colonyName
+        ? fallbackRouteDistance
+        : getKnownRouteLength(ownedRoomName, targetRoom, routeDistanceLookupContext);
+    if (typeof routeDistance !== 'number') {
+      continue;
+    }
+
+    nearestDistance = nearestDistance === undefined ? routeDistance : Math.min(nearestDistance, routeDistance);
+  }
+
+  return nearestDistance;
+}
+
+function getVisibleOwnedRoomNames(fallbackRoomName: string): string[] {
+  const roomNames = new Set<string>([fallbackRoomName]);
+  const rooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+  if (!rooms) {
+    return Array.from(roomNames);
+  }
+
+  for (const room of Object.values(rooms)) {
+    if (room?.controller?.my === true && isNonEmptyString(room.name)) {
+      roomNames.add(room.name);
+    }
+  }
+
+  return Array.from(roomNames);
 }
 
 function getKnownRouteLength(

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -12,6 +12,7 @@ describe('occupation recommendation scoring', () => {
   afterEach(() => {
     delete (globalThis as { Game?: Partial<Game> }).Game;
     delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+    delete (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
   });
 
   it('keeps occupy recommendations ahead of richer reserve rooms', () => {
@@ -57,13 +58,13 @@ describe('occupation recommendation scoring', () => {
         makeCandidate({
           roomName: 'W2N1',
           sourceCount: 1,
-          routeDistance: 1,
+          routeDistance: 6,
           roadDistance: 1
         }),
         makeCandidate({
           roomName: 'W7N1',
           sourceCount: 2,
-          routeDistance: 6,
+          routeDistance: 1,
           roadDistance: 6
         })
       ])
@@ -77,11 +78,13 @@ describe('occupation recommendation scoring', () => {
       action: 'reserve',
       evidenceStatus: 'sufficient',
       sourceCount: 1,
+      routeDistance: 6,
       roadDistance: 1
     });
     expect(distantCandidate).toMatchObject({
       roomName: 'W7N1',
       sourceCount: 2,
+      routeDistance: 1,
       roadDistance: 6
     });
     expect(closeCandidate?.score).toBeGreaterThan(distantCandidate?.score ?? 0);
@@ -314,6 +317,79 @@ describe('occupation recommendation scoring', () => {
       routeDistance: 1
     });
     expect(report.next?.roomName).toBe('W2N1');
+  });
+
+  it('falls back to map route lookup for uncached nearest-owned road distance telemetry', () => {
+    const findRoute = jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 3, room: toRoom }]);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W5N1: {
+          name: 'W5N1',
+          controller: { my: true, owner: { username: 'me' } } as StructureController
+        } as Room,
+        W7N1: {
+          name: 'W7N1',
+          controller: { my: false } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W7N1', action: 'reserve' }],
+        routeDistances: { 'W1N1>W7N1': 6 }
+      }
+    };
+
+    const report = buildRuntimeOccupationRecommendationReport(makeRuntimeColony(), [
+      {} as Creep,
+      {} as Creep,
+      {} as Creep
+    ]);
+
+    expect(report.candidates.find((candidate) => candidate.roomName === 'W7N1')).toMatchObject({
+      roomName: 'W7N1',
+      routeDistance: 6,
+      roadDistance: 1
+    });
+    expect(findRoute).toHaveBeenCalledWith('W5N1', 'W7N1');
+    expect(Memory.territory?.routeDistances).toEqual({ 'W1N1>W7N1': 6 });
+  });
+
+  it('leaves uncached nearest-owned road distance unavailable when route lookup has no path', () => {
+    (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;
+    const findRoute = jest.fn(() => ERR_NO_PATH);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W5N1: {
+          name: 'W5N1',
+          controller: { my: true, owner: { username: 'me' } } as StructureController
+        } as Room,
+        W7N1: {
+          name: 'W7N1',
+          controller: { my: false } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W7N1', action: 'reserve' }]
+      }
+    };
+
+    const report = buildRuntimeOccupationRecommendationReport(makeRuntimeColony(), [
+      {} as Creep,
+      {} as Creep,
+      {} as Creep
+    ]);
+
+    expect(report.candidates.find((candidate) => candidate.roomName === 'W7N1')).toMatchObject({
+      roomName: 'W7N1'
+    });
+    expect(report.candidates.find((candidate) => candidate.roomName === 'W7N1')).not.toHaveProperty('roadDistance');
+    expect(findRoute).toHaveBeenCalledWith('W5N1', 'W7N1');
+    expect(Memory.territory?.routeDistances).toBeUndefined();
   });
 
   it('persists the selected recommendation as a territory follow-up intent', () => {

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -51,6 +51,43 @@ describe('occupation recommendation scoring', () => {
     expect(report.candidates.map((candidate) => candidate.roomName)).toEqual(['W3N1', 'W2N1']);
   });
 
+  it('uses road distance to prefer closer reserve rooms with similar resource potential', () => {
+    const report = scoreOccupationRecommendations(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          sourceCount: 1,
+          routeDistance: 1,
+          roadDistance: 1
+        }),
+        makeCandidate({
+          roomName: 'W7N1',
+          sourceCount: 2,
+          routeDistance: 6,
+          roadDistance: 6
+        })
+      ])
+    );
+
+    const closeCandidate = report.candidates.find((candidate) => candidate.roomName === 'W2N1');
+    const distantCandidate = report.candidates.find((candidate) => candidate.roomName === 'W7N1');
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      action: 'reserve',
+      evidenceStatus: 'sufficient',
+      sourceCount: 1,
+      roadDistance: 1
+    });
+    expect(distantCandidate).toMatchObject({
+      roomName: 'W7N1',
+      sourceCount: 2,
+      roadDistance: 6
+    });
+    expect(closeCandidate?.score).toBeGreaterThan(distantCandidate?.score ?? 0);
+    expect(report.candidates.map((candidate) => candidate.roomName)).toEqual(['W2N1', 'W7N1']);
+  });
+
   it('recommends scouting when visibility evidence is missing', () => {
     const report = scoreOccupationRecommendations(
       makeInput([

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -721,6 +721,76 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('scores expansion candidates by road distance from the nearest owned room', () => {
+    const colony = makeSafeColony();
+    const secondaryOwnedRoom = {
+      name: 'W8N1',
+      controller: { my: true, owner: { username: 'me' }, level: 3, ticksToDowngrade: 10_000 }
+    } as Room;
+    const findRoute = jest.fn((fromRoom: string, toRoom: string) =>
+      Array.from(
+        {
+          length:
+            fromRoom === 'W8N1' && toRoom === 'W9N1'
+              ? 1
+              : fromRoom === 'W1N1' && toRoom === 'W3N1'
+                ? 2
+                : fromRoom === 'W1N1' && toRoom === 'W9N1'
+                  ? 6
+                  : 8
+        },
+        (_value, index) => ({
+          exit: 3,
+          room: `${toRoom}-${index}`
+        })
+      )
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W8N1: secondaryOwnedRoom,
+        W3N1: makeRecommendationRoom('W3N1', { sourceCount: 1 }),
+        W9N1: makeRecommendationRoom('W9N1', { sourceCount: 1 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W9N1', action: 'reserve' }
+        ]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 566)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W9N1',
+      action: 'reserve'
+    });
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W3N1');
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W9N1');
+    expect(findRoute).toHaveBeenCalledWith('W8N1', 'W3N1');
+    expect(findRoute).toHaveBeenCalledWith('W8N1', 'W9N1');
+    expect(Memory.territory?.routeDistances).toEqual({
+      'W1N1>W3N1': 2,
+      'W8N1>W3N1': 8,
+      'W1N1>W9N1': 6,
+      'W8N1>W9N1': 1
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W9N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 566
+      }
+    ]);
+  });
+
   it('excludes a cached no-route recommendation before selecting the next visible reserve candidate', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;


### PR DESCRIPTION
## Summary
Adds distance-aware expansion candidate scoring to the territory occupation recommender. When scoring candidate rooms, road distance to the nearest owned room is now factored into scoring, so closer rooms with similar resource potential outrank farther ones.

## Changes
- `prod/src/territory/occupationRecommendation.ts`: Added `roadDistance` computation via `getNearestOwnedRoomRouteDistance()` and added it to candidate scoring
- `prod/src/strategy/kpiEvaluator.ts`, `shadowEvaluator.ts`: Updated telemetry to pass through `roadDistance` in occupation recommendation evidence
- `prod/src/territory/territoryPlanner.ts`: Added `routeDistances` caching and multi-owned-room routing for expansion intent decisions
- `prod/test/occupationRecommendation.test.ts`, `territoryPlanner.test.ts`: Tests for distance-aware scoring and multi-owned-room routing

## Verification
- TypeScript typecheck: PASS
- Jest: 24 suites, 677 tests PASS
- Build: PASS

Closes #467
