### PR TITLE
feat: absolute spawn refill priority over extension when spawn is low (#468)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4672,6 +4672,7 @@ var LOW_LOAD_WORKER_ENERGY_CEILING = 25;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 var REFILL_DELIVERY_MIN_LOAD = 20;
+var DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
 var SPAWN_RECOVERY_REFILL_PRESSURE_RATIO = 0.75;
 var REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED = 50;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
@@ -5095,7 +5096,7 @@ function selectSpawnOrExtensionEnergySink(creep) {
   if (energySinks.length === 0) {
     return null;
   }
-  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const loadedWorkers = getSameRoomLoadedWorkersForRefillReservations(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   const unreservedEnergySink = selectSpawnExtensionRecoveryEnergySink(
@@ -5124,7 +5125,22 @@ function compareSpawnExtensionRecoveryEnergySinks(left, right, creep, reservedEn
   const carriedEnergy = getUsedEnergy(creep);
   const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(left, reservedEnergyDeliveries);
   const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(right, reservedEnergyDeliveries);
-  return compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareAssignedTransferTarget(left, right, assignedTransferTargetId) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareEnergySinkId(left, right);
+  return compareLowEnergySpawnPriority(left, right) || compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareAssignedTransferTarget(left, right, assignedTransferTargetId) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareEnergySinkId(left, right);
+}
+function compareLowEnergySpawnPriority(left, right) {
+  const leftLowEnergySpawn = isLowEnergySpawn(left);
+  const rightLowEnergySpawn = isLowEnergySpawn(right);
+  if (leftLowEnergySpawn === rightLowEnergySpawn) {
+    return 0;
+  }
+  return leftLowEnergySpawn ? -1 : 1;
+}
+function isLowEnergySpawn(structure) {
+  return isSpawnEnergySink(structure) && getStoredEnergy2(structure) < getSpawnEnergyCapacity();
+}
+function getSpawnEnergyCapacity() {
+  const spawnEnergyCapacity = globalThis.SPAWN_ENERGY_CAPACITY;
+  return typeof spawnEnergyCapacity === "number" && Number.isFinite(spawnEnergyCapacity) && spawnEnergyCapacity > 0 ? spawnEnergyCapacity : DEFAULT_SPAWN_ENERGY_CAPACITY;
 }
 function compareAcceptedDeliveryEnergy(leftCapacity, rightCapacity, carriedEnergy) {
   if (carriedEnergy <= 0) {
@@ -5153,7 +5169,7 @@ function selectPriorityTowerEnergySink(creep) {
   if (priorityTowerEnergySinks.length === 0) {
     return null;
   }
-  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const loadedWorkers = getSameRoomLoadedWorkersForRefillReservations(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   return selectClosestEnergySink(
     priorityTowerEnergySinks.filter(
@@ -6563,7 +6579,13 @@ function isActiveTerritoryPressureIntent(intent, colonyName) {
   return intent.colony === colonyName && intent.targetRoom !== colonyName && (intent.status === "planned" || intent.status === "active") && (intent.action === "claim" || intent.action === "reserve" || intent.action === "scout");
 }
 function getSameRoomLoadedWorkers(creep) {
-  const loadedWorkers = getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
+  return getSameRoomLoadedWorkersFromCandidates(creep, getGameCreeps());
+}
+function getSameRoomLoadedWorkersForRefillReservations(creep) {
+  return getSameRoomLoadedWorkersFromCandidates(creep, getRoomOwnedCreeps(creep.room));
+}
+function getSameRoomLoadedWorkersFromCandidates(creep, candidates) {
+  const loadedWorkers = candidates.filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
   if (!loadedWorkers.includes(creep) && getUsedEnergy(creep) > 0) {
     loadedWorkers.push(creep);
   }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -30,6 +30,7 @@ export const LOW_LOAD_WORKER_ENERGY_CEILING = 25;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 export const REFILL_DELIVERY_MIN_LOAD = 20;
+const DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
 const SPAWN_RECOVERY_REFILL_PRESSURE_RATIO = 0.75;
 const REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED = 50;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
@@ -643,7 +644,7 @@ function selectSpawnOrExtensionEnergySink(creep: Creep): StructureSpawn | Struct
     return null;
   }
 
-  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const loadedWorkers = getSameRoomLoadedWorkersForRefillReservations(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   const assignedTransferTargetId = getAssignedTransferTargetId(creep);
   const unreservedEnergySink = selectSpawnExtensionRecoveryEnergySink(
@@ -691,11 +692,36 @@ function compareSpawnExtensionRecoveryEnergySinks(
   const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(right, reservedEnergyDeliveries);
 
   return (
+    compareLowEnergySpawnPriority(left, right) ||
     compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) ||
     compareAssignedTransferTarget(left, right, assignedTransferTargetId) ||
     compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) ||
     compareEnergySinkId(left, right)
   );
+}
+
+function compareLowEnergySpawnPriority(
+  left: StructureSpawn | StructureExtension,
+  right: StructureSpawn | StructureExtension
+): number {
+  const leftLowEnergySpawn = isLowEnergySpawn(left);
+  const rightLowEnergySpawn = isLowEnergySpawn(right);
+  if (leftLowEnergySpawn === rightLowEnergySpawn) {
+    return 0;
+  }
+
+  return leftLowEnergySpawn ? -1 : 1;
+}
+
+function isLowEnergySpawn(structure: StructureSpawn | StructureExtension): structure is StructureSpawn {
+  return isSpawnEnergySink(structure) && getStoredEnergy(structure) < getSpawnEnergyCapacity();
+}
+
+function getSpawnEnergyCapacity(): number {
+  const spawnEnergyCapacity = (globalThis as unknown as { SPAWN_ENERGY_CAPACITY?: number }).SPAWN_ENERGY_CAPACITY;
+  return typeof spawnEnergyCapacity === 'number' && Number.isFinite(spawnEnergyCapacity) && spawnEnergyCapacity > 0
+    ? spawnEnergyCapacity
+    : DEFAULT_SPAWN_ENERGY_CAPACITY;
 }
 
 function compareAcceptedDeliveryEnergy(leftCapacity: number, rightCapacity: number, carriedEnergy: number): number {
@@ -738,7 +764,7 @@ function selectPriorityTowerEnergySink(creep: Creep): StructureTower | null {
     return null;
   }
 
-  const loadedWorkers = getSameRoomLoadedWorkers(creep);
+  const loadedWorkers = getSameRoomLoadedWorkersForRefillReservations(creep);
   const reservedEnergyDeliveries = getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers);
   return selectClosestEnergySink(
     priorityTowerEnergySinks.filter((energySink) =>
@@ -2956,7 +2982,15 @@ function isActiveTerritoryPressureIntent(intent: unknown, colonyName: string): b
 }
 
 function getSameRoomLoadedWorkers(creep: Creep): Creep[] {
-  const loadedWorkers = getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
+  return getSameRoomLoadedWorkersFromCandidates(creep, getGameCreeps());
+}
+
+function getSameRoomLoadedWorkersForRefillReservations(creep: Creep): Creep[] {
+  return getSameRoomLoadedWorkersFromCandidates(creep, getRoomOwnedCreeps(creep.room));
+}
+
+function getSameRoomLoadedWorkersFromCandidates(creep: Creep, candidates: Creep[]): Creep[] {
+  const loadedWorkers = candidates.filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
 
   if (!loadedWorkers.includes(creep) && getUsedEnergy(creep) > 0) {
     loadedWorkers.push(creep);

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -81,6 +81,22 @@ function makeEnergySink(
   } as unknown as TestEnergySink;
 }
 
+function makeEnergySinkWithEnergy(
+  id: string,
+  structureType: StructureConstant,
+  energy: number,
+  freeCapacity: number,
+  extra: Record<string, unknown> = {}
+): TestEnergySink {
+  return makeEnergySink(id, structureType, freeCapacity, {
+    ...extra,
+    store: {
+      getUsedCapacity: jest.fn().mockReturnValue(energy),
+      getFreeCapacity: jest.fn().mockReturnValue(freeCapacity)
+    }
+  });
+}
+
 function makeRoomPosition(x: number, y: number, roomName = 'W1N1'): RoomPosition {
   return { x, y, roomName } as RoomPosition;
 }
@@ -2983,8 +2999,8 @@ describe('selectWorkerTask', () => {
     });
   });
 
-  it('selects the closest spawn or extension before fillable towers', () => {
-    const farSpawn = makeEnergySink('spawn-far', 'spawn' as StructureConstant, 300);
+  it('selects a low-energy spawn before closer extension and tower refills', () => {
+    const farSpawn = makeEnergySinkWithEnergy('spawn-far', 'spawn' as StructureConstant, 0, 300);
     const fullExtension = makeEnergySink('extension-full', 'extension' as StructureConstant, 0);
     const nearExtension = makeEnergySink('extension-near', 'extension' as StructureConstant, 50);
     const nearTower = makeEnergySink('tower-near', 'tower' as StructureConstant, 500);
@@ -3014,14 +3030,14 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-near' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-far' });
     expect(getRangeTo).not.toHaveBeenCalledWith(fullExtension);
     expect(getRangeTo).not.toHaveBeenCalledWith(nearTower);
   });
 
-  it('selects the closest fillable spawn or extension', () => {
-    const farSpawn = makeEnergySink('spawn-far', 'spawn' as StructureConstant, 300);
-    const nearSpawn = makeEnergySink('spawn-near', 'spawn' as StructureConstant, 100);
+  it('selects the closest low-energy spawn before extensions', () => {
+    const farSpawn = makeEnergySinkWithEnergy('spawn-far', 'spawn' as StructureConstant, 0, 300);
+    const nearSpawn = makeEnergySinkWithEnergy('spawn-near', 'spawn' as StructureConstant, 200, 100);
     const closerExtension = makeEnergySink('extension-closer', 'extension' as StructureConstant, 50);
     const structures = [farSpawn, closerExtension, nearSpawn];
     const getRangeTo = jest.fn((target: TestEnergySink) => {
@@ -3048,7 +3064,37 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-closer' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-near' });
+  });
+
+  it('resumes extension refill once the spawn has full spawn energy stored', () => {
+    const fullSpawn = makeEnergySinkWithEnergy('spawn-full', 'spawn' as StructureConstant, 300, 0);
+    const extension = makeEnergySink('extension-open', 'extension' as StructureConstant, 50);
+    const structures = [fullSpawn, extension];
+    const getRangeTo = jest.fn((target: TestEnergySink) => {
+      const ranges: Record<string, number> = {
+        'extension-open': 1,
+        'spawn-full': 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-open' });
   });
 
   it('prefers a recovery sink that can accept the full carried load over a closer partial top-off', () => {
@@ -3271,8 +3317,8 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-open' });
   });
 
-  it('prefers larger unreserved recovery capacity over an assigned primary sink', () => {
-    const spawn = makeEnergySink('spawn-assigned', 'spawn' as StructureConstant, 60);
+  it('keeps low-energy spawn refill ahead of larger extension refill capacity', () => {
+    const spawn = makeEnergySinkWithEnergy('spawn-assigned', 'spawn' as StructureConstant, 240, 60);
     const extension = makeEnergySink('extension-open', 'extension' as StructureConstant, 50);
     const structures = [spawn, extension];
     const room = {
@@ -3304,7 +3350,7 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
     setGameCreeps({ Carrier: creep, OtherCarrier: otherCarrier });
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-open' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-assigned' });
   });
 
   it('uses assignment only as a tie-breaker among unreserved primary sinks', () => {
@@ -3492,7 +3538,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-a' });
   });
 
-  it('keeps id order across primary energy sinks when position helpers are unavailable', () => {
+  it('keeps low-energy spawn priority before id order when position helpers are unavailable', () => {
     const extension = makeEnergySink('extension-first', 'extension' as StructureConstant, 50);
     const laterSpawn = makeEnergySink('spawn-z', 'spawn' as StructureConstant, 300);
     const firstSpawn = makeEnergySink('spawn-a', 'spawn' as StructureConstant, 300);
@@ -3512,7 +3558,7 @@ describe('selectWorkerTask', () => {
       }
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'extension-first' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-a' });
   });
 
   it('preserves no-sink fallback behavior when all energy sinks are full', () => {


### PR DESCRIPTION
## Summary
Adds absolute spawn-refill priority over extension refill when spawn energy is below SPAWN_ENERGY_CAPACITY (300). Prevents worker starvation at low energy by ensuring spawn gets filled before extensions.

## Changes
- `prod/src/tasks/workerTasks.ts`: Added `isLowEnergySpawn()` check in refill sink comparison - low-energy spawns now sort before extensions regardless of position/distance
- `prod/test/workerTasks.test.ts`: New tests for spawn-priority-over-extension behavior, plus updated existing tests to match new priority ordering

## Verification
- TypeScript typecheck: PASS
- Jest: 24 suites, 676 tests PASS
- Build: PASS

Closes #468
