### PR TITLE
feat: hostile-aware territory intent suspension (#469)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1279,6 +1279,84 @@ function getOkCode() {
   return typeof OK === "number" ? OK : 0;
 }
 
+// src/territory/territoryMemoryUtils.ts
+function normalizeTerritoryIntents(rawIntents) {
+  return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
+    const normalizedIntent = normalizeTerritoryIntent(intent);
+    return normalizedIntent ? [normalizedIntent] : [];
+  }) : [];
+}
+function normalizeTerritoryIntent(rawIntent) {
+  if (!isRecord(rawIntent)) {
+    return null;
+  }
+  if (!isNonEmptyString2(rawIntent.colony) || !isNonEmptyString2(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
+    return null;
+  }
+  const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
+  const suspended = normalizeTerritoryIntentSuspension(rawIntent.suspended);
+  return {
+    colony: rawIntent.colony,
+    targetRoom: rawIntent.targetRoom,
+    action: rawIntent.action,
+    status: rawIntent.status,
+    updatedAt: rawIntent.updatedAt,
+    ...followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
+    ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
+    ...rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
+    ...followUp ? { followUp } : {},
+    ...suspended ? { suspended } : {}
+  };
+}
+function normalizeTerritoryIntentSuspension(rawSuspension) {
+  if (!isRecord(rawSuspension)) {
+    return null;
+  }
+  if (rawSuspension.reason !== "hostile_presence" || !isFiniteNumber(rawSuspension.hostileCount) || rawSuspension.hostileCount <= 0 || !isFiniteNumber(rawSuspension.updatedAt)) {
+    return null;
+  }
+  return {
+    reason: rawSuspension.reason,
+    hostileCount: Math.floor(rawSuspension.hostileCount),
+    updatedAt: rawSuspension.updatedAt
+  };
+}
+function normalizeTerritoryFollowUp(rawFollowUp) {
+  if (!isRecord(rawFollowUp) || !isTerritoryFollowUpSource(rawFollowUp.source)) {
+    return null;
+  }
+  const originAction = getTerritoryFollowUpOriginAction(rawFollowUp.source);
+  if (!isNonEmptyString2(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
+    return null;
+  }
+  return {
+    source: rawFollowUp.source,
+    originRoom: rawFollowUp.originRoom,
+    originAction
+  };
+}
+function getTerritoryFollowUpOriginAction(source) {
+  return source === "satisfiedClaimAdjacent" ? "claim" : "reserve";
+}
+function isTerritoryIntentAction(action) {
+  return action === "claim" || action === "reserve" || action === "scout";
+}
+function isTerritoryIntentStatus(status) {
+  return status === "planned" || status === "active" || status === "suppressed";
+}
+function isTerritoryFollowUpSource(source) {
+  return source === "satisfiedClaimAdjacent" || source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent";
+}
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+function isNonEmptyString2(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/territory/occupationRecommendation.ts
 var EXIT_DIRECTION_ORDER = ["1", "3", "5", "7"];
 var TERRITORY_BODY_ENERGY_CAPACITY = 650;
@@ -1366,7 +1444,7 @@ function persistOccupationRecommendationTarget(report, intent) {
 }
 function revokeStaleOccupationRecommendationTargetsWithoutFollowUp(report) {
   const colony = report.colonyName;
-  if (!isNonEmptyString2(colony)) {
+  if (!isNonEmptyString3(colony)) {
     return;
   }
   const territoryMemory = getTerritoryMemoryRecord();
@@ -1429,7 +1507,7 @@ function upsertTerritoryTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord(existingTarget) && existingTarget.enabled !== false && !existingTarget.controllerId && target.controllerId) {
+  if (isRecord2(existingTarget) && existingTarget.enabled !== false && !existingTarget.controllerId && target.controllerId) {
     existingTarget.controllerId = target.controllerId;
   }
 }
@@ -1736,7 +1814,7 @@ function getAdjacentRoomNames(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord(exits)) {
+  if (!isRecord2(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER.flatMap((direction) => {
@@ -1745,7 +1823,7 @@ function getAdjacentRoomNames(roomName) {
   });
 }
 function normalizeTerritoryTarget(rawTarget) {
-  if (!isRecord(rawTarget)) {
+  if (!isRecord2(rawTarget)) {
     return null;
   }
   if (typeof rawTarget.colony !== "string" || rawTarget.colony.length === 0 || typeof rawTarget.roomName !== "string" || rawTarget.roomName.length === 0 || rawTarget.action !== "claim" && rawTarget.action !== "reserve") {
@@ -1763,7 +1841,7 @@ function normalizeTerritoryTarget(rawTarget) {
 function getCachedRouteDistance(fromRoom, targetRoom) {
   var _a;
   const routeDistances = (_a = getTerritoryMemoryRecord()) == null ? void 0 : _a.routeDistances;
-  if (!isRecord(routeDistances)) {
+  if (!isRecord2(routeDistances)) {
     return void 0;
   }
   const distance = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`];
@@ -1819,68 +1897,10 @@ function getWritableTerritoryMemoryRecord() {
   if (!memory) {
     return null;
   }
-  if (!isRecord(memory.territory)) {
+  if (!isRecord2(memory.territory)) {
     memory.territory = {};
   }
   return memory.territory;
-}
-function normalizeTerritoryIntents(rawIntents) {
-  return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
-    const normalizedIntent = normalizeTerritoryIntent(intent);
-    return normalizedIntent ? [normalizedIntent] : [];
-  }) : [];
-}
-function normalizeTerritoryIntent(rawIntent) {
-  if (!isRecord(rawIntent)) {
-    return null;
-  }
-  if (!isNonEmptyString2(rawIntent.colony) || !isNonEmptyString2(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
-    return null;
-  }
-  const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
-  const suspended = normalizeTerritoryIntentSuspension(rawIntent.suspended);
-  return {
-    colony: rawIntent.colony,
-    targetRoom: rawIntent.targetRoom,
-    action: rawIntent.action,
-    status: rawIntent.status,
-    updatedAt: rawIntent.updatedAt,
-    ...followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
-    ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
-    ...rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
-    ...followUp ? { followUp } : {},
-    ...suspended ? { suspended } : {}
-  };
-}
-function normalizeTerritoryIntentSuspension(rawSuspension) {
-  if (!isRecord(rawSuspension)) {
-    return null;
-  }
-  if (rawSuspension.reason !== "hostile_presence" || !isFiniteNumber(rawSuspension.hostileCount) || rawSuspension.hostileCount <= 0 || !isFiniteNumber(rawSuspension.updatedAt)) {
-    return null;
-  }
-  return {
-    reason: rawSuspension.reason,
-    hostileCount: Math.floor(rawSuspension.hostileCount),
-    updatedAt: rawSuspension.updatedAt
-  };
-}
-function normalizeTerritoryFollowUp(rawFollowUp) {
-  if (!isRecord(rawFollowUp) || !isTerritoryFollowUpSource(rawFollowUp.source)) {
-    return null;
-  }
-  const originAction = getTerritoryFollowUpOriginAction(rawFollowUp.source);
-  if (!isNonEmptyString2(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
-    return null;
-  }
-  return {
-    source: rawFollowUp.source,
-    originRoom: rawFollowUp.originRoom,
-    originAction
-  };
-}
-function getTerritoryFollowUpOriginAction(source) {
-  return source === "satisfiedClaimAdjacent" ? "claim" : "reserve";
 }
 function upsertTerritoryIntent(intents, nextIntent) {
   var _a;
@@ -1950,27 +1970,18 @@ function isTerritorySuppressionFresh(intent, gameTime) {
   return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS;
 }
 function isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime) {
-  return intent.followUp !== void 0 && isFiniteNumber(intent.lastAttemptAt) && gameTime >= intent.lastAttemptAt && gameTime - intent.lastAttemptAt <= TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS;
+  return intent.followUp !== void 0 && isFiniteNumber2(intent.lastAttemptAt) && gameTime >= intent.lastAttemptAt && gameTime - intent.lastAttemptAt <= TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS;
 }
 function isRecoveredTerritoryFollowUpRetryPending(intent) {
-  return intent.followUp !== void 0 && intent.status === "suppressed" && isFiniteNumber(intent.lastAttemptAt);
+  return intent.followUp !== void 0 && intent.status === "suppressed" && isFiniteNumber2(intent.lastAttemptAt);
 }
-function isTerritoryIntentAction(action) {
-  return action === "claim" || action === "reserve" || action === "scout";
-}
-function isTerritoryIntentStatus(status) {
-  return status === "planned" || status === "active" || status === "suppressed";
-}
-function isTerritoryFollowUpSource(source) {
-  return source === "satisfiedClaimAdjacent" || source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent";
-}
-function isRecord(value) {
+function isRecord2(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString2(value) {
+function isNonEmptyString3(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isFiniteNumber(value) {
+function isFiniteNumber2(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
 
@@ -2068,7 +2079,7 @@ function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameT
   if (!territoryMemory) {
     return;
   }
-  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const existingIndex = intents.findIndex(
     (intent) => intent.colony === plan.colony && intent.targetRoom === plan.targetRoom && intent.action === plan.action
@@ -2151,7 +2162,7 @@ function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTim
   return (_a = demand == null ? void 0 : demand.workerCount) != null ? _a : 0;
 }
 function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime4()) {
-  if (!isNonEmptyString3(colony)) {
+  if (!isNonEmptyString4(colony)) {
     return false;
   }
   const territoryMemory = getTerritoryMemoryRecord2();
@@ -2163,14 +2174,14 @@ function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameT
   );
 }
 function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime4()) {
-  if (!isNonEmptyString3(colony)) {
+  if (!isNonEmptyString4(colony)) {
     return false;
   }
   const territoryMemory = getTerritoryMemoryRecord2();
   if (!territoryMemory) {
     return false;
   }
-  return normalizeTerritoryIntents2(territoryMemory.intents).some(
+  return normalizeTerritoryIntents(territoryMemory.intents).some(
     (intent) => intent.colony === colony && intent.followUp !== void 0 && isTerritoryControlAction2(intent.action) && !isTerritoryIntentSuspensionActive(intent, gameTime) && isVisibleTerritoryIntentActionable(
       intent.targetRoom,
       intent.action,
@@ -2184,14 +2195,14 @@ function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
   if (!territoryMemory) {
     return [];
   }
-  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   return getBoundedActiveTerritoryFollowUpExecutionHints(
     normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
     intents
-  ).filter((hint) => !isNonEmptyString3(colony) || hint.colony === colony);
+  ).filter((hint) => !isNonEmptyString4(colony) || hint.colony === colony);
 }
 function getTerritoryIntentProgressSummaries(colony, roleCounts) {
-  if (!isNonEmptyString3(colony)) {
+  if (!isNonEmptyString4(colony)) {
     return [];
   }
   const territoryMemory = getTerritoryMemoryRecord2();
@@ -2199,7 +2210,7 @@ function getTerritoryIntentProgressSummaries(colony, roleCounts) {
     return [];
   }
   const gameTime = getGameTime4();
-  return normalizeTerritoryIntents2(territoryMemory.intents).filter(
+  return normalizeTerritoryIntents(territoryMemory.intents).filter(
     (intent) => isTerritoryIntentProgressVisibleForColony(intent, colony, gameTime)
   ).map((intent) => {
     const activeCreepCount = getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action);
@@ -2219,7 +2230,7 @@ function getTerritoryIntentProgressSummaries(colony, roleCounts) {
 }
 function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime4()) {
   var _a;
-  if (!isNonEmptyString3(colony)) {
+  if (!isNonEmptyString4(colony)) {
     return {};
   }
   const territoryMemory = getTerritoryMemoryRecord2();
@@ -2227,7 +2238,7 @@ function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime4
     return {};
   }
   const countsByRoom = {};
-  for (const intent of normalizeTerritoryIntents2(territoryMemory.intents)) {
+  for (const intent of normalizeTerritoryIntents(territoryMemory.intents)) {
     if (intent.colony !== colony || !isTerritoryIntentSuspensionActive(intent, gameTime)) {
       continue;
     }
@@ -2280,7 +2291,7 @@ function canCreepReserveTerritoryController(creep, controller, colony) {
     return true;
   }
   const actorUsername = getTerritoryActorUsername(creep, colony);
-  if (!isNonEmptyString3(actorUsername) || !isNonEmptyString3(reservation.username) || reservation.username !== actorUsername || typeof reservation.ticksToEnd !== "number") {
+  if (!isNonEmptyString4(actorUsername) || !isNonEmptyString4(reservation.username) || reservation.username !== actorUsername || typeof reservation.ticksToEnd !== "number") {
     return false;
   }
   const reservationTicksToEnd = reservation.ticksToEnd;
@@ -2312,7 +2323,7 @@ function selectUrgentVisibleReservationRenewalTask(creep) {
   return { type: "reserve", targetId: controller.id };
 }
 function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
-  if (!isNonEmptyString3(assignment.targetRoom)) {
+  if (!isNonEmptyString4(assignment.targetRoom)) {
     return false;
   }
   if (isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
@@ -2324,7 +2335,7 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   if (!isTerritoryControlAction2(assignment.action)) {
     return false;
   }
-  if (isNonEmptyString3(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
+  if (isNonEmptyString4(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
@@ -2343,14 +2354,14 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   return targetState === "available" || assignment.action === "reserve" && targetState === "satisfied";
 }
 function isVisibleTerritoryAssignmentComplete(assignment, creep) {
-  if (assignment.action !== "claim" || !isNonEmptyString3(assignment.targetRoom)) {
+  if (assignment.action !== "claim" || !isNonEmptyString4(assignment.targetRoom)) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
   return (controller == null ? void 0 : controller.my) === true && !shouldSignOccupiedController(controller);
 }
 function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, creep) {
-  if (assignment.action !== "claim" || !isNonEmptyString3(assignment.targetRoom)) {
+  if (assignment.action !== "claim" || !isNonEmptyString4(assignment.targetRoom)) {
     return false;
   }
   if (!isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
@@ -2360,16 +2371,16 @@ function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, cree
   return (controller == null ? void 0 : controller.my) === true && shouldSignOccupiedController(controller);
 }
 function suppressTerritoryIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString3(colony) || !isNonEmptyString3(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
+  if (!isNonEmptyString4(colony) || !isNonEmptyString4(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
     return;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord2();
   if (!territoryMemory) {
     return;
   }
-  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
-  const followUp = normalizeTerritoryFollowUp2(assignment.followUp);
+  const followUp = normalizeTerritoryFollowUp(assignment.followUp);
   const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
     intents,
     colony,
@@ -2392,14 +2403,14 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
   removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
 function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString3(colony) || !isNonEmptyString3(assignment.targetRoom) || assignment.action !== "reserve") {
+  if (!isNonEmptyString4(colony) || !isNonEmptyString4(assignment.targetRoom) || assignment.action !== "reserve") {
     return null;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord2();
   if (!territoryMemory) {
     return null;
   }
-  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const followUp = getTerritoryReserveFallbackFollowUp(assignment, intents, colony, gameTime);
   const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
@@ -2461,7 +2472,7 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord2();
-  let intents = normalizeTerritoryIntents2(territoryMemory == null ? void 0 : territoryMemory.intents);
+  let intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
   const refreshedHostileSuspensions = refreshHostileTerritoryIntentSuspensions(
     territoryMemory,
     intents,
@@ -3262,7 +3273,7 @@ function summarizeOccupationController(controller) {
 function getControllerReservationUsername(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString3(username) ? username : void 0;
+  return isNonEmptyString4(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd(controller) {
   var _a;
@@ -3412,7 +3423,7 @@ function getTerritoryCandidateSourcePriority(source) {
 }
 function buildTerritoryFollowUp(source, originRoom) {
   const originAction = getTerritoryFollowUpOriginAction2(source);
-  if (originAction === null || !isTerritoryFollowUpSource2(source) || !isNonEmptyString3(originRoom)) {
+  if (originAction === null || !isTerritoryFollowUpSource2(source) || !isNonEmptyString4(originRoom)) {
     return {};
   }
   return {
@@ -3477,7 +3488,7 @@ function getTerritoryRouteDistanceCache() {
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord2(territoryMemory.routeDistances)) {
+  if (!isRecord3(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
@@ -3536,22 +3547,22 @@ function getAdjacentRoomNames2(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord2(exits)) {
+  if (!isRecord3(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER2.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString3(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString4(exitRoom) ? [exitRoom] : [];
   });
 }
 function isRoomAdjacentToColony(colonyName, targetRoom) {
   return getAdjacentRoomNames2(colonyName).includes(targetRoom);
 }
 function normalizeTerritoryTarget2(rawTarget) {
-  if (!isRecord2(rawTarget)) {
+  if (!isRecord3(rawTarget)) {
     return null;
   }
-  if (!isNonEmptyString3(rawTarget.colony) || !isNonEmptyString3(rawTarget.roomName) || !isTerritoryControlAction2(rawTarget.action)) {
+  if (!isNonEmptyString4(rawTarget.colony) || !isNonEmptyString4(rawTarget.roomName) || !isTerritoryControlAction2(rawTarget.action)) {
     return null;
   }
   return {
@@ -3571,7 +3582,7 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null, rout
   if (seededTarget) {
     appendTerritoryTarget(territoryMemory, seededTarget);
   }
-  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const nextIntent = {
     colony: plan.colony,
@@ -3586,12 +3597,6 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null, rout
   upsertTerritoryIntent2(intents, nextIntent);
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
   recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime, routeDistanceLookupContext);
-}
-function normalizeTerritoryIntents2(rawIntents) {
-  return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
-    const normalizedIntent = normalizeTerritoryIntent2(intent);
-    return normalizedIntent ? [normalizedIntent] : [];
-  }) : [];
 }
 function upsertTerritoryIntent2(intents, nextIntent) {
   var _a;
@@ -3637,17 +3642,19 @@ function refreshHostileTerritoryIntentSuspensions(territoryMemory, intents, colo
   let changed = false;
   const suspendedIntents = [];
   const refreshedIntents = intents.map((intent) => {
-    var _a;
+    var _a, _b;
     if (intent.colony !== colonyName || !isTerritoryControlAction2(intent.action)) {
       return intent;
     }
     const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
     if (hostileCount !== null && hostileCount > 0) {
-      const suspended = buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime);
-      if (isSameTerritoryIntentSuspension(intent.suspended, suspended)) {
-        suspendedIntents.push(intent);
+      if (((_a = intent.suspended) == null ? void 0 : _a.reason) === "hostile_presence") {
+        if (isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime)) {
+          suspendedIntents.push(intent);
+        }
         return intent;
       }
+      const suspended = buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime);
       changed = true;
       const suspendedIntent = {
         ...intent,
@@ -3656,7 +3663,7 @@ function refreshHostileTerritoryIntentSuspensions(territoryMemory, intents, colo
       suspendedIntents.push(suspendedIntent);
       return suspendedIntent;
     }
-    if (((_a = intent.suspended) == null ? void 0 : _a.reason) === "hostile_presence" && (hostileCount === 0 || gameTime - intent.suspended.updatedAt > TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS)) {
+    if (((_b = intent.suspended) == null ? void 0 : _b.reason) === "hostile_presence" && (hostileCount === 0 || !isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime))) {
       changed = true;
       return withoutTerritoryIntentSuspension(intent);
     }
@@ -3818,7 +3825,7 @@ function getPersistedTerritoryIntentFollowUp(intents, colony, targetRoom, action
 }
 function getTerritoryReserveFallbackFollowUp(assignment, intents, colony, gameTime) {
   var _a, _b, _c;
-  const assignmentFollowUp = normalizeTerritoryFollowUp2(assignment.followUp);
+  const assignmentFollowUp = normalizeTerritoryFollowUp(assignment.followUp);
   if (assignmentFollowUp) {
     return assignmentFollowUp;
   }
@@ -3903,7 +3910,7 @@ function getCurrentTerritoryFollowUpDemand(plan, gameTime) {
   )) != null ? _a : null;
 }
 function recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime, routeDistanceLookupContext = createRouteDistanceLookupContext()) {
-  const intents = normalizeTerritoryIntents2(territoryMemory.intents);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   const currentHints = getBoundedActiveTerritoryFollowUpExecutionHints(
     normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
     intents,
@@ -4044,13 +4051,13 @@ function normalizeTerritoryFollowUpExecutionHints(rawHints) {
   }) : [];
 }
 function normalizeTerritoryFollowUpExecutionHint(rawHint) {
-  if (!isRecord2(rawHint)) {
+  if (!isRecord3(rawHint)) {
     return null;
   }
-  if (rawHint.type !== "activeFollowUpExecution" || !isNonEmptyString3(rawHint.colony) || !isNonEmptyString3(rawHint.targetRoom) || !isTerritoryIntentAction2(rawHint.action) || !isTerritoryExecutionHintReason(rawHint.reason) || typeof rawHint.updatedAt !== "number") {
+  if (rawHint.type !== "activeFollowUpExecution" || !isNonEmptyString4(rawHint.colony) || !isNonEmptyString4(rawHint.targetRoom) || !isTerritoryIntentAction2(rawHint.action) || !isTerritoryExecutionHintReason(rawHint.reason) || typeof rawHint.updatedAt !== "number") {
     return null;
   }
-  const followUp = normalizeTerritoryFollowUp2(rawHint.followUp);
+  const followUp = normalizeTerritoryFollowUp(rawHint.followUp);
   if (!followUp) {
     return null;
   }
@@ -4068,41 +4075,6 @@ function normalizeTerritoryFollowUpExecutionHint(rawHint) {
 function isSameTerritoryFollowUp(left, right) {
   return left.source === right.source && left.originRoom === right.originRoom && left.originAction === right.originAction;
 }
-function normalizeTerritoryIntent2(rawIntent) {
-  if (!isRecord2(rawIntent)) {
-    return null;
-  }
-  if (!isNonEmptyString3(rawIntent.colony) || !isNonEmptyString3(rawIntent.targetRoom) || !isTerritoryIntentAction2(rawIntent.action) || !isTerritoryIntentStatus2(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
-    return null;
-  }
-  const followUp = normalizeTerritoryFollowUp2(rawIntent.followUp);
-  const suspended = normalizeTerritoryIntentSuspension2(rawIntent.suspended);
-  return {
-    colony: rawIntent.colony,
-    targetRoom: rawIntent.targetRoom,
-    action: rawIntent.action,
-    status: rawIntent.status,
-    updatedAt: rawIntent.updatedAt,
-    ...followUp && isFiniteNumber2(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
-    ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
-    ...rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
-    ...followUp ? { followUp } : {},
-    ...suspended ? { suspended } : {}
-  };
-}
-function normalizeTerritoryIntentSuspension2(rawSuspension) {
-  if (!isRecord2(rawSuspension)) {
-    return null;
-  }
-  if (rawSuspension.reason !== "hostile_presence" || !isFiniteNumber2(rawSuspension.hostileCount) || rawSuspension.hostileCount <= 0 || !isFiniteNumber2(rawSuspension.updatedAt)) {
-    return null;
-  }
-  return {
-    reason: rawSuspension.reason,
-    hostileCount: Math.floor(rawSuspension.hostileCount),
-    updatedAt: rawSuspension.updatedAt
-  };
-}
 function normalizeTerritoryFollowUpDemands(rawDemands) {
   return Array.isArray(rawDemands) ? rawDemands.flatMap((demand) => {
     const normalizedDemand = normalizeTerritoryFollowUpDemand(demand);
@@ -4110,13 +4082,13 @@ function normalizeTerritoryFollowUpDemands(rawDemands) {
   }) : [];
 }
 function normalizeTerritoryFollowUpDemand(rawDemand) {
-  if (!isRecord2(rawDemand)) {
+  if (!isRecord3(rawDemand)) {
     return null;
   }
-  if (rawDemand.type !== "followUpPreparation" || !isNonEmptyString3(rawDemand.colony) || !isNonEmptyString3(rawDemand.targetRoom) || !isTerritoryControlAction2(rawDemand.action) || typeof rawDemand.updatedAt !== "number") {
+  if (rawDemand.type !== "followUpPreparation" || !isNonEmptyString4(rawDemand.colony) || !isNonEmptyString4(rawDemand.targetRoom) || !isTerritoryControlAction2(rawDemand.action) || typeof rawDemand.updatedAt !== "number") {
     return null;
   }
-  const followUp = normalizeTerritoryFollowUp2(rawDemand.followUp);
+  const followUp = normalizeTerritoryFollowUp(rawDemand.followUp);
   const workerCount = getBoundedTerritoryFollowUpWorkerDemand(rawDemand.workerCount);
   if (!followUp || workerCount <= 0) {
     return null;
@@ -4140,24 +4112,6 @@ function getBoundedTerritoryFollowUpWorkerDemand(rawWorkerCount) {
   }
   return Math.max(0, Math.min(TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND, Math.floor(rawWorkerCount)));
 }
-function normalizeTerritoryFollowUp2(rawFollowUp) {
-  if (!isRecord2(rawFollowUp)) {
-    return null;
-  }
-  if (!isTerritoryFollowUpSource2(rawFollowUp.source)) {
-    return null;
-  }
-  const source = rawFollowUp.source;
-  const originAction = getTerritoryFollowUpOriginAction2(source);
-  if (originAction === null || !isNonEmptyString3(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
-    return null;
-  }
-  return {
-    source,
-    originRoom: rawFollowUp.originRoom,
-    originAction
-  };
-}
 function getTerritoryCreepCountForTarget(roleCounts, targetRoom, action) {
   var _a, _b, _c, _d, _e, _f;
   if (action === "scout") {
@@ -4175,12 +4129,12 @@ function buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime) {
     updatedAt: gameTime
   };
 }
-function isSameTerritoryIntentSuspension(left, right) {
-  return left !== void 0 && left.reason === right.reason && left.hostileCount === right.hostileCount && left.updatedAt === right.updatedAt;
-}
 function withoutTerritoryIntentSuspension(intent) {
   const { suspended: _suspended, ...unsuspendedIntent } = intent;
   return unsuspendedIntent;
+}
+function isHostileTerritoryIntentSuspensionCoolingDown(suspension, gameTime) {
+  return gameTime - suspension.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
 }
 function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGameTime4()) {
   const territoryMemory = getTerritoryMemoryRecord2();
@@ -4188,7 +4142,7 @@ function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGa
     return false;
   }
   return isTerritoryIntentSuspendedForAction(
-    normalizeTerritoryIntents2(territoryMemory.intents),
+    normalizeTerritoryIntents(territoryMemory.intents),
     colony,
     targetRoom,
     action,
@@ -4212,10 +4166,10 @@ function isTerritoryIntentSuspensionActive(intent, gameTime) {
   if (intent.suspended.reason === "hostile_presence") {
     const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
     if (hostileCount !== null) {
-      return hostileCount > 0;
+      return hostileCount > 0 && isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime);
     }
   }
-  return gameTime - intent.suspended.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
+  return isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime);
 }
 function isTerritoryTargetSuppressed(target, intents, gameTime) {
   return isSuppressedTerritoryIntentForAction(intents, target.colony, target.roomName, target.action, gameTime);
@@ -4230,7 +4184,7 @@ function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getG
   if (!territoryMemory) {
     return false;
   }
-  return normalizeTerritoryIntents2(territoryMemory.intents).some(
+  return normalizeTerritoryIntents(territoryMemory.intents).some(
     (intent) => isTerritorySuppressionFresh2(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
@@ -4244,7 +4198,7 @@ function isRecoveredTerritoryFollowUpIntent(intent, gameTime) {
   return intent.status === "suppressed" && gameTime - intent.updatedAt > TERRITORY_SUPPRESSION_RETRY_TICKS2;
 }
 function isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) {
-  return intent.followUp !== void 0 && isFiniteNumber2(intent.lastAttemptAt) && gameTime >= intent.lastAttemptAt && gameTime - intent.lastAttemptAt <= TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS2;
+  return intent.followUp !== void 0 && isFiniteNumber3(intent.lastAttemptAt) && gameTime >= intent.lastAttemptAt && gameTime - intent.lastAttemptAt <= TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS2;
 }
 function isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colony, targetRoom, action, gameTime) {
   return intents.some(
@@ -4254,7 +4208,7 @@ function isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colony
 function selectVisibleTerritoryControllerIntent(creep) {
   var _a, _b, _c;
   const roomName = (_a = creep.room) == null ? void 0 : _a.name;
-  if (!isNonEmptyString3(roomName) || isVisibleRoomUnsafe(creep.room)) {
+  if (!isNonEmptyString4(roomName) || isVisibleRoomUnsafe(creep.room)) {
     return null;
   }
   const assignmentIntent = normalizeCreepTerritoryIntent(creep, roomName);
@@ -4263,16 +4217,16 @@ function selectVisibleTerritoryControllerIntent(creep) {
   }
   const territoryMemory = getTerritoryMemoryRecord2();
   const colony = (_b = creep.memory) == null ? void 0 : _b.colony;
-  const intents = normalizeTerritoryIntents2(territoryMemory == null ? void 0 : territoryMemory.intents).filter((intent) => isActiveVisibleControllerIntentForCreep(intent, roomName, colony)).sort(compareVisibleControllerIntents);
+  const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents).filter((intent) => isActiveVisibleControllerIntentForCreep(intent, roomName, colony)).sort(compareVisibleControllerIntents);
   return (_c = intents.find((intent) => isCreepVisibleTerritoryIntentActionable(creep, intent))) != null ? _c : null;
 }
 function normalizeCreepTerritoryIntent(creep, roomName) {
   var _a, _b, _c, _d;
   const assignment = (_a = creep.memory) == null ? void 0 : _a.territory;
-  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction2(assignment.action) || isNonEmptyString3((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
+  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction2(assignment.action) || isNonEmptyString4((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
     return null;
   }
-  const followUp = normalizeTerritoryFollowUp2(assignment.followUp);
+  const followUp = normalizeTerritoryFollowUp(assignment.followUp);
   return {
     colony: (_d = (_c = creep.memory) == null ? void 0 : _c.colony) != null ? _d : "",
     targetRoom: assignment.targetRoom,
@@ -4284,7 +4238,7 @@ function normalizeCreepTerritoryIntent(creep, roomName) {
   };
 }
 function isActiveVisibleControllerIntentForCreep(intent, roomName, creepColony) {
-  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction2(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString3(creepColony) || intent.colony === creepColony);
+  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction2(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString4(creepColony) || intent.colony === creepColony);
 }
 function compareVisibleControllerIntents(left, right) {
   return getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) || getIntentActionPriority(left.action) - getIntentActionPriority(right.action) || right.updatedAt - left.updatedAt || left.colony.localeCompare(right.colony);
@@ -4358,12 +4312,12 @@ function getClaimControllerTargetState(controller) {
 }
 function getTerritoryActorUsername(creep, colony) {
   var _a;
-  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString3(colony) ? getVisibleColonyOwnerUsername2(colony) : null;
+  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString4(colony) ? getVisibleColonyOwnerUsername2(colony) : null;
 }
 function getCreepOwnerUsername(creep) {
   var _a;
   const username = (_a = creep == null ? void 0 : creep.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString3(username) ? username : null;
+  return isNonEmptyString4(username) ? username : null;
 }
 function canUseControllerClaimPart(creep) {
   return getActiveControllerClaimPartCount(creep) > 0;
@@ -4474,7 +4428,7 @@ function isControllerOwned(controller) {
 }
 function isControllerOwnedByColony2(controller, colonyOwnerUsername) {
   const ownerUsername = getControllerOwnerUsername2(controller);
-  return controller.my === true || isNonEmptyString3(ownerUsername) && ownerUsername === colonyOwnerUsername;
+  return controller.my === true || isNonEmptyString4(ownerUsername) && ownerUsername === colonyOwnerUsername;
 }
 function getReserveControllerTargetState(controller, colonyOwnerUsername) {
   if (isControllerOwned(controller)) {
@@ -4484,17 +4438,17 @@ function getReserveControllerTargetState(controller, colonyOwnerUsername) {
   if (!reservation) {
     return "available";
   }
-  if (!isNonEmptyString3(reservation.username) || reservation.username !== colonyOwnerUsername) {
+  if (!isNonEmptyString4(reservation.username) || reservation.username !== colonyOwnerUsername) {
     return "unavailable";
   }
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) === null ? "satisfied" : "available";
 }
 function isForeignReservedController(controller, actorUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString3(actorUsername)) {
+  if (isControllerOwned(controller) || !isNonEmptyString4(actorUsername)) {
     return false;
   }
   const reservation = controller.reservation;
-  return isNonEmptyString3(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
+  return isNonEmptyString4(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
 }
 function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
   if (target.action !== "reserve" || colonyOwnerUsername === null) {
@@ -4523,7 +4477,7 @@ function getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? ticksToEnd : null;
 }
 function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString3(colonyOwnerUsername)) {
+  if (isControllerOwned(controller) || !isNonEmptyString4(colonyOwnerUsername)) {
     return null;
   }
   const reservation = controller.reservation;
@@ -4539,7 +4493,7 @@ function getVisibleColonyOwnerUsername2(colonyName) {
 function getControllerOwnerUsername2(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString3(username) ? username : null;
+  return isNonEmptyString4(username) ? username : null;
 }
 function getVisibleController2(targetRoom, controllerId) {
   var _a, _b;
@@ -4564,14 +4518,14 @@ function getWritableTerritoryMemoryRecord2() {
   if (!memory) {
     return null;
   }
-  if (!isRecord2(memory.territory)) {
+  if (!isRecord3(memory.territory)) {
     memory.territory = {};
   }
   return memory.territory;
 }
 function getTerritoryMemoryRecord2() {
   const memory = getMemoryRecord();
-  if (!memory || !isRecord2(memory.territory)) {
+  if (!memory || !isRecord3(memory.territory)) {
     return null;
   }
   return memory.territory;
@@ -4589,19 +4543,16 @@ function isTerritoryIntentAction2(action) {
 function isTerritoryFollowUpSource2(source) {
   return source === "satisfiedClaimAdjacent" || source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent";
 }
-function isTerritoryIntentStatus2(status) {
-  return status === "planned" || status === "active" || status === "suppressed";
-}
 function isTerritoryExecutionHintReason(reason) {
   return reason === "controlEvidenceStillMissing" || reason === "followUpTargetStillUnseen" || reason === "visibleControlEvidenceStillActionable";
 }
-function isNonEmptyString3(value) {
+function isNonEmptyString4(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isFiniteNumber2(value) {
+function isFiniteNumber3(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isRecord2(value) {
+function isRecord3(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -4640,7 +4591,7 @@ function findLogisticsTargetPositions(room) {
   return [...sourcePositions, ...controllerPosition];
 }
 function findColonyRoomLogisticsAnchorPositions(room, colonyRoomName, targetPositions) {
-  if (targetPositions.length === 0 || !isNonEmptyString4(room.name) || !isNonEmptyString4(colonyRoomName) || colonyRoomName === room.name) {
+  if (targetPositions.length === 0 || !isNonEmptyString5(room.name) || !isNonEmptyString5(colonyRoomName) || colonyRoomName === room.name) {
     return [];
   }
   return uniqueRoomPositions(
@@ -4656,7 +4607,7 @@ function findColonyRoomSpawnPositions(colonyRoomName) {
   return uniqueRoomPositions([...roomSpawnPositions, ...globalSpawnPositions]);
 }
 function projectHomeAnchorIntoRoom(anchor, roomName) {
-  if (!isNonEmptyString4(anchor.roomName) || anchor.roomName === roomName) {
+  if (!isNonEmptyString5(anchor.roomName) || anchor.roomName === roomName) {
     return null;
   }
   const anchorCoordinates = parseRoomCoordinates(anchor.roomName);
@@ -4748,20 +4699,20 @@ function hasRemoteTerritoryReference(value, roomName, roomKey) {
     return false;
   }
   return value.some((entry) => {
-    if (!isRecord3(entry)) {
+    if (!isRecord4(entry)) {
       return false;
     }
-    return entry[roomKey] === roomName && isNonEmptyString4(entry.colony) && entry.colony !== roomName && isTerritoryControlAction3(entry.action) && entry.status !== "suppressed" && entry.enabled !== false;
+    return entry[roomKey] === roomName && isNonEmptyString5(entry.colony) && entry.colony !== roomName && isTerritoryControlAction3(entry.action) && entry.status !== "suppressed" && entry.enabled !== false;
   });
 }
 function isSelfReservedRoom(room) {
   var _a, _b;
   const reservationUsername = (_b = (_a = room.controller) == null ? void 0 : _a.reservation) == null ? void 0 : _b.username;
-  return isNonEmptyString4(reservationUsername) && getOwnedUsernames().has(reservationUsername);
+  return isNonEmptyString5(reservationUsername) && getOwnedUsernames().has(reservationUsername);
 }
 function getTerritoryMemoryRecord3() {
   const memory = globalThis.Memory;
-  return memory && isRecord3(memory.territory) ? memory.territory : null;
+  return memory && isRecord4(memory.territory) ? memory.territory : null;
 }
 function getOwnedUsernames() {
   var _a, _b, _c, _d;
@@ -4783,7 +4734,7 @@ function getOwnedUsernames() {
 function addOwnedUsername(usernames, object) {
   var _a;
   const username = (_a = object == null ? void 0 : object.owner) == null ? void 0 : _a.username;
-  if (isNonEmptyString4(username)) {
+  if (isNonEmptyString5(username)) {
     usernames.add(username);
   }
 }
@@ -4819,10 +4770,10 @@ function getSquaredDistance(left, right) {
 function isSameRoomPosition2(position, roomName) {
   return !!position && (!position.roomName || !roomName || position.roomName === roomName);
 }
-function isRecord3(value) {
+function isRecord4(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString4(value) {
+function isNonEmptyString5(value) {
   return typeof value === "string" && value.length > 0;
 }
 function matchesStructureType3(actual, globalName, fallback) {
@@ -8465,7 +8416,7 @@ function countTerritoryIntents(roomName) {
   }
   return intents.reduce(
     (counts, intent) => {
-      if (!isRecord4(intent)) {
+      if (!isRecord5(intent)) {
         return counts;
       }
       if (intent.colony !== roomName) {
@@ -8481,7 +8432,7 @@ function countTerritoryIntents(roomName) {
     { active: 0, planned: 0 }
   );
 }
-function isRecord4(value) {
+function isRecord5(value) {
   return typeof value === "object" && value !== null;
 }
 function matchesStructureType5(actual, globalName, fallback) {
@@ -8794,7 +8745,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord5(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord6(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio(numerator, denominator) {
   if (denominator <= 0) {
@@ -8809,7 +8760,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord5(value)) {
+  if (!isRecord6(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -8898,7 +8849,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord5(constructionSite)) {
+  if (!isRecord6(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -8912,7 +8863,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord5(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord6(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -9134,10 +9085,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord5(entry) || typeof entry.event !== "number") {
+    if (!isRecord6(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord5(entry.data) ? entry.data : {};
+    const data = isRecord6(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -9203,7 +9154,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord5(structure) && (matchesStructureType6(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType6(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord6(structure) && (matchesStructureType6(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType6(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -9212,7 +9163,7 @@ function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
 function getObjectId2(value) {
-  return isRecord5(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+  return isRecord6(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects5(room, constantName) {
   const findConstant = getGlobalNumber4(constantName);
@@ -9243,7 +9194,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord5(object) || !isRecord5(object.store)) {
+  if (!isRecord6(object) || !isRecord6(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -9257,7 +9208,7 @@ function getEnergyInStore(object) {
 function sumDroppedEnergy(droppedResources) {
   const energyResource = getEnergyResource3();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord5(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord6(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -9286,7 +9237,7 @@ function getEnergyResource3() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord5(value) {
+function isRecord6(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -10083,7 +10034,7 @@ function parseStrategyEvaluationArtifacts(input) {
   });
 }
 function normalizeStrategyEvaluationArtifact(rawArtifact) {
-  if (!isRecord6(rawArtifact)) {
+  if (!isRecord7(rawArtifact)) {
     return null;
   }
   if (rawArtifact.type === "runtime-summary" || Array.isArray(rawArtifact.rooms)) {
@@ -10092,7 +10043,7 @@ function normalizeStrategyEvaluationArtifact(rawArtifact) {
   if (rawArtifact.artifactType === "runtime-summary") {
     return normalizeRuntimeSummaryArtifact(rawArtifact);
   }
-  if (rawArtifact.artifactType === "room-snapshot" || Array.isArray(rawArtifact.objects) || isRecord6(rawArtifact.objects)) {
+  if (rawArtifact.artifactType === "room-snapshot" || Array.isArray(rawArtifact.objects) || isRecord7(rawArtifact.objects)) {
     return normalizeRoomSnapshotArtifact(rawArtifact);
   }
   return null;
@@ -10174,45 +10125,45 @@ function normalizeRuntimeSummaryArtifact(rawArtifact) {
   }) : [];
   return {
     artifactType: "runtime-summary",
-    ...isFiniteNumber3(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
+    ...isFiniteNumber4(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
     rooms,
-    ...isRecord6(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {},
-    ...isRecord6(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {}
+    ...isRecord7(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {},
+    ...isRecord7(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {}
   };
 }
 function normalizeRuntimeSummaryRoom(rawRoom) {
-  if (!isRecord6(rawRoom) || !isNonEmptyString5(rawRoom.roomName)) {
+  if (!isRecord7(rawRoom) || !isNonEmptyString6(rawRoom.roomName)) {
     return null;
   }
   return {
     roomName: rawRoom.roomName,
-    ...isFiniteNumber3(rawRoom.energyAvailable) ? { energyAvailable: rawRoom.energyAvailable } : {},
-    ...isFiniteNumber3(rawRoom.energyCapacity) ? { energyCapacity: rawRoom.energyCapacity } : {},
-    ...isFiniteNumber3(rawRoom.workerCount) ? { workerCount: rawRoom.workerCount } : {},
+    ...isFiniteNumber4(rawRoom.energyAvailable) ? { energyAvailable: rawRoom.energyAvailable } : {},
+    ...isFiniteNumber4(rawRoom.energyCapacity) ? { energyCapacity: rawRoom.energyCapacity } : {},
+    ...isFiniteNumber4(rawRoom.workerCount) ? { workerCount: rawRoom.workerCount } : {},
     ...Array.isArray(rawRoom.spawnStatus) ? { spawnStatus: rawRoom.spawnStatus.map(normalizeSpawnStatus) } : {},
-    ...isRecord6(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {},
-    ...isRecord6(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {},
-    ...isRecord6(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {},
-    ...isRecord6(rawRoom.constructionPriority) ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) } : {},
-    ...isRecord6(rawRoom.territoryRecommendation) ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) } : {}
+    ...isRecord7(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {},
+    ...isRecord7(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {},
+    ...isRecord7(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {},
+    ...isRecord7(rawRoom.constructionPriority) ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) } : {},
+    ...isRecord7(rawRoom.territoryRecommendation) ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) } : {}
   };
 }
 function normalizeRoomSnapshotArtifact(rawArtifact) {
-  if (!Array.isArray(rawArtifact.objects) && !isRecord6(rawArtifact.objects)) {
+  if (!Array.isArray(rawArtifact.objects) && !isRecord7(rawArtifact.objects)) {
     return null;
   }
-  const objects = Array.isArray(rawArtifact.objects) ? rawArtifact.objects.flatMap((rawObject) => isRecord6(rawObject) ? [rawObject] : []) : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
-    if (!isRecord6(rawObject)) {
+  const objects = Array.isArray(rawArtifact.objects) ? rawArtifact.objects.flatMap((rawObject) => isRecord7(rawObject) ? [rawObject] : []) : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
+    if (!isRecord7(rawObject)) {
       return [];
     }
     return [{ ...rawObject, id }];
   });
   return {
     artifactType: "room-snapshot",
-    ...isFiniteNumber3(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
-    ...isNonEmptyString5(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {},
-    ...isNonEmptyString5(rawArtifact.room) ? { roomName: rawArtifact.room } : {},
-    ...isNonEmptyString5(rawArtifact.owner) ? { owner: rawArtifact.owner } : {},
+    ...isFiniteNumber4(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
+    ...isNonEmptyString6(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {},
+    ...isNonEmptyString6(rawArtifact.room) ? { roomName: rawArtifact.room } : {},
+    ...isNonEmptyString6(rawArtifact.owner) ? { owner: rawArtifact.owner } : {},
     objects
   };
 }
@@ -10232,74 +10183,74 @@ function parseJson(text) {
   }
 }
 function normalizeSpawnStatus(rawStatus) {
-  if (!isRecord6(rawStatus)) {
+  if (!isRecord7(rawStatus)) {
     return {};
   }
   return {
-    ...isNonEmptyString5(rawStatus.name) ? { name: rawStatus.name } : {},
-    ...isNonEmptyString5(rawStatus.status) ? { status: rawStatus.status } : {},
-    ...isNonEmptyString5(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {},
-    ...isFiniteNumber3(rawStatus.remainingTime) ? { remainingTime: rawStatus.remainingTime } : {}
+    ...isNonEmptyString6(rawStatus.name) ? { name: rawStatus.name } : {},
+    ...isNonEmptyString6(rawStatus.status) ? { status: rawStatus.status } : {},
+    ...isNonEmptyString6(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {},
+    ...isFiniteNumber4(rawStatus.remainingTime) ? { remainingTime: rawStatus.remainingTime } : {}
   };
 }
 function normalizeControllerSummary(rawController) {
   return {
-    level: isFiniteNumber3(rawController.level) ? rawController.level : 0,
-    ...isFiniteNumber3(rawController.progress) ? { progress: rawController.progress } : {},
-    ...isFiniteNumber3(rawController.progressTotal) ? { progressTotal: rawController.progressTotal } : {},
-    ...isFiniteNumber3(rawController.ticksToDowngrade) ? { ticksToDowngrade: rawController.ticksToDowngrade } : {}
+    level: isFiniteNumber4(rawController.level) ? rawController.level : 0,
+    ...isFiniteNumber4(rawController.progress) ? { progress: rawController.progress } : {},
+    ...isFiniteNumber4(rawController.progressTotal) ? { progressTotal: rawController.progressTotal } : {},
+    ...isFiniteNumber4(rawController.ticksToDowngrade) ? { ticksToDowngrade: rawController.ticksToDowngrade } : {}
   };
 }
 function normalizeResourceSummary(rawResources) {
   return {
-    ...isFiniteNumber3(rawResources.storedEnergy) ? { storedEnergy: rawResources.storedEnergy } : {},
-    ...isFiniteNumber3(rawResources.workerCarriedEnergy) ? { workerCarriedEnergy: rawResources.workerCarriedEnergy } : {},
-    ...isFiniteNumber3(rawResources.droppedEnergy) ? { droppedEnergy: rawResources.droppedEnergy } : {},
-    ...isFiniteNumber3(rawResources.sourceCount) ? { sourceCount: rawResources.sourceCount } : {},
-    ...isRecord6(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {}
+    ...isFiniteNumber4(rawResources.storedEnergy) ? { storedEnergy: rawResources.storedEnergy } : {},
+    ...isFiniteNumber4(rawResources.workerCarriedEnergy) ? { workerCarriedEnergy: rawResources.workerCarriedEnergy } : {},
+    ...isFiniteNumber4(rawResources.droppedEnergy) ? { droppedEnergy: rawResources.droppedEnergy } : {},
+    ...isFiniteNumber4(rawResources.sourceCount) ? { sourceCount: rawResources.sourceCount } : {},
+    ...isRecord7(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {}
   };
 }
 function normalizeResourceEvents(rawEvents) {
   return {
-    ...isFiniteNumber3(rawEvents.harvestedEnergy) ? { harvestedEnergy: rawEvents.harvestedEnergy } : {},
-    ...isFiniteNumber3(rawEvents.transferredEnergy) ? { transferredEnergy: rawEvents.transferredEnergy } : {}
+    ...isFiniteNumber4(rawEvents.harvestedEnergy) ? { harvestedEnergy: rawEvents.harvestedEnergy } : {},
+    ...isFiniteNumber4(rawEvents.transferredEnergy) ? { transferredEnergy: rawEvents.transferredEnergy } : {}
   };
 }
 function normalizeCombatSummary(rawCombat) {
   return {
-    ...isFiniteNumber3(rawCombat.hostileCreepCount) ? { hostileCreepCount: rawCombat.hostileCreepCount } : {},
-    ...isFiniteNumber3(rawCombat.hostileStructureCount) ? { hostileStructureCount: rawCombat.hostileStructureCount } : {},
-    ...isRecord6(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {}
+    ...isFiniteNumber4(rawCombat.hostileCreepCount) ? { hostileCreepCount: rawCombat.hostileCreepCount } : {},
+    ...isFiniteNumber4(rawCombat.hostileStructureCount) ? { hostileStructureCount: rawCombat.hostileStructureCount } : {},
+    ...isRecord7(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {}
   };
 }
 function normalizeCombatEvents(rawEvents) {
   return {
-    ...isFiniteNumber3(rawEvents.attackCount) ? { attackCount: rawEvents.attackCount } : {},
-    ...isFiniteNumber3(rawEvents.attackDamage) ? { attackDamage: rawEvents.attackDamage } : {},
-    ...isFiniteNumber3(rawEvents.objectDestroyedCount) ? { objectDestroyedCount: rawEvents.objectDestroyedCount } : {},
-    ...isFiniteNumber3(rawEvents.creepDestroyedCount) ? { creepDestroyedCount: rawEvents.creepDestroyedCount } : {}
+    ...isFiniteNumber4(rawEvents.attackCount) ? { attackCount: rawEvents.attackCount } : {},
+    ...isFiniteNumber4(rawEvents.attackDamage) ? { attackDamage: rawEvents.attackDamage } : {},
+    ...isFiniteNumber4(rawEvents.objectDestroyedCount) ? { objectDestroyedCount: rawEvents.objectDestroyedCount } : {},
+    ...isFiniteNumber4(rawEvents.creepDestroyedCount) ? { creepDestroyedCount: rawEvents.creepDestroyedCount } : {}
   };
 }
 function normalizeConstructionPrioritySummary(rawSummary) {
   var _a;
   return {
     ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeConstructionCandidate) } : {},
-    ...rawSummary.nextPrimary === null ? { nextPrimary: null } : isRecord6(rawSummary.nextPrimary) ? { nextPrimary: (_a = normalizeConstructionCandidate(rawSummary.nextPrimary)[0]) != null ? _a : null } : {}
+    ...rawSummary.nextPrimary === null ? { nextPrimary: null } : isRecord7(rawSummary.nextPrimary) ? { nextPrimary: (_a = normalizeConstructionCandidate(rawSummary.nextPrimary)[0]) != null ? _a : null } : {}
   };
 }
 function normalizeConstructionCandidate(rawCandidate) {
-  if (!isRecord6(rawCandidate) || !isNonEmptyString5(rawCandidate.buildItem)) {
+  if (!isRecord7(rawCandidate) || !isNonEmptyString6(rawCandidate.buildItem)) {
     return [];
   }
   return [
     {
       buildItem: rawCandidate.buildItem,
-      ...isNonEmptyString5(rawCandidate.room) ? { room: rawCandidate.room } : {},
-      ...isFiniteNumber3(rawCandidate.score) ? { score: rawCandidate.score } : {},
-      ...isNonEmptyString5(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {},
-      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString5) } : {},
-      ...Array.isArray(rawCandidate.expectedKpiMovement) ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString5) } : {},
-      ...Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString5) } : {}
+      ...isNonEmptyString6(rawCandidate.room) ? { room: rawCandidate.room } : {},
+      ...isFiniteNumber4(rawCandidate.score) ? { score: rawCandidate.score } : {},
+      ...isNonEmptyString6(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString6) } : {},
+      ...Array.isArray(rawCandidate.expectedKpiMovement) ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString6) } : {},
+      ...Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString6) } : {}
     }
   ];
 }
@@ -10307,42 +10258,42 @@ function normalizeTerritoryRecommendationSummary(rawSummary) {
   var _a;
   return {
     ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeTerritoryCandidate) } : {},
-    ...rawSummary.next === null ? { next: null } : isRecord6(rawSummary.next) ? { next: (_a = normalizeTerritoryCandidate(rawSummary.next)[0]) != null ? _a : null } : {},
+    ...rawSummary.next === null ? { next: null } : isRecord7(rawSummary.next) ? { next: (_a = normalizeTerritoryCandidate(rawSummary.next)[0]) != null ? _a : null } : {},
     ...rawSummary.followUpIntent !== void 0 ? { followUpIntent: rawSummary.followUpIntent } : {}
   };
 }
 function normalizeTerritoryCandidate(rawCandidate) {
-  if (!isRecord6(rawCandidate) || !isNonEmptyString5(rawCandidate.roomName)) {
+  if (!isRecord7(rawCandidate) || !isNonEmptyString6(rawCandidate.roomName)) {
     return [];
   }
   return [
     {
       roomName: rawCandidate.roomName,
-      ...isNonEmptyString5(rawCandidate.action) ? { action: rawCandidate.action } : {},
-      ...isFiniteNumber3(rawCandidate.score) ? { score: rawCandidate.score } : {},
-      ...isNonEmptyString5(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {},
-      ...isNonEmptyString5(rawCandidate.source) ? { source: rawCandidate.source } : {},
-      ...Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString5) } : {},
-      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString5) } : {},
-      ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString5) } : {},
-      ...isFiniteNumber3(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {},
-      ...isFiniteNumber3(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {},
-      ...isFiniteNumber3(rawCandidate.hostileCreepCount) ? { hostileCreepCount: rawCandidate.hostileCreepCount } : {},
-      ...isFiniteNumber3(rawCandidate.hostileStructureCount) ? { hostileStructureCount: rawCandidate.hostileStructureCount } : {}
+      ...isNonEmptyString6(rawCandidate.action) ? { action: rawCandidate.action } : {},
+      ...isFiniteNumber4(rawCandidate.score) ? { score: rawCandidate.score } : {},
+      ...isNonEmptyString6(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {},
+      ...isNonEmptyString6(rawCandidate.source) ? { source: rawCandidate.source } : {},
+      ...Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString6) } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString6) } : {},
+      ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString6) } : {},
+      ...isFiniteNumber4(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {},
+      ...isFiniteNumber4(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {},
+      ...isFiniteNumber4(rawCandidate.hostileCreepCount) ? { hostileCreepCount: rawCandidate.hostileCreepCount } : {},
+      ...isFiniteNumber4(rawCandidate.hostileStructureCount) ? { hostileStructureCount: rawCandidate.hostileStructureCount } : {}
     }
   ];
 }
 function normalizeCpuSummary(rawCpu) {
   return {
-    ...isFiniteNumber3(rawCpu.used) ? { used: rawCpu.used } : {},
-    ...isFiniteNumber3(rawCpu.bucket) ? { bucket: rawCpu.bucket } : {}
+    ...isFiniteNumber4(rawCpu.used) ? { used: rawCpu.used } : {},
+    ...isFiniteNumber4(rawCpu.bucket) ? { bucket: rawCpu.bucket } : {}
   };
 }
 function normalizeReliabilitySignals(rawReliability) {
   return {
-    ...isFiniteNumber3(rawReliability.loopExceptionCount) ? { loopExceptionCount: rawReliability.loopExceptionCount } : {},
-    ...isFiniteNumber3(rawReliability.telemetrySilenceTicks) ? { telemetrySilenceTicks: rawReliability.telemetrySilenceTicks } : {},
-    ...isFiniteNumber3(rawReliability.globalResetCount) ? { globalResetCount: rawReliability.globalResetCount } : {}
+    ...isFiniteNumber4(rawReliability.loopExceptionCount) ? { loopExceptionCount: rawReliability.loopExceptionCount } : {},
+    ...isFiniteNumber4(rawReliability.telemetrySilenceTicks) ? { telemetrySilenceTicks: rawReliability.telemetrySilenceTicks } : {},
+    ...isFiniteNumber4(rawReliability.globalResetCount) ? { globalResetCount: rawReliability.globalResetCount } : {}
   };
 }
 function reduceRuntimeSummaryArtifact(artifact, reliabilityMetrics, territoryComponents, resourceComponents, killComponents, thresholds) {
@@ -10467,11 +10418,11 @@ function getSnapshotObjectEnergy(object) {
 function getSnapshotObjectOwner(object) {
   var _a;
   const objectUser = object == null ? void 0 : object.user;
-  if (isNonEmptyString5(objectUser)) {
+  if (isNonEmptyString6(objectUser)) {
     return objectUser;
   }
   const ownerUsername = (_a = object == null ? void 0 : object.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString5(ownerUsername) ? ownerUsername : void 0;
+  return isNonEmptyString6(ownerUsername) ? ownerUsername : void 0;
 }
 function isOwnedSnapshotObject(object, owner) {
   var _a;
@@ -10483,13 +10434,13 @@ function isOwnedSnapshotObject(object, owner) {
   }
   return object.user === owner || ((_a = object.owner) == null ? void 0 : _a.username) === owner;
 }
-function isRecord6(value) {
+function isRecord7(value) {
   return typeof value === "object" && value !== null;
 }
-function isFiniteNumber3(value) {
+function isFiniteNumber4(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isNonEmptyString5(value) {
+function isNonEmptyString6(value) {
   return typeof value === "string" && value.length > 0;
 }
 

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1339,7 +1339,8 @@ function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGam
     updatedAt: gameTime,
     ...controllerId ? { controllerId } : {},
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
-    ...followUp ? { followUp } : {}
+    ...followUp ? { followUp } : {},
+    ...(existingIntent == null ? void 0 : existingIntent.suspended) ? { suspended: existingIntent.suspended } : {}
   };
   upsertTerritoryIntent(intents, nextIntent);
   persistOccupationRecommendationTarget(report, nextIntent);
@@ -1837,6 +1838,7 @@ function normalizeTerritoryIntent(rawIntent) {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
+  const suspended = normalizeTerritoryIntentSuspension(rawIntent.suspended);
   return {
     colony: rawIntent.colony,
     targetRoom: rawIntent.targetRoom,
@@ -1846,7 +1848,21 @@ function normalizeTerritoryIntent(rawIntent) {
     ...followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
     ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
     ...rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
-    ...followUp ? { followUp } : {}
+    ...followUp ? { followUp } : {},
+    ...suspended ? { suspended } : {}
+  };
+}
+function normalizeTerritoryIntentSuspension(rawSuspension) {
+  if (!isRecord(rawSuspension)) {
+    return null;
+  }
+  if (rawSuspension.reason !== "hostile_presence" || !isFiniteNumber(rawSuspension.hostileCount) || rawSuspension.hostileCount <= 0 || !isFiniteNumber(rawSuspension.updatedAt)) {
+    return null;
+  }
+  return {
+    reason: rawSuspension.reason,
+    hostileCount: Math.floor(rawSuspension.hostileCount),
+    updatedAt: rawSuspension.updatedAt
   };
 }
 function normalizeTerritoryFollowUp(rawFollowUp) {
@@ -1990,6 +2006,7 @@ var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
 var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 var TERRITORY_SUPPRESSION_RETRY_TICKS2 = 1500;
+var TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS = 1500;
 var TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS2 = 50;
 var TERRITORY_RECOVERED_INTENT_SPAWN_PRIORITY = 1e3;
 var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
@@ -2075,6 +2092,9 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
     return false;
   }
+  if (isTerritoryIntentSuspended(plan.colony, plan.targetRoom, plan.action, gameTime)) {
+    return false;
+  }
   if (plan.action === "scout" && isVisibleRoomKnown(plan.targetRoom)) {
     return false;
   }
@@ -2116,6 +2136,9 @@ function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTim
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
     return 0;
   }
+  if (isTerritoryIntentSuspended(plan.colony, plan.targetRoom, plan.action, gameTime)) {
+    return 0;
+  }
   if (!isVisibleTerritoryIntentActionable(
     plan.targetRoom,
     plan.action,
@@ -2148,7 +2171,7 @@ function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGam
     return false;
   }
   return normalizeTerritoryIntents2(territoryMemory.intents).some(
-    (intent) => intent.colony === colony && intent.followUp !== void 0 && isTerritoryControlAction2(intent.action) && isVisibleTerritoryIntentActionable(
+    (intent) => intent.colony === colony && intent.followUp !== void 0 && isTerritoryControlAction2(intent.action) && !isTerritoryIntentSuspensionActive(intent, gameTime) && isVisibleTerritoryIntentActionable(
       intent.targetRoom,
       intent.action,
       intent.controllerId,
@@ -2175,8 +2198,9 @@ function getTerritoryIntentProgressSummaries(colony, roleCounts) {
   if (!territoryMemory) {
     return [];
   }
+  const gameTime = getGameTime4();
   return normalizeTerritoryIntents2(territoryMemory.intents).filter(
-    (intent) => isTerritoryIntentProgressVisibleForColony(intent, colony)
+    (intent) => isTerritoryIntentProgressVisibleForColony(intent, colony, gameTime)
   ).map((intent) => {
     const activeCreepCount = getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action);
     return {
@@ -2193,8 +2217,26 @@ function getTerritoryIntentProgressSummaries(colony, roleCounts) {
     };
   }).sort(compareTerritoryIntentProgressSummaries);
 }
-function isTerritoryIntentProgressVisibleForColony(intent, colony) {
-  return intent.colony === colony && (intent.status === "planned" || intent.status === "active");
+function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime4()) {
+  var _a;
+  if (!isNonEmptyString3(colony)) {
+    return {};
+  }
+  const territoryMemory = getTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return {};
+  }
+  const countsByRoom = {};
+  for (const intent of normalizeTerritoryIntents2(territoryMemory.intents)) {
+    if (intent.colony !== colony || !isTerritoryIntentSuspensionActive(intent, gameTime)) {
+      continue;
+    }
+    countsByRoom[intent.targetRoom] = ((_a = countsByRoom[intent.targetRoom]) != null ? _a : 0) + 1;
+  }
+  return countsByRoom;
+}
+function isTerritoryIntentProgressVisibleForColony(intent, colony, gameTime) {
+  return intent.colony === colony && (intent.status === "planned" || intent.status === "active") && !isTerritoryIntentSuspensionActive(intent, gameTime);
 }
 function buildTerritoryCreepMemory(plan) {
   return {
@@ -2420,6 +2462,15 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
   const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord2();
   let intents = normalizeTerritoryIntents2(territoryMemory == null ? void 0 : territoryMemory.intents);
+  const refreshedHostileSuspensions = refreshHostileTerritoryIntentSuspensions(
+    territoryMemory,
+    intents,
+    colonyName,
+    gameTime
+  );
+  if (refreshedHostileSuspensions.changed) {
+    intents = refreshedHostileSuspensions.intents;
+  }
   const sanitizedClaimReserveHandoffs = sanitizeSatisfiedClaimReserveHandoffs(
     territoryMemory,
     intents,
@@ -2434,7 +2485,8 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
     intents,
     colonyName,
     colonyOwnerUsername,
-    roleCounts
+    roleCounts,
+    gameTime
   );
   if (sanitizedStaleProgress.changed) {
     intents = sanitizedStaleProgress.intents;
@@ -2688,7 +2740,7 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget2(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) || !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)) {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) || isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername, gameTime) || !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)) {
       return [];
     }
     const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
@@ -2734,7 +2786,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
   const configuredTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return intents.flatMap((intent, order) => {
     const recoveredFollowUp = isRecoveredTerritoryFollowUpIntent(intent, gameTime);
-    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction2(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)) {
+    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction2(intent.action) || isTerritoryIntentSuspensionActive(intent, gameTime) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)) {
       return [];
     }
     const intentKey = `${intent.targetRoom}:${intent.action}`;
@@ -2783,7 +2835,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
     if (target.enabled === false || target.roomName === colonyName) {
       return true;
     }
-    if (isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername)) {
+    if (isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername, gameTime)) {
       return false;
     }
     if (isTerritoryTargetSuppressed(target, intents, gameTime)) {
@@ -2825,12 +2877,12 @@ function isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, game
     persistedFollowUp.requiresControllerPressure === true
   );
 }
-function isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) {
+function isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername, gameTime) {
   if (target.action !== "claim") {
     return false;
   }
   const reserveIntent = intents.find(
-    (intent) => intent.colony === target.colony && intent.targetRoom === target.roomName && intent.action === "reserve" && (intent.status === "active" || intent.status === "planned")
+    (intent) => intent.colony === target.colony && intent.targetRoom === target.roomName && intent.action === "reserve" && (intent.status === "active" || intent.status === "planned") && !isTerritoryIntentSuspensionActive(intent, gameTime)
   );
   if (!reserveIntent) {
     return false;
@@ -2848,7 +2900,7 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return adjacentRooms.flatMap((roomName, order) => {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName === colonyName || existingTargetRooms.has(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
+    if (roomName === colonyName || existingTargetRooms.has(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryRoomSuspendedForColony(intents, colonyName, roomName, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
       return [];
     }
     const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
@@ -3022,7 +3074,7 @@ function getActiveCoveredConfiguredReserveTargets(colonyName, colonyOwnerUsernam
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget2(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || !isVisibleRoomKnown(target.roomName) || getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || !isVisibleRoomKnown(target.roomName) || getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
     return [{ target, order }];
@@ -3045,7 +3097,7 @@ function getSatisfiedConfiguredTargets(colonyName, colonyOwnerUsername, territor
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget2(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== action || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== action || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
       return [];
     }
     return [{ target, order }];
@@ -3578,6 +3630,53 @@ function shouldRecordTerritoryIntentControllerPressure(nextIntent, controllerId,
     getVisibleColonyOwnerUsername2(nextIntent.colony)
   ) || existingIntent !== void 0 && shouldPreservePersistedTerritoryIntentPressureRequirement2(existingIntent, controllerId);
 }
+function refreshHostileTerritoryIntentSuspensions(territoryMemory, intents, colonyName, gameTime) {
+  if (!territoryMemory || intents.length === 0) {
+    return { intents, changed: false };
+  }
+  let changed = false;
+  const suspendedIntents = [];
+  const refreshedIntents = intents.map((intent) => {
+    var _a;
+    if (intent.colony !== colonyName || !isTerritoryControlAction2(intent.action)) {
+      return intent;
+    }
+    const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
+    if (hostileCount !== null && hostileCount > 0) {
+      const suspended = buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime);
+      if (isSameTerritoryIntentSuspension(intent.suspended, suspended)) {
+        suspendedIntents.push(intent);
+        return intent;
+      }
+      changed = true;
+      const suspendedIntent = {
+        ...intent,
+        suspended
+      };
+      suspendedIntents.push(suspendedIntent);
+      return suspendedIntent;
+    }
+    if (((_a = intent.suspended) == null ? void 0 : _a.reason) === "hostile_presence" && (hostileCount === 0 || gameTime - intent.suspended.updatedAt > TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS)) {
+      changed = true;
+      return withoutTerritoryIntentSuspension(intent);
+    }
+    return intent;
+  });
+  if (!changed) {
+    return { intents, changed: false };
+  }
+  setTerritoryIntents(territoryMemory, refreshedIntents);
+  for (const intent of suspendedIntents) {
+    removeTerritoryFollowUpDemand(territoryMemory, intent.colony, intent.targetRoom, intent.action);
+    removeTerritoryFollowUpExecutionHint(
+      territoryMemory,
+      intent.colony,
+      intent.targetRoom,
+      intent.action
+    );
+  }
+  return { intents: refreshedIntents, changed: true };
+}
 function sanitizeSatisfiedClaimReserveHandoffs(territoryMemory, intents, colonyName, colonyOwnerUsername) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return { intents, changed: false };
@@ -3619,10 +3718,10 @@ function getSatisfiedConfiguredClaimRoomNames(rawTargets, colonyName, colonyOwne
   }
   return satisfiedClaimRooms;
 }
-function sanitizeStaleTerritoryProgressIntents(territoryMemory, intents, colonyName, colonyOwnerUsername, roleCounts) {
+function sanitizeStaleTerritoryProgressIntents(territoryMemory, intents, colonyName, colonyOwnerUsername, roleCounts, gameTime) {
   const staleIntents = [];
   const sanitizedIntents = intents.filter((intent) => {
-    if (!isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername, roleCounts)) {
+    if (!isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername, roleCounts, gameTime)) {
       return true;
     }
     staleIntents.push(intent);
@@ -3639,8 +3738,11 @@ function sanitizeStaleTerritoryProgressIntents(territoryMemory, intents, colonyN
   }
   return { intents: sanitizedIntents, changed: true };
 }
-function isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername, roleCounts) {
+function isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername, roleCounts, gameTime) {
   if (intent.colony !== colonyName) {
+    return false;
+  }
+  if (isTerritoryIntentSuspensionActive(intent, gameTime)) {
     return false;
   }
   if (intent.action === "scout") {
@@ -3873,7 +3975,7 @@ function hasActiveTerritoryFollowUpIntentForColony(intents, colony) {
   return intents.some((intent) => intent.colony === colony && isActiveTerritoryFollowUpIntent(intent));
 }
 function isActiveTerritoryFollowUpIntent(intent) {
-  return (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0;
+  return (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0 && !isTerritoryIntentSuspensionActive(intent, getGameTime4());
 }
 function buildTerritoryFollowUpExecutionHint(plan, gameTime) {
   if (!plan.followUp) {
@@ -3974,6 +4076,7 @@ function normalizeTerritoryIntent2(rawIntent) {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp2(rawIntent.followUp);
+  const suspended = normalizeTerritoryIntentSuspension2(rawIntent.suspended);
   return {
     colony: rawIntent.colony,
     targetRoom: rawIntent.targetRoom,
@@ -3983,7 +4086,21 @@ function normalizeTerritoryIntent2(rawIntent) {
     ...followUp && isFiniteNumber2(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
     ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
     ...rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
-    ...followUp ? { followUp } : {}
+    ...followUp ? { followUp } : {},
+    ...suspended ? { suspended } : {}
+  };
+}
+function normalizeTerritoryIntentSuspension2(rawSuspension) {
+  if (!isRecord2(rawSuspension)) {
+    return null;
+  }
+  if (rawSuspension.reason !== "hostile_presence" || !isFiniteNumber2(rawSuspension.hostileCount) || rawSuspension.hostileCount <= 0 || !isFiniteNumber2(rawSuspension.updatedAt)) {
+    return null;
+  }
+  return {
+    reason: rawSuspension.reason,
+    hostileCount: Math.floor(rawSuspension.hostileCount),
+    updatedAt: rawSuspension.updatedAt
   };
 }
 function normalizeTerritoryFollowUpDemands(rawDemands) {
@@ -4051,6 +4168,55 @@ function getTerritoryCreepCountForTarget(roleCounts, targetRoom, action) {
   }
   return (_f = (_e = roleCounts.claimersByTargetRoom) == null ? void 0 : _e[targetRoom]) != null ? _f : 0;
 }
+function buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime) {
+  return {
+    reason: "hostile_presence",
+    hostileCount,
+    updatedAt: gameTime
+  };
+}
+function isSameTerritoryIntentSuspension(left, right) {
+  return left !== void 0 && left.reason === right.reason && left.hostileCount === right.hostileCount && left.updatedAt === right.updatedAt;
+}
+function withoutTerritoryIntentSuspension(intent) {
+  const { suspended: _suspended, ...unsuspendedIntent } = intent;
+  return unsuspendedIntent;
+}
+function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGameTime4()) {
+  const territoryMemory = getTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return false;
+  }
+  return isTerritoryIntentSuspendedForAction(
+    normalizeTerritoryIntents2(territoryMemory.intents),
+    colony,
+    targetRoom,
+    action,
+    gameTime
+  );
+}
+function isTerritoryIntentSuspendedForAction(intents, colony, targetRoom, action, gameTime) {
+  return intents.some(
+    (intent) => intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action && isTerritoryIntentSuspensionActive(intent, gameTime)
+  );
+}
+function isTerritoryRoomSuspendedForColony(intents, colony, targetRoom, gameTime) {
+  return intents.some(
+    (intent) => intent.colony === colony && intent.targetRoom === targetRoom && isTerritoryIntentSuspensionActive(intent, gameTime)
+  );
+}
+function isTerritoryIntentSuspensionActive(intent, gameTime) {
+  if (!intent.suspended) {
+    return false;
+  }
+  if (intent.suspended.reason === "hostile_presence") {
+    const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
+    if (hostileCount !== null) {
+      return hostileCount > 0;
+    }
+  }
+  return gameTime - intent.suspended.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
+}
 function isTerritoryTargetSuppressed(target, intents, gameTime) {
   return isSuppressedTerritoryIntentForAction(intents, target.colony, target.roomName, target.action, gameTime);
 }
@@ -4072,7 +4238,7 @@ function isTerritorySuppressionFresh2(intent, gameTime) {
   return intent.status === "suppressed" && gameTime - intent.updatedAt <= TERRITORY_SUPPRESSION_RETRY_TICKS2;
 }
 function isRecoveredTerritoryFollowUpIntent(intent, gameTime) {
-  if (intent.followUp === void 0 || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime)) {
+  if (intent.followUp === void 0 || isTerritoryIntentSuspensionActive(intent, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime)) {
     return false;
   }
   return intent.status === "suppressed" && gameTime - intent.updatedAt > TERRITORY_SUPPRESSION_RETRY_TICKS2;
@@ -4251,6 +4417,11 @@ function isVisibleRoomSafe(room) {
 }
 function isVisibleRoomUnsafe(room) {
   return findVisibleHostileCreeps(room).length > 0 || findVisibleHostileStructures(room).length > 0;
+}
+function getVisibleHostileCreepCount(targetRoom) {
+  var _a, _b;
+  const room = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[targetRoom];
+  return room ? findVisibleHostileCreeps(room).length : null;
 }
 function findVisibleHostileCreeps(room) {
   return typeof FIND_HOSTILE_CREEPS === "number" && typeof room.find === "function" ? room.find(FIND_HOSTILE_CREEPS) : [];
@@ -8433,13 +8604,16 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  if (territoryIntents.length === 0) {
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime5());
+  const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
+  if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
   }
   const reportedIntents = territoryIntents.slice(0, MAX_TERRITORY_INTENT_SUMMARIES);
   return {
-    territoryIntents: reportedIntents,
-    ...territoryIntents.length > MAX_TERRITORY_INTENT_SUMMARIES ? { omittedTerritoryIntentCount: territoryIntents.length - MAX_TERRITORY_INTENT_SUMMARIES } : {}
+    ...reportedIntents.length > 0 ? { territoryIntents: reportedIntents } : {},
+    ...territoryIntents.length > MAX_TERRITORY_INTENT_SUMMARIES ? { omittedTerritoryIntentCount: territoryIntents.length - MAX_TERRITORY_INTENT_SUMMARIES } : {},
+    ...hasSuspendedTerritoryIntents ? { suspendedTerritoryIntentCounts } : {}
   };
 }
 function buildTerritoryExecutionHintSummary(colonyName) {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -13,6 +13,7 @@ import {
 } from '../territory/occupationRecommendation';
 import {
   getActiveTerritoryFollowUpExecutionHints,
+  getSuspendedTerritoryIntentCountsByRoom,
   getTerritoryIntentProgressSummaries,
   type TerritoryIntentProgressSummary
 } from '../territory/territoryPlanner';
@@ -79,6 +80,7 @@ interface RuntimeRoomSummary {
   territoryRecommendation: OccupationRecommendationReport;
   territoryIntents?: TerritoryIntentProgressSummary[];
   omittedTerritoryIntentCount?: number;
+  suspendedTerritoryIntentCounts?: Record<string, number>;
   territoryExecutionHints?: TerritoryExecutionHintMemory[];
 }
 
@@ -385,18 +387,25 @@ function summarizeRoom(
 function buildTerritoryIntentSummary(
   colonyName: string,
   roleCounts: RoleCounts
-): { territoryIntents?: TerritoryIntentProgressSummary[]; omittedTerritoryIntentCount?: number } {
+): {
+  territoryIntents?: TerritoryIntentProgressSummary[];
+  omittedTerritoryIntentCount?: number;
+  suspendedTerritoryIntentCounts?: Record<string, number>;
+} {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  if (territoryIntents.length === 0) {
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime());
+  const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
+  if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
   }
 
   const reportedIntents = territoryIntents.slice(0, MAX_TERRITORY_INTENT_SUMMARIES);
   return {
-    territoryIntents: reportedIntents,
+    ...(reportedIntents.length > 0 ? { territoryIntents: reportedIntents } : {}),
     ...(territoryIntents.length > MAX_TERRITORY_INTENT_SUMMARIES
       ? { omittedTerritoryIntentCount: territoryIntents.length - MAX_TERRITORY_INTENT_SUMMARIES }
-      : {})
+      : {}),
+    ...(hasSuspendedTerritoryIntents ? { suspendedTerritoryIntentCounts } : {})
   };
 }
 

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -1,4 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { normalizeTerritoryFollowUp, normalizeTerritoryIntents } from './territoryMemoryUtils';
 
 export type OccupationRecommendationAction = 'occupy' | 'reserve' | 'scout';
 export type OccupationRecommendationEvidenceStatus = 'sufficient' | 'insufficient-evidence' | 'unavailable';
@@ -876,90 +877,6 @@ function getWritableTerritoryMemoryRecord(): TerritoryMemory | null {
   return memory.territory as TerritoryMemory;
 }
 
-function normalizeTerritoryIntents(rawIntents: TerritoryMemory['intents'] | unknown): TerritoryIntentMemory[] {
-  return Array.isArray(rawIntents)
-    ? rawIntents.flatMap((intent) => {
-        const normalizedIntent = normalizeTerritoryIntent(intent);
-        return normalizedIntent ? [normalizedIntent] : [];
-      })
-    : [];
-}
-
-function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | null {
-  if (!isRecord(rawIntent)) {
-    return null;
-  }
-
-  if (
-    !isNonEmptyString(rawIntent.colony) ||
-    !isNonEmptyString(rawIntent.targetRoom) ||
-    !isTerritoryIntentAction(rawIntent.action) ||
-    !isTerritoryIntentStatus(rawIntent.status) ||
-    typeof rawIntent.updatedAt !== 'number'
-  ) {
-    return null;
-  }
-
-  const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
-  const suspended = normalizeTerritoryIntentSuspension(rawIntent.suspended);
-  return {
-    colony: rawIntent.colony,
-    targetRoom: rawIntent.targetRoom,
-    action: rawIntent.action,
-    status: rawIntent.status,
-    updatedAt: rawIntent.updatedAt,
-    ...(followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {}),
-    ...(typeof rawIntent.controllerId === 'string'
-      ? { controllerId: rawIntent.controllerId as Id<StructureController> }
-      : {}),
-    ...(rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
-    ...(followUp ? { followUp } : {}),
-    ...(suspended ? { suspended } : {})
-  };
-}
-
-function normalizeTerritoryIntentSuspension(rawSuspension: unknown): TerritoryIntentSuspensionMemory | null {
-  if (!isRecord(rawSuspension)) {
-    return null;
-  }
-
-  if (
-    rawSuspension.reason !== 'hostile_presence' ||
-    !isFiniteNumber(rawSuspension.hostileCount) ||
-    rawSuspension.hostileCount <= 0 ||
-    !isFiniteNumber(rawSuspension.updatedAt)
-  ) {
-    return null;
-  }
-
-  return {
-    reason: rawSuspension.reason,
-    hostileCount: Math.floor(rawSuspension.hostileCount),
-    updatedAt: rawSuspension.updatedAt
-  };
-}
-
-function normalizeTerritoryFollowUp(rawFollowUp: unknown): TerritoryFollowUpMemory | null {
-  if (!isRecord(rawFollowUp) || !isTerritoryFollowUpSource(rawFollowUp.source)) {
-    return null;
-  }
-
-  const originAction = getTerritoryFollowUpOriginAction(rawFollowUp.source);
-  if (!isNonEmptyString(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
-    return null;
-  }
-
-  return {
-    source: rawFollowUp.source,
-    originRoom: rawFollowUp.originRoom,
-    originAction
-  };
-}
-
-function getTerritoryFollowUpOriginAction(source: TerritoryFollowUpSource): TerritoryControlAction {
-  return source === 'satisfiedClaimAdjacent' ? 'claim' : 'reserve';
-}
-
 function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: TerritoryIntentMemory): void {
   const existingIndex = intents.findIndex((intent) => isSameTerritoryIntent(intent, nextIntent));
   if (existingIndex >= 0) {
@@ -1088,22 +1005,6 @@ function isRecoveredTerritoryFollowUpAttemptCoolingDown(intent: TerritoryIntentM
 
 function isRecoveredTerritoryFollowUpRetryPending(intent: TerritoryIntentMemory): boolean {
   return intent.followUp !== undefined && intent.status === 'suppressed' && isFiniteNumber(intent.lastAttemptAt);
-}
-
-function isTerritoryIntentAction(action: unknown): action is TerritoryIntentAction {
-  return action === 'claim' || action === 'reserve' || action === 'scout';
-}
-
-function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {
-  return status === 'planned' || status === 'active' || status === 'suppressed';
-}
-
-function isTerritoryFollowUpSource(source: unknown): source is TerritoryFollowUpSource {
-  return (
-    source === 'satisfiedClaimAdjacent' ||
-    source === 'satisfiedReserveAdjacent' ||
-    source === 'activeReserveAdjacent'
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -162,7 +162,8 @@ export function persistOccupationRecommendationFollowUpIntent(
     updatedAt: gameTime,
     ...(controllerId ? { controllerId } : {}),
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
-    ...(followUp ? { followUp } : {})
+    ...(followUp ? { followUp } : {}),
+    ...(existingIntent?.suspended ? { suspended: existingIntent.suspended } : {})
   };
 
   upsertTerritoryIntent(intents, nextIntent);
@@ -900,6 +901,7 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
   }
 
   const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
+  const suspended = normalizeTerritoryIntentSuspension(rawIntent.suspended);
   return {
     colony: rawIntent.colony,
     targetRoom: rawIntent.targetRoom,
@@ -911,7 +913,29 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
       ? { controllerId: rawIntent.controllerId as Id<StructureController> }
       : {}),
     ...(rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
-    ...(followUp ? { followUp } : {})
+    ...(followUp ? { followUp } : {}),
+    ...(suspended ? { suspended } : {})
+  };
+}
+
+function normalizeTerritoryIntentSuspension(rawSuspension: unknown): TerritoryIntentSuspensionMemory | null {
+  if (!isRecord(rawSuspension)) {
+    return null;
+  }
+
+  if (
+    rawSuspension.reason !== 'hostile_presence' ||
+    !isFiniteNumber(rawSuspension.hostileCount) ||
+    rawSuspension.hostileCount <= 0 ||
+    !isFiniteNumber(rawSuspension.updatedAt)
+  ) {
+    return null;
+  }
+
+  return {
+    reason: rawSuspension.reason,
+    hostileCount: Math.floor(rawSuspension.hostileCount),
+    updatedAt: rawSuspension.updatedAt
   };
 }
 

--- a/prod/src/territory/territoryMemoryUtils.ts
+++ b/prod/src/territory/territoryMemoryUtils.ts
@@ -30,7 +30,7 @@ export function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMem
     action: rawIntent.action,
     status: rawIntent.status,
     updatedAt: rawIntent.updatedAt,
-    ...(followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {}),
+    ...(isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {}),
     ...(typeof rawIntent.controllerId === 'string'
       ? { controllerId: rawIntent.controllerId as Id<StructureController> }
       : {}),

--- a/prod/src/territory/territoryMemoryUtils.ts
+++ b/prod/src/territory/territoryMemoryUtils.ts
@@ -1,0 +1,113 @@
+export function normalizeTerritoryIntents(rawIntents: TerritoryMemory['intents'] | unknown): TerritoryIntentMemory[] {
+  return Array.isArray(rawIntents)
+    ? rawIntents.flatMap((intent) => {
+        const normalizedIntent = normalizeTerritoryIntent(intent);
+        return normalizedIntent ? [normalizedIntent] : [];
+      })
+    : [];
+}
+
+export function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | null {
+  if (!isRecord(rawIntent)) {
+    return null;
+  }
+
+  if (
+    !isNonEmptyString(rawIntent.colony) ||
+    !isNonEmptyString(rawIntent.targetRoom) ||
+    !isTerritoryIntentAction(rawIntent.action) ||
+    !isTerritoryIntentStatus(rawIntent.status) ||
+    typeof rawIntent.updatedAt !== 'number'
+  ) {
+    return null;
+  }
+
+  const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
+  const suspended = normalizeTerritoryIntentSuspension(rawIntent.suspended);
+  return {
+    colony: rawIntent.colony,
+    targetRoom: rawIntent.targetRoom,
+    action: rawIntent.action,
+    status: rawIntent.status,
+    updatedAt: rawIntent.updatedAt,
+    ...(followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {}),
+    ...(typeof rawIntent.controllerId === 'string'
+      ? { controllerId: rawIntent.controllerId as Id<StructureController> }
+      : {}),
+    ...(rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
+    ...(followUp ? { followUp } : {}),
+    ...(suspended ? { suspended } : {})
+  };
+}
+
+export function normalizeTerritoryIntentSuspension(
+  rawSuspension: unknown
+): TerritoryIntentSuspensionMemory | null {
+  if (!isRecord(rawSuspension)) {
+    return null;
+  }
+
+  if (
+    rawSuspension.reason !== 'hostile_presence' ||
+    !isFiniteNumber(rawSuspension.hostileCount) ||
+    rawSuspension.hostileCount <= 0 ||
+    !isFiniteNumber(rawSuspension.updatedAt)
+  ) {
+    return null;
+  }
+
+  return {
+    reason: rawSuspension.reason,
+    hostileCount: Math.floor(rawSuspension.hostileCount),
+    updatedAt: rawSuspension.updatedAt
+  };
+}
+
+export function normalizeTerritoryFollowUp(rawFollowUp: unknown): TerritoryFollowUpMemory | null {
+  if (!isRecord(rawFollowUp) || !isTerritoryFollowUpSource(rawFollowUp.source)) {
+    return null;
+  }
+
+  const originAction = getTerritoryFollowUpOriginAction(rawFollowUp.source);
+  if (!isNonEmptyString(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
+    return null;
+  }
+
+  return {
+    source: rawFollowUp.source,
+    originRoom: rawFollowUp.originRoom,
+    originAction
+  };
+}
+
+function getTerritoryFollowUpOriginAction(source: TerritoryFollowUpSource): TerritoryControlAction {
+  return source === 'satisfiedClaimAdjacent' ? 'claim' : 'reserve';
+}
+
+function isTerritoryIntentAction(action: unknown): action is TerritoryIntentAction {
+  return action === 'claim' || action === 'reserve' || action === 'scout';
+}
+
+function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {
+  return status === 'planned' || status === 'active' || status === 'suppressed';
+}
+
+function isTerritoryFollowUpSource(source: unknown): source is TerritoryFollowUpSource {
+  return (
+    source === 'satisfiedClaimAdjacent' ||
+    source === 'satisfiedReserveAdjacent' ||
+    source === 'activeReserveAdjacent'
+  );
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -21,6 +21,7 @@ export const TERRITORY_RESERVATION_RENEWAL_TICKS = 1_000;
 export const TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 export const TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
+export const TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS = 1_500;
 export const TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 export const TERRITORY_RECOVERED_INTENT_SPAWN_PRIORITY = 1_000;
 export const TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
@@ -225,6 +226,10 @@ export function shouldSpawnTerritoryControllerCreep(
     return false;
   }
 
+  if (isTerritoryIntentSuspended(plan.colony, plan.targetRoom, plan.action, gameTime)) {
+    return false;
+  }
+
   if (plan.action === 'scout' && isVisibleRoomKnown(plan.targetRoom)) {
     return false;
   }
@@ -284,6 +289,10 @@ export function getTerritoryFollowUpPreparationWorkerDemand(
     return 0;
   }
 
+  if (isTerritoryIntentSuspended(plan.colony, plan.targetRoom, plan.action, gameTime)) {
+    return 0;
+  }
+
   if (
     !isVisibleTerritoryIntentActionable(
       plan.targetRoom,
@@ -336,6 +345,7 @@ export function hasPendingTerritoryFollowUpIntent(
       intent.colony === colony &&
       intent.followUp !== undefined &&
       isTerritoryControlAction(intent.action) &&
+      !isTerritoryIntentSuspensionActive(intent, gameTime) &&
       isVisibleTerritoryIntentActionable(
         intent.targetRoom,
         intent.action,
@@ -377,9 +387,10 @@ export function getTerritoryIntentProgressSummaries(
     return [];
   }
 
+  const gameTime = getGameTime();
   return normalizeTerritoryIntents(territoryMemory.intents)
     .filter((intent): intent is TerritoryIntentMemory & { status: 'planned' | 'active' } =>
-      isTerritoryIntentProgressVisibleForColony(intent, colony)
+      isTerritoryIntentProgressVisibleForColony(intent, colony, gameTime)
     )
     .map((intent): TerritoryIntentProgressSummary => {
       const activeCreepCount = getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action);
@@ -399,11 +410,41 @@ export function getTerritoryIntentProgressSummaries(
     .sort(compareTerritoryIntentProgressSummaries);
 }
 
+export function getSuspendedTerritoryIntentCountsByRoom(
+  colony: string | null | undefined,
+  gameTime = getGameTime()
+): Record<string, number> {
+  if (!isNonEmptyString(colony)) {
+    return {};
+  }
+
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return {};
+  }
+
+  const countsByRoom: Record<string, number> = {};
+  for (const intent of normalizeTerritoryIntents(territoryMemory.intents)) {
+    if (intent.colony !== colony || !isTerritoryIntentSuspensionActive(intent, gameTime)) {
+      continue;
+    }
+
+    countsByRoom[intent.targetRoom] = (countsByRoom[intent.targetRoom] ?? 0) + 1;
+  }
+
+  return countsByRoom;
+}
+
 function isTerritoryIntentProgressVisibleForColony(
   intent: TerritoryIntentMemory,
-  colony: string
+  colony: string,
+  gameTime: number
 ): intent is TerritoryIntentMemory & { status: 'planned' | 'active' } {
-  return intent.colony === colony && (intent.status === 'planned' || intent.status === 'active');
+  return (
+    intent.colony === colony &&
+    (intent.status === 'planned' || intent.status === 'active') &&
+    !isTerritoryIntentSuspensionActive(intent, gameTime)
+  );
 }
 
 export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemory {
@@ -727,6 +768,15 @@ function selectTerritoryTarget(
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   let intents = normalizeTerritoryIntents(territoryMemory?.intents);
+  const refreshedHostileSuspensions = refreshHostileTerritoryIntentSuspensions(
+    territoryMemory,
+    intents,
+    colonyName,
+    gameTime
+  );
+  if (refreshedHostileSuspensions.changed) {
+    intents = refreshedHostileSuspensions.intents;
+  }
   const sanitizedClaimReserveHandoffs = sanitizeSatisfiedClaimReserveHandoffs(
     territoryMemory,
     intents,
@@ -741,7 +791,8 @@ function selectTerritoryTarget(
     intents,
     colonyName,
     colonyOwnerUsername,
-    roleCounts
+    roleCounts,
+    gameTime
   );
   if (sanitizedStaleProgress.changed) {
     intents = sanitizedStaleProgress.intents;
@@ -1120,7 +1171,8 @@ function getConfiguredTerritoryCandidates(
       target.colony !== colonyName ||
       target.roomName === colonyName ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
-      isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) ||
+      isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) ||
+      isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername, gameTime) ||
       !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)
     ) {
       return [];
@@ -1189,6 +1241,7 @@ function getPersistedTerritoryIntentCandidates(
       isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime) ||
       (intent.status !== 'planned' && intent.status !== 'active' && !recoveredFollowUp) ||
       !isTerritoryControlAction(intent.action) ||
+      isTerritoryIntentSuspensionActive(intent, gameTime) ||
       isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) ||
       !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)
     ) {
@@ -1257,7 +1310,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       return true;
     }
 
-    if (isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername)) {
+    if (isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername, gameTime)) {
       return false;
     }
 
@@ -1327,7 +1380,8 @@ function isClaimTargetDeferredBySameRoomReserveLane(
   target: TerritoryTargetMemory,
   intents: TerritoryIntentMemory[],
   roleCounts: RoleCounts,
-  colonyOwnerUsername: string | null
+  colonyOwnerUsername: string | null,
+  gameTime: number
 ): boolean {
   if (target.action !== 'claim') {
     return false;
@@ -1338,7 +1392,8 @@ function isClaimTargetDeferredBySameRoomReserveLane(
       intent.colony === target.colony &&
       intent.targetRoom === target.roomName &&
       intent.action === 'reserve' &&
-      (intent.status === 'active' || intent.status === 'planned')
+      (intent.status === 'active' || intent.status === 'planned') &&
+      !isTerritoryIntentSuspensionActive(intent, gameTime)
   );
   if (!reserveIntent) {
     return false;
@@ -1381,6 +1436,7 @@ function getAdjacentReserveCandidates(
       roomName === colonyName ||
       existingTargetRooms.has(roomName) ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
+      isTerritoryRoomSuspendedForColony(intents, colonyName, roomName, gameTime) ||
       isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, 'reserve', gameTime)
     ) {
       return [];
@@ -1635,6 +1691,7 @@ function getActiveCoveredConfiguredReserveTargets(
       target.action !== 'reserve' ||
       target.roomName === colonyName ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
+      isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) ||
       hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) ||
       !isVisibleRoomKnown(target.roomName) ||
       getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 ||
@@ -1689,6 +1746,7 @@ function getSatisfiedConfiguredTargets(
       target.action !== action ||
       target.roomName === colonyName ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
+      isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) ||
       hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) ||
       getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !==
         'satisfied'
@@ -2522,6 +2580,69 @@ function shouldRecordTerritoryIntentControllerPressure(
   );
 }
 
+function refreshHostileTerritoryIntentSuspensions(
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  colonyName: string,
+  gameTime: number
+): { intents: TerritoryIntentMemory[]; changed: boolean } {
+  if (!territoryMemory || intents.length === 0) {
+    return { intents, changed: false };
+  }
+
+  let changed = false;
+  const suspendedIntents: TerritoryIntentMemory[] = [];
+  const refreshedIntents = intents.map((intent) => {
+    if (intent.colony !== colonyName || !isTerritoryControlAction(intent.action)) {
+      return intent;
+    }
+
+    const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
+    if (hostileCount !== null && hostileCount > 0) {
+      const suspended = buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime);
+      if (isSameTerritoryIntentSuspension(intent.suspended, suspended)) {
+        suspendedIntents.push(intent);
+        return intent;
+      }
+
+      changed = true;
+      const suspendedIntent = {
+        ...intent,
+        suspended
+      };
+      suspendedIntents.push(suspendedIntent);
+      return suspendedIntent;
+    }
+
+    if (
+      intent.suspended?.reason === 'hostile_presence' &&
+      (hostileCount === 0 || gameTime - intent.suspended.updatedAt > TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS)
+    ) {
+      changed = true;
+      return withoutTerritoryIntentSuspension(intent);
+    }
+
+    return intent;
+  });
+
+  if (!changed) {
+    return { intents, changed: false };
+  }
+
+  setTerritoryIntents(territoryMemory, refreshedIntents);
+  for (const intent of suspendedIntents) {
+    removeTerritoryFollowUpDemand(territoryMemory as TerritoryMemory, intent.colony, intent.targetRoom, intent.action);
+    removeTerritoryFollowUpExecutionHint(
+      territoryMemory as TerritoryMemory,
+      intent.colony,
+      intent.targetRoom,
+      intent.action
+    );
+  }
+
+  return { intents: refreshedIntents, changed: true };
+}
+
 function sanitizeSatisfiedClaimReserveHandoffs(
   territoryMemory: Record<string, unknown> | null,
   intents: TerritoryIntentMemory[],
@@ -2598,11 +2719,12 @@ function sanitizeStaleTerritoryProgressIntents(
   intents: TerritoryIntentMemory[],
   colonyName: string,
   colonyOwnerUsername: string | null,
-  roleCounts: RoleCounts
+  roleCounts: RoleCounts,
+  gameTime: number
 ): { intents: TerritoryIntentMemory[]; changed: boolean } {
   const staleIntents: TerritoryIntentMemory[] = [];
   const sanitizedIntents = intents.filter((intent) => {
-    if (!isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername, roleCounts)) {
+    if (!isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername, roleCounts, gameTime)) {
       return true;
     }
 
@@ -2628,9 +2750,14 @@ function isStaleTerritoryProgressIntent(
   intent: TerritoryIntentMemory,
   colonyName: string,
   colonyOwnerUsername: string | null,
-  roleCounts: RoleCounts
+  roleCounts: RoleCounts,
+  gameTime: number
 ): boolean {
   if (intent.colony !== colonyName) {
+    return false;
+  }
+
+  if (isTerritoryIntentSuspensionActive(intent, gameTime)) {
     return false;
   }
 
@@ -3029,7 +3156,11 @@ function hasActiveTerritoryFollowUpIntentForColony(intents: TerritoryIntentMemor
 }
 
 function isActiveTerritoryFollowUpIntent(intent: TerritoryIntentMemory): boolean {
-  return (intent.status === 'planned' || intent.status === 'active') && intent.followUp !== undefined;
+  return (
+    (intent.status === 'planned' || intent.status === 'active') &&
+    intent.followUp !== undefined &&
+    !isTerritoryIntentSuspensionActive(intent, getGameTime())
+  );
 }
 
 function buildTerritoryFollowUpExecutionHint(
@@ -3191,6 +3322,7 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
   }
 
   const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
+  const suspended = normalizeTerritoryIntentSuspension(rawIntent.suspended);
   return {
     colony: rawIntent.colony,
     targetRoom: rawIntent.targetRoom,
@@ -3202,7 +3334,29 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
       ? { controllerId: rawIntent.controllerId as Id<StructureController> }
       : {}),
     ...(rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
-    ...(followUp ? { followUp } : {})
+    ...(followUp ? { followUp } : {}),
+    ...(suspended ? { suspended } : {})
+  };
+}
+
+function normalizeTerritoryIntentSuspension(rawSuspension: unknown): TerritoryIntentSuspensionMemory | null {
+  if (!isRecord(rawSuspension)) {
+    return null;
+  }
+
+  if (
+    rawSuspension.reason !== 'hostile_presence' ||
+    !isFiniteNumber(rawSuspension.hostileCount) ||
+    rawSuspension.hostileCount <= 0 ||
+    !isFiniteNumber(rawSuspension.updatedAt)
+  ) {
+    return null;
+  }
+
+  return {
+    reason: rawSuspension.reason,
+    hostileCount: Math.floor(rawSuspension.hostileCount),
+    updatedAt: rawSuspension.updatedAt
   };
 }
 
@@ -3297,6 +3451,99 @@ function getTerritoryCreepCountForTarget(
   return roleCounts.claimersByTargetRoom?.[targetRoom] ?? 0;
 }
 
+function buildHostilePresenceTerritoryIntentSuspension(
+  hostileCount: number,
+  gameTime: number
+): TerritoryIntentSuspensionMemory {
+  return {
+    reason: 'hostile_presence',
+    hostileCount,
+    updatedAt: gameTime
+  };
+}
+
+function isSameTerritoryIntentSuspension(
+  left: TerritoryIntentSuspensionMemory | undefined,
+  right: TerritoryIntentSuspensionMemory
+): boolean {
+  return (
+    left !== undefined &&
+    left.reason === right.reason &&
+    left.hostileCount === right.hostileCount &&
+    left.updatedAt === right.updatedAt
+  );
+}
+
+function withoutTerritoryIntentSuspension(intent: TerritoryIntentMemory): TerritoryIntentMemory {
+  const { suspended: _suspended, ...unsuspendedIntent } = intent;
+  return unsuspendedIntent;
+}
+
+function isTerritoryIntentSuspended(
+  colony: string,
+  targetRoom: string,
+  action: TerritoryIntentAction,
+  gameTime = getGameTime()
+): boolean {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return false;
+  }
+
+  return isTerritoryIntentSuspendedForAction(
+    normalizeTerritoryIntents(territoryMemory.intents),
+    colony,
+    targetRoom,
+    action,
+    gameTime
+  );
+}
+
+function isTerritoryIntentSuspendedForAction(
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  targetRoom: string,
+  action: TerritoryIntentAction,
+  gameTime: number
+): boolean {
+  return intents.some(
+    (intent) =>
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      intent.action === action &&
+      isTerritoryIntentSuspensionActive(intent, gameTime)
+  );
+}
+
+function isTerritoryRoomSuspendedForColony(
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  targetRoom: string,
+  gameTime: number
+): boolean {
+  return intents.some(
+    (intent) =>
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      isTerritoryIntentSuspensionActive(intent, gameTime)
+  );
+}
+
+function isTerritoryIntentSuspensionActive(intent: TerritoryIntentMemory, gameTime: number): boolean {
+  if (!intent.suspended) {
+    return false;
+  }
+
+  if (intent.suspended.reason === 'hostile_presence') {
+    const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
+    if (hostileCount !== null) {
+      return hostileCount > 0;
+    }
+  }
+
+  return gameTime - intent.suspended.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
+}
+
 function isTerritoryTargetSuppressed(
   target: TerritoryTargetMemory,
   intents: TerritoryIntentMemory[],
@@ -3346,7 +3593,11 @@ function isTerritorySuppressionFresh(intent: TerritoryIntentMemory, gameTime: nu
 }
 
 function isRecoveredTerritoryFollowUpIntent(intent: TerritoryIntentMemory, gameTime: number): boolean {
-  if (intent.followUp === undefined || isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime)) {
+  if (
+    intent.followUp === undefined ||
+    isTerritoryIntentSuspensionActive(intent, gameTime) ||
+    isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime)
+  ) {
     return false;
   }
 
@@ -3632,6 +3883,11 @@ function isVisibleRoomSafe(room: Room): boolean {
 
 function isVisibleRoomUnsafe(room: Room): boolean {
   return findVisibleHostileCreeps(room).length > 0 || findVisibleHostileStructures(room).length > 0;
+}
+
+function getVisibleHostileCreepCount(targetRoom: string): number | null {
+  const room = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[targetRoom];
+  return room ? findVisibleHostileCreeps(room).length : null;
 }
 
 function findVisibleHostileCreeps(room: Room): Creep[] {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -13,6 +13,7 @@ import {
   type OccupationRecommendationScore
 } from './occupationRecommendation';
 import { shouldSignOccupiedController } from './controllerSigning';
+import { normalizeTerritoryFollowUp, normalizeTerritoryIntents } from './territoryMemoryUtils';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
@@ -2519,15 +2520,6 @@ function recordTerritoryIntent(
   recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime, routeDistanceLookupContext);
 }
 
-function normalizeTerritoryIntents(rawIntents: TerritoryMemory['intents'] | unknown): TerritoryIntentMemory[] {
-  return Array.isArray(rawIntents)
-    ? rawIntents.flatMap((intent) => {
-        const normalizedIntent = normalizeTerritoryIntent(intent);
-        return normalizedIntent ? [normalizedIntent] : [];
-      })
-    : [];
-}
-
 function upsertTerritoryIntent(intents: TerritoryIntentMemory[], nextIntent: TerritoryIntentMemory): void {
   const existingIndex = intents.findIndex(
     (intent) =>
@@ -2599,12 +2591,14 @@ function refreshHostileTerritoryIntentSuspensions(
 
     const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
     if (hostileCount !== null && hostileCount > 0) {
-      const suspended = buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime);
-      if (isSameTerritoryIntentSuspension(intent.suspended, suspended)) {
-        suspendedIntents.push(intent);
+      if (intent.suspended?.reason === 'hostile_presence') {
+        if (isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime)) {
+          suspendedIntents.push(intent);
+        }
         return intent;
       }
 
+      const suspended = buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime);
       changed = true;
       const suspendedIntent = {
         ...intent,
@@ -2616,7 +2610,7 @@ function refreshHostileTerritoryIntentSuspensions(
 
     if (
       intent.suspended?.reason === 'hostile_presence' &&
-      (hostileCount === 0 || gameTime - intent.suspended.updatedAt > TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS)
+      (hostileCount === 0 || !isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime))
     ) {
       changed = true;
       return withoutTerritoryIntentSuspension(intent);
@@ -3306,60 +3300,6 @@ function isSameTerritoryFollowUp(left: TerritoryFollowUpMemory, right: Territory
   );
 }
 
-function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | null {
-  if (!isRecord(rawIntent)) {
-    return null;
-  }
-
-  if (
-    !isNonEmptyString(rawIntent.colony) ||
-    !isNonEmptyString(rawIntent.targetRoom) ||
-    !isTerritoryIntentAction(rawIntent.action) ||
-    !isTerritoryIntentStatus(rawIntent.status) ||
-    typeof rawIntent.updatedAt !== 'number'
-  ) {
-    return null;
-  }
-
-  const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
-  const suspended = normalizeTerritoryIntentSuspension(rawIntent.suspended);
-  return {
-    colony: rawIntent.colony,
-    targetRoom: rawIntent.targetRoom,
-    action: rawIntent.action,
-    status: rawIntent.status,
-    updatedAt: rawIntent.updatedAt,
-    ...(followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {}),
-    ...(typeof rawIntent.controllerId === 'string'
-      ? { controllerId: rawIntent.controllerId as Id<StructureController> }
-      : {}),
-    ...(rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {}),
-    ...(followUp ? { followUp } : {}),
-    ...(suspended ? { suspended } : {})
-  };
-}
-
-function normalizeTerritoryIntentSuspension(rawSuspension: unknown): TerritoryIntentSuspensionMemory | null {
-  if (!isRecord(rawSuspension)) {
-    return null;
-  }
-
-  if (
-    rawSuspension.reason !== 'hostile_presence' ||
-    !isFiniteNumber(rawSuspension.hostileCount) ||
-    rawSuspension.hostileCount <= 0 ||
-    !isFiniteNumber(rawSuspension.updatedAt)
-  ) {
-    return null;
-  }
-
-  return {
-    reason: rawSuspension.reason,
-    hostileCount: Math.floor(rawSuspension.hostileCount),
-    updatedAt: rawSuspension.updatedAt
-  };
-}
-
 function normalizeTerritoryFollowUpDemands(rawDemands: unknown): TerritoryFollowUpDemandMemory[] {
   return Array.isArray(rawDemands)
     ? rawDemands.flatMap((demand) => {
@@ -3413,28 +3353,6 @@ function getBoundedTerritoryFollowUpWorkerDemand(rawWorkerCount: unknown): numbe
   return Math.max(0, Math.min(TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND, Math.floor(rawWorkerCount)));
 }
 
-function normalizeTerritoryFollowUp(rawFollowUp: unknown): TerritoryFollowUpMemory | null {
-  if (!isRecord(rawFollowUp)) {
-    return null;
-  }
-
-  if (!isTerritoryFollowUpSource(rawFollowUp.source)) {
-    return null;
-  }
-
-  const source = rawFollowUp.source;
-  const originAction = getTerritoryFollowUpOriginAction(source);
-  if (originAction === null || !isNonEmptyString(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
-    return null;
-  }
-
-  return {
-    source,
-    originRoom: rawFollowUp.originRoom,
-    originAction
-  };
-}
-
 function getTerritoryCreepCountForTarget(
   roleCounts: RoleCounts,
   targetRoom: string,
@@ -3462,21 +3380,16 @@ function buildHostilePresenceTerritoryIntentSuspension(
   };
 }
 
-function isSameTerritoryIntentSuspension(
-  left: TerritoryIntentSuspensionMemory | undefined,
-  right: TerritoryIntentSuspensionMemory
-): boolean {
-  return (
-    left !== undefined &&
-    left.reason === right.reason &&
-    left.hostileCount === right.hostileCount &&
-    left.updatedAt === right.updatedAt
-  );
-}
-
 function withoutTerritoryIntentSuspension(intent: TerritoryIntentMemory): TerritoryIntentMemory {
   const { suspended: _suspended, ...unsuspendedIntent } = intent;
   return unsuspendedIntent;
+}
+
+function isHostileTerritoryIntentSuspensionCoolingDown(
+  suspension: TerritoryIntentSuspensionMemory,
+  gameTime: number
+): boolean {
+  return gameTime - suspension.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
 }
 
 function isTerritoryIntentSuspended(
@@ -3537,11 +3450,11 @@ function isTerritoryIntentSuspensionActive(intent: TerritoryIntentMemory, gameTi
   if (intent.suspended.reason === 'hostile_presence') {
     const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
     if (hostileCount !== null) {
-      return hostileCount > 0;
+      return hostileCount > 0 && isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime);
     }
   }
 
-  return gameTime - intent.suspended.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
+  return isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime);
 }
 
 function isTerritoryTargetSuppressed(
@@ -4147,10 +4060,6 @@ function isTerritoryFollowUpSource(source: unknown): source is TerritoryFollowUp
     source === 'satisfiedReserveAdjacent' ||
     source === 'activeReserveAdjacent'
   );
-}
-
-function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {
-  return status === 'planned' || status === 'active' || status === 'suppressed';
 }
 
 function isTerritoryExecutionHintReason(reason: unknown): reason is TerritoryExecutionHintReason {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -54,6 +54,7 @@ declare global {
   type TerritoryIntentAction = TerritoryControlAction | 'scout';
   type TerritoryDemandType = 'followUpPreparation';
   type TerritoryFollowUpSource = 'satisfiedClaimAdjacent' | 'satisfiedReserveAdjacent' | 'activeReserveAdjacent';
+  type TerritoryIntentSuspensionReason = 'hostile_presence';
   type TerritoryExecutionHintReason =
     | 'controlEvidenceStillMissing'
     | 'followUpTargetStillUnseen'
@@ -86,6 +87,13 @@ declare global {
     controllerId?: Id<StructureController>;
     requiresControllerPressure?: boolean;
     followUp?: TerritoryFollowUpMemory;
+    suspended?: TerritoryIntentSuspensionMemory;
+  }
+
+  interface TerritoryIntentSuspensionMemory {
+    reason: TerritoryIntentSuspensionReason;
+    hostileCount: number;
+    updatedAt: number;
   }
 
   interface TerritoryFollowUpMemory {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -732,6 +732,62 @@ describe('runtime telemetry summaries', () => {
     expect(describeExits).toHaveBeenCalledWith('W1N1');
   });
 
+  it('emits suspended territory intent counts by target room in room telemetry', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 2,
+            suspended: {
+              reason: 'hostile_presence',
+              hostileCount: 1,
+              updatedAt: RUNTIME_SUMMARY_INTERVAL - 1
+            }
+          },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 2,
+            suspended: {
+              reason: 'hostile_presence',
+              hostileCount: 2,
+              updatedAt: RUNTIME_SUMMARY_INTERVAL - 1
+            }
+          },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 2,
+            suspended: {
+              reason: 'hostile_presence',
+              hostileCount: 1,
+              updatedAt: RUNTIME_SUMMARY_INTERVAL - 1
+            }
+          }
+        ]
+      }
+    };
+
+    emitRuntimeSummary([colony], [], [], { persistOccupationRecommendations: false });
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.suspendedTerritoryIntentCounts).toEqual({
+      W2N1: 2,
+      W3N1: 1
+    });
+    expect(room.territoryIntents).toBeUndefined();
+  });
+
   it('keeps emission gating deterministic', () => {
     expect(shouldEmitRuntimeSummary(1, [])).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [])).toBe(true);

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1303,6 +1303,70 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('does not re-stamp a hostile suspension while visible hostiles persist', () => {
+    const colony = makeSafeColony();
+    const suspendedAt = 572;
+    const retryTime = suspendedAt + TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS + 1;
+    const suspendedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 571,
+      suspended: {
+        reason: 'hostile_presence',
+        hostileCount: 1,
+        updatedAt: suspendedAt
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1', { hostileCreepCount: 3 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [suspendedIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, suspendedAt + 1)
+    ).toBeNull();
+    expect(Memory.territory?.intents).toEqual([suspendedIntent]);
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime)
+    ).toBeNull();
+    expect(Memory.territory?.intents).toEqual([suspendedIntent]);
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {};
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime + 1)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'scout'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 571
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: retryTime + 1
+      }
+    ]);
+  });
+
   it('clears a hostile suspension immediately when visible hostile creeps leave', () => {
     const colony = makeSafeColony();
     const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -10,6 +10,7 @@ import {
   shouldSpawnTerritoryControllerCreep,
   suppressTerritoryIntent,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
+  TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS,
   TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS,
   TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
   TERRITORY_RESERVATION_RENEWAL_TICKS,
@@ -1208,6 +1209,201 @@ describe('planTerritoryIntent', () => {
       )
     ).toBe(false);
     expect(Memory.territory?.intents).toEqual([persistedIntent]);
+  });
+
+  it('suspends a persisted intent with visible hostile creeps instead of selecting it', () => {
+    const colony = makeSafeColony();
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const persistedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 570,
+      followUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1', { hostileCreepCount: 2 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [persistedIntent]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 571)).toBeNull();
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', followUp },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+        571
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        ...persistedIntent,
+        suspended: {
+          reason: 'hostile_presence',
+          hostileCount: 2,
+          updatedAt: 571
+        }
+      }
+    ]);
+  });
+
+  it('retries a hostile-suspended intent after the cooldown when target visibility is unavailable', () => {
+    const colony = makeSafeColony();
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const suspendedAt = 572;
+    const retryTime = suspendedAt + TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS + 1;
+    const suspendedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 571,
+      followUp,
+      suspended: {
+        reason: 'hostile_presence',
+        hostileCount: 1,
+        updatedAt: suspendedAt
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {};
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [suspendedIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, suspendedAt + 1)
+    ).toBeNull();
+    expect(Memory.territory?.intents).toEqual([suspendedIntent]);
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      followUp
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: retryTime,
+        followUp
+      }
+    ]);
+  });
+
+  it('clears a hostile suspension immediately when visible hostile creeps leave', () => {
+    const colony = makeSafeColony();
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const suspendedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 573,
+      followUp,
+      suspended: {
+        reason: 'hostile_presence',
+        hostileCount: 1,
+        updatedAt: 574
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1')
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [suspendedIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 575)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      followUp
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 575,
+        followUp
+      }
+    ]);
+  });
+
+  it('selects an unsuspended persisted intent when another persisted intent sees hostiles', () => {
+    const colony = makeSafeColony();
+    const blockedFollowUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
+    const readyFollowUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N3', 'reserve');
+    const blockedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 575,
+      followUp: blockedFollowUp
+    };
+    const readyIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      status: 'planned',
+      updatedAt: 576,
+      followUp: readyFollowUp
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1', { hostileCreepCount: 1, sourceCount: 2 }),
+        W3N1: makeRecommendationRoom('W3N1', { sourceCount: 2 })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [blockedIntent, readyIntent]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 577)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'reserve',
+      followUp: readyFollowUp
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        ...blockedIntent,
+        suspended: {
+          reason: 'hostile_presence',
+          hostileCount: 1,
+          updatedAt: 577
+        }
+      },
+      {
+        ...readyIntent,
+        updatedAt: 577
+      }
+    ]);
   });
 
   it('prioritizes lower reservation TTL among persisted occupation claim follow-up intents', () => {
@@ -3075,7 +3271,7 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.executionHints).toBeUndefined();
   });
 
-  it('clears stale follow-up controller intent after visible target becomes unsafe', () => {
+  it('suspends a stale follow-up controller intent after visible target hostiles appear', () => {
     const colony = makeSafeColony();
     const genericTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' };
     const staleFollowUpTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' };
@@ -3132,6 +3328,14 @@ describe('planTerritoryIntent', () => {
       action: 'reserve'
     });
     expect(Memory.territory?.intents).toEqual([
+      {
+        ...staleFollowUpIntent,
+        suspended: {
+          reason: 'hostile_presence',
+          hostileCount: 1,
+          updatedAt: 592
+        }
+      },
       {
         colony: 'W1N1',
         targetRoom: 'W2N1',
@@ -3221,6 +3425,19 @@ describe('planTerritoryIntent', () => {
       requiresControllerPressure: true
     });
     expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 592,
+        followUp,
+        suspended: {
+          reason: 'hostile_presence',
+          hostileCount: 1,
+          updatedAt: 593
+        }
+      },
       {
         colony: 'W1N1',
         targetRoom: 'W3N1',


### PR DESCRIPTION
## Summary
Implements #469: hostile-aware territory intent suspension and telemetry.

## Changes
- Territory intents targeting rooms with visible hostile creeps are marked as `suspended` with reason `hostile_presence`
- Suspended intents are excluded from spawn candidate selection
- Suspension cooldown (1500 ticks default) with early unsuspension when hostile count drops to 0
- Suspended intent counts emitted in room-level telemetry via runtimeSummary
- Added `suspended` field to territory intent type

## Verification
- `npm run typecheck` — PASS
- `npm test -- --runInBand` — 24 suites, 680 tests PASS
- `npm run build` — PASS

Closes #469
