### PR TITLE
feat: combat QA dead-zone safety tests (#407)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -61,6 +61,186 @@ function getOwnedColonies() {
   }));
 }
 
+// src/defense/deadZone.ts
+var ERR_NO_PATH_CODE = -2;
+function refreshVisibleDeadZoneMemory(gameTime = getGameTime()) {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return;
+  }
+  for (const room of Object.values(rooms)) {
+    refreshVisibleRoomDeadZoneMemory(room, gameTime);
+  }
+}
+function refreshVisibleRoomDeadZoneMemory(room, gameTime = getGameTime()) {
+  var _a;
+  const assessment = assessVisibleRoomDeadZone(room);
+  if (!assessment.unsafe || !assessment.reason) {
+    clearKnownDeadZoneRoom(room.name);
+    return false;
+  }
+  const defenseMemory = getWritableDefenseMemory();
+  if (!defenseMemory) {
+    return true;
+  }
+  const unsafeRooms = (_a = defenseMemory.unsafeRooms) != null ? _a : {};
+  unsafeRooms[room.name] = {
+    roomName: room.name,
+    unsafe: true,
+    reason: assessment.reason,
+    updatedAt: gameTime,
+    hostileCreepCount: assessment.hostileCreepCount,
+    hostileStructureCount: assessment.hostileStructureCount,
+    hostileTowerCount: assessment.hostileTowerCount
+  };
+  defenseMemory.unsafeRooms = unsafeRooms;
+  return true;
+}
+function isKnownDeadZoneRoom(roomName) {
+  var _a, _b;
+  const visibleRoom = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+  if (visibleRoom) {
+    return refreshVisibleRoomDeadZoneMemory(visibleRoom);
+  }
+  return getKnownDeadZoneRoom(roomName) !== null;
+}
+function getKnownDeadZoneRoom(roomName) {
+  var _a, _b, _c;
+  const roomMemory = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.defense) == null ? void 0 : _b.unsafeRooms) == null ? void 0 : _c[roomName];
+  return isDefenseUnsafeRoomMemory(roomMemory) ? roomMemory : null;
+}
+function clearKnownDeadZoneRoom(roomName) {
+  var _a;
+  const defenseMemory = (_a = globalThis.Memory) == null ? void 0 : _a.defense;
+  const unsafeRooms = defenseMemory == null ? void 0 : defenseMemory.unsafeRooms;
+  if (!unsafeRooms || unsafeRooms[roomName] === void 0) {
+    return;
+  }
+  delete unsafeRooms[roomName];
+  if (Object.keys(unsafeRooms).length === 0) {
+    delete defenseMemory.unsafeRooms;
+  }
+}
+function hasSafeRouteAvoidingDeadZones(fromRoom, targetRoom) {
+  if (fromRoom === targetRoom) {
+    return true;
+  }
+  const gameMap = getGameMapWithFindRoute();
+  if (!gameMap) {
+    return null;
+  }
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName) => isKnownDeadZoneRoom(roomName) ? Infinity : 1
+  });
+  if (route === getNoPathResultCode()) {
+    return false;
+  }
+  return Array.isArray(route) ? true : null;
+}
+function isRouteBlockedByKnownDeadZone(fromRoom, targetRoom) {
+  if (fromRoom === targetRoom || !hasAnyKnownDeadZoneRoom()) {
+    return false;
+  }
+  const gameMap = getGameMapWithFindRoute();
+  if (!gameMap) {
+    return false;
+  }
+  let touchedDeadZone = false;
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName) => {
+      const deadZone = isKnownDeadZoneRoom(roomName);
+      touchedDeadZone || (touchedDeadZone = deadZone);
+      return deadZone ? Infinity : 1;
+    }
+  });
+  return touchedDeadZone && route === getNoPathResultCode();
+}
+function assessVisibleRoomDeadZone(room) {
+  const hostileCreeps = findRoomObjects(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects(room, "FIND_HOSTILE_STRUCTURES");
+  const hostileTowerCount = hostileStructures.filter(isTowerStructure).length;
+  const hostileStructureCount = hostileStructures.length;
+  const hostileCreepCount = hostileCreeps.length;
+  if (hostileTowerCount > 0) {
+    return {
+      unsafe: true,
+      reason: "enemyTower",
+      hostileCreepCount,
+      hostileStructureCount,
+      hostileTowerCount
+    };
+  }
+  if (hostileCreepCount > 0 || hostileStructureCount > 0) {
+    return {
+      unsafe: true,
+      reason: "hostilePresence",
+      hostileCreepCount,
+      hostileStructureCount,
+      hostileTowerCount
+    };
+  }
+  return {
+    unsafe: false,
+    hostileCreepCount,
+    hostileStructureCount,
+    hostileTowerCount
+  };
+}
+function findRoomObjects(room, constantName) {
+  const findConstant = globalThis[constantName];
+  const find = room.find;
+  if (typeof findConstant !== "number" || typeof find !== "function") {
+    return [];
+  }
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function isTowerStructure(structure) {
+  var _a;
+  const towerType = (_a = globalThis.STRUCTURE_TOWER) != null ? _a : "tower";
+  return structure.structureType === towerType;
+}
+function hasAnyKnownDeadZoneRoom() {
+  var _a, _b;
+  const unsafeRooms = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.defense) == null ? void 0 : _b.unsafeRooms;
+  return unsafeRooms !== void 0 && Object.keys(unsafeRooms).length > 0;
+}
+function isDefenseUnsafeRoomMemory(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value;
+  return typeof candidate.roomName === "string" && candidate.unsafe === true && (candidate.reason === "enemyTower" || candidate.reason === "hostilePresence") && typeof candidate.updatedAt === "number";
+}
+function getWritableDefenseMemory() {
+  var _a;
+  const memory = globalThis.Memory;
+  if (!memory) {
+    return null;
+  }
+  const defenseMemory = (_a = memory.defense) != null ? _a : {};
+  memory.defense = defenseMemory;
+  return defenseMemory;
+}
+function getGameMapWithFindRoute() {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  return typeof (gameMap == null ? void 0 : gameMap.findRoute) === "function" ? gameMap : null;
+}
+function getNoPathResultCode() {
+  const noPathCode = globalThis.ERR_NO_PATH;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE;
+}
+function getGameTime() {
+  var _a, _b;
+  return typeof ((_a = globalThis.Game) == null ? void 0 : _a.time) === "number" ? (_b = globalThis.Game.time) != null ? _b : 0 : 0;
+}
+
 // src/defense/defenseLoop.ts
 var DEFENDER_ROLE = "defender";
 var MAX_RECORDED_DEFENSE_ACTIONS = 20;
@@ -71,6 +251,7 @@ var OK_CODE = 0;
 var ERR_NOT_IN_RANGE_CODE = -9;
 function runDefense() {
   const telemetryEvents = [];
+  refreshVisibleDeadZoneMemory();
   const colonies = getOwnedColonies();
   for (const colony of colonies) {
     runColonyDefense(createDefenseContext(colony), telemetryEvents);
@@ -225,12 +406,23 @@ function runDefender(creep, telemetryEvents) {
   if (target && typeof creep.attack === "function") {
     const attackResult = creep.attack(target);
     if (attackResult === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === "function") {
+      if (shouldSuppressDefenderMove(creep, target)) {
+        return;
+      }
       const moveResult = creep.moveTo(target);
       recordDefenderAction(creep, "defenderMove", target, moveResult, telemetryEvents);
       return;
     }
     recordDefenderAction(creep, "defenderAttack", target, attackResult, telemetryEvents);
   }
+}
+function shouldSuppressDefenderMove(creep, target) {
+  var _a;
+  const targetRoom = (_a = target.pos) == null ? void 0 : _a.roomName;
+  if (!targetRoom || targetRoom === creep.room.name || !getKnownDeadZoneRoom(targetRoom)) {
+    return false;
+  }
+  return hasSafeRouteAvoidingDeadZones(creep.room.name, targetRoom) === false;
 }
 function recordDefenderAction(creep, action, target, result, telemetryEvents) {
   const roomName = creep.room.name;
@@ -363,7 +555,7 @@ function recordDefenseAction(input, telemetryEvents) {
   const actionMemory = {
     type: input.action,
     roomName: input.context.colony.room.name,
-    tick: getGameTime(),
+    tick: getGameTime2(),
     reason: input.reason,
     hostileCreepCount: input.context.hostileCreeps.length,
     hostileStructureCount: input.context.hostileStructures.length,
@@ -401,18 +593,18 @@ function recordDefenseActionMemory(action) {
   globalMemory.defense = defenseMemory;
 }
 function findHostileCreeps(room) {
-  return findRoomObjects(room, "FIND_HOSTILE_CREEPS");
+  return findRoomObjects2(room, "FIND_HOSTILE_CREEPS");
 }
 function findHostileStructures(room) {
-  return findRoomObjects(room, "FIND_HOSTILE_STRUCTURES");
+  return findRoomObjects2(room, "FIND_HOSTILE_STRUCTURES");
 }
 function findOwnedStructures(room) {
-  return findRoomObjects(room, "FIND_MY_STRUCTURES");
+  return findRoomObjects2(room, "FIND_MY_STRUCTURES");
 }
 function findMyCreeps(room) {
-  return findRoomObjects(room, "FIND_MY_CREEPS");
+  return findRoomObjects2(room, "FIND_MY_CREEPS");
 }
-function findRoomObjects(room, constantName) {
+function findRoomObjects2(room, constantName) {
   const findConstant = getGlobalNumber(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
@@ -457,7 +649,7 @@ function getEnergyResource() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function getGameTime() {
+function getGameTime2() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -735,13 +927,13 @@ function getWorkerTarget(colony, roleCounts) {
   }
   return Math.min(MAX_WORKER_TARGET, firstBonusTarget + CONSTRUCTION_BACKLOG_WORKER_BONUS);
 }
-function recordColonySurvivalAssessment(colonyName, assessment, tick = getGameTime2()) {
+function recordColonySurvivalAssessment(colonyName, assessment, tick = getGameTime3()) {
   if (!isNonEmptyString(colonyName) || tick === null) {
     return;
   }
   survivalAssessmentByColony.set(colonyName, { assessment, tick });
 }
-function getRecordedColonySurvivalAssessment(colonyName, tick = getGameTime2()) {
+function getRecordedColonySurvivalAssessment(colonyName, tick = getGameTime3()) {
   if (!isNonEmptyString(colonyName) || tick === null) {
     return null;
   }
@@ -854,7 +1046,7 @@ function getGlobalNumber2(name) {
 function getRoomName(room) {
   return typeof room.name === "string" && room.name.length > 0 ? room.name : null;
 }
-function getGameTime2() {
+function getGameTime3() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : null;
@@ -1310,7 +1502,7 @@ function scoreOccupationRecommendations(input) {
     input.colonyName
   );
 }
-function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGameTime3()) {
+function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGameTime4()) {
   var _a, _b;
   const followUpIntent = report.followUpIntent;
   if (!followUpIntent) {
@@ -1517,11 +1709,11 @@ function enrichVisibleOccupationCandidate(candidate) {
   if (!room) {
     return candidate;
   }
-  const hostileCreeps = findRoomObjects2(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects2(room, "FIND_HOSTILE_STRUCTURES");
-  const sources = findRoomObjects2(room, "FIND_SOURCES");
-  const constructionSites = findRoomObjects2(room, "FIND_MY_CONSTRUCTION_SITES");
-  const ownedStructures = findRoomObjects2(room, "FIND_MY_STRUCTURES");
+  const hostileCreeps = findRoomObjects3(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects3(room, "FIND_HOSTILE_STRUCTURES");
+  const sources = findRoomObjects3(room, "FIND_SOURCES");
+  const constructionSites = findRoomObjects3(room, "FIND_MY_CONSTRUCTION_SITES");
+  const ownedStructures = findRoomObjects3(room, "FIND_MY_STRUCTURES");
   const controllerId = (_b = room.controller) == null ? void 0 : _b.id;
   return {
     ...candidate,
@@ -1768,7 +1960,7 @@ function getCachedRouteDistance(fromRoom, targetRoom) {
   const distance = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`];
   return typeof distance === "number" || distance === null ? distance : void 0;
 }
-function findRoomObjects2(room, constantName) {
+function findRoomObjects3(room, constantName) {
   const findConstant = getGlobalNumber3(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
@@ -1804,7 +1996,7 @@ function getGameRooms() {
   var _a;
   return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
 }
-function getGameTime3() {
+function getGameTime4() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -1996,7 +2188,7 @@ var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 var TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 0;
 var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
-var ERR_NO_PATH_CODE = -2;
+var ERR_NO_PATH_CODE2 = -2;
 var TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL = 0;
 var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM = 1;
 var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE = 2;
@@ -2039,7 +2231,7 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options
   );
   return plan;
 }
-function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime4()) {
+function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime5()) {
   if (!plan || !plan.followUp || !isTerritoryControlAction2(plan.action)) {
     return;
   }
@@ -2071,7 +2263,10 @@ function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameT
   removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, plan.colony, plan.targetRoom, plan.action);
 }
-function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime4()) {
+function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime5()) {
+  if (isKnownDeadZoneRoom(plan.targetRoom)) {
+    return false;
+  }
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
     return false;
   }
@@ -2108,7 +2303,7 @@ function isTerritoryIntentPlanSpawnCapable(plan) {
   const energyCapacityAvailable = (_a = getVisibleRoom(plan.colony)) == null ? void 0 : _a.energyCapacityAvailable;
   return typeof energyCapacityAvailable !== "number" || energyCapacityAvailable >= TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
 }
-function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime4()) {
+function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime5()) {
   var _a;
   if (!plan || !isTerritoryControlAction2(plan.action)) {
     return 0;
@@ -2127,7 +2322,7 @@ function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTim
   const demand = getCurrentTerritoryFollowUpDemand(plan, gameTime);
   return (_a = demand == null ? void 0 : demand.workerCount) != null ? _a : 0;
 }
-function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime4()) {
+function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime5()) {
   if (!isNonEmptyString3(colony)) {
     return false;
   }
@@ -2139,7 +2334,7 @@ function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameT
     (demand) => demand.updatedAt === gameTime && demand.colony === colony && demand.workerCount > 0
   );
 }
-function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime4()) {
+function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime5()) {
   if (!isNonEmptyString3(colony)) {
     return false;
   }
@@ -2440,6 +2635,16 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
     intents = sanitizedStaleProgress.intents;
   }
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
+  const deadZoneSuppression = suppressDeadZoneTerritoryTargets(
+    territoryMemory,
+    intents,
+    colonyName,
+    gameTime,
+    routeDistanceLookupContext
+  );
+  if (deadZoneSuppression.changed) {
+    intents = deadZoneSuppression.intents;
+  }
   refreshTerritoryFollowUpExecutionHints(territoryMemory, intents, routeDistanceLookupContext);
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     colony,
@@ -2688,7 +2893,7 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget2(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) || !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)) {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isKnownDeadZoneRoom(target.roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) || !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)) {
       return [];
     }
     const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
@@ -2734,7 +2939,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
   const configuredTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return intents.flatMap((intent, order) => {
     const recoveredFollowUp = isRecoveredTerritoryFollowUpIntent(intent, gameTime);
-    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction2(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)) {
+    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || isKnownDeadZoneRoom(intent.targetRoom) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction2(intent.action) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)) {
       return [];
     }
     const intentKey = `${intent.targetRoom}:${intent.action}`;
@@ -2783,6 +2988,9 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
     if (target.enabled === false || target.roomName === colonyName) {
       return true;
     }
+    if (isKnownDeadZoneRoom(target.roomName)) {
+      return false;
+    }
     if (isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername)) {
       return false;
     }
@@ -2809,6 +3017,68 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
     }
     return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
   });
+}
+function suppressDeadZoneTerritoryTargets(territoryMemory, intents, colonyName, gameTime, routeDistanceLookupContext) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return { intents, changed: false };
+  }
+  let nextIntents = intents;
+  let changed = false;
+  for (const rawTarget of territoryMemory.targets) {
+    const target = normalizeTerritoryTarget2(rawTarget);
+    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName) {
+      continue;
+    }
+    const reason = getTerritoryDeadZoneSuppressionReason(
+      colonyName,
+      target.roomName,
+      routeDistanceLookupContext
+    );
+    if (!reason) {
+      const filteredIntents = removeDeadZoneSuppression(nextIntents, target);
+      if (filteredIntents.length !== nextIntents.length) {
+        nextIntents = filteredIntents;
+        territoryMemory.intents = nextIntents;
+        changed = true;
+      }
+      continue;
+    }
+    territoryMemory.intents = nextIntents;
+    upsertTerritoryIntent2(nextIntents, {
+      colony: target.colony,
+      targetRoom: target.roomName,
+      action: target.action,
+      status: "suppressed",
+      updatedAt: gameTime,
+      reason,
+      ...target.controllerId ? { controllerId: target.controllerId } : {}
+    });
+    removeTerritoryFollowUpDemand(territoryMemory, target.colony, target.roomName, target.action);
+    removeTerritoryFollowUpExecutionHint(
+      territoryMemory,
+      target.colony,
+      target.roomName,
+      target.action
+    );
+    changed = true;
+  }
+  return { intents: nextIntents, changed };
+}
+function getTerritoryDeadZoneSuppressionReason(colonyName, targetRoom, routeDistanceLookupContext) {
+  var _a;
+  isKnownDeadZoneRoom(targetRoom);
+  if (((_a = getKnownDeadZoneRoom(targetRoom)) == null ? void 0 : _a.reason) === "enemyTower") {
+    return "deadZoneTarget";
+  }
+  return isRouteBlockedByKnownDeadZone(colonyName, targetRoom) && getKnownRouteLength(colonyName, targetRoom, routeDistanceLookupContext) !== null ? "deadZoneRoute" : null;
+}
+function removeDeadZoneSuppression(intents, target) {
+  return intents.filter(
+    (intent) => !(intent.colony === target.colony && intent.targetRoom === target.roomName && intent.action === target.action && intent.status === "suppressed" && isDeadZoneTerritorySuppressionReason(intent.reason))
+  );
+}
+function isDeadZoneTerritorySuppressionReason(reason) {
+  return reason === "deadZoneTarget" || reason === "deadZoneRoute";
 }
 function isConfiguredFollowUpTargetBlockedBySpawnReadiness(target, intents, gameTime, colony) {
   const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
@@ -2848,7 +3118,7 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
   const existingTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return adjacentRooms.flatMap((roomName, order) => {
     const target = { colony: colonyName, roomName, action: "reserve" };
-    if (roomName === colonyName || existingTargetRooms.has(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
+    if (roomName === colonyName || existingTargetRooms.has(roomName) || isKnownDeadZoneRoom(roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, "reserve", gameTime)) {
       return [];
     }
     const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
@@ -3022,7 +3292,7 @@ function getActiveCoveredConfiguredReserveTargets(colonyName, colonyOwnerUsernam
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget2(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || !isVisibleRoomKnown(target.roomName) || getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName || isKnownDeadZoneRoom(target.roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || !isVisibleRoomKnown(target.roomName) || getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
     return [{ target, order }];
@@ -3045,7 +3315,7 @@ function getSatisfiedConfiguredTargets(colonyName, colonyOwnerUsername, territor
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget2(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== action || target.roomName === colonyName || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== action || target.roomName === colonyName || isKnownDeadZoneRoom(target.roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
       return [];
     }
     return [{ target, order }];
@@ -3405,7 +3675,7 @@ function getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) {
     return void 0;
   }
   const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom);
-  if (route === getNoPathResultCode()) {
+  if (route === getNoPathResultCode2()) {
     if (cache) {
       cache[cacheKey] = null;
     }
@@ -3433,9 +3703,9 @@ function getTerritoryRouteDistanceCache() {
 function getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom) {
   return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR2}${targetRoom}`;
 }
-function getNoPathResultCode() {
+function getNoPathResultCode2() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE2;
 }
 function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
   if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
@@ -3980,6 +4250,7 @@ function normalizeTerritoryIntent2(rawIntent) {
     action: rawIntent.action,
     status: rawIntent.status,
     updatedAt: rawIntent.updatedAt,
+    ...isDeadZoneTerritorySuppressionReason(rawIntent.reason) ? { reason: rawIntent.reason } : {},
     ...followUp && isFiniteNumber2(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {},
     ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
     ...rawIntent.requiresControllerPressure === true ? { requiresControllerPressure: true } : {},
@@ -4059,7 +4330,7 @@ function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, actio
     (intent) => isTerritorySuppressionFresh2(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
-function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime4()) {
+function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime5()) {
   const territoryMemory = getTerritoryMemoryRecord2();
   if (!territoryMemory) {
     return false;
@@ -4112,7 +4383,7 @@ function normalizeCreepTerritoryIntent(creep, roomName) {
     targetRoom: assignment.targetRoom,
     action: assignment.action,
     status: "active",
-    updatedAt: getGameTime4(),
+    updatedAt: getGameTime5(),
     ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
     ...followUp ? { followUp } : {}
   };
@@ -4243,6 +4514,9 @@ function getEnergyResource2() {
 }
 function isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom) {
   var _a, _b;
+  if (isKnownDeadZoneRoom(targetRoom)) {
+    return true;
+  }
   const room = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[targetRoom];
   return room ? isVisibleRoomUnsafe(room) : false;
 }
@@ -4383,7 +4657,7 @@ function getVisibleController2(targetRoom, controllerId) {
   }
   return null;
 }
-function getGameTime4() {
+function getGameTime5() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -4458,13 +4732,13 @@ function isCriticalRoadLogisticsWork(target, context) {
   );
 }
 function findOwnedSpawnPositions(room) {
-  return findRoomObjects3(room, "FIND_MY_STRUCTURES").filter(
+  return findRoomObjects4(room, "FIND_MY_STRUCTURES").filter(
     (structure) => matchesStructureType3(structure.structureType, "STRUCTURE_SPAWN", "spawn")
   ).map((spawn) => spawn.pos).filter((position) => isSameRoomPosition2(position, room.name));
 }
 function findLogisticsTargetPositions(room) {
   var _a;
-  const sourcePositions = findRoomObjects3(room, "FIND_SOURCES").map((source) => source.pos).filter((position) => isSameRoomPosition2(position, room.name));
+  const sourcePositions = findRoomObjects4(room, "FIND_SOURCES").map((source) => source.pos).filter((position) => isSameRoomPosition2(position, room.name));
   const controllerPosition = isSameRoomPosition2((_a = room.controller) == null ? void 0 : _a.pos, room.name) ? [room.controller.pos] : [];
   return [...sourcePositions, ...controllerPosition];
 }
@@ -4546,7 +4820,7 @@ function findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions) {
   }
   return targetPositions.slice(0, 1);
 }
-function findRoomObjects3(room, constantName) {
+function findRoomObjects4(room, constantName) {
   const findConstant = globalThis[constantName];
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return [];
@@ -7936,12 +8210,12 @@ function clampScore(score) {
 function buildRuntimeConstructionPriorityState(colony, creeps) {
   var _a, _b, _c;
   const room = colony.room;
-  const ownedConstructionSites = findRoomObjects4(room, "FIND_MY_CONSTRUCTION_SITES");
-  const ownedStructures = findRoomObjects4(room, "FIND_MY_STRUCTURES");
-  const visibleStructures = findRoomObjects4(room, "FIND_STRUCTURES");
-  const hostileCreeps = findRoomObjects4(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects4(room, "FIND_HOSTILE_STRUCTURES");
-  const sources = findRoomObjects4(room, "FIND_SOURCES");
+  const ownedConstructionSites = findRoomObjects5(room, "FIND_MY_CONSTRUCTION_SITES");
+  const ownedStructures = findRoomObjects5(room, "FIND_MY_STRUCTURES");
+  const visibleStructures = findRoomObjects5(room, "FIND_STRUCTURES");
+  const hostileCreeps = findRoomObjects5(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects5(room, "FIND_HOSTILE_STRUCTURES");
+  const sources = findRoomObjects5(room, "FIND_SOURCES");
   const colonyWorkers = creeps.filter((creep) => {
     var _a2, _b2;
     return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && ((_b2 = creep.memory) == null ? void 0 : _b2.colony) === room.name;
@@ -8217,7 +8491,7 @@ function getConstructionSiteRemainingProgress2(site) {
   const progress = typeof site.progress === "number" ? site.progress : 0;
   return Math.max(0, progressTotal - progress);
 }
-function findRoomObjects4(room, constantName) {
+function findRoomObjects5(room, constantName) {
   const findConstant = globalThis[constantName];
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return null;
@@ -8316,7 +8590,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return;
   }
-  const tick = getGameTime5();
+  const tick = getGameTime6();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -8410,7 +8684,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime5());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime6());
   }
   return {
     roomName: colony.room.name,
@@ -8419,8 +8693,8 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime5()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime5()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime6()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime6()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -8646,10 +8920,10 @@ function buildControllerSummary(room) {
 }
 function summarizeResources(colony, colonyWorkers, events) {
   var _a, _b, _c, _d;
-  const roomStructures = (_a = findRoomObjects5(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const constructionSites = (_b = findRoomObjects5(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
-  const droppedResources = (_c = findRoomObjects5(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
-  const sources = (_d = findRoomObjects5(colony.room, "FIND_SOURCES")) != null ? _d : [];
+  const roomStructures = (_a = findRoomObjects6(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const constructionSites = (_b = findRoomObjects6(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
+  const droppedResources = (_c = findRoomObjects6(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
+  const sources = (_d = findRoomObjects6(colony.room, "FIND_SOURCES")) != null ? _d : [];
   return {
     storedEnergy: sumEnergyInStores(roomStructures),
     workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
@@ -8747,8 +9021,8 @@ function buildControllerProgressRemaining(room) {
 }
 function summarizeCombat(room, events) {
   var _a, _b;
-  const hostileCreeps = (_a = findRoomObjects5(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
-  const hostileStructures = (_b = findRoomObjects5(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
+  const hostileCreeps = (_a = findRoomObjects6(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
+  const hostileStructures = (_b = findRoomObjects6(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
   return {
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -8993,7 +9267,7 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
 }
 function getSpawnExtensionEnergyStructureIds(room) {
   var _a, _b;
-  const structures = (_b = (_a = findRoomObjects5(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects5(room, "FIND_STRUCTURES")) != null ? _b : [];
+  const structures = (_b = (_a = findRoomObjects6(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects6(room, "FIND_STRUCTURES")) != null ? _b : [];
   const ids = /* @__PURE__ */ new Set();
   for (const structure of structures) {
     if (!isSpawnExtensionEnergyStructure2(structure)) {
@@ -9018,7 +9292,7 @@ function buildEventObjectId(entry) {
 function getObjectId2(value) {
   return isRecord5(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
-function findRoomObjects5(room, constantName) {
+function findRoomObjects6(room, constantName) {
   const findConstant = getGlobalNumber4(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
@@ -9108,7 +9382,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime5() {
+function getGameTime6() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -9204,7 +9478,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime6();
+  const gameTime = getGameTime7();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -9224,7 +9498,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime6());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime7());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -9280,7 +9554,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime6() {
+function getGameTime7() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -9485,7 +9759,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime7())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime8())
     );
   }
 };
@@ -9557,7 +9831,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime7() {
+function getGameTime8() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -62,9 +62,11 @@ function getOwnedColonies() {
 }
 
 // src/defense/deadZone.ts
+var DEAD_ZONE_MEMORY_TTL = 250;
 var ERR_NO_PATH_CODE = -2;
 function refreshVisibleDeadZoneMemory(gameTime = getGameTime()) {
   var _a;
+  clearExpiredDeadZoneRooms(gameTime);
   const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
   if (!rooms) {
     return;
@@ -101,14 +103,26 @@ function isKnownDeadZoneRoom(roomName) {
   var _a, _b;
   const visibleRoom = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
   if (visibleRoom) {
-    return refreshVisibleRoomDeadZoneMemory(visibleRoom);
+    return assessVisibleRoomDeadZone(visibleRoom).unsafe;
   }
-  return getKnownDeadZoneRoom(roomName) !== null;
+  return readKnownDeadZoneRoom(roomName, false) !== null;
 }
 function getKnownDeadZoneRoom(roomName) {
+  return readKnownDeadZoneRoom(roomName, true);
+}
+function readKnownDeadZoneRoom(roomName, clearExpired) {
   var _a, _b, _c;
   const roomMemory = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.defense) == null ? void 0 : _b.unsafeRooms) == null ? void 0 : _c[roomName];
-  return isDefenseUnsafeRoomMemory(roomMemory) ? roomMemory : null;
+  if (!isDefenseUnsafeRoomMemory(roomMemory)) {
+    return null;
+  }
+  if (isDeadZoneMemoryExpired(roomMemory)) {
+    if (clearExpired) {
+      clearKnownDeadZoneRoom(roomName);
+    }
+    return null;
+  }
+  return roomMemory;
 }
 function clearKnownDeadZoneRoom(roomName) {
   var _a;
@@ -206,9 +220,13 @@ function isTowerStructure(structure) {
   return structure.structureType === towerType;
 }
 function hasAnyKnownDeadZoneRoom() {
-  var _a, _b;
+  var _a, _b, _c;
   const unsafeRooms = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.defense) == null ? void 0 : _b.unsafeRooms;
-  return unsafeRooms !== void 0 && Object.keys(unsafeRooms).length > 0;
+  if (unsafeRooms && Object.keys(unsafeRooms).some((roomName) => readKnownDeadZoneRoom(roomName, false) !== null)) {
+    return true;
+  }
+  const visibleRooms = (_c = globalThis.Game) == null ? void 0 : _c.rooms;
+  return visibleRooms ? Object.values(visibleRooms).some((room) => assessVisibleRoomDeadZone(room).unsafe) : false;
 }
 function isDefenseUnsafeRoomMemory(value) {
   if (typeof value !== "object" || value === null) {
@@ -216,6 +234,21 @@ function isDefenseUnsafeRoomMemory(value) {
   }
   const candidate = value;
   return typeof candidate.roomName === "string" && candidate.unsafe === true && (candidate.reason === "enemyTower" || candidate.reason === "hostilePresence") && typeof candidate.updatedAt === "number";
+}
+function isDeadZoneMemoryExpired(roomMemory, gameTime = getGameTime()) {
+  return gameTime >= roomMemory.updatedAt && gameTime - roomMemory.updatedAt > DEAD_ZONE_MEMORY_TTL;
+}
+function clearExpiredDeadZoneRooms(gameTime) {
+  var _a, _b;
+  const unsafeRooms = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.defense) == null ? void 0 : _b.unsafeRooms;
+  if (!unsafeRooms) {
+    return;
+  }
+  for (const [roomName, roomMemory] of Object.entries(unsafeRooms)) {
+    if (isDefenseUnsafeRoomMemory(roomMemory) && isDeadZoneMemoryExpired(roomMemory, gameTime)) {
+      clearKnownDeadZoneRoom(roomName);
+    }
+  }
 }
 function getWritableDefenseMemory() {
   var _a;
@@ -405,13 +438,15 @@ function runDefender(creep, telemetryEvents) {
   const target = selectDefenderTarget(creep);
   if (target && typeof creep.attack === "function") {
     const attackResult = creep.attack(target);
-    if (attackResult === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === "function") {
+    if (attackResult === ERR_NOT_IN_RANGE_CODE) {
       if (shouldSuppressDefenderMove(creep, target)) {
         return;
       }
-      const moveResult = creep.moveTo(target);
-      recordDefenderAction(creep, "defenderMove", target, moveResult, telemetryEvents);
-      return;
+      if (typeof creep.moveTo === "function") {
+        const moveResult = creep.moveTo(target);
+        recordDefenderAction(creep, "defenderMove", target, moveResult, telemetryEvents);
+        return;
+      }
     }
     recordDefenderAction(creep, "defenderAttack", target, attackResult, telemetryEvents);
   }
@@ -419,7 +454,7 @@ function runDefender(creep, telemetryEvents) {
 function shouldSuppressDefenderMove(creep, target) {
   var _a;
   const targetRoom = (_a = target.pos) == null ? void 0 : _a.roomName;
-  if (!targetRoom || targetRoom === creep.room.name || !getKnownDeadZoneRoom(targetRoom)) {
+  if (!targetRoom || targetRoom === creep.room.name || !isKnownDeadZoneRoom(targetRoom)) {
     return false;
   }
   return hasSafeRouteAvoidingDeadZones(creep.room.name, targetRoom) === false;
@@ -3065,9 +3100,12 @@ function suppressDeadZoneTerritoryTargets(territoryMemory, intents, colonyName, 
   return { intents: nextIntents, changed };
 }
 function getTerritoryDeadZoneSuppressionReason(colonyName, targetRoom, routeDistanceLookupContext) {
-  var _a;
-  isKnownDeadZoneRoom(targetRoom);
-  if (((_a = getKnownDeadZoneRoom(targetRoom)) == null ? void 0 : _a.reason) === "enemyTower") {
+  var _a, _b, _c;
+  const visibleTargetRoom = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[targetRoom];
+  if (visibleTargetRoom) {
+    refreshVisibleRoomDeadZoneMemory(visibleTargetRoom);
+  }
+  if (((_c = getKnownDeadZoneRoom(targetRoom)) == null ? void 0 : _c.reason) === "enemyTower") {
     return "deadZoneTarget";
   }
   return isRouteBlockedByKnownDeadZone(colonyName, targetRoom) && getKnownRouteLength(colonyName, targetRoom, routeDistanceLookupContext) !== null ? "deadZoneRoute" : null;

--- a/prod/src/defense/deadZone.ts
+++ b/prod/src/defense/deadZone.ts
@@ -1,0 +1,242 @@
+interface DeadZoneAssessment {
+  unsafe: boolean;
+  hostileCreepCount: number;
+  hostileStructureCount: number;
+  hostileTowerCount: number;
+  reason?: DefenseUnsafeRoomReason;
+}
+
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+
+export function refreshVisibleDeadZoneMemory(gameTime = getGameTime()): void {
+  const rooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+  if (!rooms) {
+    return;
+  }
+
+  for (const room of Object.values(rooms)) {
+    refreshVisibleRoomDeadZoneMemory(room, gameTime);
+  }
+}
+
+export function refreshVisibleRoomDeadZoneMemory(room: Room, gameTime = getGameTime()): boolean {
+  const assessment = assessVisibleRoomDeadZone(room);
+  if (!assessment.unsafe || !assessment.reason) {
+    clearKnownDeadZoneRoom(room.name);
+    return false;
+  }
+
+  const defenseMemory = getWritableDefenseMemory();
+  if (!defenseMemory) {
+    return true;
+  }
+
+  const unsafeRooms = defenseMemory.unsafeRooms ?? {};
+  unsafeRooms[room.name] = {
+    roomName: room.name,
+    unsafe: true,
+    reason: assessment.reason,
+    updatedAt: gameTime,
+    hostileCreepCount: assessment.hostileCreepCount,
+    hostileStructureCount: assessment.hostileStructureCount,
+    hostileTowerCount: assessment.hostileTowerCount
+  };
+  defenseMemory.unsafeRooms = unsafeRooms;
+  return true;
+}
+
+export function isKnownDeadZoneRoom(roomName: string): boolean {
+  const visibleRoom = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[roomName];
+  if (visibleRoom) {
+    return refreshVisibleRoomDeadZoneMemory(visibleRoom);
+  }
+
+  return getKnownDeadZoneRoom(roomName) !== null;
+}
+
+export function getKnownDeadZoneRoom(roomName: string): DefenseUnsafeRoomMemory | null {
+  const roomMemory = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense?.unsafeRooms?.[roomName];
+  return isDefenseUnsafeRoomMemory(roomMemory) ? roomMemory : null;
+}
+
+export function clearKnownDeadZoneRoom(roomName: string): void {
+  const defenseMemory = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense;
+  const unsafeRooms = defenseMemory?.unsafeRooms;
+  if (!unsafeRooms || unsafeRooms[roomName] === undefined) {
+    return;
+  }
+
+  delete unsafeRooms[roomName];
+  if (Object.keys(unsafeRooms).length === 0) {
+    delete defenseMemory.unsafeRooms;
+  }
+}
+
+export function hasSafeRouteAvoidingDeadZones(fromRoom: string, targetRoom: string): boolean | null {
+  if (fromRoom === targetRoom) {
+    return true;
+  }
+
+  const gameMap = getGameMapWithFindRoute();
+  if (!gameMap) {
+    return null;
+  }
+
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName: string) => (isKnownDeadZoneRoom(roomName) ? Infinity : 1)
+  });
+
+  if (route === getNoPathResultCode()) {
+    return false;
+  }
+
+  return Array.isArray(route) ? true : null;
+}
+
+export function isRouteBlockedByKnownDeadZone(fromRoom: string, targetRoom: string): boolean {
+  if (fromRoom === targetRoom || !hasAnyKnownDeadZoneRoom()) {
+    return false;
+  }
+
+  const gameMap = getGameMapWithFindRoute();
+  if (!gameMap) {
+    return false;
+  }
+
+  let touchedDeadZone = false;
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName: string) => {
+      const deadZone = isKnownDeadZoneRoom(roomName);
+      touchedDeadZone ||= deadZone;
+      return deadZone ? Infinity : 1;
+    }
+  });
+
+  return touchedDeadZone && route === getNoPathResultCode();
+}
+
+function assessVisibleRoomDeadZone(room: Room): DeadZoneAssessment {
+  const hostileCreeps = findRoomObjects<Creep>(room, 'FIND_HOSTILE_CREEPS');
+  const hostileStructures = findRoomObjects<Structure>(room, 'FIND_HOSTILE_STRUCTURES');
+  const hostileTowerCount = hostileStructures.filter(isTowerStructure).length;
+  const hostileStructureCount = hostileStructures.length;
+  const hostileCreepCount = hostileCreeps.length;
+
+  if (hostileTowerCount > 0) {
+    return {
+      unsafe: true,
+      reason: 'enemyTower',
+      hostileCreepCount,
+      hostileStructureCount,
+      hostileTowerCount
+    };
+  }
+
+  if (hostileCreepCount > 0 || hostileStructureCount > 0) {
+    return {
+      unsafe: true,
+      reason: 'hostilePresence',
+      hostileCreepCount,
+      hostileStructureCount,
+      hostileTowerCount
+    };
+  }
+
+  return {
+    unsafe: false,
+    hostileCreepCount,
+    hostileStructureCount,
+    hostileTowerCount
+  };
+}
+
+function findRoomObjects<T>(room: Room, constantName: 'FIND_HOSTILE_CREEPS' | 'FIND_HOSTILE_STRUCTURES'): T[] {
+  const findConstant = (globalThis as Record<string, unknown>)[constantName];
+  const find = (room as Room & { find?: unknown }).find;
+  if (typeof findConstant !== 'number' || typeof find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = (find as (type: number) => unknown).call(room, findConstant);
+    return Array.isArray(result) ? (result as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function isTowerStructure(structure: Structure): boolean {
+  const towerType = (globalThis as { STRUCTURE_TOWER?: StructureConstant }).STRUCTURE_TOWER ?? 'tower';
+  return structure.structureType === towerType;
+}
+
+function hasAnyKnownDeadZoneRoom(): boolean {
+  const unsafeRooms = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense?.unsafeRooms;
+  return unsafeRooms !== undefined && Object.keys(unsafeRooms).length > 0;
+}
+
+function isDefenseUnsafeRoomMemory(value: unknown): value is DefenseUnsafeRoomMemory {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<DefenseUnsafeRoomMemory>;
+  return (
+    typeof candidate.roomName === 'string' &&
+    candidate.unsafe === true &&
+    (candidate.reason === 'enemyTower' || candidate.reason === 'hostilePresence') &&
+    typeof candidate.updatedAt === 'number'
+  );
+}
+
+function getWritableDefenseMemory(): DefenseMemory | null {
+  const memory = (globalThis as { Memory?: Partial<Memory> }).Memory;
+  if (!memory) {
+    return null;
+  }
+
+  const defenseMemory = memory.defense ?? {};
+  memory.defense = defenseMemory;
+  return defenseMemory;
+}
+
+function getGameMapWithFindRoute():
+  | (Partial<GameMap> & {
+      findRoute: (
+        fromRoom: string,
+        toRoom: string,
+        opts?: { routeCallback?: (roomName: string, fromRoomName: string) => number }
+      ) => unknown;
+    })
+  | null {
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map as
+    | (Partial<GameMap> & {
+        findRoute?: (
+          fromRoom: string,
+          toRoom: string,
+          opts?: { routeCallback?: (roomName: string, fromRoomName: string) => number }
+        ) => unknown;
+      })
+    | undefined;
+
+  return typeof gameMap?.findRoute === 'function'
+    ? (gameMap as Partial<GameMap> & {
+        findRoute: (
+          fromRoom: string,
+          toRoom: string,
+          opts?: { routeCallback?: (roomName: string, fromRoomName: string) => number }
+        ) => unknown;
+      })
+    : null;
+}
+
+function getNoPathResultCode(): ScreepsReturnCode {
+  const noPathCode = (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
+  return typeof noPathCode === 'number' ? noPathCode : ERR_NO_PATH_CODE;
+}
+
+function getGameTime(): number {
+  return typeof (globalThis as { Game?: Partial<Game> }).Game?.time === 'number'
+    ? (globalThis as { Game: Partial<Game> }).Game.time ?? 0
+    : 0;
+}

--- a/prod/src/defense/deadZone.ts
+++ b/prod/src/defense/deadZone.ts
@@ -6,9 +6,13 @@ interface DeadZoneAssessment {
   reason?: DefenseUnsafeRoomReason;
 }
 
+export const DEAD_ZONE_MEMORY_TTL = 250;
+
 const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 
 export function refreshVisibleDeadZoneMemory(gameTime = getGameTime()): void {
+  clearExpiredDeadZoneRooms(gameTime);
+
   const rooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
   if (!rooms) {
     return;
@@ -48,15 +52,30 @@ export function refreshVisibleRoomDeadZoneMemory(room: Room, gameTime = getGameT
 export function isKnownDeadZoneRoom(roomName: string): boolean {
   const visibleRoom = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[roomName];
   if (visibleRoom) {
-    return refreshVisibleRoomDeadZoneMemory(visibleRoom);
+    return assessVisibleRoomDeadZone(visibleRoom).unsafe;
   }
 
-  return getKnownDeadZoneRoom(roomName) !== null;
+  return readKnownDeadZoneRoom(roomName, false) !== null;
 }
 
 export function getKnownDeadZoneRoom(roomName: string): DefenseUnsafeRoomMemory | null {
+  return readKnownDeadZoneRoom(roomName, true);
+}
+
+function readKnownDeadZoneRoom(roomName: string, clearExpired: boolean): DefenseUnsafeRoomMemory | null {
   const roomMemory = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense?.unsafeRooms?.[roomName];
-  return isDefenseUnsafeRoomMemory(roomMemory) ? roomMemory : null;
+  if (!isDefenseUnsafeRoomMemory(roomMemory)) {
+    return null;
+  }
+
+  if (isDeadZoneMemoryExpired(roomMemory)) {
+    if (clearExpired) {
+      clearKnownDeadZoneRoom(roomName);
+    }
+    return null;
+  }
+
+  return roomMemory;
 }
 
 export function clearKnownDeadZoneRoom(roomName: string): void {
@@ -172,7 +191,12 @@ function isTowerStructure(structure: Structure): boolean {
 
 function hasAnyKnownDeadZoneRoom(): boolean {
   const unsafeRooms = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense?.unsafeRooms;
-  return unsafeRooms !== undefined && Object.keys(unsafeRooms).length > 0;
+  if (unsafeRooms && Object.keys(unsafeRooms).some((roomName) => readKnownDeadZoneRoom(roomName, false) !== null)) {
+    return true;
+  }
+
+  const visibleRooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+  return visibleRooms ? Object.values(visibleRooms).some((room) => assessVisibleRoomDeadZone(room).unsafe) : false;
 }
 
 function isDefenseUnsafeRoomMemory(value: unknown): value is DefenseUnsafeRoomMemory {
@@ -187,6 +211,23 @@ function isDefenseUnsafeRoomMemory(value: unknown): value is DefenseUnsafeRoomMe
     (candidate.reason === 'enemyTower' || candidate.reason === 'hostilePresence') &&
     typeof candidate.updatedAt === 'number'
   );
+}
+
+function isDeadZoneMemoryExpired(roomMemory: DefenseUnsafeRoomMemory, gameTime = getGameTime()): boolean {
+  return gameTime >= roomMemory.updatedAt && gameTime - roomMemory.updatedAt > DEAD_ZONE_MEMORY_TTL;
+}
+
+function clearExpiredDeadZoneRooms(gameTime: number): void {
+  const unsafeRooms = (globalThis as { Memory?: Partial<Memory> }).Memory?.defense?.unsafeRooms;
+  if (!unsafeRooms) {
+    return;
+  }
+
+  for (const [roomName, roomMemory] of Object.entries(unsafeRooms)) {
+    if (isDefenseUnsafeRoomMemory(roomMemory) && isDeadZoneMemoryExpired(roomMemory, gameTime)) {
+      clearKnownDeadZoneRoom(roomName);
+    }
+  }
 }
 
 function getWritableDefenseMemory(): DefenseMemory | null {

--- a/prod/src/defense/defenseLoop.ts
+++ b/prod/src/defense/defenseLoop.ts
@@ -1,5 +1,10 @@
 import { getOwnedColonies, type ColonySnapshot } from '../colony/colonyRegistry';
 import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
+import {
+  getKnownDeadZoneRoom,
+  hasSafeRouteAvoidingDeadZones,
+  refreshVisibleDeadZoneMemory
+} from './deadZone';
 
 export const DEFENDER_ROLE = 'defender';
 
@@ -43,6 +48,7 @@ interface TowerDefenseResult {
 
 export function runDefense(): RuntimeTelemetryEvent[] {
   const telemetryEvents: RuntimeTelemetryEvent[] = [];
+  refreshVisibleDeadZoneMemory();
   const colonies = getOwnedColonies();
 
   for (const colony of colonies) {
@@ -235,6 +241,10 @@ function runDefender(creep: Creep, telemetryEvents: RuntimeTelemetryEvent[]): vo
   if (target && typeof creep.attack === 'function') {
     const attackResult = creep.attack(target);
     if (attackResult === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {
+      if (shouldSuppressDefenderMove(creep, target)) {
+        return;
+      }
+
       const moveResult = creep.moveTo(target);
       recordDefenderAction(creep, 'defenderMove', target, moveResult, telemetryEvents);
       return;
@@ -242,6 +252,15 @@ function runDefender(creep: Creep, telemetryEvents: RuntimeTelemetryEvent[]): vo
 
     recordDefenderAction(creep, 'defenderAttack', target, attackResult, telemetryEvents);
   }
+}
+
+function shouldSuppressDefenderMove(creep: Creep, target: HostileTarget): boolean {
+  const targetRoom = target.pos?.roomName;
+  if (!targetRoom || targetRoom === creep.room.name || !getKnownDeadZoneRoom(targetRoom)) {
+    return false;
+  }
+
+  return hasSafeRouteAvoidingDeadZones(creep.room.name, targetRoom) === false;
 }
 
 function recordDefenderAction(

--- a/prod/src/defense/defenseLoop.ts
+++ b/prod/src/defense/defenseLoop.ts
@@ -1,8 +1,8 @@
 import { getOwnedColonies, type ColonySnapshot } from '../colony/colonyRegistry';
 import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 import {
-  getKnownDeadZoneRoom,
   hasSafeRouteAvoidingDeadZones,
+  isKnownDeadZoneRoom,
   refreshVisibleDeadZoneMemory
 } from './deadZone';
 
@@ -240,14 +240,16 @@ function runDefender(creep: Creep, telemetryEvents: RuntimeTelemetryEvent[]): vo
   const target = selectDefenderTarget(creep);
   if (target && typeof creep.attack === 'function') {
     const attackResult = creep.attack(target);
-    if (attackResult === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {
+    if (attackResult === ERR_NOT_IN_RANGE_CODE) {
       if (shouldSuppressDefenderMove(creep, target)) {
         return;
       }
 
-      const moveResult = creep.moveTo(target);
-      recordDefenderAction(creep, 'defenderMove', target, moveResult, telemetryEvents);
-      return;
+      if (typeof creep.moveTo === 'function') {
+        const moveResult = creep.moveTo(target);
+        recordDefenderAction(creep, 'defenderMove', target, moveResult, telemetryEvents);
+        return;
+      }
     }
 
     recordDefenderAction(creep, 'defenderAttack', target, attackResult, telemetryEvents);
@@ -256,7 +258,7 @@ function runDefender(creep: Creep, telemetryEvents: RuntimeTelemetryEvent[]): vo
 
 function shouldSuppressDefenderMove(creep: Creep, target: HostileTarget): boolean {
   const targetRoom = target.pos?.roomName;
-  if (!targetRoom || targetRoom === creep.room.name || !getKnownDeadZoneRoom(targetRoom)) {
+  if (!targetRoom || targetRoom === creep.room.name || !isKnownDeadZoneRoom(targetRoom)) {
     return false;
   }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -13,7 +13,12 @@ import {
   type OccupationRecommendationScore
 } from './occupationRecommendation';
 import { shouldSignOccupiedController } from './controllerSigning';
-import { getKnownDeadZoneRoom, isKnownDeadZoneRoom, isRouteBlockedByKnownDeadZone } from '../defense/deadZone';
+import {
+  getKnownDeadZoneRoom,
+  isKnownDeadZoneRoom,
+  isRouteBlockedByKnownDeadZone,
+  refreshVisibleRoomDeadZoneMemory
+} from '../defense/deadZone';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
@@ -1382,7 +1387,11 @@ function getTerritoryDeadZoneSuppressionReason(
   targetRoom: string,
   routeDistanceLookupContext: RouteDistanceLookupContext
 ): TerritoryIntentSuppressionReason | null {
-  isKnownDeadZoneRoom(targetRoom);
+  const visibleTargetRoom = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[targetRoom];
+  if (visibleTargetRoom) {
+    refreshVisibleRoomDeadZoneMemory(visibleTargetRoom);
+  }
+
   if (getKnownDeadZoneRoom(targetRoom)?.reason === 'enemyTower') {
     return 'deadZoneTarget';
   }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -13,6 +13,7 @@ import {
   type OccupationRecommendationScore
 } from './occupationRecommendation';
 import { shouldSignOccupiedController } from './controllerSigning';
+import { getKnownDeadZoneRoom, isKnownDeadZoneRoom, isRouteBlockedByKnownDeadZone } from '../defense/deadZone';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
@@ -221,6 +222,10 @@ export function shouldSpawnTerritoryControllerCreep(
   roleCounts: RoleCounts,
   gameTime = getGameTime()
 ): boolean {
+  if (isKnownDeadZoneRoom(plan.targetRoom)) {
+    return false;
+  }
+
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
     return false;
   }
@@ -747,6 +752,16 @@ function selectTerritoryTarget(
     intents = sanitizedStaleProgress.intents;
   }
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
+  const deadZoneSuppression = suppressDeadZoneTerritoryTargets(
+    territoryMemory,
+    intents,
+    colonyName,
+    gameTime,
+    routeDistanceLookupContext
+  );
+  if (deadZoneSuppression.changed) {
+    intents = deadZoneSuppression.intents;
+  }
   refreshTerritoryFollowUpExecutionHints(territoryMemory, intents, routeDistanceLookupContext);
   const hasBlockingConfiguredTarget = hasBlockingConfiguredTerritoryTargetForColony(
     colony,
@@ -1119,6 +1134,7 @@ function getConfiguredTerritoryCandidates(
       target.enabled === false ||
       target.colony !== colonyName ||
       target.roomName === colonyName ||
+      isKnownDeadZoneRoom(target.roomName) ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
       isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername) ||
       !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)
@@ -1186,6 +1202,7 @@ function getPersistedTerritoryIntentCandidates(
       intent.colony !== colonyName ||
       intent.targetRoom === colonyName ||
       configuredTargetRooms.has(intent.targetRoom) ||
+      isKnownDeadZoneRoom(intent.targetRoom) ||
       isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime) ||
       (intent.status !== 'planned' && intent.status !== 'active' && !recoveredFollowUp) ||
       !isTerritoryControlAction(intent.action) ||
@@ -1257,6 +1274,10 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       return true;
     }
 
+    if (isKnownDeadZoneRoom(target.roomName)) {
+      return false;
+    }
+
     if (isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername)) {
       return false;
     }
@@ -1297,6 +1318,99 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       'satisfied'
     );
   });
+}
+
+function suppressDeadZoneTerritoryTargets(
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  colonyName: string,
+  gameTime: number,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): { intents: TerritoryIntentMemory[]; changed: boolean } {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return { intents, changed: false };
+  }
+
+  let nextIntents = intents;
+  let changed = false;
+  for (const rawTarget of territoryMemory.targets) {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName) {
+      continue;
+    }
+
+    const reason = getTerritoryDeadZoneSuppressionReason(
+      colonyName,
+      target.roomName,
+      routeDistanceLookupContext
+    );
+    if (!reason) {
+      const filteredIntents = removeDeadZoneSuppression(nextIntents, target);
+      if (filteredIntents.length !== nextIntents.length) {
+        nextIntents = filteredIntents;
+        territoryMemory.intents = nextIntents;
+        changed = true;
+      }
+      continue;
+    }
+
+    territoryMemory.intents = nextIntents;
+    upsertTerritoryIntent(nextIntents, {
+      colony: target.colony,
+      targetRoom: target.roomName,
+      action: target.action,
+      status: 'suppressed',
+      updatedAt: gameTime,
+      reason,
+      ...(target.controllerId ? { controllerId: target.controllerId } : {})
+    });
+    removeTerritoryFollowUpDemand(territoryMemory as TerritoryMemory, target.colony, target.roomName, target.action);
+    removeTerritoryFollowUpExecutionHint(
+      territoryMemory as TerritoryMemory,
+      target.colony,
+      target.roomName,
+      target.action
+    );
+    changed = true;
+  }
+
+  return { intents: nextIntents, changed };
+}
+
+function getTerritoryDeadZoneSuppressionReason(
+  colonyName: string,
+  targetRoom: string,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): TerritoryIntentSuppressionReason | null {
+  isKnownDeadZoneRoom(targetRoom);
+  if (getKnownDeadZoneRoom(targetRoom)?.reason === 'enemyTower') {
+    return 'deadZoneTarget';
+  }
+
+  return isRouteBlockedByKnownDeadZone(colonyName, targetRoom) &&
+    getKnownRouteLength(colonyName, targetRoom, routeDistanceLookupContext) !== null
+    ? 'deadZoneRoute'
+    : null;
+}
+
+function removeDeadZoneSuppression(
+  intents: TerritoryIntentMemory[],
+  target: TerritoryTargetMemory
+): TerritoryIntentMemory[] {
+  return intents.filter(
+    (intent) =>
+      !(
+        intent.colony === target.colony &&
+        intent.targetRoom === target.roomName &&
+        intent.action === target.action &&
+        intent.status === 'suppressed' &&
+        isDeadZoneTerritorySuppressionReason(intent.reason)
+      )
+  );
+}
+
+function isDeadZoneTerritorySuppressionReason(reason: unknown): reason is TerritoryIntentSuppressionReason {
+  return reason === 'deadZoneTarget' || reason === 'deadZoneRoute';
 }
 
 function isConfiguredFollowUpTargetBlockedBySpawnReadiness(
@@ -1380,6 +1494,7 @@ function getAdjacentReserveCandidates(
     if (
       roomName === colonyName ||
       existingTargetRooms.has(roomName) ||
+      isKnownDeadZoneRoom(roomName) ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
       isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colonyName, roomName, 'reserve', gameTime)
     ) {
@@ -1634,6 +1749,7 @@ function getActiveCoveredConfiguredReserveTargets(
       target.colony !== colonyName ||
       target.action !== 'reserve' ||
       target.roomName === colonyName ||
+      isKnownDeadZoneRoom(target.roomName) ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
       hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) ||
       !isVisibleRoomKnown(target.roomName) ||
@@ -1688,6 +1804,7 @@ function getSatisfiedConfiguredTargets(
       target.colony !== colonyName ||
       target.action !== action ||
       target.roomName === colonyName ||
+      isKnownDeadZoneRoom(target.roomName) ||
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
       hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) ||
       getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !==
@@ -3197,6 +3314,7 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
     action: rawIntent.action,
     status: rawIntent.status,
     updatedAt: rawIntent.updatedAt,
+    ...(isDeadZoneTerritorySuppressionReason(rawIntent.reason) ? { reason: rawIntent.reason } : {}),
     ...(followUp && isFiniteNumber(rawIntent.lastAttemptAt) ? { lastAttemptAt: rawIntent.lastAttemptAt } : {}),
     ...(typeof rawIntent.controllerId === 'string'
       ? { controllerId: rawIntent.controllerId as Id<StructureController> }
@@ -3622,6 +3740,10 @@ function getEnergyResource(): ResourceConstant {
 }
 
 function isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom: string): boolean {
+  if (isKnownDeadZoneRoom(targetRoom)) {
+    return true;
+  }
+
   const room = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[targetRoom];
   return room ? isVisibleRoomUnsafe(room) : false;
 }

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -27,10 +27,13 @@ declare global {
     | 'defenderAttack'
     | 'defenderMove'
     | 'workerFallback';
+  type DefenseUnsafeRoomReason = 'enemyTower' | 'hostilePresence';
+  type TerritoryIntentSuppressionReason = 'deadZoneTarget' | 'deadZoneRoute';
 
   interface DefenseMemory {
     actions?: DefenseActionMemory[];
     rooms?: Record<string, DefenseActionMemory>;
+    unsafeRooms?: Record<string, DefenseUnsafeRoomMemory>;
   }
 
   interface DefenseActionMemory {
@@ -44,6 +47,16 @@ declare global {
     structureId?: string;
     targetId?: string;
     result?: ScreepsReturnCode;
+  }
+
+  interface DefenseUnsafeRoomMemory {
+    roomName: string;
+    unsafe: true;
+    reason: DefenseUnsafeRoomReason;
+    updatedAt: number;
+    hostileCreepCount: number;
+    hostileStructureCount: number;
+    hostileTowerCount: number;
   }
 
   interface CreepDefenseMemory {
@@ -82,6 +95,7 @@ declare global {
     action: TerritoryIntentAction;
     status: 'planned' | 'active' | 'suppressed';
     updatedAt: number;
+    reason?: TerritoryIntentSuppressionReason;
     lastAttemptAt?: number;
     controllerId?: Id<StructureController>;
     requiresControllerPressure?: boolean;

--- a/prod/test/deadZone.test.ts
+++ b/prod/test/deadZone.test.ts
@@ -1,0 +1,163 @@
+import {
+  DEAD_ZONE_MEMORY_TTL,
+  getKnownDeadZoneRoom,
+  hasSafeRouteAvoidingDeadZones,
+  isKnownDeadZoneRoom,
+  refreshVisibleDeadZoneMemory
+} from '../src/defense/deadZone';
+
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+type TestFindRouteOptions = { routeCallback?: (roomName: string, fromRoomName: string) => number };
+
+const TEST_GLOBALS = {
+  FIND_HOSTILE_CREEPS: 101,
+  FIND_HOSTILE_STRUCTURES: 102,
+  STRUCTURE_TOWER: 'tower'
+} as const;
+
+describe('dead-zone memory', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, TEST_GLOBALS);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+  });
+
+  it('expires stale unseen unsafe room memory before returning it', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        unsafeRooms: {
+          W2N1: makeUnsafeRoomMemory('W2N1', 100)
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 100 + DEAD_ZONE_MEMORY_TTL + 1,
+      rooms: {}
+    };
+
+    expect(getKnownDeadZoneRoom('W2N1')).toBeNull();
+    expect(Memory.defense?.unsafeRooms).toBeUndefined();
+  });
+
+  it('keeps fresh unsafe room memory through the TTL boundary', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        unsafeRooms: {
+          W2N1: makeUnsafeRoomMemory('W2N1', 100)
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 100 + DEAD_ZONE_MEMORY_TTL,
+      rooms: {}
+    };
+
+    expect(getKnownDeadZoneRoom('W2N1')).toMatchObject({
+      roomName: 'W2N1',
+      updatedAt: 100
+    });
+  });
+
+  it('clears stale unsafe room memory during the once-per-tick visible refresh', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        unsafeRooms: {
+          W2N1: makeUnsafeRoomMemory('W2N1', 100)
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 100 + DEAD_ZONE_MEMORY_TTL + 1,
+      rooms: {}
+    };
+
+    refreshVisibleDeadZoneMemory();
+
+    expect(Memory.defense?.unsafeRooms).toBeUndefined();
+  });
+
+  it('checks visible rooms without writing defense memory', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 200,
+      rooms: { W2N1: makeRoom('W2N1', [makeHostileTower('tower1', 'W2N1')]) }
+    };
+
+    expect(isKnownDeadZoneRoom('W2N1')).toBe(true);
+    expect(Memory.defense).toBeUndefined();
+  });
+
+  it('keeps route callbacks read-only for visible unsafe rooms', () => {
+    const findRoute = jest.fn((_fromRoom: string, _toRoom: string, options?: TestFindRouteOptions) =>
+      options?.routeCallback?.('W2N1', 'W1N1') === Infinity
+        ? ERR_NO_PATH_CODE
+        : [{ exit: 3, room: 'W2N1' }]
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 201,
+      map: { findRoute } as unknown as GameMap,
+      rooms: { W2N1: makeRoom('W2N1', [makeHostileTower('tower1', 'W2N1')]) }
+    };
+
+    expect(hasSafeRouteAvoidingDeadZones('W1N1', 'W3N1')).toBe(false);
+    expect(Memory.defense).toBeUndefined();
+  });
+
+  it('expires stale unseen memory used by route callbacks', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        unsafeRooms: {
+          W2N1: makeUnsafeRoomMemory('W2N1', 100)
+        }
+      }
+    };
+    const findRoute = jest.fn((_fromRoom: string, _toRoom: string, options?: TestFindRouteOptions) =>
+      options?.routeCallback?.('W2N1', 'W1N1') === Infinity
+        ? ERR_NO_PATH_CODE
+        : [{ exit: 3, room: 'W2N1' }]
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 100 + DEAD_ZONE_MEMORY_TTL + 1,
+      map: { findRoute } as unknown as GameMap,
+      rooms: {}
+    };
+
+    expect(hasSafeRouteAvoidingDeadZones('W1N1', 'W3N1')).toBe(true);
+    expect(Memory.defense?.unsafeRooms?.W2N1).toMatchObject({
+      roomName: 'W2N1',
+      updatedAt: 100
+    });
+  });
+});
+
+function makeUnsafeRoomMemory(roomName: string, updatedAt: number): DefenseUnsafeRoomMemory {
+  return {
+    roomName,
+    unsafe: true,
+    reason: 'enemyTower',
+    updatedAt,
+    hostileCreepCount: 0,
+    hostileStructureCount: 1,
+    hostileTowerCount: 1
+  };
+}
+
+function makeRoom(roomName: string, hostileStructures: Structure[] = []): Room {
+  return {
+    name: roomName,
+    find: jest.fn((type: number) => {
+      if (type === TEST_GLOBALS.FIND_HOSTILE_STRUCTURES) {
+        return hostileStructures;
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+}
+
+function makeHostileTower(id: string, roomName: string): Structure {
+  return {
+    id,
+    structureType: TEST_GLOBALS.STRUCTURE_TOWER,
+    pos: { roomName }
+  } as unknown as Structure;
+}

--- a/prod/test/defenseLoop.test.ts
+++ b/prod/test/defenseLoop.test.ts
@@ -1,7 +1,10 @@
 import { runDefense } from '../src/defense/defenseLoop';
+import { planTerritoryIntent } from '../src/territory/territoryPlanner';
 
 const OK_CODE = 0 as ScreepsReturnCode;
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+type TestFindRouteOptions = { routeCallback?: (roomName: string, fromRoomName: string) => number };
 
 const TEST_GLOBALS = {
   FIND_HOSTILE_CREEPS: 101,
@@ -392,6 +395,136 @@ describe('runDefense', () => {
       }
     ]);
   });
+
+  it('does not path a defender toward a known enemy tower room when no safe route exists', () => {
+    const hostileTower = makeHostileStructure('enemy-tower', 25, 25, 'W2N1', TEST_GLOBALS.STRUCTURE_TOWER);
+    const deadZoneRoom = makeRoom({
+      roomName: 'W2N1',
+      controller: makeController({ my: false }),
+      hostileStructures: [hostileTower]
+    });
+    const remoteHostile = makeHostile('remote-hostile', 25, 25, 'W2N1');
+    const homeRoom = makeRoom({
+      roomName: 'W1N1',
+      controller: makeController(),
+      hostiles: [remoteHostile]
+    });
+    const findRoute = jest.fn((_fromRoom: string, _toRoom: string, options?: TestFindRouteOptions) =>
+      options?.routeCallback?.('W2N1', 'W1N1') === Infinity
+        ? ERR_NO_PATH_CODE
+        : [{ exit: 3, room: 'W2N1' }]
+    );
+    const defender = {
+      name: 'Defender1',
+      memory: { role: 'defender', colony: 'W1N1' },
+      pos: makePosition(25, 25, 'W1N1'),
+      room: homeRoom,
+      attack: jest.fn().mockReturnValue(ERR_NOT_IN_RANGE_CODE),
+      moveTo: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 108,
+      map: { findRoute } as unknown as GameMap,
+      rooms: { W1N1: homeRoom, W2N1: deadZoneRoom },
+      spawns: {},
+      creeps: { Defender1: defender }
+    };
+
+    const events = runDefense();
+
+    expect(defender.attack).toHaveBeenCalledWith(remoteHostile);
+    expect(defender.moveTo).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+    expect(Memory.defense?.unsafeRooms?.W2N1).toMatchObject({
+      roomName: 'W2N1',
+      unsafe: true,
+      reason: 'enemyTower',
+      hostileTowerCount: 1
+    });
+  });
+
+  it('marks dead-zone rooms as unsafe in defense memory', () => {
+    const hostileTower = makeHostileStructure('enemy-tower', 25, 25, 'W2N1', TEST_GLOBALS.STRUCTURE_TOWER);
+    const deadZoneRoom = makeRoom({
+      roomName: 'W2N1',
+      controller: makeController({ my: false }),
+      hostileStructures: [hostileTower]
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 109,
+      rooms: { W2N1: deadZoneRoom },
+      spawns: {},
+      creeps: {}
+    };
+
+    runDefense();
+
+    expect(Memory.defense?.unsafeRooms?.W2N1).toEqual({
+      roomName: 'W2N1',
+      unsafe: true,
+      reason: 'enemyTower',
+      updatedAt: 109,
+      hostileCreepCount: 0,
+      hostileStructureCount: 1,
+      hostileTowerCount: 1
+    });
+  });
+
+  it('suppresses territory intent with a dead-zone reason when all paths to target cross dead zones', () => {
+    const colonyRoom = makeRoom({ roomName: 'W1N1', controller: makeController() });
+    const hostileTower = makeHostileStructure('enemy-tower', 25, 25, 'W2N1', TEST_GLOBALS.STRUCTURE_TOWER);
+    const deadZoneRoom = makeRoom({
+      roomName: 'W2N1',
+      controller: makeController({ my: false }),
+      hostileStructures: [hostileTower]
+    });
+    const targetRoom = makeRoom({
+      roomName: 'W3N1',
+      controller: makeController({ my: false })
+    });
+    const findRoute = jest.fn((_fromRoom: string, toRoom: string, options?: TestFindRouteOptions) =>
+      options?.routeCallback?.('W2N1', 'W1N1') === Infinity
+        ? ERR_NO_PATH_CODE
+        : [
+            { exit: 3, room: 'W2N1' },
+            { exit: 3, room: toRoom }
+          ]
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 110,
+      map: { findRoute } as unknown as GameMap,
+      rooms: { W1N1: colonyRoom, W2N1: deadZoneRoom, W3N1: targetRoom },
+      spawns: {},
+      creeps: {}
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      meta: { version: 1 },
+      creeps: {},
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }]
+      }
+    };
+
+    runDefense();
+    const plan = planTerritoryIntent(
+      { room: colonyRoom, spawns: [], energyAvailable: 650, energyCapacityAvailable: 650 },
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      110
+    );
+
+    expect(plan).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: 110,
+        reason: 'deadZoneRoute'
+      }
+    ]);
+  });
 });
 
 interface OwnedRoomFixture {
@@ -558,10 +691,16 @@ function makeHostile(id: string, x = 25, y = 25, roomName = 'W1N1'): Creep {
   } as unknown as Creep;
 }
 
-function makeHostileStructure(id: string, x = 25, y = 25, roomName = 'W1N1'): Structure {
+function makeHostileStructure(
+  id: string,
+  x = 25,
+  y = 25,
+  roomName = 'W1N1',
+  structureType: StructureConstant = 'rampart'
+): Structure {
   return {
     id,
-    structureType: 'rampart',
+    structureType,
     pos: makePosition(x, y, roomName)
   } as unknown as Structure;
 }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -841,6 +841,103 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('does not select a territory target in a known dead zone as spawnable', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W3N1: { name: 'W3N1', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        unsafeRooms: {
+          W2N1: {
+            roomName: 'W2N1',
+            unsafe: true,
+            reason: 'enemyTower',
+            updatedAt: 517,
+            hostileCreepCount: 0,
+            hostileStructureCount: 1,
+            hostileTowerCount: 1
+          }
+        }
+      },
+      territory: {
+        targets: [
+          { colony: 'W1N1', roomName: 'W2N1', action: 'reserve' },
+          { colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }
+        ]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 518);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W3N1', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        { colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' },
+        { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+        518
+      )
+    ).toBe(false);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: 518,
+        reason: 'deadZoneTarget'
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 518
+      }
+    ]);
+  });
+
+  it('clears a dead-zone flag when the room becomes safe', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false } as StructureController,
+          find: jest.fn().mockReturnValue([])
+        } as unknown as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      defense: {
+        unsafeRooms: {
+          W2N1: {
+            roomName: 'W2N1',
+            unsafe: true,
+            reason: 'enemyTower',
+            updatedAt: 517,
+            hostileCreepCount: 0,
+            hostileStructureCount: 1,
+            hostileTowerCount: 1
+          }
+        }
+      },
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 519);
+
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(
+      shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 519)
+    ).toBe(true);
+    expect(Memory.defense?.unsafeRooms?.W2N1).toBeUndefined();
+  });
+
   it('skips visible adjacent rooms without controllers', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -899,6 +899,50 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('refreshes a visible dead-zone target before deciding suppression reason', () => {
+    const colony = makeSafeColony();
+    const hostileTower = { id: 'enemy-tower', structureType: 'tower' } as Structure;
+    (globalThis as unknown as { STRUCTURE_TOWER: string }).STRUCTURE_TOWER = 'tower';
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 520,
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: { my: false } as StructureController,
+          find: jest.fn((findType: number) => (findType === FIND_HOSTILE_STRUCTURES ? [hostileTower] : []))
+        } as unknown as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 520);
+
+    expect(plan).toBeNull();
+    expect(Memory.defense?.unsafeRooms?.W2N1).toEqual({
+      roomName: 'W2N1',
+      unsafe: true,
+      reason: 'enemyTower',
+      updatedAt: 520,
+      hostileCreepCount: 0,
+      hostileStructureCount: 1,
+      hostileTowerCount: 1
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'suppressed',
+        updatedAt: 520,
+        reason: 'deadZoneTarget'
+      }
+    ]);
+  });
+
   it('clears a dead-zone flag when the room becomes safe', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {


### PR DESCRIPTION
## Summary
Implements #407: Combat QA — dead-zone safety tests and placeholder survival logic rejection.

## Changes
- Added `prod/src/defense/deadZone.ts` with dead-zone detection logic
- Updated `defenseLoop.ts`: dead-zone rooms marked as unsafe in colony memory
- Updated `territoryPlanner.ts`: territory targets in dead zones excluded from spawn selection
- Added `prod/test/defenseLoop.test.ts` tests: dead-zone path avoidance, colony memory marking, intent suppression
- Added `prod/test/territoryPlanner.test.ts` tests: dead-zone spawn exclusion, safety flag clearing

## Verification
- `npm run typecheck` — PASS
- `npm test -- --runInBand` — 24 suites, 680 tests PASS
- `npm run build` — PASS

Closes #407
