### PR TITLE
fix: PR #472 review follow-up — self-referential test fixtures, re-suspension cooldown, non-finite validation

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1517,7 +1517,7 @@ function normalizeTerritoryIntent(rawIntent) {
   if (!isRecord(rawIntent)) {
     return null;
   }
-  if (!isNonEmptyString2(rawIntent.colony) || !isNonEmptyString2(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
+  if (!isNonEmptyString2(rawIntent.colony) || !isNonEmptyString2(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || !isFiniteNumber(rawIntent.updatedAt)) {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
@@ -4061,8 +4061,8 @@ function refreshHostileTerritoryIntentSuspensions(territoryMemory, intents, colo
       if (((_a = intent.suspended) == null ? void 0 : _a.reason) === "hostile_presence") {
         if (isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime)) {
           suspendedIntents.push(intent);
+          return intent;
         }
-        return intent;
       }
       const suspended = buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime);
       changed = true;

--- a/prod/src/territory/territoryMemoryUtils.ts
+++ b/prod/src/territory/territoryMemoryUtils.ts
@@ -17,7 +17,7 @@ export function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMem
     !isNonEmptyString(rawIntent.targetRoom) ||
     !isTerritoryIntentAction(rawIntent.action) ||
     !isTerritoryIntentStatus(rawIntent.status) ||
-    typeof rawIntent.updatedAt !== 'number'
+    !isFiniteNumber(rawIntent.updatedAt)
   ) {
     return null;
   }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2767,8 +2767,8 @@ function refreshHostileTerritoryIntentSuspensions(
       if (intent.suspended?.reason === 'hostile_presence') {
         if (isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime)) {
           suspendedIntents.push(intent);
+          return intent;
         }
-        return intent;
       }
 
       const suspended = buildHostilePresenceTerritoryIntentSuspension(hostileCount, gameTime);

--- a/prod/test/territoryMemoryUtils.test.ts
+++ b/prod/test/territoryMemoryUtils.test.ts
@@ -1,0 +1,39 @@
+import { normalizeTerritoryIntents } from '../src/territory/territoryMemoryUtils';
+
+describe('normalizeTerritoryIntents', () => {
+  it('rejects intents with non-finite updatedAt values', () => {
+    expect(
+      normalizeTerritoryIntents([
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'reserve',
+          status: 'planned',
+          updatedAt: Number.NaN
+        },
+        {
+          colony: 'W1N1',
+          targetRoom: 'W3N1',
+          action: 'claim',
+          status: 'planned',
+          updatedAt: Number.POSITIVE_INFINITY
+        },
+        {
+          colony: 'W1N1',
+          targetRoom: 'W4N1',
+          action: 'scout',
+          status: 'planned',
+          updatedAt: 701
+        }
+      ])
+    ).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W4N1',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 701
+      }
+    ]);
+  });
+});

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1454,7 +1454,16 @@ describe('planTerritoryIntent', () => {
     ).toBe(false);
     expect(Memory.territory?.intents).toEqual([
       {
-        ...persistedIntent,
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 570,
+        followUp: {
+          source: 'satisfiedReserveAdjacent',
+          originRoom: 'W1N2',
+          originAction: 'reserve'
+        },
         suspended: {
           reason: 'hostile_presence',
           hostileCount: 2,
@@ -1492,7 +1501,25 @@ describe('planTerritoryIntent', () => {
     expect(
       planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, suspendedAt + 1)
     ).toBeNull();
-    expect(Memory.territory?.intents).toEqual([suspendedIntent]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 571,
+        followUp: {
+          source: 'satisfiedReserveAdjacent',
+          originRoom: 'W1N2',
+          originAction: 'reserve'
+        },
+        suspended: {
+          reason: 'hostile_presence',
+          hostileCount: 1,
+          updatedAt: suspendedAt
+        }
+      }
+    ]);
 
     expect(
       planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime)
@@ -1500,7 +1527,11 @@ describe('planTerritoryIntent', () => {
       colony: 'W1N1',
       targetRoom: 'W2N1',
       action: 'reserve',
-      followUp
+      followUp: {
+        source: 'satisfiedReserveAdjacent',
+        originRoom: 'W1N2',
+        originAction: 'reserve'
+      }
     });
     expect(Memory.territory?.intents).toEqual([
       {
@@ -1509,15 +1540,20 @@ describe('planTerritoryIntent', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: retryTime,
-        followUp
+        followUp: {
+          source: 'satisfiedReserveAdjacent',
+          originRoom: 'W1N2',
+          originAction: 'reserve'
+        }
       }
     ]);
   });
 
-  it('does not re-stamp a hostile suspension while visible hostiles persist', () => {
+  it('re-suspends a hostile-suspended intent after cooldown when visible hostiles persist', () => {
     const colony = makeSafeColony();
     const suspendedAt = 572;
     const retryTime = suspendedAt + TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS + 1;
+    const secondRetryTime = retryTime + TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS + 1;
     const suspendedIntent: TerritoryIntentMemory = {
       colony: 'W1N1',
       targetRoom: 'W2N1',
@@ -1544,17 +1580,61 @@ describe('planTerritoryIntent', () => {
     expect(
       planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, suspendedAt + 1)
     ).toBeNull();
-    expect(Memory.territory?.intents).toEqual([suspendedIntent]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 571,
+        suspended: {
+          reason: 'hostile_presence',
+          hostileCount: 1,
+          updatedAt: suspendedAt
+        }
+      }
+    ]);
 
     expect(
       planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime)
     ).toBeNull();
-    expect(Memory.territory?.intents).toEqual([suspendedIntent]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 571,
+        suspended: {
+          reason: 'hostile_presence',
+          hostileCount: 3,
+          updatedAt: retryTime
+        }
+      }
+    ]);
 
     (globalThis as unknown as { Game: Partial<Game> }).Game = {};
 
     expect(
       planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, retryTime + 1)
+    ).toBeNull();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 571,
+        suspended: {
+          reason: 'hostile_presence',
+          hostileCount: 3,
+          updatedAt: retryTime
+        }
+      }
+    ]);
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, secondRetryTime)
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W2N1',
@@ -1573,7 +1653,7 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'W2N1',
         action: 'scout',
         status: 'planned',
-        updatedAt: retryTime + 1
+        updatedAt: secondRetryTime
       }
     ]);
   });


### PR DESCRIPTION
Follow-up to #472 which was merged before the review-fix commit was pushed.

## What this fixes

1. **Self-referential test fixtures** (CodeRabbit feedback): Test assertions in territoryPlanner.test.ts no longer reference `suspendedIntent` from fixture context; they now use explicit literal values.

2. **Hostile re-suspension cooldown** (ChatGPT Codex Connector feedback): When hostile presence persists past a cooldown window on a suspended intent, the suspension is now re-applied with a reset cooldown rather than expiring silently.

3. **Non-finite `updatedAt` validation** (CodeRabbit feedback): `normalizeTerritoryIntent` in territoryMemoryUtils.ts now uses `Number.isFinite()` instead of `typeof !== 'number'` to reject NaN/Infinity.

## Verification

All changes were verified by Codex (typecheck + Jest 698+ tests + build) before the original commit.