### PR TITLE
feat(territory): reservation decay tracking and pre-renew scout deferral (#475)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2312,6 +2312,7 @@ var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
 var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
 var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
+var TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS = 50;
 var TERRITORY_SUPPRESSION_RETRY_TICKS2 = 1500;
 var TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS = 1500;
 var TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS2 = 50;
@@ -2802,6 +2803,7 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
     intents = sanitizedStaleProgress.intents;
   }
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
+  refreshTerritoryReservationMemory(territoryMemory, colonyName, colonyOwnerUsername, gameTime);
   const deadZoneSuppression = suppressDeadZoneTerritoryTargets(
     territoryMemory,
     intents,
@@ -3060,7 +3062,12 @@ function getConfiguredTerritoryCandidates(colonyName, colonyOwnerUsername, terri
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
     const target = normalizeTerritoryTarget2(rawTarget);
-    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isKnownDeadZoneRoom(target.roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) || isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername, gameTime) || !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)) {
+    if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName || isKnownDeadZoneRoom(target.roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) || isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername, gameTime) || isConfiguredReserveScoutDeferredByReservationDecay(
+      target,
+      territoryMemory,
+      gameTime,
+      routeDistanceLookupContext
+    ) || !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)) {
       return [];
     }
     const persistedFollowUp = getPersistedTerritoryIntentFollowUp(
@@ -3184,6 +3191,131 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
     }
     return getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied";
   });
+}
+function refreshTerritoryReservationMemory(territoryMemory, colonyName, colonyOwnerUsername, gameTime) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return;
+  }
+  const reservations = normalizeTerritoryReservations(territoryMemory.reservations);
+  const activeConfiguredReserveKeys = /* @__PURE__ */ new Set();
+  let changed = hasMalformedTerritoryReservationMemory(territoryMemory.reservations, reservations);
+  for (const rawTarget of territoryMemory.targets) {
+    const target = normalizeTerritoryTarget2(rawTarget);
+    if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName) {
+      continue;
+    }
+    const reservationKey = getTerritoryReservationMemoryKey(target.colony, target.roomName);
+    activeConfiguredReserveKeys.add(reservationKey);
+    const controller = getVisibleController2(target.roomName, target.controllerId);
+    if (!controller) {
+      continue;
+    }
+    const ticksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+    if (ticksToEnd === null) {
+      if (reservations[reservationKey]) {
+        delete reservations[reservationKey];
+        changed = true;
+      }
+      continue;
+    }
+    const nextReservation = {
+      colony: target.colony,
+      roomName: target.roomName,
+      ticksToEnd,
+      updatedAt: gameTime,
+      ...target.controllerId ? { controllerId: target.controllerId } : {}
+    };
+    if (!isSameTerritoryReservation(reservations[reservationKey], nextReservation)) {
+      reservations[reservationKey] = nextReservation;
+      changed = true;
+    }
+  }
+  for (const [reservationKey, reservation] of Object.entries(reservations)) {
+    if (reservation.colony === colonyName && (!activeConfiguredReserveKeys.has(reservationKey) || getEstimatedTerritoryReservationTicksToEnd(reservation, gameTime) <= 0)) {
+      delete reservations[reservationKey];
+      changed = true;
+    }
+  }
+  if (changed) {
+    setTerritoryReservations(territoryMemory, reservations);
+  }
+}
+function isConfiguredReserveScoutDeferredByReservationDecay(target, territoryMemory, gameTime, routeDistanceLookupContext) {
+  if (target.action !== "reserve" || isVisibleRoomKnown(target.roomName)) {
+    return false;
+  }
+  const reservation = getStoredTerritoryReservation(territoryMemory, target);
+  if (!reservation) {
+    return false;
+  }
+  return getEstimatedTerritoryReservationTicksToEnd(reservation, gameTime) > getTerritoryReservationPreRenewScoutLeadTicks(
+    target.colony,
+    target.roomName,
+    routeDistanceLookupContext
+  );
+}
+function getStoredTerritoryReservation(territoryMemory, target) {
+  if (!territoryMemory) {
+    return null;
+  }
+  const reservation = normalizeTerritoryReservation(
+    isRecord3(territoryMemory.reservations) ? territoryMemory.reservations[getTerritoryReservationMemoryKey(target.colony, target.roomName)] : void 0
+  );
+  if (!reservation || reservation.colony !== target.colony || reservation.roomName !== target.roomName || target.controllerId !== void 0 && reservation.controllerId !== void 0 && reservation.controllerId !== target.controllerId) {
+    return null;
+  }
+  return reservation;
+}
+function getTerritoryReservationPreRenewScoutLeadTicks(colonyName, targetRoom, routeDistanceLookupContext) {
+  const routeDistance = getKnownRouteLength(colonyName, targetRoom, routeDistanceLookupContext);
+  return TERRITORY_RESERVATION_RENEWAL_TICKS + (typeof routeDistance === "number" ? routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS : 0);
+}
+function normalizeTerritoryReservations(rawReservations) {
+  if (!isRecord3(rawReservations)) {
+    return {};
+  }
+  const reservations = {};
+  for (const [key, rawReservation] of Object.entries(rawReservations)) {
+    const reservation = normalizeTerritoryReservation(rawReservation);
+    if (reservation) {
+      reservations[key] = reservation;
+    }
+  }
+  return reservations;
+}
+function normalizeTerritoryReservation(rawReservation) {
+  if (!isRecord3(rawReservation)) {
+    return null;
+  }
+  if (!isNonEmptyString4(rawReservation.colony) || !isNonEmptyString4(rawReservation.roomName) || !isFiniteNumber3(rawReservation.ticksToEnd) || !isFiniteNumber3(rawReservation.updatedAt)) {
+    return null;
+  }
+  return {
+    colony: rawReservation.colony,
+    roomName: rawReservation.roomName,
+    ticksToEnd: Math.floor(Math.max(0, rawReservation.ticksToEnd)),
+    updatedAt: Math.floor(rawReservation.updatedAt),
+    ...typeof rawReservation.controllerId === "string" ? { controllerId: rawReservation.controllerId } : {}
+  };
+}
+function hasMalformedTerritoryReservationMemory(rawReservations, reservations) {
+  return isRecord3(rawReservations) && Object.keys(rawReservations).length !== Object.keys(reservations).length;
+}
+function getTerritoryReservationMemoryKey(colonyName, roomName) {
+  return `${colonyName}${TERRITORY_ROUTE_DISTANCE_SEPARATOR2}${roomName}`;
+}
+function getEstimatedTerritoryReservationTicksToEnd(reservation, gameTime) {
+  return Math.max(0, reservation.ticksToEnd - Math.max(0, gameTime - reservation.updatedAt));
+}
+function isSameTerritoryReservation(left, right) {
+  return left !== void 0 && left.colony === right.colony && left.roomName === right.roomName && left.ticksToEnd === right.ticksToEnd && left.updatedAt === right.updatedAt && left.controllerId === right.controllerId;
+}
+function setTerritoryReservations(territoryMemory, reservations) {
+  if (Object.keys(reservations).length > 0) {
+    territoryMemory.reservations = reservations;
+  } else {
+    delete territoryMemory.reservations;
+  }
 }
 function suppressDeadZoneTerritoryTargets(territoryMemory, intents, colonyName, gameTime, routeDistanceLookupContext) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3268,7 +3268,7 @@ function getStoredTerritoryReservation(territoryMemory, target) {
 }
 function getTerritoryReservationPreRenewScoutLeadTicks(colonyName, targetRoom, routeDistanceLookupContext) {
   const routeDistance = getKnownRouteLength(colonyName, targetRoom, routeDistanceLookupContext);
-  return TERRITORY_RESERVATION_RENEWAL_TICKS + (typeof routeDistance === "number" ? routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS : 0);
+  return TERRITORY_RESERVATION_RENEWAL_TICKS + (typeof routeDistance === "number" ? routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS * 2 : 0);
 }
 function normalizeTerritoryReservations(rawReservations) {
   if (!isRecord3(rawReservations)) {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1520,7 +1520,7 @@ function getTerritoryReservationPreRenewScoutLeadTicks(
   return (
     TERRITORY_RESERVATION_RENEWAL_TICKS +
     (typeof routeDistance === 'number'
-      ? routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS
+      ? routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS * 2
       : 0)
   );
 }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -27,6 +27,7 @@ export const TERRITORY_DOWNGRADE_GUARD_TICKS = 5_000;
 export const TERRITORY_RESERVATION_RENEWAL_TICKS = 1_000;
 export const TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
 export const TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
+export const TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS = 50;
 export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
 export const TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS = 1_500;
 export const TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
@@ -810,6 +811,7 @@ function selectTerritoryTarget(
     intents = sanitizedStaleProgress.intents;
   }
   const routeDistanceLookupContext = createRouteDistanceLookupContext();
+  refreshTerritoryReservationMemory(territoryMemory, colonyName, colonyOwnerUsername, gameTime);
   const deadZoneSuppression = suppressDeadZoneTerritoryTargets(
     territoryMemory,
     intents,
@@ -1196,6 +1198,12 @@ function getConfiguredTerritoryCandidates(
       isTerritoryTargetSuppressed(target, intents, gameTime) ||
       isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) ||
       isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts, colonyOwnerUsername, gameTime) ||
+      isConfiguredReserveScoutDeferredByReservationDecay(
+        target,
+        territoryMemory,
+        gameTime,
+        routeDistanceLookupContext
+      ) ||
       !isVisibleTerritoryIntentActionable(target.roomName, target.action, target.controllerId, colonyOwnerUsername)
     ) {
       return [];
@@ -1378,6 +1386,227 @@ function hasBlockingConfiguredTerritoryTargetForColony(
       'satisfied'
     );
   });
+}
+
+function refreshTerritoryReservationMemory(
+  territoryMemory: Record<string, unknown> | null,
+  colonyName: string,
+  colonyOwnerUsername: string | null,
+  gameTime: number
+): void {
+  if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
+    return;
+  }
+
+  const reservations = normalizeTerritoryReservations(territoryMemory.reservations);
+  const activeConfiguredReserveKeys = new Set<string>();
+  let changed = hasMalformedTerritoryReservationMemory(territoryMemory.reservations, reservations);
+
+  for (const rawTarget of territoryMemory.targets) {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (
+      !target ||
+      target.enabled === false ||
+      target.colony !== colonyName ||
+      target.action !== 'reserve' ||
+      target.roomName === colonyName
+    ) {
+      continue;
+    }
+
+    const reservationKey = getTerritoryReservationMemoryKey(target.colony, target.roomName);
+    activeConfiguredReserveKeys.add(reservationKey);
+    const controller = getVisibleController(target.roomName, target.controllerId);
+    if (!controller) {
+      continue;
+    }
+
+    const ticksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+    if (ticksToEnd === null) {
+      if (reservations[reservationKey]) {
+        delete reservations[reservationKey];
+        changed = true;
+      }
+      continue;
+    }
+
+    const nextReservation: TerritoryReservationMemory = {
+      colony: target.colony,
+      roomName: target.roomName,
+      ticksToEnd,
+      updatedAt: gameTime,
+      ...(target.controllerId ? { controllerId: target.controllerId } : {})
+    };
+    if (!isSameTerritoryReservation(reservations[reservationKey], nextReservation)) {
+      reservations[reservationKey] = nextReservation;
+      changed = true;
+    }
+  }
+
+  for (const [reservationKey, reservation] of Object.entries(reservations)) {
+    if (
+      reservation.colony === colonyName &&
+      (!activeConfiguredReserveKeys.has(reservationKey) ||
+        getEstimatedTerritoryReservationTicksToEnd(reservation, gameTime) <= 0)
+    ) {
+      delete reservations[reservationKey];
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    setTerritoryReservations(territoryMemory, reservations);
+  }
+}
+
+function isConfiguredReserveScoutDeferredByReservationDecay(
+  target: TerritoryTargetMemory,
+  territoryMemory: Record<string, unknown> | null,
+  gameTime: number,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): boolean {
+  if (target.action !== 'reserve' || isVisibleRoomKnown(target.roomName)) {
+    return false;
+  }
+
+  const reservation = getStoredTerritoryReservation(territoryMemory, target);
+  if (!reservation) {
+    return false;
+  }
+
+  return (
+    getEstimatedTerritoryReservationTicksToEnd(reservation, gameTime) >
+    getTerritoryReservationPreRenewScoutLeadTicks(
+      target.colony,
+      target.roomName,
+      routeDistanceLookupContext
+    )
+  );
+}
+
+function getStoredTerritoryReservation(
+  territoryMemory: Record<string, unknown> | null,
+  target: TerritoryTargetMemory
+): TerritoryReservationMemory | null {
+  if (!territoryMemory) {
+    return null;
+  }
+
+  const reservation = normalizeTerritoryReservation(
+    isRecord(territoryMemory.reservations)
+      ? territoryMemory.reservations[getTerritoryReservationMemoryKey(target.colony, target.roomName)]
+      : undefined
+  );
+  if (
+    !reservation ||
+    reservation.colony !== target.colony ||
+    reservation.roomName !== target.roomName ||
+    (target.controllerId !== undefined &&
+      reservation.controllerId !== undefined &&
+      reservation.controllerId !== target.controllerId)
+  ) {
+    return null;
+  }
+
+  return reservation;
+}
+
+function getTerritoryReservationPreRenewScoutLeadTicks(
+  colonyName: string,
+  targetRoom: string,
+  routeDistanceLookupContext: RouteDistanceLookupContext
+): number {
+  const routeDistance = getKnownRouteLength(colonyName, targetRoom, routeDistanceLookupContext);
+  return (
+    TERRITORY_RESERVATION_RENEWAL_TICKS +
+    (typeof routeDistance === 'number'
+      ? routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS
+      : 0)
+  );
+}
+
+function normalizeTerritoryReservations(rawReservations: unknown): Record<string, TerritoryReservationMemory> {
+  if (!isRecord(rawReservations)) {
+    return {};
+  }
+
+  const reservations: Record<string, TerritoryReservationMemory> = {};
+  for (const [key, rawReservation] of Object.entries(rawReservations)) {
+    const reservation = normalizeTerritoryReservation(rawReservation);
+    if (reservation) {
+      reservations[key] = reservation;
+    }
+  }
+
+  return reservations;
+}
+
+function normalizeTerritoryReservation(rawReservation: unknown): TerritoryReservationMemory | null {
+  if (!isRecord(rawReservation)) {
+    return null;
+  }
+
+  if (
+    !isNonEmptyString(rawReservation.colony) ||
+    !isNonEmptyString(rawReservation.roomName) ||
+    !isFiniteNumber(rawReservation.ticksToEnd) ||
+    !isFiniteNumber(rawReservation.updatedAt)
+  ) {
+    return null;
+  }
+
+  return {
+    colony: rawReservation.colony,
+    roomName: rawReservation.roomName,
+    ticksToEnd: Math.floor(Math.max(0, rawReservation.ticksToEnd)),
+    updatedAt: Math.floor(rawReservation.updatedAt),
+    ...(typeof rawReservation.controllerId === 'string'
+      ? { controllerId: rawReservation.controllerId as Id<StructureController> }
+      : {})
+  };
+}
+
+function hasMalformedTerritoryReservationMemory(
+  rawReservations: unknown,
+  reservations: Record<string, TerritoryReservationMemory>
+): boolean {
+  return isRecord(rawReservations) && Object.keys(rawReservations).length !== Object.keys(reservations).length;
+}
+
+function getTerritoryReservationMemoryKey(colonyName: string, roomName: string): string {
+  return `${colonyName}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${roomName}`;
+}
+
+function getEstimatedTerritoryReservationTicksToEnd(
+  reservation: TerritoryReservationMemory,
+  gameTime: number
+): number {
+  return Math.max(0, reservation.ticksToEnd - Math.max(0, gameTime - reservation.updatedAt));
+}
+
+function isSameTerritoryReservation(
+  left: TerritoryReservationMemory | undefined,
+  right: TerritoryReservationMemory
+): boolean {
+  return (
+    left !== undefined &&
+    left.colony === right.colony &&
+    left.roomName === right.roomName &&
+    left.ticksToEnd === right.ticksToEnd &&
+    left.updatedAt === right.updatedAt &&
+    left.controllerId === right.controllerId
+  );
+}
+
+function setTerritoryReservations(
+  territoryMemory: TerritoryMemory | Record<string, unknown>,
+  reservations: Record<string, TerritoryReservationMemory>
+): void {
+  if (Object.keys(reservations).length > 0) {
+    territoryMemory.reservations = reservations;
+  } else {
+    delete territoryMemory.reservations;
+  }
 }
 
 function suppressDeadZoneTerritoryTargets(

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -78,6 +78,7 @@ declare global {
     intents?: TerritoryIntentMemory[];
     demands?: TerritoryFollowUpDemandMemory[];
     executionHints?: TerritoryExecutionHintMemory[];
+    reservations?: Record<string, TerritoryReservationMemory>;
     routeDistances?: Record<string, number | null>;
   }
 
@@ -108,6 +109,14 @@ declare global {
     reason: TerritoryIntentSuspensionReason;
     hostileCount: number;
     updatedAt: number;
+  }
+
+  interface TerritoryReservationMemory {
+    colony: string;
+    roomName: string;
+    ticksToEnd: number;
+    updatedAt: number;
+    controllerId?: Id<StructureController>;
   }
 
   interface TerritoryFollowUpMemory {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -4697,7 +4697,7 @@ describe('planTerritoryIntent', () => {
     const routeDistance = 5;
     const observedTicksToEnd =
       TERRITORY_RESERVATION_RENEWAL_TICKS +
-      routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS;
+      routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS * 2;
     const findRoute = jest.fn(() =>
       Array.from({ length: routeDistance }, (_value, index) => ({ exit: 3, room: `W1N2-${index}` }))
     );

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -11,6 +11,7 @@ import {
   suppressTerritoryIntent,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
   TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS,
+  TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS,
   TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS,
   TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
   TERRITORY_RESERVATION_RENEWAL_TICKS,
@@ -4633,6 +4634,139 @@ describe('planTerritoryIntent', () => {
       )
     ).toBe(false);
     expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('defers unseen configured reserve scouting until observed reservation decay nears renewal', () => {
+    const colony = makeSafeColony();
+    const target: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: {
+          name: 'W1N2',
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500 }
+          } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [target]
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 100)).toBeNull();
+    expect(Memory.territory?.reservations).toEqual({
+      'W1N1>W1N2': {
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS + 500,
+        updatedAt: 100
+      }
+    });
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 200)).toBeNull();
+    expect(Memory.territory?.intents).toBeUndefined();
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 601)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'scout'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 601
+      }
+    ]);
+  });
+
+  it('uses route distance lead when scheduling an unseen reservation renewal scout', () => {
+    const colony = makeSafeColony();
+    const routeDistance = 5;
+    const observedTicksToEnd =
+      TERRITORY_RESERVATION_RENEWAL_TICKS +
+      routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS;
+    const findRoute = jest.fn(() =>
+      Array.from({ length: routeDistance }, (_value, index) => ({ exit: 3, room: `W1N2-${index}` }))
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { findRoute } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W1N2', action: 'reserve' }],
+        reservations: {
+          'W1N1>W1N2': {
+            colony: 'W1N1',
+            roomName: 'W1N2',
+            ticksToEnd: observedTicksToEnd,
+            updatedAt: 100
+          }
+        }
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 101)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'scout'
+    });
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W1N2');
+    expect(Memory.territory?.routeDistances).toEqual({ 'W1N1>W1N2': routeDistance });
+  });
+
+  it('clears stale reservation memory when a configured reserve target becomes unreserved', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W1N2: { name: 'W1N2', controller: { my: false } as StructureController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W1N2', action: 'reserve' }],
+        reservations: {
+          'W1N1>W1N2': {
+            colony: 'W1N1',
+            roomName: 'W1N2',
+            ticksToEnd: 3_000,
+            updatedAt: 100
+          }
+        }
+      }
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 150)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      action: 'reserve'
+    });
+    expect(Memory.territory?.reservations).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 150
+      }
+    ]);
   });
 
   it('keeps an unreserved target ahead of enemy-reserved controller pressure', () => {


### PR DESCRIPTION
## Summary
Implements reservation decay tracking in the territory planner so configured reserve scouts are deferred when the existing reservation is healthy.

## Changes
- Adds `TerritoryReservationMemory` tracking with per-room reservation ticks-to-end
- Refreshes reservation memory at the start of territory target selection
- Defers configured reserve scouts when reservation time remaining exceeds `TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS`
- Cleans up stale reservation entries when the controller is no longer own-reserved
- New constant: `TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS = 50`

## Verification
- Typecheck: passed
- Tests: 702/702 passing
- Build: OK (dist/main.js 459.3kb)
- Whitespace: clean

## Related
Closes #475
