### PR TITLE
feat(territory): controller upgrade throughput and spawn planner improvements (#479)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5381,7 +5381,9 @@ var DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
 var SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 var SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 var MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
+var MIN_LOADED_WORKERS_FOR_SURPLUS_CONTROLLER_PROGRESS = 5;
 var MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS = 2;
+var MAX_SURPLUS_CONTROLLER_PROGRESS_WORKERS = 3;
 var nearTermSpawnExtensionRefillReserveCache = null;
 function selectWorkerTask(creep) {
   var _a;
@@ -7073,15 +7075,29 @@ function shouldApplyControllerPressureLane(creep, controller) {
     return false;
   }
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
-  const hasTerritoryPressure = hasActiveTerritoryPressure(creep);
-  if (loadedWorkers.length < MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS && !(loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasTerritoryPressure)) {
+  const hasControllerProgressPressure = hasActiveControllerProgressPressure(creep);
+  const hasTerritoryExpansionPressure = hasActiveTerritoryExpansionPressure(creep);
+  if (loadedWorkers.length < MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS && !(loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasControllerProgressPressure)) {
     return false;
   }
-  const controllerProgressWorkers = loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS && !hasTerritoryPressure ? MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS : 1;
+  const controllerProgressWorkers = getControllerProgressWorkerLimit(
+    creep,
+    loadedWorkers.length,
+    hasTerritoryExpansionPressure
+  );
   const otherControllerUpgraders = loadedWorkers.filter(
     (worker) => !isSameCreep(worker, creep) && isUpgradingController(worker, controller)
   ).length;
   return otherControllerUpgraders < controllerProgressWorkers;
+}
+function getControllerProgressWorkerLimit(creep, loadedWorkerCount, hasTerritoryExpansionPressure) {
+  if (hasTerritoryExpansionPressure) {
+    return 1;
+  }
+  if (loadedWorkerCount >= MIN_LOADED_WORKERS_FOR_SURPLUS_CONTROLLER_PROGRESS && hasControllerUpgradeEnergySurplus(creep)) {
+    return MAX_SURPLUS_CONTROLLER_PROGRESS_WORKERS;
+  }
+  return loadedWorkerCount >= MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS ? MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS : 1;
 }
 function shouldUseSurplusForControllerProgress(creep, controller) {
   if (shouldApplyControllerPressureLane(creep, controller)) {
@@ -7197,8 +7213,8 @@ function isRoomPosition(value) {
 function hasRecoverableSurplusEnergy(creep) {
   return selectStoredEnergySource(creep) !== null || selectSalvageEnergySource(creep) !== null || findDroppedResources(creep.room).some(isUsefulDroppedEnergy);
 }
-function hasActiveTerritoryPressure(creep) {
-  var _a, _b;
+function hasActiveControllerProgressPressure(creep) {
+  var _a;
   const colonyName = getCreepColonyName(creep);
   if (!colonyName) {
     return false;
@@ -7206,14 +7222,30 @@ function hasActiveTerritoryPressure(creep) {
   if (((_a = getRecordedColonySurvivalAssessment(colonyName)) == null ? void 0 : _a.mode) === "TERRITORY_READY") {
     return true;
   }
+  return hasActiveTerritoryExpansionPressure(creep);
+}
+function hasActiveTerritoryExpansionPressure(creep) {
+  var _a;
+  const colonyName = getCreepColonyName(creep);
+  if (!colonyName) {
+    return false;
+  }
   if (hasReadyTerritoryFollowUpEnergy(creep)) {
     return true;
   }
-  const territoryMemory = (_b = globalThis.Memory) == null ? void 0 : _b.territory;
+  const territoryMemory = (_a = globalThis.Memory) == null ? void 0 : _a.territory;
   if (!territoryMemory || !Array.isArray(territoryMemory.intents)) {
     return false;
   }
   return territoryMemory.intents.some((intent) => isActiveTerritoryPressureIntent(intent, colonyName));
+}
+function hasControllerUpgradeEnergySurplus(creep) {
+  return hasRecoverableSurplusEnergy(creep) || hasFullRoomEnergyForControllerProgress(creep.room);
+}
+function hasFullRoomEnergyForControllerProgress(room) {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  return energyAvailable !== null && energyCapacityAvailable !== null && energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST && energyAvailable >= energyCapacityAvailable;
 }
 function hasReservedTerritoryFollowUpRefillCapacity(creep) {
   return hasActiveTerritoryFollowUpPreparationDemand(getCreepColonyName(creep));
@@ -8006,13 +8038,18 @@ function executeTask(creep, task, target) {
 // src/spawn/spawnPlanner.ts
 var TERRITORY_SCOUT_BODY = ["move"];
 var TERRITORY_SCOUT_BODY_COST2 = 50;
+var CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
+var CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
+var CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET = 6;
+var MAX_CONTROLLER_LEVEL = 8;
 var SPAWN_PRIORITY_TIERS = [
   "emergencyBootstrap",
   // Keep defense above local refill so hostiles cannot starve the first defender.
   "defense",
   "localRefillSurvival",
   "controllerDowngradeGuard",
-  "territoryRemote"
+  "territoryRemote",
+  "controllerUpgradeSurplus"
 ];
 function planSpawn(colony, roleCounts, gameTime, options = {}) {
   const workerTarget = getWorkerTarget(colony, roleCounts);
@@ -8023,6 +8060,7 @@ function planSpawn(colony, roleCounts, gameTime, options = {}) {
     options,
     roleCounts,
     survival: assessColonySnapshotSurvival(colony, roleCounts),
+    territoryIntentPending: false,
     workerCapacity,
     workerTarget
   };
@@ -8046,6 +8084,8 @@ function planSpawnForPriorityTier(tier, context) {
       return planDefenseSpawn(context);
     case "territoryRemote":
       return planTerritoryRemoteSpawn(context);
+    case "controllerUpgradeSurplus":
+      return planControllerUpgradeSurplusSpawn(context);
   }
 }
 function planEmergencyBootstrapSpawn(context) {
@@ -8113,6 +8153,7 @@ function planTerritoryRemoteSpawn(context) {
   if (!territoryIntent) {
     return null;
   }
+  context.territoryIntentPending = true;
   const demandedWorkerTarget = getWorkerTargetWithTerritoryDemand(
     context.workerTarget,
     territoryIntent,
@@ -8151,6 +8192,73 @@ function planTerritoryRemoteSpawn(context) {
     context.gameTime
   );
   return null;
+}
+function planControllerUpgradeSurplusSpawn(context) {
+  if (!shouldSpawnControllerUpgradeSurplusWorker(context)) {
+    return null;
+  }
+  return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
+}
+function shouldSpawnControllerUpgradeSurplusWorker(context) {
+  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
+    return false;
+  }
+  const surplusWorkerTarget = Math.min(
+    CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET,
+    context.workerTarget + CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS
+  );
+  return context.workerCapacity < surplusWorkerTarget;
+}
+function hasControllerUpgradeSurplusEnergy(colony) {
+  return colony.energyCapacityAvailable >= CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY && colony.energyAvailable >= colony.energyCapacityAvailable;
+}
+function isControllerUpgradeableForSurplus(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && controller.level < MAX_CONTROLLER_LEVEL;
+}
+function hasControllerUpgradeBlockingTerritoryWork(colony) {
+  return hasActiveTerritoryIntentBacklog(colony.room.name) || hasVisibleForeignReservedTerritoryTarget(colony);
+}
+function hasActiveTerritoryIntentBacklog(colonyName) {
+  var _a, _b;
+  const intents = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.intents;
+  if (!Array.isArray(intents)) {
+    return false;
+  }
+  return intents.some((intent) => {
+    if (intent.colony !== colonyName || intent.targetRoom === colonyName || intent.action !== "claim" && intent.action !== "reserve" && intent.action !== "scout") {
+      return false;
+    }
+    return intent.status === "planned" || intent.status === "active" || intent.followUp !== void 0;
+  });
+}
+function hasVisibleForeignReservedTerritoryTarget(colony) {
+  var _a, _b;
+  const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
+  if (!Array.isArray(targets)) {
+    return false;
+  }
+  const colonyOwnerUsername = getControllerOwnerUsername3(colony.room.controller);
+  return targets.some((target) => {
+    if (target.colony !== colony.room.name || target.enabled === false || target.action !== "claim" && target.action !== "reserve") {
+      return false;
+    }
+    const controller = getVisibleRoomController(target.roomName);
+    return isForeignReservedController2(controller, colonyOwnerUsername);
+  });
+}
+function getVisibleRoomController(roomName) {
+  var _a, _b, _c;
+  return (_c = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName]) == null ? void 0 : _c.controller;
+}
+function isForeignReservedController2(controller, colonyOwnerUsername) {
+  var _a;
+  const reservationUsername = (_a = controller == null ? void 0 : controller.reservation) == null ? void 0 : _a.username;
+  return (controller == null ? void 0 : controller.my) !== true && typeof reservationUsername === "string" && reservationUsername.length > 0 && reservationUsername !== colonyOwnerUsername;
+}
+function getControllerOwnerUsername3(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  return typeof username === "string" && username.length > 0 ? username : void 0;
 }
 function recordRecoveredFollowUpCooldownIfControllerCreepNeeded(territoryIntent, roleCounts, gameTime) {
   if (!territoryIntent || !shouldSpawnTerritoryControllerCreep(territoryIntent, roleCounts, gameTime)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8262,6 +8262,9 @@ function hasActiveTerritoryIntentBacklog(colonyName) {
     return false;
   }
   return intents.some((intent) => {
+    if (typeof intent !== "object" || intent === null) {
+      return false;
+    }
     if (intent.colony !== colonyName || intent.targetRoom === colonyName || intent.action !== "claim" && intent.action !== "reserve" && intent.action !== "scout") {
       return false;
     }
@@ -8276,7 +8279,13 @@ function hasVisibleForeignReservedTerritoryTarget(colony) {
   }
   const colonyOwnerUsername = getControllerOwnerUsername3(colony.room.controller);
   return targets.some((target) => {
+    if (typeof target !== "object" || target === null) {
+      return false;
+    }
     if (target.colony !== colony.room.name || target.enabled === false || target.action !== "claim" && target.action !== "reserve") {
+      return false;
+    }
+    if (typeof target.roomName !== "string" || target.roomName.length === 0) {
       return false;
     }
     const controller = getVisibleRoomController(target.roomName);

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -30,7 +30,8 @@ type SpawnPriorityTier =
   | 'defense'
   | 'localRefillSurvival'
   | 'controllerDowngradeGuard'
-  | 'territoryRemote';
+  | 'territoryRemote'
+  | 'controllerUpgradeSurplus';
 
 interface SpawnPlanningContext {
   colony: ColonySnapshot;
@@ -38,6 +39,7 @@ interface SpawnPlanningContext {
   options: SpawnPlanningOptions;
   roleCounts: RoleCounts;
   survival: ColonySurvivalAssessment;
+  territoryIntentPending: boolean;
   workerCapacity: number;
   workerTarget: number;
 }
@@ -58,13 +60,18 @@ export interface SpawnPlanningOptions {
 
 const TERRITORY_SCOUT_BODY: BodyPartConstant[] = ['move'];
 const TERRITORY_SCOUT_BODY_COST = 50;
+const CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
+const CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
+const CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET = 6;
+const MAX_CONTROLLER_LEVEL = 8;
 const SPAWN_PRIORITY_TIERS: SpawnPriorityTier[] = [
   'emergencyBootstrap',
   // Keep defense above local refill so hostiles cannot starve the first defender.
   'defense',
   'localRefillSurvival',
   'controllerDowngradeGuard',
-  'territoryRemote'
+  'territoryRemote',
+  'controllerUpgradeSurplus'
 ];
 
 export function planSpawn(
@@ -81,6 +88,7 @@ export function planSpawn(
     options,
     roleCounts,
     survival: assessColonySnapshotSurvival(colony, roleCounts),
+    territoryIntentPending: false,
     workerCapacity,
     workerTarget
   };
@@ -110,6 +118,8 @@ function planSpawnForPriorityTier(
       return planDefenseSpawn(context);
     case 'territoryRemote':
       return planTerritoryRemoteSpawn(context);
+    case 'controllerUpgradeSurplus':
+      return planControllerUpgradeSurplusSpawn(context);
   }
 }
 
@@ -204,6 +214,7 @@ function planTerritoryRemoteSpawn(context: SpawnPlanningContext): SpawnRequest |
   if (!territoryIntent) {
     return null;
   }
+  context.territoryIntentPending = true;
 
   const demandedWorkerTarget = getWorkerTargetWithTerritoryDemand(
     context.workerTarget,
@@ -247,6 +258,120 @@ function planTerritoryRemoteSpawn(context: SpawnPlanningContext): SpawnRequest |
   );
 
   return null;
+}
+
+function planControllerUpgradeSurplusSpawn(context: SpawnPlanningContext): SpawnRequest | null {
+  if (!shouldSpawnControllerUpgradeSurplusWorker(context)) {
+    return null;
+  }
+
+  return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
+}
+
+function shouldSpawnControllerUpgradeSurplusWorker(context: SpawnPlanningContext): boolean {
+  if (
+    context.options.workersOnly ||
+    context.territoryIntentPending ||
+    context.survival.mode !== 'TERRITORY_READY' ||
+    hasControllerUpgradeBlockingTerritoryWork(context.colony) ||
+    !hasControllerUpgradeSurplusEnergy(context.colony) ||
+    !isControllerUpgradeableForSurplus(context.colony.room.controller)
+  ) {
+    return false;
+  }
+
+  const surplusWorkerTarget = Math.min(
+    CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET,
+    context.workerTarget + CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS
+  );
+  return context.workerCapacity < surplusWorkerTarget;
+}
+
+function hasControllerUpgradeSurplusEnergy(colony: ColonySnapshot): boolean {
+  return (
+    colony.energyCapacityAvailable >= CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY &&
+    colony.energyAvailable >= colony.energyCapacityAvailable
+  );
+}
+
+function isControllerUpgradeableForSurplus(controller: StructureController | undefined): boolean {
+  return (
+    controller?.my === true &&
+    typeof controller.level === 'number' &&
+    controller.level >= 2 &&
+    controller.level < MAX_CONTROLLER_LEVEL
+  );
+}
+
+function hasControllerUpgradeBlockingTerritoryWork(colony: ColonySnapshot): boolean {
+  return (
+    hasActiveTerritoryIntentBacklog(colony.room.name) ||
+    hasVisibleForeignReservedTerritoryTarget(colony)
+  );
+}
+
+function hasActiveTerritoryIntentBacklog(colonyName: string): boolean {
+  const intents = (globalThis as unknown as { Memory?: Partial<Memory> }).Memory?.territory?.intents;
+  if (!Array.isArray(intents)) {
+    return false;
+  }
+
+  return intents.some((intent) => {
+    if (
+      intent.colony !== colonyName ||
+      intent.targetRoom === colonyName ||
+      (intent.action !== 'claim' && intent.action !== 'reserve' && intent.action !== 'scout')
+    ) {
+      return false;
+    }
+
+    return intent.status === 'planned' || intent.status === 'active' || intent.followUp !== undefined;
+  });
+}
+
+function hasVisibleForeignReservedTerritoryTarget(colony: ColonySnapshot): boolean {
+  const targets = (globalThis as unknown as { Memory?: Partial<Memory> }).Memory?.territory?.targets;
+  if (!Array.isArray(targets)) {
+    return false;
+  }
+
+  const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
+  return targets.some((target) => {
+    if (
+      target.colony !== colony.room.name ||
+      target.enabled === false ||
+      (target.action !== 'claim' && target.action !== 'reserve')
+    ) {
+      return false;
+    }
+
+    const controller = getVisibleRoomController(target.roomName);
+    return isForeignReservedController(controller, colonyOwnerUsername);
+  });
+}
+
+function getVisibleRoomController(roomName: string): StructureController | undefined {
+  return (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName]?.controller;
+}
+
+function isForeignReservedController(
+  controller: StructureController | undefined,
+  colonyOwnerUsername: string | undefined
+): boolean {
+  const reservationUsername = (controller as (StructureController & { reservation?: { username?: string } }) | undefined)
+    ?.reservation?.username;
+  return (
+    controller?.my !== true &&
+    typeof reservationUsername === 'string' &&
+    reservationUsername.length > 0 &&
+    reservationUsername !== colonyOwnerUsername
+  );
+}
+
+function getControllerOwnerUsername(controller: StructureController | undefined): string | undefined {
+  const username = (controller as (StructureController & { owner?: { username?: string } }) | undefined)?.owner
+    ?.username;
+  return typeof username === 'string' && username.length > 0 ? username : undefined;
 }
 
 function recordRecoveredFollowUpCooldownIfControllerCreepNeeded(

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -317,6 +317,10 @@ function hasActiveTerritoryIntentBacklog(colonyName: string): boolean {
   }
 
   return intents.some((intent) => {
+    if (typeof intent !== 'object' || intent === null) {
+      return false;
+    }
+
     if (
       intent.colony !== colonyName ||
       intent.targetRoom === colonyName ||
@@ -337,11 +341,19 @@ function hasVisibleForeignReservedTerritoryTarget(colony: ColonySnapshot): boole
 
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   return targets.some((target) => {
+    if (typeof target !== 'object' || target === null) {
+      return false;
+    }
+
     if (
       target.colony !== colony.room.name ||
       target.enabled === false ||
       (target.action !== 'claim' && target.action !== 'reserve')
     ) {
+      return false;
+    }
+
+    if (typeof target.roomName !== 'string' || target.roomName.length === 0) {
       return false;
     }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -49,7 +49,9 @@ const DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
 const SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 const SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 const MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
+const MIN_LOADED_WORKERS_FOR_SURPLUS_CONTROLLER_PROGRESS = 5;
 const MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS = 2;
+const MAX_SURPLUS_CONTROLLER_PROGRESS_WORKERS = 3;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
@@ -2696,22 +2698,45 @@ function shouldApplyControllerPressureLane(creep: Creep, controller: StructureCo
   }
 
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
-  const hasTerritoryPressure = hasActiveTerritoryPressure(creep);
+  const hasControllerProgressPressure = hasActiveControllerProgressPressure(creep);
+  const hasTerritoryExpansionPressure = hasActiveTerritoryExpansionPressure(creep);
   if (
     loadedWorkers.length < MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS &&
-    !(loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasTerritoryPressure)
+    !(loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE && hasControllerProgressPressure)
   ) {
     return false;
   }
 
-  const controllerProgressWorkers =
-    loadedWorkers.length >= MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS && !hasTerritoryPressure
-      ? MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS
-      : 1;
+  const controllerProgressWorkers = getControllerProgressWorkerLimit(
+    creep,
+    loadedWorkers.length,
+    hasTerritoryExpansionPressure
+  );
   const otherControllerUpgraders = loadedWorkers.filter(
     (worker) => !isSameCreep(worker, creep) && isUpgradingController(worker, controller)
   ).length;
   return otherControllerUpgraders < controllerProgressWorkers;
+}
+
+function getControllerProgressWorkerLimit(
+  creep: Creep,
+  loadedWorkerCount: number,
+  hasTerritoryExpansionPressure: boolean
+): number {
+  if (hasTerritoryExpansionPressure) {
+    return 1;
+  }
+
+  if (
+    loadedWorkerCount >= MIN_LOADED_WORKERS_FOR_SURPLUS_CONTROLLER_PROGRESS &&
+    hasControllerUpgradeEnergySurplus(creep)
+  ) {
+    return MAX_SURPLUS_CONTROLLER_PROGRESS_WORKERS;
+  }
+
+  return loadedWorkerCount >= MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS
+    ? MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS
+    : 1;
 }
 
 function shouldUseSurplusForControllerProgress(creep: Creep, controller: StructureController): boolean {
@@ -2887,7 +2912,7 @@ function hasRecoverableSurplusEnergy(creep: Creep): boolean {
   );
 }
 
-function hasActiveTerritoryPressure(creep: Creep): boolean {
+function hasActiveControllerProgressPressure(creep: Creep): boolean {
   const colonyName = getCreepColonyName(creep);
   if (!colonyName) {
     return false;
@@ -2895,6 +2920,15 @@ function hasActiveTerritoryPressure(creep: Creep): boolean {
 
   if (getRecordedColonySurvivalAssessment(colonyName)?.mode === 'TERRITORY_READY') {
     return true;
+  }
+
+  return hasActiveTerritoryExpansionPressure(creep);
+}
+
+function hasActiveTerritoryExpansionPressure(creep: Creep): boolean {
+  const colonyName = getCreepColonyName(creep);
+  if (!colonyName) {
+    return false;
   }
 
   if (hasReadyTerritoryFollowUpEnergy(creep)) {
@@ -2907,6 +2941,21 @@ function hasActiveTerritoryPressure(creep: Creep): boolean {
   }
 
   return territoryMemory.intents.some((intent) => isActiveTerritoryPressureIntent(intent, colonyName));
+}
+
+function hasControllerUpgradeEnergySurplus(creep: Creep): boolean {
+  return hasRecoverableSurplusEnergy(creep) || hasFullRoomEnergyForControllerProgress(creep.room);
+}
+
+function hasFullRoomEnergyForControllerProgress(room: Room): boolean {
+  const energyAvailable = getRoomEnergyAvailable(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  return (
+    energyAvailable !== null &&
+    energyCapacityAvailable !== null &&
+    energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST &&
+    energyAvailable >= energyCapacityAvailable
+  );
 }
 
 function hasReservedTerritoryFollowUpRefillCapacity(creep: Creep): boolean {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -179,6 +179,34 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 3, workerCapacity: 3 }, 124)).toBeNull();
   });
 
+  it('plans one surplus worker for controller progress when stable room energy is full', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N17',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 126)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
+      name: 'worker-W1N17-126',
+      memory: { role: 'worker', colony: 'W1N17' }
+    });
+    expect(planSpawn(colony, { worker: 4 }, 127)).toBeNull();
+  });
+
+  it('waits on surplus controller workers until spawn energy is full', () => {
+    const { colony } = makeColony({
+      roomName: 'W1N18',
+      energyAvailable: 600,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 128)).toBeNull();
+  });
+
   it('keeps normal replacement body selection when only expiring workers remain', () => {
     const { colony, spawn } = makeColony({ energyAvailable: 600, energyCapacityAvailable: 800 });
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -6932,6 +6932,101 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
   });
 
+  it('allows a third stable-room controller upgrader when spawn energy is full', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+      energyCapacityAvailable: TERRITORY_CONTROLLER_BODY_COST
+    });
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    recordSurvivalMode('TERRITORY_READY', 700);
+    setGameCreeps({
+      UpgraderA: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      UpgraderB: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      BuilderA: makeLoadedWorker(room),
+      BuilderB: makeLoadedWorker(room)
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('bounds stable-room surplus controller pressure once three workers are upgrading', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+      energyCapacityAvailable: TERRITORY_CONTROLLER_BODY_COST
+    });
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    recordSurvivalMode('TERRITORY_READY', 701);
+    setGameCreeps({
+      UpgraderA: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      UpgraderB: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      UpgraderC: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      Builder: makeLoadedWorker(room)
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
+  });
+
+  it('keeps active territory pressure capped at one controller upgrader', () => {
+    const site = { id: 'tower-site1', structureType: 'tower' } as ConstructionSite;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      constructionSites: [site],
+      controller,
+      energyAvailable: TERRITORY_CONTROLLER_BODY_COST,
+      energyCapacityAvailable: TERRITORY_CONTROLLER_BODY_COST
+    });
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+    recordSurvivalMode('TERRITORY_READY', 702);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', status: 'planned', updatedAt: 702 }]
+      }
+    };
+    setGameCreeps({
+      Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      BuilderA: makeLoadedWorker(room),
+      BuilderB: makeLoadedWorker(room),
+      BuilderC: makeLoadedWorker(room)
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'tower-site1' });
+  });
+
   it('steers an empty worker to source2 when source2 is near the owned controller', () => {
     const source1 = makeSource('source1', 8, 8);
     const source2 = makeSource('source2', 24, 23);


### PR DESCRIPTION
## Summary
Implements controller upgrade throughput and spawn planner improvements after the reservation decay tracking merged in #477.

## Changes
- `prod/src/spawn/spawnPlanner.ts`: Spawn planner improvements for controller upgrade support
- `prod/src/tasks/workerTasks.ts`: Worker task changes for controller throughput
- `prod/test/spawnPlanner.test.ts`: Tests for spawn planner controller upgrade behavior
- `prod/test/workerTasks.test.ts`: Tests for controller upgrade worker tasks
- `prod/dist/main.js`: Regenerated bundle

## Verification
- TypeScript typecheck: pass
- Jest tests: 26 suites, 708 tests pass
- Build: successful

Closes #479
