### PR TITLE
feat(economy): enforce minimum useful worker load before non-urgent energy spending (#485)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5357,14 +5357,10 @@ var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
 var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 var NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
-var LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
-var LOW_LOAD_WORKER_ENERGY_CEILING = 25;
+var MINIMUM_USEFUL_LOAD_RATIO = 0.4;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
-var REFILL_DELIVERY_MIN_LOAD = 20;
 var DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
-var SPAWN_RECOVERY_REFILL_PRESSURE_RATIO = 0.75;
-var REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED = 50;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -5442,7 +5438,12 @@ function selectWorkerTask(creep) {
   }
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller) && !remoteProductiveSpendingSuppressed) {
-    return { type: "upgrade", targetId: controller.id };
+    const downgradeGuardTask = {
+      type: "upgrade",
+      targetId: controller.id
+    };
+    recordLowLoadReturnTelemetry(creep, downgradeGuardTask, "controllerDowngradeGuard");
+    return downgradeGuardTask;
   }
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   if (spawnOrExtensionEnergySink) {
@@ -5450,25 +5451,11 @@ function selectWorkerTask(creep) {
       type: "transfer",
       targetId: spawnOrExtensionEnergySink.id
     };
-    if (shouldPrioritizeSpawnOrExtensionRefill(creep)) {
-      const refillMinLoadContinuationTask = selectUrgentRefillMinLoadContinuationTask(
-        creep,
-        spawnOrExtensionEnergySink
-      );
-      if (refillMinLoadContinuationTask) {
-        return refillMinLoadContinuationTask;
-      }
-      recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, "urgentSpawnExtensionRefill");
+    if (hasEmergencySpawnExtensionRefillDemand(creep)) {
+      recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, "emergencySpawnExtensionRefill");
       return spawnOrExtensionRefillTask;
     }
-    if (!remoteProductiveSpendingSuppressed) {
-      const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
-      if (lowLoadEnergyContinuationTask) {
-        return lowLoadEnergyContinuationTask;
-      }
-    }
-    recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, "noNearbyEnergy");
-    return spawnOrExtensionRefillTask;
+    return applyMinimumUsefulLoadPolicy(creep, spawnOrExtensionRefillTask);
   }
   if (remoteProductiveSpendingSuppressed) {
     const suppressedRemoteEnergyHandlingTask = selectSuppressedRemoteEnergyHandlingTask(creep);
@@ -5493,15 +5480,21 @@ function selectWorkerTask(creep) {
       constructionReservationContext
     );
     if (baselineLogisticsConstructionSite) {
-      return { type: "build", targetId: baselineLogisticsConstructionSite.id };
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: "build",
+        targetId: baselineLogisticsConstructionSite.id
+      });
     }
     if (capacityConstructionSite) {
-      return { type: "build", targetId: capacityConstructionSite.id };
+      return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
     }
   }
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
-    return { type: "transfer", targetId: priorityTowerEnergySink.id };
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "transfer",
+      targetId: priorityTowerEnergySink.id
+    });
   }
   if (!remoteProductiveSpendingSuppressed) {
     const lowLoadEnergyAcquisitionCandidate = selectLowLoadWorkerEnergyAcquisitionCandidate(creep);
@@ -5527,24 +5520,27 @@ function selectWorkerTask(creep) {
     constructionReservationContext
   );
   if (readyFollowUpProductiveEnergySinkTask) {
-    return readyFollowUpProductiveEnergySinkTask;
+    return applyMinimumUsefulLoadPolicy(creep, readyFollowUpProductiveEnergySinkTask);
   }
   if (territoryControllerTask) {
     return territoryControllerTask;
   }
   const source2ControllerLaneLoadedTask = controller ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites, constructionReservationContext) : null;
   if (source2ControllerLaneLoadedTask) {
-    return source2ControllerLaneLoadedTask;
+    return applyMinimumUsefulLoadPolicy(creep, source2ControllerLaneLoadedTask);
   }
   if (capacityConstructionSite) {
-    return { type: "build", targetId: capacityConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
   }
   if (controller && shouldRushRcl1Controller(controller)) {
-    return { type: "upgrade", targetId: controller.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
   }
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
-    return { type: "repair", targetId: criticalRepairTarget.id };
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "repair",
+      targetId: criticalRepairTarget.id
+    });
   }
   if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
     return null;
@@ -5555,7 +5551,7 @@ function selectWorkerTask(creep) {
     constructionReservationContext
   );
   if (criticalRoadConstructionSite) {
-    return { type: "build", targetId: criticalRoadConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: criticalRoadConstructionSite.id });
   }
   const containerConstructionSite = selectUnreservedConstructionSite(
     creep,
@@ -5564,13 +5560,9 @@ function selectWorkerTask(creep) {
     isContainerConstructionSite
   );
   if (containerConstructionSite) {
-    return { type: "build", targetId: containerConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: containerConstructionSite.id });
   }
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
-    const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
-    if (lowLoadEnergyContinuationTask) {
-      return lowLoadEnergyContinuationTask;
-    }
     const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
       creep,
       constructionSites,
@@ -5578,9 +5570,9 @@ function selectWorkerTask(creep) {
       constructionReservationContext
     );
     if (productiveEnergySinkTask) {
-      return productiveEnergySinkTask;
+      return applyMinimumUsefulLoadPolicy(creep, productiveEnergySinkTask);
     }
-    return { type: "upgrade", targetId: controller.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
   }
   const roadConstructionSite = selectUnreservedConstructionSite(
     creep,
@@ -5589,7 +5581,7 @@ function selectWorkerTask(creep) {
     isRoadConstructionSite2
   );
   if (roadConstructionSite) {
-    return { type: "build", targetId: roadConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: roadConstructionSite.id });
   }
   const constructionSite = selectUnreservedConstructionSite(
     creep,
@@ -5597,18 +5589,14 @@ function selectWorkerTask(creep) {
     constructionReservationContext
   );
   if (constructionSite) {
-    return { type: "build", targetId: constructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: constructionSite.id });
   }
   const repairTarget = selectRepairTarget(creep);
   if (repairTarget) {
-    return { type: "repair", targetId: repairTarget.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "repair", targetId: repairTarget.id });
   }
   if (controller == null ? void 0 : controller.my) {
-    const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
-    if (lowLoadEnergyContinuationTask) {
-      return lowLoadEnergyContinuationTask;
-    }
-    return { type: "upgrade", targetId: controller.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
   }
   return null;
 }
@@ -5649,14 +5637,17 @@ function selectFirstEnergySinkByStableId(energySinks) {
 }
 function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSites, constructionReservationContext, recoveryOnlyWorkSuppressed) {
   if (controller && shouldRushRcl1Controller(controller) && !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)) {
-    return { type: "upgrade", targetId: controller.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
   }
   if (recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep)) {
     return null;
   }
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
-    return { type: "repair", targetId: criticalRepairTarget.id };
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "repair",
+      targetId: criticalRepairTarget.id
+    });
   }
   if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
     return null;
@@ -5667,7 +5658,7 @@ function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSite
     constructionReservationContext
   );
   if (criticalRoadConstructionSite) {
-    return { type: "build", targetId: criticalRoadConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: criticalRoadConstructionSite.id });
   }
   return null;
 }
@@ -5699,38 +5690,9 @@ function estimateNearTermSpawnCompletionRefillReserve(room, spawnExtensionEnergy
 function isTerritoryControlTask(task) {
   return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
 }
-function shouldPrioritizeSpawnOrExtensionRefill(creep) {
+function hasEmergencySpawnExtensionRefillDemand(creep) {
   const energyAvailable = getRoomEnergyAvailable(creep.room);
-  if (energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD) {
-    return true;
-  }
-  if (hasSpawnRecoveryRefillPressure(creep, energyAvailable)) {
-    return true;
-  }
-  if (hasReservedTerritoryFollowUpRefillCapacity(creep) && !hasReadyTerritoryFollowUpEnergy(creep)) {
-    return true;
-  }
-  return hasNearTermSpawnCompletionRefillDemand(creep.room);
-}
-function selectUrgentRefillMinLoadContinuationTask(creep, energySink) {
-  if (getUsedEnergy(creep) >= REFILL_DELIVERY_MIN_LOAD) {
-    return null;
-  }
-  if (getFreeStoredEnergyCapacity(energySink) <= REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED) {
-    return null;
-  }
-  return selectLowLoadWorkerEnergyContinuationTask(creep);
-}
-function hasSpawnRecoveryRefillPressure(creep, energyAvailable) {
-  const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
-  if (!survivalAssessment || survivalAssessment.workerCapacity >= survivalAssessment.workerTarget) {
-    return false;
-  }
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
-  return energyCapacityAvailable !== null && energyCapacityAvailable > 0 && energyAvailable < energyCapacityAvailable * SPAWN_RECOVERY_REFILL_PRESSURE_RATIO;
-}
-function hasNearTermSpawnCompletionRefillDemand(room) {
-  return findSpawnExtensionEnergyStructures(room).some(isNearTermSpawningSpawn);
+  return energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 function getLowLoadWorkerEnergyContext(creep) {
   const carriedEnergy = getUsedEnergy(creep);
@@ -5738,12 +5700,23 @@ function getLowLoadWorkerEnergyContext(creep) {
   if (carriedEnergy <= 0 || freeCapacity <= 0) {
     return null;
   }
-  const capacity = carriedEnergy + freeCapacity;
-  const lowLoadEnergyLimit = Math.min(
-    LOW_LOAD_WORKER_ENERGY_CEILING,
-    Math.max(1, Math.floor(capacity * LOW_LOAD_WORKER_ENERGY_RATIO))
-  );
-  return carriedEnergy <= lowLoadEnergyLimit ? { carriedEnergy, freeCapacity } : null;
+  const capacity = getEnergyCapacity(creep, carriedEnergy, freeCapacity);
+  return capacity > 0 && carriedEnergy < capacity * MINIMUM_USEFUL_LOAD_RATIO ? { carriedEnergy, capacity, freeCapacity } : null;
+}
+function applyMinimumUsefulLoadPolicy(creep, task) {
+  if (!getLowLoadWorkerEnergyContext(creep)) {
+    return task;
+  }
+  if (hasVisibleHostilePresence(creep.room)) {
+    recordLowLoadReturnTelemetry(creep, task, "hostileSafety");
+    return task;
+  }
+  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+  if (lowLoadEnergyContinuationTask) {
+    return lowLoadEnergyContinuationTask;
+  }
+  recordLowLoadReturnTelemetry(creep, task, "noReachableEnergy");
+  return task;
 }
 function clearWorkerEfficiencyTelemetry(creep) {
   const memory = creep.memory;
@@ -7357,6 +7330,15 @@ function getFreeStoredEnergyCapacity(object) {
   const freeCapacity = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
   return typeof freeCapacity === "number" ? freeCapacity : 0;
 }
+function getEnergyCapacity(creep, carriedEnergy = getUsedEnergy(creep), freeCapacity = getFreeEnergyCapacity(creep)) {
+  var _a;
+  const store = getStore(creep);
+  const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
+  if (typeof capacity === "number" && Number.isFinite(capacity) && capacity > 0) {
+    return capacity;
+  }
+  return Math.max(0, carriedEnergy + freeCapacity);
+}
 function getStore(object) {
   if (!isWorkerTaskRecord(object) || !isWorkerTaskRecord(object.store)) {
     return null;
@@ -7770,7 +7752,7 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, 
   if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
     return false;
   }
-  return isUrgentEnergySpendingTask(selectedTask);
+  return isUrgentEnergySpendingTask(selectedTask) || isDowngradeGuardUpgradeTask(creep, selectedTask);
 }
 function shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, task, selectedTask) {
   var _a;
@@ -7875,7 +7857,7 @@ function isEnergyAcquisitionTask(task) {
   return task.type === "harvest" || task.type === "pickup" || task.type === "withdraw";
 }
 function isLowLoadReturnTask(task) {
-  return task.type === "transfer" || task.type === "upgrade";
+  return task.type === "transfer" || task.type === "build" || task.type === "repair" || task.type === "upgrade";
 }
 function isRecoverableEnergyTask(task) {
   return (task == null ? void 0 : task.type) === "pickup" || (task == null ? void 0 : task.type) === "withdraw";
@@ -9051,6 +9033,7 @@ var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
 var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+var MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 var MAX_REFILL_DELIVERY_SAMPLES = 5;
 var MAX_TERRITORY_INTENT_SUMMARIES = 5;
 var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
@@ -9243,14 +9226,50 @@ function summarizeWorkerEfficiency(workers, tick) {
     return {};
   }
   const reportedSamples = samples.slice(0, MAX_WORKER_EFFICIENCY_SAMPLES).map(toRuntimeWorkerEfficiencySample);
+  const lowLoadReturnSamples = samples.filter((entry) => entry.sample.type === "lowLoadReturn");
+  const emergencyLowLoadReturnCount = lowLoadReturnSamples.filter(
+    (entry) => isEmergencyLowLoadReturnReason(getLowLoadReturnReason(entry.sample))
+  ).length;
+  const lowLoadReturnReasons = summarizeLowLoadReturnReasons(lowLoadReturnSamples);
   return {
     workerEfficiency: {
-      lowLoadReturnCount: samples.filter((entry) => entry.sample.type === "lowLoadReturn").length,
+      lowLoadReturnCount: lowLoadReturnSamples.length,
+      emergencyLowLoadReturnCount,
+      avoidableLowLoadReturnCount: lowLoadReturnSamples.length - emergencyLowLoadReturnCount,
       nearbyEnergyChoiceCount: samples.filter((entry) => entry.sample.type === "nearbyEnergyChoice").length,
+      ...lowLoadReturnReasons.length > 0 ? { lowLoadReturnReasons } : {},
       samples: reportedSamples,
       ...samples.length > MAX_WORKER_EFFICIENCY_SAMPLES ? { omittedSampleCount: samples.length - MAX_WORKER_EFFICIENCY_SAMPLES } : {}
     }
   };
+}
+function summarizeLowLoadReturnReasons(samples) {
+  var _a;
+  const countsByReason = /* @__PURE__ */ new Map();
+  for (const entry of samples) {
+    const reason = getLowLoadReturnReason(entry.sample);
+    countsByReason.set(reason, ((_a = countsByReason.get(reason)) != null ? _a : 0) + 1);
+  }
+  return [...countsByReason.entries()].map(([reason, count]) => ({
+    reason,
+    category: getLowLoadReturnReasonCategory(reason),
+    count
+  })).sort(compareLowLoadReturnReasonSummaries).slice(0, MAX_WORKER_EFFICIENCY_REASON_SAMPLES);
+}
+function compareLowLoadReturnReasonSummaries(left, right) {
+  return right.count - left.count || left.reason.localeCompare(right.reason);
+}
+function getLowLoadReturnReason(sample) {
+  return isLowLoadReturnReason(sample.reason) ? sample.reason : "unknown";
+}
+function getLowLoadReturnReasonCategory(reason) {
+  return isEmergencyLowLoadReturnReason(reason) ? "emergency" : "avoidable";
+}
+function isEmergencyLowLoadReturnReason(reason) {
+  return reason === "emergencySpawnExtensionRefill" || reason === "controllerDowngradeGuard" || reason === "hostileSafety" || reason === "urgentSpawnExtensionRefill";
+}
+function isLowLoadReturnReason(value) {
+  return value === "emergencySpawnExtensionRefill" || value === "controllerDowngradeGuard" || value === "hostileSafety" || value === "noReachableEnergy" || value === "urgentSpawnExtensionRefill" || value === "noNearbyEnergy";
 }
 function compareWorkerEfficiencySampleEntries(left, right) {
   var _a, _b;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -263,7 +263,7 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(
     return false;
   }
 
-  return isUrgentEnergySpendingTask(selectedTask);
+  return isUrgentEnergySpendingTask(selectedTask) || isDowngradeGuardUpgradeTask(creep, selectedTask);
 }
 
 function shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(
@@ -447,8 +447,8 @@ function isEnergyAcquisitionTask(task: CreepTaskMemory): task is Extract<
 
 function isLowLoadReturnTask(
   task: CreepTaskMemory
-): task is Extract<CreepTaskMemory, { type: 'transfer' | 'upgrade' }> {
-  return task.type === 'transfer' || task.type === 'upgrade';
+): task is Extract<CreepTaskMemory, { type: 'transfer' | 'build' | 'repair' | 'upgrade' }> {
+  return task.type === 'transfer' || task.type === 'build' || task.type === 'repair' || task.type === 'upgrade';
 }
 
 function isRecoverableEnergyTask(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -25,14 +25,10 @@ export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 export const TOWER_REFILL_ENERGY_FLOOR = 500;
 export const URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 export const NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
-export const LOW_LOAD_WORKER_ENERGY_RATIO = 0.25;
-export const LOW_LOAD_WORKER_ENERGY_CEILING = 25;
+export const MINIMUM_USEFUL_LOAD_RATIO = 0.4;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
-export const REFILL_DELIVERY_MIN_LOAD = 20;
 const DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
-const SPAWN_RECOVERY_REFILL_PRESSURE_RATIO = 0.75;
-const REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED = 50;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
@@ -66,6 +62,11 @@ type WorkerEnergyAcquisitionTask = Extract<CreepTaskMemory, { type: 'pickup' | '
 type LowLoadWorkerEnergyAcquisitionSource = WorkerEnergyAcquisitionSource | Source;
 type LowLoadWorkerEnergyAcquisitionTask = Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }>;
 type ProductiveEnergySinkTask = Extract<CreepTaskMemory, { type: 'build' | 'repair' }>;
+type WorkerEnergySpendingTask =
+  | Extract<CreepTaskMemory, { type: 'transfer' }>
+  | Extract<CreepTaskMemory, { type: 'build' }>
+  | Extract<CreepTaskMemory, { type: 'repair' }>
+  | Extract<CreepTaskMemory, { type: 'upgrade' }>;
 
 interface StoredEnergySourceContext {
   creepOwnerUsername: string | null;
@@ -180,7 +181,12 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
 
   const controller = creep.room.controller;
   if (controller && shouldGuardControllerDowngrade(controller) && !remoteProductiveSpendingSuppressed) {
-    return { type: 'upgrade', targetId: controller.id };
+    const downgradeGuardTask: Extract<CreepTaskMemory, { type: 'upgrade' }> = {
+      type: 'upgrade',
+      targetId: controller.id
+    };
+    recordLowLoadReturnTelemetry(creep, downgradeGuardTask, 'controllerDowngradeGuard');
+    return downgradeGuardTask;
   }
 
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
@@ -189,28 +195,12 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
       type: 'transfer',
       targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure>
     };
-    if (shouldPrioritizeSpawnOrExtensionRefill(creep)) {
-      const refillMinLoadContinuationTask = selectUrgentRefillMinLoadContinuationTask(
-        creep,
-        spawnOrExtensionEnergySink
-      );
-      if (refillMinLoadContinuationTask) {
-        return refillMinLoadContinuationTask;
-      }
-
-      recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, 'urgentSpawnExtensionRefill');
+    if (hasEmergencySpawnExtensionRefillDemand(creep)) {
+      recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, 'emergencySpawnExtensionRefill');
       return spawnOrExtensionRefillTask;
     }
 
-    if (!remoteProductiveSpendingSuppressed) {
-      const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
-      if (lowLoadEnergyContinuationTask) {
-        return lowLoadEnergyContinuationTask;
-      }
-    }
-
-    recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, 'noNearbyEnergy');
-    return spawnOrExtensionRefillTask;
+    return applyMinimumUsefulLoadPolicy(creep, spawnOrExtensionRefillTask);
   }
 
   if (remoteProductiveSpendingSuppressed) {
@@ -241,17 +231,23 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
       constructionReservationContext
     );
     if (baselineLogisticsConstructionSite) {
-      return { type: 'build', targetId: baselineLogisticsConstructionSite.id };
+      return applyMinimumUsefulLoadPolicy(creep, {
+        type: 'build',
+        targetId: baselineLogisticsConstructionSite.id
+      });
     }
 
     if (capacityConstructionSite) {
-      return { type: 'build', targetId: capacityConstructionSite.id };
+      return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: capacityConstructionSite.id });
     }
   }
 
   const priorityTowerEnergySink = selectPriorityTowerEnergySink(creep);
   if (priorityTowerEnergySink) {
-    return { type: 'transfer', targetId: priorityTowerEnergySink.id as Id<AnyStoreStructure> };
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'transfer',
+      targetId: priorityTowerEnergySink.id as Id<AnyStoreStructure>
+    });
   }
 
   if (!remoteProductiveSpendingSuppressed) {
@@ -280,7 +276,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     constructionReservationContext
   );
   if (readyFollowUpProductiveEnergySinkTask) {
-    return readyFollowUpProductiveEnergySinkTask;
+    return applyMinimumUsefulLoadPolicy(creep, readyFollowUpProductiveEnergySinkTask);
   }
 
   if (territoryControllerTask) {
@@ -291,20 +287,23 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     ? selectSource2ControllerLaneLoadedTask(creep, controller, constructionSites, constructionReservationContext)
     : null;
   if (source2ControllerLaneLoadedTask) {
-    return source2ControllerLaneLoadedTask;
+    return applyMinimumUsefulLoadPolicy(creep, source2ControllerLaneLoadedTask);
   }
 
   if (capacityConstructionSite) {
-    return { type: 'build', targetId: capacityConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: capacityConstructionSite.id });
   }
 
   if (controller && shouldRushRcl1Controller(controller)) {
-    return { type: 'upgrade', targetId: controller.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id });
   }
 
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
-    return { type: 'repair', targetId: criticalRepairTarget.id as Id<Structure> };
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'repair',
+      targetId: criticalRepairTarget.id as Id<Structure>
+    });
   }
 
   if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
@@ -317,7 +316,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     constructionReservationContext
   );
   if (criticalRoadConstructionSite) {
-    return { type: 'build', targetId: criticalRoadConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: criticalRoadConstructionSite.id });
   }
 
   const containerConstructionSite = selectUnreservedConstructionSite(
@@ -327,15 +326,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     isContainerConstructionSite
   );
   if (containerConstructionSite) {
-    return { type: 'build', targetId: containerConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: containerConstructionSite.id });
   }
 
   if (controller && shouldUseSurplusForControllerProgress(creep, controller)) {
-    const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
-    if (lowLoadEnergyContinuationTask) {
-      return lowLoadEnergyContinuationTask;
-    }
-
     const productiveEnergySinkTask = selectNearbyProductiveEnergySinkTask(
       creep,
       constructionSites,
@@ -343,10 +337,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
       constructionReservationContext
     );
     if (productiveEnergySinkTask) {
-      return productiveEnergySinkTask;
+      return applyMinimumUsefulLoadPolicy(creep, productiveEnergySinkTask);
     }
 
-    return { type: 'upgrade', targetId: controller.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id });
   }
 
   const roadConstructionSite = selectUnreservedConstructionSite(
@@ -356,7 +350,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     isRoadConstructionSite
   );
   if (roadConstructionSite) {
-    return { type: 'build', targetId: roadConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: roadConstructionSite.id });
   }
 
   const constructionSite = selectUnreservedConstructionSite(
@@ -365,21 +359,16 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     constructionReservationContext
   );
   if (constructionSite) {
-    return { type: 'build', targetId: constructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: constructionSite.id });
   }
 
   const repairTarget = selectRepairTarget(creep);
   if (repairTarget) {
-    return { type: 'repair', targetId: repairTarget.id as Id<Structure> };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'repair', targetId: repairTarget.id as Id<Structure> });
   }
 
   if (controller?.my) {
-    const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
-    if (lowLoadEnergyContinuationTask) {
-      return lowLoadEnergyContinuationTask;
-    }
-
-    return { type: 'upgrade', targetId: controller.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id });
   }
 
   return null;
@@ -442,7 +431,7 @@ function selectBootstrapSurvivalSpendingTask(
     shouldRushRcl1Controller(controller) &&
     !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)
   ) {
-    return { type: 'upgrade', targetId: controller.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id });
   }
 
   if (recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep)) {
@@ -451,7 +440,10 @@ function selectBootstrapSurvivalSpendingTask(
 
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
-    return { type: 'repair', targetId: criticalRepairTarget.id as Id<Structure> };
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'repair',
+      targetId: criticalRepairTarget.id as Id<Structure>
+    });
   }
 
   if (shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep)) {
@@ -464,7 +456,7 @@ function selectBootstrapSurvivalSpendingTask(
     constructionReservationContext
   );
   if (criticalRoadConstructionSite) {
-    return { type: 'build', targetId: criticalRoadConstructionSite.id };
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: criticalRoadConstructionSite.id });
   }
 
   return null;
@@ -516,58 +508,14 @@ function isTerritoryControlTask(task: CreepTaskMemory | null): task is Extract<C
   return task?.type === 'claim' || task?.type === 'reserve';
 }
 
-function shouldPrioritizeSpawnOrExtensionRefill(creep: Creep): boolean {
+function hasEmergencySpawnExtensionRefillDemand(creep: Creep): boolean {
   const energyAvailable = getRoomEnergyAvailable(creep.room);
-  if (energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD) {
-    return true;
-  }
-
-  if (hasSpawnRecoveryRefillPressure(creep, energyAvailable)) {
-    return true;
-  }
-
-  if (hasReservedTerritoryFollowUpRefillCapacity(creep) && !hasReadyTerritoryFollowUpEnergy(creep)) {
-    return true;
-  }
-
-  return hasNearTermSpawnCompletionRefillDemand(creep.room);
-}
-
-function selectUrgentRefillMinLoadContinuationTask(
-  creep: Creep,
-  energySink: SpawnExtensionEnergyStructure
-): LowLoadWorkerEnergyAcquisitionTask | null {
-  if (getUsedEnergy(creep) >= REFILL_DELIVERY_MIN_LOAD) {
-    return null;
-  }
-
-  if (getFreeStoredEnergyCapacity(energySink) <= REFILL_DELIVERY_SIGNIFICANT_TARGET_NEED) {
-    return null;
-  }
-
-  return selectLowLoadWorkerEnergyContinuationTask(creep);
-}
-
-function hasSpawnRecoveryRefillPressure(creep: Creep, energyAvailable: number): boolean {
-  const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
-  if (!survivalAssessment || survivalAssessment.workerCapacity >= survivalAssessment.workerTarget) {
-    return false;
-  }
-
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
-  return (
-    energyCapacityAvailable !== null &&
-    energyCapacityAvailable > 0 &&
-    energyAvailable < energyCapacityAvailable * SPAWN_RECOVERY_REFILL_PRESSURE_RATIO
-  );
-}
-
-function hasNearTermSpawnCompletionRefillDemand(room: Room): boolean {
-  return findSpawnExtensionEnergyStructures(room).some(isNearTermSpawningSpawn);
+  return energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 
 interface LowLoadWorkerEnergyContext {
   carriedEnergy: number;
+  capacity: number;
   freeCapacity: number;
 }
 
@@ -578,12 +526,32 @@ function getLowLoadWorkerEnergyContext(creep: Creep): LowLoadWorkerEnergyContext
     return null;
   }
 
-  const capacity = carriedEnergy + freeCapacity;
-  const lowLoadEnergyLimit = Math.min(
-    LOW_LOAD_WORKER_ENERGY_CEILING,
-    Math.max(1, Math.floor(capacity * LOW_LOAD_WORKER_ENERGY_RATIO))
-  );
-  return carriedEnergy <= lowLoadEnergyLimit ? { carriedEnergy, freeCapacity } : null;
+  const capacity = getEnergyCapacity(creep, carriedEnergy, freeCapacity);
+  return capacity > 0 && carriedEnergy < capacity * MINIMUM_USEFUL_LOAD_RATIO
+    ? { carriedEnergy, capacity, freeCapacity }
+    : null;
+}
+
+function applyMinimumUsefulLoadPolicy(
+  creep: Creep,
+  task: WorkerEnergySpendingTask
+): WorkerEnergySpendingTask | LowLoadWorkerEnergyAcquisitionTask {
+  if (!getLowLoadWorkerEnergyContext(creep)) {
+    return task;
+  }
+
+  if (hasVisibleHostilePresence(creep.room)) {
+    recordLowLoadReturnTelemetry(creep, task, 'hostileSafety');
+    return task;
+  }
+
+  const lowLoadEnergyContinuationTask = selectLowLoadWorkerEnergyContinuationTask(creep);
+  if (lowLoadEnergyContinuationTask) {
+    return lowLoadEnergyContinuationTask;
+  }
+
+  recordLowLoadReturnTelemetry(creep, task, 'noReachableEnergy');
+  return task;
 }
 
 function clearWorkerEfficiencyTelemetry(creep: Creep): void {
@@ -617,7 +585,7 @@ function recordNearbyEnergyChoiceTelemetry(
 
 function recordLowLoadReturnTelemetry(
   creep: Creep,
-  task: Extract<CreepTaskMemory, { type: 'transfer' }>,
+  task: WorkerEnergySpendingTask,
   reason: WorkerEfficiencyLowLoadReturnReason
 ): void {
   const context = getLowLoadWorkerEnergyContext(creep);
@@ -3076,6 +3044,7 @@ function getFreeEnergyCapacity(creep: Creep): number {
 }
 
 interface StoreLike {
+  getCapacity?: (resource?: ResourceConstant) => number | null;
   getUsedCapacity?: (resource?: ResourceConstant) => number | null;
   getFreeCapacity?: (resource?: ResourceConstant) => number | null;
   [resource: string]: unknown;
@@ -3104,6 +3073,20 @@ function getFreeStoredEnergyCapacity(object: unknown): number {
 
   const freeCapacity = store.getFreeCapacity?.(getWorkerEnergyResource());
   return typeof freeCapacity === 'number' ? freeCapacity : 0;
+}
+
+function getEnergyCapacity(
+  creep: Creep,
+  carriedEnergy = getUsedEnergy(creep),
+  freeCapacity = getFreeEnergyCapacity(creep)
+): number {
+  const store = getStore(creep);
+  const capacity = store?.getCapacity?.(getWorkerEnergyResource());
+  if (typeof capacity === 'number' && Number.isFinite(capacity) && capacity > 0) {
+    return capacity;
+  }
+
+  return Math.max(0, carriedEnergy + freeCapacity);
 }
 
 function getStore(object: unknown): StoreLike | null {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -22,6 +22,7 @@ export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
 const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+const MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 const MAX_REFILL_DELIVERY_SAMPLES = 5;
 const MAX_TERRITORY_INTENT_SUMMARIES = 5;
 const WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
@@ -122,13 +123,24 @@ interface RuntimeProductiveEnergySummary {
 
 interface RuntimeWorkerEfficiencySummary {
   lowLoadReturnCount: number;
+  emergencyLowLoadReturnCount: number;
+  avoidableLowLoadReturnCount: number;
   nearbyEnergyChoiceCount: number;
+  lowLoadReturnReasons?: RuntimeWorkerEfficiencyLowLoadReturnReasonSummary[];
   samples: RuntimeWorkerEfficiencySampleSummary[];
   omittedSampleCount?: number;
 }
 
 interface RuntimeWorkerEfficiencySampleSummary extends WorkerEfficiencySampleMemory {
   creepName?: string;
+}
+
+type RuntimeWorkerEfficiencyLowLoadReturnCategory = 'emergency' | 'avoidable';
+
+interface RuntimeWorkerEfficiencyLowLoadReturnReasonSummary {
+  reason: WorkerEfficiencyLowLoadReturnReason | 'unknown';
+  category: RuntimeWorkerEfficiencyLowLoadReturnCategory;
+  count: number;
 }
 
 interface RuntimeWorkerEfficiencySampleEntry {
@@ -475,17 +487,83 @@ function summarizeWorkerEfficiency(
   }
 
   const reportedSamples = samples.slice(0, MAX_WORKER_EFFICIENCY_SAMPLES).map(toRuntimeWorkerEfficiencySample);
+  const lowLoadReturnSamples = samples.filter((entry) => entry.sample.type === 'lowLoadReturn');
+  const emergencyLowLoadReturnCount = lowLoadReturnSamples.filter((entry) =>
+    isEmergencyLowLoadReturnReason(getLowLoadReturnReason(entry.sample))
+  ).length;
+  const lowLoadReturnReasons = summarizeLowLoadReturnReasons(lowLoadReturnSamples);
 
   return {
     workerEfficiency: {
-      lowLoadReturnCount: samples.filter((entry) => entry.sample.type === 'lowLoadReturn').length,
+      lowLoadReturnCount: lowLoadReturnSamples.length,
+      emergencyLowLoadReturnCount,
+      avoidableLowLoadReturnCount: lowLoadReturnSamples.length - emergencyLowLoadReturnCount,
       nearbyEnergyChoiceCount: samples.filter((entry) => entry.sample.type === 'nearbyEnergyChoice').length,
+      ...(lowLoadReturnReasons.length > 0 ? { lowLoadReturnReasons } : {}),
       samples: reportedSamples,
       ...(samples.length > MAX_WORKER_EFFICIENCY_SAMPLES
         ? { omittedSampleCount: samples.length - MAX_WORKER_EFFICIENCY_SAMPLES }
         : {})
     }
   };
+}
+
+function summarizeLowLoadReturnReasons(
+  samples: RuntimeWorkerEfficiencySampleEntry[]
+): RuntimeWorkerEfficiencyLowLoadReturnReasonSummary[] {
+  const countsByReason = new Map<WorkerEfficiencyLowLoadReturnReason | 'unknown', number>();
+  for (const entry of samples) {
+    const reason = getLowLoadReturnReason(entry.sample);
+    countsByReason.set(reason, (countsByReason.get(reason) ?? 0) + 1);
+  }
+
+  return [...countsByReason.entries()]
+    .map(([reason, count]) => ({
+      reason,
+      category: getLowLoadReturnReasonCategory(reason),
+      count
+    }))
+    .sort(compareLowLoadReturnReasonSummaries)
+    .slice(0, MAX_WORKER_EFFICIENCY_REASON_SAMPLES);
+}
+
+function compareLowLoadReturnReasonSummaries(
+  left: RuntimeWorkerEfficiencyLowLoadReturnReasonSummary,
+  right: RuntimeWorkerEfficiencyLowLoadReturnReasonSummary
+): number {
+  return right.count - left.count || left.reason.localeCompare(right.reason);
+}
+
+function getLowLoadReturnReason(
+  sample: WorkerEfficiencySampleMemory
+): WorkerEfficiencyLowLoadReturnReason | 'unknown' {
+  return isLowLoadReturnReason(sample.reason) ? sample.reason : 'unknown';
+}
+
+function getLowLoadReturnReasonCategory(
+  reason: WorkerEfficiencyLowLoadReturnReason | 'unknown'
+): RuntimeWorkerEfficiencyLowLoadReturnCategory {
+  return isEmergencyLowLoadReturnReason(reason) ? 'emergency' : 'avoidable';
+}
+
+function isEmergencyLowLoadReturnReason(reason: WorkerEfficiencyLowLoadReturnReason | 'unknown'): boolean {
+  return (
+    reason === 'emergencySpawnExtensionRefill' ||
+    reason === 'controllerDowngradeGuard' ||
+    reason === 'hostileSafety' ||
+    reason === 'urgentSpawnExtensionRefill'
+  );
+}
+
+function isLowLoadReturnReason(value: unknown): value is WorkerEfficiencyLowLoadReturnReason {
+  return (
+    value === 'emergencySpawnExtensionRefill' ||
+    value === 'controllerDowngradeGuard' ||
+    value === 'hostileSafety' ||
+    value === 'noReachableEnergy' ||
+    value === 'urgentSpawnExtensionRefill' ||
+    value === 'noNearbyEnergy'
+  );
 }
 
 function compareWorkerEfficiencySampleEntries(

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -154,7 +154,13 @@ declare global {
   }
 
   type WorkerEfficiencySampleType = 'lowLoadReturn' | 'nearbyEnergyChoice';
-  type WorkerEfficiencyLowLoadReturnReason = 'urgentSpawnExtensionRefill' | 'noNearbyEnergy';
+  type WorkerEfficiencyLowLoadReturnReason =
+    | 'emergencySpawnExtensionRefill'
+    | 'controllerDowngradeGuard'
+    | 'hostileSafety'
+    | 'noReachableEnergy'
+    | 'urgentSpawnExtensionRefill'
+    | 'noNearbyEnergy';
 
   interface WorkerEfficiencySampleMemory {
     type: WorkerEfficiencySampleType;

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -409,6 +409,11 @@ describe('runtime telemetry summaries', () => {
 
   it('reports bounded room-level worker efficiency samples', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const lowLoadReturnReasons: WorkerEfficiencyLowLoadReturnReason[] = [
+      'noReachableEnergy',
+      'emergencySpawnExtensionRefill',
+      'hostileSafety'
+    ];
     const recentWorkers = Array.from({ length: 7 }, (_, index) =>
       makeWorker(
         {
@@ -433,7 +438,7 @@ describe('runtime telemetry summaries', () => {
                   freeCapacity: 45,
                   selectedTask: 'transfer',
                   targetId: `spawn-${index}`,
-                  reason: 'noNearbyEnergy'
+                  reason: lowLoadReturnReasons[Math.floor(index / 2)]
                 }
         },
         5,
@@ -451,7 +456,7 @@ describe('runtime telemetry summaries', () => {
           freeCapacity: 45,
           selectedTask: 'transfer',
           targetId: 'spawn-stale',
-          reason: 'urgentSpawnExtensionRefill'
+          reason: 'emergencySpawnExtensionRefill'
         }
       },
       5,
@@ -464,7 +469,26 @@ describe('runtime telemetry summaries', () => {
     const [room] = payload.rooms as Array<Record<string, unknown>>;
     expect(room.workerEfficiency).toEqual({
       lowLoadReturnCount: 3,
+      emergencyLowLoadReturnCount: 2,
+      avoidableLowLoadReturnCount: 1,
       nearbyEnergyChoiceCount: 4,
+      lowLoadReturnReasons: [
+        {
+          reason: 'emergencySpawnExtensionRefill',
+          category: 'emergency',
+          count: 1
+        },
+        {
+          reason: 'hostileSafety',
+          category: 'emergency',
+          count: 1
+        },
+        {
+          reason: 'noReachableEnergy',
+          category: 'avoidable',
+          count: 1
+        }
+      ],
       samples: [
         {
           creepName: 'Worker0',
@@ -485,7 +509,7 @@ describe('runtime telemetry summaries', () => {
           freeCapacity: 45,
           selectedTask: 'transfer',
           targetId: 'spawn-1',
-          reason: 'noNearbyEnergy'
+          reason: 'noReachableEnergy'
         },
         {
           creepName: 'Worker2',
@@ -506,7 +530,7 @@ describe('runtime telemetry summaries', () => {
           freeCapacity: 45,
           selectedTask: 'transfer',
           targetId: 'spawn-3',
-          reason: 'noNearbyEnergy'
+          reason: 'emergencySpawnExtensionRefill'
         },
         {
           creepName: 'Worker4',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4,7 +4,7 @@ import {
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   LOW_LOAD_NEARBY_ENERGY_RANGE,
   LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
-  REFILL_DELIVERY_MIN_LOAD,
+  MINIMUM_USEFUL_LOAD_RATIO,
   TOWER_REFILL_ENERGY_FLOOR,
   URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
   estimateNearTermSpawnExtensionRefillReserve,
@@ -1978,8 +1978,8 @@ describe('selectWorkerTask', () => {
         }
       },
       store: {
-        getUsedCapacity: jest.fn().mockReturnValue(50),
-        getFreeCapacity: jest.fn().mockReturnValue(150)
+        getUsedCapacity: jest.fn().mockReturnValue(100),
+        getFreeCapacity: jest.fn().mockReturnValue(100)
       },
       room: {
         energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
@@ -2060,6 +2060,8 @@ describe('selectWorkerTask', () => {
   it('keeps a low-load worker harvesting instead of making a non-urgent primary refill trip', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const source = { id: 'source1', energy: 300 } as Source;
+    const capacity = 50;
+    const carriedEnergy = Math.ceil(capacity * MINIMUM_USEFUL_LOAD_RATIO) - 1;
     const getRangeTo = jest.fn((target: { id: string }) => {
       const ranges: Record<string, number> = {
         source1: 6,
@@ -2091,8 +2093,9 @@ describe('selectWorkerTask', () => {
     const creep = {
       memory: { role: 'worker' },
       store: {
-        getUsedCapacity: jest.fn().mockReturnValue(2),
-        getFreeCapacity: jest.fn().mockReturnValue(48)
+        getCapacity: jest.fn().mockReturnValue(capacity),
+        getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy),
+        getFreeCapacity: jest.fn().mockReturnValue(capacity - carriedEnergy)
       },
       pos: { getRangeTo },
       room: {
@@ -2106,8 +2109,8 @@ describe('selectWorkerTask', () => {
     expect(creep.memory.workerEfficiency).toEqual({
       type: 'nearbyEnergyChoice',
       tick: 327,
-      carriedEnergy: 2,
-      freeCapacity: 48,
+      carriedEnergy,
+      freeCapacity: capacity - carriedEnergy,
       selectedTask: 'harvest',
       targetId: 'source1',
       energy: 300,
@@ -2115,10 +2118,61 @@ describe('selectWorkerTask', () => {
     });
   });
 
+  it('lets a worker at the minimum useful load proceed with normal refill', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const source = { id: 'source1', energy: 300 } as Source;
+    const capacity = 50;
+    const carriedEnergy = Math.ceil(capacity * MINIMUM_USEFUL_LOAD_RATIO);
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        source1: 1,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_STRUCTURES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return type === FIND_SOURCES ? [source] : [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getCapacity: jest.fn().mockReturnValue(capacity),
+        getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy),
+        getFreeCapacity: jest.fn().mockReturnValue(capacity - carriedEnergy)
+      },
+      pos: { getRangeTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toBeUndefined();
+  });
+
   it.each([
     ['spawn', 'spawn1'],
     ['extension', 'extension1']
-  ])('keeps urgent %s refill worker acquiring energy until the min delivery load during spawn recovery', (structureType, id) => {
+  ])('keeps %s refill worker acquiring energy until the minimum useful load during spawn recovery', (structureType, id) => {
     const energySink = makeEnergySink(id, structureType as StructureConstant, 300);
     const lowEnergySource = makeSource('source-low', 8, 8, 10);
     const loadReadySource = makeSource('source-ready', 20, 20, 300);
@@ -2165,6 +2219,7 @@ describe('selectWorkerTask', () => {
   it('returns early for urgent refill when the only visible source is depleted', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const depletedSource = makeSource('source-empty', 8, 8, 0);
+    const carriedEnergy = 2;
     const getRangeTo = jest.fn((target: { id: string }) => {
       const ranges: Record<string, number> = {
         'source-empty': 1,
@@ -2182,8 +2237,8 @@ describe('selectWorkerTask', () => {
       name: 'RecoveryCarrier',
       memory: { role: 'worker', colony: 'W1N1' },
       store: {
-        getUsedCapacity: jest.fn().mockReturnValue(REFILL_DELIVERY_MIN_LOAD - 1),
-        getFreeCapacity: jest.fn().mockReturnValue(81)
+        getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
       },
       pos: { getRangeTo },
       room
@@ -2194,11 +2249,11 @@ describe('selectWorkerTask', () => {
     expect(creep.memory.workerEfficiency).toEqual({
       type: 'lowLoadReturn',
       tick: 0,
-      carriedEnergy: REFILL_DELIVERY_MIN_LOAD - 1,
-      freeCapacity: 81,
+      carriedEnergy,
+      freeCapacity: 48,
       selectedTask: 'transfer',
       targetId: 'spawn1',
-      reason: 'urgentSpawnExtensionRefill'
+      reason: 'emergencySpawnExtensionRefill'
     });
   });
 
@@ -2396,7 +2451,7 @@ describe('selectWorkerTask', () => {
       freeCapacity: 48,
       selectedTask: 'transfer',
       targetId: 'spawn1',
-      reason: 'noNearbyEnergy'
+      reason: 'noReachableEnergy'
     });
   });
 
@@ -2646,7 +2701,7 @@ describe('selectWorkerTask', () => {
       freeCapacity: 40,
       selectedTask: 'transfer',
       targetId: 'spawn1',
-      reason: 'noNearbyEnergy'
+      reason: 'noReachableEnergy'
     });
     expect(findPathTo).toHaveBeenCalledWith(blockedDroppedEnergy, { ignoreCreeps: true });
   });
@@ -2700,7 +2755,7 @@ describe('selectWorkerTask', () => {
       freeCapacity: 40,
       selectedTask: 'transfer',
       targetId: 'spawn1',
-      reason: 'noNearbyEnergy'
+      reason: 'noReachableEnergy'
     });
     expect(getActiveBodyparts).toHaveBeenCalledWith('work');
   });
@@ -2838,7 +2893,7 @@ describe('selectWorkerTask', () => {
     expect(findPathTo).not.toHaveBeenCalled();
   });
 
-  it('keeps urgent spawn refill worker acquiring nearby energy while below the min delivery load', () => {
+  it('lets emergency spawn refill preempt the minimum useful load requirement', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const droppedEnergy = { id: 'drop-near', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;
     const getRangeTo = jest.fn((target: { id: string }) => (target.id === 'drop-near' ? 1 : 99));
@@ -2880,20 +2935,100 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 322 };
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-near' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
     expect(creep.memory.workerEfficiency).toEqual({
-      type: 'nearbyEnergyChoice',
+      type: 'lowLoadReturn',
       tick: 322,
       carriedEnergy: 10,
       freeCapacity: 40,
-      selectedTask: 'pickup',
-      targetId: 'drop-near',
-      energy: 50,
-      range: 1
+      selectedTask: 'transfer',
+      targetId: 'spawn1',
+      reason: 'emergencySpawnExtensionRefill'
     });
   });
 
-  it('keeps urgent tower refill allowed for low-load workers that could keep harvesting', () => {
+  it('lets controller downgrade guard preempt the minimum useful load requirement', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        controller1: 2,
+        source1: 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const room = makeWorkerTaskRoom({
+      controller,
+      sources: [source]
+    });
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 335 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 335,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'upgrade',
+      targetId: 'controller1',
+      reason: 'controllerDowngradeGuard'
+    });
+  });
+
+  it('lets hostile safety conditions preempt the minimum useful load requirement', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const source = { id: 'source1', energy: 300 } as Source;
+    const hostile = { id: 'hostile1' } as Creep;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        source1: 1,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const room = makeWorkerTaskRoom({
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+      hostileCreeps: [hostile],
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [source]
+    });
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 336 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 336,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'transfer',
+      targetId: 'spawn1',
+      reason: 'hostileSafety'
+    });
+  });
+
+  it('keeps low-load workers acquiring before non-emergency tower refill', () => {
     const lowTower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
     const source = { id: 'source1', energy: 300 } as Source;
     const getRangeTo = jest.fn((target: { id: string }) => {
@@ -2938,7 +3073,7 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
     creep.room.find = roomFind as unknown as Room['find'];
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
   it('keeps a low-load worker harvesting instead of making a normal controller upgrade trip', () => {


### PR DESCRIPTION
## Summary
Enforce minimum useful worker load before non-urgent energy spending. Workers must carry enough energy for a useful action before spending on non-urgent tasks, improving economy throughput under energy-constrained conditions.

Closes #485

## Verification
- `npm run typecheck`: PASS
- `npm test -- --runInBand`: PASS (26 suites, 709 tests)
- `npm run build`: PASS
- `git diff --check`: clean

## Changes
| File | Purpose |
|---|---|
| `prod/src/creeps/workerRunner.ts` | Minimum load enforcement in worker run loop |
| `prod/src/tasks/workerTasks.ts` | Worker task energy load thresholds |
| `prod/src/telemetry/runtimeSummary.ts` | Telemetry for worker load decisions |
| `prod/src/types.d.ts` | Type definitions for min load config |
| `prod/test/runtimeSummary.test.ts` | Telemetry coverage |
| `prod/test/workerTasks.test.ts` | Load enforcement tests |
| `prod/dist/main.js` | Generated bundle |

## Commit
`b3dc524` — lanyusea's bot <lanyusea@gmail.com>
