### PR TITLE
feat(territory): post-claim room bootstrap and initial economy setup

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9157,7 +9157,6 @@ var OK_CODE3 = 0;
 var ERR_INVALID_TARGET_CODE = -7;
 var ROOM_EDGE_MIN4 = 2;
 var ROOM_EDGE_MAX4 = 47;
-var MAX_SPAWN_SITE_SCAN_RADIUS = 6;
 var DEFAULT_TERRAIN_WALL_MASK3 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
@@ -9336,8 +9335,9 @@ function findInitialSpawnConstructionPosition(room) {
   if (!anchor) {
     return null;
   }
-  const lookups = buildSpawnPlacementLookups(room, anchor);
-  for (let radius = 0; radius <= MAX_SPAWN_SITE_SCAN_RADIUS; radius += 1) {
+  const maximumScanRadius = getMaximumSpawnSiteScanRadius(anchor);
+  const lookups = buildSpawnPlacementLookups(room, anchor, maximumScanRadius);
+  for (let radius = 0; radius <= maximumScanRadius; radius += 1) {
     for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
       for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
         if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
@@ -9367,13 +9367,13 @@ function selectInitialSpawnAnchor(room) {
     y: Math.round((controllerPosition.y + nearestSourcePosition.y) / 2)
   });
 }
-function buildSpawnPlacementLookups(room, anchor) {
+function buildSpawnPlacementLookups(room, anchor, maximumScanRadius) {
   const blockingPositions = /* @__PURE__ */ new Set();
   for (const object of [
     room.controller,
     ...findSources(room),
-    ...lookForArea(room, "LOOK_STRUCTURES", anchor),
-    ...lookForArea(room, "LOOK_CONSTRUCTION_SITES", anchor)
+    ...lookForArea(room, "LOOK_STRUCTURES", anchor, maximumScanRadius),
+    ...lookForArea(room, "LOOK_CONSTRUCTION_SITES", anchor, maximumScanRadius)
   ]) {
     const position = getRoomObjectPosition2(object);
     if (position) {
@@ -9385,12 +9385,12 @@ function buildSpawnPlacementLookups(room, anchor) {
     terrain: getRoomTerrain3(room.name)
   };
 }
-function lookForArea(room, lookConstantName, anchor) {
+function lookForArea(room, lookConstantName, anchor, maximumScanRadius) {
   const lookConstant = getGlobalString(lookConstantName);
   if (!lookConstant || typeof room.lookForAtArea !== "function") {
     return [];
   }
-  const bounds = getScanBounds2(anchor);
+  const bounds = getScanBounds2(anchor, maximumScanRadius);
   return room.lookForAtArea(
     lookConstant,
     bounds.top,
@@ -9400,12 +9400,12 @@ function lookForArea(room, lookConstantName, anchor) {
     true
   );
 }
-function getScanBounds2(anchor) {
+function getScanBounds2(anchor, maximumScanRadius) {
   return {
-    top: Math.max(ROOM_EDGE_MIN4, anchor.y - MAX_SPAWN_SITE_SCAN_RADIUS),
-    left: Math.max(ROOM_EDGE_MIN4, anchor.x - MAX_SPAWN_SITE_SCAN_RADIUS),
-    bottom: Math.min(ROOM_EDGE_MAX4, anchor.y + MAX_SPAWN_SITE_SCAN_RADIUS),
-    right: Math.min(ROOM_EDGE_MAX4, anchor.x + MAX_SPAWN_SITE_SCAN_RADIUS)
+    top: Math.max(ROOM_EDGE_MIN4, anchor.y - maximumScanRadius),
+    left: Math.max(ROOM_EDGE_MIN4, anchor.x - maximumScanRadius),
+    bottom: Math.min(ROOM_EDGE_MAX4, anchor.y + maximumScanRadius),
+    right: Math.min(ROOM_EDGE_MAX4, anchor.x + maximumScanRadius)
   };
 }
 function canPlaceInitialSpawn(lookups, position) {
@@ -9506,6 +9506,14 @@ function clampPosition(position) {
 }
 function clamp(value, min, max) {
   return Math.max(min, Math.min(max, value));
+}
+function getMaximumSpawnSiteScanRadius(anchor) {
+  return Math.max(
+    anchor.x - ROOM_EDGE_MIN4,
+    ROOM_EDGE_MAX4 - anchor.x,
+    anchor.y - ROOM_EDGE_MIN4,
+    ROOM_EDGE_MAX4 - anchor.y
+  );
 }
 function getRange(left, right) {
   return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5477,6 +5477,9 @@ function selectWorkerTask(creep) {
     controller,
     constructionReservationContext
   );
+  if (territoryControllerTask && capacityConstructionSite && isSpawnConstructionSite(capacityConstructionSite)) {
+    return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
+  }
   if (!territoryControllerTask) {
     const baselineLogisticsConstructionSite = selectBaselineLogisticsConstructionSiteBeforeAdditionalExtension(
       creep,
@@ -9148,6 +9151,407 @@ function matchesStructureType5(actual, globalName, fallback) {
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 
+// src/territory/postClaimBootstrap.ts
+var POST_CLAIM_BOOTSTRAP_WORKER_TARGET = 2;
+var OK_CODE3 = 0;
+var ERR_INVALID_TARGET_CODE = -7;
+var ROOM_EDGE_MIN4 = 2;
+var ROOM_EDGE_MAX4 = 47;
+var MAX_SPAWN_SITE_SCAN_RADIUS = 6;
+var DEFAULT_TERRAIN_WALL_MASK3 = 1;
+function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
+  var _a, _b;
+  if (!isNonEmptyString6(input.colony) || !isNonEmptyString6(input.roomName)) {
+    return;
+  }
+  const bootstraps = getWritablePostClaimBootstrapRecords();
+  if (!bootstraps) {
+    return;
+  }
+  const gameTime = getGameTime6();
+  const existing = getPostClaimBootstrapRecord(input.roomName);
+  const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
+  bootstraps[input.roomName] = {
+    colony: input.colony,
+    roomName: input.roomName,
+    status: "detected",
+    claimedAt,
+    updatedAt: gameTime,
+    workerTarget: (_b = existing == null ? void 0 : existing.workerTarget) != null ? _b : POST_CLAIM_BOOTSTRAP_WORKER_TARGET,
+    ...input.controllerId ? { controllerId: input.controllerId } : {}
+  };
+  telemetryEvents.push({
+    type: "postClaimBootstrap",
+    roomName: input.roomName,
+    colony: input.colony,
+    phase: "detected",
+    ...input.controllerId ? { controllerId: input.controllerId } : {},
+    workerTarget: POST_CLAIM_BOOTSTRAP_WORKER_TARGET
+  });
+}
+function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents = []) {
+  var _a, _b;
+  const roomName = colony.room.name;
+  const record = getPostClaimBootstrapRecord(roomName);
+  if (!record || record.status === "ready" || ((_a = colony.room.controller) == null ? void 0 : _a.my) !== true) {
+    return { active: false, spawnConstructionPending: false };
+  }
+  const workerTarget = getPostClaimBootstrapWorkerTarget(record);
+  const workerCount = (_b = roleCounts.worker) != null ? _b : 0;
+  const spawnCount = colony.spawns.length;
+  if (spawnCount > 0 && workerCount >= workerTarget) {
+    updatePostClaimBootstrapRecord(roomName, {
+      status: "ready",
+      updatedAt: gameTime,
+      workerTarget
+    });
+    telemetryEvents.push({
+      type: "postClaimBootstrap",
+      roomName,
+      colony: record.colony,
+      phase: "ready",
+      ...record.controllerId ? { controllerId: record.controllerId } : {},
+      workerCount,
+      workerTarget,
+      spawnCount
+    });
+    return { active: false, spawnConstructionPending: false };
+  }
+  if (spawnCount > 0) {
+    updatePostClaimBootstrapRecord(roomName, {
+      status: "spawningWorkers",
+      updatedAt: gameTime,
+      workerTarget
+    });
+    return { active: true, spawnConstructionPending: false };
+  }
+  const existingSpawnSite = findExistingSpawnConstructionSite(colony.room);
+  if (existingSpawnSite) {
+    const spawnSite = toSpawnSiteMemory(existingSpawnSite);
+    const shouldReportExistingSite = record.status !== "spawnSitePending" || !isSameSpawnSite(record.spawnSite, spawnSite);
+    updatePostClaimBootstrapRecord(roomName, {
+      status: "spawnSitePending",
+      updatedAt: gameTime,
+      workerTarget,
+      spawnSite,
+      lastResult: OK_CODE3
+    });
+    if (shouldReportExistingSite) {
+      telemetryEvents.push({
+        type: "postClaimBootstrap",
+        roomName,
+        colony: record.colony,
+        phase: "spawnSite",
+        ...record.controllerId ? { controllerId: record.controllerId } : {},
+        result: OK_CODE3,
+        spawnSite,
+        workerCount,
+        workerTarget,
+        spawnCount
+      });
+    }
+    return { active: true, spawnConstructionPending: true };
+  }
+  const sitePlan = planInitialSpawnConstructionSite(colony.room);
+  const nextStatus = sitePlan.result === OK_CODE3 ? "spawnSitePending" : "spawnSiteBlocked";
+  const shouldReportSitePlan = record.status !== nextStatus || record.lastResult !== sitePlan.result || sitePlan.position !== void 0 && !isSameSpawnSite(record.spawnSite, sitePlan.position);
+  updatePostClaimBootstrapRecord(roomName, {
+    status: nextStatus,
+    updatedAt: gameTime,
+    workerTarget,
+    ...sitePlan.position ? { spawnSite: sitePlan.position } : {},
+    lastResult: sitePlan.result
+  });
+  if (shouldReportSitePlan) {
+    telemetryEvents.push({
+      type: "postClaimBootstrap",
+      roomName,
+      colony: record.colony,
+      phase: "spawnSite",
+      ...record.controllerId ? { controllerId: record.controllerId } : {},
+      result: sitePlan.result,
+      ...sitePlan.position ? { spawnSite: sitePlan.position } : {},
+      workerCount,
+      workerTarget,
+      spawnCount
+    });
+  }
+  return { active: true, spawnConstructionPending: true };
+}
+function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
+  if (!isNonEmptyString6(roomName)) {
+    return;
+  }
+  const record = getPostClaimBootstrapRecord(roomName);
+  if (!record || record.status === "ready") {
+    return;
+  }
+  updatePostClaimBootstrapRecord(roomName, {
+    status: "spawningWorkers",
+    updatedAt: getGameTime6()
+  });
+  telemetryEvents.push({
+    type: "postClaimBootstrap",
+    roomName,
+    colony: record.colony,
+    phase: "workerSpawn",
+    ...record.controllerId ? { controllerId: record.controllerId } : {},
+    spawnName,
+    creepName,
+    result,
+    workerTarget: getPostClaimBootstrapWorkerTarget(record)
+  });
+}
+function getPostClaimBootstrapSummary(roomName) {
+  const record = getPostClaimBootstrapRecord(roomName);
+  if (!record || record.status === "ready") {
+    return null;
+  }
+  return {
+    colony: record.colony,
+    status: record.status,
+    claimedAt: record.claimedAt,
+    updatedAt: record.updatedAt,
+    workerTarget: getPostClaimBootstrapWorkerTarget(record),
+    ...record.controllerId ? { controllerId: record.controllerId } : {},
+    ...record.spawnSite ? { spawnSite: record.spawnSite } : {},
+    ...record.lastResult !== void 0 ? { lastResult: record.lastResult } : {}
+  };
+}
+function planInitialSpawnConstructionSite(room) {
+  if (typeof room.createConstructionSite !== "function") {
+    return { result: ERR_INVALID_TARGET_CODE };
+  }
+  const position = findInitialSpawnConstructionPosition(room);
+  if (!position) {
+    return { result: ERR_INVALID_TARGET_CODE };
+  }
+  return {
+    result: room.createConstructionSite(position.x, position.y, getStructureConstant("STRUCTURE_SPAWN", "spawn")),
+    position: { ...position, roomName: room.name }
+  };
+}
+function findInitialSpawnConstructionPosition(room) {
+  const anchor = selectInitialSpawnAnchor(room);
+  if (!anchor) {
+    return null;
+  }
+  const lookups = buildSpawnPlacementLookups(room, anchor);
+  for (let radius = 0; radius <= MAX_SPAWN_SITE_SCAN_RADIUS; radius += 1) {
+    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
+      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
+          continue;
+        }
+        const position = { x, y };
+        if (canPlaceInitialSpawn(lookups, position)) {
+          return position;
+        }
+      }
+    }
+  }
+  return null;
+}
+function selectInitialSpawnAnchor(room) {
+  const controllerPosition = getRoomObjectPosition2(room.controller);
+  if (!controllerPosition) {
+    return null;
+  }
+  const sources = findSources(room).map(getRoomObjectPosition2).filter((position) => position !== null).sort((left, right) => getRange(controllerPosition, left) - getRange(controllerPosition, right));
+  const nearestSourcePosition = sources[0];
+  if (!nearestSourcePosition) {
+    return clampPosition(controllerPosition);
+  }
+  return clampPosition({
+    x: Math.round((controllerPosition.x + nearestSourcePosition.x) / 2),
+    y: Math.round((controllerPosition.y + nearestSourcePosition.y) / 2)
+  });
+}
+function buildSpawnPlacementLookups(room, anchor) {
+  const blockingPositions = /* @__PURE__ */ new Set();
+  for (const object of [
+    room.controller,
+    ...findSources(room),
+    ...lookForArea(room, "LOOK_STRUCTURES", anchor),
+    ...lookForArea(room, "LOOK_CONSTRUCTION_SITES", anchor)
+  ]) {
+    const position = getRoomObjectPosition2(object);
+    if (position) {
+      blockingPositions.add(getPositionKey3(position));
+    }
+  }
+  return {
+    blockingPositions,
+    terrain: getRoomTerrain3(room.name)
+  };
+}
+function lookForArea(room, lookConstantName, anchor) {
+  const lookConstant = getGlobalString(lookConstantName);
+  if (!lookConstant || typeof room.lookForAtArea !== "function") {
+    return [];
+  }
+  const bounds = getScanBounds2(anchor);
+  return room.lookForAtArea(
+    lookConstant,
+    bounds.top,
+    bounds.left,
+    bounds.bottom,
+    bounds.right,
+    true
+  );
+}
+function getScanBounds2(anchor) {
+  return {
+    top: Math.max(ROOM_EDGE_MIN4, anchor.y - MAX_SPAWN_SITE_SCAN_RADIUS),
+    left: Math.max(ROOM_EDGE_MIN4, anchor.x - MAX_SPAWN_SITE_SCAN_RADIUS),
+    bottom: Math.min(ROOM_EDGE_MAX4, anchor.y + MAX_SPAWN_SITE_SCAN_RADIUS),
+    right: Math.min(ROOM_EDGE_MAX4, anchor.x + MAX_SPAWN_SITE_SCAN_RADIUS)
+  };
+}
+function canPlaceInitialSpawn(lookups, position) {
+  return isWithinRoomBuildBounds(position) && !lookups.blockingPositions.has(getPositionKey3(position)) && !isTerrainWall3(lookups.terrain, position);
+}
+function isWithinRoomBuildBounds(position) {
+  return position.x >= ROOM_EDGE_MIN4 && position.x <= ROOM_EDGE_MAX4 && position.y >= ROOM_EDGE_MIN4 && position.y <= ROOM_EDGE_MAX4;
+}
+function isTerrainWall3(terrain, position) {
+  return terrain !== null && (terrain.get(position.x, position.y) & getTerrainWallMask4()) !== 0;
+}
+function findExistingSpawnConstructionSite(room) {
+  var _a;
+  const findConstant = getGlobalNumber4("FIND_MY_CONSTRUCTION_SITES");
+  if (typeof room.find !== "function" || findConstant === null) {
+    return null;
+  }
+  const sites = room.find(findConstant, {
+    filter: (site) => matchesStructureType6(site.structureType, "STRUCTURE_SPAWN", "spawn")
+  });
+  return (_a = sites[0]) != null ? _a : null;
+}
+function findSources(room) {
+  const findConstant = getGlobalNumber4("FIND_SOURCES");
+  if (typeof room.find !== "function" || findConstant === null) {
+    return [];
+  }
+  return room.find(findConstant);
+}
+function getRoomObjectPosition2(object) {
+  if (!isRecord6(object)) {
+    return null;
+  }
+  if (isFiniteNumber4(object.x) && isFiniteNumber4(object.y)) {
+    return { x: object.x, y: object.y };
+  }
+  const pos = object.pos;
+  if (isRecord6(pos) && isFiniteNumber4(pos.x) && isFiniteNumber4(pos.y)) {
+    return { x: pos.x, y: pos.y };
+  }
+  return null;
+}
+function toSpawnSiteMemory(site) {
+  var _a, _b, _c, _d, _e, _f;
+  const position = getRoomObjectPosition2(site);
+  return {
+    roomName: (_d = (_c = (_a = site.pos) == null ? void 0 : _a.roomName) != null ? _c : (_b = site.room) == null ? void 0 : _b.name) != null ? _d : "",
+    x: (_e = position == null ? void 0 : position.x) != null ? _e : site.pos.x,
+    y: (_f = position == null ? void 0 : position.y) != null ? _f : site.pos.y
+  };
+}
+function isSameSpawnSite(left, right) {
+  return (left == null ? void 0 : left.roomName) === right.roomName && left.x === right.x && left.y === right.y;
+}
+function updatePostClaimBootstrapRecord(roomName, updates) {
+  const bootstraps = getWritablePostClaimBootstrapRecords();
+  const record = bootstraps == null ? void 0 : bootstraps[roomName];
+  if (!bootstraps || !record) {
+    return;
+  }
+  bootstraps[roomName] = {
+    ...record,
+    ...updates
+  };
+}
+function getPostClaimBootstrapRecord(roomName) {
+  var _a, _b, _c;
+  const record = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps) == null ? void 0 : _c[roomName];
+  return isPostClaimBootstrapRecord(record, roomName) ? record : null;
+}
+function getWritablePostClaimBootstrapRecords() {
+  const memory = globalThis.Memory;
+  if (!memory) {
+    return null;
+  }
+  if (!memory.territory) {
+    memory.territory = {};
+  }
+  if (!memory.territory.postClaimBootstraps) {
+    memory.territory.postClaimBootstraps = {};
+  }
+  return memory.territory.postClaimBootstraps;
+}
+function isPostClaimBootstrapRecord(value, expectedRoomName) {
+  return isRecord6(value) && value.roomName === expectedRoomName && isNonEmptyString6(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber4(value.claimedAt) && isFiniteNumber4(value.updatedAt);
+}
+function isPostClaimBootstrapStatus(value) {
+  return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
+}
+function getPostClaimBootstrapWorkerTarget(record) {
+  return isFiniteNumber4(record.workerTarget) && record.workerTarget > 0 ? Math.floor(record.workerTarget) : POST_CLAIM_BOOTSTRAP_WORKER_TARGET;
+}
+function clampPosition(position) {
+  return {
+    x: clamp(position.x, ROOM_EDGE_MIN4, ROOM_EDGE_MAX4),
+    y: clamp(position.y, ROOM_EDGE_MIN4, ROOM_EDGE_MAX4)
+  };
+}
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+function getRange(left, right) {
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
+}
+function getPositionKey3(position) {
+  return `${position.x},${position.y}`;
+}
+function getRoomTerrain3(roomName) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  return typeof (gameMap == null ? void 0 : gameMap.getRoomTerrain) === "function" ? gameMap.getRoomTerrain(roomName) : null;
+}
+function getTerrainWallMask4() {
+  return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK3;
+}
+function matchesStructureType6(actual, globalName, fallback) {
+  return actual === getStructureConstant(globalName, fallback);
+}
+function getStructureConstant(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function getGlobalNumber4(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : null;
+}
+function getGlobalString(name) {
+  const value = globalThis[name];
+  return typeof value === "string" ? value : null;
+}
+function getGameTime6() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
+}
+function isRecord6(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString6(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function isFiniteNumber4(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
 // src/telemetry/runtimeSummary.ts
 var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
@@ -9168,7 +9572,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return;
   }
-  const tick = getGameTime6();
+  const tick = getGameTime7();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -9262,7 +9666,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime6());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime7());
   }
   return {
     roomName: colony.room.name,
@@ -9271,8 +9675,8 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime6()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime6()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime7()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime7()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -9280,12 +9684,17 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     survival: summarizeSurvival(colony, roleCounts),
     territoryRecommendation,
     ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
-    ...buildTerritoryExecutionHintSummary(colony.room.name)
+    ...buildTerritoryExecutionHintSummary(colony.room.name),
+    ...buildPostClaimBootstrapSummary(colony.room.name)
   };
+}
+function buildPostClaimBootstrapSummary(roomName) {
+  const postClaimBootstrap = getPostClaimBootstrapSummary(roomName);
+  return postClaimBootstrap ? { postClaimBootstrap } : {};
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime6());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime7());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -9489,7 +9898,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord6(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord7(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio(numerator, denominator) {
   if (denominator <= 0) {
@@ -9504,7 +9913,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord6(value)) {
+  if (!isRecord7(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -9593,7 +10002,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord6(constructionSite)) {
+  if (!isRecord7(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -9607,7 +10016,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord6(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord7(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -9619,10 +10028,10 @@ function getRepairBacklogHits(structure) {
   return Math.max(0, Math.ceil(repairCeiling - hits));
 }
 function isObservableRepairBacklogStructure(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType6(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
+  return matchesStructureType7(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType7(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
 }
 function isObservedOwnedRampart(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
+  return matchesStructureType7(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
 }
 function buildControllerProgressRemaining(room) {
   const controller = room.controller;
@@ -9805,13 +10214,13 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   if (!eventLog) {
     return {};
   }
-  const harvestEvent = getGlobalNumber4("EVENT_HARVEST");
-  const transferEvent = getGlobalNumber4("EVENT_TRANSFER");
-  const buildEvent = getGlobalNumber4("EVENT_BUILD");
-  const repairEvent = getGlobalNumber4("EVENT_REPAIR");
-  const upgradeControllerEvent = getGlobalNumber4("EVENT_UPGRADE_CONTROLLER");
-  const attackEvent = getGlobalNumber4("EVENT_ATTACK");
-  const objectDestroyedEvent = getGlobalNumber4("EVENT_OBJECT_DESTROYED");
+  const harvestEvent = getGlobalNumber5("EVENT_HARVEST");
+  const transferEvent = getGlobalNumber5("EVENT_TRANSFER");
+  const buildEvent = getGlobalNumber5("EVENT_BUILD");
+  const repairEvent = getGlobalNumber5("EVENT_REPAIR");
+  const upgradeControllerEvent = getGlobalNumber5("EVENT_UPGRADE_CONTROLLER");
+  const attackEvent = getGlobalNumber5("EVENT_ATTACK");
+  const objectDestroyedEvent = getGlobalNumber5("EVENT_OBJECT_DESTROYED");
   const resourceEvents = {
     harvestedEnergy: 0,
     transferredEnergy: 0,
@@ -9829,10 +10238,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord6(entry) || typeof entry.event !== "number") {
+    if (!isRecord7(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord6(entry.data) ? entry.data : {};
+    const data = isRecord7(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -9898,7 +10307,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord6(structure) && (matchesStructureType6(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType6(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord7(structure) && (matchesStructureType7(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType7(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -9907,10 +10316,10 @@ function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
 function getObjectId2(value) {
-  return isRecord6(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+  return isRecord7(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects6(room, constantName) {
-  const findConstant = getGlobalNumber4(constantName);
+  const findConstant = getGlobalNumber5(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return void 0;
@@ -9938,7 +10347,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord6(object) || !isRecord6(object.store)) {
+  if (!isRecord7(object) || !isRecord7(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -9952,7 +10361,7 @@ function getEnergyInStore(object) {
 function sumDroppedEnergy(droppedResources) {
   const energyResource = getEnergyResource3();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord6(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord7(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -9965,11 +10374,11 @@ function getNumericEventData(data, key) {
   const value = data[key];
   return typeof value === "number" ? value : 0;
 }
-function getGlobalNumber4(name) {
+function getGlobalNumber5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function matchesStructureType6(value, globalName, fallback) {
+function matchesStructureType7(value, globalName, fallback) {
   var _a;
   const expectedValue = (_a = globalThis[globalName]) != null ? _a : fallback;
   return value === expectedValue;
@@ -9981,7 +10390,7 @@ function getEnergyResource3() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord6(value) {
+function isRecord7(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -9999,15 +10408,15 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime6() {
+function getGameTime7() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
 // src/territory/claimExecutor.ts
 var AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR = "autonomousExpansionClaim";
-var OK_CODE3 = 0;
+var OK_CODE4 = 0;
 var ERR_NOT_IN_RANGE_CODE3 = -9;
-var ERR_INVALID_TARGET_CODE = -7;
+var ERR_INVALID_TARGET_CODE2 = -7;
 var ERR_NO_BODYPART_CODE = -12;
 var ERR_GCL_NOT_ENOUGH_CODE = -15;
 function refreshAutonomousExpansionClaimIntent(colony, report, gameTime, telemetryEvents = []) {
@@ -10039,7 +10448,7 @@ function shouldPruneAutonomousExpansionClaimTargets(reason) {
 }
 function executeExpansionClaim(creep, controller, telemetryEvents = []) {
   var _a, _b, _c, _d, _e, _f, _g, _h;
-  const result = typeof creep.claimController === "function" ? creep.claimController(controller) : OK_CODE3;
+  const result = typeof creep.claimController === "function" ? creep.claimController(controller) : OK_CODE4;
   const reason = getClaimResultReason(result);
   recordTerritoryClaimTelemetry(telemetryEvents, {
     colony: (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown",
@@ -10165,7 +10574,7 @@ function upsertTerritoryTarget2(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord7(existingTarget)) {
+  if (isRecord8(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -10196,7 +10605,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget(target, activeTarget)) {
       return true;
     }
-    if (isRecord7(target) && isNonEmptyString6(target.roomName) && target.action === "claim") {
+    if (isRecord8(target) && isNonEmptyString7(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey(target.roomName, "claim"));
     }
     return false;
@@ -10213,7 +10622,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord7(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord8(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime) {
@@ -10239,11 +10648,11 @@ function recordTerritoryClaimTelemetry(telemetryEvents, event) {
 }
 function getClaimResultReason(result) {
   switch (result) {
-    case OK_CODE3:
+    case OK_CODE4:
       return null;
     case ERR_NOT_IN_RANGE_CODE3:
       return "notInRange";
-    case ERR_INVALID_TARGET_CODE:
+    case ERR_INVALID_TARGET_CODE2:
       return "invalidTarget";
     case ERR_NO_BODYPART_CODE:
       return "missingClaimPart";
@@ -10258,17 +10667,17 @@ function getControllerClaimCooldown(controller) {
   return typeof upgradeBlocked === "number" && upgradeBlocked > 0 ? upgradeBlocked : 0;
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord7(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord8(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isExistingAutonomousExpansionClaimTarget(colony, roomName) {
   var _a;
   const targets = (_a = getTerritoryMemoryRecord4()) == null ? void 0 : _a.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isAutonomousExpansionClaimTarget(target, colony) && isRecord7(target) && target.roomName === roomName
+    (target) => isAutonomousExpansionClaimTarget(target, colony) && isRecord8(target) && target.roomName === roomName
   ) : false;
 }
 function isSameTarget(left, right) {
-  return isRecord7(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord8(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey(roomName, action) {
   return `${roomName}:${action}`;
@@ -10306,32 +10715,32 @@ function isControllerOwned2(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString6(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString7(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
 function getControllerOwnerUsername4(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString6(username) ? username : void 0;
+  return isNonEmptyString7(username) ? username : void 0;
 }
-function isRecord7(value) {
+function isRecord8(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString6(value) {
+function isNonEmptyString7(value) {
   return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/territoryRunner.ts
 var ERR_NOT_IN_RANGE_CODE4 = -9;
-var ERR_INVALID_TARGET_CODE2 = -7;
+var ERR_INVALID_TARGET_CODE3 = -7;
 var ERR_NO_BODYPART_CODE2 = -12;
 var ERR_GCL_NOT_ENOUGH_CODE2 = -15;
-var OK_CODE4 = 0;
+var OK_CODE5 = 0;
 var CLAIM_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([
-  ERR_INVALID_TARGET_CODE2,
+  ERR_INVALID_TARGET_CODE3,
   ERR_NO_BODYPART_CODE2,
   ERR_GCL_NOT_ENOUGH_CODE2
 ]);
-var RESERVE_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([ERR_INVALID_TARGET_CODE2, ERR_NO_BODYPART_CODE2]);
+var RESERVE_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([ERR_INVALID_TARGET_CODE3, ERR_NO_BODYPART_CODE2]);
 var PRESSURE_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([ERR_NO_BODYPART_CODE2]);
 function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   var _a;
@@ -10388,7 +10797,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
       suppressTerritoryAssignment(creep, assignment);
       return;
     }
-    if (pressureResult !== ERR_INVALID_TARGET_CODE2) {
+    if (pressureResult !== ERR_INVALID_TARGET_CODE3) {
       return;
     }
   }
@@ -10403,6 +10812,9 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   const result = assignment.action === "claim" ? executeExpansionClaim(creep, controller, telemetryEvents) : executeControllerAction(creep, controller, "reserveController");
+  if (assignment.action === "claim" && result === OK_CODE5) {
+    recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents);
+  }
   if (result === ERR_NOT_IN_RANGE_CODE4 && typeof creep.moveTo === "function") {
     creep.moveTo(controller);
     return;
@@ -10419,7 +10831,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime7();
+  const gameTime = getGameTime8();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -10439,11 +10851,35 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime7());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime8());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
   delete creep.memory.territory;
+}
+function recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents) {
+  var _a, _b;
+  const room = getVisibleClaimedRoom(assignment.targetRoom, controller);
+  if (!((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my)) {
+    return;
+  }
+  recordPostClaimBootstrapClaimSuccess(
+    {
+      colony: (_b = creep.memory.colony) != null ? _b : room.name,
+      roomName: room.name,
+      controllerId: controller.id
+    },
+    telemetryEvents
+  );
+}
+function getVisibleClaimedRoom(targetRoom, controller) {
+  var _a, _b, _c, _d;
+  const controllerRoom = controller.room;
+  if (((_a = controllerRoom == null ? void 0 : controllerRoom.controller) == null ? void 0 : _a.my) === true) {
+    return controllerRoom;
+  }
+  const gameRoom = (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[targetRoom];
+  return ((_d = gameRoom == null ? void 0 : gameRoom.controller) == null ? void 0 : _d.my) === true ? gameRoom : null;
 }
 function selectTargetController(creep, assignment) {
   var _a, _b;
@@ -10462,7 +10898,7 @@ function selectTargetController(creep, assignment) {
 function executeControllerAction(creep, controller, action) {
   const controllerAction = creep[action];
   if (typeof controllerAction !== "function") {
-    return OK_CODE4;
+    return OK_CODE5;
   }
   return controllerAction.call(creep, controller);
 }
@@ -10495,7 +10931,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime7() {
+function getGameTime8() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -10533,18 +10969,19 @@ function isTerritoryAssignment(assignment) {
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
-var OK_CODE5 = 0;
+var OK_CODE6 = 0;
 function runEconomy(preludeTelemetryEvents = []) {
   const creeps = Object.values(Game.creeps);
   const colonies = getOwnedColonies();
   const telemetryEvents = [...preludeTelemetryEvents];
   clearColonySurvivalAssessmentCache();
   for (const colony of colonies) {
-    const extensionResult = planExtensionConstruction(colony);
-    if (extensionResult === null) {
+    let roleCounts = countCreepsByRole(creeps, colony.room.name);
+    const bootstrapResult = refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
+    const extensionResult = bootstrapResult.spawnConstructionPending ? null : planExtensionConstruction(colony);
+    if (extensionResult === null && !bootstrapResult.spawnConstructionPending) {
       planEarlyRoadConstruction(colony);
     }
-    let roleCounts = countCreepsByRole(creeps, colony.room.name);
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
@@ -10576,7 +11013,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         telemetryEvents,
         planningColony.spawns
       );
-      if (!outcome || outcome.result !== OK_CODE5) {
+      if (!outcome || outcome.result !== OK_CODE6) {
         break;
       }
       usedSpawns.add(outcome.spawn);
@@ -10685,6 +11122,15 @@ function attemptSpawn(spawnRequest, roomName, telemetryEvents) {
     role: spawnRequest.memory.role,
     result
   });
+  if (spawnRequest.memory.role === "worker") {
+    recordPostClaimBootstrapWorkerSpawn(
+      spawnRequest.memory.colony,
+      spawnRequest.spawn.name,
+      spawnRequest.name,
+      result,
+      telemetryEvents
+    );
+  }
   return result;
 }
 
@@ -10706,7 +11152,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime8())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime9())
     );
   }
 };
@@ -10778,7 +11224,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime8() {
+function getGameTime9() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -11108,7 +11554,7 @@ function parseStrategyEvaluationArtifacts(input) {
   });
 }
 function normalizeStrategyEvaluationArtifact(rawArtifact) {
-  if (!isRecord8(rawArtifact)) {
+  if (!isRecord9(rawArtifact)) {
     return null;
   }
   if (rawArtifact.type === "runtime-summary" || Array.isArray(rawArtifact.rooms)) {
@@ -11117,7 +11563,7 @@ function normalizeStrategyEvaluationArtifact(rawArtifact) {
   if (rawArtifact.artifactType === "runtime-summary") {
     return normalizeRuntimeSummaryArtifact(rawArtifact);
   }
-  if (rawArtifact.artifactType === "room-snapshot" || Array.isArray(rawArtifact.objects) || isRecord8(rawArtifact.objects)) {
+  if (rawArtifact.artifactType === "room-snapshot" || Array.isArray(rawArtifact.objects) || isRecord9(rawArtifact.objects)) {
     return normalizeRoomSnapshotArtifact(rawArtifact);
   }
   return null;
@@ -11199,45 +11645,45 @@ function normalizeRuntimeSummaryArtifact(rawArtifact) {
   }) : [];
   return {
     artifactType: "runtime-summary",
-    ...isFiniteNumber4(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
+    ...isFiniteNumber5(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
     rooms,
-    ...isRecord8(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {},
-    ...isRecord8(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {}
+    ...isRecord9(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {},
+    ...isRecord9(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {}
   };
 }
 function normalizeRuntimeSummaryRoom(rawRoom) {
-  if (!isRecord8(rawRoom) || !isNonEmptyString7(rawRoom.roomName)) {
+  if (!isRecord9(rawRoom) || !isNonEmptyString8(rawRoom.roomName)) {
     return null;
   }
   return {
     roomName: rawRoom.roomName,
-    ...isFiniteNumber4(rawRoom.energyAvailable) ? { energyAvailable: rawRoom.energyAvailable } : {},
-    ...isFiniteNumber4(rawRoom.energyCapacity) ? { energyCapacity: rawRoom.energyCapacity } : {},
-    ...isFiniteNumber4(rawRoom.workerCount) ? { workerCount: rawRoom.workerCount } : {},
+    ...isFiniteNumber5(rawRoom.energyAvailable) ? { energyAvailable: rawRoom.energyAvailable } : {},
+    ...isFiniteNumber5(rawRoom.energyCapacity) ? { energyCapacity: rawRoom.energyCapacity } : {},
+    ...isFiniteNumber5(rawRoom.workerCount) ? { workerCount: rawRoom.workerCount } : {},
     ...Array.isArray(rawRoom.spawnStatus) ? { spawnStatus: rawRoom.spawnStatus.map(normalizeSpawnStatus) } : {},
-    ...isRecord8(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {},
-    ...isRecord8(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {},
-    ...isRecord8(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {},
-    ...isRecord8(rawRoom.constructionPriority) ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) } : {},
-    ...isRecord8(rawRoom.territoryRecommendation) ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) } : {}
+    ...isRecord9(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {},
+    ...isRecord9(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {},
+    ...isRecord9(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {},
+    ...isRecord9(rawRoom.constructionPriority) ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) } : {},
+    ...isRecord9(rawRoom.territoryRecommendation) ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) } : {}
   };
 }
 function normalizeRoomSnapshotArtifact(rawArtifact) {
-  if (!Array.isArray(rawArtifact.objects) && !isRecord8(rawArtifact.objects)) {
+  if (!Array.isArray(rawArtifact.objects) && !isRecord9(rawArtifact.objects)) {
     return null;
   }
-  const objects = Array.isArray(rawArtifact.objects) ? rawArtifact.objects.flatMap((rawObject) => isRecord8(rawObject) ? [rawObject] : []) : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
-    if (!isRecord8(rawObject)) {
+  const objects = Array.isArray(rawArtifact.objects) ? rawArtifact.objects.flatMap((rawObject) => isRecord9(rawObject) ? [rawObject] : []) : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
+    if (!isRecord9(rawObject)) {
       return [];
     }
     return [{ ...rawObject, id }];
   });
   return {
     artifactType: "room-snapshot",
-    ...isFiniteNumber4(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
-    ...isNonEmptyString7(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {},
-    ...isNonEmptyString7(rawArtifact.room) ? { roomName: rawArtifact.room } : {},
-    ...isNonEmptyString7(rawArtifact.owner) ? { owner: rawArtifact.owner } : {},
+    ...isFiniteNumber5(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
+    ...isNonEmptyString8(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {},
+    ...isNonEmptyString8(rawArtifact.room) ? { roomName: rawArtifact.room } : {},
+    ...isNonEmptyString8(rawArtifact.owner) ? { owner: rawArtifact.owner } : {},
     objects
   };
 }
@@ -11257,74 +11703,74 @@ function parseJson(text) {
   }
 }
 function normalizeSpawnStatus(rawStatus) {
-  if (!isRecord8(rawStatus)) {
+  if (!isRecord9(rawStatus)) {
     return {};
   }
   return {
-    ...isNonEmptyString7(rawStatus.name) ? { name: rawStatus.name } : {},
-    ...isNonEmptyString7(rawStatus.status) ? { status: rawStatus.status } : {},
-    ...isNonEmptyString7(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {},
-    ...isFiniteNumber4(rawStatus.remainingTime) ? { remainingTime: rawStatus.remainingTime } : {}
+    ...isNonEmptyString8(rawStatus.name) ? { name: rawStatus.name } : {},
+    ...isNonEmptyString8(rawStatus.status) ? { status: rawStatus.status } : {},
+    ...isNonEmptyString8(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {},
+    ...isFiniteNumber5(rawStatus.remainingTime) ? { remainingTime: rawStatus.remainingTime } : {}
   };
 }
 function normalizeControllerSummary(rawController) {
   return {
-    level: isFiniteNumber4(rawController.level) ? rawController.level : 0,
-    ...isFiniteNumber4(rawController.progress) ? { progress: rawController.progress } : {},
-    ...isFiniteNumber4(rawController.progressTotal) ? { progressTotal: rawController.progressTotal } : {},
-    ...isFiniteNumber4(rawController.ticksToDowngrade) ? { ticksToDowngrade: rawController.ticksToDowngrade } : {}
+    level: isFiniteNumber5(rawController.level) ? rawController.level : 0,
+    ...isFiniteNumber5(rawController.progress) ? { progress: rawController.progress } : {},
+    ...isFiniteNumber5(rawController.progressTotal) ? { progressTotal: rawController.progressTotal } : {},
+    ...isFiniteNumber5(rawController.ticksToDowngrade) ? { ticksToDowngrade: rawController.ticksToDowngrade } : {}
   };
 }
 function normalizeResourceSummary(rawResources) {
   return {
-    ...isFiniteNumber4(rawResources.storedEnergy) ? { storedEnergy: rawResources.storedEnergy } : {},
-    ...isFiniteNumber4(rawResources.workerCarriedEnergy) ? { workerCarriedEnergy: rawResources.workerCarriedEnergy } : {},
-    ...isFiniteNumber4(rawResources.droppedEnergy) ? { droppedEnergy: rawResources.droppedEnergy } : {},
-    ...isFiniteNumber4(rawResources.sourceCount) ? { sourceCount: rawResources.sourceCount } : {},
-    ...isRecord8(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {}
+    ...isFiniteNumber5(rawResources.storedEnergy) ? { storedEnergy: rawResources.storedEnergy } : {},
+    ...isFiniteNumber5(rawResources.workerCarriedEnergy) ? { workerCarriedEnergy: rawResources.workerCarriedEnergy } : {},
+    ...isFiniteNumber5(rawResources.droppedEnergy) ? { droppedEnergy: rawResources.droppedEnergy } : {},
+    ...isFiniteNumber5(rawResources.sourceCount) ? { sourceCount: rawResources.sourceCount } : {},
+    ...isRecord9(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {}
   };
 }
 function normalizeResourceEvents(rawEvents) {
   return {
-    ...isFiniteNumber4(rawEvents.harvestedEnergy) ? { harvestedEnergy: rawEvents.harvestedEnergy } : {},
-    ...isFiniteNumber4(rawEvents.transferredEnergy) ? { transferredEnergy: rawEvents.transferredEnergy } : {}
+    ...isFiniteNumber5(rawEvents.harvestedEnergy) ? { harvestedEnergy: rawEvents.harvestedEnergy } : {},
+    ...isFiniteNumber5(rawEvents.transferredEnergy) ? { transferredEnergy: rawEvents.transferredEnergy } : {}
   };
 }
 function normalizeCombatSummary(rawCombat) {
   return {
-    ...isFiniteNumber4(rawCombat.hostileCreepCount) ? { hostileCreepCount: rawCombat.hostileCreepCount } : {},
-    ...isFiniteNumber4(rawCombat.hostileStructureCount) ? { hostileStructureCount: rawCombat.hostileStructureCount } : {},
-    ...isRecord8(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {}
+    ...isFiniteNumber5(rawCombat.hostileCreepCount) ? { hostileCreepCount: rawCombat.hostileCreepCount } : {},
+    ...isFiniteNumber5(rawCombat.hostileStructureCount) ? { hostileStructureCount: rawCombat.hostileStructureCount } : {},
+    ...isRecord9(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {}
   };
 }
 function normalizeCombatEvents(rawEvents) {
   return {
-    ...isFiniteNumber4(rawEvents.attackCount) ? { attackCount: rawEvents.attackCount } : {},
-    ...isFiniteNumber4(rawEvents.attackDamage) ? { attackDamage: rawEvents.attackDamage } : {},
-    ...isFiniteNumber4(rawEvents.objectDestroyedCount) ? { objectDestroyedCount: rawEvents.objectDestroyedCount } : {},
-    ...isFiniteNumber4(rawEvents.creepDestroyedCount) ? { creepDestroyedCount: rawEvents.creepDestroyedCount } : {}
+    ...isFiniteNumber5(rawEvents.attackCount) ? { attackCount: rawEvents.attackCount } : {},
+    ...isFiniteNumber5(rawEvents.attackDamage) ? { attackDamage: rawEvents.attackDamage } : {},
+    ...isFiniteNumber5(rawEvents.objectDestroyedCount) ? { objectDestroyedCount: rawEvents.objectDestroyedCount } : {},
+    ...isFiniteNumber5(rawEvents.creepDestroyedCount) ? { creepDestroyedCount: rawEvents.creepDestroyedCount } : {}
   };
 }
 function normalizeConstructionPrioritySummary(rawSummary) {
   var _a;
   return {
     ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeConstructionCandidate) } : {},
-    ...rawSummary.nextPrimary === null ? { nextPrimary: null } : isRecord8(rawSummary.nextPrimary) ? { nextPrimary: (_a = normalizeConstructionCandidate(rawSummary.nextPrimary)[0]) != null ? _a : null } : {}
+    ...rawSummary.nextPrimary === null ? { nextPrimary: null } : isRecord9(rawSummary.nextPrimary) ? { nextPrimary: (_a = normalizeConstructionCandidate(rawSummary.nextPrimary)[0]) != null ? _a : null } : {}
   };
 }
 function normalizeConstructionCandidate(rawCandidate) {
-  if (!isRecord8(rawCandidate) || !isNonEmptyString7(rawCandidate.buildItem)) {
+  if (!isRecord9(rawCandidate) || !isNonEmptyString8(rawCandidate.buildItem)) {
     return [];
   }
   return [
     {
       buildItem: rawCandidate.buildItem,
-      ...isNonEmptyString7(rawCandidate.room) ? { room: rawCandidate.room } : {},
-      ...isFiniteNumber4(rawCandidate.score) ? { score: rawCandidate.score } : {},
-      ...isNonEmptyString7(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {},
-      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString7) } : {},
-      ...Array.isArray(rawCandidate.expectedKpiMovement) ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString7) } : {},
-      ...Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString7) } : {}
+      ...isNonEmptyString8(rawCandidate.room) ? { room: rawCandidate.room } : {},
+      ...isFiniteNumber5(rawCandidate.score) ? { score: rawCandidate.score } : {},
+      ...isNonEmptyString8(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString8) } : {},
+      ...Array.isArray(rawCandidate.expectedKpiMovement) ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString8) } : {},
+      ...Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString8) } : {}
     }
   ];
 }
@@ -11332,43 +11778,43 @@ function normalizeTerritoryRecommendationSummary(rawSummary) {
   var _a;
   return {
     ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeTerritoryCandidate) } : {},
-    ...rawSummary.next === null ? { next: null } : isRecord8(rawSummary.next) ? { next: (_a = normalizeTerritoryCandidate(rawSummary.next)[0]) != null ? _a : null } : {},
+    ...rawSummary.next === null ? { next: null } : isRecord9(rawSummary.next) ? { next: (_a = normalizeTerritoryCandidate(rawSummary.next)[0]) != null ? _a : null } : {},
     ...rawSummary.followUpIntent !== void 0 ? { followUpIntent: rawSummary.followUpIntent } : {}
   };
 }
 function normalizeTerritoryCandidate(rawCandidate) {
-  if (!isRecord8(rawCandidate) || !isNonEmptyString7(rawCandidate.roomName)) {
+  if (!isRecord9(rawCandidate) || !isNonEmptyString8(rawCandidate.roomName)) {
     return [];
   }
   return [
     {
       roomName: rawCandidate.roomName,
-      ...isNonEmptyString7(rawCandidate.action) ? { action: rawCandidate.action } : {},
-      ...isFiniteNumber4(rawCandidate.score) ? { score: rawCandidate.score } : {},
-      ...isNonEmptyString7(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {},
-      ...isNonEmptyString7(rawCandidate.source) ? { source: rawCandidate.source } : {},
-      ...Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString7) } : {},
-      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString7) } : {},
-      ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString7) } : {},
-      ...isFiniteNumber4(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {},
-      ...isFiniteNumber4(rawCandidate.roadDistance) ? { roadDistance: rawCandidate.roadDistance } : {},
-      ...isFiniteNumber4(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {},
-      ...isFiniteNumber4(rawCandidate.hostileCreepCount) ? { hostileCreepCount: rawCandidate.hostileCreepCount } : {},
-      ...isFiniteNumber4(rawCandidate.hostileStructureCount) ? { hostileStructureCount: rawCandidate.hostileStructureCount } : {}
+      ...isNonEmptyString8(rawCandidate.action) ? { action: rawCandidate.action } : {},
+      ...isFiniteNumber5(rawCandidate.score) ? { score: rawCandidate.score } : {},
+      ...isNonEmptyString8(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {},
+      ...isNonEmptyString8(rawCandidate.source) ? { source: rawCandidate.source } : {},
+      ...Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString8) } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString8) } : {},
+      ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString8) } : {},
+      ...isFiniteNumber5(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {},
+      ...isFiniteNumber5(rawCandidate.roadDistance) ? { roadDistance: rawCandidate.roadDistance } : {},
+      ...isFiniteNumber5(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {},
+      ...isFiniteNumber5(rawCandidate.hostileCreepCount) ? { hostileCreepCount: rawCandidate.hostileCreepCount } : {},
+      ...isFiniteNumber5(rawCandidate.hostileStructureCount) ? { hostileStructureCount: rawCandidate.hostileStructureCount } : {}
     }
   ];
 }
 function normalizeCpuSummary(rawCpu) {
   return {
-    ...isFiniteNumber4(rawCpu.used) ? { used: rawCpu.used } : {},
-    ...isFiniteNumber4(rawCpu.bucket) ? { bucket: rawCpu.bucket } : {}
+    ...isFiniteNumber5(rawCpu.used) ? { used: rawCpu.used } : {},
+    ...isFiniteNumber5(rawCpu.bucket) ? { bucket: rawCpu.bucket } : {}
   };
 }
 function normalizeReliabilitySignals(rawReliability) {
   return {
-    ...isFiniteNumber4(rawReliability.loopExceptionCount) ? { loopExceptionCount: rawReliability.loopExceptionCount } : {},
-    ...isFiniteNumber4(rawReliability.telemetrySilenceTicks) ? { telemetrySilenceTicks: rawReliability.telemetrySilenceTicks } : {},
-    ...isFiniteNumber4(rawReliability.globalResetCount) ? { globalResetCount: rawReliability.globalResetCount } : {}
+    ...isFiniteNumber5(rawReliability.loopExceptionCount) ? { loopExceptionCount: rawReliability.loopExceptionCount } : {},
+    ...isFiniteNumber5(rawReliability.telemetrySilenceTicks) ? { telemetrySilenceTicks: rawReliability.telemetrySilenceTicks } : {},
+    ...isFiniteNumber5(rawReliability.globalResetCount) ? { globalResetCount: rawReliability.globalResetCount } : {}
   };
 }
 function reduceRuntimeSummaryArtifact(artifact, reliabilityMetrics, territoryComponents, resourceComponents, killComponents, thresholds) {
@@ -11493,11 +11939,11 @@ function getSnapshotObjectEnergy(object) {
 function getSnapshotObjectOwner(object) {
   var _a;
   const objectUser = object == null ? void 0 : object.user;
-  if (isNonEmptyString7(objectUser)) {
+  if (isNonEmptyString8(objectUser)) {
     return objectUser;
   }
   const ownerUsername = (_a = object == null ? void 0 : object.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString7(ownerUsername) ? ownerUsername : void 0;
+  return isNonEmptyString8(ownerUsername) ? ownerUsername : void 0;
 }
 function isOwnedSnapshotObject(object, owner) {
   var _a;
@@ -11509,13 +11955,13 @@ function isOwnedSnapshotObject(object, owner) {
   }
   return object.user === owner || ((_a = object.owner) == null ? void 0 : _a.username) === owner;
 }
-function isRecord8(value) {
+function isRecord9(value) {
   return typeof value === "object" && value !== null;
 }
-function isFiniteNumber4(value) {
+function isFiniteNumber5(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isNonEmptyString7(value) {
+function isNonEmptyString8(value) {
   return typeof value === "string" && value.length > 0;
 }
 

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9385,22 +9385,30 @@ function planInitialSpawnConstructionSite(room) {
   if (typeof room.createConstructionSite !== "function") {
     return { result: ERR_INVALID_TARGET_CODE };
   }
-  const position = findInitialSpawnConstructionPosition(room);
-  if (!position) {
+  const positions = findInitialSpawnConstructionPositions(room);
+  if (positions.length === 0) {
     return { result: ERR_INVALID_TARGET_CODE };
   }
-  return {
-    result: room.createConstructionSite(position.x, position.y, getStructureConstant("STRUCTURE_SPAWN", "spawn")),
-    position: { ...position, roomName: room.name }
-  };
+  let lastResult = ERR_INVALID_TARGET_CODE;
+  for (const position of positions) {
+    lastResult = room.createConstructionSite(position.x, position.y, getStructureConstant("STRUCTURE_SPAWN", "spawn"));
+    if (lastResult === OK_CODE3) {
+      return {
+        result: lastResult,
+        position: { ...position, roomName: room.name }
+      };
+    }
+  }
+  return { result: lastResult };
 }
-function findInitialSpawnConstructionPosition(room) {
+function findInitialSpawnConstructionPositions(room) {
   const anchor = selectInitialSpawnAnchor(room);
   if (!anchor) {
-    return null;
+    return [];
   }
   const maximumScanRadius = getMaximumSpawnSiteScanRadius(anchor);
   const lookups = buildSpawnPlacementLookups(room, anchor, maximumScanRadius);
+  const positions = [];
   for (let radius = 0; radius <= maximumScanRadius; radius += 1) {
     for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
       for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
@@ -9409,12 +9417,12 @@ function findInitialSpawnConstructionPosition(room) {
         }
         const position = { x, y };
         if (canPlaceInitialSpawn(lookups, position)) {
-          return position;
+          positions.push(position);
         }
       }
     }
   }
-  return null;
+  return positions;
 }
 function selectInitialSpawnAnchor(room) {
   const controllerPosition = getRoomObjectPosition2(room.controller);
@@ -9444,8 +9452,16 @@ function buildSpawnPlacementLookups(room, anchor, maximumScanRadius) {
       blockingPositions.add(getPositionKey3(position));
     }
   }
+  const mineralPositions = /* @__PURE__ */ new Set();
+  for (const object of lookForArea(room, "LOOK_MINERALS", anchor, maximumScanRadius)) {
+    const position = getRoomObjectPosition2(object);
+    if (position) {
+      mineralPositions.add(getPositionKey3(position));
+    }
+  }
   return {
     blockingPositions,
+    mineralPositions,
     terrain: getRoomTerrain3(room.name)
   };
 }
@@ -9473,7 +9489,7 @@ function getScanBounds2(anchor, maximumScanRadius) {
   };
 }
 function canPlaceInitialSpawn(lookups, position) {
-  return isWithinRoomBuildBounds(position) && !lookups.blockingPositions.has(getPositionKey3(position)) && !isTerrainWall3(lookups.terrain, position);
+  return isWithinRoomBuildBounds(position) && !lookups.blockingPositions.has(getPositionKey3(position)) && !lookups.mineralPositions.has(getPositionKey3(position)) && !isTerrainWall3(lookups.terrain, position);
 }
 function isWithinRoomBuildBounds(position) {
   return position.x >= ROOM_EDGE_MIN4 && position.x <= ROOM_EDGE_MAX4 && position.y >= ROOM_EDGE_MIN4 && position.y <= ROOM_EDGE_MAX4;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -26,6 +26,10 @@ import {
   TERRITORY_SCOUT_ROLE
 } from '../territory/territoryPlanner';
 import { runTerritoryControllerCreep } from '../territory/territoryRunner';
+import {
+  recordPostClaimBootstrapWorkerSpawn,
+  refreshPostClaimBootstrap
+} from '../territory/postClaimBootstrap';
 
 const ERR_BUSY_CODE = -4 as ScreepsReturnCode;
 const OK_CODE = 0 as ScreepsReturnCode;
@@ -42,12 +46,13 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   clearColonySurvivalAssessmentCache();
 
   for (const colony of colonies) {
-    const extensionResult = planExtensionConstruction(colony);
-    if (extensionResult === null) {
+    let roleCounts = countCreepsByRole(creeps, colony.room.name);
+    const bootstrapResult = refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
+    const extensionResult = bootstrapResult.spawnConstructionPending ? null : planExtensionConstruction(colony);
+    if (extensionResult === null && !bootstrapResult.spawnConstructionPending) {
       planEarlyRoadConstruction(colony);
     }
 
-    let roleCounts = countCreepsByRole(creeps, colony.room.name);
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
@@ -241,6 +246,15 @@ function attemptSpawn(spawnRequest: SpawnRequest, roomName: string, telemetryEve
     role: spawnRequest.memory.role,
     result
   });
+  if (spawnRequest.memory.role === 'worker') {
+    recordPostClaimBootstrapWorkerSpawn(
+      spawnRequest.memory.colony,
+      spawnRequest.spawn.name,
+      spawnRequest.name,
+      result,
+      telemetryEvents
+    );
+  }
 
   return result;
 }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -225,6 +225,10 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     controller,
     constructionReservationContext
   );
+  if (territoryControllerTask && capacityConstructionSite && isSpawnConstructionSite(capacityConstructionSite)) {
+    return applyMinimumUsefulLoadPolicy(creep, { type: 'build', targetId: capacityConstructionSite.id });
+  }
+
   if (!territoryControllerTask) {
     const baselineLogisticsConstructionSite = selectBaselineLogisticsConstructionSiteBeforeAdditionalExtension(
       creep,

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -17,6 +17,7 @@ import {
   getTerritoryIntentProgressSummaries,
   type TerritoryIntentProgressSummary
 } from '../territory/territoryPlanner';
+import { getPostClaimBootstrapSummary, type PostClaimBootstrapSummary } from '../territory/postClaimBootstrap';
 
 export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
@@ -42,7 +43,8 @@ interface WorkerTaskCounts extends Record<WorkerTaskType, number> {
 export type RuntimeTelemetryEvent =
   | RuntimeSpawnTelemetryEvent
   | RuntimeDefenseTelemetryEvent
-  | RuntimeTerritoryClaimTelemetryEvent;
+  | RuntimeTerritoryClaimTelemetryEvent
+  | RuntimePostClaimBootstrapTelemetryEvent;
 
 export type RuntimeTerritoryClaimTelemetryReason =
   | 'noAdjacentCandidate'
@@ -88,6 +90,21 @@ export interface RuntimeTerritoryClaimTelemetryEvent {
   score?: number;
 }
 
+export interface RuntimePostClaimBootstrapTelemetryEvent {
+  type: 'postClaimBootstrap';
+  roomName: string;
+  colony: string;
+  phase: 'detected' | 'spawnSite' | 'workerSpawn' | 'ready';
+  controllerId?: Id<StructureController>;
+  spawnName?: string;
+  creepName?: string;
+  result?: ScreepsReturnCode;
+  workerCount?: number;
+  workerTarget?: number;
+  spawnCount?: number;
+  spawnSite?: TerritoryPostClaimBootstrapSpawnSiteMemory;
+}
+
 interface RuntimeSpawnStatus {
   name: string;
   status: 'idle' | 'spawning';
@@ -115,6 +132,7 @@ interface RuntimeRoomSummary {
   omittedTerritoryIntentCount?: number;
   suspendedTerritoryIntentCounts?: Record<string, number>;
   territoryExecutionHints?: TerritoryExecutionHintMemory[];
+  postClaimBootstrap?: PostClaimBootstrapSummary;
 }
 
 interface RuntimeControllerSummary {
@@ -424,8 +442,16 @@ function summarizeRoom(
     survival: summarizeSurvival(colony, roleCounts),
     territoryRecommendation,
     ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
-    ...buildTerritoryExecutionHintSummary(colony.room.name)
+    ...buildTerritoryExecutionHintSummary(colony.room.name),
+    ...buildPostClaimBootstrapSummary(colony.room.name)
   };
+}
+
+function buildPostClaimBootstrapSummary(
+  roomName: string
+): { postClaimBootstrap?: PostClaimBootstrapSummary } {
+  const postClaimBootstrap = getPostClaimBootstrapSummary(roomName);
+  return postClaimBootstrap ? { postClaimBootstrap } : {};
 }
 
 function buildTerritoryIntentSummary(

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -1,0 +1,569 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import type { RoleCounts } from '../creeps/roleCounts';
+import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
+
+export const POST_CLAIM_BOOTSTRAP_WORKER_TARGET = 2;
+
+const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
+const ROOM_EDGE_MIN = 2;
+const ROOM_EDGE_MAX = 47;
+const MAX_SPAWN_SITE_SCAN_RADIUS = 6;
+const DEFAULT_TERRAIN_WALL_MASK = 1;
+
+type StructureConstantGlobal = 'STRUCTURE_SPAWN';
+type FindConstantGlobal = 'FIND_MY_CONSTRUCTION_SITES' | 'FIND_SOURCES';
+type LookConstantGlobal = 'LOOK_STRUCTURES' | 'LOOK_CONSTRUCTION_SITES';
+
+interface CandidatePosition {
+  x: number;
+  y: number;
+}
+
+interface SpawnSitePlanResult {
+  result: ScreepsReturnCode;
+  position?: TerritoryPostClaimBootstrapSpawnSiteMemory;
+}
+
+interface SpawnPlacementLookups {
+  blockingPositions: Set<string>;
+  terrain: RoomTerrain | null;
+}
+
+export interface PostClaimBootstrapRefreshResult {
+  active: boolean;
+  spawnConstructionPending: boolean;
+}
+
+export interface PostClaimBootstrapSummary {
+  colony: string;
+  status: TerritoryPostClaimBootstrapStatus;
+  claimedAt: number;
+  updatedAt: number;
+  workerTarget: number;
+  controllerId?: Id<StructureController>;
+  spawnSite?: TerritoryPostClaimBootstrapSpawnSiteMemory;
+  lastResult?: ScreepsReturnCode;
+}
+
+export function recordPostClaimBootstrapClaimSuccess(
+  input: {
+    colony: string;
+    roomName: string;
+    controllerId?: Id<StructureController>;
+  },
+  telemetryEvents: RuntimeTelemetryEvent[] = []
+): void {
+  if (!isNonEmptyString(input.colony) || !isNonEmptyString(input.roomName)) {
+    return;
+  }
+
+  const bootstraps = getWritablePostClaimBootstrapRecords();
+  if (!bootstraps) {
+    return;
+  }
+
+  const gameTime = getGameTime();
+  const existing = getPostClaimBootstrapRecord(input.roomName);
+  const claimedAt = existing?.status === 'ready' ? gameTime : existing?.claimedAt ?? gameTime;
+  bootstraps[input.roomName] = {
+    colony: input.colony,
+    roomName: input.roomName,
+    status: 'detected',
+    claimedAt,
+    updatedAt: gameTime,
+    workerTarget: existing?.workerTarget ?? POST_CLAIM_BOOTSTRAP_WORKER_TARGET,
+    ...(input.controllerId ? { controllerId: input.controllerId } : {})
+  };
+
+  telemetryEvents.push({
+    type: 'postClaimBootstrap',
+    roomName: input.roomName,
+    colony: input.colony,
+    phase: 'detected',
+    ...(input.controllerId ? { controllerId: input.controllerId } : {}),
+    workerTarget: POST_CLAIM_BOOTSTRAP_WORKER_TARGET
+  });
+}
+
+export function refreshPostClaimBootstrap(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  gameTime: number,
+  telemetryEvents: RuntimeTelemetryEvent[] = []
+): PostClaimBootstrapRefreshResult {
+  const roomName = colony.room.name;
+  const record = getPostClaimBootstrapRecord(roomName);
+  if (!record || record.status === 'ready' || colony.room.controller?.my !== true) {
+    return { active: false, spawnConstructionPending: false };
+  }
+
+  const workerTarget = getPostClaimBootstrapWorkerTarget(record);
+  const workerCount = roleCounts.worker ?? 0;
+  const spawnCount = colony.spawns.length;
+  if (spawnCount > 0 && workerCount >= workerTarget) {
+    updatePostClaimBootstrapRecord(roomName, {
+      status: 'ready',
+      updatedAt: gameTime,
+      workerTarget
+    });
+    telemetryEvents.push({
+      type: 'postClaimBootstrap',
+      roomName,
+      colony: record.colony,
+      phase: 'ready',
+      ...(record.controllerId ? { controllerId: record.controllerId } : {}),
+      workerCount,
+      workerTarget,
+      spawnCount
+    });
+    return { active: false, spawnConstructionPending: false };
+  }
+
+  if (spawnCount > 0) {
+    updatePostClaimBootstrapRecord(roomName, {
+      status: 'spawningWorkers',
+      updatedAt: gameTime,
+      workerTarget
+    });
+    return { active: true, spawnConstructionPending: false };
+  }
+
+  const existingSpawnSite = findExistingSpawnConstructionSite(colony.room);
+  if (existingSpawnSite) {
+    const spawnSite = toSpawnSiteMemory(existingSpawnSite);
+    const shouldReportExistingSite =
+      record.status !== 'spawnSitePending' ||
+      !isSameSpawnSite(record.spawnSite, spawnSite);
+    updatePostClaimBootstrapRecord(roomName, {
+      status: 'spawnSitePending',
+      updatedAt: gameTime,
+      workerTarget,
+      spawnSite,
+      lastResult: OK_CODE
+    });
+    if (shouldReportExistingSite) {
+      telemetryEvents.push({
+        type: 'postClaimBootstrap',
+        roomName,
+        colony: record.colony,
+        phase: 'spawnSite',
+        ...(record.controllerId ? { controllerId: record.controllerId } : {}),
+        result: OK_CODE,
+        spawnSite,
+        workerCount,
+        workerTarget,
+        spawnCount
+      });
+    }
+    return { active: true, spawnConstructionPending: true };
+  }
+
+  const sitePlan = planInitialSpawnConstructionSite(colony.room);
+  const nextStatus = sitePlan.result === OK_CODE ? 'spawnSitePending' : 'spawnSiteBlocked';
+  const shouldReportSitePlan =
+    record.status !== nextStatus ||
+    record.lastResult !== sitePlan.result ||
+    (sitePlan.position !== undefined && !isSameSpawnSite(record.spawnSite, sitePlan.position));
+  updatePostClaimBootstrapRecord(roomName, {
+    status: nextStatus,
+    updatedAt: gameTime,
+    workerTarget,
+    ...(sitePlan.position ? { spawnSite: sitePlan.position } : {}),
+    lastResult: sitePlan.result
+  });
+  if (shouldReportSitePlan) {
+    telemetryEvents.push({
+      type: 'postClaimBootstrap',
+      roomName,
+      colony: record.colony,
+      phase: 'spawnSite',
+      ...(record.controllerId ? { controllerId: record.controllerId } : {}),
+      result: sitePlan.result,
+      ...(sitePlan.position ? { spawnSite: sitePlan.position } : {}),
+      workerCount,
+      workerTarget,
+      spawnCount
+    });
+  }
+
+  return { active: true, spawnConstructionPending: true };
+}
+
+export function recordPostClaimBootstrapWorkerSpawn(
+  roomName: string | undefined,
+  spawnName: string,
+  creepName: string,
+  result: ScreepsReturnCode,
+  telemetryEvents: RuntimeTelemetryEvent[] = []
+): void {
+  if (!isNonEmptyString(roomName)) {
+    return;
+  }
+
+  const record = getPostClaimBootstrapRecord(roomName);
+  if (!record || record.status === 'ready') {
+    return;
+  }
+
+  updatePostClaimBootstrapRecord(roomName, {
+    status: 'spawningWorkers',
+    updatedAt: getGameTime()
+  });
+  telemetryEvents.push({
+    type: 'postClaimBootstrap',
+    roomName,
+    colony: record.colony,
+    phase: 'workerSpawn',
+    ...(record.controllerId ? { controllerId: record.controllerId } : {}),
+    spawnName,
+    creepName,
+    result,
+    workerTarget: getPostClaimBootstrapWorkerTarget(record)
+  });
+}
+
+export function getPostClaimBootstrapSummary(roomName: string): PostClaimBootstrapSummary | null {
+  const record = getPostClaimBootstrapRecord(roomName);
+  if (!record || record.status === 'ready') {
+    return null;
+  }
+
+  return {
+    colony: record.colony,
+    status: record.status,
+    claimedAt: record.claimedAt,
+    updatedAt: record.updatedAt,
+    workerTarget: getPostClaimBootstrapWorkerTarget(record),
+    ...(record.controllerId ? { controllerId: record.controllerId } : {}),
+    ...(record.spawnSite ? { spawnSite: record.spawnSite } : {}),
+    ...(record.lastResult !== undefined ? { lastResult: record.lastResult } : {})
+  };
+}
+
+function planInitialSpawnConstructionSite(room: Room): SpawnSitePlanResult {
+  if (typeof room.createConstructionSite !== 'function') {
+    return { result: ERR_INVALID_TARGET_CODE };
+  }
+
+  const position = findInitialSpawnConstructionPosition(room);
+  if (!position) {
+    return { result: ERR_INVALID_TARGET_CODE };
+  }
+
+  return {
+    result: room.createConstructionSite(position.x, position.y, getStructureConstant('STRUCTURE_SPAWN', 'spawn')),
+    position: { ...position, roomName: room.name }
+  };
+}
+
+function findInitialSpawnConstructionPosition(room: Room): CandidatePosition | null {
+  const anchor = selectInitialSpawnAnchor(room);
+  if (!anchor) {
+    return null;
+  }
+
+  const lookups = buildSpawnPlacementLookups(room, anchor);
+  for (let radius = 0; radius <= MAX_SPAWN_SITE_SCAN_RADIUS; radius += 1) {
+    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
+      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
+          continue;
+        }
+
+        const position = { x, y };
+        if (canPlaceInitialSpawn(lookups, position)) {
+          return position;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function selectInitialSpawnAnchor(room: Room): CandidatePosition | null {
+  const controllerPosition = getRoomObjectPosition(room.controller);
+  if (!controllerPosition) {
+    return null;
+  }
+
+  const sources = findSources(room)
+    .map(getRoomObjectPosition)
+    .filter((position): position is CandidatePosition => position !== null)
+    .sort((left, right) => getRange(controllerPosition, left) - getRange(controllerPosition, right));
+  const nearestSourcePosition = sources[0];
+  if (!nearestSourcePosition) {
+    return clampPosition(controllerPosition);
+  }
+
+  return clampPosition({
+    x: Math.round((controllerPosition.x + nearestSourcePosition.x) / 2),
+    y: Math.round((controllerPosition.y + nearestSourcePosition.y) / 2)
+  });
+}
+
+function buildSpawnPlacementLookups(room: Room, anchor: CandidatePosition): SpawnPlacementLookups {
+  const blockingPositions = new Set<string>();
+  for (const object of [
+    room.controller,
+    ...findSources(room),
+    ...lookForArea(room, 'LOOK_STRUCTURES', anchor),
+    ...lookForArea(room, 'LOOK_CONSTRUCTION_SITES', anchor)
+  ]) {
+    const position = getRoomObjectPosition(object);
+    if (position) {
+      blockingPositions.add(getPositionKey(position));
+    }
+  }
+
+  return {
+    blockingPositions,
+    terrain: getRoomTerrain(room.name)
+  };
+}
+
+function lookForArea(room: Room, lookConstantName: LookConstantGlobal, anchor: CandidatePosition): unknown[] {
+  const lookConstant = getGlobalString(lookConstantName);
+  if (!lookConstant || typeof room.lookForAtArea !== 'function') {
+    return [];
+  }
+
+  const bounds = getScanBounds(anchor);
+  return room.lookForAtArea(
+    lookConstant as LookConstant,
+    bounds.top,
+    bounds.left,
+    bounds.bottom,
+    bounds.right,
+    true
+  ) as unknown[];
+}
+
+function getScanBounds(anchor: CandidatePosition): {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+} {
+  return {
+    top: Math.max(ROOM_EDGE_MIN, anchor.y - MAX_SPAWN_SITE_SCAN_RADIUS),
+    left: Math.max(ROOM_EDGE_MIN, anchor.x - MAX_SPAWN_SITE_SCAN_RADIUS),
+    bottom: Math.min(ROOM_EDGE_MAX, anchor.y + MAX_SPAWN_SITE_SCAN_RADIUS),
+    right: Math.min(ROOM_EDGE_MAX, anchor.x + MAX_SPAWN_SITE_SCAN_RADIUS)
+  };
+}
+
+function canPlaceInitialSpawn(lookups: SpawnPlacementLookups, position: CandidatePosition): boolean {
+  return (
+    isWithinRoomBuildBounds(position) &&
+    !lookups.blockingPositions.has(getPositionKey(position)) &&
+    !isTerrainWall(lookups.terrain, position)
+  );
+}
+
+function isWithinRoomBuildBounds(position: CandidatePosition): boolean {
+  return (
+    position.x >= ROOM_EDGE_MIN &&
+    position.x <= ROOM_EDGE_MAX &&
+    position.y >= ROOM_EDGE_MIN &&
+    position.y <= ROOM_EDGE_MAX
+  );
+}
+
+function isTerrainWall(terrain: RoomTerrain | null, position: CandidatePosition): boolean {
+  return terrain !== null && (terrain.get(position.x, position.y) & getTerrainWallMask()) !== 0;
+}
+
+function findExistingSpawnConstructionSite(room: Room): ConstructionSite | null {
+  const findConstant = getGlobalNumber('FIND_MY_CONSTRUCTION_SITES');
+  if (typeof room.find !== 'function' || findConstant === null) {
+    return null;
+  }
+
+  const sites = room.find(findConstant as FindConstant, {
+    filter: (site: ConstructionSite) => matchesStructureType(site.structureType, 'STRUCTURE_SPAWN', 'spawn')
+  }) as ConstructionSite[];
+  return sites[0] ?? null;
+}
+
+function findSources(room: Room): Source[] {
+  const findConstant = getGlobalNumber('FIND_SOURCES');
+  if (typeof room.find !== 'function' || findConstant === null) {
+    return [];
+  }
+
+  return room.find(findConstant as FindConstant) as Source[];
+}
+
+function getRoomObjectPosition(object: unknown): CandidatePosition | null {
+  if (!isRecord(object)) {
+    return null;
+  }
+
+  if (isFiniteNumber(object.x) && isFiniteNumber(object.y)) {
+    return { x: object.x, y: object.y };
+  }
+
+  const pos = object.pos;
+  if (isRecord(pos) && isFiniteNumber(pos.x) && isFiniteNumber(pos.y)) {
+    return { x: pos.x, y: pos.y };
+  }
+
+  return null;
+}
+
+function toSpawnSiteMemory(site: ConstructionSite): TerritoryPostClaimBootstrapSpawnSiteMemory {
+  const position = getRoomObjectPosition(site);
+  return {
+    roomName: site.pos?.roomName ?? site.room?.name ?? '',
+    x: position?.x ?? site.pos.x,
+    y: position?.y ?? site.pos.y
+  };
+}
+
+function isSameSpawnSite(
+  left: TerritoryPostClaimBootstrapSpawnSiteMemory | undefined,
+  right: TerritoryPostClaimBootstrapSpawnSiteMemory
+): boolean {
+  return left?.roomName === right.roomName && left.x === right.x && left.y === right.y;
+}
+
+function updatePostClaimBootstrapRecord(
+  roomName: string,
+  updates: Partial<Omit<TerritoryPostClaimBootstrapMemory, 'colony' | 'roomName' | 'claimedAt'>>
+): void {
+  const bootstraps = getWritablePostClaimBootstrapRecords();
+  const record = bootstraps?.[roomName];
+  if (!bootstraps || !record) {
+    return;
+  }
+
+  bootstraps[roomName] = {
+    ...record,
+    ...updates
+  };
+}
+
+function getPostClaimBootstrapRecord(roomName: string): TerritoryPostClaimBootstrapMemory | null {
+  const record = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.postClaimBootstraps?.[roomName];
+  return isPostClaimBootstrapRecord(record, roomName) ? record : null;
+}
+
+function getWritablePostClaimBootstrapRecords(): Record<string, TerritoryPostClaimBootstrapMemory> | null {
+  const memory = (globalThis as { Memory?: Partial<Memory> }).Memory;
+  if (!memory) {
+    return null;
+  }
+
+  if (!memory.territory) {
+    memory.territory = {};
+  }
+
+  if (!memory.territory.postClaimBootstraps) {
+    memory.territory.postClaimBootstraps = {};
+  }
+
+  return memory.territory.postClaimBootstraps;
+}
+
+function isPostClaimBootstrapRecord(
+  value: unknown,
+  expectedRoomName: string
+): value is TerritoryPostClaimBootstrapMemory {
+  return (
+    isRecord(value) &&
+    value.roomName === expectedRoomName &&
+    isNonEmptyString(value.colony) &&
+    isPostClaimBootstrapStatus(value.status) &&
+    isFiniteNumber(value.claimedAt) &&
+    isFiniteNumber(value.updatedAt)
+  );
+}
+
+function isPostClaimBootstrapStatus(value: unknown): value is TerritoryPostClaimBootstrapStatus {
+  return (
+    value === 'detected' ||
+    value === 'spawnSitePending' ||
+    value === 'spawnSiteBlocked' ||
+    value === 'spawningWorkers' ||
+    value === 'ready'
+  );
+}
+
+function getPostClaimBootstrapWorkerTarget(record: TerritoryPostClaimBootstrapMemory): number {
+  return isFiniteNumber(record.workerTarget) && record.workerTarget > 0
+    ? Math.floor(record.workerTarget)
+    : POST_CLAIM_BOOTSTRAP_WORKER_TARGET;
+}
+
+function clampPosition(position: CandidatePosition): CandidatePosition {
+  return {
+    x: clamp(position.x, ROOM_EDGE_MIN, ROOM_EDGE_MAX),
+    y: clamp(position.y, ROOM_EDGE_MIN, ROOM_EDGE_MAX)
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function getRange(left: CandidatePosition, right: CandidatePosition): number {
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
+}
+
+function getPositionKey(position: CandidatePosition): string {
+  return `${position.x},${position.y}`;
+}
+
+function getRoomTerrain(roomName: string): RoomTerrain | null {
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map;
+  return typeof gameMap?.getRoomTerrain === 'function' ? gameMap.getRoomTerrain(roomName) : null;
+}
+
+function getTerrainWallMask(): number {
+  return typeof TERRAIN_MASK_WALL === 'number' ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK;
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: StructureConstantGlobal,
+  fallback: BuildableStructureConstant
+): boolean {
+  return actual === getStructureConstant(globalName, fallback);
+}
+
+function getStructureConstant(
+  globalName: StructureConstantGlobal,
+  fallback: BuildableStructureConstant
+): BuildableStructureConstant {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, BuildableStructureConstant>>;
+  return constants[globalName] ?? fallback;
+}
+
+function getGlobalNumber(name: FindConstantGlobal): number | null {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : null;
+}
+
+function getGlobalString(name: LookConstantGlobal): string | null {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'string' ? value : null;
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof gameTime === 'number' && Number.isFinite(gameTime) ? gameTime : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -12,7 +12,7 @@ const DEFAULT_TERRAIN_WALL_MASK = 1;
 
 type StructureConstantGlobal = 'STRUCTURE_SPAWN';
 type FindConstantGlobal = 'FIND_MY_CONSTRUCTION_SITES' | 'FIND_SOURCES';
-type LookConstantGlobal = 'LOOK_STRUCTURES' | 'LOOK_CONSTRUCTION_SITES';
+type LookConstantGlobal = 'LOOK_STRUCTURES' | 'LOOK_CONSTRUCTION_SITES' | 'LOOK_MINERALS';
 
 interface CandidatePosition {
   x: number;
@@ -26,6 +26,7 @@ interface SpawnSitePlanResult {
 
 interface SpawnPlacementLookups {
   blockingPositions: Set<string>;
+  mineralPositions: Set<string>;
   terrain: RoomTerrain | null;
 }
 
@@ -245,25 +246,34 @@ function planInitialSpawnConstructionSite(room: Room): SpawnSitePlanResult {
     return { result: ERR_INVALID_TARGET_CODE };
   }
 
-  const position = findInitialSpawnConstructionPosition(room);
-  if (!position) {
+  const positions = findInitialSpawnConstructionPositions(room);
+  if (positions.length === 0) {
     return { result: ERR_INVALID_TARGET_CODE };
   }
 
-  return {
-    result: room.createConstructionSite(position.x, position.y, getStructureConstant('STRUCTURE_SPAWN', 'spawn')),
-    position: { ...position, roomName: room.name }
-  };
+  let lastResult = ERR_INVALID_TARGET_CODE;
+  for (const position of positions) {
+    lastResult = room.createConstructionSite(position.x, position.y, getStructureConstant('STRUCTURE_SPAWN', 'spawn'));
+    if (lastResult === OK_CODE) {
+      return {
+        result: lastResult,
+        position: { ...position, roomName: room.name }
+      };
+    }
+  }
+
+  return { result: lastResult };
 }
 
-function findInitialSpawnConstructionPosition(room: Room): CandidatePosition | null {
+function findInitialSpawnConstructionPositions(room: Room): CandidatePosition[] {
   const anchor = selectInitialSpawnAnchor(room);
   if (!anchor) {
-    return null;
+    return [];
   }
 
   const maximumScanRadius = getMaximumSpawnSiteScanRadius(anchor);
   const lookups = buildSpawnPlacementLookups(room, anchor, maximumScanRadius);
+  const positions: CandidatePosition[] = [];
   for (let radius = 0; radius <= maximumScanRadius; radius += 1) {
     for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
       for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
@@ -273,13 +283,13 @@ function findInitialSpawnConstructionPosition(room: Room): CandidatePosition | n
 
         const position = { x, y };
         if (canPlaceInitialSpawn(lookups, position)) {
-          return position;
+          positions.push(position);
         }
       }
     }
   }
 
-  return null;
+  return positions;
 }
 
 function selectInitialSpawnAnchor(room: Room): CandidatePosition | null {
@@ -320,9 +330,17 @@ function buildSpawnPlacementLookups(
       blockingPositions.add(getPositionKey(position));
     }
   }
+  const mineralPositions = new Set<string>();
+  for (const object of lookForArea(room, 'LOOK_MINERALS', anchor, maximumScanRadius)) {
+    const position = getRoomObjectPosition(object);
+    if (position) {
+      mineralPositions.add(getPositionKey(position));
+    }
+  }
 
   return {
     blockingPositions,
+    mineralPositions,
     terrain: getRoomTerrain(room.name)
   };
 }
@@ -370,6 +388,7 @@ function canPlaceInitialSpawn(lookups: SpawnPlacementLookups, position: Candidat
   return (
     isWithinRoomBuildBounds(position) &&
     !lookups.blockingPositions.has(getPositionKey(position)) &&
+    !lookups.mineralPositions.has(getPositionKey(position)) &&
     !isTerrainWall(lookups.terrain, position)
   );
 }

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -8,7 +8,6 @@ const OK_CODE = 0 as ScreepsReturnCode;
 const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
 const ROOM_EDGE_MIN = 2;
 const ROOM_EDGE_MAX = 47;
-const MAX_SPAWN_SITE_SCAN_RADIUS = 6;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
 
 type StructureConstantGlobal = 'STRUCTURE_SPAWN';
@@ -263,8 +262,9 @@ function findInitialSpawnConstructionPosition(room: Room): CandidatePosition | n
     return null;
   }
 
-  const lookups = buildSpawnPlacementLookups(room, anchor);
-  for (let radius = 0; radius <= MAX_SPAWN_SITE_SCAN_RADIUS; radius += 1) {
+  const maximumScanRadius = getMaximumSpawnSiteScanRadius(anchor);
+  const lookups = buildSpawnPlacementLookups(room, anchor, maximumScanRadius);
+  for (let radius = 0; radius <= maximumScanRadius; radius += 1) {
     for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
       for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
         if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
@@ -303,13 +303,17 @@ function selectInitialSpawnAnchor(room: Room): CandidatePosition | null {
   });
 }
 
-function buildSpawnPlacementLookups(room: Room, anchor: CandidatePosition): SpawnPlacementLookups {
+function buildSpawnPlacementLookups(
+  room: Room,
+  anchor: CandidatePosition,
+  maximumScanRadius: number
+): SpawnPlacementLookups {
   const blockingPositions = new Set<string>();
   for (const object of [
     room.controller,
     ...findSources(room),
-    ...lookForArea(room, 'LOOK_STRUCTURES', anchor),
-    ...lookForArea(room, 'LOOK_CONSTRUCTION_SITES', anchor)
+    ...lookForArea(room, 'LOOK_STRUCTURES', anchor, maximumScanRadius),
+    ...lookForArea(room, 'LOOK_CONSTRUCTION_SITES', anchor, maximumScanRadius)
   ]) {
     const position = getRoomObjectPosition(object);
     if (position) {
@@ -323,13 +327,18 @@ function buildSpawnPlacementLookups(room: Room, anchor: CandidatePosition): Spaw
   };
 }
 
-function lookForArea(room: Room, lookConstantName: LookConstantGlobal, anchor: CandidatePosition): unknown[] {
+function lookForArea(
+  room: Room,
+  lookConstantName: LookConstantGlobal,
+  anchor: CandidatePosition,
+  maximumScanRadius: number
+): unknown[] {
   const lookConstant = getGlobalString(lookConstantName);
   if (!lookConstant || typeof room.lookForAtArea !== 'function') {
     return [];
   }
 
-  const bounds = getScanBounds(anchor);
+  const bounds = getScanBounds(anchor, maximumScanRadius);
   return room.lookForAtArea(
     lookConstant as LookConstant,
     bounds.top,
@@ -340,17 +349,20 @@ function lookForArea(room: Room, lookConstantName: LookConstantGlobal, anchor: C
   ) as unknown[];
 }
 
-function getScanBounds(anchor: CandidatePosition): {
+function getScanBounds(
+  anchor: CandidatePosition,
+  maximumScanRadius: number
+): {
   top: number;
   left: number;
   bottom: number;
   right: number;
 } {
   return {
-    top: Math.max(ROOM_EDGE_MIN, anchor.y - MAX_SPAWN_SITE_SCAN_RADIUS),
-    left: Math.max(ROOM_EDGE_MIN, anchor.x - MAX_SPAWN_SITE_SCAN_RADIUS),
-    bottom: Math.min(ROOM_EDGE_MAX, anchor.y + MAX_SPAWN_SITE_SCAN_RADIUS),
-    right: Math.min(ROOM_EDGE_MAX, anchor.x + MAX_SPAWN_SITE_SCAN_RADIUS)
+    top: Math.max(ROOM_EDGE_MIN, anchor.y - maximumScanRadius),
+    left: Math.max(ROOM_EDGE_MIN, anchor.x - maximumScanRadius),
+    bottom: Math.min(ROOM_EDGE_MAX, anchor.y + maximumScanRadius),
+    right: Math.min(ROOM_EDGE_MAX, anchor.x + maximumScanRadius)
   };
 }
 
@@ -506,6 +518,15 @@ function clampPosition(position: CandidatePosition): CandidatePosition {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
+}
+
+function getMaximumSpawnSiteScanRadius(anchor: CandidatePosition): number {
+  return Math.max(
+    anchor.x - ROOM_EDGE_MIN,
+    ROOM_EDGE_MAX - anchor.x,
+    anchor.y - ROOM_EDGE_MIN,
+    ROOM_EDGE_MAX - anchor.y
+  );
 }
 
 function getRange(left: CandidatePosition, right: CandidatePosition): number {

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -13,6 +13,7 @@ import {
   isExpansionClaimControllerOnCooldown,
   recordExpansionClaimSkipTelemetry
 } from './claimExecutor';
+import { recordPostClaimBootstrapClaimSuccess } from './postClaimBootstrap';
 import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
@@ -128,6 +129,10 @@ export function runTerritoryControllerCreep(
       ? executeExpansionClaim(creep, controller, telemetryEvents)
       : executeControllerAction(creep, controller, 'reserveController');
 
+  if (assignment.action === 'claim' && result === OK_CODE) {
+    recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents);
+  }
+
   if (result === ERR_NOT_IN_RANGE_CODE && typeof creep.moveTo === 'function') {
     creep.moveTo(controller);
     return;
@@ -193,6 +198,40 @@ function suppressTerritoryAssignment(creep: Creep, assignment: CreepTerritoryMem
 
 function completeTerritoryAssignment(creep: Creep): void {
   delete creep.memory.territory;
+}
+
+function recordPostClaimBootstrapIfOwned(
+  creep: Creep,
+  assignment: CreepTerritoryMemory,
+  controller: StructureController,
+  telemetryEvents: RuntimeTelemetryEvent[]
+): void {
+  const room = getVisibleClaimedRoom(assignment.targetRoom, controller);
+  if (!room?.controller?.my) {
+    return;
+  }
+
+  recordPostClaimBootstrapClaimSuccess(
+    {
+      colony: creep.memory.colony ?? room.name,
+      roomName: room.name,
+      controllerId: controller.id
+    },
+    telemetryEvents
+  );
+}
+
+function getVisibleClaimedRoom(
+  targetRoom: string,
+  controller: StructureController
+): Room | null {
+  const controllerRoom = controller.room;
+  if (controllerRoom?.controller?.my === true) {
+    return controllerRoom;
+  }
+
+  const gameRoom = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[targetRoom];
+  return gameRoom?.controller?.my === true ? gameRoom : null;
 }
 
 function selectTargetController(creep: Creep, assignment: CreepTerritoryMemory): StructureController | null {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -69,6 +69,12 @@ declare global {
   type TerritoryFollowUpSource = 'satisfiedClaimAdjacent' | 'satisfiedReserveAdjacent' | 'activeReserveAdjacent';
   type TerritoryAutomationSource = 'occupationRecommendation' | 'autonomousExpansionClaim';
   type TerritoryIntentSuspensionReason = 'hostile_presence';
+  type TerritoryPostClaimBootstrapStatus =
+    | 'detected'
+    | 'spawnSitePending'
+    | 'spawnSiteBlocked'
+    | 'spawningWorkers'
+    | 'ready';
   type TerritoryExecutionHintReason =
     | 'controlEvidenceStillMissing'
     | 'followUpTargetStillUnseen'
@@ -79,6 +85,7 @@ declare global {
     intents?: TerritoryIntentMemory[];
     demands?: TerritoryFollowUpDemandMemory[];
     executionHints?: TerritoryExecutionHintMemory[];
+    postClaimBootstraps?: Record<string, TerritoryPostClaimBootstrapMemory>;
     reservations?: Record<string, TerritoryReservationMemory>;
     routeDistances?: Record<string, number | null>;
   }
@@ -145,6 +152,24 @@ declare global {
     updatedAt: number;
     controllerId?: Id<StructureController>;
     followUp: TerritoryFollowUpMemory;
+  }
+
+  interface TerritoryPostClaimBootstrapSpawnSiteMemory {
+    roomName: string;
+    x: number;
+    y: number;
+  }
+
+  interface TerritoryPostClaimBootstrapMemory {
+    colony: string;
+    roomName: string;
+    status: TerritoryPostClaimBootstrapStatus;
+    claimedAt: number;
+    updatedAt: number;
+    workerTarget: number;
+    controllerId?: Id<StructureController>;
+    spawnSite?: TerritoryPostClaimBootstrapSpawnSiteMemory;
+    lastResult?: ScreepsReturnCode;
   }
 
   interface CreepTerritoryMemory {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -971,6 +971,95 @@ describe('runEconomy', () => {
     });
   });
 
+  it('plans an initial spawn construction site beyond radius 6 when nearer tiles are blocked', () => {
+    (globalThis as unknown as {
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_SOURCES: number;
+      LOOK_STRUCTURES: LOOK_STRUCTURES;
+      LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
+      STRUCTURE_SPAWN: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      Memory: Partial<Memory>;
+    }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+    (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES =
+      'constructionSite';
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'detected',
+            claimedAt: 402,
+            updatedAt: 402,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        }
+      }
+    };
+    const constructionSites: ConstructionSite[] = [];
+    const room = {
+      name: 'W2N1',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: {
+        id: 'controller2',
+        my: true,
+        level: 1,
+        pos: { x: 25, y: 25, roomName: 'W2N1' }
+      } as StructureController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_SOURCES) {
+          return [{ id: 'source1', pos: { x: 21, y: 21, roomName: 'W2N1' } } as Source];
+        }
+
+        if (type === FIND_MY_CONSTRUCTION_SITES) {
+          return constructionSites;
+        }
+
+        return [];
+      }),
+      lookForAtArea: jest.fn().mockReturnValue([]),
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        constructionSites.push({
+          id: `site-${x}-${y}`,
+          structureType,
+          pos: { x, y, roomName: 'W2N1' }
+        } as ConstructionSite);
+        return OK_CODE;
+      })
+    } as unknown as Room;
+    const terrain = {
+      get: jest.fn((x: number, y: number) => (Math.max(Math.abs(x - 23), Math.abs(y - 23)) <= 6 ? 1 : 0))
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 403,
+      rooms: { W2N1: room },
+      spawns: {},
+      creeps: {},
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue(terrain)
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_STRUCTURES, 2, 2, 47, 47, true);
+    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_CONSTRUCTION_SITES, 2, 2, 47, 47, true);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(16, 16, STRUCTURE_SPAWN);
+    expect(Memory.territory?.postClaimBootstraps?.W2N1).toMatchObject({
+      status: 'spawnSitePending',
+      updatedAt: 403,
+      spawnSite: { roomName: 'W2N1', x: 16, y: 16 },
+      lastResult: OK_CODE
+    });
+  });
+
   it('spawns initial local workers for a post-claim room that already has a spawn', () => {
     (globalThis as unknown as {
       FIND_SOURCES: number;

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -860,6 +860,191 @@ describe('runEconomy', () => {
     });
   });
 
+  it('plans an initial spawn construction site for a post-claim room without a spawn', () => {
+    (globalThis as unknown as {
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_SOURCES: number;
+      LOOK_STRUCTURES: LOOK_STRUCTURES;
+      LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
+      STRUCTURE_SPAWN: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      Memory: Partial<Memory>;
+    }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+    (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES = 'constructionSite';
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'detected',
+            claimedAt: 400,
+            updatedAt: 400,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        }
+      }
+    };
+    const constructionSites: ConstructionSite[] = [];
+    const room = {
+      name: 'W2N1',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: {
+        id: 'controller2',
+        my: true,
+        level: 1,
+        pos: { x: 25, y: 25, roomName: 'W2N1' }
+      } as StructureController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_SOURCES) {
+          return [{ id: 'source1', pos: { x: 21, y: 21, roomName: 'W2N1' } } as Source];
+        }
+
+        if (type === FIND_MY_CONSTRUCTION_SITES) {
+          return constructionSites;
+        }
+
+        return [];
+      }),
+      lookForAtArea: jest.fn().mockReturnValue([]),
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        constructionSites.push({
+          id: `site-${x}-${y}`,
+          structureType,
+          pos: { x, y, roomName: 'W2N1' }
+        } as ConstructionSite);
+        return OK_CODE;
+      })
+    } as unknown as Room;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 401,
+      rooms: { W2N1: room },
+      spawns: {},
+      creeps: {},
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(room.createConstructionSite).toHaveBeenCalledWith(23, 23, STRUCTURE_SPAWN);
+    expect(Memory.territory?.postClaimBootstraps?.W2N1).toMatchObject({
+      status: 'spawnSitePending',
+      updatedAt: 401,
+      spawnSite: { roomName: 'W2N1', x: 23, y: 23 },
+      lastResult: OK_CODE
+    });
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const [message] = logSpy.mock.calls[0];
+    expect(JSON.parse((message as string).slice(RUNTIME_SUMMARY_PREFIX.length))).toMatchObject({
+      events: [
+        {
+          type: 'postClaimBootstrap',
+          roomName: 'W2N1',
+          colony: 'W1N1',
+          phase: 'spawnSite',
+          result: OK_CODE,
+          spawnSite: { roomName: 'W2N1', x: 23, y: 23 },
+          workerCount: 0,
+          workerTarget: 2,
+          spawnCount: 0
+        }
+      ],
+      rooms: [
+        {
+          roomName: 'W2N1',
+          postClaimBootstrap: {
+            colony: 'W1N1',
+            status: 'spawnSitePending',
+            spawnSite: { roomName: 'W2N1', x: 23, y: 23 },
+            lastResult: OK_CODE
+          }
+        }
+      ]
+    });
+  });
+
+  it('spawns initial local workers for a post-claim room that already has a spawn', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'detected',
+            claimedAt: 410,
+            updatedAt: 410,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        }
+      }
+    };
+    const room = {
+      name: 'W2N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controller: { id: 'controller2', my: true, level: 1 } as StructureController,
+      find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: 'source1' } as Source] : []))
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn2',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 411,
+      rooms: { W2N1: room },
+      spawns: { Spawn2: spawn },
+      creeps: {}
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W2N1-411', {
+      memory: { role: 'worker', colony: 'W2N1' }
+    });
+    expect(Memory.territory?.postClaimBootstraps?.W2N1).toMatchObject({
+      status: 'spawningWorkers',
+      updatedAt: 411
+    });
+    const [message] = logSpy.mock.calls[0];
+    expect(JSON.parse((message as string).slice(RUNTIME_SUMMARY_PREFIX.length))).toMatchObject({
+      events: [
+        {
+          type: 'spawn',
+          roomName: 'W2N1',
+          spawnName: 'Spawn2',
+          creepName: 'worker-W2N1-411',
+          role: 'worker',
+          result: OK_CODE
+        },
+        {
+          type: 'postClaimBootstrap',
+          roomName: 'W2N1',
+          colony: 'W1N1',
+          phase: 'workerSpawn',
+          spawnName: 'Spawn2',
+          creepName: 'worker-W2N1-411',
+          result: OK_CODE,
+          workerTarget: 2
+        }
+      ]
+    });
+  });
+
   it('keeps unsafe occupation recommendations on worker recovery before territory spawn pressure', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -4,6 +4,7 @@ import { RUNTIME_SUMMARY_PREFIX } from '../src/telemetry/runtimeSummary';
 
 const OK_CODE = 0 as ScreepsReturnCode;
 const ERR_BUSY_CODE = -4 as ScreepsReturnCode;
+const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
 
 describe('runEconomy', () => {
   let logSpy: jest.SpyInstance<void, [message?: unknown, ...optionalParams: unknown[]]>;
@@ -1056,6 +1057,102 @@ describe('runEconomy', () => {
       status: 'spawnSitePending',
       updatedAt: 403,
       spawnSite: { roomName: 'W2N1', x: 16, y: 16 },
+      lastResult: OK_CODE
+    });
+  });
+
+  it('skips mineral spawn tiles and retries when initial spawn site creation fails', () => {
+    (globalThis as unknown as {
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_SOURCES: number;
+      LOOK_STRUCTURES: LOOK_STRUCTURES;
+      LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
+      LOOK_MINERALS: LOOK_MINERALS;
+      STRUCTURE_SPAWN: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      Memory: Partial<Memory>;
+    }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+    (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES =
+      'constructionSite';
+    (globalThis as unknown as { LOOK_MINERALS: LOOK_MINERALS }).LOOK_MINERALS = 'mineral';
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'detected',
+            claimedAt: 404,
+            updatedAt: 404,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        }
+      }
+    };
+    const constructionSites: ConstructionSite[] = [];
+    const room = {
+      name: 'W2N1',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: {
+        id: 'controller2',
+        my: true,
+        level: 1,
+        pos: { x: 25, y: 25, roomName: 'W2N1' }
+      } as StructureController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_SOURCES) {
+          return [{ id: 'source1', pos: { x: 21, y: 21, roomName: 'W2N1' } } as Source];
+        }
+
+        if (type === FIND_MY_CONSTRUCTION_SITES) {
+          return constructionSites;
+        }
+
+        return [];
+      }),
+      lookForAtArea: jest.fn((lookType: LookConstant) =>
+        lookType === LOOK_MINERALS
+          ? [{ x: 23, y: 23, mineral: { id: 'mineral1', pos: { x: 23, y: 23, roomName: 'W2N1' } } as Mineral }]
+          : []
+      ),
+      createConstructionSite: jest
+        .fn()
+        .mockReturnValueOnce(ERR_INVALID_TARGET_CODE)
+        .mockImplementation((x: number, y: number, structureType: StructureConstant) => {
+          constructionSites.push({
+            id: `site-${x}-${y}`,
+            structureType,
+            pos: { x, y, roomName: 'W2N1' }
+          } as ConstructionSite);
+          return OK_CODE;
+        })
+    } as unknown as Room;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 405,
+      rooms: { W2N1: room },
+      spawns: {},
+      creeps: {},
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_MINERALS, 2, 2, 47, 47, true);
+    expect(room.createConstructionSite).not.toHaveBeenCalledWith(23, 23, STRUCTURE_SPAWN);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 22, 22, STRUCTURE_SPAWN);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(2, 23, 22, STRUCTURE_SPAWN);
+    expect(Memory.territory?.postClaimBootstraps?.W2N1).toMatchObject({
+      status: 'spawnSitePending',
+      updatedAt: 405,
+      spawnSite: { roomName: 'W2N1', x: 23, y: 22 },
       lastResult: OK_CODE
     });
   });

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -261,6 +261,54 @@ describe('runTerritoryControllerCreep', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('records post-claim bootstrap when a successful claim makes the target room owned', () => {
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const targetRoom = { name: 'W1N2', controller } as Room;
+    const getObjectById = jest.fn().mockReturnValue(controller);
+    const telemetryEvents: RuntimeTelemetryEvent[] = [];
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 503,
+      rooms: { W1N2: targetRoom },
+      getObjectById
+    };
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W1N2', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W1N2', controller },
+      claimController: jest.fn(() => {
+        (controller as StructureController & { my: boolean }).my = true;
+        return 0 as ScreepsReturnCode;
+      }),
+      signController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runTerritoryControllerCreep(creep, telemetryEvents);
+
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(Memory.territory?.postClaimBootstraps?.W1N2).toEqual({
+      colony: 'W1N1',
+      roomName: 'W1N2',
+      status: 'detected',
+      claimedAt: 503,
+      updatedAt: 503,
+      workerTarget: 2,
+      controllerId: 'controller1'
+    });
+    expect(telemetryEvents).toContainEqual({
+      type: 'postClaimBootstrap',
+      roomName: 'W1N2',
+      colony: 'W1N1',
+      phase: 'detected',
+      controllerId: 'controller1',
+      workerTarget: 2
+    });
+  });
+
   it('moves a claimer into range without suppressing the target', () => {
     const controller = { id: 'controller1', my: false } as StructureController;
     const creep = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -4688,6 +4688,27 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller2' });
   });
 
+  it('builds claimed-room spawn construction before fallback territory upgrading', () => {
+    const controller = { id: 'controller2', my: true, level: 1 } as StructureController;
+    const site = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [{ colony: 'W1N1', targetRoom: 'W2N1', action: 'claim', status: 'active', updatedAt: 102 }]
+      }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
+  });
+
   it('does not prioritize a freshly suppressed urgent reservation renewal', () => {
     const controller = {
       id: 'controller2',


### PR DESCRIPTION
## Summary
Implements post-claim bootstrap for newly claimed rooms: initial spawn construction planning, minimal worker spawning, energy acquisition routing, and basic economyLoop integration for claimed rooms. Adds territory runner post-claim state transitions and worker task prioritization for bootstrap phase.

## Test Plan
- [x] TypeScript typecheck passes
- [x] All 724 Jest tests pass (`npm test -- --runInBand`)
- [x] Build succeeds (`npm run build`)
- [x] `git diff --check` clean

## Verification
```
npm run typecheck  # PASS
npm test -- --runInBand  # 27 suites, 724 tests PASS
npm run build  # OK
```

Closes #489
