### PR TITLE
feat(economy): spawn-critical refill priority over extensions

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5358,7 +5358,8 @@ var CONTROLLER_DOWNGRADE_GUARD_TICKS2 = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
-var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
+var CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
+var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
 var NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
 var MINIMUM_USEFUL_LOAD_RATIO = 0.4;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
@@ -5456,6 +5457,9 @@ function selectWorkerTask(creep) {
       type: "transfer",
       targetId: spawnOrExtensionEnergySink.id
     };
+    if (isCriticalSpawnEnergySink(spawnOrExtensionEnergySink)) {
+      recordSpawnCriticalRefillTelemetry(creep, spawnOrExtensionEnergySink);
+    }
     if (hasEmergencySpawnExtensionRefillDemand(creep)) {
       recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, "emergencySpawnExtensionRefill");
       return spawnOrExtensionRefillTask;
@@ -5729,6 +5733,22 @@ function clearWorkerEfficiencyTelemetry(creep) {
     delete memory.workerEfficiency;
   }
 }
+function recordSpawnCriticalRefillTelemetry(creep, spawn) {
+  var _a, _b;
+  const memory = creep.memory;
+  if (!memory) {
+    return;
+  }
+  memory.spawnCriticalRefill = {
+    type: "spawnCriticalRefill",
+    tick: (_a = getGameTick()) != null ? _a : 0,
+    targetId: String(spawn.id),
+    carriedEnergy: getUsedEnergy(creep),
+    spawnEnergy: (_b = getKnownStoredEnergy(spawn)) != null ? _b : 0,
+    freeCapacity: getFreeStoredEnergyCapacity(spawn),
+    threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
+  };
+}
 function recordNearbyEnergyChoiceTelemetry(creep, candidate) {
   var _a;
   const context = getLowLoadWorkerEnergyContext(creep);
@@ -5805,7 +5825,18 @@ function compareSpawnExtensionRecoveryEnergySinks(left, right, creep, reservedEn
   const carriedEnergy = getUsedEnergy(creep);
   const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(left, reservedEnergyDeliveries);
   const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(right, reservedEnergyDeliveries);
-  return compareLowEnergySpawnPriority(left, right) || compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareAssignedTransferTarget(left, right, assignedTransferTargetId) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareEnergySinkId(left, right);
+  return compareCriticalSpawnPriority(left, right) || compareLowEnergySpawnPriority(left, right) || compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareAssignedTransferTarget(left, right, assignedTransferTargetId) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareEnergySinkId(left, right);
+}
+function compareCriticalSpawnPriority(left, right) {
+  if (isSpawnEnergySink(left) && isSpawnEnergySink(right)) {
+    return 0;
+  }
+  const leftCriticalSpawn = isCriticalSpawnEnergySink(left);
+  const rightCriticalSpawn = isCriticalSpawnEnergySink(right);
+  if (leftCriticalSpawn === rightCriticalSpawn) {
+    return 0;
+  }
+  return leftCriticalSpawn ? -1 : 1;
 }
 function compareLowEnergySpawnPriority(left, right) {
   const leftLowEnergySpawn = isLowEnergySpawn(left);
@@ -5817,6 +5848,10 @@ function compareLowEnergySpawnPriority(left, right) {
 }
 function isLowEnergySpawn(structure) {
   return isSpawnEnergySink(structure) && getStoredEnergy2(structure) < getSpawnEnergyCapacity();
+}
+function isCriticalSpawnEnergySink(structure) {
+  const storedEnergy = getKnownStoredEnergy(structure);
+  return isSpawnEnergySink(structure) && storedEnergy !== null && storedEnergy < CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 function getSpawnEnergyCapacity() {
   const spawnEnergyCapacity = globalThis.SPAWN_ENERGY_CAPACITY;
@@ -7345,16 +7380,23 @@ function getFreeEnergyCapacity(creep) {
 }
 function getStoredEnergy2(object) {
   var _a;
+  return (_a = getKnownStoredEnergy(object)) != null ? _a : 0;
+}
+function getKnownStoredEnergy(object) {
+  var _a;
   const store = getStore(object);
-  if (!store) {
-    return 0;
+  if (store) {
+    const usedCapacity = (_a = store.getUsedCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
+    if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+      return usedCapacity;
+    }
+    const storedEnergy = store[getWorkerEnergyResource()];
+    if (typeof storedEnergy === "number" && Number.isFinite(storedEnergy)) {
+      return storedEnergy;
+    }
   }
-  const usedCapacity = (_a = store.getUsedCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
-  if (typeof usedCapacity === "number") {
-    return usedCapacity;
-  }
-  const storedEnergy = store[getWorkerEnergyResource()];
-  return typeof storedEnergy === "number" ? storedEnergy : 0;
+  const legacyEnergy = object == null ? void 0 : object.energy;
+  return typeof legacyEnergy === "number" && Number.isFinite(legacyEnergy) ? legacyEnergy : null;
 }
 function getFreeStoredEnergyCapacity(object) {
   var _a;
@@ -7995,10 +8037,32 @@ function getTransferSinkPriority(target) {
   if (typeof structureType !== "string") {
     return 0;
   }
-  if (matchesTransferSinkStructureType(structureType, "STRUCTURE_SPAWN", "spawn") || matchesTransferSinkStructureType(structureType, "STRUCTURE_EXTENSION", "extension")) {
+  if (matchesTransferSinkStructureType(structureType, "STRUCTURE_SPAWN", "spawn")) {
+    return isCriticalSpawnRefillTarget(target) ? 3 : 2;
+  }
+  if (matchesTransferSinkStructureType(structureType, "STRUCTURE_EXTENSION", "extension")) {
     return 2;
   }
   return matchesTransferSinkStructureType(structureType, "STRUCTURE_TOWER", "tower") ? 1 : 0;
+}
+function isCriticalSpawnRefillTarget(target) {
+  const structureType = target == null ? void 0 : target.structureType;
+  const storedEnergy = getKnownStoredTransferEnergy(target);
+  return typeof structureType === "string" && matchesTransferSinkStructureType(structureType, "STRUCTURE_SPAWN", "spawn") && storedEnergy !== null && storedEnergy < CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
+}
+function getKnownStoredTransferEnergy(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, RESOURCE_ENERGY);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return usedCapacity;
+  }
+  const storedEnergy = store == null ? void 0 : store[RESOURCE_ENERGY];
+  if (typeof storedEnergy === "number" && Number.isFinite(storedEnergy)) {
+    return storedEnergy;
+  }
+  const legacyEnergy = target == null ? void 0 : target.energy;
+  return typeof legacyEnergy === "number" && Number.isFinite(legacyEnergy) ? legacyEnergy : null;
 }
 function matchesTransferSinkStructureType(actual, globalName, fallback) {
   var _a;
@@ -9155,9 +9219,11 @@ var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 var MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 var MAX_REFILL_DELIVERY_SAMPLES = 5;
+var MAX_SPAWN_CRITICAL_REFILL_SAMPLES = 5;
 var MAX_TERRITORY_INTENT_SUMMARIES = 5;
 var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
+var SPAWN_CRITICAL_REFILL_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var WORKER_TASK_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
 var PRODUCTIVE_WORKER_TASK_TYPES = ["build", "repair", "upgrade"];
@@ -9273,6 +9339,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     taskCounts: countWorkerTasks(colonyWorkers),
     ...summarizeWorkerEfficiency(colonyWorkers, getGameTime6()),
     ...summarizeRefillTelemetry(colonyWorkers, getGameTime6()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime6()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -9511,6 +9578,41 @@ function isWorkerEfficiencySample(value) {
 }
 function isWorkerEfficiencyTaskType(value) {
   return value === "harvest" || value === "pickup" || value === "withdraw" || value === "transfer" || value === "build" || value === "repair" || value === "claim" || value === "reserve" || value === "upgrade";
+}
+function summarizeSpawnCriticalRefill(workers, tick) {
+  const samples = workers.map((worker) => ({ creepName: getCreepName2(worker), sample: worker.memory.spawnCriticalRefill })).filter(
+    (entry) => isRecentSpawnCriticalRefillSample(entry.sample, tick)
+  ).sort(compareSpawnCriticalRefillSampleEntries);
+  if (samples.length === 0) {
+    return {};
+  }
+  const reportedSamples = samples.slice(0, MAX_SPAWN_CRITICAL_REFILL_SAMPLES).map(toRuntimeSpawnCriticalRefillSample);
+  const assignedCarriedEnergy = samples.reduce((total, entry) => total + Math.max(0, entry.sample.carriedEnergy), 0);
+  return {
+    spawnCriticalRefill: {
+      assignedWorkerCount: samples.length,
+      assignedCarriedEnergy,
+      threshold: samples[0].sample.threshold,
+      samples: reportedSamples,
+      ...samples.length > MAX_SPAWN_CRITICAL_REFILL_SAMPLES ? { omittedSampleCount: samples.length - MAX_SPAWN_CRITICAL_REFILL_SAMPLES } : {}
+    }
+  };
+}
+function compareSpawnCriticalRefillSampleEntries(left, right) {
+  var _a, _b;
+  return right.sample.tick - left.sample.tick || ((_a = left.creepName) != null ? _a : "").localeCompare((_b = right.creepName) != null ? _b : "") || left.sample.targetId.localeCompare(right.sample.targetId);
+}
+function toRuntimeSpawnCriticalRefillSample(entry) {
+  return {
+    ...entry.creepName ? { creepName: entry.creepName } : {},
+    ...entry.sample
+  };
+}
+function isRecentSpawnCriticalRefillSample(sample, tick) {
+  return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
+}
+function isSpawnCriticalRefillSample(value) {
+  return isRecord6(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1,4 +1,5 @@
 import {
+  CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
   isWorkerRepairTargetComplete,
   selectWorkerTask,
@@ -583,14 +584,49 @@ function getTransferSinkPriority(target: unknown): number {
     return 0;
   }
 
-  if (
-    matchesTransferSinkStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn') ||
-    matchesTransferSinkStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')
-  ) {
+  if (matchesTransferSinkStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn')) {
+    return isCriticalSpawnRefillTarget(target) ? 3 : 2;
+  }
+
+  if (matchesTransferSinkStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')) {
     return 2;
   }
 
   return matchesTransferSinkStructureType(structureType, 'STRUCTURE_TOWER', 'tower') ? 1 : 0;
+}
+
+function isCriticalSpawnRefillTarget(target: unknown): boolean {
+  const structureType = (target as { structureType?: unknown } | null)?.structureType;
+  const storedEnergy = getKnownStoredTransferEnergy(target);
+  return (
+    typeof structureType === 'string' &&
+    matchesTransferSinkStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn') &&
+    storedEnergy !== null &&
+    storedEnergy < CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
+  );
+}
+
+function getKnownStoredTransferEnergy(target: unknown): number | null {
+  const store = (
+    target as {
+      store?: {
+        getUsedCapacity?: (resource?: ResourceConstant) => number | null;
+        [resource: string]: unknown;
+      };
+    } | null
+  )?.store;
+  const usedCapacity = store?.getUsedCapacity?.(RESOURCE_ENERGY);
+  if (typeof usedCapacity === 'number' && Number.isFinite(usedCapacity)) {
+    return usedCapacity;
+  }
+
+  const storedEnergy = store?.[RESOURCE_ENERGY];
+  if (typeof storedEnergy === 'number' && Number.isFinite(storedEnergy)) {
+    return storedEnergy;
+  }
+
+  const legacyEnergy = (target as { energy?: unknown } | null)?.energy;
+  return typeof legacyEnergy === 'number' && Number.isFinite(legacyEnergy) ? legacyEnergy : null;
 }
 
 function matchesTransferSinkStructureType(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -23,7 +23,8 @@ export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 export const TOWER_REFILL_ENERGY_FLOOR = 500;
-export const URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
+export const CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
+export const URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
 export const NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
 export const MINIMUM_USEFUL_LOAD_RATIO = 0.4;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
@@ -197,6 +198,9 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
       type: 'transfer',
       targetId: spawnOrExtensionEnergySink.id as Id<AnyStoreStructure>
     };
+    if (isCriticalSpawnEnergySink(spawnOrExtensionEnergySink)) {
+      recordSpawnCriticalRefillTelemetry(creep, spawnOrExtensionEnergySink);
+    }
     if (hasEmergencySpawnExtensionRefillDemand(creep)) {
       recordLowLoadReturnTelemetry(creep, spawnOrExtensionRefillTask, 'emergencySpawnExtensionRefill');
       return spawnOrExtensionRefillTask;
@@ -563,6 +567,23 @@ function clearWorkerEfficiencyTelemetry(creep: Creep): void {
   }
 }
 
+function recordSpawnCriticalRefillTelemetry(creep: Creep, spawn: StructureSpawn): void {
+  const memory = creep.memory;
+  if (!memory) {
+    return;
+  }
+
+  memory.spawnCriticalRefill = {
+    type: 'spawnCriticalRefill',
+    tick: getGameTick() ?? 0,
+    targetId: String(spawn.id),
+    carriedEnergy: getUsedEnergy(creep),
+    spawnEnergy: getKnownStoredEnergy(spawn) ?? 0,
+    freeCapacity: getFreeStoredEnergyCapacity(spawn),
+    threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
+  };
+}
+
 function recordNearbyEnergyChoiceTelemetry(
   creep: Creep,
   candidate: LowLoadWorkerEnergyAcquisitionCandidate
@@ -675,12 +696,30 @@ function compareSpawnExtensionRecoveryEnergySinks(
   const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(right, reservedEnergyDeliveries);
 
   return (
+    compareCriticalSpawnPriority(left, right) ||
     compareLowEnergySpawnPriority(left, right) ||
     compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) ||
     compareAssignedTransferTarget(left, right, assignedTransferTargetId) ||
     compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) ||
     compareEnergySinkId(left, right)
   );
+}
+
+function compareCriticalSpawnPriority(
+  left: StructureSpawn | StructureExtension,
+  right: StructureSpawn | StructureExtension
+): number {
+  if (isSpawnEnergySink(left) && isSpawnEnergySink(right)) {
+    return 0;
+  }
+
+  const leftCriticalSpawn = isCriticalSpawnEnergySink(left);
+  const rightCriticalSpawn = isCriticalSpawnEnergySink(right);
+  if (leftCriticalSpawn === rightCriticalSpawn) {
+    return 0;
+  }
+
+  return leftCriticalSpawn ? -1 : 1;
 }
 
 function compareLowEnergySpawnPriority(
@@ -698,6 +737,15 @@ function compareLowEnergySpawnPriority(
 
 function isLowEnergySpawn(structure: StructureSpawn | StructureExtension): structure is StructureSpawn {
   return isSpawnEnergySink(structure) && getStoredEnergy(structure) < getSpawnEnergyCapacity();
+}
+
+function isCriticalSpawnEnergySink(structure: StructureSpawn | StructureExtension): structure is StructureSpawn {
+  const storedEnergy = getKnownStoredEnergy(structure);
+  return (
+    isSpawnEnergySink(structure) &&
+    storedEnergy !== null &&
+    storedEnergy < CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
+  );
 }
 
 function getSpawnEnergyCapacity(): number {
@@ -3100,18 +3148,25 @@ interface StoreLike {
 }
 
 function getStoredEnergy(object: unknown): number {
+  return getKnownStoredEnergy(object) ?? 0;
+}
+
+function getKnownStoredEnergy(object: unknown): number | null {
   const store = getStore(object);
-  if (!store) {
-    return 0;
+  if (store) {
+    const usedCapacity = store.getUsedCapacity?.(getWorkerEnergyResource());
+    if (typeof usedCapacity === 'number' && Number.isFinite(usedCapacity)) {
+      return usedCapacity;
+    }
+
+    const storedEnergy = store[getWorkerEnergyResource()];
+    if (typeof storedEnergy === 'number' && Number.isFinite(storedEnergy)) {
+      return storedEnergy;
+    }
   }
 
-  const usedCapacity = store.getUsedCapacity?.(getWorkerEnergyResource());
-  if (typeof usedCapacity === 'number') {
-    return usedCapacity;
-  }
-
-  const storedEnergy = store[getWorkerEnergyResource()];
-  return typeof storedEnergy === 'number' ? storedEnergy : 0;
+  const legacyEnergy = (object as { energy?: unknown } | null)?.energy;
+  return typeof legacyEnergy === 'number' && Number.isFinite(legacyEnergy) ? legacyEnergy : null;
 }
 
 function getFreeStoredEnergyCapacity(object: unknown): number {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -24,9 +24,11 @@ const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
 const MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 const MAX_REFILL_DELIVERY_SAMPLES = 5;
+const MAX_SPAWN_CRITICAL_REFILL_SAMPLES = 5;
 const MAX_TERRITORY_INTENT_SUMMARIES = 5;
 const WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
+const SPAWN_CRITICAL_REFILL_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const OBSERVED_RAMPART_REPAIR_HITS_CEILING = 100_000;
 
 const WORKER_TASK_TYPES = ['harvest', 'transfer', 'build', 'repair', 'upgrade'] as const;
@@ -105,6 +107,7 @@ interface RuntimeRoomSummary {
   workerEfficiency?: RuntimeWorkerEfficiencySummary;
   refillDeliveryTicks?: RuntimeRefillDeliveryTicksSummary;
   refillWorkerUtilization?: RuntimeRefillWorkerUtilizationSummary;
+  spawnCriticalRefill?: RuntimeSpawnCriticalRefillSummary;
   controller?: RuntimeControllerSummary;
   resources: RuntimeResourceSummary;
   combat: RuntimeCombatSummary;
@@ -210,6 +213,23 @@ interface RuntimeRefillWorkerUtilizationWorkerSummary {
   refillActiveTicks: number;
   idleOrOtherTaskTicks: number;
   ratio: number;
+}
+
+interface RuntimeSpawnCriticalRefillSummary {
+  assignedWorkerCount: number;
+  assignedCarriedEnergy: number;
+  threshold: number;
+  samples: RuntimeSpawnCriticalRefillSampleSummary[];
+  omittedSampleCount?: number;
+}
+
+interface RuntimeSpawnCriticalRefillSampleSummary extends WorkerSpawnCriticalRefillMemory {
+  creepName?: string;
+}
+
+interface RuntimeSpawnCriticalRefillSampleEntry {
+  creepName: string | undefined;
+  sample: WorkerSpawnCriticalRefillMemory;
 }
 
 interface RuntimeCombatEventSummary {
@@ -417,6 +437,7 @@ function summarizeRoom(
     taskCounts: countWorkerTasks(colonyWorkers),
     ...summarizeWorkerEfficiency(colonyWorkers, getGameTime()),
     ...summarizeRefillTelemetry(colonyWorkers, getGameTime()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -814,6 +835,85 @@ function isWorkerEfficiencyTaskType(value: unknown): value is CreepTaskMemory['t
     value === 'claim' ||
     value === 'reserve' ||
     value === 'upgrade'
+  );
+}
+
+function summarizeSpawnCriticalRefill(
+  workers: Creep[],
+  tick: number
+): { spawnCriticalRefill?: RuntimeSpawnCriticalRefillSummary } {
+  const samples = workers
+    .map((worker) => ({ creepName: getCreepName(worker), sample: worker.memory.spawnCriticalRefill }))
+    .filter((entry): entry is RuntimeSpawnCriticalRefillSampleEntry =>
+      isRecentSpawnCriticalRefillSample(entry.sample, tick)
+    )
+    .sort(compareSpawnCriticalRefillSampleEntries);
+
+  if (samples.length === 0) {
+    return {};
+  }
+
+  const reportedSamples = samples.slice(0, MAX_SPAWN_CRITICAL_REFILL_SAMPLES).map(toRuntimeSpawnCriticalRefillSample);
+  const assignedCarriedEnergy = samples.reduce((total, entry) => total + Math.max(0, entry.sample.carriedEnergy), 0);
+
+  return {
+    spawnCriticalRefill: {
+      assignedWorkerCount: samples.length,
+      assignedCarriedEnergy,
+      threshold: samples[0].sample.threshold,
+      samples: reportedSamples,
+      ...(samples.length > MAX_SPAWN_CRITICAL_REFILL_SAMPLES
+        ? { omittedSampleCount: samples.length - MAX_SPAWN_CRITICAL_REFILL_SAMPLES }
+        : {})
+    }
+  };
+}
+
+function compareSpawnCriticalRefillSampleEntries(
+  left: RuntimeSpawnCriticalRefillSampleEntry,
+  right: RuntimeSpawnCriticalRefillSampleEntry
+): number {
+  return (
+    right.sample.tick - left.sample.tick ||
+    (left.creepName ?? '').localeCompare(right.creepName ?? '') ||
+    left.sample.targetId.localeCompare(right.sample.targetId)
+  );
+}
+
+function toRuntimeSpawnCriticalRefillSample(
+  entry: RuntimeSpawnCriticalRefillSampleEntry
+): RuntimeSpawnCriticalRefillSampleSummary {
+  return {
+    ...(entry.creepName ? { creepName: entry.creepName } : {}),
+    ...entry.sample
+  };
+}
+
+function isRecentSpawnCriticalRefillSample(
+  sample: unknown,
+  tick: number
+): sample is WorkerSpawnCriticalRefillMemory {
+  return (
+    isSpawnCriticalRefillSample(sample) &&
+    (tick <= 0 || (sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL))
+  );
+}
+
+function isSpawnCriticalRefillSample(value: unknown): value is WorkerSpawnCriticalRefillMemory {
+  return (
+    isRecord(value) &&
+    value.type === 'spawnCriticalRefill' &&
+    typeof value.tick === 'number' &&
+    Number.isFinite(value.tick) &&
+    typeof value.targetId === 'string' &&
+    typeof value.carriedEnergy === 'number' &&
+    Number.isFinite(value.carriedEnergy) &&
+    typeof value.spawnEnergy === 'number' &&
+    Number.isFinite(value.spawnEnergy) &&
+    typeof value.freeCapacity === 'number' &&
+    Number.isFinite(value.freeCapacity) &&
+    typeof value.threshold === 'number' &&
+    Number.isFinite(value.threshold)
   );
 }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -17,6 +17,7 @@ declare global {
     territory?: CreepTerritoryMemory;
     workerEfficiency?: WorkerEfficiencySampleMemory;
     refillTelemetry?: WorkerRefillTelemetryMemory;
+    spawnCriticalRefill?: WorkerSpawnCriticalRefillMemory;
   }
 
   type DefenseActionType =
@@ -197,6 +198,16 @@ declare global {
     activeTicks: number;
     idleOrOtherTaskTicks: number;
     energyDelivered: number;
+  }
+
+  interface WorkerSpawnCriticalRefillMemory {
+    type: 'spawnCriticalRefill';
+    tick: number;
+    targetId: string;
+    carriedEnergy: number;
+    spawnEnergy: number;
+    freeCapacity: number;
+    threshold: number;
   }
 
   type CreepTaskMemory =

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -6,6 +6,7 @@ import {
   shouldEmitRuntimeSummary,
   type RuntimeTelemetryEvent
 } from '../src/telemetry/runtimeSummary';
+import { CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD } from '../src/tasks/workerTasks';
 
 const TEST_GLOBALS = {
   FIND_STRUCTURES: 101,
@@ -545,6 +546,67 @@ describe('runtime telemetry summaries', () => {
         }
       ],
       omittedSampleCount: 2
+    });
+  });
+
+  it('reports spawn-critical refill assignment telemetry', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const carrier = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'transfer', targetId: 'spawn1' as Id<AnyStoreStructure> },
+        spawnCriticalRefill: {
+          type: 'spawnCriticalRefill',
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          targetId: 'spawn1',
+          carriedEnergy: 50,
+          spawnEnergy: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+          freeCapacity: 101,
+          threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
+        }
+      },
+      50,
+      'CriticalCarrier'
+    );
+    const staleCarrier = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        spawnCriticalRefill: {
+          type: 'spawnCriticalRefill',
+          tick: 0,
+          targetId: 'spawn-stale',
+          carriedEnergy: 50,
+          spawnEnergy: 0,
+          freeCapacity: 300,
+          threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
+        }
+      },
+      50,
+      'StaleCarrier'
+    );
+
+    emitRuntimeSummary([colony], [carrier, staleCarrier]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.spawnCriticalRefill).toEqual({
+      assignedWorkerCount: 1,
+      assignedCarriedEnergy: 50,
+      threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
+      samples: [
+        {
+          creepName: 'CriticalCarrier',
+          type: 'spawnCriticalRefill',
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          targetId: 'spawn1',
+          carriedEnergy: 50,
+          spawnEnergy: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+          freeCapacity: 101,
+          threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
+        }
+      ]
     });
   });
 

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -1,6 +1,7 @@
 import { runWorker } from '../src/creeps/workerRunner';
 import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
+  CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   URGENT_SPAWN_REFILL_ENERGY_THRESHOLD
 } from '../src/tasks/workerTasks';
@@ -1956,6 +1957,75 @@ describe('runWorker', () => {
 
     expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'extension-far' });
     expect(creep.transfer).toHaveBeenCalledWith(farExtension, 'energy');
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('preempts active extension refill for a critical spawn refill', () => {
+    const extension = {
+      id: 'extension-current',
+      structureType: 'extension',
+      store: {
+        getFreeCapacity: jest.fn().mockReturnValue(50),
+        getUsedCapacity: jest.fn().mockReturnValue(0)
+      }
+    } as unknown as StructureExtension;
+    const criticalSpawn = {
+      id: 'spawn-critical',
+      structureType: 'spawn',
+      store: {
+        getFreeCapacity: jest.fn().mockReturnValue(101),
+        getUsedCapacity: jest.fn().mockReturnValue(CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1)
+      }
+    } as unknown as StructureSpawn;
+    const getRangeTo = jest.fn((target: StructureExtension | StructureSpawn) => {
+      const ranges: Record<string, number> = {
+        'extension-current': 1,
+        'spawn-critical': 8
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const transfer = jest.fn().mockReturnValue(0);
+    const creep = {
+      memory: { role: 'worker', task: { type: 'transfer', targetId: 'extension-current' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      pos: { getRangeTo },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: StructureExtension | StructureSpawn) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            const structures = [extension, criticalSpawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      },
+      transfer,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker: creep },
+      time: 779,
+      getObjectById: jest.fn((id: string) => (id === 'spawn-critical' ? criticalSpawn : extension))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn-critical' });
+    expect(creep.memory.spawnCriticalRefill).toEqual({
+      type: 'spawnCriticalRefill',
+      tick: 779,
+      targetId: 'spawn-critical',
+      carriedEnergy: 50,
+      spawnEnergy: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      freeCapacity: 101,
+      threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
+    });
+    expect(transfer).toHaveBeenCalledWith(criticalSpawn, 'energy');
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1,5 +1,6 @@
 import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
+  CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   LOW_LOAD_NEARBY_ENERGY_RANGE,
@@ -3168,6 +3169,84 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-far' });
     expect(getRangeTo).not.toHaveBeenCalledWith(fullExtension);
     expect(getRangeTo).not.toHaveBeenCalledWith(nearTower);
+  });
+
+  it('records critical spawn refill telemetry when a critical spawn beats a closer extension', () => {
+    const criticalSpawn = makeEnergySinkWithEnergy(
+      'spawn-critical',
+      'spawn' as StructureConstant,
+      CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      101
+    );
+    const closerExtension = makeEnergySink('extension-closer', 'extension' as StructureConstant, 200);
+    const structures = [closerExtension, criticalSpawn];
+    const getRangeTo = jest.fn((target: TestEnergySink) => {
+      const ranges: Record<string, number> = {
+        'extension-closer': 1,
+        'spawn-critical': 8
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const creep = {
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { getRangeTo },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 346 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-critical' });
+    expect(creep.memory.spawnCriticalRefill).toEqual({
+      type: 'spawnCriticalRefill',
+      tick: 346,
+      targetId: 'spawn-critical',
+      carriedEnergy: 50,
+      spawnEnergy: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+      freeCapacity: 101,
+      threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
+    });
+  });
+
+  it('preserves non-critical spawn refill behavior without critical telemetry', () => {
+    const nonCriticalSpawn = makeEnergySinkWithEnergy(
+      'spawn-non-critical',
+      'spawn' as StructureConstant,
+      CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
+      100
+    );
+    const closerExtension = makeEnergySink('extension-closer', 'extension' as StructureConstant, 200);
+    const structures = [closerExtension, nonCriticalSpawn];
+    const creep = {
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: {
+        getRangeTo: jest.fn((target: TestEnergySink) => (target.id === 'extension-closer' ? 1 : 8))
+      },
+      room: {
+        find: jest.fn(
+          (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+            if (type !== FIND_MY_STRUCTURES) {
+              return [];
+            }
+
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+        )
+      }
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn-non-critical' });
+    expect(creep.memory.spawnCriticalRefill).toBeUndefined();
   });
 
   it('selects the closest low-energy spawn before extensions', () => {


### PR DESCRIPTION
## Summary
Prioritizes spawn energy refill over extension refill when spawn energy is below spawn threshold. Workers assigned to refill tasks now check spawn energy status and redirect to spawn first when critical. Adds runtime summary fields for spawn energy level tracking.

## Test Plan
- [x] TypeScript typecheck passes
- [x] All 724 Jest tests pass (`npm test -- --runInBand`)
- [x] Build succeeds (`npm run build`)
- [x] `git diff --check` clean

## Verification
```
npm run typecheck  # PASS
npm test -- --runInBand  # 27 suites, 724 tests PASS
npm run build  # OK
```

Closes #490
