### PR TITLE
feat(economy): automated construction site placement and build-priority loop (#495)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1093,6 +1093,232 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.length > 0;
 }
 
+// src/construction/criticalRoads.ts
+var CRITICAL_ROAD_ROUTE_RANGE = 2;
+var ROOM_EDGE_MIN = 1;
+var ROOM_EDGE_MAX = 48;
+var ROOM_CENTER = 25;
+function buildCriticalRoadLogisticsContext(room, options = {}) {
+  const anchorPositions = findOwnedSpawnPositions(room);
+  const targetPositions = findLogisticsTargetPositions(room);
+  const colonyAnchorPositions = anchorPositions.length === 0 ? findColonyRoomLogisticsAnchorPositions(room, options.colonyRoomName, targetPositions) : [];
+  return {
+    anchorPositions: anchorPositions.length > 0 ? anchorPositions : colonyAnchorPositions.length > 0 ? colonyAnchorPositions : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
+    targetPositions
+  };
+}
+function isCriticalRoadLogisticsWork(target, context) {
+  if (!isRoadWorkTarget(target) || !target.pos || context.anchorPositions.length === 0 || context.targetPositions.length === 0) {
+    return false;
+  }
+  const position = target.pos;
+  return context.anchorPositions.some(
+    (anchor) => context.targetPositions.some((destination) => isNearLogisticsRoute(position, anchor, destination))
+  );
+}
+function findOwnedSpawnPositions(room) {
+  return findRoomObjects3(room, "FIND_MY_STRUCTURES").filter(
+    (structure) => matchesStructureType2(structure.structureType, "STRUCTURE_SPAWN", "spawn")
+  ).map((spawn) => spawn.pos).filter((position) => isSameRoomPosition(position, room.name));
+}
+function findLogisticsTargetPositions(room) {
+  var _a;
+  const sourcePositions = findRoomObjects3(room, "FIND_SOURCES").map((source) => source.pos).filter((position) => isSameRoomPosition(position, room.name));
+  const controllerPosition = isSameRoomPosition((_a = room.controller) == null ? void 0 : _a.pos, room.name) ? [room.controller.pos] : [];
+  return [...sourcePositions, ...controllerPosition];
+}
+function findColonyRoomLogisticsAnchorPositions(room, colonyRoomName, targetPositions) {
+  if (targetPositions.length === 0 || !isNonEmptyString2(room.name) || !isNonEmptyString2(colonyRoomName) || colonyRoomName === room.name) {
+    return [];
+  }
+  return uniqueRoomPositions(
+    findColonyRoomSpawnPositions(colonyRoomName).map((position) => projectHomeAnchorIntoRoom(position, room.name)).filter((position) => position !== null)
+  );
+}
+function findColonyRoomSpawnPositions(colonyRoomName) {
+  var _a, _b;
+  const game = globalThis.Game;
+  const homeRoom = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[colonyRoomName];
+  const roomSpawnPositions = homeRoom ? findOwnedSpawnPositions(homeRoom) : [];
+  const globalSpawnPositions = Object.values((_b = game == null ? void 0 : game.spawns) != null ? _b : {}).map((spawn) => spawn.pos).filter((position) => isSameRoomPosition(position, colonyRoomName));
+  return uniqueRoomPositions([...roomSpawnPositions, ...globalSpawnPositions]);
+}
+function projectHomeAnchorIntoRoom(anchor, roomName) {
+  if (!isNonEmptyString2(anchor.roomName) || anchor.roomName === roomName) {
+    return null;
+  }
+  const anchorCoordinates = parseRoomCoordinates(anchor.roomName);
+  const roomCoordinates = parseRoomCoordinates(roomName);
+  if (!anchorCoordinates || !roomCoordinates) {
+    return null;
+  }
+  const deltaX = roomCoordinates.x - anchorCoordinates.x;
+  const deltaY = roomCoordinates.y - anchorCoordinates.y;
+  if (deltaX === 0 && deltaY === 0) {
+    return null;
+  }
+  return {
+    x: deltaX > 0 ? ROOM_EDGE_MIN : deltaX < 0 ? ROOM_EDGE_MAX : clampRoomCoordinate(anchor.x),
+    y: deltaY > 0 ? ROOM_EDGE_MIN : deltaY < 0 ? ROOM_EDGE_MAX : clampRoomCoordinate(anchor.y),
+    roomName
+  };
+}
+function parseRoomCoordinates(roomName) {
+  const match = /^([WE])(\d+)([NS])(\d+)$/.exec(roomName);
+  if (!match) {
+    return null;
+  }
+  const horizontalValue = Number(match[2]);
+  const verticalValue = Number(match[4]);
+  if (!Number.isFinite(horizontalValue) || !Number.isFinite(verticalValue)) {
+    return null;
+  }
+  return {
+    x: match[1] === "E" ? horizontalValue : -horizontalValue - 1,
+    y: match[3] === "S" ? verticalValue : -verticalValue - 1
+  };
+}
+function clampRoomCoordinate(value) {
+  if (!Number.isFinite(value)) {
+    return ROOM_CENTER;
+  }
+  return Math.max(ROOM_EDGE_MIN, Math.min(ROOM_EDGE_MAX, Math.round(value)));
+}
+function uniqueRoomPositions(positions) {
+  const seen = /* @__PURE__ */ new Set();
+  return positions.filter((position) => {
+    const key = `${position.roomName}:${position.x}:${position.y}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+function findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions) {
+  var _a;
+  if (targetPositions.length === 0 || !isRemoteTerritoryLogisticsRoom(room)) {
+    return [];
+  }
+  if (isSameRoomPosition((_a = room.controller) == null ? void 0 : _a.pos, room.name)) {
+    return [room.controller.pos];
+  }
+  return targetPositions.slice(0, 1);
+}
+function findRoomObjects3(room, constantName) {
+  const findConstant = globalThis[constantName];
+  if (typeof findConstant !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function isRoadWorkTarget(target) {
+  return matchesStructureType2(target.structureType, "STRUCTURE_ROAD", "road");
+}
+function isRemoteTerritoryLogisticsRoom(room) {
+  var _a;
+  return isReferencedRemoteTerritoryRoom(room.name) || ((_a = room.controller) == null ? void 0 : _a.my) !== true && isSelfReservedRoom(room);
+}
+function isReferencedRemoteTerritoryRoom(roomName) {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return false;
+  }
+  return hasRemoteTerritoryReference(territoryMemory.targets, roomName, "roomName") || hasRemoteTerritoryReference(territoryMemory.intents, roomName, "targetRoom") || hasRemoteTerritoryReference(territoryMemory.demands, roomName, "targetRoom") || hasRemoteTerritoryReference(territoryMemory.executionHints, roomName, "targetRoom");
+}
+function hasRemoteTerritoryReference(value, roomName, roomKey) {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((entry) => {
+    if (!isRecord(entry)) {
+      return false;
+    }
+    return entry[roomKey] === roomName && isNonEmptyString2(entry.colony) && entry.colony !== roomName && isTerritoryControlAction(entry.action) && entry.status !== "suppressed" && entry.enabled !== false;
+  });
+}
+function isSelfReservedRoom(room) {
+  var _a, _b;
+  const reservationUsername = (_b = (_a = room.controller) == null ? void 0 : _a.reservation) == null ? void 0 : _b.username;
+  return isNonEmptyString2(reservationUsername) && getOwnedUsernames().has(reservationUsername);
+}
+function getTerritoryMemoryRecord() {
+  const memory = globalThis.Memory;
+  return memory && isRecord(memory.territory) ? memory.territory : null;
+}
+function getOwnedUsernames() {
+  var _a, _b, _c, _d;
+  const usernames = /* @__PURE__ */ new Set();
+  const game = globalThis.Game;
+  for (const spawn of Object.values((_a = game == null ? void 0 : game.spawns) != null ? _a : {})) {
+    addOwnedUsername(usernames, spawn);
+  }
+  for (const creep of Object.values((_b = game == null ? void 0 : game.creeps) != null ? _b : {})) {
+    addOwnedUsername(usernames, creep);
+  }
+  for (const visibleRoom of Object.values((_c = game == null ? void 0 : game.rooms) != null ? _c : {})) {
+    if (((_d = visibleRoom.controller) == null ? void 0 : _d.my) === true) {
+      addOwnedUsername(usernames, visibleRoom.controller);
+    }
+  }
+  return usernames;
+}
+function addOwnedUsername(usernames, object) {
+  var _a;
+  const username = (_a = object == null ? void 0 : object.owner) == null ? void 0 : _a.username;
+  if (isNonEmptyString2(username)) {
+    usernames.add(username);
+  }
+}
+function isTerritoryControlAction(action) {
+  return action === "claim" || action === "reserve";
+}
+function isNearLogisticsRoute(position, anchor, destination) {
+  if (!isSameRoomPosition(position, anchor.roomName) || !isSameRoomPosition(position, destination.roomName)) {
+    return false;
+  }
+  return getSquaredDistanceToSegment(position, anchor, destination) <= CRITICAL_ROAD_ROUTE_RANGE ** 2;
+}
+function getSquaredDistanceToSegment(position, start, end) {
+  const deltaX = end.x - start.x;
+  const deltaY = end.y - start.y;
+  const lengthSquared = deltaX * deltaX + deltaY * deltaY;
+  if (lengthSquared === 0) {
+    return getSquaredDistance(position, start);
+  }
+  const projection = ((position.x - start.x) * deltaX + (position.y - start.y) * deltaY) / lengthSquared;
+  const clampedProjection = Math.max(0, Math.min(1, projection));
+  const closestX = start.x + clampedProjection * deltaX;
+  const closestY = start.y + clampedProjection * deltaY;
+  const distanceX = position.x - closestX;
+  const distanceY = position.y - closestY;
+  return distanceX * distanceX + distanceY * distanceY;
+}
+function getSquaredDistance(left, right) {
+  const distanceX = left.x - right.x;
+  const distanceY = left.y - right.y;
+  return distanceX * distanceX + distanceY * distanceY;
+}
+function isSameRoomPosition(position, roomName) {
+  return !!position && (!position.roomName || !roomName || position.roomName === roomName);
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString2(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function matchesStructureType2(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+
 // src/construction/extensionPlanner.ts
 var EXTENSION_LIMITS_BY_RCL = {
   2: 5,
@@ -1104,8 +1330,8 @@ var EXTENSION_LIMITS_BY_RCL = {
   8: 60
 };
 var MAX_EXTENSION_PLANNER_RADIUS = 6;
-var ROOM_EDGE_MIN = 1;
-var ROOM_EDGE_MAX = 48;
+var ROOM_EDGE_MIN2 = 1;
+var ROOM_EDGE_MAX2 = 48;
 var DEFAULT_TERRAIN_WALL_MASK = 1;
 function planExtensionConstruction(colony) {
   var _a;
@@ -1173,10 +1399,10 @@ function createPlannerLookups(room, anchor) {
 }
 function getScanBounds(anchor) {
   return {
-    top: Math.max(ROOM_EDGE_MIN, anchor.y - MAX_EXTENSION_PLANNER_RADIUS),
-    left: Math.max(ROOM_EDGE_MIN, anchor.x - MAX_EXTENSION_PLANNER_RADIUS),
-    bottom: Math.min(ROOM_EDGE_MAX, anchor.y + MAX_EXTENSION_PLANNER_RADIUS),
-    right: Math.min(ROOM_EDGE_MAX, anchor.x + MAX_EXTENSION_PLANNER_RADIUS)
+    top: Math.max(ROOM_EDGE_MIN2, anchor.y - MAX_EXTENSION_PLANNER_RADIUS),
+    left: Math.max(ROOM_EDGE_MIN2, anchor.x - MAX_EXTENSION_PLANNER_RADIUS),
+    bottom: Math.min(ROOM_EDGE_MAX2, anchor.y + MAX_EXTENSION_PLANNER_RADIUS),
+    right: Math.min(ROOM_EDGE_MAX2, anchor.x + MAX_EXTENSION_PLANNER_RADIUS)
   };
 }
 function getBlockingPositions(room, bounds) {
@@ -1192,7 +1418,7 @@ function getBlockingPositions(room, bounds) {
   return blockingPositions;
 }
 function canPlaceExtension(lookups, anchorParity, position) {
-  if (position.x < ROOM_EDGE_MIN || position.x > ROOM_EDGE_MAX || position.y < ROOM_EDGE_MIN || position.y > ROOM_EDGE_MAX) {
+  if (position.x < ROOM_EDGE_MIN2 || position.x > ROOM_EDGE_MAX2 || position.y < ROOM_EDGE_MIN2 || position.y > ROOM_EDGE_MAX2) {
     return false;
   }
   if (lookups.reservedWalkwayPositions.has(getPositionKey(position))) {
@@ -1217,7 +1443,7 @@ function getReservedWalkwayPositions(anchor) {
   );
 }
 function isWithinRoomBounds(position) {
-  return position.x >= ROOM_EDGE_MIN && position.x <= ROOM_EDGE_MAX && position.y >= ROOM_EDGE_MIN && position.y <= ROOM_EDGE_MAX;
+  return position.x >= ROOM_EDGE_MIN2 && position.x <= ROOM_EDGE_MAX2 && position.y >= ROOM_EDGE_MIN2 && position.y <= ROOM_EDGE_MAX2;
 }
 function getPositionParity(position) {
   return (position.x + position.y) % 2;
@@ -1239,8 +1465,8 @@ var DEFAULT_MAX_ROAD_TARGETS_PER_TICK = 4;
 var DEFAULT_MAX_PATH_OPS_PER_TARGET = 1e3;
 var MIN_CONTROLLER_LEVEL_FOR_ROADS = 2;
 var SOURCE_CONTROLLER_ROAD_MAX_RANGE = 6;
-var ROOM_EDGE_MIN2 = 1;
-var ROOM_EDGE_MAX2 = 48;
+var ROOM_EDGE_MIN3 = 1;
+var ROOM_EDGE_MAX3 = 48;
 var ROOM_COORDINATE_MIN = 0;
 var ROOM_COORDINATE_MAX = 49;
 var DEFAULT_TERRAIN_WALL_MASK2 = 1;
@@ -1329,15 +1555,15 @@ function selectRoadTargets(room) {
   var _a;
   const targets = getSortedSources(room).map((source) => ({ pos: source.pos }));
   const controllerPosition = (_a = room.controller) == null ? void 0 : _a.pos;
-  if (controllerPosition && isSameRoomPosition(controllerPosition, room.name)) {
+  if (controllerPosition && isSameRoomPosition2(controllerPosition, room.name)) {
     targets.push({ pos: controllerPosition });
   }
-  return targets.filter((target) => isSameRoomPosition(target.pos, room.name));
+  return targets.filter((target) => isSameRoomPosition2(target.pos, room.name));
 }
 function selectSourceControllerRoadRoutes(room) {
   var _a;
   const controllerPosition = (_a = room.controller) == null ? void 0 : _a.pos;
-  if (!controllerPosition || !isSameRoomPosition(controllerPosition, room.name)) {
+  if (!controllerPosition || !isSameRoomPosition2(controllerPosition, room.name)) {
     return [];
   }
   return getSortedSources(room).filter((source) => getRangeBetweenPositions(source.pos, controllerPosition) <= SOURCE_CONTROLLER_ROAD_MAX_RANGE).map((source) => createRoadRoute(source.pos, { pos: controllerPosition }, 0));
@@ -1349,7 +1575,7 @@ function getSortedSources(room) {
   if (typeof FIND_SOURCES !== "number") {
     return [];
   }
-  return room.find(FIND_SOURCES).filter((source) => source.pos && isSameRoomPosition(source.pos, room.name)).sort((left, right) => String(left.id).localeCompare(String(right.id)));
+  return room.find(FIND_SOURCES).filter((source) => source.pos && isSameRoomPosition2(source.pos, room.name)).sort((left, right) => String(left.id).localeCompare(String(right.id)));
 }
 function countPendingRoadConstructionSites(room) {
   if (typeof FIND_MY_CONSTRUCTION_SITES !== "number") {
@@ -1398,7 +1624,7 @@ function blockRoomEdges(lookups) {
 function cacheRoomStructures(room, lookups) {
   for (const structure of room.find(FIND_STRUCTURES)) {
     const position = structure.pos;
-    if (!position || !isSameRoomPosition(position, room.name)) {
+    if (!position || !isSameRoomPosition2(position, room.name)) {
       continue;
     }
     const key = getPositionKey2(position);
@@ -1414,7 +1640,7 @@ function cacheRoomStructures(room, lookups) {
 function cacheRoomConstructionSites(room, lookups) {
   for (const constructionSite of room.find(FIND_CONSTRUCTION_SITES)) {
     const position = constructionSite.pos;
-    if (!position || !isSameRoomPosition(position, room.name)) {
+    if (!position || !isSameRoomPosition2(position, room.name)) {
       continue;
     }
     const key = getPositionKey2(position);
@@ -1433,7 +1659,7 @@ function selectRoadCandidates(roomName, routes, lookups, limits) {
     const path = findRoadPath(roomName, route.origin, route.target, lookups, limits);
     const seenInRoute = /* @__PURE__ */ new Set();
     path.forEach((position, pathIndex) => {
-      if (!isSameRoomPosition(position, roomName) || !canPlaceRoad(lookups, position)) {
+      if (!isSameRoomPosition2(position, roomName) || !canPlaceRoad(lookups, position)) {
         return;
       }
       const key = getPositionKey2(position);
@@ -1492,9 +1718,9 @@ function setRoadPathCostIfOpen(lookups, position) {
   }
 }
 function isWithinBuildableRoomBounds(position) {
-  return position.x >= ROOM_EDGE_MIN2 && position.x <= ROOM_EDGE_MAX2 && position.y >= ROOM_EDGE_MIN2 && position.y <= ROOM_EDGE_MAX2;
+  return position.x >= ROOM_EDGE_MIN3 && position.x <= ROOM_EDGE_MAX3 && position.y >= ROOM_EDGE_MIN3 && position.y <= ROOM_EDGE_MAX3;
 }
-function isSameRoomPosition(position, roomName) {
+function isSameRoomPosition2(position, roomName) {
   return !position.roomName || position.roomName === roomName;
 }
 function getRangeBetweenPositions(left, right) {
@@ -1504,12 +1730,12 @@ function isTerrainWall2(terrain, position) {
   return (terrain.get(position.x, position.y) & getTerrainWallMask2()) !== 0;
 }
 function isRoadStructure(structure) {
-  return matchesStructureType2(structure.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType3(structure.structureType, "STRUCTURE_ROAD", "road");
 }
 function isRoadConstructionSite(site) {
-  return matchesStructureType2(site.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType3(site.structureType, "STRUCTURE_ROAD", "road");
 }
-function matchesStructureType2(actual, globalName, fallback) {
+function matchesStructureType3(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -1529,6 +1755,1037 @@ function getOkCode() {
   return typeof OK === "number" ? OK : 0;
 }
 
+// src/construction/constructionPriority.ts
+var CONTROLLER_DOWNGRADE_CRITICAL_TICKS = 5e3;
+var CONTROLLER_DOWNGRADE_WARNING_TICKS = 1e4;
+var EARLY_ENERGY_CAPACITY_TARGET = 550;
+var MIN_SAFE_WORKERS_FOR_EXPANSION = 3;
+var MIN_RCL_FOR_AUTOMATED_CONSTRUCTION = 2;
+var MIN_RCL_FOR_AUTOMATED_ROADS = 4;
+var DEFAULT_MAX_CONTAINER_SITES_PER_TICK = 1;
+var DEFAULT_TERRAIN_WALL_MASK3 = 1;
+var ROOM_EDGE_MIN4 = 1;
+var ROOM_EDGE_MAX4 = 48;
+var MAX_SCORE = 100;
+var MAX_URGENCY_POINTS = 35;
+var MAX_ROOM_STATE_POINTS = 20;
+var MAX_EXPANSION_POINTS = 20;
+var MAX_ECONOMIC_POINTS = 20;
+var MAX_VISION_POINTS = 15;
+var MAX_RISK_COST = 25;
+var CRITICAL_REPAIR_HITS_RATIO = 0.5;
+var DECAYING_REPAIR_HITS_RATIO = 0.8;
+var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
+var STRUCTURE_BUILD_COSTS = {
+  spawn: 15e3,
+  extension: 3e3,
+  tower: 5e3,
+  rampart: 1,
+  road: 300,
+  container: 5e3,
+  storage: 3e4,
+  "remote-logistics": 5e3,
+  observation: 0
+};
+var EXPOSURE_COST = {
+  none: 0,
+  low: 2,
+  medium: 5,
+  high: 9
+};
+var OBSERVATION_LABELS = {
+  "room-controller": "missing observation: room controller/RCL",
+  "energy-capacity": "missing observation: room energy capacity",
+  "worker-count": "missing observation: available worker count",
+  "spawn-count": "missing observation: spawn count",
+  "construction-sites": "missing observation: construction site backlog",
+  "repair-decay": "missing observation: repair/decay signals",
+  "hostile-presence": "missing observation: hostile pressure",
+  sources: "missing observation: source count",
+  "territory-intents": "missing observation: territory intent state",
+  "remote-paths": "missing observation: remote path/logistics exposure"
+};
+function scoreConstructionPriorities(roomState, candidates) {
+  const scoredCandidates = candidates.map((candidate) => scoreConstructionCandidate(roomState, candidate)).sort(compareConstructionPriorityScores);
+  return {
+    candidates: scoredCandidates,
+    nextPrimary: selectNextPrimaryConstruction(scoredCandidates)
+  };
+}
+function scoreConstructionCandidate(roomState, candidate) {
+  var _a, _b, _c, _d, _e;
+  const missingObservations = getMissingObservations(roomState, candidate);
+  const blockingPreconditions = getBlockingPreconditions(roomState, candidate, missingObservations);
+  const preconditions = [
+    ...(_a = candidate.preconditions) != null ? _a : [],
+    ...missingObservations.map((observation) => OBSERVATION_LABELS[observation]),
+    ...blockingPreconditions
+  ];
+  const blocked = missingObservations.length > 0 || blockingPreconditions.length > 0;
+  if (blocked) {
+    return {
+      buildItem: candidate.buildItem,
+      room: (_b = candidate.roomName) != null ? _b : roomState.roomName,
+      score: 0,
+      urgency: "blocked",
+      preconditions,
+      expectedKpiMovement: candidate.expectedKpiMovement,
+      risk: (_c = candidate.risk) != null ? _c : [],
+      factors: {
+        urgency: 0,
+        roomState: 0,
+        expansionPrerequisites: 0,
+        economicBenefit: 0,
+        visionWeight: 0,
+        riskCost: 0
+      },
+      missingObservations,
+      blocked
+    };
+  }
+  const urgencyMagnitude = getUrgencyMagnitude(roomState, candidate);
+  const factors = {
+    urgency: Math.round(urgencyMagnitude * MAX_URGENCY_POINTS),
+    roomState: scoreRoomState(roomState, candidate),
+    expansionPrerequisites: scoreExpansionPrerequisites(roomState, candidate),
+    economicBenefit: scoreEconomicBenefit(roomState, candidate),
+    visionWeight: scoreVisionWeight(candidate),
+    riskCost: scoreRiskCost(roomState, candidate)
+  };
+  const rawScore = factors.urgency + factors.roomState + factors.expansionPrerequisites + factors.economicBenefit + factors.visionWeight - factors.riskCost;
+  const gatedScore = applySurvivalGate(roomState, candidate, rawScore);
+  const score = clampScore(Math.round(gatedScore));
+  return {
+    buildItem: candidate.buildItem,
+    room: (_d = candidate.roomName) != null ? _d : roomState.roomName,
+    score,
+    urgency: classifyUrgency(score, urgencyMagnitude),
+    preconditions,
+    expectedKpiMovement: candidate.expectedKpiMovement,
+    risk: (_e = candidate.risk) != null ? _e : [],
+    factors,
+    missingObservations,
+    blocked
+  };
+}
+function selectNextPrimaryConstruction(candidates) {
+  var _a;
+  if (candidates.length === 0) {
+    return null;
+  }
+  return (_a = candidates.find((candidate) => !candidate.blocked)) != null ? _a : candidates[0];
+}
+function buildRuntimeConstructionPriorityReport(colony, creeps) {
+  const state = buildRuntimeConstructionPriorityState(colony, creeps);
+  return scoreConstructionPriorities(state, buildRuntimeConstructionCandidates(state));
+}
+function planPriorityConstructionSites(colony, options = {}) {
+  const rcl = getOwnedRoomRcl(colony.room);
+  if (rcl < MIN_RCL_FOR_AUTOMATED_CONSTRUCTION) {
+    return {
+      sourceContainerResults: [],
+      extensionResult: null,
+      roadResults: []
+    };
+  }
+  const sourceContainerResults = planSourceContainerConstruction(colony, options);
+  const extensionResult = planExtensionConstruction(colony);
+  const roadResults = rcl >= MIN_RCL_FOR_AUTOMATED_ROADS ? planEarlyRoadConstruction(colony, options.roadOptions) : [];
+  return {
+    sourceContainerResults,
+    extensionResult,
+    roadResults
+  };
+}
+function planSourceContainerConstruction(colony, options = {}) {
+  const room = colony.room;
+  if (getOwnedRoomRcl(room) < MIN_RCL_FOR_AUTOMATED_CONSTRUCTION || !hasRequiredSourceContainerPlannerApis(room)) {
+    return [];
+  }
+  const maxSitesPerTick = resolveNonNegativeInteger2(
+    options.maxContainerSitesPerTick,
+    DEFAULT_MAX_CONTAINER_SITES_PER_TICK
+  );
+  if (maxSitesPerTick <= 0) {
+    return [];
+  }
+  const sources = getSortedSources2(room);
+  if (sources.length === 0) {
+    return [];
+  }
+  const lookups = createSourceContainerPlannerLookups(room, sources);
+  if (!lookups) {
+    return [];
+  }
+  const maxPendingContainerSites = resolveNonNegativeInteger2(
+    options.maxPendingContainerSites,
+    sources.length
+  );
+  const pendingContainerSites = countPendingSourceContainers(sources, lookups);
+  const remainingSiteBudget = Math.min(maxSitesPerTick, maxPendingContainerSites - pendingContainerSites);
+  if (remainingSiteBudget <= 0) {
+    return [];
+  }
+  const anchor = selectConstructionAnchor(colony);
+  const results = [];
+  for (const source of sources) {
+    if (results.length >= remainingSiteBudget) {
+      break;
+    }
+    if (hasSourceContainerCoverage(source, lookups)) {
+      continue;
+    }
+    const position = selectSourceContainerPosition(room.name, source, lookups, anchor);
+    if (!position) {
+      continue;
+    }
+    const result = room.createConstructionSite(position.x, position.y, getContainerStructureType());
+    results.push(result);
+    if (result !== getOkCode2()) {
+      break;
+    }
+    lookups.pendingContainerPositions.push(position);
+    lookups.blockingPositions.add(getPositionKey3(position));
+  }
+  return results;
+}
+function getOwnedRoomRcl(room) {
+  var _a;
+  const level = ((_a = room.controller) == null ? void 0 : _a.my) === true ? room.controller.level : 0;
+  return typeof level === "number" && Number.isFinite(level) ? Math.max(0, Math.floor(level)) : 0;
+}
+function hasRequiredSourceContainerPlannerApis(room) {
+  return typeof room.find === "function" && typeof room.createConstructionSite === "function" && getFindConstant("FIND_SOURCES") !== null && getFindConstant("FIND_STRUCTURES") !== null && getFindConstant("FIND_CONSTRUCTION_SITES") !== null;
+}
+function resolveNonNegativeInteger2(value, fallback) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(0, Math.floor(value));
+}
+function getSortedSources2(room) {
+  const sources = findRoomObjects4(room, "FIND_SOURCES");
+  return (sources != null ? sources : []).filter((source) => isSameRoomPosition3(getRoomObjectPosition(source), room.name)).sort((left, right) => String(left.id).localeCompare(String(right.id)));
+}
+function createSourceContainerPlannerLookups(room, sources) {
+  const terrain = getRoomTerrain2(room);
+  const structures = findRoomObjects4(room, "FIND_STRUCTURES");
+  const constructionSites = findRoomObjects4(room, "FIND_CONSTRUCTION_SITES");
+  if (!terrain || structures === null || constructionSites === null) {
+    return null;
+  }
+  const lookups = {
+    blockingPositions: /* @__PURE__ */ new Set(),
+    existingContainerPositions: [],
+    pendingContainerPositions: [],
+    terrain
+  };
+  for (const source of sources) {
+    addBlockingPosition(lookups, getRoomObjectPosition(source));
+  }
+  for (const structure of structures) {
+    const position = getRoomObjectPosition(structure);
+    addBlockingPosition(lookups, position);
+    if (matchesStructureType4(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+      addPosition(lookups.existingContainerPositions, position);
+    }
+  }
+  for (const site of constructionSites) {
+    const position = getRoomObjectPosition(site);
+    addBlockingPosition(lookups, position);
+    if (matchesStructureType4(site.structureType, "STRUCTURE_CONTAINER", "container")) {
+      addPosition(lookups.pendingContainerPositions, position);
+    }
+  }
+  return lookups;
+}
+function addBlockingPosition(lookups, position) {
+  if (position) {
+    lookups.blockingPositions.add(getPositionKey3(position));
+  }
+}
+function addPosition(positions, position) {
+  if (position) {
+    positions.push(position);
+  }
+}
+function countPendingSourceContainers(sources, lookups) {
+  return lookups.pendingContainerPositions.filter(
+    (position) => sources.some((source) => isNearRoomObject(source, position))
+  ).length;
+}
+function hasSourceContainerCoverage(source, lookups) {
+  return lookups.existingContainerPositions.some((position) => isNearRoomObject(source, position)) || lookups.pendingContainerPositions.some((position) => isNearRoomObject(source, position));
+}
+function selectSourceContainerPosition(roomName, source, lookups, anchor) {
+  var _a;
+  const sourcePosition = getRoomObjectPosition(source);
+  if (!isSameRoomPosition3(sourcePosition, roomName)) {
+    return null;
+  }
+  const candidates = getAdjacentBuildPositions(sourcePosition, roomName).filter((position) => canPlaceSourceContainer(lookups, position)).sort((left, right) => compareSourceContainerPositions(left, right, anchor));
+  return (_a = candidates[0]) != null ? _a : null;
+}
+function getAdjacentBuildPositions(center, roomName) {
+  const positions = [];
+  for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -1; dx <= 1; dx += 1) {
+      if (dx === 0 && dy === 0) {
+        continue;
+      }
+      positions.push({ x: center.x + dx, y: center.y + dy, roomName });
+    }
+  }
+  return positions;
+}
+function canPlaceSourceContainer(lookups, position) {
+  return isWithinBuildableRoomBounds2(position) && !isTerrainWall3(lookups.terrain, position) && !lookups.blockingPositions.has(getPositionKey3(position));
+}
+function compareSourceContainerPositions(left, right, anchor) {
+  return compareOptionalNumber(getRangeBetweenPositions2(left, anchor), getRangeBetweenPositions2(right, anchor)) || left.y - right.y || left.x - right.x;
+}
+function selectConstructionAnchor(colony) {
+  var _a;
+  const [primarySpawn] = colony.spawns.filter((spawn) => getRoomObjectPosition(spawn) !== null).sort((left, right) => left.name.localeCompare(right.name));
+  return (_a = getRoomObjectPosition(primarySpawn)) != null ? _a : getRoomObjectPosition(colony.room.controller);
+}
+function isNearRoomObject(object, position) {
+  const objectPosition = getRoomObjectPosition(object);
+  const range = getRangeBetweenPositions2(objectPosition, position);
+  return isSameRoomPosition3(objectPosition, position.roomName) && range !== null && range <= 1;
+}
+function getRoomObjectPosition(object) {
+  const position = object == null ? void 0 : object.pos;
+  if (!position || typeof position.x !== "number" || typeof position.y !== "number" || !Number.isFinite(position.x) || !Number.isFinite(position.y)) {
+    return null;
+  }
+  return {
+    x: position.x,
+    y: position.y,
+    ...typeof position.roomName === "string" ? { roomName: position.roomName } : {}
+  };
+}
+function isSameRoomPosition3(position, roomName) {
+  return position !== null && (!position.roomName || !roomName || position.roomName === roomName);
+}
+function isWithinBuildableRoomBounds2(position) {
+  return position.x >= ROOM_EDGE_MIN4 && position.x <= ROOM_EDGE_MAX4 && position.y >= ROOM_EDGE_MIN4 && position.y <= ROOM_EDGE_MAX4;
+}
+function getRangeBetweenPositions2(left, right) {
+  if (!left || !right) {
+    return null;
+  }
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
+}
+function compareOptionalNumber(left, right) {
+  if (left !== null && right !== null) {
+    return left - right;
+  }
+  if (left !== null) {
+    return -1;
+  }
+  if (right !== null) {
+    return 1;
+  }
+  return 0;
+}
+function isTerrainWall3(terrain, position) {
+  return (terrain.get(position.x, position.y) & getTerrainWallMask3()) !== 0;
+}
+function getRoomTerrain2(room) {
+  const game = globalThis.Game;
+  if (!(game == null ? void 0 : game.map) || typeof game.map.getRoomTerrain !== "function") {
+    return null;
+  }
+  return game.map.getRoomTerrain(room.name);
+}
+function getPositionKey3(position) {
+  return `${position.x},${position.y}`;
+}
+function getContainerStructureType() {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants.STRUCTURE_CONTAINER) != null ? _a : "container";
+}
+function getTerrainWallMask3() {
+  return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK3;
+}
+function getOkCode2() {
+  return typeof OK === "number" ? OK : 0;
+}
+function getMissingObservations(roomState, candidate) {
+  var _a;
+  return ((_a = candidate.requiredObservations) != null ? _a : []).filter((observation) => !hasObservation(roomState, observation));
+}
+function hasObservation(roomState, observation) {
+  var _a;
+  const explicitObservation = (_a = roomState.observations) == null ? void 0 : _a[observation];
+  if (typeof explicitObservation === "boolean") {
+    return explicitObservation;
+  }
+  switch (observation) {
+    case "room-controller":
+      return typeof roomState.rcl === "number";
+    case "energy-capacity":
+      return typeof roomState.energyCapacity === "number";
+    case "worker-count":
+      return typeof roomState.workerCount === "number";
+    case "spawn-count":
+      return typeof roomState.spawnCount === "number";
+    case "construction-sites":
+      return typeof roomState.constructionSiteCount === "number";
+    case "repair-decay":
+      return typeof roomState.criticalRepairCount === "number" && typeof roomState.decayingStructureCount === "number";
+    case "hostile-presence":
+      return typeof roomState.hostileCreepCount === "number" && typeof roomState.hostileStructureCount === "number";
+    case "sources":
+      return typeof roomState.sourceCount === "number";
+    case "territory-intents":
+      return typeof roomState.activeTerritoryIntentCount === "number" && typeof roomState.plannedTerritoryIntentCount === "number";
+    case "remote-paths":
+      return roomState.remoteLogisticsReady === true;
+    default:
+      return false;
+  }
+}
+function getBlockingPreconditions(roomState, candidate, missingObservations) {
+  var _a, _b, _c, _d, _e, _f;
+  if (missingObservations.length > 0) {
+    return [];
+  }
+  const preconditions = [];
+  if (typeof candidate.minimumRcl === "number" && ((_a = roomState.rcl) != null ? _a : 0) < candidate.minimumRcl) {
+    preconditions.push(`requires RCL ${candidate.minimumRcl} (current RCL ${(_b = roomState.rcl) != null ? _b : "unknown"})`);
+  }
+  if (typeof candidate.minimumWorkers === "number" && ((_c = roomState.workerCount) != null ? _c : 0) < candidate.minimumWorkers) {
+    preconditions.push(`needs ${candidate.minimumWorkers} available workers (current ${(_d = roomState.workerCount) != null ? _d : "unknown"})`);
+  }
+  if (typeof candidate.minimumEnergyCapacity === "number" && ((_e = roomState.energyCapacity) != null ? _e : 0) < candidate.minimumEnergyCapacity) {
+    preconditions.push(
+      `needs ${candidate.minimumEnergyCapacity} energy capacity (current ${(_f = roomState.energyCapacity) != null ? _f : "unknown"})`
+    );
+  }
+  if (candidate.requiresSafeHome && hasSurvivalPressure(roomState)) {
+    preconditions.push("resolve survival/recovery pressure before expansion construction");
+  }
+  return preconditions;
+}
+function getUrgencyMagnitude(roomState, candidate) {
+  var _a;
+  const signals = (_a = candidate.signals) != null ? _a : {};
+  const recoveryUrgency = Math.max(
+    normalizeSignal(signals.survivalRecovery),
+    isRecoveryCandidate(candidate) ? getWorkerRecoveryPressure(roomState) : 0
+  );
+  const downgradeUrgency = Math.max(
+    normalizeSignal(signals.controllerDowngrade),
+    isControllerProtectionCandidate(candidate) ? getControllerDowngradePressure(roomState) : 0
+  );
+  const defenseUrgency = Math.max(
+    normalizeSignal(signals.defense),
+    isDefenseCandidate(candidate) ? getDefensePressure(roomState) : 0
+  );
+  const energyUrgency = Math.max(
+    normalizeSignal(signals.energyBottleneck),
+    isEnergyCapacityCandidate(candidate) ? getEnergyBottleneckPressure(roomState) : 0
+  );
+  const repairUrgency = Math.max(
+    normalizeSignal(signals.repairDecay),
+    isRepairSupportCandidate(candidate) ? getRepairDecayPressure(roomState) : 0
+  );
+  return Math.max(recoveryUrgency, downgradeUrgency, defenseUrgency, energyUrgency, repairUrgency);
+}
+function scoreRoomState(roomState, candidate) {
+  var _a, _b, _c, _d, _e;
+  let score = 0;
+  if (candidate.status === "existing-site") {
+    score += 4;
+  }
+  if (typeof roomState.rcl === "number" && (!candidate.minimumRcl || roomState.rcl >= candidate.minimumRcl)) {
+    score += Math.min(5, Math.max(1, roomState.rcl));
+  }
+  if (isRecoveryCandidate(candidate)) {
+    score += Math.round(getWorkerRecoveryPressure(roomState) * 7);
+  } else if (((_a = roomState.workerCount) != null ? _a : 0) >= MIN_SAFE_WORKERS_FOR_EXPANSION) {
+    score += 4;
+  }
+  if (isEnergyCapacityCandidate(candidate) && ((_b = roomState.energyCapacity) != null ? _b : EARLY_ENERGY_CAPACITY_TARGET) < EARLY_ENERGY_CAPACITY_TARGET) {
+    score += 4;
+  }
+  if (isRepairSupportCandidate(candidate)) {
+    score += Math.min(4, ((_c = roomState.criticalRepairCount) != null ? _c : 0) * 2 + ((_d = roomState.decayingStructureCount) != null ? _d : 0));
+  }
+  if (isDefenseCandidate(candidate)) {
+    score += Math.round(getDefensePressure(roomState) * 5);
+  }
+  if (((_e = roomState.constructionSiteCount) != null ? _e : 0) > 0 && candidate.status === "existing-site") {
+    score += 2;
+  }
+  return Math.min(MAX_ROOM_STATE_POINTS, score);
+}
+function scoreExpansionPrerequisites(roomState, candidate) {
+  var _a, _b, _c;
+  const signal = normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.expansionPrerequisite);
+  const territoryIntentPressure = Math.min(
+    1,
+    ((_b = roomState.activeTerritoryIntentCount) != null ? _b : 0) * 0.7 + ((_c = roomState.plannedTerritoryIntentCount) != null ? _c : 0) * 0.45
+  );
+  const structureMultiplier = candidate.buildType === "remote-logistics" || candidate.buildType === "road" || candidate.buildType === "container" || candidate.buildType === "tower" || candidate.buildType === "rampart" ? 1 : 0.35;
+  return Math.min(
+    MAX_EXPANSION_POINTS,
+    Math.round(signal * 14 + territoryIntentPressure * structureMultiplier * 6)
+  );
+}
+function scoreEconomicBenefit(roomState, candidate) {
+  var _a;
+  const signals = (_a = candidate.signals) != null ? _a : {};
+  const score = normalizeSignal(signals.harvestThroughput) * 8 + normalizeSignal(signals.spawnUtilization) * 5 + normalizeSignal(signals.rclAcceleration) * 5 + normalizeSignal(signals.storageLogistics) * 4 + normalizeSignal(signals.energyBottleneck) * 4 + getSourceBenefit(roomState, candidate);
+  return Math.min(MAX_ECONOMIC_POINTS, Math.round(score));
+}
+function scoreVisionWeight(candidate) {
+  var _a;
+  const vision = (_a = candidate.vision) != null ? _a : {};
+  const score = normalizeSignal(vision.survival) * 15 + normalizeSignal(vision.territory) * 13 + normalizeSignal(vision.resources) * 9 + normalizeSignal(vision.enemyKills) * 5;
+  return Math.min(MAX_VISION_POINTS, Math.round(score));
+}
+function scoreRiskCost(roomState, candidate) {
+  var _a, _b, _c, _d, _e, _f, _g, _h;
+  const energyCost = (_b = (_a = candidate.estimatedEnergyCost) != null ? _a : STRUCTURE_BUILD_COSTS[candidate.buildType]) != null ? _b : 0;
+  const buildTicks = (_c = candidate.estimatedBuildTicks) != null ? _c : 0;
+  const energyRisk = Math.min(8, energyCost / 4e3);
+  const buildTimeRisk = Math.min(5, buildTicks / 1500);
+  const exposureRisk = EXPOSURE_COST[(_d = candidate.pathExposure) != null ? _d : "none"] + EXPOSURE_COST[(_e = candidate.hostileExposure) != null ? _e : "none"];
+  const backlogRisk = Math.max(0, (((_f = roomState.constructionSiteCount) != null ? _f : 0) - 3) * 1.5);
+  const hostilePressureRisk = ((_g = roomState.hostileCreepCount) != null ? _g : 0) > 0 && !isDefenseCandidate(candidate) ? 4 : 0;
+  const lowWorkerRisk = ((_h = roomState.workerCount) != null ? _h : MIN_SAFE_WORKERS_FOR_EXPANSION) < MIN_SAFE_WORKERS_FOR_EXPANSION && !isSurvivalCandidate(candidate) ? 4 : 0;
+  return Math.min(
+    MAX_RISK_COST,
+    Math.round(energyRisk + buildTimeRisk + exposureRisk + backlogRisk + hostilePressureRisk + lowWorkerRisk)
+  );
+}
+function applySurvivalGate(roomState, candidate, rawScore) {
+  var _a, _b;
+  if (!hasSurvivalPressure(roomState) || isSurvivalCandidate(candidate)) {
+    return rawScore;
+  }
+  const hardRecoveryPressure = ((_a = roomState.workerCount) != null ? _a : MIN_SAFE_WORKERS_FOR_EXPANSION) === 0 || ((_b = roomState.spawnCount) != null ? _b : 1) === 0 || getControllerDowngradePressure(roomState) >= 0.85 || getDefensePressure(roomState) >= 0.9;
+  return Math.min(rawScore, hardRecoveryPressure ? 45 : 60);
+}
+function classifyUrgency(score, urgencyMagnitude) {
+  if (score >= 85 || urgencyMagnitude >= 0.9) {
+    return "critical";
+  }
+  if (score >= 70 || urgencyMagnitude >= 0.7) {
+    return "high";
+  }
+  if (score >= 45 || urgencyMagnitude >= 0.4) {
+    return "medium";
+  }
+  return "low";
+}
+function compareConstructionPriorityScores(left, right) {
+  if (left.blocked !== right.blocked) {
+    return left.blocked ? 1 : -1;
+  }
+  return right.score - left.score || urgencyRank(right.urgency) - urgencyRank(left.urgency) || right.factors.visionWeight - left.factors.visionWeight || left.buildItem.localeCompare(right.buildItem) || left.room.localeCompare(right.room);
+}
+function urgencyRank(urgency) {
+  switch (urgency) {
+    case "critical":
+      return 4;
+    case "high":
+      return 3;
+    case "medium":
+      return 2;
+    case "low":
+      return 1;
+    case "blocked":
+      return 0;
+    default:
+      return 0;
+  }
+}
+function hasSurvivalPressure(roomState) {
+  var _a, _b;
+  return ((_a = roomState.workerCount) != null ? _a : MIN_SAFE_WORKERS_FOR_EXPANSION) === 0 || ((_b = roomState.spawnCount) != null ? _b : 1) === 0 || getControllerDowngradePressure(roomState) >= 0.7 || getDefensePressure(roomState) >= 0.7;
+}
+function isSurvivalCandidate(candidate) {
+  return isRecoveryCandidate(candidate) || isDefenseCandidate(candidate) || isControllerProtectionCandidate(candidate);
+}
+function isRecoveryCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "spawn" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.survivalRecovery) > 0;
+}
+function isControllerProtectionCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "container" || candidate.buildType === "road" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.controllerDowngrade) > 0;
+}
+function isDefenseCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "tower" || candidate.buildType === "rampart" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.defense) > 0;
+}
+function isEnergyCapacityCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "extension" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.energyBottleneck) > 0;
+}
+function isRepairSupportCandidate(candidate) {
+  var _a;
+  return candidate.buildType === "road" || candidate.buildType === "container" || candidate.buildType === "rampart" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.repairDecay) > 0;
+}
+function getWorkerRecoveryPressure(roomState) {
+  if (roomState.spawnCount === 0) {
+    return 1;
+  }
+  const workerCount = roomState.workerCount;
+  if (typeof workerCount !== "number") {
+    return 0;
+  }
+  if (workerCount <= 0) {
+    return 1;
+  }
+  if (workerCount === 1) {
+    return 0.65;
+  }
+  if (workerCount === 2) {
+    return 0.35;
+  }
+  return 0;
+}
+function getControllerDowngradePressure(roomState) {
+  const ticksToDowngrade = roomState.controllerTicksToDowngrade;
+  if (typeof ticksToDowngrade !== "number") {
+    return 0;
+  }
+  if (ticksToDowngrade <= 1e3) {
+    return 1;
+  }
+  if (ticksToDowngrade <= CONTROLLER_DOWNGRADE_CRITICAL_TICKS) {
+    return 0.85;
+  }
+  if (ticksToDowngrade <= CONTROLLER_DOWNGRADE_WARNING_TICKS) {
+    return 0.35;
+  }
+  return 0;
+}
+function getDefensePressure(roomState) {
+  var _a, _b;
+  if (((_a = roomState.hostileCreepCount) != null ? _a : 0) > 0) {
+    return 0.9;
+  }
+  if (((_b = roomState.hostileStructureCount) != null ? _b : 0) > 0) {
+    return 0.55;
+  }
+  return 0;
+}
+function getEnergyBottleneckPressure(roomState) {
+  const energyCapacity = roomState.energyCapacity;
+  if (typeof energyCapacity !== "number") {
+    return 0;
+  }
+  if (energyCapacity < 350) {
+    return 0.85;
+  }
+  if (energyCapacity < EARLY_ENERGY_CAPACITY_TARGET) {
+    return 0.65;
+  }
+  return 0;
+}
+function getRepairDecayPressure(roomState) {
+  var _a, _b;
+  if (((_a = roomState.criticalRepairCount) != null ? _a : 0) > 0) {
+    return 0.7;
+  }
+  if (((_b = roomState.decayingStructureCount) != null ? _b : 0) > 0) {
+    return 0.35;
+  }
+  return 0;
+}
+function getSourceBenefit(roomState, candidate) {
+  var _a;
+  if (candidate.buildType !== "container" && candidate.buildType !== "road" && candidate.buildType !== "remote-logistics") {
+    return 0;
+  }
+  return Math.min(3, (_a = roomState.sourceCount) != null ? _a : 0);
+}
+function normalizeSignal(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
+}
+function clampScore(score) {
+  return Math.max(0, Math.min(MAX_SCORE, score));
+}
+function buildRuntimeConstructionPriorityState(colony, creeps) {
+  var _a, _b, _c;
+  const room = colony.room;
+  const ownedConstructionSites = findRoomObjects4(room, "FIND_MY_CONSTRUCTION_SITES");
+  const ownedStructures = findRoomObjects4(room, "FIND_MY_STRUCTURES");
+  const visibleStructures = findRoomObjects4(room, "FIND_STRUCTURES");
+  const hostileCreeps = findRoomObjects4(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects4(room, "FIND_HOSTILE_STRUCTURES");
+  const sources = findRoomObjects4(room, "FIND_SOURCES");
+  const colonyWorkers = creeps.filter((creep) => {
+    var _a2, _b2;
+    return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && ((_b2 = creep.memory) == null ? void 0 : _b2.colony) === room.name;
+  });
+  const repairSignals = summarizeRepairSignals(visibleStructures, buildCriticalRoadLogisticsContext(room));
+  const territoryIntentCounts = countTerritoryIntents(room.name);
+  return {
+    roomName: room.name,
+    rcl: ((_a = room.controller) == null ? void 0 : _a.my) === true ? room.controller.level : void 0,
+    energyAvailable: colony.energyAvailable,
+    energyCapacity: colony.energyCapacityAvailable,
+    workerCount: colonyWorkers.length,
+    spawnCount: colony.spawns.length,
+    sourceCount: sources == null ? void 0 : sources.length,
+    extensionCount: countStructuresByType(ownedStructures, "STRUCTURE_EXTENSION", "extension"),
+    towerCount: countStructuresByType(ownedStructures, "STRUCTURE_TOWER", "tower"),
+    constructionSiteCount: ownedConstructionSites == null ? void 0 : ownedConstructionSites.length,
+    criticalRepairCount: repairSignals == null ? void 0 : repairSignals.criticalRepairCount,
+    decayingStructureCount: repairSignals == null ? void 0 : repairSignals.decayingStructureCount,
+    controllerTicksToDowngrade: ((_b = room.controller) == null ? void 0 : _b.my) === true ? room.controller.ticksToDowngrade : void 0,
+    hostileCreepCount: hostileCreeps == null ? void 0 : hostileCreeps.length,
+    hostileStructureCount: hostileStructures == null ? void 0 : hostileStructures.length,
+    activeTerritoryIntentCount: territoryIntentCounts.active,
+    plannedTerritoryIntentCount: territoryIntentCounts.planned,
+    remoteLogisticsReady: false,
+    observations: {
+      "room-controller": ((_c = room.controller) == null ? void 0 : _c.my) === true && typeof room.controller.level === "number",
+      "energy-capacity": typeof colony.energyCapacityAvailable === "number",
+      "worker-count": true,
+      "spawn-count": true,
+      "construction-sites": ownedConstructionSites !== null,
+      "repair-decay": visibleStructures !== null,
+      "hostile-presence": hostileCreeps !== null && hostileStructures !== null,
+      sources: sources !== null,
+      "territory-intents": true,
+      "remote-paths": false
+    },
+    ownedConstructionSites,
+    ownedStructures,
+    visibleStructures
+  };
+}
+function buildRuntimeConstructionCandidates(state) {
+  const candidates = [
+    ...buildExistingSiteCandidates(state),
+    ...buildPlannedLocalCandidates(state),
+    ...buildRemoteLogisticsCandidates(state)
+  ];
+  if (candidates.length > 0) {
+    return candidates;
+  }
+  return [
+    {
+      buildItem: "observe construction backlog",
+      buildType: "observation",
+      requiredObservations: ["construction-sites"],
+      expectedKpiMovement: ["construction priority table becomes evidence-backed"],
+      risk: ["no build action should be selected until construction-site observations exist"],
+      vision: { resources: 0.2 }
+    }
+  ];
+}
+function buildExistingSiteCandidates(state) {
+  var _a;
+  return ((_a = state.ownedConstructionSites) != null ? _a : []).map((site) => {
+    const buildType = mapStructureTypeToBuildType(String(site.structureType));
+    return {
+      ...createCandidateForBuildType(buildType, state),
+      buildItem: `finish ${site.structureType} site`,
+      status: "existing-site",
+      estimatedEnergyCost: getConstructionSiteRemainingProgress(site)
+    };
+  });
+}
+function buildPlannedLocalCandidates(state) {
+  var _a, _b, _c, _d, _e, _f;
+  const candidates = [];
+  const rcl = (_a = state.rcl) != null ? _a : 0;
+  const extensionLimit = getExtensionLimitForRcl(state.rcl);
+  if (extensionLimit > 0 && ((_b = state.extensionCount) != null ? _b : 0) < extensionLimit) {
+    candidates.push(createCandidateForBuildType("extension", state));
+  }
+  if (rcl >= 2 && ((_c = state.sourceCount) != null ? _c : 0) > 0) {
+    candidates.push(createCandidateForBuildType("container", state));
+  }
+  if (rcl >= MIN_RCL_FOR_AUTOMATED_ROADS && ((_d = state.sourceCount) != null ? _d : 0) > 0) {
+    candidates.push(createCandidateForBuildType("road", state));
+  }
+  if (rcl >= 2 && getDefensePressure(state) > 0) {
+    candidates.push(createCandidateForBuildType("rampart", state));
+  }
+  if (rcl >= 3 && ((_e = state.towerCount) != null ? _e : 0) === 0) {
+    candidates.push(createCandidateForBuildType("tower", state));
+  }
+  if (((_f = state.spawnCount) != null ? _f : 1) === 0) {
+    candidates.push(createCandidateForBuildType("spawn", state));
+  }
+  return candidates;
+}
+function buildRemoteLogisticsCandidates(state) {
+  var _a, _b;
+  const territoryIntentCount = ((_a = state.activeTerritoryIntentCount) != null ? _a : 0) + ((_b = state.plannedTerritoryIntentCount) != null ? _b : 0);
+  if (territoryIntentCount === 0) {
+    return [];
+  }
+  return [createCandidateForBuildType("remote-logistics", state)];
+}
+function createCandidateForBuildType(buildType, state) {
+  var _a, _b;
+  switch (buildType) {
+    case "spawn":
+      return {
+        buildItem: "build spawn recovery",
+        buildType,
+        minimumRcl: 1,
+        requiredObservations: ["spawn-count", "worker-count", "room-controller"],
+        expectedKpiMovement: ["restores worker production and prevents room loss"],
+        risk: ["high energy commitment before economy is recovered"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.spawn,
+        signals: { survivalRecovery: 1, spawnUtilization: 0.8 },
+        vision: { survival: 1, territory: 0.6 }
+      };
+    case "extension":
+      return {
+        buildItem: "build extension capacity",
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ["room-controller", "energy-capacity", "worker-count", "construction-sites"],
+        expectedKpiMovement: ["raises spawn energy capacity", "unlocks larger workers and faster RCL progress"],
+        risk: ["adds build backlog before roads/containers if worker capacity is low"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.extension,
+        signals: {
+          energyBottleneck: getEnergyBottleneckPressure(state),
+          spawnUtilization: 0.8,
+          rclAcceleration: 0.65
+        },
+        vision: { resources: 1, territory: 0.35 }
+      };
+    case "tower":
+      return {
+        buildItem: "build tower defense",
+        buildType,
+        minimumRcl: 3,
+        requiredObservations: ["room-controller", "hostile-presence", "energy-capacity", "worker-count"],
+        expectedKpiMovement: ["improves room hold safety", "adds hostile damage and repair response capacity"],
+        risk: ["requires steady energy income to keep tower effective"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.tower,
+        hostileExposure: "medium",
+        signals: { defense: Math.max(0.75, getDefensePressure(state)), enemyKillPotential: 0.7 },
+        vision: { survival: getDefensePressure(state), territory: 0.9, enemyKills: 0.5 }
+      };
+    case "rampart":
+      return {
+        buildItem: "build rampart defense",
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ["room-controller", "hostile-presence", "repair-decay", "worker-count"],
+        expectedKpiMovement: ["improves spawn/controller survivability under pressure"],
+        risk: ["decays without sustained repair budget"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.rampart,
+        hostileExposure: "medium",
+        signals: { defense: getDefensePressure(state), repairDecay: getRepairDecayPressure(state) },
+        vision: { survival: getDefensePressure(state), territory: 0.8, enemyKills: 0.15 }
+      };
+    case "road":
+      return {
+        buildItem: "build source/controller roads",
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ["room-controller", "sources", "repair-decay", "worker-count"],
+        expectedKpiMovement: ["reduces worker travel time", "improves harvest-to-spawn throughput"],
+        risk: ["road decay creates recurring repair load"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.road,
+        pathExposure: "low",
+        signals: {
+          harvestThroughput: 0.55,
+          rclAcceleration: 0.45,
+          expansionPrerequisite: ((_a = state.activeTerritoryIntentCount) != null ? _a : 0) > 0 ? 0.45 : 0.2,
+          controllerDowngrade: getControllerDowngradePressure(state) >= 0.7 ? 0.55 : 0
+        },
+        vision: { resources: 0.8, territory: 0.45 }
+      };
+    case "container":
+      return {
+        buildItem: "build source containers",
+        buildType,
+        minimumRcl: 2,
+        requiredObservations: ["room-controller", "sources", "worker-count"],
+        expectedKpiMovement: ["raises harvest throughput", "reduces dropped-energy waste"],
+        risk: ["large early build cost and decay upkeep"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.container,
+        pathExposure: "low",
+        signals: {
+          harvestThroughput: 0.9,
+          storageLogistics: 0.65,
+          rclAcceleration: 0.35,
+          expansionPrerequisite: ((_b = state.activeTerritoryIntentCount) != null ? _b : 0) > 0 ? 0.4 : 0.15,
+          controllerDowngrade: getControllerDowngradePressure(state) >= 0.7 ? 0.5 : 0
+        },
+        vision: { resources: 1, territory: 0.35 }
+      };
+    case "storage":
+      return {
+        buildItem: "build storage logistics",
+        buildType,
+        minimumRcl: 4,
+        minimumWorkers: MIN_SAFE_WORKERS_FOR_EXPANSION,
+        requiredObservations: ["room-controller", "energy-capacity", "worker-count"],
+        expectedKpiMovement: ["improves durable resource buffering and logistics"],
+        risk: ["very high energy commitment"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.storage,
+        signals: { storageLogistics: 0.95 },
+        vision: { resources: 1, territory: 0.25 }
+      };
+    case "remote-logistics":
+      return {
+        buildItem: "build remote road/container logistics",
+        buildType,
+        minimumRcl: 2,
+        minimumWorkers: MIN_SAFE_WORKERS_FOR_EXPANSION,
+        requiresSafeHome: true,
+        requiredObservations: ["territory-intents", "remote-paths", "worker-count", "hostile-presence"],
+        expectedKpiMovement: ["turns reserved/scouted territory into sustainable income", "improves remote room hold viability"],
+        risk: ["path exposure and hostile pressure can waste builder time"],
+        estimatedEnergyCost: STRUCTURE_BUILD_COSTS["remote-logistics"],
+        pathExposure: "high",
+        hostileExposure: "medium",
+        signals: {
+          expansionPrerequisite: 1,
+          harvestThroughput: 0.75,
+          storageLogistics: 0.5
+        },
+        vision: { territory: 1, resources: 0.6 }
+      };
+    case "observation":
+    default:
+      return {
+        buildItem: "observe construction backlog",
+        buildType: "observation",
+        requiredObservations: ["construction-sites"],
+        expectedKpiMovement: ["construction priority table becomes evidence-backed"],
+        risk: ["no build action should be selected until construction-site observations exist"],
+        signals: {},
+        vision: { resources: 0.2 }
+      };
+  }
+}
+function mapStructureTypeToBuildType(structureType) {
+  if (matchesStructureType4(structureType, "STRUCTURE_SPAWN", "spawn")) {
+    return "spawn";
+  }
+  if (matchesStructureType4(structureType, "STRUCTURE_EXTENSION", "extension")) {
+    return "extension";
+  }
+  if (matchesStructureType4(structureType, "STRUCTURE_TOWER", "tower")) {
+    return "tower";
+  }
+  if (matchesStructureType4(structureType, "STRUCTURE_RAMPART", "rampart")) {
+    return "rampart";
+  }
+  if (matchesStructureType4(structureType, "STRUCTURE_ROAD", "road")) {
+    return "road";
+  }
+  if (matchesStructureType4(structureType, "STRUCTURE_CONTAINER", "container")) {
+    return "container";
+  }
+  if (matchesStructureType4(structureType, "STRUCTURE_STORAGE", "storage")) {
+    return "storage";
+  }
+  return "observation";
+}
+function getConstructionSiteRemainingProgress(site) {
+  var _a;
+  const progressTotal = typeof site.progressTotal === "number" ? site.progressTotal : (_a = STRUCTURE_BUILD_COSTS.observation) != null ? _a : 0;
+  const progress = typeof site.progress === "number" ? site.progress : 0;
+  return Math.max(0, progressTotal - progress);
+}
+function findRoomObjects4(room, constantName) {
+  const findConstant = getFindConstant(constantName);
+  if (findConstant === null || typeof room.find !== "function") {
+    return null;
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return null;
+  }
+}
+function getFindConstant(constantName) {
+  const findConstant = globalThis[constantName];
+  return typeof findConstant === "number" ? findConstant : null;
+}
+function countStructuresByType(structures, globalName, fallback) {
+  return structures == null ? void 0 : structures.filter((structure) => matchesStructureType4(structure.structureType, globalName, fallback)).length;
+}
+function summarizeRepairSignals(structures, criticalRoadContext) {
+  if (structures === null) {
+    return null;
+  }
+  return structures.reduce(
+    (summary, structure) => {
+      if (!isRepairSignalStructure(structure) || !hasHits(structure)) {
+        return summary;
+      }
+      if (matchesStructureType4(structure.structureType, "STRUCTURE_ROAD", "road") && !isCriticalRoadLogisticsWork(structure, criticalRoadContext)) {
+        return summary;
+      }
+      const hitsRatio = structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
+      if (hitsRatio <= CRITICAL_REPAIR_HITS_RATIO) {
+        summary.criticalRepairCount += 1;
+      } else if (hitsRatio <= DECAYING_REPAIR_HITS_RATIO) {
+        summary.decayingStructureCount += 1;
+      }
+      return summary;
+    },
+    { criticalRepairCount: 0, decayingStructureCount: 0 }
+  );
+}
+function isRepairSignalStructure(structure) {
+  if (matchesStructureType4(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType4(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+    return true;
+  }
+  return matchesStructureType4(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true && structure.hits <= IDLE_RAMPART_REPAIR_HITS_CEILING;
+}
+function hasHits(structure) {
+  return typeof structure.hits === "number" && typeof structure.hitsMax === "number";
+}
+function countTerritoryIntents(roomName) {
+  var _a, _b;
+  const intents = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.intents;
+  if (!Array.isArray(intents)) {
+    return { active: 0, planned: 0 };
+  }
+  return intents.reduce(
+    (counts, intent) => {
+      if (!isRecord2(intent)) {
+        return counts;
+      }
+      if (intent.colony !== roomName) {
+        return counts;
+      }
+      if (intent.status === "active") {
+        counts.active += 1;
+      } else if (intent.status === "planned") {
+        counts.planned += 1;
+      }
+      return counts;
+    },
+    { active: 0, planned: 0 }
+  );
+}
+function isRecord2(value) {
+  return typeof value === "object" && value !== null;
+}
+function matchesStructureType4(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+
 // src/territory/territoryMemoryUtils.ts
 function normalizeTerritoryIntents(rawIntents) {
   return Array.isArray(rawIntents) ? rawIntents.flatMap((intent) => {
@@ -1537,10 +2794,10 @@ function normalizeTerritoryIntents(rawIntents) {
   }) : [];
 }
 function normalizeTerritoryIntent(rawIntent) {
-  if (!isRecord(rawIntent)) {
+  if (!isRecord3(rawIntent)) {
     return null;
   }
-  if (!isNonEmptyString2(rawIntent.colony) || !isNonEmptyString2(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || !isFiniteNumber(rawIntent.updatedAt)) {
+  if (!isNonEmptyString3(rawIntent.colony) || !isNonEmptyString3(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || !isFiniteNumber(rawIntent.updatedAt)) {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
@@ -1560,7 +2817,7 @@ function normalizeTerritoryIntent(rawIntent) {
   };
 }
 function normalizeTerritoryIntentSuspension(rawSuspension) {
-  if (!isRecord(rawSuspension)) {
+  if (!isRecord3(rawSuspension)) {
     return null;
   }
   if (rawSuspension.reason !== "hostile_presence" || !isFiniteNumber(rawSuspension.hostileCount) || rawSuspension.hostileCount <= 0 || !isFiniteNumber(rawSuspension.updatedAt)) {
@@ -1573,11 +2830,11 @@ function normalizeTerritoryIntentSuspension(rawSuspension) {
   };
 }
 function normalizeTerritoryFollowUp(rawFollowUp) {
-  if (!isRecord(rawFollowUp) || !isTerritoryFollowUpSource(rawFollowUp.source)) {
+  if (!isRecord3(rawFollowUp) || !isTerritoryFollowUpSource(rawFollowUp.source)) {
     return null;
   }
   const originAction = getTerritoryFollowUpOriginAction(rawFollowUp.source);
-  if (!isNonEmptyString2(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
+  if (!isNonEmptyString3(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
     return null;
   }
   return {
@@ -1604,10 +2861,10 @@ function isTerritoryFollowUpSource(source) {
 function isFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isNonEmptyString2(value) {
+function isNonEmptyString3(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord(value) {
+function isRecord3(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -1701,10 +2958,10 @@ function persistOccupationRecommendationTarget(report, intent) {
 }
 function revokeStaleOccupationRecommendationTargetsWithoutFollowUp(report) {
   const colony = report.colonyName;
-  if (!isNonEmptyString3(colony)) {
+  if (!isNonEmptyString4(colony)) {
     return;
   }
-  const territoryMemory = getTerritoryMemoryRecord();
+  const territoryMemory = getTerritoryMemoryRecord2();
   if (!territoryMemory) {
     return;
   }
@@ -1712,7 +2969,7 @@ function revokeStaleOccupationRecommendationTargetsWithoutFollowUp(report) {
 }
 function buildPersistableOccupationRecommendationTarget(report, intent) {
   const recommendation = report.next;
-  if (!recommendation || recommendation.roomName !== intent.targetRoom || getTerritoryIntentAction(recommendation.action) !== intent.action || recommendation.evidenceStatus !== "sufficient" || recommendation.preconditions.length > 0 || !isTerritoryControlAction(intent.action)) {
+  if (!recommendation || recommendation.roomName !== intent.targetRoom || getTerritoryIntentAction(recommendation.action) !== intent.action || recommendation.evidenceStatus !== "sufficient" || recommendation.preconditions.length > 0 || !isTerritoryControlAction2(intent.action)) {
     return null;
   }
   return {
@@ -1738,13 +2995,13 @@ function buildActiveOccupationRecommendationControlTarget(report) {
     return null;
   }
   const action = getTerritoryIntentAction(recommendation.action);
-  if (!isTerritoryControlAction(action)) {
+  if (!isTerritoryControlAction2(action)) {
     return null;
   }
   return { roomName: recommendation.roomName, action };
 }
 function revokeOccupationRecommendationTarget(territoryMemory, intent) {
-  if (!isTerritoryControlAction(intent.action) || !Array.isArray(territoryMemory.targets)) {
+  if (!isTerritoryControlAction2(intent.action) || !Array.isArray(territoryMemory.targets)) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter((rawTarget) => {
@@ -1764,7 +3021,7 @@ function upsertTerritoryTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord2(existingTarget) && existingTarget.enabled !== false && !existingTarget.controllerId && target.controllerId) {
+  if (isRecord4(existingTarget) && existingTarget.enabled !== false && !existingTarget.controllerId && target.controllerId) {
     existingTarget.controllerId = target.controllerId;
   }
 }
@@ -1790,7 +3047,7 @@ function buildRuntimeOccupationRecommendationInput(colony, colonyWorkers) {
 }
 function buildRuntimeOccupationCandidates(colonyName) {
   const candidatesByRoom = /* @__PURE__ */ new Map();
-  const territoryMemory = getTerritoryMemoryRecord();
+  const territoryMemory = getTerritoryMemoryRecord2();
   let order = 0;
   if (Array.isArray(territoryMemory == null ? void 0 : territoryMemory.targets)) {
     for (const rawTarget of territoryMemory.targets) {
@@ -1859,11 +3116,11 @@ function enrichVisibleOccupationCandidate(candidate) {
   if (!room) {
     return candidate;
   }
-  const hostileCreeps = findRoomObjects3(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects3(room, "FIND_HOSTILE_STRUCTURES");
-  const sources = findRoomObjects3(room, "FIND_SOURCES");
-  const constructionSites = findRoomObjects3(room, "FIND_MY_CONSTRUCTION_SITES");
-  const ownedStructures = findRoomObjects3(room, "FIND_MY_STRUCTURES");
+  const hostileCreeps = findRoomObjects5(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects5(room, "FIND_HOSTILE_STRUCTURES");
+  const sources = findRoomObjects5(room, "FIND_SOURCES");
+  const constructionSites = findRoomObjects5(room, "FIND_MY_CONSTRUCTION_SITES");
+  const ownedStructures = findRoomObjects5(room, "FIND_MY_STRUCTURES");
   const controllerId = (_b = room.controller) == null ? void 0 : _b.id;
   return {
     ...candidate,
@@ -1991,7 +3248,7 @@ function getCandidateRoadDistance(candidate) {
   return (_a = candidate.roadDistance) != null ? _a : typeof candidate.routeDistance === "number" ? candidate.routeDistance : void 0;
 }
 function getControllerPressureEvidence(input, candidate) {
-  if (candidate.source !== "configured" || !isTerritoryControlAction(candidate.actionHint) || !candidate.controller || !isForeignReservation(input, candidate.controller)) {
+  if (candidate.source !== "configured" || !isTerritoryControlAction2(candidate.actionHint) || !candidate.controller || !isForeignReservation(input, candidate.controller)) {
     return null;
   }
   return "foreign reservation can be pressured";
@@ -2083,7 +3340,7 @@ function getAdjacentRoomNames(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord2(exits)) {
+  if (!isRecord4(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER.flatMap((direction) => {
@@ -2092,7 +3349,7 @@ function getAdjacentRoomNames(roomName) {
   });
 }
 function normalizeTerritoryTarget(rawTarget) {
-  if (!isRecord2(rawTarget)) {
+  if (!isRecord4(rawTarget)) {
     return null;
   }
   if (typeof rawTarget.colony !== "string" || rawTarget.colony.length === 0 || typeof rawTarget.roomName !== "string" || rawTarget.roomName.length === 0 || rawTarget.action !== "claim" && rawTarget.action !== "reserve") {
@@ -2109,8 +3366,8 @@ function normalizeTerritoryTarget(rawTarget) {
 }
 function getCachedRouteDistance(fromRoom, targetRoom) {
   var _a;
-  const routeDistances = (_a = getTerritoryMemoryRecord()) == null ? void 0 : _a.routeDistances;
-  if (!isRecord2(routeDistances)) {
+  const routeDistances = (_a = getTerritoryMemoryRecord2()) == null ? void 0 : _a.routeDistances;
+  if (!isRecord4(routeDistances)) {
     return void 0;
   }
   const distance = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`];
@@ -2166,7 +3423,7 @@ function getVisibleOwnedRoomNames(fallbackRoomName) {
   }
   return Array.from(roomNames);
 }
-function findRoomObjects3(room, constantName) {
+function findRoomObjects5(room, constantName) {
   const findConstant = getGlobalNumber3(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
@@ -2207,7 +3464,7 @@ function getGameTime4() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function getTerritoryMemoryRecord() {
+function getTerritoryMemoryRecord2() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
@@ -2216,7 +3473,7 @@ function getWritableTerritoryMemoryRecord() {
   if (!memory) {
     return null;
   }
-  if (!isRecord2(memory.territory)) {
+  if (!isRecord4(memory.territory)) {
     memory.territory = {};
   }
   return memory.territory;
@@ -2249,16 +3506,16 @@ function shouldPreservePersistedTerritoryIntentPressureRequirement(intent, contr
   return intent.requiresControllerPressure === true && (isTerritoryControllerPressureVisibilityMissing(intent.targetRoom, intent.action, controllerId) || isVisibleTerritoryControllerPressureAvailable(intent.targetRoom, intent.action, controllerId, intent.colony));
 }
 function isTerritoryControllerPressureVisibilityMissing(targetRoom, action, controllerId) {
-  return isTerritoryControlAction(action) && getVisibleController(targetRoom, controllerId) === null;
+  return isTerritoryControlAction2(action) && getVisibleController(targetRoom, controllerId) === null;
 }
 function isVisibleTerritoryControllerPressureAvailable(targetRoom, action, controllerId, colonyName) {
-  if (!isTerritoryControlAction(action)) {
+  if (!isTerritoryControlAction2(action)) {
     return false;
   }
   const controller = getVisibleController(targetRoom, controllerId);
   return controller !== null && isForeignVisibleReservation(controller, getVisibleColonyOwnerUsername(colonyName));
 }
-function isTerritoryControlAction(action) {
+function isTerritoryControlAction2(action) {
   return action === "claim" || action === "reserve";
 }
 function getVisibleController(targetRoom, controllerId) {
@@ -2294,10 +3551,10 @@ function isRecoveredTerritoryFollowUpAttemptCoolingDown(intent, gameTime) {
 function isRecoveredTerritoryFollowUpRetryPending(intent) {
   return intent.followUp !== void 0 && intent.status === "suppressed" && isFiniteNumber2(intent.lastAttemptAt);
 }
-function isRecord2(value) {
+function isRecord4(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString3(value) {
+function isNonEmptyString4(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber2(value) {
@@ -2388,7 +3645,7 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options
   return plan;
 }
 function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime5()) {
-  if (!plan || !plan.followUp || !isTerritoryControlAction2(plan.action)) {
+  if (!plan || !plan.followUp || !isTerritoryControlAction3(plan.action)) {
     return;
   }
   const recoveredFollowUpMetadata = recoveredTerritoryFollowUpRetryMetadata.get(plan);
@@ -2447,7 +3704,7 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
   return activeCoverageCount === 0 || shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount);
 }
 function requiresTerritoryControllerPressure(plan) {
-  return isTerritoryControlAction2(plan.action) && (plan.requiresControllerPressure === true || isVisibleTerritoryReservePressureAvailable(
+  return isTerritoryControlAction3(plan.action) && (plan.requiresControllerPressure === true || isVisibleTerritoryReservePressureAvailable(
     plan.targetRoom,
     plan.action,
     plan.controllerId,
@@ -2464,7 +3721,7 @@ function isTerritoryIntentPlanSpawnCapable(plan) {
 }
 function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime5()) {
   var _a;
-  if (!plan || !isTerritoryControlAction2(plan.action)) {
+  if (!plan || !isTerritoryControlAction3(plan.action)) {
     return 0;
   }
   if (isTerritoryIntentSuppressed(plan.colony, plan.targetRoom, plan.action, gameTime)) {
@@ -2485,10 +3742,10 @@ function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTim
   return (_a = demand == null ? void 0 : demand.workerCount) != null ? _a : 0;
 }
 function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime5()) {
-  if (!isNonEmptyString4(colony)) {
+  if (!isNonEmptyString5(colony)) {
     return false;
   }
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return false;
   }
@@ -2497,15 +3754,15 @@ function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameT
   );
 }
 function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime5()) {
-  if (!isNonEmptyString4(colony)) {
+  if (!isNonEmptyString5(colony)) {
     return false;
   }
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return false;
   }
   return normalizeTerritoryIntents(territoryMemory.intents).some(
-    (intent) => intent.colony === colony && intent.followUp !== void 0 && isTerritoryControlAction2(intent.action) && !isTerritoryIntentSuspensionActive(intent, gameTime) && isVisibleTerritoryIntentActionable(
+    (intent) => intent.colony === colony && intent.followUp !== void 0 && isTerritoryControlAction3(intent.action) && !isTerritoryIntentSuspensionActive(intent, gameTime) && isVisibleTerritoryIntentActionable(
       intent.targetRoom,
       intent.action,
       intent.controllerId,
@@ -2514,7 +3771,7 @@ function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGam
   );
 }
 function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return [];
   }
@@ -2522,13 +3779,13 @@ function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
   return getBoundedActiveTerritoryFollowUpExecutionHints(
     normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
     intents
-  ).filter((hint) => !isNonEmptyString4(colony) || hint.colony === colony);
+  ).filter((hint) => !isNonEmptyString5(colony) || hint.colony === colony);
 }
 function getTerritoryIntentProgressSummaries(colony, roleCounts) {
-  if (!isNonEmptyString4(colony)) {
+  if (!isNonEmptyString5(colony)) {
     return [];
   }
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return [];
   }
@@ -2553,10 +3810,10 @@ function getTerritoryIntentProgressSummaries(colony, roleCounts) {
 }
 function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime5()) {
   var _a;
-  if (!isNonEmptyString4(colony)) {
+  if (!isNonEmptyString5(colony)) {
     return {};
   }
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return {};
   }
@@ -2614,7 +3871,7 @@ function canCreepReserveTerritoryController(creep, controller, colony) {
     return true;
   }
   const actorUsername = getTerritoryActorUsername(creep, colony);
-  if (!isNonEmptyString4(actorUsername) || !isNonEmptyString4(reservation.username) || reservation.username !== actorUsername || typeof reservation.ticksToEnd !== "number") {
+  if (!isNonEmptyString5(actorUsername) || !isNonEmptyString5(reservation.username) || reservation.username !== actorUsername || typeof reservation.ticksToEnd !== "number") {
     return false;
   }
   const reservationTicksToEnd = reservation.ticksToEnd;
@@ -2646,7 +3903,7 @@ function selectUrgentVisibleReservationRenewalTask(creep) {
   return { type: "reserve", targetId: controller.id };
 }
 function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
-  if (!isNonEmptyString4(assignment.targetRoom)) {
+  if (!isNonEmptyString5(assignment.targetRoom)) {
     return false;
   }
   if (isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
@@ -2655,10 +3912,10 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   if (assignment.action === "scout") {
     return true;
   }
-  if (!isTerritoryControlAction2(assignment.action)) {
+  if (!isTerritoryControlAction3(assignment.action)) {
     return false;
   }
-  if (isNonEmptyString4(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
+  if (isNonEmptyString5(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
@@ -2677,14 +3934,14 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   return targetState === "available" || assignment.action === "reserve" && targetState === "satisfied";
 }
 function isVisibleTerritoryAssignmentComplete(assignment, creep) {
-  if (assignment.action !== "claim" || !isNonEmptyString4(assignment.targetRoom)) {
+  if (assignment.action !== "claim" || !isNonEmptyString5(assignment.targetRoom)) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
   return (controller == null ? void 0 : controller.my) === true && !shouldSignOccupiedController(controller);
 }
 function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, creep) {
-  if (assignment.action !== "claim" || !isNonEmptyString4(assignment.targetRoom)) {
+  if (assignment.action !== "claim" || !isNonEmptyString5(assignment.targetRoom)) {
     return false;
   }
   if (!isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
@@ -2694,7 +3951,7 @@ function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, cree
   return (controller == null ? void 0 : controller.my) === true && shouldSignOccupiedController(controller);
 }
 function suppressTerritoryIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString4(colony) || !isNonEmptyString4(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
+  if (!isNonEmptyString5(colony) || !isNonEmptyString5(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
     return;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord2();
@@ -2726,7 +3983,7 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
   removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
 function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString4(colony) || !isNonEmptyString4(assignment.targetRoom) || assignment.action !== "reserve") {
+  if (!isNonEmptyString5(colony) || !isNonEmptyString5(assignment.targetRoom) || assignment.action !== "reserve") {
     return null;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord2();
@@ -2794,7 +4051,7 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
   var _a, _b, _c;
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername2(colony.room.controller);
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   let intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
   const refreshedHostileSuspensions = refreshHostileTerritoryIntentSuspensions(
     territoryMemory,
@@ -2983,10 +4240,10 @@ function filterTerritoryCandidatesForPlanningOptions(candidates, options) {
   return candidates;
 }
 function isControllerPressureCandidate(candidate) {
-  return isTerritoryControlAction2(candidate.intentAction) && candidate.requiresControllerPressure === true;
+  return isTerritoryControlAction3(candidate.intentAction) && candidate.requiresControllerPressure === true;
 }
 function isTerritoryFollowUpControlCandidate(candidate) {
-  return candidate.followUp !== void 0 && isTerritoryControlAction2(candidate.intentAction);
+  return candidate.followUp !== void 0 && isTerritoryControlAction3(candidate.intentAction);
 }
 function selectBestScoredTerritoryCandidate(candidates) {
   let bestCandidate = null;
@@ -3043,7 +4300,7 @@ function withImmediateControllerFollowUpState(candidates, roleCounts) {
   });
 }
 function isImmediateControllerFollowUpCandidate(candidate, roleCounts) {
-  return candidate.followUp !== void 0 && isTerritoryControlAction2(candidate.intentAction) && getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.intentAction) > 0;
+  return candidate.followUp !== void 0 && isTerritoryControlAction3(candidate.intentAction) && getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.intentAction) > 0;
 }
 function isTerritoryCandidateSpawnRequired(candidate, roleCounts) {
   const activeCoverageCount = getTerritoryCreepCountForTarget(
@@ -3071,7 +4328,7 @@ function getTerritoryCandidateBodyCost(candidate) {
   );
 }
 function getTerritoryIntentActionBodyCost(action, requiresControllerPressure = false) {
-  if (isTerritoryControlAction2(action) && requiresControllerPressure) {
+  if (isTerritoryControlAction3(action) && requiresControllerPressure) {
     return TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
   }
   return action === "scout" ? TERRITORY_SCOUT_BODY_COST : TERRITORY_CONTROLLER_BODY_COST;
@@ -3136,7 +4393,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
   const configuredTargetRooms = getConfiguredTargetRoomsForColony(territoryMemory, colonyName);
   return intents.flatMap((intent, order) => {
     const recoveredFollowUp = isRecoveredTerritoryFollowUpIntent(intent, gameTime);
-    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || isKnownDeadZoneRoom(intent.targetRoom) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction2(intent.action) || isTerritoryIntentSuspensionActive(intent, gameTime) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)) {
+    if (intent.colony !== colonyName || intent.targetRoom === colonyName || configuredTargetRooms.has(intent.targetRoom) || isKnownDeadZoneRoom(intent.targetRoom) || isRecoveredTerritoryFollowUpAttemptCoolingDown2(intent, gameTime) || intent.status !== "planned" && intent.status !== "active" && !recoveredFollowUp || !isTerritoryControlAction3(intent.action) || isTerritoryIntentSuspensionActive(intent, gameTime) || isSuppressedTerritoryIntentForAction(intents, colonyName, intent.targetRoom, intent.action, gameTime) || !isVisibleTerritoryIntentActionable(intent.targetRoom, intent.action, intent.controllerId, colonyOwnerUsername)) {
       return [];
     }
     const intentKey = `${intent.targetRoom}:${intent.action}`;
@@ -3282,7 +4539,7 @@ function getStoredTerritoryReservation(territoryMemory, target) {
     return null;
   }
   const reservation = normalizeTerritoryReservation(
-    isRecord3(territoryMemory.reservations) ? territoryMemory.reservations[getTerritoryReservationMemoryKey(target.colony, target.roomName)] : void 0
+    isRecord5(territoryMemory.reservations) ? territoryMemory.reservations[getTerritoryReservationMemoryKey(target.colony, target.roomName)] : void 0
   );
   if (!reservation || reservation.colony !== target.colony || reservation.roomName !== target.roomName || target.controllerId !== void 0 && reservation.controllerId !== void 0 && reservation.controllerId !== target.controllerId) {
     return null;
@@ -3294,7 +4551,7 @@ function getTerritoryReservationPreRenewScoutLeadTicks(colonyName, targetRoom, r
   return TERRITORY_RESERVATION_RENEWAL_TICKS + (typeof routeDistance === "number" ? routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS * 2 : 0);
 }
 function normalizeTerritoryReservations(rawReservations) {
-  if (!isRecord3(rawReservations)) {
+  if (!isRecord5(rawReservations)) {
     return {};
   }
   const reservations = {};
@@ -3307,10 +4564,10 @@ function normalizeTerritoryReservations(rawReservations) {
   return reservations;
 }
 function normalizeTerritoryReservation(rawReservation) {
-  if (!isRecord3(rawReservation)) {
+  if (!isRecord5(rawReservation)) {
     return null;
   }
-  if (!isNonEmptyString4(rawReservation.colony) || !isNonEmptyString4(rawReservation.roomName) || !isFiniteNumber3(rawReservation.ticksToEnd) || !isFiniteNumber3(rawReservation.updatedAt)) {
+  if (!isNonEmptyString5(rawReservation.colony) || !isNonEmptyString5(rawReservation.roomName) || !isFiniteNumber3(rawReservation.ticksToEnd) || !isFiniteNumber3(rawReservation.updatedAt)) {
     return null;
   }
   return {
@@ -3322,7 +4579,7 @@ function normalizeTerritoryReservation(rawReservation) {
   };
 }
 function hasMalformedTerritoryReservationMemory(rawReservations, reservations) {
-  return isRecord3(rawReservations) && Object.keys(rawReservations).length !== Object.keys(reservations).length;
+  return isRecord5(rawReservations) && Object.keys(rawReservations).length !== Object.keys(reservations).length;
 }
 function getTerritoryReservationMemoryKey(colonyName, roomName) {
   return `${colonyName}${TERRITORY_ROUTE_DISTANCE_SEPARATOR2}${roomName}`;
@@ -3716,7 +4973,7 @@ function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, c
 function applyOccupationRecommendationScore(candidate, recommendation, roleCounts, adjacentControllerProgressReady) {
   var _a;
   const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
-  const requiresControllerPressure = isTerritoryControlAction2(intentAction) && candidate.requiresControllerPressure === true;
+  const requiresControllerPressure = isTerritoryControlAction3(intentAction) && candidate.requiresControllerPressure === true;
   const nextSelection = {
     target: candidate.target,
     intentAction,
@@ -3758,7 +5015,7 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
     if (isRecoveredTerritoryFollowUpControlCandidate(candidate)) {
       return candidate.intentAction;
     }
-    if (isTerritoryControlAction2(candidate.intentAction) && candidate.requiresControllerPressure === true) {
+    if (isTerritoryControlAction3(candidate.intentAction) && candidate.requiresControllerPressure === true) {
       return candidate.intentAction;
     }
     if (candidate.source === "configured" && getTerritoryCreepCountForTarget(roleCounts, candidate.target.roomName, candidate.target.action) > 0) {
@@ -3772,7 +5029,7 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
   return recommendation.action === "reserve" ? "reserve" : candidate.intentAction;
 }
 function isRecoveredTerritoryFollowUpControlCandidate(candidate) {
-  return candidate.recoveredFollowUp === true && candidate.followUp !== void 0 && isTerritoryControlAction2(candidate.intentAction);
+  return candidate.recoveredFollowUp === true && candidate.followUp !== void 0 && isTerritoryControlAction3(candidate.intentAction);
 }
 function buildOccupationRecommendationCandidate(candidate) {
   const room = getVisibleRoom(candidate.target.roomName);
@@ -3792,11 +5049,11 @@ function buildVisibleOccupationRecommendationEvidence(room, controllerId) {
   const controller = getVisibleController2(room.name, controllerId);
   return {
     ...controller ? { controller: summarizeOccupationController(controller) } : {},
-    sourceCount: countVisibleRoomObjects(room, getFindConstant("FIND_SOURCES")),
+    sourceCount: countVisibleRoomObjects(room, getFindConstant2("FIND_SOURCES")),
     hostileCreepCount: findVisibleHostileCreeps(room).length,
     hostileStructureCount: findVisibleHostileStructures(room).length,
-    constructionSiteCount: countVisibleRoomObjects(room, getFindConstant("FIND_MY_CONSTRUCTION_SITES")),
-    ownedStructureCount: countVisibleRoomObjects(room, getFindConstant("FIND_MY_STRUCTURES"))
+    constructionSiteCount: countVisibleRoomObjects(room, getFindConstant2("FIND_MY_CONSTRUCTION_SITES")),
+    ownedStructureCount: countVisibleRoomObjects(room, getFindConstant2("FIND_MY_STRUCTURES"))
   };
 }
 function summarizeOccupationController(controller) {
@@ -3813,7 +5070,7 @@ function summarizeOccupationController(controller) {
 function getControllerReservationUsername(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString4(username) ? username : void 0;
+  return isNonEmptyString5(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd(controller) {
   var _a;
@@ -3822,7 +5079,7 @@ function getControllerReservationTicksToEnd(controller) {
 }
 function getOccupationIntentActionableTicks(selection, colonyOwnerUsername) {
   var _a, _b;
-  if (!isTerritoryControlAction2(selection.intentAction)) {
+  if (!isTerritoryControlAction3(selection.intentAction)) {
     return void 0;
   }
   const controller = getVisibleController2(selection.target.roomName, selection.target.controllerId);
@@ -3860,7 +5117,7 @@ function countVisibleRoomObjects(room, findConstant) {
     return 0;
   }
 }
-function getFindConstant(name) {
+function getFindConstant2(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -3896,7 +5153,7 @@ function comparePersistedControllerFollowUpPreference(left, right) {
   return leftPersisted ? -1 : 1;
 }
 function isPersistedControllerFollowUpCandidate(candidate) {
-  return candidate.persistedFollowUp === true && candidate.followUp !== void 0 && isTerritoryControlAction2(candidate.intentAction);
+  return candidate.persistedFollowUp === true && candidate.followUp !== void 0 && isTerritoryControlAction3(candidate.intentAction);
 }
 function compareRecoveredFollowUpPreference(left, right) {
   if (left.recoveredFollowUp === right.recoveredFollowUp) {
@@ -3923,7 +5180,7 @@ function shouldPreferVisibleAdjacentFollowUp(candidate, other) {
   return isVisibleAdjacentControllerFollowUpCandidate(candidate) && isLowerConfidenceDistantSameActionCandidate(other, candidate);
 }
 function isVisibleAdjacentControllerFollowUpCandidate(candidate) {
-  return isTerritoryFollowUpSource2(candidate.source) && candidate.intentAction === candidate.target.action && isTerritoryControlAction2(candidate.intentAction) && candidate.recommendationEvidenceStatus === "sufficient" && isTerritoryTargetVisible(candidate.target);
+  return isTerritoryFollowUpSource2(candidate.source) && candidate.intentAction === candidate.target.action && isTerritoryControlAction3(candidate.intentAction) && candidate.recommendationEvidenceStatus === "sufficient" && isTerritoryTargetVisible(candidate.target);
 }
 function isLowerConfidenceDistantSameActionCandidate(candidate, followUpCandidate) {
   if (candidate.target.action !== followUpCandidate.target.action || !isPrimaryTerritoryCandidateSource(candidate.source) || !isFartherTerritoryCandidate(candidate, followUpCandidate)) {
@@ -3963,7 +5220,7 @@ function getTerritoryCandidateSourcePriority(source) {
 }
 function buildTerritoryFollowUp(source, originRoom) {
   const originAction = getTerritoryFollowUpOriginAction2(source);
-  if (originAction === null || !isTerritoryFollowUpSource2(source) || !isNonEmptyString4(originRoom)) {
+  if (originAction === null || !isTerritoryFollowUpSource2(source) || !isNonEmptyString5(originRoom)) {
     return {};
   }
   return {
@@ -4008,7 +5265,7 @@ function getVisibleOwnedRoomNames2(fallbackRoomName) {
     return Array.from(roomNames);
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString4(room.name)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString5(room.name)) {
       roomNames.add(room.name);
     }
   }
@@ -4049,11 +5306,11 @@ function getKnownRouteLength(fromRoom, targetRoom, routeDistanceLookupContext) {
   return route.length;
 }
 function getTerritoryRouteDistanceCache() {
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord3(territoryMemory.routeDistances)) {
+  if (!isRecord5(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
@@ -4112,22 +5369,22 @@ function getAdjacentRoomNames2(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord3(exits)) {
+  if (!isRecord5(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER2.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString4(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString5(exitRoom) ? [exitRoom] : [];
   });
 }
 function isRoomAdjacentToColony(colonyName, targetRoom) {
   return getAdjacentRoomNames2(colonyName).includes(targetRoom);
 }
 function normalizeTerritoryTarget2(rawTarget) {
-  if (!isRecord3(rawTarget)) {
+  if (!isRecord5(rawTarget)) {
     return null;
   }
-  if (!isNonEmptyString4(rawTarget.colony) || !isNonEmptyString4(rawTarget.roomName) || !isTerritoryControlAction2(rawTarget.action)) {
+  if (!isNonEmptyString5(rawTarget.colony) || !isNonEmptyString5(rawTarget.roomName) || !isTerritoryControlAction3(rawTarget.action)) {
     return null;
   }
   return {
@@ -4211,7 +5468,7 @@ function refreshHostileTerritoryIntentSuspensions(territoryMemory, intents, colo
   const suspendedIntents = [];
   const refreshedIntents = intents.map((intent) => {
     var _a, _b;
-    if (intent.colony !== colonyName || !isTerritoryControlAction2(intent.action)) {
+    if (intent.colony !== colonyName || !isTerritoryControlAction3(intent.action)) {
       return intent;
     }
     const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
@@ -4323,7 +5580,7 @@ function isStaleTerritoryProgressIntent(intent, colonyName, colonyOwnerUsername,
   if (intent.action === "scout") {
     return isVisibleRoomKnown(intent.targetRoom);
   }
-  if (intent.followUp === void 0 || !isTerritoryControlAction2(intent.action) || intent.status === "suppressed") {
+  if (intent.followUp === void 0 || !isTerritoryControlAction3(intent.action) || intent.status === "suppressed") {
     return false;
   }
   if (intent.status === "active" && getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action) > 0) {
@@ -4347,7 +5604,7 @@ function getVisibleTerritoryControllerEvidenceState(targetRoom, action, controll
   return getTerritoryControllerTargetState(controller, action, colonyOwnerUsername);
 }
 function removeStaleTerritoryProgressIntentState(territoryMemory, intent) {
-  if (isTerritoryControlAction2(intent.action)) {
+  if (isTerritoryControlAction3(intent.action)) {
     removeTerritoryFollowUpDemand(territoryMemory, intent.colony, intent.targetRoom, intent.action);
   }
   removeTerritoryFollowUpExecutionHint(territoryMemory, intent.colony, intent.targetRoom, intent.action);
@@ -4363,7 +5620,7 @@ function shouldPreservePersistedTerritoryIntentPressureRequirement2(intent, cont
   return intent.requiresControllerPressure === true && isTerritoryControllerPressureVisibilityMissing2(intent.targetRoom, intent.action, controllerId);
 }
 function isTerritoryControllerPressureVisibilityMissing2(targetRoom, action, controllerId) {
-  return isTerritoryControlAction2(action) && getVisibleController2(targetRoom, controllerId) === null;
+  return isTerritoryControlAction3(action) && getVisibleController2(targetRoom, controllerId) === null;
 }
 function getPersistedTerritoryIntentPressureRequirement(intents, colony, targetRoom, action, controllerId) {
   if (!isTerritoryControllerPressureVisibilityMissing2(targetRoom, action, controllerId)) {
@@ -4419,7 +5676,7 @@ function getTerritoryReserveFallbackFollowUp(assignment, intents, colony, gameTi
 }
 function recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime) {
   const demands = pruneCurrentTerritoryFollowUpDemands(territoryMemory, gameTime);
-  if (!plan.followUp || !isTerritoryControlAction2(plan.action)) {
+  if (!plan.followUp || !isTerritoryControlAction3(plan.action)) {
     return;
   }
   upsertTerritoryFollowUpDemand(demands, {
@@ -4455,7 +5712,7 @@ function upsertTerritoryFollowUpDemand(demands, nextDemand) {
   demands.push(nextDemand);
 }
 function removeTerritoryFollowUpDemand(territoryMemory, colony, targetRoom, action) {
-  if (!isTerritoryControlAction2(action)) {
+  if (!isTerritoryControlAction3(action)) {
     return;
   }
   const demands = normalizeTerritoryFollowUpDemands(territoryMemory.demands).filter(
@@ -4469,7 +5726,7 @@ function removeTerritoryFollowUpDemand(territoryMemory, colony, targetRoom, acti
 }
 function getCurrentTerritoryFollowUpDemand(plan, gameTime) {
   var _a;
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return null;
   }
@@ -4619,10 +5876,10 @@ function normalizeTerritoryFollowUpExecutionHints(rawHints) {
   }) : [];
 }
 function normalizeTerritoryFollowUpExecutionHint(rawHint) {
-  if (!isRecord3(rawHint)) {
+  if (!isRecord5(rawHint)) {
     return null;
   }
-  if (rawHint.type !== "activeFollowUpExecution" || !isNonEmptyString4(rawHint.colony) || !isNonEmptyString4(rawHint.targetRoom) || !isTerritoryIntentAction2(rawHint.action) || !isTerritoryExecutionHintReason(rawHint.reason) || typeof rawHint.updatedAt !== "number") {
+  if (rawHint.type !== "activeFollowUpExecution" || !isNonEmptyString5(rawHint.colony) || !isNonEmptyString5(rawHint.targetRoom) || !isTerritoryIntentAction2(rawHint.action) || !isTerritoryExecutionHintReason(rawHint.reason) || typeof rawHint.updatedAt !== "number") {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(rawHint.followUp);
@@ -4650,10 +5907,10 @@ function normalizeTerritoryFollowUpDemands(rawDemands) {
   }) : [];
 }
 function normalizeTerritoryFollowUpDemand(rawDemand) {
-  if (!isRecord3(rawDemand)) {
+  if (!isRecord5(rawDemand)) {
     return null;
   }
-  if (rawDemand.type !== "followUpPreparation" || !isNonEmptyString4(rawDemand.colony) || !isNonEmptyString4(rawDemand.targetRoom) || !isTerritoryControlAction2(rawDemand.action) || typeof rawDemand.updatedAt !== "number") {
+  if (rawDemand.type !== "followUpPreparation" || !isNonEmptyString5(rawDemand.colony) || !isNonEmptyString5(rawDemand.targetRoom) || !isTerritoryControlAction3(rawDemand.action) || typeof rawDemand.updatedAt !== "number") {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(rawDemand.followUp);
@@ -4705,7 +5962,7 @@ function isHostileTerritoryIntentSuspensionCoolingDown(suspension, gameTime) {
   return gameTime - suspension.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
 }
 function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGameTime5()) {
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return false;
   }
@@ -4748,7 +6005,7 @@ function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, actio
   );
 }
 function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime5()) {
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return false;
   }
@@ -4776,14 +6033,14 @@ function isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colony
 function selectVisibleTerritoryControllerIntent(creep) {
   var _a, _b, _c;
   const roomName = (_a = creep.room) == null ? void 0 : _a.name;
-  if (!isNonEmptyString4(roomName) || isVisibleRoomUnsafe(creep.room)) {
+  if (!isNonEmptyString5(roomName) || isVisibleRoomUnsafe(creep.room)) {
     return null;
   }
   const assignmentIntent = normalizeCreepTerritoryIntent(creep, roomName);
   if (assignmentIntent && isCreepVisibleTerritoryIntentActionable(creep, assignmentIntent)) {
     return assignmentIntent;
   }
-  const territoryMemory = getTerritoryMemoryRecord2();
+  const territoryMemory = getTerritoryMemoryRecord3();
   const colony = (_b = creep.memory) == null ? void 0 : _b.colony;
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents).filter((intent) => isActiveVisibleControllerIntentForCreep(intent, roomName, colony)).sort(compareVisibleControllerIntents);
   return (_c = intents.find((intent) => isCreepVisibleTerritoryIntentActionable(creep, intent))) != null ? _c : null;
@@ -4791,7 +6048,7 @@ function selectVisibleTerritoryControllerIntent(creep) {
 function normalizeCreepTerritoryIntent(creep, roomName) {
   var _a, _b, _c, _d;
   const assignment = (_a = creep.memory) == null ? void 0 : _a.territory;
-  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction2(assignment.action) || isNonEmptyString4((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
+  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction3(assignment.action) || isNonEmptyString5((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(assignment.followUp);
@@ -4806,7 +6063,7 @@ function normalizeCreepTerritoryIntent(creep, roomName) {
   };
 }
 function isActiveVisibleControllerIntentForCreep(intent, roomName, creepColony) {
-  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction2(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString4(creepColony) || intent.colony === creepColony);
+  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction3(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString5(creepColony) || intent.colony === creepColony);
 }
 function compareVisibleControllerIntents(left, right) {
   return getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) || getIntentActionPriority(left.action) - getIntentActionPriority(right.action) || right.updatedAt - left.updatedAt || left.colony.localeCompare(right.colony);
@@ -4821,7 +6078,7 @@ function getIntentActionPriority(action) {
   return action === "claim" ? 0 : 1;
 }
 function isCreepVisibleTerritoryIntentActionable(creep, intent) {
-  if (!isTerritoryControlAction2(intent.action)) {
+  if (!isTerritoryControlAction3(intent.action)) {
     return false;
   }
   const controller = selectCreepRoomController(creep, intent.controllerId);
@@ -4880,12 +6137,12 @@ function getClaimControllerTargetState(controller) {
 }
 function getTerritoryActorUsername(creep, colony) {
   var _a;
-  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString4(colony) ? getVisibleColonyOwnerUsername2(colony) : null;
+  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString5(colony) ? getVisibleColonyOwnerUsername2(colony) : null;
 }
 function getCreepOwnerUsername(creep) {
   var _a;
   const username = (_a = creep == null ? void 0 : creep.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString4(username) ? username : null;
+  return isNonEmptyString5(username) ? username : null;
 }
 function canUseControllerClaimPart(creep) {
   return getActiveControllerClaimPartCount(creep) > 0;
@@ -4977,7 +6234,7 @@ function isVisibleTerritoryIntentActionable(targetRoom, action, controllerId, co
   return getVisibleTerritoryTargetState(targetRoom, action, controllerId, colonyOwnerUsername) === "available" || isVisibleTerritoryReservePressureAvailable(targetRoom, action, controllerId, colonyOwnerUsername);
 }
 function isVisibleTerritoryReservePressureAvailable(targetRoom, action, controllerId, colonyOwnerUsername) {
-  if (!isTerritoryControlAction2(action) || isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
+  if (!isTerritoryControlAction3(action) || isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
     return false;
   }
   const controller = getVisibleController2(targetRoom, controllerId);
@@ -4999,7 +6256,7 @@ function isControllerOwned(controller) {
 }
 function isControllerOwnedByColony2(controller, colonyOwnerUsername) {
   const ownerUsername = getControllerOwnerUsername2(controller);
-  return controller.my === true || isNonEmptyString4(ownerUsername) && ownerUsername === colonyOwnerUsername;
+  return controller.my === true || isNonEmptyString5(ownerUsername) && ownerUsername === colonyOwnerUsername;
 }
 function getReserveControllerTargetState(controller, colonyOwnerUsername) {
   if (isControllerOwned(controller)) {
@@ -5009,17 +6266,17 @@ function getReserveControllerTargetState(controller, colonyOwnerUsername) {
   if (!reservation) {
     return "available";
   }
-  if (!isNonEmptyString4(reservation.username) || reservation.username !== colonyOwnerUsername) {
+  if (!isNonEmptyString5(reservation.username) || reservation.username !== colonyOwnerUsername) {
     return "unavailable";
   }
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) === null ? "satisfied" : "available";
 }
 function isForeignReservedController(controller, actorUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString4(actorUsername)) {
+  if (isControllerOwned(controller) || !isNonEmptyString5(actorUsername)) {
     return false;
   }
   const reservation = controller.reservation;
-  return isNonEmptyString4(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
+  return isNonEmptyString5(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
 }
 function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
   if (target.action !== "reserve" || colonyOwnerUsername === null) {
@@ -5048,7 +6305,7 @@ function getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? ticksToEnd : null;
 }
 function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString4(colonyOwnerUsername)) {
+  if (isControllerOwned(controller) || !isNonEmptyString5(colonyOwnerUsername)) {
     return null;
   }
   const reservation = controller.reservation;
@@ -5064,7 +6321,7 @@ function getVisibleColonyOwnerUsername2(colonyName) {
 function getControllerOwnerUsername2(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString4(username) ? username : null;
+  return isNonEmptyString5(username) ? username : null;
 }
 function getVisibleController2(targetRoom, controllerId) {
   var _a, _b;
@@ -5089,14 +6346,14 @@ function getWritableTerritoryMemoryRecord2() {
   if (!memory) {
     return null;
   }
-  if (!isRecord3(memory.territory)) {
+  if (!isRecord5(memory.territory)) {
     memory.territory = {};
   }
   return memory.territory;
 }
-function getTerritoryMemoryRecord2() {
+function getTerritoryMemoryRecord3() {
   const memory = getMemoryRecord();
-  if (!memory || !isRecord3(memory.territory)) {
+  if (!memory || !isRecord5(memory.territory)) {
     return null;
   }
   return memory.territory;
@@ -5105,11 +6362,11 @@ function getMemoryRecord() {
   const memory = globalThis.Memory;
   return memory != null ? memory : null;
 }
-function isTerritoryControlAction2(action) {
+function isTerritoryControlAction3(action) {
   return action === "claim" || action === "reserve";
 }
 function isTerritoryIntentAction2(action) {
-  return isTerritoryControlAction2(action) || action === "scout";
+  return isTerritoryControlAction3(action) || action === "scout";
 }
 function isTerritoryFollowUpSource2(source) {
   return source === "satisfiedClaimAdjacent" || source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent";
@@ -5117,246 +6374,20 @@ function isTerritoryFollowUpSource2(source) {
 function isTerritoryExecutionHintReason(reason) {
   return reason === "controlEvidenceStillMissing" || reason === "followUpTargetStillUnseen" || reason === "visibleControlEvidenceStillActionable";
 }
-function isNonEmptyString4(value) {
+function isNonEmptyString5(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber3(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isRecord3(value) {
+function isRecord5(value) {
   return typeof value === "object" && value !== null;
-}
-
-// src/construction/criticalRoads.ts
-var CRITICAL_ROAD_ROUTE_RANGE = 2;
-var ROOM_EDGE_MIN3 = 1;
-var ROOM_EDGE_MAX3 = 48;
-var ROOM_CENTER = 25;
-function buildCriticalRoadLogisticsContext(room, options = {}) {
-  const anchorPositions = findOwnedSpawnPositions(room);
-  const targetPositions = findLogisticsTargetPositions(room);
-  const colonyAnchorPositions = anchorPositions.length === 0 ? findColonyRoomLogisticsAnchorPositions(room, options.colonyRoomName, targetPositions) : [];
-  return {
-    anchorPositions: anchorPositions.length > 0 ? anchorPositions : colonyAnchorPositions.length > 0 ? colonyAnchorPositions : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
-    targetPositions
-  };
-}
-function isCriticalRoadLogisticsWork(target, context) {
-  if (!isRoadWorkTarget(target) || !target.pos || context.anchorPositions.length === 0 || context.targetPositions.length === 0) {
-    return false;
-  }
-  const position = target.pos;
-  return context.anchorPositions.some(
-    (anchor) => context.targetPositions.some((destination) => isNearLogisticsRoute(position, anchor, destination))
-  );
-}
-function findOwnedSpawnPositions(room) {
-  return findRoomObjects4(room, "FIND_MY_STRUCTURES").filter(
-    (structure) => matchesStructureType3(structure.structureType, "STRUCTURE_SPAWN", "spawn")
-  ).map((spawn) => spawn.pos).filter((position) => isSameRoomPosition2(position, room.name));
-}
-function findLogisticsTargetPositions(room) {
-  var _a;
-  const sourcePositions = findRoomObjects4(room, "FIND_SOURCES").map((source) => source.pos).filter((position) => isSameRoomPosition2(position, room.name));
-  const controllerPosition = isSameRoomPosition2((_a = room.controller) == null ? void 0 : _a.pos, room.name) ? [room.controller.pos] : [];
-  return [...sourcePositions, ...controllerPosition];
-}
-function findColonyRoomLogisticsAnchorPositions(room, colonyRoomName, targetPositions) {
-  if (targetPositions.length === 0 || !isNonEmptyString5(room.name) || !isNonEmptyString5(colonyRoomName) || colonyRoomName === room.name) {
-    return [];
-  }
-  return uniqueRoomPositions(
-    findColonyRoomSpawnPositions(colonyRoomName).map((position) => projectHomeAnchorIntoRoom(position, room.name)).filter((position) => position !== null)
-  );
-}
-function findColonyRoomSpawnPositions(colonyRoomName) {
-  var _a, _b;
-  const game = globalThis.Game;
-  const homeRoom = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[colonyRoomName];
-  const roomSpawnPositions = homeRoom ? findOwnedSpawnPositions(homeRoom) : [];
-  const globalSpawnPositions = Object.values((_b = game == null ? void 0 : game.spawns) != null ? _b : {}).map((spawn) => spawn.pos).filter((position) => isSameRoomPosition2(position, colonyRoomName));
-  return uniqueRoomPositions([...roomSpawnPositions, ...globalSpawnPositions]);
-}
-function projectHomeAnchorIntoRoom(anchor, roomName) {
-  if (!isNonEmptyString5(anchor.roomName) || anchor.roomName === roomName) {
-    return null;
-  }
-  const anchorCoordinates = parseRoomCoordinates(anchor.roomName);
-  const roomCoordinates = parseRoomCoordinates(roomName);
-  if (!anchorCoordinates || !roomCoordinates) {
-    return null;
-  }
-  const deltaX = roomCoordinates.x - anchorCoordinates.x;
-  const deltaY = roomCoordinates.y - anchorCoordinates.y;
-  if (deltaX === 0 && deltaY === 0) {
-    return null;
-  }
-  return {
-    x: deltaX > 0 ? ROOM_EDGE_MIN3 : deltaX < 0 ? ROOM_EDGE_MAX3 : clampRoomCoordinate(anchor.x),
-    y: deltaY > 0 ? ROOM_EDGE_MIN3 : deltaY < 0 ? ROOM_EDGE_MAX3 : clampRoomCoordinate(anchor.y),
-    roomName
-  };
-}
-function parseRoomCoordinates(roomName) {
-  const match = /^([WE])(\d+)([NS])(\d+)$/.exec(roomName);
-  if (!match) {
-    return null;
-  }
-  const horizontalValue = Number(match[2]);
-  const verticalValue = Number(match[4]);
-  if (!Number.isFinite(horizontalValue) || !Number.isFinite(verticalValue)) {
-    return null;
-  }
-  return {
-    x: match[1] === "E" ? horizontalValue : -horizontalValue - 1,
-    y: match[3] === "S" ? verticalValue : -verticalValue - 1
-  };
-}
-function clampRoomCoordinate(value) {
-  if (!Number.isFinite(value)) {
-    return ROOM_CENTER;
-  }
-  return Math.max(ROOM_EDGE_MIN3, Math.min(ROOM_EDGE_MAX3, Math.round(value)));
-}
-function uniqueRoomPositions(positions) {
-  const seen = /* @__PURE__ */ new Set();
-  return positions.filter((position) => {
-    const key = `${position.roomName}:${position.x}:${position.y}`;
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
-}
-function findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions) {
-  var _a;
-  if (targetPositions.length === 0 || !isRemoteTerritoryLogisticsRoom(room)) {
-    return [];
-  }
-  if (isSameRoomPosition2((_a = room.controller) == null ? void 0 : _a.pos, room.name)) {
-    return [room.controller.pos];
-  }
-  return targetPositions.slice(0, 1);
-}
-function findRoomObjects4(room, constantName) {
-  const findConstant = globalThis[constantName];
-  if (typeof findConstant !== "number" || typeof room.find !== "function") {
-    return [];
-  }
-  try {
-    const result = room.find(findConstant);
-    return Array.isArray(result) ? result : [];
-  } catch {
-    return [];
-  }
-}
-function isRoadWorkTarget(target) {
-  return matchesStructureType3(target.structureType, "STRUCTURE_ROAD", "road");
-}
-function isRemoteTerritoryLogisticsRoom(room) {
-  var _a;
-  return isReferencedRemoteTerritoryRoom(room.name) || ((_a = room.controller) == null ? void 0 : _a.my) !== true && isSelfReservedRoom(room);
-}
-function isReferencedRemoteTerritoryRoom(roomName) {
-  const territoryMemory = getTerritoryMemoryRecord3();
-  if (!territoryMemory) {
-    return false;
-  }
-  return hasRemoteTerritoryReference(territoryMemory.targets, roomName, "roomName") || hasRemoteTerritoryReference(territoryMemory.intents, roomName, "targetRoom") || hasRemoteTerritoryReference(territoryMemory.demands, roomName, "targetRoom") || hasRemoteTerritoryReference(territoryMemory.executionHints, roomName, "targetRoom");
-}
-function hasRemoteTerritoryReference(value, roomName, roomKey) {
-  if (!Array.isArray(value)) {
-    return false;
-  }
-  return value.some((entry) => {
-    if (!isRecord4(entry)) {
-      return false;
-    }
-    return entry[roomKey] === roomName && isNonEmptyString5(entry.colony) && entry.colony !== roomName && isTerritoryControlAction3(entry.action) && entry.status !== "suppressed" && entry.enabled !== false;
-  });
-}
-function isSelfReservedRoom(room) {
-  var _a, _b;
-  const reservationUsername = (_b = (_a = room.controller) == null ? void 0 : _a.reservation) == null ? void 0 : _b.username;
-  return isNonEmptyString5(reservationUsername) && getOwnedUsernames().has(reservationUsername);
-}
-function getTerritoryMemoryRecord3() {
-  const memory = globalThis.Memory;
-  return memory && isRecord4(memory.territory) ? memory.territory : null;
-}
-function getOwnedUsernames() {
-  var _a, _b, _c, _d;
-  const usernames = /* @__PURE__ */ new Set();
-  const game = globalThis.Game;
-  for (const spawn of Object.values((_a = game == null ? void 0 : game.spawns) != null ? _a : {})) {
-    addOwnedUsername(usernames, spawn);
-  }
-  for (const creep of Object.values((_b = game == null ? void 0 : game.creeps) != null ? _b : {})) {
-    addOwnedUsername(usernames, creep);
-  }
-  for (const visibleRoom of Object.values((_c = game == null ? void 0 : game.rooms) != null ? _c : {})) {
-    if (((_d = visibleRoom.controller) == null ? void 0 : _d.my) === true) {
-      addOwnedUsername(usernames, visibleRoom.controller);
-    }
-  }
-  return usernames;
-}
-function addOwnedUsername(usernames, object) {
-  var _a;
-  const username = (_a = object == null ? void 0 : object.owner) == null ? void 0 : _a.username;
-  if (isNonEmptyString5(username)) {
-    usernames.add(username);
-  }
-}
-function isTerritoryControlAction3(action) {
-  return action === "claim" || action === "reserve";
-}
-function isNearLogisticsRoute(position, anchor, destination) {
-  if (!isSameRoomPosition2(position, anchor.roomName) || !isSameRoomPosition2(position, destination.roomName)) {
-    return false;
-  }
-  return getSquaredDistanceToSegment(position, anchor, destination) <= CRITICAL_ROAD_ROUTE_RANGE ** 2;
-}
-function getSquaredDistanceToSegment(position, start, end) {
-  const deltaX = end.x - start.x;
-  const deltaY = end.y - start.y;
-  const lengthSquared = deltaX * deltaX + deltaY * deltaY;
-  if (lengthSquared === 0) {
-    return getSquaredDistance(position, start);
-  }
-  const projection = ((position.x - start.x) * deltaX + (position.y - start.y) * deltaY) / lengthSquared;
-  const clampedProjection = Math.max(0, Math.min(1, projection));
-  const closestX = start.x + clampedProjection * deltaX;
-  const closestY = start.y + clampedProjection * deltaY;
-  const distanceX = position.x - closestX;
-  const distanceY = position.y - closestY;
-  return distanceX * distanceX + distanceY * distanceY;
-}
-function getSquaredDistance(left, right) {
-  const distanceX = left.x - right.x;
-  const distanceY = left.y - right.y;
-  return distanceX * distanceX + distanceY * distanceY;
-}
-function isSameRoomPosition2(position, roomName) {
-  return !!position && (!position.roomName || !roomName || position.roomName === roomName);
-}
-function isRecord4(value) {
-  return typeof value === "object" && value !== null;
-}
-function isNonEmptyString5(value) {
-  return typeof value === "string" && value.length > 0;
-}
-function matchesStructureType3(actual, globalName, fallback) {
-  var _a;
-  const constants = globalThis;
-  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS2 = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
-var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
+var IDLE_RAMPART_REPAIR_HITS_CEILING2 = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
 var CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
@@ -5788,7 +6819,7 @@ function recordLowLoadReturnTelemetry(creep, task, reason) {
   };
 }
 function isFillableEnergySink(structure) {
-  return (matchesStructureType4(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType4(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType4(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
+  return (matchesStructureType5(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType5(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType5(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
 function selectFillableEnergySink(creep) {
   var _a;
@@ -5982,14 +7013,14 @@ function findSpawnExtensionEnergyStructures(room) {
   return room.find(FIND_MY_STRUCTURES).filter((structure) => isSpawnExtensionEnergyStructure(structure));
 }
 function isSpawnExtensionEnergyStructure(structure) {
-  return (matchesStructureType4(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType4(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;
+  return (matchesStructureType5(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType5(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;
 }
 function isSpawnEnergySink(structure) {
-  return matchesStructureType4(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType5(structure.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isNearTermSpawningSpawn(structure) {
   var _a;
-  if (!matchesStructureType4(structure.structureType, "STRUCTURE_SPAWN", "spawn")) {
+  if (!matchesStructureType5(structure.structureType, "STRUCTURE_SPAWN", "spawn")) {
     return false;
   }
   const remainingTime = (_a = structure.spawning) == null ? void 0 : _a.remainingTime;
@@ -5999,10 +7030,10 @@ function isSpawnOrExtensionEnergySink(structure) {
   return isSpawnEnergySink(structure) || isExtensionEnergySink(structure);
 }
 function isExtensionEnergySink(structure) {
-  return matchesStructureType4(structure.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType5(structure.structureType, "STRUCTURE_EXTENSION", "extension");
 }
 function isTowerEnergySink(structure) {
-  return matchesStructureType4(structure.structureType, "STRUCTURE_TOWER", "tower");
+  return matchesStructureType5(structure.structureType, "STRUCTURE_TOWER", "tower");
 }
 function isPriorityTowerEnergySink(structure) {
   return isTowerEnergySink(structure) && getStoredEnergy2(structure) < TOWER_REFILL_ENERGY_FLOOR;
@@ -6068,7 +7099,7 @@ function hasUnreservedConstructionProgress(creep, site, constructionReservationC
   if (isWorkerAssignedToConstructionSite(creep, site)) {
     return true;
   }
-  const remainingProgress = getConstructionSiteRemainingProgress(site);
+  const remainingProgress = getConstructionSiteRemainingProgress2(site);
   if (!Number.isFinite(remainingProgress)) {
     return true;
   }
@@ -6145,7 +7176,7 @@ function compareConstructionSiteCompletion(creep, left, right, constructionReser
   return leftCompletable && rightCompletable ? compareNearTermCompletableConstructionSites(left, right) : 0;
 }
 function compareNearTermCompletableConstructionSites(left, right) {
-  return getConstructionSiteRemainingProgress(left) - getConstructionSiteRemainingProgress(right) || compareConstructionSiteId(left, right);
+  return getConstructionSiteRemainingProgress2(left) - getConstructionSiteRemainingProgress2(right) || compareConstructionSiteId(left, right);
 }
 function canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionReservationContext = createEmptyConstructionReservationContext()) {
   const remainingProgress = getUnreservedConstructionProgressForWorker(
@@ -6156,7 +7187,7 @@ function canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionR
   return remainingProgress > 0 && remainingProgress <= getUsedEnergy(creep) * getBuildPower();
 }
 function getUnreservedConstructionProgressForWorker(creep, site, constructionReservationContext) {
-  const remainingProgress = getConstructionSiteRemainingProgress(site);
+  const remainingProgress = getConstructionSiteRemainingProgress2(site);
   if (!Number.isFinite(remainingProgress)) {
     return remainingProgress;
   }
@@ -6164,7 +7195,7 @@ function getUnreservedConstructionProgressForWorker(creep, site, constructionRes
   const workerReservedProgress = isWorkerAssignedToConstructionSite(creep, site) ? getUsedEnergy(creep) * getBuildPower() : 0;
   return Math.max(0, remainingProgress - Math.max(0, reservedProgress - workerReservedProgress));
 }
-function getConstructionSiteRemainingProgress(site) {
+function getConstructionSiteRemainingProgress2(site) {
   const progress = site.progress;
   const progressTotal = site.progressTotal;
   if (typeof progress !== "number" || typeof progressTotal !== "number" || !Number.isFinite(progress) || !Number.isFinite(progressTotal)) {
@@ -6304,18 +7335,18 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
   return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
 }
 function isSpawnConstructionSite(site) {
-  return matchesStructureType4(site.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType5(site.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isExtensionConstructionSite(site) {
-  return matchesStructureType4(site.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType5(site.structureType, "STRUCTURE_EXTENSION", "extension");
 }
 function isContainerConstructionSite(site) {
-  return matchesStructureType4(site.structureType, "STRUCTURE_CONTAINER", "container");
+  return matchesStructureType5(site.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isRoadConstructionSite2(site) {
-  return matchesStructureType4(site.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType5(site.structureType, "STRUCTURE_ROAD", "road");
 }
-function matchesStructureType4(actual, globalName, fallback) {
+function matchesStructureType5(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -6363,7 +7394,7 @@ function isSafeStoredEnergySource(structure, context) {
   return isStoredWorkerEnergySource(structure) && hasStoredEnergy2(structure) && isFriendlyStoredEnergySource(structure, context);
 }
 function isStoredWorkerEnergySource(structure) {
-  return matchesStructureType4(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType4(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType4(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
+  return matchesStructureType5(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType5(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType5(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function hasStoredEnergy2(structure) {
   return getStoredEnergy2(structure) > 0;
@@ -6377,7 +7408,7 @@ function isFriendlyStoredEnergySource(structure, context) {
   if (((_a = context.room.controller) == null ? void 0 : _a.my) === true) {
     return true;
   }
-  return matchesStructureType4(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
+  return matchesStructureType5(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
 }
 function isRoomSafeForUnownedContainerWithdrawal(context) {
   var _a;
@@ -6945,7 +7976,7 @@ function isSafeRepairTarget(structure) {
   if (isRoadOrContainerRepairTarget(structure)) {
     return true;
   }
-  return matchesStructureType4(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+  return matchesStructureType5(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
 }
 function isCriticalInfrastructureRepairTarget(structure, criticalRoadContext, options) {
   if (!isSafeRepairTarget(structure) || !isRoadOrContainerRepairTarget(structure) || getHitsRatio(structure) > CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO) {
@@ -6960,17 +7991,17 @@ function isRoadOrContainerRepairTarget(structure) {
   return isRoadRepairTarget(structure) || isContainerRepairTarget(structure);
 }
 function isRoadRepairTarget(structure) {
-  return matchesStructureType4(structure.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType5(structure.structureType, "STRUCTURE_ROAD", "road");
 }
 function isContainerRepairTarget(structure) {
-  return matchesStructureType4(structure.structureType, "STRUCTURE_CONTAINER", "container");
+  return matchesStructureType5(structure.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isWorkerRepairTargetComplete(structure) {
   return structure.hits >= getWorkerRepairHitsCeiling(structure);
 }
 function getWorkerRepairHitsCeiling(structure) {
-  if (matchesStructureType4(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
-    return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING);
+  if (matchesStructureType5(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
+    return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING2);
   }
   return structure.hitsMax;
 }
@@ -6981,10 +8012,10 @@ function compareRepairTargets(left, right) {
   return getRepairPriority(left) - getRepairPriority(right) || getHitsRatio(left) - getHitsRatio(right) || left.hits - right.hits || String(left.id).localeCompare(String(right.id));
 }
 function getRepairPriority(structure) {
-  if (matchesStructureType4(structure.structureType, "STRUCTURE_ROAD", "road")) {
+  if (matchesStructureType5(structure.structureType, "STRUCTURE_ROAD", "road")) {
     return 0;
   }
-  if (matchesStructureType4(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType5(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
     return 1;
   }
   return 2;
@@ -7190,7 +8221,7 @@ function selectSource2ControllerLaneHarvestTask(creep) {
   return { type: "harvest", targetId: topology.source.id };
 }
 function getSource2ControllerLaneTopology(room, controller) {
-  if (controller.my !== true || typeof controller.level !== "number" || controller.level < 2 || getRoomObjectPosition(controller) === null || !isHomeRoomName(room, controller) || hasVisibleHostilePresence(room)) {
+  if (controller.my !== true || typeof controller.level !== "number" || controller.level < 2 || getRoomObjectPosition2(controller) === null || !isHomeRoomName(room, controller) || hasVisibleHostilePresence(room)) {
     return null;
   }
   const source = getSource2(room);
@@ -7233,9 +8264,9 @@ function isSource2ControllerLaneTask(creep, topology) {
   return (task == null ? void 0 : task.type) === "harvest" && task.targetId === topology.source.id || (task == null ? void 0 : task.type) === "upgrade" && task.targetId === topology.controller.id;
 }
 function getRangeBetweenRoomObjectPositions(left, right) {
-  const leftPosition = getRoomObjectPosition(left);
-  const rightPosition = getRoomObjectPosition(right);
-  if (!leftPosition || !rightPosition || !isSameRoomPosition3(leftPosition, rightPosition)) {
+  const leftPosition = getRoomObjectPosition2(left);
+  const rightPosition = getRoomObjectPosition2(right);
+  if (!leftPosition || !rightPosition || !isSameRoomPosition4(leftPosition, rightPosition)) {
     return null;
   }
   const rangeFromApi = getRangeBetweenRoomObjects(left, right);
@@ -7244,15 +8275,15 @@ function getRangeBetweenRoomObjectPositions(left, right) {
   }
   return Math.max(Math.abs(leftPosition.x - rightPosition.x), Math.abs(leftPosition.y - rightPosition.y));
 }
-function getRoomObjectPosition(object) {
+function getRoomObjectPosition2(object) {
   const position = object.pos;
   return isRoomPosition(position) ? position : null;
 }
 function getPositionRoomName(object) {
   var _a, _b;
-  return (_b = (_a = getRoomObjectPosition(object)) == null ? void 0 : _a.roomName) != null ? _b : null;
+  return (_b = (_a = getRoomObjectPosition2(object)) == null ? void 0 : _a.roomName) != null ? _b : null;
 }
-function isSameRoomPosition3(left, right) {
+function isSameRoomPosition4(left, right) {
   if (typeof left.roomName === "string" && typeof right.roomName === "string") {
     return left.roomName === right.roomName;
   }
@@ -7532,15 +8563,15 @@ function createEmptyHarvestSourceAssignmentLoad() {
   return { assignedWorkParts: 0, assignmentCount: 0 };
 }
 function getHarvestSourceAccessCapacity(source) {
-  const position = getRoomObjectPosition(source);
+  const position = getRoomObjectPosition2(source);
   if (!position) {
     return 1;
   }
-  const terrain = getRoomTerrain2(position.roomName);
+  const terrain = getRoomTerrain3(position.roomName);
   if (!terrain) {
     return 1;
   }
-  const wallMask = getTerrainWallMask3();
+  const wallMask = getTerrainWallMask4();
   let capacity = 0;
   for (let dx = -1; dx <= 1; dx += 1) {
     for (let dy = -1; dy <= 1; dy += 1) {
@@ -7576,7 +8607,7 @@ function getSourceEnergyRegenTicks() {
   const regenTicks = globalThis.ENERGY_REGEN_TIME;
   return typeof regenTicks === "number" && Number.isFinite(regenTicks) && regenTicks > 0 ? regenTicks : DEFAULT_SOURCE_ENERGY_REGEN_TICKS;
 }
-function getRoomTerrain2(roomName) {
+function getRoomTerrain3(roomName) {
   var _a;
   const map = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (typeof (map == null ? void 0 : map.getRoomTerrain) !== "function") {
@@ -7584,7 +8615,7 @@ function getRoomTerrain2(roomName) {
   }
   return map.getRoomTerrain(roomName);
 }
-function getTerrainWallMask3() {
+function getTerrainWallMask4() {
   const terrainWallMask = globalThis.TERRAIN_MASK_WALL;
   return typeof terrainWallMask === "number" ? terrainWallMask : 1;
 }
@@ -8430,798 +9461,13 @@ function buildTerritorySpawnBody(energyAvailable, intent) {
   return buildTerritoryControllerBody(energyAvailable);
 }
 
-// src/construction/constructionPriority.ts
-var CONTROLLER_DOWNGRADE_CRITICAL_TICKS = 5e3;
-var CONTROLLER_DOWNGRADE_WARNING_TICKS = 1e4;
-var EARLY_ENERGY_CAPACITY_TARGET = 550;
-var MIN_SAFE_WORKERS_FOR_EXPANSION = 3;
-var MAX_SCORE = 100;
-var MAX_URGENCY_POINTS = 35;
-var MAX_ROOM_STATE_POINTS = 20;
-var MAX_EXPANSION_POINTS = 20;
-var MAX_ECONOMIC_POINTS = 20;
-var MAX_VISION_POINTS = 15;
-var MAX_RISK_COST = 25;
-var CRITICAL_REPAIR_HITS_RATIO = 0.5;
-var DECAYING_REPAIR_HITS_RATIO = 0.8;
-var IDLE_RAMPART_REPAIR_HITS_CEILING2 = 1e5;
-var STRUCTURE_BUILD_COSTS = {
-  spawn: 15e3,
-  extension: 3e3,
-  tower: 5e3,
-  rampart: 1,
-  road: 300,
-  container: 5e3,
-  storage: 3e4,
-  "remote-logistics": 5e3,
-  observation: 0
-};
-var EXPOSURE_COST = {
-  none: 0,
-  low: 2,
-  medium: 5,
-  high: 9
-};
-var OBSERVATION_LABELS = {
-  "room-controller": "missing observation: room controller/RCL",
-  "energy-capacity": "missing observation: room energy capacity",
-  "worker-count": "missing observation: available worker count",
-  "spawn-count": "missing observation: spawn count",
-  "construction-sites": "missing observation: construction site backlog",
-  "repair-decay": "missing observation: repair/decay signals",
-  "hostile-presence": "missing observation: hostile pressure",
-  sources: "missing observation: source count",
-  "territory-intents": "missing observation: territory intent state",
-  "remote-paths": "missing observation: remote path/logistics exposure"
-};
-function scoreConstructionPriorities(roomState, candidates) {
-  const scoredCandidates = candidates.map((candidate) => scoreConstructionCandidate(roomState, candidate)).sort(compareConstructionPriorityScores);
-  return {
-    candidates: scoredCandidates,
-    nextPrimary: selectNextPrimaryConstruction(scoredCandidates)
-  };
-}
-function scoreConstructionCandidate(roomState, candidate) {
-  var _a, _b, _c, _d, _e;
-  const missingObservations = getMissingObservations(roomState, candidate);
-  const blockingPreconditions = getBlockingPreconditions(roomState, candidate, missingObservations);
-  const preconditions = [
-    ...(_a = candidate.preconditions) != null ? _a : [],
-    ...missingObservations.map((observation) => OBSERVATION_LABELS[observation]),
-    ...blockingPreconditions
-  ];
-  const blocked = missingObservations.length > 0 || blockingPreconditions.length > 0;
-  if (blocked) {
-    return {
-      buildItem: candidate.buildItem,
-      room: (_b = candidate.roomName) != null ? _b : roomState.roomName,
-      score: 0,
-      urgency: "blocked",
-      preconditions,
-      expectedKpiMovement: candidate.expectedKpiMovement,
-      risk: (_c = candidate.risk) != null ? _c : [],
-      factors: {
-        urgency: 0,
-        roomState: 0,
-        expansionPrerequisites: 0,
-        economicBenefit: 0,
-        visionWeight: 0,
-        riskCost: 0
-      },
-      missingObservations,
-      blocked
-    };
-  }
-  const urgencyMagnitude = getUrgencyMagnitude(roomState, candidate);
-  const factors = {
-    urgency: Math.round(urgencyMagnitude * MAX_URGENCY_POINTS),
-    roomState: scoreRoomState(roomState, candidate),
-    expansionPrerequisites: scoreExpansionPrerequisites(roomState, candidate),
-    economicBenefit: scoreEconomicBenefit(roomState, candidate),
-    visionWeight: scoreVisionWeight(candidate),
-    riskCost: scoreRiskCost(roomState, candidate)
-  };
-  const rawScore = factors.urgency + factors.roomState + factors.expansionPrerequisites + factors.economicBenefit + factors.visionWeight - factors.riskCost;
-  const gatedScore = applySurvivalGate(roomState, candidate, rawScore);
-  const score = clampScore(Math.round(gatedScore));
-  return {
-    buildItem: candidate.buildItem,
-    room: (_d = candidate.roomName) != null ? _d : roomState.roomName,
-    score,
-    urgency: classifyUrgency(score, urgencyMagnitude),
-    preconditions,
-    expectedKpiMovement: candidate.expectedKpiMovement,
-    risk: (_e = candidate.risk) != null ? _e : [],
-    factors,
-    missingObservations,
-    blocked
-  };
-}
-function selectNextPrimaryConstruction(candidates) {
-  var _a;
-  if (candidates.length === 0) {
-    return null;
-  }
-  return (_a = candidates.find((candidate) => !candidate.blocked)) != null ? _a : candidates[0];
-}
-function buildRuntimeConstructionPriorityReport(colony, creeps) {
-  const state = buildRuntimeConstructionPriorityState(colony, creeps);
-  return scoreConstructionPriorities(state, buildRuntimeConstructionCandidates(state));
-}
-function getMissingObservations(roomState, candidate) {
-  var _a;
-  return ((_a = candidate.requiredObservations) != null ? _a : []).filter((observation) => !hasObservation(roomState, observation));
-}
-function hasObservation(roomState, observation) {
-  var _a;
-  const explicitObservation = (_a = roomState.observations) == null ? void 0 : _a[observation];
-  if (typeof explicitObservation === "boolean") {
-    return explicitObservation;
-  }
-  switch (observation) {
-    case "room-controller":
-      return typeof roomState.rcl === "number";
-    case "energy-capacity":
-      return typeof roomState.energyCapacity === "number";
-    case "worker-count":
-      return typeof roomState.workerCount === "number";
-    case "spawn-count":
-      return typeof roomState.spawnCount === "number";
-    case "construction-sites":
-      return typeof roomState.constructionSiteCount === "number";
-    case "repair-decay":
-      return typeof roomState.criticalRepairCount === "number" && typeof roomState.decayingStructureCount === "number";
-    case "hostile-presence":
-      return typeof roomState.hostileCreepCount === "number" && typeof roomState.hostileStructureCount === "number";
-    case "sources":
-      return typeof roomState.sourceCount === "number";
-    case "territory-intents":
-      return typeof roomState.activeTerritoryIntentCount === "number" && typeof roomState.plannedTerritoryIntentCount === "number";
-    case "remote-paths":
-      return roomState.remoteLogisticsReady === true;
-    default:
-      return false;
-  }
-}
-function getBlockingPreconditions(roomState, candidate, missingObservations) {
-  var _a, _b, _c, _d, _e, _f;
-  if (missingObservations.length > 0) {
-    return [];
-  }
-  const preconditions = [];
-  if (typeof candidate.minimumRcl === "number" && ((_a = roomState.rcl) != null ? _a : 0) < candidate.minimumRcl) {
-    preconditions.push(`requires RCL ${candidate.minimumRcl} (current RCL ${(_b = roomState.rcl) != null ? _b : "unknown"})`);
-  }
-  if (typeof candidate.minimumWorkers === "number" && ((_c = roomState.workerCount) != null ? _c : 0) < candidate.minimumWorkers) {
-    preconditions.push(`needs ${candidate.minimumWorkers} available workers (current ${(_d = roomState.workerCount) != null ? _d : "unknown"})`);
-  }
-  if (typeof candidate.minimumEnergyCapacity === "number" && ((_e = roomState.energyCapacity) != null ? _e : 0) < candidate.minimumEnergyCapacity) {
-    preconditions.push(
-      `needs ${candidate.minimumEnergyCapacity} energy capacity (current ${(_f = roomState.energyCapacity) != null ? _f : "unknown"})`
-    );
-  }
-  if (candidate.requiresSafeHome && hasSurvivalPressure(roomState)) {
-    preconditions.push("resolve survival/recovery pressure before expansion construction");
-  }
-  return preconditions;
-}
-function getUrgencyMagnitude(roomState, candidate) {
-  var _a;
-  const signals = (_a = candidate.signals) != null ? _a : {};
-  const recoveryUrgency = Math.max(
-    normalizeSignal(signals.survivalRecovery),
-    isRecoveryCandidate(candidate) ? getWorkerRecoveryPressure(roomState) : 0
-  );
-  const downgradeUrgency = Math.max(
-    normalizeSignal(signals.controllerDowngrade),
-    isControllerProtectionCandidate(candidate) ? getControllerDowngradePressure(roomState) : 0
-  );
-  const defenseUrgency = Math.max(
-    normalizeSignal(signals.defense),
-    isDefenseCandidate(candidate) ? getDefensePressure(roomState) : 0
-  );
-  const energyUrgency = Math.max(
-    normalizeSignal(signals.energyBottleneck),
-    isEnergyCapacityCandidate(candidate) ? getEnergyBottleneckPressure(roomState) : 0
-  );
-  const repairUrgency = Math.max(
-    normalizeSignal(signals.repairDecay),
-    isRepairSupportCandidate(candidate) ? getRepairDecayPressure(roomState) : 0
-  );
-  return Math.max(recoveryUrgency, downgradeUrgency, defenseUrgency, energyUrgency, repairUrgency);
-}
-function scoreRoomState(roomState, candidate) {
-  var _a, _b, _c, _d, _e;
-  let score = 0;
-  if (candidate.status === "existing-site") {
-    score += 4;
-  }
-  if (typeof roomState.rcl === "number" && (!candidate.minimumRcl || roomState.rcl >= candidate.minimumRcl)) {
-    score += Math.min(5, Math.max(1, roomState.rcl));
-  }
-  if (isRecoveryCandidate(candidate)) {
-    score += Math.round(getWorkerRecoveryPressure(roomState) * 7);
-  } else if (((_a = roomState.workerCount) != null ? _a : 0) >= MIN_SAFE_WORKERS_FOR_EXPANSION) {
-    score += 4;
-  }
-  if (isEnergyCapacityCandidate(candidate) && ((_b = roomState.energyCapacity) != null ? _b : EARLY_ENERGY_CAPACITY_TARGET) < EARLY_ENERGY_CAPACITY_TARGET) {
-    score += 4;
-  }
-  if (isRepairSupportCandidate(candidate)) {
-    score += Math.min(4, ((_c = roomState.criticalRepairCount) != null ? _c : 0) * 2 + ((_d = roomState.decayingStructureCount) != null ? _d : 0));
-  }
-  if (isDefenseCandidate(candidate)) {
-    score += Math.round(getDefensePressure(roomState) * 5);
-  }
-  if (((_e = roomState.constructionSiteCount) != null ? _e : 0) > 0 && candidate.status === "existing-site") {
-    score += 2;
-  }
-  return Math.min(MAX_ROOM_STATE_POINTS, score);
-}
-function scoreExpansionPrerequisites(roomState, candidate) {
-  var _a, _b, _c;
-  const signal = normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.expansionPrerequisite);
-  const territoryIntentPressure = Math.min(
-    1,
-    ((_b = roomState.activeTerritoryIntentCount) != null ? _b : 0) * 0.7 + ((_c = roomState.plannedTerritoryIntentCount) != null ? _c : 0) * 0.45
-  );
-  const structureMultiplier = candidate.buildType === "remote-logistics" || candidate.buildType === "road" || candidate.buildType === "container" || candidate.buildType === "tower" || candidate.buildType === "rampart" ? 1 : 0.35;
-  return Math.min(
-    MAX_EXPANSION_POINTS,
-    Math.round(signal * 14 + territoryIntentPressure * structureMultiplier * 6)
-  );
-}
-function scoreEconomicBenefit(roomState, candidate) {
-  var _a;
-  const signals = (_a = candidate.signals) != null ? _a : {};
-  const score = normalizeSignal(signals.harvestThroughput) * 8 + normalizeSignal(signals.spawnUtilization) * 5 + normalizeSignal(signals.rclAcceleration) * 5 + normalizeSignal(signals.storageLogistics) * 4 + normalizeSignal(signals.energyBottleneck) * 4 + getSourceBenefit(roomState, candidate);
-  return Math.min(MAX_ECONOMIC_POINTS, Math.round(score));
-}
-function scoreVisionWeight(candidate) {
-  var _a;
-  const vision = (_a = candidate.vision) != null ? _a : {};
-  const score = normalizeSignal(vision.survival) * 15 + normalizeSignal(vision.territory) * 13 + normalizeSignal(vision.resources) * 9 + normalizeSignal(vision.enemyKills) * 5;
-  return Math.min(MAX_VISION_POINTS, Math.round(score));
-}
-function scoreRiskCost(roomState, candidate) {
-  var _a, _b, _c, _d, _e, _f, _g, _h;
-  const energyCost = (_b = (_a = candidate.estimatedEnergyCost) != null ? _a : STRUCTURE_BUILD_COSTS[candidate.buildType]) != null ? _b : 0;
-  const buildTicks = (_c = candidate.estimatedBuildTicks) != null ? _c : 0;
-  const energyRisk = Math.min(8, energyCost / 4e3);
-  const buildTimeRisk = Math.min(5, buildTicks / 1500);
-  const exposureRisk = EXPOSURE_COST[(_d = candidate.pathExposure) != null ? _d : "none"] + EXPOSURE_COST[(_e = candidate.hostileExposure) != null ? _e : "none"];
-  const backlogRisk = Math.max(0, (((_f = roomState.constructionSiteCount) != null ? _f : 0) - 3) * 1.5);
-  const hostilePressureRisk = ((_g = roomState.hostileCreepCount) != null ? _g : 0) > 0 && !isDefenseCandidate(candidate) ? 4 : 0;
-  const lowWorkerRisk = ((_h = roomState.workerCount) != null ? _h : MIN_SAFE_WORKERS_FOR_EXPANSION) < MIN_SAFE_WORKERS_FOR_EXPANSION && !isSurvivalCandidate(candidate) ? 4 : 0;
-  return Math.min(
-    MAX_RISK_COST,
-    Math.round(energyRisk + buildTimeRisk + exposureRisk + backlogRisk + hostilePressureRisk + lowWorkerRisk)
-  );
-}
-function applySurvivalGate(roomState, candidate, rawScore) {
-  var _a, _b;
-  if (!hasSurvivalPressure(roomState) || isSurvivalCandidate(candidate)) {
-    return rawScore;
-  }
-  const hardRecoveryPressure = ((_a = roomState.workerCount) != null ? _a : MIN_SAFE_WORKERS_FOR_EXPANSION) === 0 || ((_b = roomState.spawnCount) != null ? _b : 1) === 0 || getControllerDowngradePressure(roomState) >= 0.85 || getDefensePressure(roomState) >= 0.9;
-  return Math.min(rawScore, hardRecoveryPressure ? 45 : 60);
-}
-function classifyUrgency(score, urgencyMagnitude) {
-  if (score >= 85 || urgencyMagnitude >= 0.9) {
-    return "critical";
-  }
-  if (score >= 70 || urgencyMagnitude >= 0.7) {
-    return "high";
-  }
-  if (score >= 45 || urgencyMagnitude >= 0.4) {
-    return "medium";
-  }
-  return "low";
-}
-function compareConstructionPriorityScores(left, right) {
-  if (left.blocked !== right.blocked) {
-    return left.blocked ? 1 : -1;
-  }
-  return right.score - left.score || urgencyRank(right.urgency) - urgencyRank(left.urgency) || right.factors.visionWeight - left.factors.visionWeight || left.buildItem.localeCompare(right.buildItem) || left.room.localeCompare(right.room);
-}
-function urgencyRank(urgency) {
-  switch (urgency) {
-    case "critical":
-      return 4;
-    case "high":
-      return 3;
-    case "medium":
-      return 2;
-    case "low":
-      return 1;
-    case "blocked":
-      return 0;
-    default:
-      return 0;
-  }
-}
-function hasSurvivalPressure(roomState) {
-  var _a, _b;
-  return ((_a = roomState.workerCount) != null ? _a : MIN_SAFE_WORKERS_FOR_EXPANSION) === 0 || ((_b = roomState.spawnCount) != null ? _b : 1) === 0 || getControllerDowngradePressure(roomState) >= 0.7 || getDefensePressure(roomState) >= 0.7;
-}
-function isSurvivalCandidate(candidate) {
-  return isRecoveryCandidate(candidate) || isDefenseCandidate(candidate) || isControllerProtectionCandidate(candidate);
-}
-function isRecoveryCandidate(candidate) {
-  var _a;
-  return candidate.buildType === "spawn" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.survivalRecovery) > 0;
-}
-function isControllerProtectionCandidate(candidate) {
-  var _a;
-  return candidate.buildType === "container" || candidate.buildType === "road" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.controllerDowngrade) > 0;
-}
-function isDefenseCandidate(candidate) {
-  var _a;
-  return candidate.buildType === "tower" || candidate.buildType === "rampart" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.defense) > 0;
-}
-function isEnergyCapacityCandidate(candidate) {
-  var _a;
-  return candidate.buildType === "extension" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.energyBottleneck) > 0;
-}
-function isRepairSupportCandidate(candidate) {
-  var _a;
-  return candidate.buildType === "road" || candidate.buildType === "container" || candidate.buildType === "rampart" || normalizeSignal((_a = candidate.signals) == null ? void 0 : _a.repairDecay) > 0;
-}
-function getWorkerRecoveryPressure(roomState) {
-  if (roomState.spawnCount === 0) {
-    return 1;
-  }
-  const workerCount = roomState.workerCount;
-  if (typeof workerCount !== "number") {
-    return 0;
-  }
-  if (workerCount <= 0) {
-    return 1;
-  }
-  if (workerCount === 1) {
-    return 0.65;
-  }
-  if (workerCount === 2) {
-    return 0.35;
-  }
-  return 0;
-}
-function getControllerDowngradePressure(roomState) {
-  const ticksToDowngrade = roomState.controllerTicksToDowngrade;
-  if (typeof ticksToDowngrade !== "number") {
-    return 0;
-  }
-  if (ticksToDowngrade <= 1e3) {
-    return 1;
-  }
-  if (ticksToDowngrade <= CONTROLLER_DOWNGRADE_CRITICAL_TICKS) {
-    return 0.85;
-  }
-  if (ticksToDowngrade <= CONTROLLER_DOWNGRADE_WARNING_TICKS) {
-    return 0.35;
-  }
-  return 0;
-}
-function getDefensePressure(roomState) {
-  var _a, _b;
-  if (((_a = roomState.hostileCreepCount) != null ? _a : 0) > 0) {
-    return 0.9;
-  }
-  if (((_b = roomState.hostileStructureCount) != null ? _b : 0) > 0) {
-    return 0.55;
-  }
-  return 0;
-}
-function getEnergyBottleneckPressure(roomState) {
-  const energyCapacity = roomState.energyCapacity;
-  if (typeof energyCapacity !== "number") {
-    return 0;
-  }
-  if (energyCapacity < 350) {
-    return 0.85;
-  }
-  if (energyCapacity < EARLY_ENERGY_CAPACITY_TARGET) {
-    return 0.65;
-  }
-  return 0;
-}
-function getRepairDecayPressure(roomState) {
-  var _a, _b;
-  if (((_a = roomState.criticalRepairCount) != null ? _a : 0) > 0) {
-    return 0.7;
-  }
-  if (((_b = roomState.decayingStructureCount) != null ? _b : 0) > 0) {
-    return 0.35;
-  }
-  return 0;
-}
-function getSourceBenefit(roomState, candidate) {
-  var _a;
-  if (candidate.buildType !== "container" && candidate.buildType !== "road" && candidate.buildType !== "remote-logistics") {
-    return 0;
-  }
-  return Math.min(3, (_a = roomState.sourceCount) != null ? _a : 0);
-}
-function normalizeSignal(value) {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return 0;
-  }
-  return Math.max(0, Math.min(1, value));
-}
-function clampScore(score) {
-  return Math.max(0, Math.min(MAX_SCORE, score));
-}
-function buildRuntimeConstructionPriorityState(colony, creeps) {
-  var _a, _b, _c;
-  const room = colony.room;
-  const ownedConstructionSites = findRoomObjects5(room, "FIND_MY_CONSTRUCTION_SITES");
-  const ownedStructures = findRoomObjects5(room, "FIND_MY_STRUCTURES");
-  const visibleStructures = findRoomObjects5(room, "FIND_STRUCTURES");
-  const hostileCreeps = findRoomObjects5(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects5(room, "FIND_HOSTILE_STRUCTURES");
-  const sources = findRoomObjects5(room, "FIND_SOURCES");
-  const colonyWorkers = creeps.filter((creep) => {
-    var _a2, _b2;
-    return ((_a2 = creep.memory) == null ? void 0 : _a2.role) === "worker" && ((_b2 = creep.memory) == null ? void 0 : _b2.colony) === room.name;
-  });
-  const repairSignals = summarizeRepairSignals(visibleStructures, buildCriticalRoadLogisticsContext(room));
-  const territoryIntentCounts = countTerritoryIntents(room.name);
-  return {
-    roomName: room.name,
-    rcl: ((_a = room.controller) == null ? void 0 : _a.my) === true ? room.controller.level : void 0,
-    energyAvailable: colony.energyAvailable,
-    energyCapacity: colony.energyCapacityAvailable,
-    workerCount: colonyWorkers.length,
-    spawnCount: colony.spawns.length,
-    sourceCount: sources == null ? void 0 : sources.length,
-    extensionCount: countStructuresByType(ownedStructures, "STRUCTURE_EXTENSION", "extension"),
-    towerCount: countStructuresByType(ownedStructures, "STRUCTURE_TOWER", "tower"),
-    constructionSiteCount: ownedConstructionSites == null ? void 0 : ownedConstructionSites.length,
-    criticalRepairCount: repairSignals == null ? void 0 : repairSignals.criticalRepairCount,
-    decayingStructureCount: repairSignals == null ? void 0 : repairSignals.decayingStructureCount,
-    controllerTicksToDowngrade: ((_b = room.controller) == null ? void 0 : _b.my) === true ? room.controller.ticksToDowngrade : void 0,
-    hostileCreepCount: hostileCreeps == null ? void 0 : hostileCreeps.length,
-    hostileStructureCount: hostileStructures == null ? void 0 : hostileStructures.length,
-    activeTerritoryIntentCount: territoryIntentCounts.active,
-    plannedTerritoryIntentCount: territoryIntentCounts.planned,
-    remoteLogisticsReady: false,
-    observations: {
-      "room-controller": ((_c = room.controller) == null ? void 0 : _c.my) === true && typeof room.controller.level === "number",
-      "energy-capacity": typeof colony.energyCapacityAvailable === "number",
-      "worker-count": true,
-      "spawn-count": true,
-      "construction-sites": ownedConstructionSites !== null,
-      "repair-decay": visibleStructures !== null,
-      "hostile-presence": hostileCreeps !== null && hostileStructures !== null,
-      sources: sources !== null,
-      "territory-intents": true,
-      "remote-paths": false
-    },
-    ownedConstructionSites,
-    ownedStructures,
-    visibleStructures
-  };
-}
-function buildRuntimeConstructionCandidates(state) {
-  const candidates = [
-    ...buildExistingSiteCandidates(state),
-    ...buildPlannedLocalCandidates(state),
-    ...buildRemoteLogisticsCandidates(state)
-  ];
-  if (candidates.length > 0) {
-    return candidates;
-  }
-  return [
-    {
-      buildItem: "observe construction backlog",
-      buildType: "observation",
-      requiredObservations: ["construction-sites"],
-      expectedKpiMovement: ["construction priority table becomes evidence-backed"],
-      risk: ["no build action should be selected until construction-site observations exist"],
-      vision: { resources: 0.2 }
-    }
-  ];
-}
-function buildExistingSiteCandidates(state) {
-  var _a;
-  return ((_a = state.ownedConstructionSites) != null ? _a : []).map((site) => {
-    const buildType = mapStructureTypeToBuildType(String(site.structureType));
-    return {
-      ...createCandidateForBuildType(buildType, state),
-      buildItem: `finish ${site.structureType} site`,
-      status: "existing-site",
-      estimatedEnergyCost: getConstructionSiteRemainingProgress2(site)
-    };
-  });
-}
-function buildPlannedLocalCandidates(state) {
-  var _a, _b, _c, _d, _e;
-  const candidates = [];
-  const rcl = (_a = state.rcl) != null ? _a : 0;
-  const extensionLimit = getExtensionLimitForRcl(state.rcl);
-  if (extensionLimit > 0 && ((_b = state.extensionCount) != null ? _b : 0) < extensionLimit) {
-    candidates.push(createCandidateForBuildType("extension", state));
-  }
-  if (rcl >= 2 && ((_c = state.sourceCount) != null ? _c : 0) > 0) {
-    candidates.push(createCandidateForBuildType("road", state));
-    candidates.push(createCandidateForBuildType("container", state));
-  }
-  if (rcl >= 2 && getDefensePressure(state) > 0) {
-    candidates.push(createCandidateForBuildType("rampart", state));
-  }
-  if (rcl >= 3 && ((_d = state.towerCount) != null ? _d : 0) === 0) {
-    candidates.push(createCandidateForBuildType("tower", state));
-  }
-  if (((_e = state.spawnCount) != null ? _e : 1) === 0) {
-    candidates.push(createCandidateForBuildType("spawn", state));
-  }
-  return candidates;
-}
-function buildRemoteLogisticsCandidates(state) {
-  var _a, _b;
-  const territoryIntentCount = ((_a = state.activeTerritoryIntentCount) != null ? _a : 0) + ((_b = state.plannedTerritoryIntentCount) != null ? _b : 0);
-  if (territoryIntentCount === 0) {
-    return [];
-  }
-  return [createCandidateForBuildType("remote-logistics", state)];
-}
-function createCandidateForBuildType(buildType, state) {
-  var _a, _b;
-  switch (buildType) {
-    case "spawn":
-      return {
-        buildItem: "build spawn recovery",
-        buildType,
-        minimumRcl: 1,
-        requiredObservations: ["spawn-count", "worker-count", "room-controller"],
-        expectedKpiMovement: ["restores worker production and prevents room loss"],
-        risk: ["high energy commitment before economy is recovered"],
-        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.spawn,
-        signals: { survivalRecovery: 1, spawnUtilization: 0.8 },
-        vision: { survival: 1, territory: 0.6 }
-      };
-    case "extension":
-      return {
-        buildItem: "build extension capacity",
-        buildType,
-        minimumRcl: 2,
-        requiredObservations: ["room-controller", "energy-capacity", "worker-count", "construction-sites"],
-        expectedKpiMovement: ["raises spawn energy capacity", "unlocks larger workers and faster RCL progress"],
-        risk: ["adds build backlog before roads/containers if worker capacity is low"],
-        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.extension,
-        signals: {
-          energyBottleneck: getEnergyBottleneckPressure(state),
-          spawnUtilization: 0.8,
-          rclAcceleration: 0.65
-        },
-        vision: { resources: 1, territory: 0.35 }
-      };
-    case "tower":
-      return {
-        buildItem: "build tower defense",
-        buildType,
-        minimumRcl: 3,
-        requiredObservations: ["room-controller", "hostile-presence", "energy-capacity", "worker-count"],
-        expectedKpiMovement: ["improves room hold safety", "adds hostile damage and repair response capacity"],
-        risk: ["requires steady energy income to keep tower effective"],
-        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.tower,
-        hostileExposure: "medium",
-        signals: { defense: Math.max(0.75, getDefensePressure(state)), enemyKillPotential: 0.7 },
-        vision: { survival: getDefensePressure(state), territory: 0.9, enemyKills: 0.5 }
-      };
-    case "rampart":
-      return {
-        buildItem: "build rampart defense",
-        buildType,
-        minimumRcl: 2,
-        requiredObservations: ["room-controller", "hostile-presence", "repair-decay", "worker-count"],
-        expectedKpiMovement: ["improves spawn/controller survivability under pressure"],
-        risk: ["decays without sustained repair budget"],
-        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.rampart,
-        hostileExposure: "medium",
-        signals: { defense: getDefensePressure(state), repairDecay: getRepairDecayPressure(state) },
-        vision: { survival: getDefensePressure(state), territory: 0.8, enemyKills: 0.15 }
-      };
-    case "road":
-      return {
-        buildItem: "build source/controller roads",
-        buildType,
-        minimumRcl: 2,
-        requiredObservations: ["room-controller", "sources", "repair-decay", "worker-count"],
-        expectedKpiMovement: ["reduces worker travel time", "improves harvest-to-spawn throughput"],
-        risk: ["road decay creates recurring repair load"],
-        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.road,
-        pathExposure: "low",
-        signals: {
-          harvestThroughput: 0.55,
-          rclAcceleration: 0.45,
-          expansionPrerequisite: ((_a = state.activeTerritoryIntentCount) != null ? _a : 0) > 0 ? 0.45 : 0.2,
-          controllerDowngrade: getControllerDowngradePressure(state) >= 0.7 ? 0.55 : 0
-        },
-        vision: { resources: 0.8, territory: 0.45 }
-      };
-    case "container":
-      return {
-        buildItem: "build source containers",
-        buildType,
-        minimumRcl: 2,
-        requiredObservations: ["room-controller", "sources", "worker-count"],
-        expectedKpiMovement: ["raises harvest throughput", "reduces dropped-energy waste"],
-        risk: ["large early build cost and decay upkeep"],
-        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.container,
-        pathExposure: "low",
-        signals: {
-          harvestThroughput: 0.9,
-          storageLogistics: 0.65,
-          rclAcceleration: 0.35,
-          expansionPrerequisite: ((_b = state.activeTerritoryIntentCount) != null ? _b : 0) > 0 ? 0.4 : 0.15,
-          controllerDowngrade: getControllerDowngradePressure(state) >= 0.7 ? 0.5 : 0
-        },
-        vision: { resources: 1, territory: 0.35 }
-      };
-    case "storage":
-      return {
-        buildItem: "build storage logistics",
-        buildType,
-        minimumRcl: 4,
-        minimumWorkers: MIN_SAFE_WORKERS_FOR_EXPANSION,
-        requiredObservations: ["room-controller", "energy-capacity", "worker-count"],
-        expectedKpiMovement: ["improves durable resource buffering and logistics"],
-        risk: ["very high energy commitment"],
-        estimatedEnergyCost: STRUCTURE_BUILD_COSTS.storage,
-        signals: { storageLogistics: 0.95 },
-        vision: { resources: 1, territory: 0.25 }
-      };
-    case "remote-logistics":
-      return {
-        buildItem: "build remote road/container logistics",
-        buildType,
-        minimumRcl: 2,
-        minimumWorkers: MIN_SAFE_WORKERS_FOR_EXPANSION,
-        requiresSafeHome: true,
-        requiredObservations: ["territory-intents", "remote-paths", "worker-count", "hostile-presence"],
-        expectedKpiMovement: ["turns reserved/scouted territory into sustainable income", "improves remote room hold viability"],
-        risk: ["path exposure and hostile pressure can waste builder time"],
-        estimatedEnergyCost: STRUCTURE_BUILD_COSTS["remote-logistics"],
-        pathExposure: "high",
-        hostileExposure: "medium",
-        signals: {
-          expansionPrerequisite: 1,
-          harvestThroughput: 0.75,
-          storageLogistics: 0.5
-        },
-        vision: { territory: 1, resources: 0.6 }
-      };
-    case "observation":
-    default:
-      return {
-        buildItem: "observe construction backlog",
-        buildType: "observation",
-        requiredObservations: ["construction-sites"],
-        expectedKpiMovement: ["construction priority table becomes evidence-backed"],
-        risk: ["no build action should be selected until construction-site observations exist"],
-        signals: {},
-        vision: { resources: 0.2 }
-      };
-  }
-}
-function mapStructureTypeToBuildType(structureType) {
-  if (matchesStructureType5(structureType, "STRUCTURE_SPAWN", "spawn")) {
-    return "spawn";
-  }
-  if (matchesStructureType5(structureType, "STRUCTURE_EXTENSION", "extension")) {
-    return "extension";
-  }
-  if (matchesStructureType5(structureType, "STRUCTURE_TOWER", "tower")) {
-    return "tower";
-  }
-  if (matchesStructureType5(structureType, "STRUCTURE_RAMPART", "rampart")) {
-    return "rampart";
-  }
-  if (matchesStructureType5(structureType, "STRUCTURE_ROAD", "road")) {
-    return "road";
-  }
-  if (matchesStructureType5(structureType, "STRUCTURE_CONTAINER", "container")) {
-    return "container";
-  }
-  if (matchesStructureType5(structureType, "STRUCTURE_STORAGE", "storage")) {
-    return "storage";
-  }
-  return "observation";
-}
-function getConstructionSiteRemainingProgress2(site) {
-  var _a;
-  const progressTotal = typeof site.progressTotal === "number" ? site.progressTotal : (_a = STRUCTURE_BUILD_COSTS.observation) != null ? _a : 0;
-  const progress = typeof site.progress === "number" ? site.progress : 0;
-  return Math.max(0, progressTotal - progress);
-}
-function findRoomObjects5(room, constantName) {
-  const findConstant = globalThis[constantName];
-  if (typeof findConstant !== "number" || typeof room.find !== "function") {
-    return null;
-  }
-  try {
-    const result = room.find(findConstant);
-    return Array.isArray(result) ? result : [];
-  } catch {
-    return null;
-  }
-}
-function countStructuresByType(structures, globalName, fallback) {
-  return structures == null ? void 0 : structures.filter((structure) => matchesStructureType5(structure.structureType, globalName, fallback)).length;
-}
-function summarizeRepairSignals(structures, criticalRoadContext) {
-  if (structures === null) {
-    return null;
-  }
-  return structures.reduce(
-    (summary, structure) => {
-      if (!isRepairSignalStructure(structure) || !hasHits(structure)) {
-        return summary;
-      }
-      if (matchesStructureType5(structure.structureType, "STRUCTURE_ROAD", "road") && !isCriticalRoadLogisticsWork(structure, criticalRoadContext)) {
-        return summary;
-      }
-      const hitsRatio = structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
-      if (hitsRatio <= CRITICAL_REPAIR_HITS_RATIO) {
-        summary.criticalRepairCount += 1;
-      } else if (hitsRatio <= DECAYING_REPAIR_HITS_RATIO) {
-        summary.decayingStructureCount += 1;
-      }
-      return summary;
-    },
-    { criticalRepairCount: 0, decayingStructureCount: 0 }
-  );
-}
-function isRepairSignalStructure(structure) {
-  if (matchesStructureType5(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType5(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
-    return true;
-  }
-  return matchesStructureType5(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true && structure.hits <= IDLE_RAMPART_REPAIR_HITS_CEILING2;
-}
-function hasHits(structure) {
-  return typeof structure.hits === "number" && typeof structure.hitsMax === "number";
-}
-function countTerritoryIntents(roomName) {
-  var _a, _b;
-  const intents = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.intents;
-  if (!Array.isArray(intents)) {
-    return { active: 0, planned: 0 };
-  }
-  return intents.reduce(
-    (counts, intent) => {
-      if (!isRecord5(intent)) {
-        return counts;
-      }
-      if (intent.colony !== roomName) {
-        return counts;
-      }
-      if (intent.status === "active") {
-        counts.active += 1;
-      } else if (intent.status === "planned") {
-        counts.planned += 1;
-      }
-      return counts;
-    },
-    { active: 0, planned: 0 }
-  );
-}
-function isRecord5(value) {
-  return typeof value === "object" && value !== null;
-}
-function matchesStructureType5(actual, globalName, fallback) {
-  var _a;
-  const constants = globalThis;
-  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
-}
-
 // src/territory/postClaimBootstrap.ts
 var POST_CLAIM_BOOTSTRAP_WORKER_TARGET = 2;
 var OK_CODE3 = 0;
 var ERR_INVALID_TARGET_CODE = -7;
-var ROOM_EDGE_MIN4 = 2;
-var ROOM_EDGE_MAX4 = 47;
-var DEFAULT_TERRAIN_WALL_MASK3 = 1;
+var ROOM_EDGE_MIN5 = 2;
+var ROOM_EDGE_MAX5 = 47;
+var DEFAULT_TERRAIN_WALL_MASK4 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
   if (!isNonEmptyString6(input.colony) || !isNonEmptyString6(input.roomName)) {
@@ -9425,11 +9671,11 @@ function findInitialSpawnConstructionPositions(room) {
   return positions;
 }
 function selectInitialSpawnAnchor(room) {
-  const controllerPosition = getRoomObjectPosition2(room.controller);
+  const controllerPosition = getRoomObjectPosition3(room.controller);
   if (!controllerPosition) {
     return null;
   }
-  const sources = findSources(room).map(getRoomObjectPosition2).filter((position) => position !== null).sort((left, right) => getRange(controllerPosition, left) - getRange(controllerPosition, right));
+  const sources = findSources(room).map(getRoomObjectPosition3).filter((position) => position !== null).sort((left, right) => getRange(controllerPosition, left) - getRange(controllerPosition, right));
   const nearestSourcePosition = sources[0];
   if (!nearestSourcePosition) {
     return clampPosition(controllerPosition);
@@ -9447,22 +9693,22 @@ function buildSpawnPlacementLookups(room, anchor, maximumScanRadius) {
     ...lookForArea(room, "LOOK_STRUCTURES", anchor, maximumScanRadius),
     ...lookForArea(room, "LOOK_CONSTRUCTION_SITES", anchor, maximumScanRadius)
   ]) {
-    const position = getRoomObjectPosition2(object);
+    const position = getRoomObjectPosition3(object);
     if (position) {
-      blockingPositions.add(getPositionKey3(position));
+      blockingPositions.add(getPositionKey4(position));
     }
   }
   const mineralPositions = /* @__PURE__ */ new Set();
   for (const object of lookForArea(room, "LOOK_MINERALS", anchor, maximumScanRadius)) {
-    const position = getRoomObjectPosition2(object);
+    const position = getRoomObjectPosition3(object);
     if (position) {
-      mineralPositions.add(getPositionKey3(position));
+      mineralPositions.add(getPositionKey4(position));
     }
   }
   return {
     blockingPositions,
     mineralPositions,
-    terrain: getRoomTerrain3(room.name)
+    terrain: getRoomTerrain4(room.name)
   };
 }
 function lookForArea(room, lookConstantName, anchor, maximumScanRadius) {
@@ -9482,20 +9728,20 @@ function lookForArea(room, lookConstantName, anchor, maximumScanRadius) {
 }
 function getScanBounds2(anchor, maximumScanRadius) {
   return {
-    top: Math.max(ROOM_EDGE_MIN4, anchor.y - maximumScanRadius),
-    left: Math.max(ROOM_EDGE_MIN4, anchor.x - maximumScanRadius),
-    bottom: Math.min(ROOM_EDGE_MAX4, anchor.y + maximumScanRadius),
-    right: Math.min(ROOM_EDGE_MAX4, anchor.x + maximumScanRadius)
+    top: Math.max(ROOM_EDGE_MIN5, anchor.y - maximumScanRadius),
+    left: Math.max(ROOM_EDGE_MIN5, anchor.x - maximumScanRadius),
+    bottom: Math.min(ROOM_EDGE_MAX5, anchor.y + maximumScanRadius),
+    right: Math.min(ROOM_EDGE_MAX5, anchor.x + maximumScanRadius)
   };
 }
 function canPlaceInitialSpawn(lookups, position) {
-  return isWithinRoomBuildBounds(position) && !lookups.blockingPositions.has(getPositionKey3(position)) && !lookups.mineralPositions.has(getPositionKey3(position)) && !isTerrainWall3(lookups.terrain, position);
+  return isWithinRoomBuildBounds(position) && !lookups.blockingPositions.has(getPositionKey4(position)) && !lookups.mineralPositions.has(getPositionKey4(position)) && !isTerrainWall4(lookups.terrain, position);
 }
 function isWithinRoomBuildBounds(position) {
-  return position.x >= ROOM_EDGE_MIN4 && position.x <= ROOM_EDGE_MAX4 && position.y >= ROOM_EDGE_MIN4 && position.y <= ROOM_EDGE_MAX4;
+  return position.x >= ROOM_EDGE_MIN5 && position.x <= ROOM_EDGE_MAX5 && position.y >= ROOM_EDGE_MIN5 && position.y <= ROOM_EDGE_MAX5;
 }
-function isTerrainWall3(terrain, position) {
-  return terrain !== null && (terrain.get(position.x, position.y) & getTerrainWallMask4()) !== 0;
+function isTerrainWall4(terrain, position) {
+  return terrain !== null && (terrain.get(position.x, position.y) & getTerrainWallMask5()) !== 0;
 }
 function findExistingSpawnConstructionSite(room) {
   var _a;
@@ -9515,7 +9761,7 @@ function findSources(room) {
   }
   return room.find(findConstant);
 }
-function getRoomObjectPosition2(object) {
+function getRoomObjectPosition3(object) {
   if (!isRecord6(object)) {
     return null;
   }
@@ -9530,7 +9776,7 @@ function getRoomObjectPosition2(object) {
 }
 function toSpawnSiteMemory(site) {
   var _a, _b, _c, _d, _e, _f;
-  const position = getRoomObjectPosition2(site);
+  const position = getRoomObjectPosition3(site);
   return {
     roomName: (_d = (_c = (_a = site.pos) == null ? void 0 : _a.roomName) != null ? _c : (_b = site.room) == null ? void 0 : _b.name) != null ? _d : "",
     x: (_e = position == null ? void 0 : position.x) != null ? _e : site.pos.x,
@@ -9580,8 +9826,8 @@ function getPostClaimBootstrapWorkerTarget(record) {
 }
 function clampPosition(position) {
   return {
-    x: clamp(position.x, ROOM_EDGE_MIN4, ROOM_EDGE_MAX4),
-    y: clamp(position.y, ROOM_EDGE_MIN4, ROOM_EDGE_MAX4)
+    x: clamp(position.x, ROOM_EDGE_MIN5, ROOM_EDGE_MAX5),
+    y: clamp(position.y, ROOM_EDGE_MIN5, ROOM_EDGE_MAX5)
   };
 }
 function clamp(value, min, max) {
@@ -9589,25 +9835,25 @@ function clamp(value, min, max) {
 }
 function getMaximumSpawnSiteScanRadius(anchor) {
   return Math.max(
-    anchor.x - ROOM_EDGE_MIN4,
-    ROOM_EDGE_MAX4 - anchor.x,
-    anchor.y - ROOM_EDGE_MIN4,
-    ROOM_EDGE_MAX4 - anchor.y
+    anchor.x - ROOM_EDGE_MIN5,
+    ROOM_EDGE_MAX5 - anchor.x,
+    anchor.y - ROOM_EDGE_MIN5,
+    ROOM_EDGE_MAX5 - anchor.y
   );
 }
 function getRange(left, right) {
   return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
-function getPositionKey3(position) {
+function getPositionKey4(position) {
   return `${position.x},${position.y}`;
 }
-function getRoomTerrain3(roomName) {
+function getRoomTerrain4(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   return typeof (gameMap == null ? void 0 : gameMap.getRoomTerrain) === "function" ? gameMap.getRoomTerrain(roomName) : null;
 }
-function getTerrainWallMask4() {
-  return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK3;
+function getTerrainWallMask5() {
+  return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK4;
 }
 function matchesStructureType6(actual, globalName, fallback) {
   return actual === getStructureConstant(globalName, fallback);
@@ -11104,9 +11350,8 @@ function runEconomy(preludeTelemetryEvents = []) {
   for (const colony of colonies) {
     let roleCounts = countCreepsByRole(creeps, colony.room.name);
     const bootstrapResult = refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
-    const extensionResult = bootstrapResult.spawnConstructionPending ? null : planExtensionConstruction(colony);
-    if (extensionResult === null && !bootstrapResult.spawnConstructionPending) {
-      planEarlyRoadConstruction(colony);
+    if (!bootstrapResult.spawnConstructionPending) {
+      planPriorityConstructionSites(colony);
     }
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -4,7 +4,8 @@ import {
   isCriticalRoadLogisticsWork,
   type CriticalRoadLogisticsContext
 } from './criticalRoads';
-import { getExtensionLimitForRcl } from './extensionPlanner';
+import { getExtensionLimitForRcl, planExtensionConstruction } from './extensionPlanner';
+import { planEarlyRoadConstruction, type EarlyRoadPlannerOptions } from './roadPlanner';
 
 export type ConstructionVisionLayer = 'survival' | 'territory' | 'resources' | 'enemyKills';
 
@@ -119,16 +120,47 @@ export interface ConstructionPriorityReport {
   nextPrimary: ConstructionPriorityScore | null;
 }
 
+export interface ConstructionPriorityPlanningOptions {
+  maxContainerSitesPerTick?: number;
+  maxPendingContainerSites?: number;
+  roadOptions?: EarlyRoadPlannerOptions;
+}
+
+export interface ConstructionPriorityPlanningResult {
+  sourceContainerResults: ScreepsReturnCode[];
+  extensionResult: ScreepsReturnCode | null;
+  roadResults: ScreepsReturnCode[];
+}
+
 interface RuntimeConstructionPriorityState extends ConstructionPriorityRoomState {
   ownedConstructionSites: ConstructionSite[] | null;
   ownedStructures: AnyOwnedStructure[] | null;
   visibleStructures: AnyStructure[] | null;
 }
 
+interface SourceContainerPlannerLookups {
+  blockingPositions: Set<string>;
+  existingContainerPositions: PositionedRoomPosition[];
+  pendingContainerPositions: PositionedRoomPosition[];
+  terrain: RoomTerrain;
+}
+
+interface PositionedRoomPosition {
+  x: number;
+  y: number;
+  roomName?: string;
+}
+
 const CONTROLLER_DOWNGRADE_CRITICAL_TICKS = 5_000;
 const CONTROLLER_DOWNGRADE_WARNING_TICKS = 10_000;
 const EARLY_ENERGY_CAPACITY_TARGET = 550;
 const MIN_SAFE_WORKERS_FOR_EXPANSION = 3;
+const MIN_RCL_FOR_AUTOMATED_CONSTRUCTION = 2;
+const MIN_RCL_FOR_AUTOMATED_ROADS = 4;
+const DEFAULT_MAX_CONTAINER_SITES_PER_TICK = 1;
+const DEFAULT_TERRAIN_WALL_MASK = 1;
+const ROOM_EDGE_MIN = 1;
+const ROOM_EDGE_MAX = 48;
 const MAX_SCORE = 100;
 const MAX_URGENCY_POINTS = 35;
 const MAX_ROOM_STATE_POINTS = 20;
@@ -270,6 +302,376 @@ export function buildRuntimeConstructionPriorityReport(
 ): ConstructionPriorityReport {
   const state = buildRuntimeConstructionPriorityState(colony, creeps);
   return scoreConstructionPriorities(state, buildRuntimeConstructionCandidates(state));
+}
+
+export function planPriorityConstructionSites(
+  colony: ColonySnapshot,
+  options: ConstructionPriorityPlanningOptions = {}
+): ConstructionPriorityPlanningResult {
+  const rcl = getOwnedRoomRcl(colony.room);
+  if (rcl < MIN_RCL_FOR_AUTOMATED_CONSTRUCTION) {
+    return {
+      sourceContainerResults: [],
+      extensionResult: null,
+      roadResults: []
+    };
+  }
+
+  const sourceContainerResults = planSourceContainerConstruction(colony, options);
+  const extensionResult = planExtensionConstruction(colony);
+  const roadResults =
+    rcl >= MIN_RCL_FOR_AUTOMATED_ROADS
+      ? planEarlyRoadConstruction(colony, options.roadOptions)
+      : [];
+
+  return {
+    sourceContainerResults,
+    extensionResult,
+    roadResults
+  };
+}
+
+export function planSourceContainerConstruction(
+  colony: ColonySnapshot,
+  options: ConstructionPriorityPlanningOptions = {}
+): ScreepsReturnCode[] {
+  const room = colony.room;
+  if (
+    getOwnedRoomRcl(room) < MIN_RCL_FOR_AUTOMATED_CONSTRUCTION ||
+    !hasRequiredSourceContainerPlannerApis(room)
+  ) {
+    return [];
+  }
+
+  const maxSitesPerTick = resolveNonNegativeInteger(
+    options.maxContainerSitesPerTick,
+    DEFAULT_MAX_CONTAINER_SITES_PER_TICK
+  );
+  if (maxSitesPerTick <= 0) {
+    return [];
+  }
+
+  const sources = getSortedSources(room);
+  if (sources.length === 0) {
+    return [];
+  }
+
+  const lookups = createSourceContainerPlannerLookups(room, sources);
+  if (!lookups) {
+    return [];
+  }
+
+  const maxPendingContainerSites = resolveNonNegativeInteger(
+    options.maxPendingContainerSites,
+    sources.length
+  );
+  const pendingContainerSites = countPendingSourceContainers(sources, lookups);
+  const remainingSiteBudget = Math.min(maxSitesPerTick, maxPendingContainerSites - pendingContainerSites);
+  if (remainingSiteBudget <= 0) {
+    return [];
+  }
+
+  const anchor = selectConstructionAnchor(colony);
+  const results: ScreepsReturnCode[] = [];
+  for (const source of sources) {
+    if (results.length >= remainingSiteBudget) {
+      break;
+    }
+
+    if (hasSourceContainerCoverage(source, lookups)) {
+      continue;
+    }
+
+    const position = selectSourceContainerPosition(room.name, source, lookups, anchor);
+    if (!position) {
+      continue;
+    }
+
+    const result = room.createConstructionSite(position.x, position.y, getContainerStructureType());
+    results.push(result);
+    if (result !== getOkCode()) {
+      break;
+    }
+
+    lookups.pendingContainerPositions.push(position);
+    lookups.blockingPositions.add(getPositionKey(position));
+  }
+
+  return results;
+}
+
+function getOwnedRoomRcl(room: Room): number {
+  const level = room.controller?.my === true ? room.controller.level : 0;
+  return typeof level === 'number' && Number.isFinite(level) ? Math.max(0, Math.floor(level)) : 0;
+}
+
+function hasRequiredSourceContainerPlannerApis(room: Room): boolean {
+  return (
+    typeof room.find === 'function' &&
+    typeof room.createConstructionSite === 'function' &&
+    getFindConstant('FIND_SOURCES') !== null &&
+    getFindConstant('FIND_STRUCTURES') !== null &&
+    getFindConstant('FIND_CONSTRUCTION_SITES') !== null
+  );
+}
+
+function resolveNonNegativeInteger(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(0, Math.floor(value));
+}
+
+function getSortedSources(room: Room): Source[] {
+  const sources = findRoomObjects(room, 'FIND_SOURCES') as Source[] | null;
+  return (sources ?? [])
+    .filter((source) => isSameRoomPosition(getRoomObjectPosition(source), room.name))
+    .sort((left, right) => String(left.id).localeCompare(String(right.id)));
+}
+
+function createSourceContainerPlannerLookups(
+  room: Room,
+  sources: Source[]
+): SourceContainerPlannerLookups | null {
+  const terrain = getRoomTerrain(room);
+  const structures = findRoomObjects(room, 'FIND_STRUCTURES') as Structure[] | null;
+  const constructionSites = findRoomObjects(room, 'FIND_CONSTRUCTION_SITES') as ConstructionSite[] | null;
+  if (!terrain || structures === null || constructionSites === null) {
+    return null;
+  }
+
+  const lookups: SourceContainerPlannerLookups = {
+    blockingPositions: new Set<string>(),
+    existingContainerPositions: [],
+    pendingContainerPositions: [],
+    terrain
+  };
+
+  for (const source of sources) {
+    addBlockingPosition(lookups, getRoomObjectPosition(source));
+  }
+
+  for (const structure of structures) {
+    const position = getRoomObjectPosition(structure);
+    addBlockingPosition(lookups, position);
+    if (matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')) {
+      addPosition(lookups.existingContainerPositions, position);
+    }
+  }
+
+  for (const site of constructionSites) {
+    const position = getRoomObjectPosition(site);
+    addBlockingPosition(lookups, position);
+    if (matchesStructureType(site.structureType, 'STRUCTURE_CONTAINER', 'container')) {
+      addPosition(lookups.pendingContainerPositions, position);
+    }
+  }
+
+  return lookups;
+}
+
+function addBlockingPosition(
+  lookups: SourceContainerPlannerLookups,
+  position: PositionedRoomPosition | null
+): void {
+  if (position) {
+    lookups.blockingPositions.add(getPositionKey(position));
+  }
+}
+
+function addPosition(positions: PositionedRoomPosition[], position: PositionedRoomPosition | null): void {
+  if (position) {
+    positions.push(position);
+  }
+}
+
+function countPendingSourceContainers(
+  sources: Source[],
+  lookups: SourceContainerPlannerLookups
+): number {
+  return lookups.pendingContainerPositions.filter((position) =>
+    sources.some((source) => isNearRoomObject(source, position))
+  ).length;
+}
+
+function hasSourceContainerCoverage(source: Source, lookups: SourceContainerPlannerLookups): boolean {
+  return (
+    lookups.existingContainerPositions.some((position) => isNearRoomObject(source, position)) ||
+    lookups.pendingContainerPositions.some((position) => isNearRoomObject(source, position))
+  );
+}
+
+function selectSourceContainerPosition(
+  roomName: string,
+  source: Source,
+  lookups: SourceContainerPlannerLookups,
+  anchor: PositionedRoomPosition | null
+): PositionedRoomPosition | null {
+  const sourcePosition = getRoomObjectPosition(source);
+  if (!isSameRoomPosition(sourcePosition, roomName)) {
+    return null;
+  }
+
+  const candidates = getAdjacentBuildPositions(sourcePosition, roomName)
+    .filter((position) => canPlaceSourceContainer(lookups, position))
+    .sort((left, right) => compareSourceContainerPositions(left, right, anchor));
+
+  return candidates[0] ?? null;
+}
+
+function getAdjacentBuildPositions(
+  center: PositionedRoomPosition,
+  roomName: string
+): PositionedRoomPosition[] {
+  const positions: PositionedRoomPosition[] = [];
+  for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -1; dx <= 1; dx += 1) {
+      if (dx === 0 && dy === 0) {
+        continue;
+      }
+
+      positions.push({ x: center.x + dx, y: center.y + dy, roomName });
+    }
+  }
+
+  return positions;
+}
+
+function canPlaceSourceContainer(
+  lookups: SourceContainerPlannerLookups,
+  position: PositionedRoomPosition
+): boolean {
+  return (
+    isWithinBuildableRoomBounds(position) &&
+    !isTerrainWall(lookups.terrain, position) &&
+    !lookups.blockingPositions.has(getPositionKey(position))
+  );
+}
+
+function compareSourceContainerPositions(
+  left: PositionedRoomPosition,
+  right: PositionedRoomPosition,
+  anchor: PositionedRoomPosition | null
+): number {
+  return (
+    compareOptionalNumber(getRangeBetweenPositions(left, anchor), getRangeBetweenPositions(right, anchor)) ||
+    left.y - right.y ||
+    left.x - right.x
+  );
+}
+
+function selectConstructionAnchor(colony: ColonySnapshot): PositionedRoomPosition | null {
+  const [primarySpawn] = colony.spawns
+    .filter((spawn) => getRoomObjectPosition(spawn) !== null)
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  return getRoomObjectPosition(primarySpawn) ?? getRoomObjectPosition(colony.room.controller);
+}
+
+function isNearRoomObject(
+  object: RoomObject,
+  position: PositionedRoomPosition
+): boolean {
+  const objectPosition = getRoomObjectPosition(object);
+  const range = getRangeBetweenPositions(objectPosition, position);
+  return (
+    isSameRoomPosition(objectPosition, position.roomName) &&
+    range !== null &&
+    range <= 1
+  );
+}
+
+function getRoomObjectPosition(object: RoomObject | undefined): PositionedRoomPosition | null {
+  const position = object?.pos as PositionedRoomPosition | undefined;
+  if (
+    !position ||
+    typeof position.x !== 'number' ||
+    typeof position.y !== 'number' ||
+    !Number.isFinite(position.x) ||
+    !Number.isFinite(position.y)
+  ) {
+    return null;
+  }
+
+  return {
+    x: position.x,
+    y: position.y,
+    ...(typeof position.roomName === 'string' ? { roomName: position.roomName } : {})
+  };
+}
+
+function isSameRoomPosition(position: PositionedRoomPosition | null, roomName: string | undefined): position is PositionedRoomPosition {
+  return (
+    position !== null &&
+    (!position.roomName || !roomName || position.roomName === roomName)
+  );
+}
+
+function isWithinBuildableRoomBounds(position: PositionedRoomPosition): boolean {
+  return (
+    position.x >= ROOM_EDGE_MIN &&
+    position.x <= ROOM_EDGE_MAX &&
+    position.y >= ROOM_EDGE_MIN &&
+    position.y <= ROOM_EDGE_MAX
+  );
+}
+
+function getRangeBetweenPositions(
+  left: PositionedRoomPosition | null,
+  right: PositionedRoomPosition | null
+): number | null {
+  if (!left || !right) {
+    return null;
+  }
+
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
+}
+
+function compareOptionalNumber(left: number | null, right: number | null): number {
+  if (left !== null && right !== null) {
+    return left - right;
+  }
+
+  if (left !== null) {
+    return -1;
+  }
+
+  if (right !== null) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function isTerrainWall(terrain: RoomTerrain, position: PositionedRoomPosition): boolean {
+  return (terrain.get(position.x, position.y) & getTerrainWallMask()) !== 0;
+}
+
+function getRoomTerrain(room: Room): RoomTerrain | null {
+  const game = (globalThis as unknown as { Game?: Partial<Game> }).Game;
+  if (!game?.map || typeof game.map.getRoomTerrain !== 'function') {
+    return null;
+  }
+
+  return game.map.getRoomTerrain(room.name);
+}
+
+function getPositionKey(position: PositionedRoomPosition): string {
+  return `${position.x},${position.y}`;
+}
+
+function getContainerStructureType(): BuildableStructureConstant {
+  const constants = globalThis as unknown as Partial<Record<'STRUCTURE_CONTAINER', BuildableStructureConstant>>;
+  return constants.STRUCTURE_CONTAINER ?? ('container' as BuildableStructureConstant);
+}
+
+function getTerrainWallMask(): number {
+  return typeof TERRAIN_MASK_WALL === 'number' ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK;
+}
+
+function getOkCode(): ScreepsReturnCode {
+  return (typeof OK === 'number' ? OK : 0) as ScreepsReturnCode;
 }
 
 function getMissingObservations(
@@ -805,8 +1207,11 @@ function buildPlannedLocalCandidates(state: RuntimeConstructionPriorityState): C
   }
 
   if (rcl >= 2 && (state.sourceCount ?? 0) > 0) {
-    candidates.push(createCandidateForBuildType('road', state));
     candidates.push(createCandidateForBuildType('container', state));
+  }
+
+  if (rcl >= MIN_RCL_FOR_AUTOMATED_ROADS && (state.sourceCount ?? 0) > 0) {
+    candidates.push(createCandidateForBuildType('road', state));
   }
 
   if (rcl >= 2 && getDefensePressure(state) > 0) {
@@ -1015,21 +1420,27 @@ function getConstructionSiteRemainingProgress(site: ConstructionSite): number {
 }
 
 function findRoomObjects(room: Room, constantName: FindConstantName): unknown[] | null {
-  const findConstant = (globalThis as unknown as Partial<Record<FindConstantName, number>>)[constantName];
-  if (typeof findConstant !== 'number' || typeof room.find !== 'function') {
+  const findConstant = getFindConstant(constantName);
+  if (findConstant === null || typeof room.find !== 'function') {
     return null;
   }
 
   try {
-    const result = room.find(findConstant as FindConstant);
+    const result = room.find(findConstant);
     return Array.isArray(result) ? result : [];
   } catch {
     return null;
   }
 }
 
+function getFindConstant(constantName: FindConstantName): FindConstant | null {
+  const findConstant = (globalThis as unknown as Partial<Record<FindConstantName, number>>)[constantName];
+  return typeof findConstant === 'number' ? (findConstant as FindConstant) : null;
+}
+
 type FindConstantName =
   | 'FIND_MY_CONSTRUCTION_SITES'
+  | 'FIND_CONSTRUCTION_SITES'
   | 'FIND_MY_STRUCTURES'
   | 'FIND_STRUCTURES'
   | 'FIND_HOSTILE_CREEPS'

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -4,8 +4,7 @@ import {
   clearColonySurvivalAssessmentCache,
   recordColonySurvivalAssessment
 } from '../colony/survivalMode';
-import { planExtensionConstruction } from '../construction/extensionPlanner';
-import { planEarlyRoadConstruction } from '../construction/roadPlanner';
+import { planPriorityConstructionSites } from '../construction/constructionPriority';
 import { countCreepsByRole, getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
 import { getBodyCost, TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS } from '../spawn/bodyBuilder';
@@ -48,9 +47,8 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   for (const colony of colonies) {
     let roleCounts = countCreepsByRole(creeps, colony.room.name);
     const bootstrapResult = refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
-    const extensionResult = bootstrapResult.spawnConstructionPending ? null : planExtensionConstruction(colony);
-    if (extensionResult === null && !bootstrapResult.spawnConstructionPending) {
-      planEarlyRoadConstruction(colony);
+    if (!bootstrapResult.spawnConstructionPending) {
+      planPriorityConstructionSites(colony);
     }
 
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);

--- a/prod/test/constructionPriorityPlanner.test.ts
+++ b/prod/test/constructionPriorityPlanner.test.ts
@@ -1,0 +1,329 @@
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import {
+  planPriorityConstructionSites,
+  planSourceContainerConstruction
+} from '../src/construction/constructionPriority';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+const TEST_GLOBALS = {
+  FIND_SOURCES: 1,
+  FIND_STRUCTURES: 2,
+  FIND_CONSTRUCTION_SITES: 3,
+  FIND_MY_STRUCTURES: 4,
+  FIND_MY_CONSTRUCTION_SITES: 5,
+  STRUCTURE_CONTAINER: 'container',
+  STRUCTURE_EXTENSION: 'extension',
+  STRUCTURE_ROAD: 'road',
+  TERRAIN_MASK_WALL: 1,
+  LOOK_STRUCTURES: 'structure',
+  LOOK_CONSTRUCTION_SITES: 'constructionSite',
+  OK: OK_CODE
+} as const;
+
+describe('construction priority placement loop', () => {
+  beforeEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const [key, value] of Object.entries(TEST_GLOBALS)) {
+      globals[key] = value;
+    }
+  });
+
+  afterEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const key of Object.keys(TEST_GLOBALS)) {
+      delete globals[key];
+    }
+
+    delete globals.Game;
+    delete globals.PathFinder;
+  });
+
+  it('skips automated construction below RCL2', () => {
+    const { room, colony } = makeColony({
+      controllerLevel: 1,
+      sources: [makeSource('source-a', { x: 20, y: 20 })]
+    });
+
+    expect(planPriorityConstructionSites(colony)).toEqual({
+      sourceContainerResults: [],
+      extensionResult: null,
+      roadResults: []
+    });
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+
+  it('places source container and extension sites at RCL2 without road planning', () => {
+    const { room, colony, pathFinderSearch } = makeColony({
+      controllerLevel: 2,
+      sources: [makeSource('source-a', { x: 20, y: 20 })],
+      pathsByTarget: {
+        '20,20': [{ x: 21, y: 20 }]
+      }
+    });
+
+    expect(planPriorityConstructionSites(colony)).toEqual({
+      sourceContainerResults: [OK_CODE],
+      extensionResult: OK_CODE,
+      roadResults: []
+    });
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(2);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 21, 21, STRUCTURE_CONTAINER);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(2, 24, 24, STRUCTURE_EXTENSION);
+    expect(pathFinderSearch).not.toHaveBeenCalled();
+  });
+
+  it('continues placing one source container per tick until each source has coverage', () => {
+    const { room, colony } = makeColony({
+      controllerLevel: 2,
+      sources: [
+        makeSource('source-a', { x: 20, y: 20 }),
+        makeSource('source-b', { x: 30, y: 30 })
+      ]
+    });
+
+    expect(planSourceContainerConstruction(colony)).toEqual([OK_CODE]);
+    expect(planSourceContainerConstruction(colony)).toEqual([OK_CODE]);
+
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(2);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 21, 21, STRUCTURE_CONTAINER);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(2, 29, 29, STRUCTURE_CONTAINER);
+  });
+
+  it('adds road planning at RCL4 while deferring roads at RCL3', () => {
+    const rcl3 = makeColony({
+      controllerLevel: 3,
+      sources: [makeSource('source-a', { x: 20, y: 10 })],
+      structures: [makeStructure('container-a', STRUCTURE_CONTAINER, { x: 20, y: 9 })],
+      extensionCount: 10,
+      spawnPosition: { x: 10, y: 10 },
+      pathsByTarget: {
+        '20,10': [{ x: 11, y: 10 }]
+      }
+    });
+
+    expect(planPriorityConstructionSites(rcl3.colony)).toEqual({
+      sourceContainerResults: [],
+      extensionResult: null,
+      roadResults: []
+    });
+    expect(rcl3.pathFinderSearch).not.toHaveBeenCalled();
+    expect(rcl3.room.createConstructionSite).not.toHaveBeenCalled();
+
+    const rcl4 = makeColony({
+      controllerLevel: 4,
+      sources: [makeSource('source-a', { x: 20, y: 10 })],
+      structures: [makeStructure('container-a', STRUCTURE_CONTAINER, { x: 20, y: 9 })],
+      extensionCount: 20,
+      spawnPosition: { x: 10, y: 10 },
+      pathsByTarget: {
+        '20,10': [{ x: 11, y: 10 }]
+      }
+    });
+
+    expect(planPriorityConstructionSites(rcl4.colony)).toEqual({
+      sourceContainerResults: [],
+      extensionResult: null,
+      roadResults: [OK_CODE]
+    });
+    expect(rcl4.pathFinderSearch).toHaveBeenCalled();
+    expect(rcl4.room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(rcl4.room.createConstructionSite).toHaveBeenCalledWith(11, 10, STRUCTURE_ROAD);
+  });
+});
+
+interface MockRoom extends Room {
+  createConstructionSite: jest.Mock;
+  find: jest.Mock;
+  lookForAtArea: jest.Mock;
+}
+
+interface TestPosition {
+  x: number;
+  y: number;
+}
+
+interface MakeColonyOptions {
+  constructionSites?: ConstructionSite[];
+  controllerLevel: number;
+  controllerPosition?: TestPosition;
+  extensionCount?: number;
+  pathsByTarget?: Record<string, TestPosition[]>;
+  sources: Source[];
+  spawnPosition?: TestPosition;
+  structures?: Structure[];
+  wallPositions?: Set<string>;
+}
+
+class MockCostMatrix {
+  private readonly costs = new Map<string, number>();
+
+  set(x: number, y: number, cost: number): void {
+    this.costs.set(`${x},${y}`, cost);
+  }
+
+  get(x: number, y: number): number {
+    return this.costs.get(`${x},${y}`) ?? 0;
+  }
+
+  clone(): CostMatrix {
+    const clone = new MockCostMatrix();
+    for (const [key, cost] of this.costs.entries()) {
+      const [x, y] = key.split(',').map(Number);
+      clone.set(x, y, cost);
+    }
+
+    return clone as unknown as CostMatrix;
+  }
+
+  serialize(): number[] {
+    return [];
+  }
+}
+
+function makeColony(options: MakeColonyOptions): {
+  colony: ColonySnapshot;
+  pathFinderSearch: jest.Mock;
+  room: MockRoom;
+} {
+  const roomName = 'W1N1';
+  const wallPositions = options.wallPositions ?? new Set<string>();
+  const constructionSites = [...(options.constructionSites ?? [])];
+  const structures = [
+    ...(options.structures ?? []),
+    ...Array.from({ length: options.extensionCount ?? 0 }, (_, index) =>
+      makeStructure(`extension-${index}`, STRUCTURE_EXTENSION, {
+        x: 40 + (index % 5),
+        y: 40 + Math.floor(index / 5)
+      })
+    )
+  ];
+  const controller = {
+    id: 'controller1',
+    my: true,
+    level: options.controllerLevel,
+    pos: makeRoomPosition(options.controllerPosition ?? { x: 25, y: 25 }, roomName)
+  } as unknown as StructureController;
+  const room = {
+    name: roomName,
+    controller,
+    energyAvailable: 300,
+    energyCapacityAvailable: 300,
+    find: jest.fn((findType: number, findOptions?: { filter?: (target: Source | Structure | ConstructionSite) => boolean }) => {
+      const targets =
+        findType === TEST_GLOBALS.FIND_SOURCES
+          ? options.sources
+          : findType === TEST_GLOBALS.FIND_STRUCTURES || findType === TEST_GLOBALS.FIND_MY_STRUCTURES
+            ? structures
+            : findType === TEST_GLOBALS.FIND_CONSTRUCTION_SITES ||
+                findType === TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES
+              ? constructionSites
+              : [];
+
+      return findOptions?.filter ? targets.filter(findOptions.filter) : targets;
+    }),
+    lookForAtArea: jest.fn((lookType: string, top: number, left: number, bottom: number, right: number) => {
+      if (lookType === TEST_GLOBALS.LOOK_STRUCTURES) {
+        return getLookResults(structures, top, left, bottom, right, 'structure');
+      }
+
+      if (lookType === TEST_GLOBALS.LOOK_CONSTRUCTION_SITES) {
+        return getLookResults(constructionSites, top, left, bottom, right, 'constructionSite');
+      }
+
+      return [];
+    }),
+    createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+      constructionSites.push(makeConstructionSite(`site-${x}-${y}`, structureType, { x, y }));
+      return OK_CODE;
+    })
+  } as unknown as MockRoom;
+  const spawn = {
+    name: 'Spawn1',
+    room,
+    pos: makeRoomPosition(options.spawnPosition ?? { x: 25, y: 25 }, roomName)
+  } as unknown as StructureSpawn;
+  const pathFinderSearch = jest.fn((origin: RoomPosition, goal: { pos: RoomPosition }) => ({
+    cost: 1,
+    incomplete: false,
+    ops: 1,
+    path: (options.pathsByTarget?.[getRouteKey(origin, goal)] ??
+      options.pathsByTarget?.[getPositionKey(goal.pos)] ??
+      []).map((position) => makeRoomPosition(position, roomName))
+  }));
+
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    map: {
+      getRoomTerrain: jest.fn().mockReturnValue({
+        get: (x: number, y: number) => (wallPositions.has(`${x},${y}`) ? TEST_GLOBALS.TERRAIN_MASK_WALL : 0)
+      })
+    } as unknown as Game['map']
+  };
+  (globalThis as unknown as { PathFinder: Partial<PathFinder> }).PathFinder = {
+    CostMatrix: MockCostMatrix as unknown as CostMatrix,
+    search: pathFinderSearch as unknown as PathFinder['search']
+  };
+
+  return {
+    colony: {
+      room,
+      spawns: [spawn],
+      energyAvailable: room.energyAvailable,
+      energyCapacityAvailable: room.energyCapacityAvailable
+    },
+    pathFinderSearch,
+    room
+  };
+}
+
+function makeSource(id: string, position: TestPosition): Source {
+  return {
+    id,
+    pos: makeRoomPosition(position, 'W1N1')
+  } as unknown as Source;
+}
+
+function makeStructure(id: string, structureType: StructureConstant, position: TestPosition): Structure {
+  return {
+    id,
+    structureType,
+    pos: makeRoomPosition(position, 'W1N1')
+  } as unknown as Structure;
+}
+
+function makeConstructionSite(id: string, structureType: StructureConstant, position: TestPosition): ConstructionSite {
+  return {
+    id,
+    structureType,
+    pos: makeRoomPosition(position, 'W1N1')
+  } as unknown as ConstructionSite;
+}
+
+function makeRoomPosition(position: TestPosition, roomName: string): RoomPosition {
+  return { ...position, roomName } as RoomPosition;
+}
+
+function getLookResults<T extends Structure | ConstructionSite>(
+  objects: T[],
+  top: number,
+  left: number,
+  bottom: number,
+  right: number,
+  property: 'structure' | 'constructionSite'
+): LookAtResultWithPos[] {
+  return objects.flatMap((object) => {
+    const position = (object as { pos?: RoomPosition }).pos;
+    return position && position.x >= left && position.x <= right && position.y >= top && position.y <= bottom
+      ? [{ x: position.x, y: position.y, [property]: object } as unknown as LookAtResultWithPos]
+      : [];
+  });
+}
+
+function getPositionKey(position: TestPosition): string {
+  return `${position.x},${position.y}`;
+}
+
+function getRouteKey(origin: unknown, goal: unknown): string {
+  return `${getPositionKey(origin as TestPosition)}->${getPositionKey((goal as { pos: TestPosition }).pos)}`;
+}

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -159,15 +159,6 @@ describe('runtime telemetry summaries', () => {
                 preconditions: [],
                 expectedKpiMovement: ['raises harvest throughput', 'reduces dropped-energy waste'],
                 risk: ['large early build cost and decay upkeep']
-              },
-              {
-                buildItem: 'build source/controller roads',
-                room: 'W1N1',
-                score: 21,
-                urgency: 'low',
-                preconditions: [],
-                expectedKpiMovement: ['reduces worker travel time', 'improves harvest-to-spawn throughput'],
-                risk: ['road decay creates recurring repair load']
               }
             ],
             nextPrimary: {


### PR DESCRIPTION
Closes #495

## Summary
Automated construction site placement and build-priority loop for economy.

## Changes
- `prod/src/construction/constructionPriority.ts`: Added automated site placement (containers near sources, extensions near spawn) and RCL-tiered priority
- `prod/src/economy/economyLoop.ts`: Integrated construction planning into economy loop
- `prod/test/constructionPriorityPlanner.test.ts`: New tests for construction priority planner
- `prod/test/runtimeSummary.test.ts`: Updated runtime summary tests
- `prod/dist/main.js`: Generated bundle

## Verification
- TypeScript typecheck: PASS
- Jest (734 tests, --runInBand): PASS
- Build: OK
- git diff --check: clean
- Commit: aed38bf, author: lanyusea's bot <lanyusea@gmail.com>
