### PR TITLE
feat(territory): prefer recovered territory follow-up intents

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -621,7 +621,8 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime) {
     colony: colony.room.name,
     targetRoom: target.roomName,
     action: selection.intentAction,
-    ...target.controllerId ? { controllerId: target.controllerId } : {}
+    ...target.controllerId ? { controllerId: target.controllerId } : {},
+    ...selection.followUp ? { followUp: selection.followUp } : {}
   };
   const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? "active" : "planned";
   recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
@@ -652,7 +653,8 @@ function buildTerritoryCreepMemory(plan) {
     territory: {
       targetRoom: plan.targetRoom,
       action: plan.action,
-      ...plan.controllerId ? { controllerId: plan.controllerId } : {}
+      ...plan.controllerId ? { controllerId: plan.controllerId } : {},
+      ...plan.followUp ? { followUp: plan.followUp } : {}
     }
   };
 }
@@ -758,13 +760,15 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
+  const followUp = normalizeTerritoryFollowUp(assignment.followUp);
   const suppressedIntent = {
     colony,
     targetRoom: assignment.targetRoom,
     action: assignment.action,
     status: "suppressed",
     updatedAt: gameTime,
-    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
+    ...followUp ? { followUp } : {}
   };
   upsertTerritoryIntent(intents, suppressedIntent);
 }
@@ -871,7 +875,8 @@ function toSelectedTerritoryTarget(candidate) {
   return candidate ? {
     target: candidate.target,
     intentAction: candidate.intentAction,
-    commitTarget: candidate.commitTarget
+    commitTarget: candidate.commitTarget,
+    ...candidate.followUp ? { followUp: candidate.followUp } : {}
   } : null;
 }
 function getSpawnableTerritoryCandidates(candidates, roleCounts) {
@@ -942,7 +947,12 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
     const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
     if (candidateState === "safe") {
       const candidate = scoreTerritoryCandidate(
-        { target, intentAction: "reserve", commitTarget: true },
+        {
+          target,
+          intentAction: "reserve",
+          commitTarget: true,
+          ...buildTerritoryFollowUp(source, originRoomName)
+        },
         source,
         orderOffset + order,
         colonyName,
@@ -953,7 +963,12 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
     }
     if (candidateState === "unknown" && includeScoutCandidates && !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, "scout", gameTime)) {
       const candidate = scoreTerritoryCandidate(
-        { target, intentAction: "scout", commitTarget: false },
+        {
+          target,
+          intentAction: "scout",
+          commitTarget: false,
+          ...buildTerritoryFollowUp(source, originRoomName)
+        },
         source,
         orderOffset + order,
         colonyName,
@@ -1114,6 +1129,25 @@ function getTerritoryCandidateSourcePriority(source) {
   }
   return source === "activeReserveAdjacent" ? 3 : 4;
 }
+function buildTerritoryFollowUp(source, originRoom) {
+  const originAction = getTerritoryFollowUpOriginAction(source);
+  if (originAction === null || !isTerritoryFollowUpSource(source) || !isNonEmptyString(originRoom)) {
+    return {};
+  }
+  return {
+    followUp: {
+      source,
+      originRoom,
+      originAction
+    }
+  };
+}
+function getTerritoryFollowUpOriginAction(source) {
+  if (source === "satisfiedClaimAdjacent") {
+    return "claim";
+  }
+  return source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent" ? "reserve" : null;
+}
 function isTerritoryTargetVisible(target) {
   return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;
 }
@@ -1251,7 +1285,8 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null) {
     action: plan.action,
     status,
     updatedAt: gameTime,
-    ...plan.controllerId ? { controllerId: plan.controllerId } : {}
+    ...plan.controllerId ? { controllerId: plan.controllerId } : {},
+    ...plan.followUp ? { followUp: plan.followUp } : {}
   };
   upsertTerritoryIntent(intents, nextIntent);
 }
@@ -1278,13 +1313,28 @@ function normalizeTerritoryIntent(rawIntent) {
   if (!isNonEmptyString(rawIntent.colony) || !isNonEmptyString(rawIntent.targetRoom) || !isTerritoryIntentAction(rawIntent.action) || !isTerritoryIntentStatus(rawIntent.status) || typeof rawIntent.updatedAt !== "number") {
     return null;
   }
+  const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
   return {
     colony: rawIntent.colony,
     targetRoom: rawIntent.targetRoom,
     action: rawIntent.action,
     status: rawIntent.status,
     updatedAt: rawIntent.updatedAt,
-    ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {}
+    ...typeof rawIntent.controllerId === "string" ? { controllerId: rawIntent.controllerId } : {},
+    ...followUp ? { followUp } : {}
+  };
+}
+function normalizeTerritoryFollowUp(rawFollowUp) {
+  if (!isRecord(rawFollowUp)) {
+    return null;
+  }
+  if (!isTerritoryFollowUpSource(rawFollowUp.source) || !isNonEmptyString(rawFollowUp.originRoom) || !isTerritoryControlAction(rawFollowUp.originAction)) {
+    return null;
+  }
+  return {
+    source: rawFollowUp.source,
+    originRoom: rawFollowUp.originRoom,
+    originAction: rawFollowUp.originAction
   };
 }
 function getTerritoryCreepCountForTarget(roleCounts, targetRoom, action) {
@@ -1338,13 +1388,15 @@ function normalizeCreepTerritoryIntent(creep, roomName) {
   if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction(assignment.action) || isNonEmptyString((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
     return null;
   }
+  const followUp = normalizeTerritoryFollowUp(assignment.followUp);
   return {
     colony: (_d = (_c = creep.memory) == null ? void 0 : _c.colony) != null ? _d : "",
     targetRoom: assignment.targetRoom,
     action: assignment.action,
     status: "active",
     updatedAt: getGameTime(),
-    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
+    ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
+    ...followUp ? { followUp } : {}
   };
 }
 function isActiveVisibleControllerIntentForCreep(intent, roomName, creepColony) {
@@ -1607,6 +1659,9 @@ function isTerritoryControlAction(action) {
 }
 function isTerritoryIntentAction(action) {
   return isTerritoryControlAction(action) || action === "scout";
+}
+function isTerritoryFollowUpSource(source) {
+  return source === "satisfiedClaimAdjacent" || source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent";
 }
 function isTerritoryIntentStatus(status) {
   return status === "planned" || status === "active" || status === "suppressed";

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1328,13 +1328,18 @@ function normalizeTerritoryFollowUp(rawFollowUp) {
   if (!isRecord(rawFollowUp)) {
     return null;
   }
-  if (!isTerritoryFollowUpSource(rawFollowUp.source) || !isNonEmptyString(rawFollowUp.originRoom) || !isTerritoryControlAction(rawFollowUp.originAction)) {
+  if (!isTerritoryFollowUpSource(rawFollowUp.source)) {
+    return null;
+  }
+  const source = rawFollowUp.source;
+  const originAction = getTerritoryFollowUpOriginAction(source);
+  if (originAction === null || !isNonEmptyString(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
     return null;
   }
   return {
-    source: rawFollowUp.source,
+    source,
     originRoom: rawFollowUp.originRoom,
-    originAction: rawFollowUp.originAction
+    originAction
   };
 }
 function getTerritoryCreepCountForTarget(roleCounts, targetRoom, action) {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1165,19 +1165,18 @@ function normalizeTerritoryFollowUp(rawFollowUp: unknown): TerritoryFollowUpMemo
     return null;
   }
 
-  const originAction = isTerritoryFollowUpSource(rawFollowUp.source)
-    ? getTerritoryFollowUpOriginAction(rawFollowUp.source)
-    : null;
-  if (
-    originAction === null ||
-    !isNonEmptyString(rawFollowUp.originRoom) ||
-    rawFollowUp.originAction !== originAction
-  ) {
+  if (!isTerritoryFollowUpSource(rawFollowUp.source)) {
+    return null;
+  }
+
+  const source = rawFollowUp.source;
+  const originAction = getTerritoryFollowUpOriginAction(source);
+  if (originAction === null || !isNonEmptyString(rawFollowUp.originRoom) || rawFollowUp.originAction !== originAction) {
     return null;
   }
 
   return {
-    source: rawFollowUp.source,
+    source,
     originRoom: rawFollowUp.originRoom,
     originAction
   };

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -28,6 +28,7 @@ export interface TerritoryIntentPlan {
   targetRoom: string;
   action: TerritoryIntentAction;
   controllerId?: Id<StructureController>;
+  followUp?: TerritoryFollowUpMemory;
 }
 
 interface MemoryRecord {
@@ -38,6 +39,7 @@ interface SelectedTerritoryTarget {
   target: TerritoryTargetMemory;
   intentAction: TerritoryIntentAction;
   commitTarget: boolean;
+  followUp?: TerritoryFollowUpMemory;
 }
 
 type TerritoryCandidateSource =
@@ -80,7 +82,8 @@ export function planTerritoryIntent(
     colony: colony.room.name,
     targetRoom: target.roomName,
     action: selection.intentAction,
-    ...(target.controllerId ? { controllerId: target.controllerId } : {})
+    ...(target.controllerId ? { controllerId: target.controllerId } : {}),
+    ...(selection.followUp ? { followUp: selection.followUp } : {})
   };
   const status = getTerritoryCreepCountForTarget(roleCounts, plan.targetRoom, plan.action) > 0 ? 'active' : 'planned';
   recordTerritoryIntent(plan, status, gameTime, selection.commitTarget ? target : null);
@@ -125,7 +128,8 @@ export function buildTerritoryCreepMemory(plan: TerritoryIntentPlan): CreepMemor
     territory: {
       targetRoom: plan.targetRoom,
       action: plan.action,
-      ...(plan.controllerId ? { controllerId: plan.controllerId } : {})
+      ...(plan.controllerId ? { controllerId: plan.controllerId } : {}),
+      ...(plan.followUp ? { followUp: plan.followUp } : {})
     }
   };
 }
@@ -288,13 +292,15 @@ export function suppressTerritoryIntent(
 
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
+  const followUp = normalizeTerritoryFollowUp(assignment.followUp);
   const suppressedIntent: TerritoryIntentMemory = {
     colony,
     targetRoom: assignment.targetRoom,
     action: assignment.action,
     status: 'suppressed',
     updatedAt: gameTime,
-    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {})
+    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {}),
+    ...(followUp ? { followUp } : {})
   };
 
   upsertTerritoryIntent(intents, suppressedIntent);
@@ -423,7 +429,8 @@ function toSelectedTerritoryTarget(candidate: ScoredTerritoryTarget | null): Sel
     ? {
         target: candidate.target,
         intentAction: candidate.intentAction,
-        commitTarget: candidate.commitTarget
+        commitTarget: candidate.commitTarget,
+        ...(candidate.followUp ? { followUp: candidate.followUp } : {})
       }
     : null;
 }
@@ -568,7 +575,12 @@ function getAdjacentReserveCandidates(
     const candidateState = getAdjacentReserveCandidateState(roomName, colonyOwnerUsername);
     if (candidateState === 'safe') {
       const candidate = scoreTerritoryCandidate(
-        { target, intentAction: 'reserve', commitTarget: true },
+        {
+          target,
+          intentAction: 'reserve',
+          commitTarget: true,
+          ...buildTerritoryFollowUp(source, originRoomName)
+        },
         source,
         orderOffset + order,
         colonyName,
@@ -584,7 +596,12 @@ function getAdjacentReserveCandidates(
       !isSuppressedTerritoryIntentForAction(intents, colonyName, roomName, 'scout', gameTime)
     ) {
       const candidate = scoreTerritoryCandidate(
-        { target, intentAction: 'scout', commitTarget: false },
+        {
+          target,
+          intentAction: 'scout',
+          commitTarget: false,
+          ...buildTerritoryFollowUp(source, originRoomName)
+        },
         source,
         orderOffset + order,
         colonyName,
@@ -860,6 +877,32 @@ function getTerritoryCandidateSourcePriority(source: TerritoryCandidateSource): 
   return source === 'activeReserveAdjacent' ? 3 : 4;
 }
 
+function buildTerritoryFollowUp(
+  source: TerritoryCandidateSource,
+  originRoom: string
+): Pick<SelectedTerritoryTarget, 'followUp'> {
+  const originAction = getTerritoryFollowUpOriginAction(source);
+  if (originAction === null || !isTerritoryFollowUpSource(source) || !isNonEmptyString(originRoom)) {
+    return {};
+  }
+
+  return {
+    followUp: {
+      source,
+      originRoom,
+      originAction
+    }
+  };
+}
+
+function getTerritoryFollowUpOriginAction(source: TerritoryCandidateSource): TerritoryControlAction | null {
+  if (source === 'satisfiedClaimAdjacent') {
+    return 'claim';
+  }
+
+  return source === 'satisfiedReserveAdjacent' || source === 'activeReserveAdjacent' ? 'reserve' : null;
+}
+
 function isTerritoryTargetVisible(target: TerritoryTargetMemory): boolean {
   return isVisibleRoomKnown(target.roomName) || getVisibleController(target.roomName, target.controllerId) !== null;
 }
@@ -1056,7 +1099,8 @@ function recordTerritoryIntent(
     action: plan.action,
     status,
     updatedAt: gameTime,
-    ...(plan.controllerId ? { controllerId: plan.controllerId } : {})
+    ...(plan.controllerId ? { controllerId: plan.controllerId } : {}),
+    ...(plan.followUp ? { followUp: plan.followUp } : {})
   };
 
   upsertTerritoryIntent(intents, nextIntent);
@@ -1102,6 +1146,7 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
     return null;
   }
 
+  const followUp = normalizeTerritoryFollowUp(rawIntent.followUp);
   return {
     colony: rawIntent.colony,
     targetRoom: rawIntent.targetRoom,
@@ -1110,7 +1155,31 @@ function normalizeTerritoryIntent(rawIntent: unknown): TerritoryIntentMemory | n
     updatedAt: rawIntent.updatedAt,
     ...(typeof rawIntent.controllerId === 'string'
       ? { controllerId: rawIntent.controllerId as Id<StructureController> }
-      : {})
+      : {}),
+    ...(followUp ? { followUp } : {})
+  };
+}
+
+function normalizeTerritoryFollowUp(rawFollowUp: unknown): TerritoryFollowUpMemory | null {
+  if (!isRecord(rawFollowUp)) {
+    return null;
+  }
+
+  const originAction = isTerritoryFollowUpSource(rawFollowUp.source)
+    ? getTerritoryFollowUpOriginAction(rawFollowUp.source)
+    : null;
+  if (
+    originAction === null ||
+    !isNonEmptyString(rawFollowUp.originRoom) ||
+    rawFollowUp.originAction !== originAction
+  ) {
+    return null;
+  }
+
+  return {
+    source: rawFollowUp.source,
+    originRoom: rawFollowUp.originRoom,
+    originAction
   };
 }
 
@@ -1210,13 +1279,15 @@ function normalizeCreepTerritoryIntent(creep: Creep, roomName: string): Territor
     return null;
   }
 
+  const followUp = normalizeTerritoryFollowUp(assignment.followUp);
   return {
     colony: creep.memory?.colony ?? '',
     targetRoom: assignment.targetRoom,
     action: assignment.action,
     status: 'active',
     updatedAt: getGameTime(),
-    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {})
+    ...(assignment.controllerId ? { controllerId: assignment.controllerId } : {}),
+    ...(followUp ? { followUp } : {})
   };
 }
 
@@ -1601,6 +1672,14 @@ function isTerritoryControlAction(action: unknown): action is TerritoryControlAc
 
 function isTerritoryIntentAction(action: unknown): action is TerritoryIntentAction {
   return isTerritoryControlAction(action) || action === 'scout';
+}
+
+function isTerritoryFollowUpSource(source: unknown): source is TerritoryFollowUpSource {
+  return (
+    source === 'satisfiedClaimAdjacent' ||
+    source === 'satisfiedReserveAdjacent' ||
+    source === 'activeReserveAdjacent'
+  );
 }
 
 function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -17,6 +17,7 @@ declare global {
 
   type TerritoryControlAction = 'claim' | 'reserve';
   type TerritoryIntentAction = TerritoryControlAction | 'scout';
+  type TerritoryFollowUpSource = 'satisfiedClaimAdjacent' | 'satisfiedReserveAdjacent' | 'activeReserveAdjacent';
 
   interface TerritoryMemory {
     targets?: TerritoryTargetMemory[];
@@ -39,12 +40,20 @@ declare global {
     status: 'planned' | 'active' | 'suppressed';
     updatedAt: number;
     controllerId?: Id<StructureController>;
+    followUp?: TerritoryFollowUpMemory;
+  }
+
+  interface TerritoryFollowUpMemory {
+    source: TerritoryFollowUpSource;
+    originRoom: string;
+    originAction: TerritoryControlAction;
   }
 
   interface CreepTerritoryMemory {
     targetRoom: string;
     action: TerritoryIntentAction;
     controllerId?: Id<StructureController>;
+    followUp?: TerritoryFollowUpMemory;
   }
 
   type CreepTaskMemory =

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1,5 +1,6 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
+  buildTerritoryCreepMemory,
   planTerritoryIntent,
   shouldSpawnTerritoryControllerCreep,
   TERRITORY_DOWNGRADE_GUARD_TICKS,
@@ -1034,6 +1035,7 @@ describe('planTerritoryIntent', () => {
   it('scouts adjacent rooms after a configured claim target is owned by the colony account', () => {
     const colony = makeSafeColony();
     const claimedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'claim' };
+    const followUp = makeFollowUp('satisfiedClaimAdjacent', 'W2N1', 'claim');
     const describeExits = jest.fn(() => ({ '3': 'W3N1' }));
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       map: { describeExits } as unknown as GameMap,
@@ -1055,7 +1057,8 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W3N1',
-      action: 'scout'
+      action: 'scout',
+      followUp
     });
     expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(Memory.territory?.targets).toEqual([claimedTarget]);
@@ -1065,7 +1068,8 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'W3N1',
         action: 'scout',
         status: 'planned',
-        updatedAt: 554
+        updatedAt: 554,
+        followUp
       }
     ]);
   });
@@ -1073,6 +1077,7 @@ describe('planTerritoryIntent', () => {
   it('prefers the satisfied claim target as the next adjacent scout origin', () => {
     const colony = makeSafeColony();
     const claimedTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'claim' };
+    const followUp = makeFollowUp('satisfiedClaimAdjacent', 'W2N1', 'claim');
     const describeExits = jest.fn((roomName: string) =>
       roomName === 'W2N1' ? { '3': 'W3N1' } : { '1': 'W1N2' }
     );
@@ -1096,7 +1101,8 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W3N1',
-      action: 'scout'
+      action: 'scout',
+      followUp
     });
     expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(describeExits).toHaveBeenCalledWith('W2N1');
@@ -1107,7 +1113,8 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'W3N1',
         action: 'scout',
         status: 'planned',
-        updatedAt: 555
+        updatedAt: 555,
+        followUp
       }
     ]);
   });
@@ -1500,6 +1507,7 @@ describe('planTerritoryIntent', () => {
   it('prioritizes a neutral adjacent reserve target over a healthy own configured reservation', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
     const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       map: { describeExits } as unknown as GameMap,
@@ -1523,7 +1531,7 @@ describe('planTerritoryIntent', () => {
 
     const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 539);
 
-    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve' });
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N1', action: 'reserve', followUp });
     expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(
       shouldSpawnTerritoryControllerCreep(
@@ -1548,7 +1556,8 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'W2N1',
         action: 'reserve',
         status: 'planned',
-        updatedAt: 539
+        updatedAt: 539,
+        followUp
       }
     ]);
   });
@@ -1556,6 +1565,7 @@ describe('planTerritoryIntent', () => {
   it('extends from a satisfied configured reservation before home-adjacent reserve pressure', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
     const describeExits = jest.fn((roomName: string) =>
       roomName === 'W1N2' ? { '3': 'W2N2' } : { '3': 'W2N1' }
     );
@@ -1582,7 +1592,7 @@ describe('planTerritoryIntent', () => {
 
     const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 562);
 
-    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N2', action: 'reserve' });
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N2', action: 'reserve', followUp });
     expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(describeExits).toHaveBeenCalledWith('W1N2');
     expect(Memory.territory?.targets).toEqual([
@@ -1599,7 +1609,8 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'W2N2',
         action: 'reserve',
         status: 'planned',
-        updatedAt: 562
+        updatedAt: 562,
+        followUp
       }
     ]);
   });
@@ -1607,6 +1618,7 @@ describe('planTerritoryIntent', () => {
   it('extends from an actively covered visible reservation before home-adjacent reserve pressure', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const followUp = makeFollowUp('activeReserveAdjacent', 'W1N2', 'reserve');
     const describeExits = jest.fn((roomName: string) =>
       roomName === 'W1N2' ? { '3': 'W2N2' } : { '1': 'W1N2', '3': 'W2N1' }
     );
@@ -1637,7 +1649,7 @@ describe('planTerritoryIntent', () => {
       563
     );
 
-    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N2', action: 'reserve' });
+    expect(plan).toEqual({ colony: 'W1N1', targetRoom: 'W2N2', action: 'reserve', followUp });
     expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(describeExits).toHaveBeenCalledWith('W1N2');
     expect(Memory.territory?.targets).toEqual([
@@ -1654,7 +1666,8 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'W2N2',
         action: 'reserve',
         status: 'planned',
-        updatedAt: 563
+        updatedAt: 563,
+        followUp
       }
     ]);
   });
@@ -1711,6 +1724,7 @@ describe('planTerritoryIntent', () => {
   it('skips hostile and suppressed adjacent reserve targets after a satisfied reservation', () => {
     const colony = makeSafeColony();
     const configuredTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W1N2', action: 'reserve' };
+    const followUp = makeFollowUp('satisfiedReserveAdjacent', 'W1N2', 'reserve');
     const suppressedIntent: TerritoryIntentMemory = {
       colony: 'W1N1',
       targetRoom: 'W2N1',
@@ -1759,7 +1773,8 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W0N1',
-      action: 'reserve'
+      action: 'reserve',
+      followUp
     });
     expect(Memory.territory?.targets).toEqual([
       configuredTarget,
@@ -1776,7 +1791,8 @@ describe('planTerritoryIntent', () => {
         targetRoom: 'W0N1',
         action: 'reserve',
         status: 'planned',
-        updatedAt: 541
+        updatedAt: 541,
+        followUp
       }
     ]);
   });
@@ -2234,7 +2250,40 @@ describe('planTerritoryIntent', () => {
       shouldSpawnTerritoryControllerCreep(plan!, { worker: 3, claimer: 0, claimersByTargetRoom: {} })
     ).toBe(true);
   });
+
+  it('carries follow-up metadata into territory creep memory', () => {
+    const followUp = makeFollowUp('activeReserveAdjacent', 'W1N2', 'reserve');
+
+    expect(
+      buildTerritoryCreepMemory({
+        colony: 'W1N1',
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        followUp
+      })
+    ).toEqual({
+      role: 'claimer',
+      colony: 'W1N1',
+      territory: {
+        targetRoom: 'W2N2',
+        action: 'reserve',
+        followUp
+      }
+    });
+  });
 });
+
+function makeFollowUp(
+  source: TerritoryFollowUpSource,
+  originRoom: string,
+  originAction: TerritoryControlAction
+): TerritoryFollowUpMemory {
+  return {
+    source,
+    originRoom,
+    originAction
+  };
+}
 
 function makeSafeColony({
   roomName = 'W1N1',


### PR DESCRIPTION
## Summary
Fix TypeScript type error in territory follow-up normalization. The normalized follow-up source was being returned directly from an unknown raw memory record, causing TS2322. Store the validated source in a typed local before deriving and returning follow-up metadata.

## Issue
#228 (territory follow-up intent)

## Verification
- [x] `npm run typecheck` passes
- [x] `npm test -- --runInBand` passes
- [x] `npm run build` passes

## Labels
- kind:code
- priority:p1
- roadmap:territory-economy

## Milestone
Phase C or territory-economy

## Project
screeps: Status=In review, Evidence=local typecheck+test+build PASS, Next action=CodeRabbit/Gemini review + merge

