### PR TITLE
feat(telemetry): per-creep behavioral telemetry and structure snapshots (#502)

### DIFF
--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -8,6 +8,14 @@ import {
 import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
 import { canCreepPressureTerritoryController } from '../territory/territoryPlanner';
 import { findSourceContainer } from '../economy/sourceContainers';
+import {
+  observeCreepBehaviorTick,
+  recordCreepBehaviorContainerTransfer,
+  recordCreepBehaviorIdle,
+  recordCreepBehaviorMove,
+  recordCreepBehaviorRepairTarget,
+  recordCreepBehaviorWork
+} from '../telemetry/behaviorTelemetry';
 
 type TransferSinkStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION' | 'STRUCTURE_TOWER';
 type CapacityConstructionStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION';
@@ -16,10 +24,17 @@ const MAX_IMMEDIATE_RESELECT_EXECUTIONS = 1;
 const OK_CODE = 0 as ScreepsReturnCode;
 const MIN_HAULER_DROPPED_ENERGY = 25;
 
+interface TaskExecutionResult {
+  result: ScreepsReturnCode;
+  action?: 'move' | 'work';
+  containerTransfer?: boolean;
+}
+
 export function runWorker(creep: Creep): void {
   if (runControllerSustainMovement(creep)) {
     return;
   }
+  observeCreepBehaviorTick(creep);
 
   const selectedTask = selectWorkerTask(creep);
   const currentTask = creep.memory.task;
@@ -246,22 +261,26 @@ function executeAssignedTask(
 ): void {
   let task: CreepTaskMemory | null | undefined = creep.memory.task;
   if (!task || !canExecuteTask(creep, task)) {
+    recordCreepBehaviorIdle(creep);
     return;
   }
 
   let target = Game.getObjectById(task.targetId);
   if (!target) {
     if (selectedTask && isSameTask(task, selectedTask)) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
 
     task = assignSelectedTask(creep, selectedTask, task);
     if (!task || !canExecuteTask(creep, task)) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
 
     target = Game.getObjectById(task.targetId);
     if (!target) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
   }
@@ -269,17 +288,20 @@ function executeAssignedTask(
   if (shouldReplaceTarget(creep, task, target)) {
     task = assignSelectedTask(creep, selectedTask, task);
     if (!task || !canExecuteTask(creep, task)) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
 
     target = Game.getObjectById(task.targetId);
     if (!target || shouldReplaceTarget(creep, task, target)) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
   }
 
-  const result = executeTask(creep, task, target);
-  if (shouldImmediatelyReselectAfterTaskResult(task, result)) {
+  const execution = executeTask(creep, task, target);
+  recordTaskBehavior(creep, task, execution);
+  if (shouldImmediatelyReselectAfterTaskResult(task, execution.result)) {
     delete creep.memory.task;
     const nextTask = assignNextTask(creep);
     if (
@@ -292,8 +314,9 @@ function executeAssignedTask(
     return;
   }
 
-  if (result === ERR_NOT_IN_RANGE) {
+  if (execution.result === ERR_NOT_IN_RANGE) {
     creep.moveTo(target as RoomObject);
+    recordCreepBehaviorMove(creep);
   }
 }
 
@@ -882,59 +905,61 @@ function executeTask(
   creep: Creep,
   task: CreepTaskMemory,
   target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController | Structure
-): ScreepsReturnCode {
+): TaskExecutionResult {
   switch (task.type) {
     case 'harvest':
       return executeHarvestTask(creep, target as Source);
     case 'pickup':
-      return creep.pickup(target as Resource<ResourceConstant>);
+      return toTaskExecutionResult(creep.pickup(target as Resource<ResourceConstant>), 'work');
     case 'withdraw':
-      return creep.withdraw(target as AnyStoreStructure, RESOURCE_ENERGY);
+      return toTaskExecutionResult(creep.withdraw(target as AnyStoreStructure, RESOURCE_ENERGY), 'work');
     case 'transfer':
-      return creep.transfer(target as AnyStoreStructure, RESOURCE_ENERGY);
+      return toTaskExecutionResult(creep.transfer(target as AnyStoreStructure, RESOURCE_ENERGY), 'work', {
+        containerTransfer: isContainerStructure(target)
+      });
     case 'build':
-      return creep.build(target as ConstructionSite);
+      return toTaskExecutionResult(creep.build(target as ConstructionSite), 'work');
     case 'repair':
-      return creep.repair(target as Structure);
+      return toTaskExecutionResult(creep.repair(target as Structure), 'work');
     case 'claim':
       if (
         typeof creep.attackController === 'function' &&
         canCreepPressureTerritoryController(creep, target as StructureController, creep.memory.colony)
       ) {
-        return creep.attackController(target as StructureController);
+        return toTaskExecutionResult(creep.attackController(target as StructureController), 'work');
       }
 
-      return creep.claimController(target as StructureController);
+      return toTaskExecutionResult(creep.claimController(target as StructureController), 'work');
     case 'reserve':
       if (
         typeof creep.attackController === 'function' &&
         canCreepPressureTerritoryController(creep, target as StructureController, creep.memory.colony)
       ) {
-        return creep.attackController(target as StructureController);
+        return toTaskExecutionResult(creep.attackController(target as StructureController), 'work');
       }
 
-      return creep.reserveController(target as StructureController);
+      return toTaskExecutionResult(creep.reserveController(target as StructureController), 'work');
     case 'upgrade':
       signOccupiedControllerIfNeeded(creep, target as StructureController);
-      return creep.upgradeController(target as StructureController);
+      return toTaskExecutionResult(creep.upgradeController(target as StructureController), 'work');
   }
 }
 
-function executeHarvestTask(creep: Creep, source: Source): ScreepsReturnCode {
+function executeHarvestTask(creep: Creep, source: Source): TaskExecutionResult {
   const sourceContainer = findSourceContainer(creep.room, source);
   if (!sourceContainer) {
-    return creep.harvest(source);
+    return toTaskExecutionResult(creep.harvest(source), 'work');
   }
 
   if (!isInRangeToRoomObject(creep, source, 1)) {
     creep.moveTo(sourceContainer);
-    return OK_CODE;
+    return { result: OK_CODE, action: 'move' };
   }
 
   if (isDepletedHarvestSource(source)) {
     return getUsedTransferEnergy(creep) > 0
       ? transferDedicatedHarvestEnergy(creep, sourceContainer)
-      : OK_CODE;
+      : { result: OK_CODE };
   }
 
   if (getFreeTransferEnergyCapacity(creep) <= 0 && getUsedTransferEnergy(creep) > 0) {
@@ -946,21 +971,65 @@ function executeHarvestTask(creep: Creep, source: Source): ScreepsReturnCode {
     return transferDedicatedHarvestEnergy(creep, sourceContainer);
   }
 
-  return result === ERR_NOT_ENOUGH_RESOURCES ? OK_CODE : result;
+  return toTaskExecutionResult(result === ERR_NOT_ENOUGH_RESOURCES ? OK_CODE : result, 'work');
 }
 
-function transferDedicatedHarvestEnergy(creep: Creep, sourceContainer: StructureContainer): ScreepsReturnCode {
+function transferDedicatedHarvestEnergy(creep: Creep, sourceContainer: StructureContainer): TaskExecutionResult {
   if (typeof creep.transfer !== 'function') {
-    return OK_CODE;
+    return { result: OK_CODE };
   }
 
   const result = creep.transfer(sourceContainer, RESOURCE_ENERGY);
   if (result === ERR_NOT_IN_RANGE) {
     creep.moveTo(sourceContainer);
-    return OK_CODE;
+    return { result: OK_CODE, action: 'move' };
   }
 
-  return result;
+  return toTaskExecutionResult(result, 'work', { containerTransfer: true });
+}
+
+function toTaskExecutionResult(
+  result: ScreepsReturnCode,
+  successAction: 'move' | 'work',
+  options: { containerTransfer?: boolean } = {}
+): TaskExecutionResult {
+  return {
+    result,
+    ...(result === OK_CODE ? { action: successAction } : {}),
+    ...(result === OK_CODE && options.containerTransfer ? { containerTransfer: true } : {})
+  };
+}
+
+function recordTaskBehavior(
+  creep: Creep,
+  task: CreepTaskMemory,
+  execution: TaskExecutionResult
+): void {
+  if (task.type === 'repair') {
+    recordCreepBehaviorRepairTarget(creep, String(task.targetId));
+  }
+
+  if (execution.action === 'move') {
+    recordCreepBehaviorMove(creep);
+  } else if (execution.action === 'work') {
+    recordCreepBehaviorWork(creep);
+  } else if (execution.result !== ERR_NOT_IN_RANGE) {
+    recordCreepBehaviorIdle(creep);
+  }
+
+  if (execution.containerTransfer) {
+    recordCreepBehaviorContainerTransfer(creep);
+  }
+}
+
+function isContainerStructure(target: unknown): boolean {
+  const structureType = (target as { structureType?: unknown } | null)?.structureType;
+  return typeof structureType === 'string' && matchesContainerStructureType(structureType);
+}
+
+function matchesContainerStructureType(actual: string): boolean {
+  const containerType = (globalThis as unknown as { STRUCTURE_CONTAINER?: string }).STRUCTURE_CONTAINER ?? 'container';
+  return actual === containerType;
 }
 
 function isDedicatedSourceContainerHarvestTask(

--- a/prod/src/telemetry/behaviorTelemetry.ts
+++ b/prod/src/telemetry/behaviorTelemetry.ts
@@ -73,13 +73,22 @@ export function recordCreepBehaviorIdle(creep: Creep, tick: number = getGameTime
 
 export function recordCreepBehaviorMove(creep: Creep, tick: number = getGameTime()): void {
   const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastMoveTick === tick) {
+    return;
+  }
+
   telemetry.moveTicks = (telemetry.moveTicks ?? 0) + 1;
   telemetry.lastMoveTick = tick;
 }
 
-export function recordCreepBehaviorWork(creep: Creep): void {
+export function recordCreepBehaviorWork(creep: Creep, tick: number = getGameTime()): void {
   const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastWorkTick === tick) {
+    return;
+  }
+
   telemetry.workTicks = (telemetry.workTicks ?? 0) + 1;
+  telemetry.lastWorkTick = tick;
 }
 
 export function recordCreepBehaviorRepairTarget(creep: Creep, targetId: string): void {
@@ -159,6 +168,7 @@ function resetCreepBehaviorCounters(creep: Creep): void {
   }
   delete telemetry.repairTargetId;
   delete telemetry.lastIdleTick;
+  delete telemetry.lastWorkTick;
 
   if (!telemetry.lastPosition && telemetry.lastMoveTick === undefined && telemetry.lastObservedTick === undefined) {
     delete creep.memory.behaviorTelemetry;

--- a/prod/src/telemetry/behaviorTelemetry.ts
+++ b/prod/src/telemetry/behaviorTelemetry.ts
@@ -1,0 +1,229 @@
+export interface RuntimeCreepBehaviorSummary {
+  creepName?: string;
+  idleTicks: number;
+  moveTicks: number;
+  workTicks: number;
+  stuckTicks: number;
+  containerTransfers: number;
+  pathLength: number;
+  repairTargetId?: string;
+}
+
+export interface RuntimeBehaviorSummary {
+  creeps: RuntimeCreepBehaviorSummary[];
+  totals: RuntimeBehaviorTotals;
+}
+
+interface RuntimeBehaviorTotals {
+  idleTicks: number;
+  moveTicks: number;
+  workTicks: number;
+  stuckTicks: number;
+  containerTransfers: number;
+  pathLength: number;
+}
+
+interface CreepBehaviorCounterKey {
+  key: keyof Pick<
+    CreepBehaviorTelemetryMemory,
+    'idleTicks' | 'moveTicks' | 'workTicks' | 'stuckTicks' | 'containerTransfers' | 'pathLength'
+  >;
+}
+
+const BEHAVIOR_COUNTER_KEYS: CreepBehaviorCounterKey[] = [
+  { key: 'idleTicks' },
+  { key: 'moveTicks' },
+  { key: 'workTicks' },
+  { key: 'stuckTicks' },
+  { key: 'containerTransfers' },
+  { key: 'pathLength' }
+];
+
+export function observeCreepBehaviorTick(creep: Creep, tick: number = getGameTime()): void {
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastObservedTick === tick) {
+    return;
+  }
+
+  const currentPosition = getCreepPositionMemory(creep);
+  if (currentPosition && telemetry.lastPosition && telemetry.lastMoveTick === tick - 1) {
+    const stepDistance = getStepDistance(telemetry.lastPosition, currentPosition);
+    if (stepDistance > 0) {
+      telemetry.pathLength = (telemetry.pathLength ?? 0) + stepDistance;
+    } else {
+      telemetry.stuckTicks = (telemetry.stuckTicks ?? 0) + 1;
+    }
+  }
+
+  if (currentPosition) {
+    telemetry.lastPosition = currentPosition;
+  }
+  telemetry.lastObservedTick = tick;
+}
+
+export function recordCreepBehaviorIdle(creep: Creep, tick: number = getGameTime()): void {
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastIdleTick === tick) {
+    return;
+  }
+
+  telemetry.idleTicks = (telemetry.idleTicks ?? 0) + 1;
+  telemetry.lastIdleTick = tick;
+}
+
+export function recordCreepBehaviorMove(creep: Creep, tick: number = getGameTime()): void {
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  telemetry.moveTicks = (telemetry.moveTicks ?? 0) + 1;
+  telemetry.lastMoveTick = tick;
+}
+
+export function recordCreepBehaviorWork(creep: Creep): void {
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  telemetry.workTicks = (telemetry.workTicks ?? 0) + 1;
+}
+
+export function recordCreepBehaviorRepairTarget(creep: Creep, targetId: string): void {
+  ensureCreepBehaviorTelemetry(creep).repairTargetId = targetId;
+}
+
+export function recordCreepBehaviorContainerTransfer(creep: Creep): void {
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  telemetry.containerTransfers = (telemetry.containerTransfers ?? 0) + 1;
+}
+
+export function summarizeAndResetCreepBehaviorTelemetry(workers: Creep[]): { behavior?: RuntimeBehaviorSummary } {
+  const creepSummaries = workers
+    .map(toRuntimeCreepBehaviorSummary)
+    .filter((summary): summary is RuntimeCreepBehaviorSummary => summary !== null)
+    .sort(compareRuntimeCreepBehaviorSummaries);
+
+  if (creepSummaries.length === 0) {
+    return {};
+  }
+
+  for (const worker of workers) {
+    resetCreepBehaviorCounters(worker);
+  }
+
+  return {
+    behavior: {
+      creeps: creepSummaries,
+      totals: summarizeBehaviorTotals(creepSummaries)
+    }
+  };
+}
+
+function ensureCreepBehaviorTelemetry(creep: Creep): CreepBehaviorTelemetryMemory {
+  if (!creep.memory.behaviorTelemetry) {
+    creep.memory.behaviorTelemetry = {};
+  }
+
+  return creep.memory.behaviorTelemetry;
+}
+
+function toRuntimeCreepBehaviorSummary(creep: Creep): RuntimeCreepBehaviorSummary | null {
+  const telemetry = creep.memory.behaviorTelemetry;
+  if (!telemetry || !hasReportableBehaviorTelemetry(telemetry)) {
+    return null;
+  }
+
+  return {
+    ...buildCreepNameSummary(creep),
+    idleTicks: getNonNegativeCounter(telemetry.idleTicks),
+    moveTicks: getNonNegativeCounter(telemetry.moveTicks),
+    workTicks: getNonNegativeCounter(telemetry.workTicks),
+    stuckTicks: getNonNegativeCounter(telemetry.stuckTicks),
+    containerTransfers: getNonNegativeCounter(telemetry.containerTransfers),
+    pathLength: getNonNegativeCounter(telemetry.pathLength),
+    ...(typeof telemetry.repairTargetId === 'string' && telemetry.repairTargetId.length > 0
+      ? { repairTargetId: telemetry.repairTargetId }
+      : {})
+  };
+}
+
+function hasReportableBehaviorTelemetry(telemetry: CreepBehaviorTelemetryMemory): boolean {
+  return (
+    BEHAVIOR_COUNTER_KEYS.some(({ key }) => getNonNegativeCounter(telemetry[key]) > 0) ||
+    (typeof telemetry.repairTargetId === 'string' && telemetry.repairTargetId.length > 0)
+  );
+}
+
+function resetCreepBehaviorCounters(creep: Creep): void {
+  const telemetry = creep.memory.behaviorTelemetry;
+  if (!telemetry) {
+    return;
+  }
+
+  for (const { key } of BEHAVIOR_COUNTER_KEYS) {
+    delete telemetry[key];
+  }
+  delete telemetry.repairTargetId;
+  delete telemetry.lastIdleTick;
+
+  if (!telemetry.lastPosition && telemetry.lastMoveTick === undefined && telemetry.lastObservedTick === undefined) {
+    delete creep.memory.behaviorTelemetry;
+  }
+}
+
+function summarizeBehaviorTotals(creeps: RuntimeCreepBehaviorSummary[]): RuntimeBehaviorTotals {
+  return creeps.reduce<RuntimeBehaviorTotals>(
+    (totals, creep) => ({
+      idleTicks: totals.idleTicks + creep.idleTicks,
+      moveTicks: totals.moveTicks + creep.moveTicks,
+      workTicks: totals.workTicks + creep.workTicks,
+      stuckTicks: totals.stuckTicks + creep.stuckTicks,
+      containerTransfers: totals.containerTransfers + creep.containerTransfers,
+      pathLength: totals.pathLength + creep.pathLength
+    }),
+    {
+      idleTicks: 0,
+      moveTicks: 0,
+      workTicks: 0,
+      stuckTicks: 0,
+      containerTransfers: 0,
+      pathLength: 0
+    }
+  );
+}
+
+function compareRuntimeCreepBehaviorSummaries(
+  left: RuntimeCreepBehaviorSummary,
+  right: RuntimeCreepBehaviorSummary
+): number {
+  return (left.creepName ?? '').localeCompare(right.creepName ?? '');
+}
+
+function buildCreepNameSummary(creep: Creep): { creepName?: string } {
+  const name = (creep as Creep & { name?: unknown }).name;
+  return typeof name === 'string' && name.length > 0 ? { creepName: name } : {};
+}
+
+function getNonNegativeCounter(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function getCreepPositionMemory(creep: Creep): CreepBehaviorPositionMemory | null {
+  const pos = (creep as Creep & { pos?: Partial<RoomPosition> }).pos;
+  if (!pos || typeof pos.x !== 'number' || typeof pos.y !== 'number' || typeof pos.roomName !== 'string') {
+    return null;
+  }
+
+  return {
+    x: pos.x,
+    y: pos.y,
+    roomName: pos.roomName
+  };
+}
+
+function getStepDistance(previous: CreepBehaviorPositionMemory, current: CreepBehaviorPositionMemory): number {
+  if (previous.roomName !== current.roomName) {
+    return 1;
+  }
+
+  return Math.max(Math.abs(current.x - previous.x), Math.abs(current.y - previous.y));
+}
+
+function getGameTime(): number {
+  const game = (globalThis as unknown as { Game?: Partial<Game> }).Game;
+  return typeof game?.time === 'number' ? game.time : 0;
+}

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -22,6 +22,10 @@ import {
   type TerritoryIntentProgressSummary
 } from '../territory/territoryPlanner';
 import { getPostClaimBootstrapSummary, type PostClaimBootstrapSummary } from '../territory/postClaimBootstrap';
+import {
+  summarizeAndResetCreepBehaviorTelemetry,
+  type RuntimeBehaviorSummary
+} from './behaviorTelemetry';
 
 export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
@@ -125,6 +129,8 @@ interface RuntimeRoomSummary {
   workerCount: number;
   spawnStatus: RuntimeSpawnStatus[];
   taskCounts: WorkerTaskCounts;
+  behavior?: RuntimeBehaviorSummary;
+  structures?: RuntimeStructureSnapshotSummary;
   workerEfficiency?: RuntimeWorkerEfficiencySummary;
   refillDeliveryTicks?: RuntimeRefillDeliveryTicksSummary;
   refillWorkerUtilization?: RuntimeRefillWorkerUtilizationSummary;
@@ -148,6 +154,30 @@ interface RuntimeControllerSummary {
   progress?: number;
   progressTotal?: number;
   ticksToDowngrade?: number;
+}
+
+interface RuntimeStructureSnapshotSummary {
+  towerCount: number;
+  rampartCount: number;
+  containers: RuntimeContainerSnapshotSummary[];
+  repairTargets: RuntimeRepairTargetSnapshotSummary[];
+  roadCount: number;
+  pendingRoadSiteCount: number;
+  roadCoverageRatio: number;
+}
+
+interface RuntimeContainerSnapshotSummary {
+  id: string;
+  energy: number;
+  capacity: number;
+}
+
+interface RuntimeRepairTargetSnapshotSummary {
+  targetId: string;
+  repairCount: number;
+  structureType?: string;
+  hits?: number;
+  hitsMax?: number;
 }
 
 interface RuntimeResourceEventSummary {
@@ -372,7 +402,8 @@ export function emitRuntimeSummary(
         colony,
         creepsByColony.get(colony.room.name) ?? [],
         persistOccupationRecommendations,
-        eventMetricsByRoom.get(colony.room.name) ?? {}
+        eventMetricsByRoom.get(colony.room.name) ?? {},
+        shouldBuildStructureSnapshot(tick)
       )
     ),
     ...(reportedEvents.length > 0 ? { events: reportedEvents } : {}),
@@ -442,7 +473,8 @@ function summarizeRoom(
   colony: ColonySnapshot,
   colonyCreeps: Creep[],
   persistOccupationRecommendations: boolean,
-  eventMetrics: RuntimeRoomEventMetrics
+  eventMetrics: RuntimeRoomEventMetrics,
+  includeStructureSnapshot: boolean
 ): RuntimeRoomSummary {
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === 'worker');
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
@@ -459,6 +491,8 @@ function summarizeRoom(
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
+    ...summarizeAndResetCreepBehaviorTelemetry(colonyWorkers),
+    ...(includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {}),
     ...summarizeWorkerEfficiency(colonyWorkers, getGameTime()),
     ...summarizeRefillTelemetry(colonyWorkers, getGameTime()),
     ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime()),
@@ -554,6 +588,128 @@ function countWorkerTasks(workers: Creep[]): WorkerTaskCounts {
 
 function isWorkerTaskType(taskType: string | undefined): taskType is WorkerTaskType {
   return WORKER_TASK_TYPES.includes(taskType as WorkerTaskType);
+}
+
+function shouldBuildStructureSnapshot(tick: number): boolean {
+  return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
+}
+
+function summarizeStructures(colony: ColonySnapshot, colonyWorkers: Creep[]): RuntimeStructureSnapshotSummary {
+  const roomStructures = findRoomObjects(colony.room, 'FIND_STRUCTURES') ?? colony.spawns;
+  const constructionSites = findRoomObjects(colony.room, 'FIND_MY_CONSTRUCTION_SITES') ?? [];
+  const roadCount = countStructuresByType(roomStructures, 'STRUCTURE_ROAD', 'road');
+  const pendingRoadSiteCount = countConstructionSitesByType(constructionSites, 'STRUCTURE_ROAD', 'road');
+
+  return {
+    towerCount: countStructuresByType(roomStructures, 'STRUCTURE_TOWER', 'tower'),
+    rampartCount: countOwnedRamparts(roomStructures),
+    containers: summarizeContainers(roomStructures),
+    repairTargets: summarizeRepairTargetDistribution(colonyWorkers, roomStructures),
+    roadCount,
+    pendingRoadSiteCount,
+    roadCoverageRatio: calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount)
+  };
+}
+
+function countStructuresByType(
+  structures: unknown[],
+  globalName: StructureConstantGlobal,
+  fallback: string
+): number {
+  return structures.filter((structure) => isStructureOfType(structure, globalName, fallback)).length;
+}
+
+function countConstructionSitesByType(
+  constructionSites: unknown[],
+  globalName: StructureConstantGlobal,
+  fallback: string
+): number {
+  return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
+}
+
+function countOwnedRamparts(structures: unknown[]): number {
+  return structures.filter((structure) => isRecord(structure) && isObservedOwnedRampart(structure)).length;
+}
+
+function summarizeContainers(structures: unknown[]): RuntimeContainerSnapshotSummary[] {
+  return structures
+    .filter((structure) => isStructureOfType(structure, 'STRUCTURE_CONTAINER', 'container'))
+    .map(toRuntimeContainerSnapshot)
+    .filter((summary): summary is RuntimeContainerSnapshotSummary => summary !== null)
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function toRuntimeContainerSnapshot(structure: unknown): RuntimeContainerSnapshotSummary | null {
+  const id = getObjectId(structure);
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id,
+    energy: getEnergyInStore(structure),
+    capacity: getEnergyCapacityInStore(structure)
+  };
+}
+
+function summarizeRepairTargetDistribution(
+  colonyWorkers: Creep[],
+  roomStructures: unknown[]
+): RuntimeRepairTargetSnapshotSummary[] {
+  const repairCounts = new Map<string, number>();
+  for (const worker of colonyWorkers) {
+    const task = worker.memory.task;
+    if (task?.type !== 'repair') {
+      continue;
+    }
+
+    const targetId = String(task.targetId);
+    repairCounts.set(targetId, (repairCounts.get(targetId) ?? 0) + 1);
+  }
+
+  const structuresById = new Map<string, unknown>();
+  for (const structure of roomStructures) {
+    const id = getObjectId(structure);
+    if (id) {
+      structuresById.set(id, structure);
+    }
+  }
+
+  return [...repairCounts.entries()]
+    .sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId))
+    .map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
+}
+
+function toRuntimeRepairTargetSnapshot(
+  targetId: string,
+  repairCount: number,
+  structure: unknown
+): RuntimeRepairTargetSnapshotSummary {
+  const structureRecord = isRecord(structure) ? structure : {};
+  const structureType = typeof structureRecord.structureType === 'string' ? structureRecord.structureType : undefined;
+  const hits = getFiniteNumber(structureRecord.hits);
+  const hitsMax = getFiniteNumber(structureRecord.hitsMax);
+
+  return {
+    targetId,
+    repairCount,
+    ...(structureType ? { structureType } : {}),
+    ...(hits !== null ? { hits } : {}),
+    ...(hitsMax !== null ? { hitsMax } : {})
+  };
+}
+
+function isStructureOfType(structure: unknown, globalName: StructureConstantGlobal, fallback: string): boolean {
+  return isRecord(structure) && matchesStructureType(structure.structureType, globalName, fallback);
+}
+
+function calculateRoadCoverageRatio(roadCount: number, pendingRoadSiteCount: number): number {
+  const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
+  if (totalKnownRoadWork <= 0) {
+    return 0;
+  }
+
+  return roundRatio(roadCount, totalKnownRoadWork);
 }
 
 function summarizeWorkerEfficiency(
@@ -1524,6 +1680,29 @@ function getEnergyInStore(object: unknown): number {
   return typeof storedEnergy === 'number' ? storedEnergy : 0;
 }
 
+function getEnergyCapacityInStore(object: unknown): number {
+  if (!isRecord(object) || !isRecord(object.store)) {
+    return 0;
+  }
+
+  const getCapacity = object.store.getCapacity;
+  if (typeof getCapacity === 'function') {
+    const capacity = getCapacity.call(object.store, getEnergyResource());
+    return typeof capacity === 'number' && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
+  }
+
+  const getFreeCapacity = object.store.getFreeCapacity;
+  if (typeof getFreeCapacity === 'function') {
+    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource());
+    if (typeof freeCapacity === 'number' && Number.isFinite(freeCapacity)) {
+      return Math.max(0, getEnergyInStore(object) + freeCapacity);
+    }
+  }
+
+  const capacity = object.store.capacity;
+  return typeof capacity === 'number' && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
+}
+
 function sumDroppedEnergy(droppedResources: unknown[]): number {
   const energyResource = getEnergyResource();
 
@@ -1554,6 +1733,7 @@ type StructureConstantGlobal =
   | 'STRUCTURE_ROAD'
   | 'STRUCTURE_CONTAINER'
   | 'STRUCTURE_RAMPART'
+  | 'STRUCTURE_TOWER'
   | 'STRUCTURE_SPAWN'
   | 'STRUCTURE_EXTENSION';
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -22,6 +22,7 @@ declare global {
     workerEfficiency?: WorkerEfficiencySampleMemory;
     refillTelemetry?: WorkerRefillTelemetryMemory;
     spawnCriticalRefill?: WorkerSpawnCriticalRefillMemory;
+    behaviorTelemetry?: CreepBehaviorTelemetryMemory;
   }
 
   type DefenseActionType =
@@ -307,6 +308,26 @@ declare global {
     spawnEnergy: number;
     freeCapacity: number;
     threshold: number;
+  }
+
+  interface CreepBehaviorPositionMemory {
+    x: number;
+    y: number;
+    roomName: string;
+  }
+
+  interface CreepBehaviorTelemetryMemory {
+    idleTicks?: number;
+    moveTicks?: number;
+    workTicks?: number;
+    stuckTicks?: number;
+    repairTargetId?: string;
+    containerTransfers?: number;
+    pathLength?: number;
+    lastPosition?: CreepBehaviorPositionMemory;
+    lastMoveTick?: number;
+    lastObservedTick?: number;
+    lastIdleTick?: number;
   }
 
   type CreepTaskMemory =

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -326,6 +326,7 @@ declare global {
     pathLength?: number;
     lastPosition?: CreepBehaviorPositionMemory;
     lastMoveTick?: number;
+    lastWorkTick?: number;
     lastObservedTick?: number;
     lastIdleTick?: number;
   }

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -89,6 +89,15 @@ describe('runtime telemetry summaries', () => {
             repair: 0,
             upgrade: 0
           },
+          structures: {
+            towerCount: 0,
+            rampartCount: 0,
+            containers: [],
+            repairTargets: [],
+            roadCount: 0,
+            pendingRoadSiteCount: 0,
+            roadCoverageRatio: 0
+          },
           controller: {
             level: 2,
             progress: 1234,
@@ -198,6 +207,147 @@ describe('runtime telemetry summaries', () => {
     emitRuntimeSummary([colony], []);
 
     expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports per-creep behavior counters and resets emitted counters', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const worker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'repair', targetId: 'road-damaged' as Id<Structure> },
+        behaviorTelemetry: {
+          idleTicks: 1,
+          moveTicks: 3,
+          workTicks: 2,
+          stuckTicks: 1,
+          containerTransfers: 1,
+          pathLength: 2,
+          repairTargetId: 'road-damaged',
+          lastPosition: { x: 10, y: 12, roomName: 'W1N1' },
+          lastMoveTick: RUNTIME_SUMMARY_INTERVAL,
+          lastObservedTick: RUNTIME_SUMMARY_INTERVAL
+        }
+      },
+      20,
+      'RepairWorker'
+    );
+
+    emitRuntimeSummary([colony], [worker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.behavior).toEqual({
+      creeps: [
+        {
+          creepName: 'RepairWorker',
+          idleTicks: 1,
+          moveTicks: 3,
+          workTicks: 2,
+          stuckTicks: 1,
+          containerTransfers: 1,
+          pathLength: 2,
+          repairTargetId: 'road-damaged'
+        }
+      ],
+      totals: {
+        idleTicks: 1,
+        moveTicks: 3,
+        workTicks: 2,
+        stuckTicks: 1,
+        containerTransfers: 1,
+        pathLength: 2
+      }
+    });
+    expect(worker.memory.behaviorTelemetry).toEqual({
+      lastPosition: { x: 10, y: 12, roomName: 'W1N1' },
+      lastMoveTick: RUNTIME_SUMMARY_INTERVAL,
+      lastObservedTick: RUNTIME_SUMMARY_INTERVAL
+    });
+  });
+
+  it('reports cadence structure snapshots with defenses, containers, repairs, and road coverage', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false,
+      structures: [
+        { id: 'tower1', structureType: TEST_GLOBALS.STRUCTURE_TOWER },
+        { id: 'rampart1', structureType: TEST_GLOBALS.STRUCTURE_RAMPART, my: true },
+        { id: 'enemy-rampart', structureType: TEST_GLOBALS.STRUCTURE_RAMPART, my: false },
+        { id: 'container-b', structureType: TEST_GLOBALS.STRUCTURE_CONTAINER, store: makeEnergyStore(400, 2000) },
+        { id: 'container-a', structureType: TEST_GLOBALS.STRUCTURE_CONTAINER, store: makeEnergyStore(50, 2000) },
+        { id: 'road-damaged', structureType: TEST_GLOBALS.STRUCTURE_ROAD, hits: 1000, hitsMax: 5000 },
+        { id: 'road-full', structureType: TEST_GLOBALS.STRUCTURE_ROAD, hits: 5000, hitsMax: 5000 }
+      ],
+      constructionSites: [
+        { id: 'road-site', structureType: TEST_GLOBALS.STRUCTURE_ROAD },
+        { id: 'extension-site', structureType: TEST_GLOBALS.STRUCTURE_EXTENSION }
+      ]
+    });
+    const workers = [
+      makeWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'repair', targetId: 'road-damaged' as Id<Structure> } },
+        10,
+        'RepairerA'
+      ),
+      makeWorker(
+        { role: 'worker', colony: 'W1N1', task: { type: 'repair', targetId: 'road-damaged' as Id<Structure> } },
+        10,
+        'RepairerB'
+      )
+    ];
+
+    emitRuntimeSummary([colony], workers, [], { persistOccupationRecommendations: false });
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.structures).toEqual({
+      towerCount: 1,
+      rampartCount: 1,
+      containers: [
+        { id: 'container-a', energy: 50, capacity: 2000 },
+        { id: 'container-b', energy: 400, capacity: 2000 }
+      ],
+      repairTargets: [
+        {
+          targetId: 'road-damaged',
+          repairCount: 2,
+          structureType: TEST_GLOBALS.STRUCTURE_ROAD,
+          hits: 1000,
+          hitsMax: 5000
+        }
+      ],
+      roadCount: 2,
+      pendingRoadSiteCount: 1,
+      roadCoverageRatio: 0.667
+    });
+  });
+
+  it('omits structure snapshots from event-only non-cadence summaries', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL + 1,
+      structures: [{ id: 'tower1', structureType: TEST_GLOBALS.STRUCTURE_TOWER }]
+    });
+
+    emitRuntimeSummary(
+      [colony],
+      [],
+      [
+        {
+          type: 'spawn',
+          roomName: 'W1N1',
+          spawnName: 'Spawn1',
+          creepName: 'worker-W1N1-event',
+          role: 'worker',
+          result: 0 as ScreepsReturnCode
+        }
+      ],
+      { persistOccupationRecommendations: false }
+    );
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.structures).toBeUndefined();
   });
 
   it('refreshes refill telemetry on non-cadence ticks from cached room data without rescanning', () => {
@@ -1109,8 +1259,18 @@ function makeRemoteRoom(
   } as unknown as Room;
 }
 
-function makeEnergyStore(energy: number): { getUsedCapacity: (resource?: ResourceConstant) => number } {
+function makeEnergyStore(
+  energy: number,
+  capacity = energy
+): {
+  getUsedCapacity: (resource?: ResourceConstant) => number;
+  getCapacity: (resource?: ResourceConstant) => number;
+  getFreeCapacity: (resource?: ResourceConstant) => number;
+} {
   return {
-    getUsedCapacity: (resource?: ResourceConstant) => (resource === TEST_GLOBALS.RESOURCE_ENERGY ? energy : 0)
+    getUsedCapacity: (resource?: ResourceConstant) => (resource === TEST_GLOBALS.RESOURCE_ENERGY ? energy : 0),
+    getCapacity: (resource?: ResourceConstant) => (resource === TEST_GLOBALS.RESOURCE_ENERGY ? capacity : 0),
+    getFreeCapacity: (resource?: ResourceConstant) =>
+      resource === TEST_GLOBALS.RESOURCE_ENERGY ? Math.max(0, capacity - energy) : 0
   };
 }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -246,6 +246,49 @@ describe('runWorker', () => {
     expect(creep.moveTo).toHaveBeenCalledWith(source);
   });
 
+  it('records worker behavior telemetry while moving and working across ticks', () => {
+    const source = { id: 'source1' } as Source;
+    const creep = {
+      name: 'Worker1',
+      memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+      pos: { x: 10, y: 10, roomName: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { find: jest.fn().mockReturnValue([source]) },
+      harvest: jest.fn().mockReturnValueOnce(ERR_NOT_IN_RANGE).mockReturnValueOnce(ERR_NOT_IN_RANGE).mockReturnValueOnce(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 10,
+      getObjectById: jest.fn().mockReturnValue(source)
+    };
+
+    runWorker(creep);
+
+    (Game as Partial<Game>).time = 11;
+    runWorker(creep);
+
+    (creep as unknown as { pos: { x: number; y: number; roomName: string } }).pos = {
+      x: 11,
+      y: 10,
+      roomName: 'W1N1'
+    };
+    (Game as Partial<Game>).time = 12;
+    runWorker(creep);
+
+    expect(creep.memory.behaviorTelemetry).toMatchObject({
+      moveTicks: 2,
+      workTicks: 1,
+      stuckTicks: 1,
+      pathLength: 1,
+      lastPosition: { x: 11, y: 10, roomName: 'W1N1' },
+      lastMoveTick: 11,
+      lastObservedTick: 12
+    });
+  });
+
   it('switches a full source-container harvester to controller work', () => {
     const source = {
       id: 'source1',


### PR DESCRIPTION
## Summary

Implements per-creep behavioral telemetry and structure snapshots for gameplay deep review (closes #502).

## Changes

- **New behaviorTelemetry.ts module**: Tracks per-creep idle/move/work/stuck ticks, repair targets, container transfers, and path length across ticks.
- **workerRunner.ts**: Injects behavior recording into task execution loop; refactors executeTask to return TaskExecutionResult.
- **runtimeSummary.ts**: Emits behavior block and structures block on cadence ticks.
- **types.d.ts**: Adds CreepBehaviorTelemetryMemory interface.
- **Tests**: New behavioral telemetry tests.

All tests pass; typecheck, Jest in-band, and build verified in worktree.