### PR TITLE
feat(territory): multi-room controller upgrade sustain from energy surplus (#522)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10406,7 +10406,17 @@ var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
 var DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
 var ERR_NO_PATH_CODE4 = -2;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR3 = ">";
-var TERRITORY_ROUTE_DISTANCE_MEMORY_TTL_TICK_KEY = "routeDistancesUpdatedAt";
+function recordPlannedMultiRoomUpgraderSpawn(memory) {
+  var _a, _b;
+  const sustain = memory.controllerSustain;
+  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString8(sustain.homeRoom) || !isNonEmptyString8(sustain.targetRoom)) {
+    return;
+  }
+  const cache = getActiveMultiRoomUpgraderCountCache();
+  const pendingByHome = (_a = cache.plannedByHomeRoom[sustain.homeRoom]) != null ? _a : {};
+  pendingByHome[sustain.targetRoom] = ((_b = pendingByHome[sustain.targetRoom]) != null ? _b : 0) + 1;
+  cache.plannedByHomeRoom[sustain.homeRoom] = pendingByHome;
+}
 function selectMultiRoomUpgradePlans(colony, options = {}) {
   const config = normalizeMultiRoomUpgraderOptions(options);
   if (config.perRoomUpgraderCap <= 0 || !hasPrimaryRoomStorageSurplus(colony, config.storageEnergyThresholdRatio)) {
@@ -10449,7 +10459,7 @@ function buildMultiRoomUpgraderBody(energyAvailable, plan) {
 function buildMultiRoomUpgraderMemory(plan) {
   return {
     role: "worker",
-    colony: plan.targetRoom,
+    colony: plan.homeRoom,
     territory: {
       targetRoom: plan.targetRoom,
       action: plan.controllerState === "reserved" ? "reserve" : "claim",
@@ -10502,11 +10512,11 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, perR
   if (!controllerState) {
     return null;
   }
-  const routeDistance = getRouteDistance(homeRoom, room.name);
-  if (routeDistance === null) {
+  if (hasVisibleHostiles(room)) {
     return null;
   }
-  if (hasVisibleHostiles(room)) {
+  const routeDistance = getRouteDistance(homeRoom, room.name);
+  if (routeDistance === null) {
     return null;
   }
   const activeUpgraderCount = (_a = activeUpgraderCounts[room.name]) != null ? _a : 0;
@@ -10592,19 +10602,10 @@ function compareOptionalNumbers3(left, right) {
 var activeMultiRoomUpgraderCountCache = null;
 function getActiveMultiRoomUpgraderCountsByTarget(homeRoom) {
   var _a, _b;
-  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  if (!creeps) {
-    return {};
-  }
-  const gameTime = getGameTime7();
-  if ((activeMultiRoomUpgraderCountCache == null ? void 0 : activeMultiRoomUpgraderCountCache.gameTime) !== gameTime || activeMultiRoomUpgraderCountCache.creeps !== creeps) {
-    activeMultiRoomUpgraderCountCache = {
-      gameTime,
-      creeps,
-      countsByHomeRoom: countActiveMultiRoomUpgradersByHomeRoom(creeps)
-    };
-  }
-  return (_b = activeMultiRoomUpgraderCountCache.countsByHomeRoom[homeRoom]) != null ? _b : {};
+  const cache = getActiveMultiRoomUpgraderCountCache();
+  const activeByTarget = (_a = cache.countsByHomeRoom[homeRoom]) != null ? _a : {};
+  const plannedByTarget = (_b = cache.plannedByHomeRoom[homeRoom]) != null ? _b : {};
+  return combineCountMaps(activeByTarget, plannedByTarget);
 }
 function countActiveMultiRoomUpgradersByHomeRoom(creeps) {
   var _a, _b, _c;
@@ -10619,6 +10620,28 @@ function countActiveMultiRoomUpgradersByHomeRoom(creeps) {
     countsByHomeRoom[sustain.homeRoom] = countsByTarget;
   }
   return countsByHomeRoom;
+}
+function combineCountMaps(baseCounts, overlayCounts) {
+  var _a;
+  const combined = { ...baseCounts };
+  for (const [targetRoom, plannedCount] of Object.entries(overlayCounts)) {
+    combined[targetRoom] = ((_a = combined[targetRoom]) != null ? _a : 0) + plannedCount;
+  }
+  return combined;
+}
+function getActiveMultiRoomUpgraderCountCache() {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  const gameTime = getGameTime7();
+  if ((activeMultiRoomUpgraderCountCache == null ? void 0 : activeMultiRoomUpgraderCountCache.gameTime) !== gameTime || activeMultiRoomUpgraderCountCache.creeps !== creeps) {
+    activeMultiRoomUpgraderCountCache = {
+      gameTime,
+      creeps,
+      countsByHomeRoom: creeps ? countActiveMultiRoomUpgradersByHomeRoom(creeps) : {},
+      plannedByHomeRoom: {}
+    };
+  }
+  return activeMultiRoomUpgraderCountCache;
 }
 function isActiveMultiRoomUpgrader(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
@@ -10675,12 +10698,6 @@ function getTerritoryRouteDistanceCache2() {
   }
   if (!isRecord8(memory.territory)) {
     memory.territory = {};
-  }
-  const gameTime = getGameTime7();
-  const territoryMemory = memory.territory;
-  if (territoryMemory[TERRITORY_ROUTE_DISTANCE_MEMORY_TTL_TICK_KEY] !== gameTime) {
-    territoryMemory[TERRITORY_ROUTE_DISTANCE_MEMORY_TTL_TICK_KEY] = gameTime;
-    territoryMemory.routeDistances = {};
   }
   if (!isRecord8(memory.territory.routeDistances)) {
     memory.territory.routeDistances = {};
@@ -14205,6 +14222,7 @@ function runEconomy(preludeTelemetryEvents = []) {
       usedSpawns.add(outcome.spawn);
       availableEnergy = Math.max(0, availableEnergy - getBodyCost(spawnRequest.body));
       successfulSpawnCount += 1;
+      recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
       if (spawnRequest.memory.role !== "worker") {
         break;
       }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10372,17 +10372,16 @@ var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
 var DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
 var ERR_NO_PATH_CODE4 = -2;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR3 = ">";
-function selectMultiRoomUpgradePlan(colony, options = {}) {
+function selectMultiRoomUpgradePlans(colony, options = {}) {
   const config = normalizeMultiRoomUpgraderOptions(options);
   if (config.perRoomUpgraderCap <= 0 || !hasPrimaryRoomStorageSurplus(colony, config.storageEnergyThresholdRatio)) {
-    return null;
+    return [];
   }
   const candidates = getVisibleMultiRoomUpgradeCandidates(colony, config);
   if (candidates.length === 0) {
-    return null;
+    return [];
   }
-  const { order: _order, ...plan } = candidates.sort(compareMultiRoomUpgradeCandidates)[0];
-  return plan;
+  return candidates.sort(compareMultiRoomUpgradeCandidates).map(({ order: _order, ...plan }) => plan);
 }
 function buildMultiRoomUpgraderBody(energyAvailable, plan) {
   const baseBody = plan.controllerState === "reserved" ? RESERVED_CONTROLLER_BASE_BODY : [];
@@ -10436,6 +10435,7 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
   }
   const homeRoom = colony.room.name;
   const ownerUsername = getControllerOwnerUsername3(colony.room.controller);
+  const activeUpgraderCounts = getActiveMultiRoomUpgraderCountsByTarget(homeRoom);
   const candidates = [];
   let order = 0;
   for (const room of Object.values(rooms)) {
@@ -10444,6 +10444,7 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
       ownerUsername,
       room,
       config.perRoomUpgraderCap,
+      activeUpgraderCounts,
       order
     );
     order += 1;
@@ -10453,7 +10454,8 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
   }
   return candidates;
 }
-function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, perRoomUpgraderCap, order) {
+function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, perRoomUpgraderCap, activeUpgraderCounts, order) {
+  var _a;
   if (!isNonEmptyString8(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
     return null;
   }
@@ -10465,11 +10467,14 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, perR
   if (!controllerState) {
     return null;
   }
+  if (hasVisibleHostiles(room)) {
+    return null;
+  }
   const routeDistance = getRouteDistance(homeRoom, room.name);
   if (routeDistance === null) {
     return null;
   }
-  const activeUpgraderCount = countActiveMultiRoomUpgraders(homeRoom, room.name);
+  const activeUpgraderCount = (_a = activeUpgraderCounts[room.name]) != null ? _a : 0;
   if (activeUpgraderCount >= perRoomUpgraderCap) {
     return null;
   }
@@ -10549,18 +10554,39 @@ function compareMultiRoomUpgradeCandidates(left, right) {
 function compareOptionalNumbers3(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
-function countActiveMultiRoomUpgraders(homeRoom, targetRoom) {
-  var _a;
+var activeMultiRoomUpgraderCountCache = null;
+function getActiveMultiRoomUpgraderCountsByTarget(homeRoom) {
+  var _a, _b;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
   if (!creeps) {
-    return 0;
+    return {};
   }
-  return Object.values(creeps).filter((creep) => isActiveMultiRoomUpgrader(creep, homeRoom, targetRoom)).length;
+  const gameTime = getGameTime7();
+  if ((activeMultiRoomUpgraderCountCache == null ? void 0 : activeMultiRoomUpgraderCountCache.gameTime) !== gameTime || activeMultiRoomUpgraderCountCache.creeps !== creeps) {
+    activeMultiRoomUpgraderCountCache = {
+      gameTime,
+      creeps,
+      countsByHomeRoom: countActiveMultiRoomUpgradersByHomeRoom(creeps)
+    };
+  }
+  return (_b = activeMultiRoomUpgraderCountCache.countsByHomeRoom[homeRoom]) != null ? _b : {};
 }
-function isActiveMultiRoomUpgrader(creep, homeRoom, targetRoom) {
-  var _a;
-  const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-  return (sustain == null ? void 0 : sustain.role) === "upgrader" && sustain.homeRoom === homeRoom && sustain.targetRoom === targetRoom && (creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE);
+function countActiveMultiRoomUpgradersByHomeRoom(creeps) {
+  var _a, _b, _c;
+  const countsByHomeRoom = {};
+  for (const creep of Object.values(creeps)) {
+    const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
+    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString8(sustain.homeRoom) || !isNonEmptyString8(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
+      continue;
+    }
+    const countsByTarget = (_b = countsByHomeRoom[sustain.homeRoom]) != null ? _b : {};
+    countsByTarget[sustain.targetRoom] = ((_c = countsByTarget[sustain.targetRoom]) != null ? _c : 0) + 1;
+    countsByHomeRoom[sustain.homeRoom] = countsByTarget;
+  }
+  return countsByHomeRoom;
+}
+function isActiveMultiRoomUpgrader(creep) {
+  return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
 function getControllerLevel(controller) {
   return typeof controller.level === "number" ? controller.level : DEFAULT_RESERVED_CONTROLLER_LEVEL;
@@ -10583,28 +10609,45 @@ function getStorageEnergyCapacity(storage) {
   const capacity = storage.store.getCapacity(RESOURCE_ENERGY);
   return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
 }
+function hasVisibleHostiles(room) {
+  const hostileCreepsFind = globalThis.FIND_HOSTILE_CREEPS;
+  const hostileStructuresFind = globalThis.FIND_HOSTILE_STRUCTURES;
+  return typeof hostileCreepsFind === "number" && room.find(hostileCreepsFind).length > 0 || typeof hostileStructuresFind === "number" && room.find(hostileStructuresFind).length > 0;
+}
 function getRouteDistance(fromRoom, targetRoom) {
   if (fromRoom === targetRoom) {
     return 0;
   }
-  const cachedRouteDistance = getCachedRouteDistance2(fromRoom, targetRoom);
-  if (cachedRouteDistance !== void 0) {
+  const cache = getTerritoryRouteDistanceCache2();
+  const cacheKey = getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom);
+  const cachedRouteDistance = cache == null ? void 0 : cache[cacheKey];
+  if (cachedRouteDistance === null || typeof cachedRouteDistance === "number") {
     return cachedRouteDistance;
   }
   const routeDistance = getRouteDistanceFromGameMap(fromRoom, targetRoom);
   if (routeDistance !== void 0) {
+    if (cache) {
+      cache[cacheKey] = routeDistance;
+    }
     return routeDistance;
   }
   return isAdjacentRoom(fromRoom, targetRoom) ? 1 : void 0;
 }
-function getCachedRouteDistance2(fromRoom, targetRoom) {
-  var _a, _b;
-  const routeDistances = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.routeDistances;
-  if (!isRecord8(routeDistances)) {
+function getTerritoryRouteDistanceCache2() {
+  const memory = globalThis.Memory;
+  if (!memory) {
     return void 0;
   }
-  const value = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR3}${targetRoom}`];
-  return typeof value === "number" || value === null ? value : void 0;
+  if (!isRecord8(memory.territory)) {
+    memory.territory = {};
+  }
+  if (!isRecord8(memory.territory.routeDistances)) {
+    memory.territory.routeDistances = {};
+  }
+  return memory.territory.routeDistances;
+}
+function getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom) {
+  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR3}${targetRoom}`;
 }
 function getRouteDistanceFromGameMap(fromRoom, targetRoom) {
   var _a;
@@ -10635,6 +10678,11 @@ function isAdjacentRoom(fromRoom, targetRoom) {
 function getNoPathResultCode4() {
   const noPathCode = globalThis.ERR_NO_PATH;
   return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE4;
+}
+function getGameTime7() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" ? gameTime : 0;
 }
 function isRecord8(value) {
   return typeof value === "object" && value !== null;
@@ -11036,27 +11084,30 @@ function planMultiRoomControllerUpgradeSpawn(context) {
   if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
     return null;
   }
-  const upgradePlan = selectMultiRoomUpgradePlan(context.colony);
-  if (!upgradePlan) {
+  const upgradePlans = selectMultiRoomUpgradePlans(context.colony);
+  if (upgradePlans.length === 0) {
     return null;
   }
   const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
   if (!spawn) {
     return null;
   }
-  const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
-  if (body.length === 0) {
-    return null;
+  for (const upgradePlan of upgradePlans) {
+    const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
+    if (body.length === 0) {
+      continue;
+    }
+    return {
+      spawn,
+      body,
+      name: appendSpawnNameSuffix(
+        `worker-${context.colony.room.name}-${upgradePlan.targetRoom}-multiroom-upgrader-${context.gameTime}`,
+        context.options
+      ),
+      memory: buildMultiRoomUpgraderMemory(upgradePlan)
+    };
   }
-  return {
-    spawn,
-    body,
-    name: appendSpawnNameSuffix(
-      `worker-${context.colony.room.name}-${upgradePlan.targetRoom}-multiroom-upgrader-${context.gameTime}`,
-      context.options
-    ),
-    memory: buildMultiRoomUpgraderMemory(upgradePlan)
-  };
+  return null;
 }
 function shouldSpawnControllerUpgradeSurplusWorker(context) {
   if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
@@ -11713,8 +11764,8 @@ function getKnownRouteLength2(fromRoom, targetRoom) {
   if (fromRoom === targetRoom) {
     return 0;
   }
-  const cache = getTerritoryRouteDistanceCache2();
-  const cacheKey = getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom);
+  const cache = getTerritoryRouteDistanceCache3();
+  const cacheKey = getTerritoryRouteDistanceCacheKey3(fromRoom, targetRoom);
   const cachedRouteLength = cache == null ? void 0 : cache[cacheKey];
   if (cachedRouteLength === null || typeof cachedRouteLength === "number") {
     return cachedRouteLength;
@@ -11738,7 +11789,7 @@ function getKnownRouteLength2(fromRoom, targetRoom) {
   }
   return route.length;
 }
-function getTerritoryRouteDistanceCache2() {
+function getTerritoryRouteDistanceCache3() {
   const territoryMemory = getWritableTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return void 0;
@@ -11748,7 +11799,7 @@ function getTerritoryRouteDistanceCache2() {
   }
   return territoryMemory.routeDistances;
 }
-function getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom) {
+function getTerritoryRouteDistanceCacheKey3(fromRoom, targetRoom) {
   return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR4}${targetRoom}`;
 }
 function getNoPathResultCode5() {
@@ -11913,7 +11964,7 @@ function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   if (!bootstraps) {
     return;
   }
-  const gameTime = getGameTime7();
+  const gameTime = getGameTime8();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
   bootstraps[input.roomName] = {
@@ -12033,7 +12084,7 @@ function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, res
   }
   updatePostClaimBootstrapRecord(roomName, {
     status: "spawningWorkers",
-    updatedAt: getGameTime7()
+    updatedAt: getGameTime8()
   });
   telemetryEvents.push({
     type: "postClaimBootstrap",
@@ -12307,7 +12358,7 @@ function getGlobalString(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getGameTime7() {
+function getGameTime8() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -12344,7 +12395,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return;
   }
-  const tick = getGameTime8();
+  const tick = getGameTime9();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -12440,7 +12491,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime8());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime9());
   }
   return {
     roomName: colony.room.name,
@@ -12451,9 +12502,9 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     taskCounts: countWorkerTasks(colonyWorkers),
     ...summarizeAndResetCreepBehaviorTelemetry(colonyWorkers),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime8()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime8()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime8()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime9()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime9()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime9()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -12472,7 +12523,7 @@ function buildPostClaimBootstrapSummary(roomName) {
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime8());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime9());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -13325,7 +13376,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime8() {
+function getGameTime9() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -13919,7 +13970,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime9();
+  const gameTime = getGameTime10();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -13939,7 +13990,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime9());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime10());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -14019,7 +14070,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime9() {
+function getGameTime10() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -14376,7 +14427,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime10())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime11())
     );
   }
 };
@@ -14448,7 +14499,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime10() {
+function getGameTime11() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9017,6 +9017,178 @@ function getGameCreeps() {
   return creeps ? Object.values(creeps) : [];
 }
 
+// src/telemetry/behaviorTelemetry.ts
+var BEHAVIOR_COUNTER_KEYS = [
+  { key: "idleTicks" },
+  { key: "moveTicks" },
+  { key: "workTicks" },
+  { key: "stuckTicks" },
+  { key: "containerTransfers" },
+  { key: "pathLength" }
+];
+function observeCreepBehaviorTick(creep, tick = getGameTime6()) {
+  var _a, _b;
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastObservedTick === tick) {
+    return;
+  }
+  const currentPosition = getCreepPositionMemory(creep);
+  if (currentPosition && telemetry.lastPosition && telemetry.lastMoveTick === tick - 1) {
+    const stepDistance = getStepDistance(telemetry.lastPosition, currentPosition);
+    if (stepDistance > 0) {
+      telemetry.pathLength = ((_a = telemetry.pathLength) != null ? _a : 0) + stepDistance;
+    } else {
+      telemetry.stuckTicks = ((_b = telemetry.stuckTicks) != null ? _b : 0) + 1;
+    }
+  }
+  if (currentPosition) {
+    telemetry.lastPosition = currentPosition;
+  }
+  telemetry.lastObservedTick = tick;
+}
+function recordCreepBehaviorIdle(creep, tick = getGameTime6()) {
+  var _a;
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastIdleTick === tick) {
+    return;
+  }
+  telemetry.idleTicks = ((_a = telemetry.idleTicks) != null ? _a : 0) + 1;
+  telemetry.lastIdleTick = tick;
+}
+function recordCreepBehaviorMove(creep, tick = getGameTime6()) {
+  var _a;
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastMoveTick === tick) {
+    return;
+  }
+  telemetry.moveTicks = ((_a = telemetry.moveTicks) != null ? _a : 0) + 1;
+  telemetry.lastMoveTick = tick;
+}
+function recordCreepBehaviorWork(creep, tick = getGameTime6()) {
+  var _a;
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastWorkTick === tick) {
+    return;
+  }
+  telemetry.workTicks = ((_a = telemetry.workTicks) != null ? _a : 0) + 1;
+  telemetry.lastWorkTick = tick;
+}
+function recordCreepBehaviorRepairTarget(creep, targetId) {
+  ensureCreepBehaviorTelemetry(creep).repairTargetId = targetId;
+}
+function recordCreepBehaviorContainerTransfer(creep) {
+  var _a;
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  telemetry.containerTransfers = ((_a = telemetry.containerTransfers) != null ? _a : 0) + 1;
+}
+function summarizeAndResetCreepBehaviorTelemetry(workers) {
+  const creepSummaries = workers.map(toRuntimeCreepBehaviorSummary).filter((summary) => summary !== null).sort(compareRuntimeCreepBehaviorSummaries);
+  if (creepSummaries.length === 0) {
+    return {};
+  }
+  for (const worker of workers) {
+    resetCreepBehaviorCounters(worker);
+  }
+  return {
+    behavior: {
+      creeps: creepSummaries,
+      totals: summarizeBehaviorTotals(creepSummaries)
+    }
+  };
+}
+function ensureCreepBehaviorTelemetry(creep) {
+  if (!creep.memory.behaviorTelemetry) {
+    creep.memory.behaviorTelemetry = {};
+  }
+  return creep.memory.behaviorTelemetry;
+}
+function toRuntimeCreepBehaviorSummary(creep) {
+  const telemetry = creep.memory.behaviorTelemetry;
+  if (!telemetry || !hasReportableBehaviorTelemetry(telemetry)) {
+    return null;
+  }
+  return {
+    ...buildCreepNameSummary(creep),
+    idleTicks: getNonNegativeCounter(telemetry.idleTicks),
+    moveTicks: getNonNegativeCounter(telemetry.moveTicks),
+    workTicks: getNonNegativeCounter(telemetry.workTicks),
+    stuckTicks: getNonNegativeCounter(telemetry.stuckTicks),
+    containerTransfers: getNonNegativeCounter(telemetry.containerTransfers),
+    pathLength: getNonNegativeCounter(telemetry.pathLength),
+    ...typeof telemetry.repairTargetId === "string" && telemetry.repairTargetId.length > 0 ? { repairTargetId: telemetry.repairTargetId } : {}
+  };
+}
+function hasReportableBehaviorTelemetry(telemetry) {
+  return BEHAVIOR_COUNTER_KEYS.some(({ key }) => getNonNegativeCounter(telemetry[key]) > 0) || typeof telemetry.repairTargetId === "string" && telemetry.repairTargetId.length > 0;
+}
+function resetCreepBehaviorCounters(creep) {
+  const telemetry = creep.memory.behaviorTelemetry;
+  if (!telemetry) {
+    return;
+  }
+  for (const { key } of BEHAVIOR_COUNTER_KEYS) {
+    delete telemetry[key];
+  }
+  delete telemetry.repairTargetId;
+  delete telemetry.lastIdleTick;
+  delete telemetry.lastWorkTick;
+  if (!telemetry.lastPosition && telemetry.lastMoveTick === void 0 && telemetry.lastObservedTick === void 0) {
+    delete creep.memory.behaviorTelemetry;
+  }
+}
+function summarizeBehaviorTotals(creeps) {
+  return creeps.reduce(
+    (totals, creep) => ({
+      idleTicks: totals.idleTicks + creep.idleTicks,
+      moveTicks: totals.moveTicks + creep.moveTicks,
+      workTicks: totals.workTicks + creep.workTicks,
+      stuckTicks: totals.stuckTicks + creep.stuckTicks,
+      containerTransfers: totals.containerTransfers + creep.containerTransfers,
+      pathLength: totals.pathLength + creep.pathLength
+    }),
+    {
+      idleTicks: 0,
+      moveTicks: 0,
+      workTicks: 0,
+      stuckTicks: 0,
+      containerTransfers: 0,
+      pathLength: 0
+    }
+  );
+}
+function compareRuntimeCreepBehaviorSummaries(left, right) {
+  var _a, _b;
+  return ((_a = left.creepName) != null ? _a : "").localeCompare((_b = right.creepName) != null ? _b : "");
+}
+function buildCreepNameSummary(creep) {
+  const name = creep.name;
+  return typeof name === "string" && name.length > 0 ? { creepName: name } : {};
+}
+function getNonNegativeCounter(value) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+function getCreepPositionMemory(creep) {
+  const pos = creep.pos;
+  if (!pos || typeof pos.x !== "number" || typeof pos.y !== "number" || typeof pos.roomName !== "string") {
+    return null;
+  }
+  return {
+    x: pos.x,
+    y: pos.y,
+    roomName: pos.roomName
+  };
+}
+function getStepDistance(previous, current) {
+  if (previous.roomName !== current.roomName) {
+    return 1;
+  }
+  return Math.max(Math.abs(current.x - previous.x), Math.abs(current.y - previous.y));
+}
+function getGameTime6() {
+  const game = globalThis.Game;
+  return typeof (game == null ? void 0 : game.time) === "number" ? game.time : 0;
+}
+
 // src/creeps/workerRunner.ts
 var MAX_IMMEDIATE_RESELECT_EXECUTIONS = 1;
 var OK_CODE3 = 0;
@@ -9025,6 +9197,7 @@ function runWorker(creep) {
   if (runControllerSustainMovement(creep)) {
     return;
   }
+  observeCreepBehaviorTick(creep);
   const selectedTask = selectWorkerTask(creep);
   const currentTask = creep.memory.task;
   if (!currentTask) {
@@ -9180,34 +9353,41 @@ function isControllerSustainMemory(value) {
 function executeAssignedTask(creep, selectedTask, immediateReselectExecutions = 0) {
   let task = creep.memory.task;
   if (!task || !canExecuteTask(creep, task)) {
+    recordCreepBehaviorIdle(creep);
     return;
   }
   let target = Game.getObjectById(task.targetId);
   if (!target) {
     if (selectedTask && isSameTask(task, selectedTask)) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
     task = assignSelectedTask(creep, selectedTask, task);
     if (!task || !canExecuteTask(creep, task)) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
     target = Game.getObjectById(task.targetId);
     if (!target) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
   }
   if (shouldReplaceTarget(creep, task, target)) {
     task = assignSelectedTask(creep, selectedTask, task);
     if (!task || !canExecuteTask(creep, task)) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
     target = Game.getObjectById(task.targetId);
     if (!target || shouldReplaceTarget(creep, task, target)) {
+      recordCreepBehaviorIdle(creep);
       return;
     }
   }
-  const result = executeTask(creep, task, target);
-  if (shouldImmediatelyReselectAfterTaskResult(task, result)) {
+  const execution = executeTask(creep, task, target);
+  recordTaskBehavior(creep, task, execution);
+  if (shouldImmediatelyReselectAfterTaskResult(task, execution.result)) {
     delete creep.memory.task;
     const nextTask = assignNextTask(creep);
     if (nextTask && !isSameTask(task, nextTask) && immediateReselectExecutions < MAX_IMMEDIATE_RESELECT_EXECUTIONS) {
@@ -9215,8 +9395,9 @@ function executeAssignedTask(creep, selectedTask, immediateReselectExecutions = 
     }
     return;
   }
-  if (result === ERR_NOT_IN_RANGE) {
+  if (execution.result === ERR_NOT_IN_RANGE) {
     creep.moveTo(target);
+    recordCreepBehaviorMove(creep);
   }
 }
 function shouldImmediatelyReselectAfterTaskResult(task, result) {
@@ -9606,41 +9787,43 @@ function executeTask(creep, task, target) {
     case "harvest":
       return executeHarvestTask(creep, target);
     case "pickup":
-      return creep.pickup(target);
+      return toTaskExecutionResult(creep.pickup(target), "work");
     case "withdraw":
-      return creep.withdraw(target, RESOURCE_ENERGY);
+      return toTaskExecutionResult(creep.withdraw(target, RESOURCE_ENERGY), "work");
     case "transfer":
-      return creep.transfer(target, RESOURCE_ENERGY);
+      return toTaskExecutionResult(creep.transfer(target, RESOURCE_ENERGY), "work", {
+        containerTransfer: isContainerStructure2(target)
+      });
     case "build":
-      return creep.build(target);
+      return toTaskExecutionResult(creep.build(target), "work");
     case "repair":
-      return creep.repair(target);
+      return toTaskExecutionResult(creep.repair(target), "work");
     case "claim":
       if (typeof creep.attackController === "function" && canCreepPressureTerritoryController(creep, target, creep.memory.colony)) {
-        return creep.attackController(target);
+        return toTaskExecutionResult(creep.attackController(target), "work");
       }
-      return creep.claimController(target);
+      return toTaskExecutionResult(creep.claimController(target), "work");
     case "reserve":
       if (typeof creep.attackController === "function" && canCreepPressureTerritoryController(creep, target, creep.memory.colony)) {
-        return creep.attackController(target);
+        return toTaskExecutionResult(creep.attackController(target), "work");
       }
-      return creep.reserveController(target);
+      return toTaskExecutionResult(creep.reserveController(target), "work");
     case "upgrade":
       signOccupiedControllerIfNeeded(creep, target);
-      return creep.upgradeController(target);
+      return toTaskExecutionResult(creep.upgradeController(target), "work");
   }
 }
 function executeHarvestTask(creep, source) {
   const sourceContainer = findSourceContainer(creep.room, source);
   if (!sourceContainer) {
-    return creep.harvest(source);
+    return toTaskExecutionResult(creep.harvest(source), "work");
   }
   if (!isInRangeToRoomObject(creep, source, 1)) {
     creep.moveTo(sourceContainer);
-    return OK_CODE3;
+    return { result: OK_CODE3, action: "move" };
   }
   if (isDepletedHarvestSource(source)) {
-    return getUsedTransferEnergy(creep) > 0 ? transferDedicatedHarvestEnergy(creep, sourceContainer) : OK_CODE3;
+    return getUsedTransferEnergy(creep) > 0 ? transferDedicatedHarvestEnergy(creep, sourceContainer) : { result: OK_CODE3 };
   }
   if (getFreeTransferEnergyCapacity(creep) <= 0 && getUsedTransferEnergy(creep) > 0) {
     return transferDedicatedHarvestEnergy(creep, sourceContainer);
@@ -9649,18 +9832,49 @@ function executeHarvestTask(creep, source) {
   if ((result === ERR_FULL || result === ERR_NOT_ENOUGH_RESOURCES) && getUsedTransferEnergy(creep) > 0) {
     return transferDedicatedHarvestEnergy(creep, sourceContainer);
   }
-  return result === ERR_NOT_ENOUGH_RESOURCES ? OK_CODE3 : result;
+  return toTaskExecutionResult(result === ERR_NOT_ENOUGH_RESOURCES ? OK_CODE3 : result, "work");
 }
 function transferDedicatedHarvestEnergy(creep, sourceContainer) {
   if (typeof creep.transfer !== "function") {
-    return OK_CODE3;
+    return { result: OK_CODE3 };
   }
   const result = creep.transfer(sourceContainer, RESOURCE_ENERGY);
   if (result === ERR_NOT_IN_RANGE) {
     creep.moveTo(sourceContainer);
-    return OK_CODE3;
+    return { result: OK_CODE3, action: "move" };
   }
-  return result;
+  return toTaskExecutionResult(result, "work", { containerTransfer: true });
+}
+function toTaskExecutionResult(result, successAction, options = {}) {
+  return {
+    result,
+    ...result === OK_CODE3 ? { action: successAction } : {},
+    ...result === OK_CODE3 && options.containerTransfer ? { containerTransfer: true } : {}
+  };
+}
+function recordTaskBehavior(creep, task, execution) {
+  if (task.type === "repair") {
+    recordCreepBehaviorRepairTarget(creep, String(task.targetId));
+  }
+  if (execution.action === "move") {
+    recordCreepBehaviorMove(creep);
+  } else if (execution.action === "work") {
+    recordCreepBehaviorWork(creep);
+  } else if (execution.result !== ERR_NOT_IN_RANGE) {
+    recordCreepBehaviorIdle(creep);
+  }
+  if (execution.containerTransfer) {
+    recordCreepBehaviorContainerTransfer(creep);
+  }
+}
+function isContainerStructure2(target) {
+  const structureType = target == null ? void 0 : target.structureType;
+  return typeof structureType === "string" && matchesContainerStructureType(structureType);
+}
+function matchesContainerStructureType(actual) {
+  var _a;
+  const containerType = (_a = globalThis.STRUCTURE_CONTAINER) != null ? _a : "container";
+  return actual === containerType;
 }
 function isDedicatedSourceContainerHarvestTask(creep, task) {
   return task.type === "harvest" && findHarvestTaskSourceContainer(creep, task) !== null;
@@ -10145,6 +10359,290 @@ function isNonEmptyString7(value) {
   return typeof value === "string" && value.length > 0;
 }
 
+// src/territory/multiRoomUpgrader.ts
+var MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO = 0.8;
+var MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP = 1;
+var REMOTE_UPGRADER_PATTERN = ["work", "carry", "move"];
+var REMOTE_UPGRADER_TRAVEL_PATTERN = ["work", "carry", "move", "move"];
+var RESERVED_CONTROLLER_BASE_BODY = ["claim", "move"];
+var REMOTE_UPGRADER_PATTERN_COST = 200;
+var MOVE_PART_COST = 50;
+var MAX_CREEP_PARTS2 = 50;
+var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
+var DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
+var ERR_NO_PATH_CODE4 = -2;
+var TERRITORY_ROUTE_DISTANCE_SEPARATOR3 = ">";
+function selectMultiRoomUpgradePlan(colony, options = {}) {
+  const config = normalizeMultiRoomUpgraderOptions(options);
+  if (config.perRoomUpgraderCap <= 0 || !hasPrimaryRoomStorageSurplus(colony, config.storageEnergyThresholdRatio)) {
+    return null;
+  }
+  const candidates = getVisibleMultiRoomUpgradeCandidates(colony, config);
+  if (candidates.length === 0) {
+    return null;
+  }
+  const { order: _order, ...plan } = candidates.sort(compareMultiRoomUpgradeCandidates)[0];
+  return plan;
+}
+function buildMultiRoomUpgraderBody(energyAvailable, plan) {
+  const baseBody = plan.controllerState === "reserved" ? RESERVED_CONTROLLER_BASE_BODY : [];
+  const remainingEnergy = energyAvailable - getBodyCost2(baseBody);
+  if (remainingEnergy < REMOTE_UPGRADER_PATTERN_COST) {
+    return [];
+  }
+  const pattern = getRemoteUpgraderPattern(plan.routeDistance);
+  const patternCost = getBodyCost2(pattern);
+  const maxPatternCountByEnergy = Math.floor(remainingEnergy / patternCost);
+  const maxPatternCountBySize = Math.floor((MAX_CREEP_PARTS2 - baseBody.length) / pattern.length);
+  const patternCount = Math.min(
+    maxPatternCountByEnergy,
+    maxPatternCountBySize,
+    MAX_REMOTE_UPGRADER_PATTERN_COUNT
+  );
+  if (patternCount <= 0) {
+    return [];
+  }
+  const body = [
+    ...baseBody,
+    ...Array.from({ length: patternCount }).flatMap(() => pattern)
+  ];
+  const unusedEnergy = energyAvailable - getBodyCost2(body);
+  if (unusedEnergy >= MOVE_PART_COST && body.length < MAX_CREEP_PARTS2) {
+    return [...body, "move"];
+  }
+  return body;
+}
+function buildMultiRoomUpgraderMemory(plan) {
+  return {
+    role: "worker",
+    colony: plan.targetRoom,
+    territory: {
+      targetRoom: plan.targetRoom,
+      action: plan.controllerState === "reserved" ? "reserve" : "claim",
+      controllerId: plan.controllerId
+    },
+    controllerSustain: {
+      homeRoom: plan.homeRoom,
+      targetRoom: plan.targetRoom,
+      role: "upgrader"
+    }
+  };
+}
+function getVisibleMultiRoomUpgradeCandidates(colony, config) {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return [];
+  }
+  const homeRoom = colony.room.name;
+  const ownerUsername = getControllerOwnerUsername3(colony.room.controller);
+  const candidates = [];
+  let order = 0;
+  for (const room of Object.values(rooms)) {
+    const candidate = getVisibleMultiRoomUpgradeCandidate(
+      homeRoom,
+      ownerUsername,
+      room,
+      config.perRoomUpgraderCap,
+      order
+    );
+    order += 1;
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, perRoomUpgraderCap, order) {
+  if (!isNonEmptyString8(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
+    return null;
+  }
+  const controller = room.controller;
+  if (!controller || !isNonEmptyString8(controller.id)) {
+    return null;
+  }
+  const controllerState = getEligibleControllerState(controller, ownerUsername);
+  if (!controllerState) {
+    return null;
+  }
+  const routeDistance = getRouteDistance(homeRoom, room.name);
+  if (routeDistance === null) {
+    return null;
+  }
+  const activeUpgraderCount = countActiveMultiRoomUpgraders(homeRoom, room.name);
+  if (activeUpgraderCount >= perRoomUpgraderCap) {
+    return null;
+  }
+  return {
+    homeRoom,
+    targetRoom: room.name,
+    controllerId: controller.id,
+    controllerLevel: getControllerLevel(controller),
+    controllerState,
+    ...typeof routeDistance === "number" ? { routeDistance } : {},
+    activeUpgraderCount,
+    order
+  };
+}
+function getEligibleControllerState(controller, ownerUsername) {
+  if (controller.my === true) {
+    return controller.level < 8 ? "owned" : null;
+  }
+  const reservationUsername = getControllerReservationUsername2(controller);
+  if (ownerUsername && reservationUsername === ownerUsername) {
+    return "reserved";
+  }
+  return null;
+}
+function hasPrimaryRoomStorageSurplus(colony, storageEnergyThresholdRatio) {
+  const storage = colony.room.storage;
+  if (!storage) {
+    return false;
+  }
+  const storedEnergy = getStoredEnergy6(storage);
+  const storageCapacity = getStorageEnergyCapacity(storage);
+  return storageCapacity > 0 && storedEnergy > storageCapacity * storageEnergyThresholdRatio;
+}
+function normalizeMultiRoomUpgraderOptions(options) {
+  return {
+    storageEnergyThresholdRatio: normalizeRatio(
+      options.storageEnergyThresholdRatio,
+      MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO
+    ),
+    perRoomUpgraderCap: normalizePerRoomCap(options.perRoomUpgraderCap)
+  };
+}
+function normalizeRatio(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+function normalizePerRoomCap(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP;
+}
+function getRemoteUpgraderPattern(routeDistance) {
+  return typeof routeDistance === "number" && routeDistance > 1 ? REMOTE_UPGRADER_TRAVEL_PATTERN : REMOTE_UPGRADER_PATTERN;
+}
+function getBodyCost2(body) {
+  return body.reduce((total, part) => total + getBodyPartCost(part), 0);
+}
+function getBodyPartCost(part) {
+  switch (part) {
+    case "work":
+      return 100;
+    case "carry":
+    case "move":
+      return 50;
+    case "claim":
+      return 600;
+    case "attack":
+      return 80;
+    case "ranged_attack":
+      return 150;
+    case "heal":
+      return 250;
+    case "tough":
+      return 10;
+  }
+}
+function compareMultiRoomUpgradeCandidates(left, right) {
+  return left.controllerLevel - right.controllerLevel || compareOptionalNumbers3(left.routeDistance, right.routeDistance) || left.targetRoom.localeCompare(right.targetRoom) || left.order - right.order;
+}
+function compareOptionalNumbers3(left, right) {
+  return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
+}
+function countActiveMultiRoomUpgraders(homeRoom, targetRoom) {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  if (!creeps) {
+    return 0;
+  }
+  return Object.values(creeps).filter((creep) => isActiveMultiRoomUpgrader(creep, homeRoom, targetRoom)).length;
+}
+function isActiveMultiRoomUpgrader(creep, homeRoom, targetRoom) {
+  var _a;
+  const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
+  return (sustain == null ? void 0 : sustain.role) === "upgrader" && sustain.homeRoom === homeRoom && sustain.targetRoom === targetRoom && (creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE);
+}
+function getControllerLevel(controller) {
+  return typeof controller.level === "number" ? controller.level : DEFAULT_RESERVED_CONTROLLER_LEVEL;
+}
+function getControllerOwnerUsername3(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  return isNonEmptyString8(username) ? username : null;
+}
+function getControllerReservationUsername2(controller) {
+  var _a;
+  const username = (_a = controller.reservation) == null ? void 0 : _a.username;
+  return isNonEmptyString8(username) ? username : null;
+}
+function getStoredEnergy6(storage) {
+  const storedEnergy = storage.store.getUsedCapacity(RESOURCE_ENERGY);
+  return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+function getStorageEnergyCapacity(storage) {
+  const capacity = storage.store.getCapacity(RESOURCE_ENERGY);
+  return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
+}
+function getRouteDistance(fromRoom, targetRoom) {
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+  const cachedRouteDistance = getCachedRouteDistance2(fromRoom, targetRoom);
+  if (cachedRouteDistance !== void 0) {
+    return cachedRouteDistance;
+  }
+  const routeDistance = getRouteDistanceFromGameMap(fromRoom, targetRoom);
+  if (routeDistance !== void 0) {
+    return routeDistance;
+  }
+  return isAdjacentRoom(fromRoom, targetRoom) ? 1 : void 0;
+}
+function getCachedRouteDistance2(fromRoom, targetRoom) {
+  var _a, _b;
+  const routeDistances = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.routeDistances;
+  if (!isRecord8(routeDistances)) {
+    return void 0;
+  }
+  const value = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR3}${targetRoom}`];
+  return typeof value === "number" || value === null ? value : void 0;
+}
+function getRouteDistanceFromGameMap(fromRoom, targetRoom) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
+    return void 0;
+  }
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName) => isKnownDeadZoneRoom(roomName) ? Infinity : 1
+  });
+  if (route === getNoPathResultCode4()) {
+    return null;
+  }
+  return Array.isArray(route) ? route.length : void 0;
+}
+function isAdjacentRoom(fromRoom, targetRoom) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (!gameMap || typeof gameMap.describeExits !== "function") {
+    return false;
+  }
+  const exits = gameMap.describeExits(fromRoom);
+  if (!isRecord8(exits)) {
+    return false;
+  }
+  return Object.values(exits).some((roomName) => roomName === targetRoom);
+}
+function getNoPathResultCode4() {
+  const noPathCode = globalThis.ERR_NO_PATH;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE4;
+}
+function isRecord8(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString8(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
 // src/spawn/spawnPlanner.ts
 var TERRITORY_SCOUT_BODY = ["move"];
 var TERRITORY_SCOUT_BODY_COST2 = 50;
@@ -10166,6 +10664,7 @@ var SPAWN_PRIORITY_TIERS = [
   "postClaimControllerSustain",
   "remoteEconomy",
   "territoryRemote",
+  "multiRoomControllerUpgrade",
   "controllerUpgradeSurplus"
 ];
 function planSpawn(colony, roleCounts, gameTime, options = {}) {
@@ -10205,6 +10704,8 @@ function planSpawnForPriorityTier(tier, context) {
       return planDefenseSpawn(context);
     case "territoryRemote":
       return planTerritoryRemoteSpawn(context);
+    case "multiRoomControllerUpgrade":
+      return planMultiRoomControllerUpgradeSpawn(context);
     case "controllerUpgradeSurplus":
       return planControllerUpgradeSurplusSpawn(context);
   }
@@ -10306,7 +10807,7 @@ function selectPostClaimControllerSustainPlan(colony) {
 function getPostClaimControllerSustainRecords(colonyName) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord8(records)) {
+  if (!isRecord9(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -10314,7 +10815,7 @@ function getPostClaimControllerSustainRecords(colonyName) {
   ).sort(comparePostClaimControllerSustainRecords);
 }
 function isPostClaimControllerSustainRecord(record, colonyName) {
-  return isRecord8(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString8(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord9(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString9(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function comparePostClaimControllerSustainRecords(left, right) {
   const leftHasSpawn = hasOperationalSpawnInRoom(left.roomName);
@@ -10531,6 +11032,32 @@ function planControllerUpgradeSurplusSpawn(context) {
   }
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
 }
+function planMultiRoomControllerUpgradeSpawn(context) {
+  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
+    return null;
+  }
+  const upgradePlan = selectMultiRoomUpgradePlan(context.colony);
+  if (!upgradePlan) {
+    return null;
+  }
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+  const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
+  if (body.length === 0) {
+    return null;
+  }
+  return {
+    spawn,
+    body,
+    name: appendSpawnNameSuffix(
+      `worker-${context.colony.room.name}-${upgradePlan.targetRoom}-multiroom-upgrader-${context.gameTime}`,
+      context.options
+    ),
+    memory: buildMultiRoomUpgraderMemory(upgradePlan)
+  };
+}
 function shouldSpawnControllerUpgradeSurplusWorker(context) {
   if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
     return false;
@@ -10572,7 +11099,7 @@ function hasVisibleForeignReservedTerritoryTarget(colony) {
   if (!Array.isArray(targets)) {
     return false;
   }
-  const colonyOwnerUsername = getControllerOwnerUsername3(colony.room.controller);
+  const colonyOwnerUsername = getControllerOwnerUsername4(colony.room.controller);
   return targets.some((target) => {
     if (typeof target !== "object" || target === null) {
       return false;
@@ -10596,7 +11123,7 @@ function isForeignReservedController2(controller, colonyOwnerUsername) {
   const reservationUsername = (_a = controller == null ? void 0 : controller.reservation) == null ? void 0 : _a.username;
   return (controller == null ? void 0 : controller.my) !== true && typeof reservationUsername === "string" && reservationUsername.length > 0 && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername3(controller) {
+function getControllerOwnerUsername4(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return typeof username === "string" && username.length > 0 ? username : void 0;
@@ -10676,18 +11203,18 @@ function getVisibleRoom3(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function isRecord8(value) {
+function isRecord9(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString8(value) {
+function isNonEmptyString9(value) {
   return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/expansionScoring.ts
 var NEXT_EXPANSION_TARGET_CREATOR = "nextExpansionScoring";
 var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
-var TERRITORY_ROUTE_DISTANCE_SEPARATOR3 = ">";
-var ERR_NO_PATH_CODE4 = -2;
+var TERRITORY_ROUTE_DISTANCE_SEPARATOR4 = ">";
+var ERR_NO_PATH_CODE5 = -2;
 var MAX_NEARBY_EXPANSION_ROUTE_DISTANCE = 2;
 var TERRAIN_SCAN_MIN = 2;
 var TERRAIN_SCAN_MAX = 47;
@@ -10729,7 +11256,7 @@ function buildRuntimeExpansionScoringInput(colony) {
   var _a, _b;
   return {
     colonyName: colony.room.name,
-    ...getControllerOwnerUsername4(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername4(colony.room.controller) } : {},
+    ...getControllerOwnerUsername5(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername5(colony.room.controller) } : {},
     energyCapacityAvailable: colony.energyCapacityAvailable,
     ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
     ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
@@ -10743,13 +11270,13 @@ function buildRuntimeExpansionCandidates(colony) {
     return [];
   }
   const colonyName = colony.room.name;
-  const ownerUsername = getControllerOwnerUsername4(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername5(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames3(colonyName, ownerUsername);
   const adjacentRoomNames = getAdjacentRoomNamesByOwnedRoom(ownedRoomNames);
   const candidates = [];
   let order = 0;
   for (const room of Object.values(rooms)) {
-    if (!room || !isNonEmptyString9(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
+    if (!room || !isNonEmptyString10(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
       continue;
     }
     const routeDistance = getKnownRouteLength2(colonyName, room.name);
@@ -11027,7 +11554,7 @@ function upsertNextExpansionTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord9(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
+  if (isRecord10(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
     existingTarget.createdBy = NEXT_EXPANSION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -11057,7 +11584,7 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
     if (activeTarget && isSameTarget(target, activeTarget)) {
       return true;
     }
-    if (isRecord9(target) && isNonEmptyString9(target.roomName) && target.action === "claim") {
+    if (isRecord10(target) && isNonEmptyString10(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey(target.roomName, "claim"));
     }
     return false;
@@ -11070,16 +11597,16 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
   );
 }
 function isNextExpansionTarget(target, colony) {
-  return isRecord9(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
+  return isRecord10(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
 }
 function isSameTarget(left, right) {
-  return isRecord9(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord10(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey(roomName, action) {
   return `${roomName}:${action}`;
 }
 function compareExpansionCandidates(left, right) {
-  return getEvidenceStatusPriority2(left.evidenceStatus) - getEvidenceStatusPriority2(right.evidenceStatus) || right.score - left.score || compareOptionalNumbers3(left.nearestOwnedRoomDistance, right.nearestOwnedRoomDistance) || compareOptionalNumbers3(left.routeDistance, right.routeDistance) || left.roomName.localeCompare(right.roomName);
+  return getEvidenceStatusPriority2(left.evidenceStatus) - getEvidenceStatusPriority2(right.evidenceStatus) || right.score - left.score || compareOptionalNumbers4(left.nearestOwnedRoomDistance, right.nearestOwnedRoomDistance) || compareOptionalNumbers4(left.routeDistance, right.routeDistance) || left.roomName.localeCompare(right.roomName);
 }
 function getEvidenceStatusPriority2(status) {
   if (status === "sufficient") {
@@ -11087,7 +11614,7 @@ function getEvidenceStatusPriority2(status) {
   }
   return status === "insufficient-evidence" ? 1 : 2;
 }
-function compareOptionalNumbers3(left, right) {
+function compareOptionalNumbers4(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 function downgradeEvidenceStatus(current, downgrade) {
@@ -11111,7 +11638,7 @@ function getVisibleOwnedRoomNames3(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString9(room.name) && (!ownerUsername || getControllerOwnerUsername4(room.controller) === ownerUsername)) {
+    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString10(room.name) && (!ownerUsername || getControllerOwnerUsername5(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -11173,12 +11700,12 @@ function getAdjacentRoomNames3(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord9(exits)) {
+  if (!isRecord10(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER3.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString9(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString10(exitRoom) ? [exitRoom] : [];
   });
 }
 function getKnownRouteLength2(fromRoom, targetRoom) {
@@ -11197,7 +11724,7 @@ function getKnownRouteLength2(fromRoom, targetRoom) {
     return void 0;
   }
   const route = gameMap.findRoute(fromRoom, targetRoom);
-  if (route === getNoPathResultCode4()) {
+  if (route === getNoPathResultCode5()) {
     if (cache) {
       cache[cacheKey] = null;
     }
@@ -11216,21 +11743,21 @@ function getTerritoryRouteDistanceCache2() {
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord9(territoryMemory.routeDistances)) {
+  if (!isRecord10(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
 }
 function getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom) {
-  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR3}${targetRoom}`;
+  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR4}${targetRoom}`;
 }
-function getNoPathResultCode4() {
+function getNoPathResultCode5() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE4;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE5;
 }
 function summarizeExpansionController(controller) {
-  const ownerUsername = getControllerOwnerUsername4(controller);
-  const reservationUsername = getControllerReservationUsername2(controller);
+  const ownerUsername = getControllerOwnerUsername5(controller);
+  const reservationUsername = getControllerReservationUsername3(controller);
   const reservationTicksToEnd = getControllerReservationTicksToEnd2(controller);
   return {
     ...controller.my === true ? { my: true } : {},
@@ -11314,15 +11841,15 @@ function getFindConstant3(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getControllerOwnerUsername4(controller) {
+function getControllerOwnerUsername5(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : void 0;
+  return isNonEmptyString10(username) ? username : void 0;
 }
-function getControllerReservationUsername2(controller) {
+function getControllerReservationUsername3(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : void 0;
+  return isNonEmptyString10(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd2(controller) {
   var _a;
@@ -11332,11 +11859,11 @@ function getControllerReservationTicksToEnd2(controller) {
 function countActivePostClaimBootstraps() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord9(records)) {
+  if (!isRecord10(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord9(record) && record.status !== "ready"
+    (record) => isRecord10(record) && record.status !== "ready"
   ).length;
 }
 function getGameRooms2() {
@@ -11363,10 +11890,10 @@ function roundRatio(numerator, denominator) {
 function toPercent(value) {
   return `${Math.round(value * 100)}%`;
 }
-function isRecord9(value) {
+function isRecord10(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString9(value) {
+function isNonEmptyString10(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -11379,14 +11906,14 @@ var ROOM_EDGE_MAX5 = 47;
 var DEFAULT_TERRAIN_WALL_MASK5 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
-  if (!isNonEmptyString10(input.colony) || !isNonEmptyString10(input.roomName)) {
+  if (!isNonEmptyString11(input.colony) || !isNonEmptyString11(input.roomName)) {
     return;
   }
   const bootstraps = getWritablePostClaimBootstrapRecords();
   if (!bootstraps) {
     return;
   }
-  const gameTime = getGameTime6();
+  const gameTime = getGameTime7();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
   bootstraps[input.roomName] = {
@@ -11497,7 +12024,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   return { active: true, spawnConstructionPending: true };
 }
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
-  if (!isNonEmptyString10(roomName)) {
+  if (!isNonEmptyString11(roomName)) {
     return;
   }
   const record = getPostClaimBootstrapRecord(roomName);
@@ -11506,7 +12033,7 @@ function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, res
   }
   updatePostClaimBootstrapRecord(roomName, {
     status: "spawningWorkers",
-    updatedAt: getGameTime6()
+    updatedAt: getGameTime7()
   });
   telemetryEvents.push({
     type: "postClaimBootstrap",
@@ -11671,14 +12198,14 @@ function findSources(room) {
   return room.find(findConstant);
 }
 function getRoomObjectPosition4(object) {
-  if (!isRecord10(object)) {
+  if (!isRecord11(object)) {
     return null;
   }
   if (isFiniteNumber4(object.x) && isFiniteNumber4(object.y)) {
     return { x: object.x, y: object.y };
   }
   const pos = object.pos;
-  if (isRecord10(pos) && isFiniteNumber4(pos.x) && isFiniteNumber4(pos.y)) {
+  if (isRecord11(pos) && isFiniteNumber4(pos.x) && isFiniteNumber4(pos.y)) {
     return { x: pos.x, y: pos.y };
   }
   return null;
@@ -11725,7 +12252,7 @@ function getWritablePostClaimBootstrapRecords() {
   return memory.territory.postClaimBootstraps;
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
-  return isRecord10(value) && value.roomName === expectedRoomName && isNonEmptyString10(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber4(value.claimedAt) && isFiniteNumber4(value.updatedAt);
+  return isRecord11(value) && value.roomName === expectedRoomName && isNonEmptyString11(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber4(value.claimedAt) && isFiniteNumber4(value.updatedAt);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
@@ -11780,15 +12307,15 @@ function getGlobalString(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getGameTime6() {
+function getGameTime7() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord10(value) {
+function isRecord11(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString10(value) {
+function isNonEmptyString11(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber4(value) {
@@ -11817,7 +12344,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return;
   }
-  const tick = getGameTime7();
+  const tick = getGameTime8();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -11853,7 +12380,8 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
           colony,
           (_a = creepsByColony.get(colony.room.name)) != null ? _a : [],
           persistOccupationRecommendations,
-          (_b = eventMetricsByRoom.get(colony.room.name)) != null ? _b : {}
+          (_b = eventMetricsByRoom.get(colony.room.name)) != null ? _b : {},
+          shouldBuildStructureSnapshot(tick)
         );
       }
     ),
@@ -11906,13 +12434,13 @@ function buildRoomEventMetricsByRoom(colonies, refillTargetIdsByRoom) {
   }
   return eventMetricsByRoom;
 }
-function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics) {
+function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, eventMetrics, includeStructureSnapshot) {
   const colonyWorkers = colonyCreeps.filter((creep) => creep.memory.role === "worker");
   const roleCounts = countCreepsByRole(colonyCreeps, colony.room.name);
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime7());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime8());
   }
   return {
     roomName: colony.room.name,
@@ -11921,9 +12449,11 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime7()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime7()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime7()),
+    ...summarizeAndResetCreepBehaviorTelemetry(colonyWorkers),
+    ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime8()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime8()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime8()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -11942,7 +12472,7 @@ function buildPostClaimBootstrapSummary(roomName) {
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime7());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime8());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -11994,6 +12524,91 @@ function countWorkerTasks(workers) {
 }
 function isWorkerTaskType(taskType) {
   return WORKER_TASK_TYPES.includes(taskType);
+}
+function shouldBuildStructureSnapshot(tick) {
+  return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
+}
+function summarizeStructures(colony, colonyWorkers) {
+  var _a, _b;
+  const roomStructures = (_a = findRoomObjects7(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const constructionSites = (_b = findRoomObjects7(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
+  const roadCount = countStructuresByType2(roomStructures, "STRUCTURE_ROAD", "road");
+  const pendingRoadSiteCount = countConstructionSitesByType(constructionSites, "STRUCTURE_ROAD", "road");
+  return {
+    towerCount: countStructuresByType2(roomStructures, "STRUCTURE_TOWER", "tower"),
+    rampartCount: countOwnedRamparts(roomStructures),
+    containers: summarizeContainers(roomStructures),
+    repairTargets: summarizeRepairTargetDistribution(colonyWorkers, roomStructures),
+    roadCount,
+    pendingRoadSiteCount,
+    roadCoverageRatio: calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount)
+  };
+}
+function countStructuresByType2(structures, globalName, fallback) {
+  return structures.filter((structure) => isStructureOfType(structure, globalName, fallback)).length;
+}
+function countConstructionSitesByType(constructionSites, globalName, fallback) {
+  return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
+}
+function countOwnedRamparts(structures) {
+  return structures.filter((structure) => isRecord12(structure) && isObservedOwnedRampart(structure)).length;
+}
+function summarizeContainers(structures) {
+  return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
+}
+function toRuntimeContainerSnapshot(structure) {
+  const id = getObjectId2(structure);
+  if (!id) {
+    return null;
+  }
+  return {
+    id,
+    energy: getEnergyInStore(structure),
+    capacity: getEnergyCapacityInStore(structure)
+  };
+}
+function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
+  var _a;
+  const repairCounts = /* @__PURE__ */ new Map();
+  for (const worker of colonyWorkers) {
+    const task = worker.memory.task;
+    if ((task == null ? void 0 : task.type) !== "repair") {
+      continue;
+    }
+    const targetId = String(task.targetId);
+    repairCounts.set(targetId, ((_a = repairCounts.get(targetId)) != null ? _a : 0) + 1);
+  }
+  const structuresById = /* @__PURE__ */ new Map();
+  for (const structure of roomStructures) {
+    const id = getObjectId2(structure);
+    if (id) {
+      structuresById.set(id, structure);
+    }
+  }
+  return [...repairCounts.entries()].sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId)).map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
+}
+function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
+  const structureRecord = isRecord12(structure) ? structure : {};
+  const structureType = typeof structureRecord.structureType === "string" ? structureRecord.structureType : void 0;
+  const hits = getFiniteNumber(structureRecord.hits);
+  const hitsMax = getFiniteNumber(structureRecord.hitsMax);
+  return {
+    targetId,
+    repairCount,
+    ...structureType ? { structureType } : {},
+    ...hits !== null ? { hits } : {},
+    ...hitsMax !== null ? { hitsMax } : {}
+  };
+}
+function isStructureOfType(structure, globalName, fallback) {
+  return isRecord12(structure) && matchesStructureType8(structure.structureType, globalName, fallback);
+}
+function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
+  const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
+  if (totalKnownRoadWork <= 0) {
+    return 0;
+  }
+  return roundRatio2(roadCount, totalKnownRoadWork);
 }
 function summarizeWorkerEfficiency(workers, tick) {
   const samples = workers.map((worker) => ({ creepName: getCreepName2(worker), sample: worker.memory.workerEfficiency })).filter(
@@ -12146,7 +12761,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord11(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord12(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio2(numerator, denominator) {
   if (denominator <= 0) {
@@ -12161,7 +12776,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord11(value)) {
+  if (!isRecord12(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -12202,7 +12817,7 @@ function isRecentSpawnCriticalRefillSample(sample, tick) {
   return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
 }
 function isSpawnCriticalRefillSample(value) {
-  return isRecord11(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
+  return isRecord12(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;
@@ -12285,7 +12900,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord11(constructionSite)) {
+  if (!isRecord12(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -12299,7 +12914,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord11(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord12(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -12521,10 +13136,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord11(entry) || typeof entry.event !== "number") {
+    if (!isRecord12(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord11(entry.data) ? entry.data : {};
+    const data = isRecord12(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -12590,7 +13205,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord11(structure) && (matchesStructureType8(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType8(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord12(structure) && (matchesStructureType8(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType8(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -12599,7 +13214,7 @@ function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
 function getObjectId2(value) {
-  return isRecord11(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+  return isRecord12(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects7(room, constantName) {
   const findConstant = getGlobalNumber5(constantName);
@@ -12630,7 +13245,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord11(object) || !isRecord11(object.store)) {
+  if (!isRecord12(object) || !isRecord12(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -12641,10 +13256,29 @@ function getEnergyInStore(object) {
   const storedEnergy = object.store[getEnergyResource5()];
   return typeof storedEnergy === "number" ? storedEnergy : 0;
 }
+function getEnergyCapacityInStore(object) {
+  if (!isRecord12(object) || !isRecord12(object.store)) {
+    return 0;
+  }
+  const getCapacity = object.store.getCapacity;
+  if (typeof getCapacity === "function") {
+    const capacity2 = getCapacity.call(object.store, getEnergyResource5());
+    return typeof capacity2 === "number" && Number.isFinite(capacity2) ? Math.max(0, capacity2) : 0;
+  }
+  const getFreeCapacity = object.store.getFreeCapacity;
+  if (typeof getFreeCapacity === "function") {
+    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource5());
+    if (typeof freeCapacity === "number" && Number.isFinite(freeCapacity)) {
+      return Math.max(0, getEnergyInStore(object) + freeCapacity);
+    }
+  }
+  const capacity = object.store.capacity;
+  return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
+}
 function sumDroppedEnergy(droppedResources) {
   const energyResource = getEnergyResource5();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord11(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord12(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -12673,7 +13307,7 @@ function getEnergyResource5() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord11(value) {
+function isRecord12(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -12691,7 +13325,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime7() {
+function getGameTime8() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -12964,7 +13598,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime) {
   if (isControllerOwned2(controller)) {
     return { ...controllerEvaluation, reason: "controllerOwned" };
   }
-  if (isControllerReserved(controller, getControllerOwnerUsername5(colony.room.controller))) {
+  if (isControllerReserved(controller, getControllerOwnerUsername6(colony.room.controller))) {
     return { ...controllerEvaluation, reason: "controllerReserved" };
   }
   if (isExpansionClaimControllerOnCooldown(controller)) {
@@ -13028,7 +13662,7 @@ function upsertTerritoryTarget2(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord12(existingTarget)) {
+  if (isRecord13(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -13059,7 +13693,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord12(target) && isNonEmptyString11(target.roomName) && target.action === "claim") {
+    if (isRecord13(target) && isNonEmptyString12(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -13076,7 +13710,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord12(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord13(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime) {
@@ -13121,17 +13755,17 @@ function getControllerClaimCooldown(controller) {
   return typeof upgradeBlocked === "number" && upgradeBlocked > 0 ? upgradeBlocked : 0;
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord12(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord13(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isExistingAutonomousExpansionClaimTarget(colony, roomName) {
   var _a;
   const targets = (_a = getTerritoryMemoryRecord5()) == null ? void 0 : _a.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isAutonomousExpansionClaimTarget(target, colony) && isRecord12(target) && target.roomName === roomName
+    (target) => isAutonomousExpansionClaimTarget(target, colony) && isRecord13(target) && target.roomName === roomName
   ) : false;
 }
 function isSameTarget2(left, right) {
-  return isRecord12(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord13(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
@@ -13169,17 +13803,17 @@ function isControllerOwned2(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString11(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString12(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername5(controller) {
+function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString11(username) ? username : void 0;
+  return isNonEmptyString12(username) ? username : void 0;
 }
-function isRecord12(value) {
+function isRecord13(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString11(value) {
+function isNonEmptyString12(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -13285,7 +13919,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime8();
+  const gameTime = getGameTime9();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -13305,7 +13939,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime8());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime9());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -13385,7 +14019,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime8() {
+function getGameTime9() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -13559,17 +14193,17 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber5(refreshedAt) || !isRecord13(rawSelection) || !isNonEmptyString12(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber5(refreshedAt) || !isRecord14(rawSelection) || !isNonEmptyString13(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord13(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord14(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString12(rawSelection.targetRoom)) {
+    if (!isNonEmptyString13(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -13606,7 +14240,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord13(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord14(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -13624,17 +14258,17 @@ function getNextExpansionSelectionCacheStateKey(colony) {
 function countActivePostClaimBootstraps2() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord13(records)) {
+  if (!isRecord14(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord13(record) && record.status !== "ready"
+    (record) => isRecord14(record) && record.status !== "ready"
   ).length;
 }
-function isRecord13(value) {
+function isRecord14(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString12(value) {
+function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber5(value) {
@@ -13742,7 +14376,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime9())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime10())
     );
   }
 };
@@ -13814,7 +14448,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime9() {
+function getGameTime10() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -14144,7 +14778,7 @@ function parseStrategyEvaluationArtifacts(input) {
   });
 }
 function normalizeStrategyEvaluationArtifact(rawArtifact) {
-  if (!isRecord14(rawArtifact)) {
+  if (!isRecord15(rawArtifact)) {
     return null;
   }
   if (rawArtifact.type === "runtime-summary" || Array.isArray(rawArtifact.rooms)) {
@@ -14153,7 +14787,7 @@ function normalizeStrategyEvaluationArtifact(rawArtifact) {
   if (rawArtifact.artifactType === "runtime-summary") {
     return normalizeRuntimeSummaryArtifact(rawArtifact);
   }
-  if (rawArtifact.artifactType === "room-snapshot" || Array.isArray(rawArtifact.objects) || isRecord14(rawArtifact.objects)) {
+  if (rawArtifact.artifactType === "room-snapshot" || Array.isArray(rawArtifact.objects) || isRecord15(rawArtifact.objects)) {
     return normalizeRoomSnapshotArtifact(rawArtifact);
   }
   return null;
@@ -14237,12 +14871,12 @@ function normalizeRuntimeSummaryArtifact(rawArtifact) {
     artifactType: "runtime-summary",
     ...isFiniteNumber6(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
     rooms,
-    ...isRecord14(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {},
-    ...isRecord14(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {}
+    ...isRecord15(rawArtifact.cpu) ? { cpu: normalizeCpuSummary(rawArtifact.cpu) } : {},
+    ...isRecord15(rawArtifact.reliability) ? { reliability: normalizeReliabilitySignals(rawArtifact.reliability) } : {}
   };
 }
 function normalizeRuntimeSummaryRoom(rawRoom) {
-  if (!isRecord14(rawRoom) || !isNonEmptyString13(rawRoom.roomName)) {
+  if (!isRecord15(rawRoom) || !isNonEmptyString14(rawRoom.roomName)) {
     return null;
   }
   return {
@@ -14251,19 +14885,19 @@ function normalizeRuntimeSummaryRoom(rawRoom) {
     ...isFiniteNumber6(rawRoom.energyCapacity) ? { energyCapacity: rawRoom.energyCapacity } : {},
     ...isFiniteNumber6(rawRoom.workerCount) ? { workerCount: rawRoom.workerCount } : {},
     ...Array.isArray(rawRoom.spawnStatus) ? { spawnStatus: rawRoom.spawnStatus.map(normalizeSpawnStatus) } : {},
-    ...isRecord14(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {},
-    ...isRecord14(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {},
-    ...isRecord14(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {},
-    ...isRecord14(rawRoom.constructionPriority) ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) } : {},
-    ...isRecord14(rawRoom.territoryRecommendation) ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) } : {}
+    ...isRecord15(rawRoom.controller) ? { controller: normalizeControllerSummary(rawRoom.controller) } : {},
+    ...isRecord15(rawRoom.resources) ? { resources: normalizeResourceSummary(rawRoom.resources) } : {},
+    ...isRecord15(rawRoom.combat) ? { combat: normalizeCombatSummary(rawRoom.combat) } : {},
+    ...isRecord15(rawRoom.constructionPriority) ? { constructionPriority: normalizeConstructionPrioritySummary(rawRoom.constructionPriority) } : {},
+    ...isRecord15(rawRoom.territoryRecommendation) ? { territoryRecommendation: normalizeTerritoryRecommendationSummary(rawRoom.territoryRecommendation) } : {}
   };
 }
 function normalizeRoomSnapshotArtifact(rawArtifact) {
-  if (!Array.isArray(rawArtifact.objects) && !isRecord14(rawArtifact.objects)) {
+  if (!Array.isArray(rawArtifact.objects) && !isRecord15(rawArtifact.objects)) {
     return null;
   }
-  const objects = Array.isArray(rawArtifact.objects) ? rawArtifact.objects.flatMap((rawObject) => isRecord14(rawObject) ? [rawObject] : []) : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
-    if (!isRecord14(rawObject)) {
+  const objects = Array.isArray(rawArtifact.objects) ? rawArtifact.objects.flatMap((rawObject) => isRecord15(rawObject) ? [rawObject] : []) : Object.entries(rawArtifact.objects).flatMap(([id, rawObject]) => {
+    if (!isRecord15(rawObject)) {
       return [];
     }
     return [{ ...rawObject, id }];
@@ -14271,9 +14905,9 @@ function normalizeRoomSnapshotArtifact(rawArtifact) {
   return {
     artifactType: "room-snapshot",
     ...isFiniteNumber6(rawArtifact.tick) ? { tick: rawArtifact.tick } : {},
-    ...isNonEmptyString13(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {},
-    ...isNonEmptyString13(rawArtifact.room) ? { roomName: rawArtifact.room } : {},
-    ...isNonEmptyString13(rawArtifact.owner) ? { owner: rawArtifact.owner } : {},
+    ...isNonEmptyString14(rawArtifact.roomName) ? { roomName: rawArtifact.roomName } : {},
+    ...isNonEmptyString14(rawArtifact.room) ? { roomName: rawArtifact.room } : {},
+    ...isNonEmptyString14(rawArtifact.owner) ? { owner: rawArtifact.owner } : {},
     objects
   };
 }
@@ -14293,13 +14927,13 @@ function parseJson(text) {
   }
 }
 function normalizeSpawnStatus(rawStatus) {
-  if (!isRecord14(rawStatus)) {
+  if (!isRecord15(rawStatus)) {
     return {};
   }
   return {
-    ...isNonEmptyString13(rawStatus.name) ? { name: rawStatus.name } : {},
-    ...isNonEmptyString13(rawStatus.status) ? { status: rawStatus.status } : {},
-    ...isNonEmptyString13(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {},
+    ...isNonEmptyString14(rawStatus.name) ? { name: rawStatus.name } : {},
+    ...isNonEmptyString14(rawStatus.status) ? { status: rawStatus.status } : {},
+    ...isNonEmptyString14(rawStatus.creepName) ? { creepName: rawStatus.creepName } : {},
     ...isFiniteNumber6(rawStatus.remainingTime) ? { remainingTime: rawStatus.remainingTime } : {}
   };
 }
@@ -14317,7 +14951,7 @@ function normalizeResourceSummary(rawResources) {
     ...isFiniteNumber6(rawResources.workerCarriedEnergy) ? { workerCarriedEnergy: rawResources.workerCarriedEnergy } : {},
     ...isFiniteNumber6(rawResources.droppedEnergy) ? { droppedEnergy: rawResources.droppedEnergy } : {},
     ...isFiniteNumber6(rawResources.sourceCount) ? { sourceCount: rawResources.sourceCount } : {},
-    ...isRecord14(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {}
+    ...isRecord15(rawResources.events) ? { events: normalizeResourceEvents(rawResources.events) } : {}
   };
 }
 function normalizeResourceEvents(rawEvents) {
@@ -14330,7 +14964,7 @@ function normalizeCombatSummary(rawCombat) {
   return {
     ...isFiniteNumber6(rawCombat.hostileCreepCount) ? { hostileCreepCount: rawCombat.hostileCreepCount } : {},
     ...isFiniteNumber6(rawCombat.hostileStructureCount) ? { hostileStructureCount: rawCombat.hostileStructureCount } : {},
-    ...isRecord14(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {}
+    ...isRecord15(rawCombat.events) ? { events: normalizeCombatEvents(rawCombat.events) } : {}
   };
 }
 function normalizeCombatEvents(rawEvents) {
@@ -14345,22 +14979,22 @@ function normalizeConstructionPrioritySummary(rawSummary) {
   var _a;
   return {
     ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeConstructionCandidate) } : {},
-    ...rawSummary.nextPrimary === null ? { nextPrimary: null } : isRecord14(rawSummary.nextPrimary) ? { nextPrimary: (_a = normalizeConstructionCandidate(rawSummary.nextPrimary)[0]) != null ? _a : null } : {}
+    ...rawSummary.nextPrimary === null ? { nextPrimary: null } : isRecord15(rawSummary.nextPrimary) ? { nextPrimary: (_a = normalizeConstructionCandidate(rawSummary.nextPrimary)[0]) != null ? _a : null } : {}
   };
 }
 function normalizeConstructionCandidate(rawCandidate) {
-  if (!isRecord14(rawCandidate) || !isNonEmptyString13(rawCandidate.buildItem)) {
+  if (!isRecord15(rawCandidate) || !isNonEmptyString14(rawCandidate.buildItem)) {
     return [];
   }
   return [
     {
       buildItem: rawCandidate.buildItem,
-      ...isNonEmptyString13(rawCandidate.room) ? { room: rawCandidate.room } : {},
+      ...isNonEmptyString14(rawCandidate.room) ? { room: rawCandidate.room } : {},
       ...isFiniteNumber6(rawCandidate.score) ? { score: rawCandidate.score } : {},
-      ...isNonEmptyString13(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {},
-      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString13) } : {},
-      ...Array.isArray(rawCandidate.expectedKpiMovement) ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString13) } : {},
-      ...Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString13) } : {}
+      ...isNonEmptyString14(rawCandidate.urgency) ? { urgency: rawCandidate.urgency } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString14) } : {},
+      ...Array.isArray(rawCandidate.expectedKpiMovement) ? { expectedKpiMovement: rawCandidate.expectedKpiMovement.filter(isNonEmptyString14) } : {},
+      ...Array.isArray(rawCandidate.risk) ? { risk: rawCandidate.risk.filter(isNonEmptyString14) } : {}
     }
   ];
 }
@@ -14368,24 +15002,24 @@ function normalizeTerritoryRecommendationSummary(rawSummary) {
   var _a;
   return {
     ...Array.isArray(rawSummary.candidates) ? { candidates: rawSummary.candidates.flatMap(normalizeTerritoryCandidate) } : {},
-    ...rawSummary.next === null ? { next: null } : isRecord14(rawSummary.next) ? { next: (_a = normalizeTerritoryCandidate(rawSummary.next)[0]) != null ? _a : null } : {},
+    ...rawSummary.next === null ? { next: null } : isRecord15(rawSummary.next) ? { next: (_a = normalizeTerritoryCandidate(rawSummary.next)[0]) != null ? _a : null } : {},
     ...rawSummary.followUpIntent !== void 0 ? { followUpIntent: rawSummary.followUpIntent } : {}
   };
 }
 function normalizeTerritoryCandidate(rawCandidate) {
-  if (!isRecord14(rawCandidate) || !isNonEmptyString13(rawCandidate.roomName)) {
+  if (!isRecord15(rawCandidate) || !isNonEmptyString14(rawCandidate.roomName)) {
     return [];
   }
   return [
     {
       roomName: rawCandidate.roomName,
-      ...isNonEmptyString13(rawCandidate.action) ? { action: rawCandidate.action } : {},
+      ...isNonEmptyString14(rawCandidate.action) ? { action: rawCandidate.action } : {},
       ...isFiniteNumber6(rawCandidate.score) ? { score: rawCandidate.score } : {},
-      ...isNonEmptyString13(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {},
-      ...isNonEmptyString13(rawCandidate.source) ? { source: rawCandidate.source } : {},
-      ...Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString13) } : {},
-      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString13) } : {},
-      ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString13) } : {},
+      ...isNonEmptyString14(rawCandidate.evidenceStatus) ? { evidenceStatus: rawCandidate.evidenceStatus } : {},
+      ...isNonEmptyString14(rawCandidate.source) ? { source: rawCandidate.source } : {},
+      ...Array.isArray(rawCandidate.evidence) ? { evidence: rawCandidate.evidence.filter(isNonEmptyString14) } : {},
+      ...Array.isArray(rawCandidate.preconditions) ? { preconditions: rawCandidate.preconditions.filter(isNonEmptyString14) } : {},
+      ...Array.isArray(rawCandidate.risks) ? { risks: rawCandidate.risks.filter(isNonEmptyString14) } : {},
       ...isFiniteNumber6(rawCandidate.routeDistance) ? { routeDistance: rawCandidate.routeDistance } : {},
       ...isFiniteNumber6(rawCandidate.roadDistance) ? { roadDistance: rawCandidate.roadDistance } : {},
       ...isFiniteNumber6(rawCandidate.sourceCount) ? { sourceCount: rawCandidate.sourceCount } : {},
@@ -14529,11 +15163,11 @@ function getSnapshotObjectEnergy(object) {
 function getSnapshotObjectOwner(object) {
   var _a;
   const objectUser = object == null ? void 0 : object.user;
-  if (isNonEmptyString13(objectUser)) {
+  if (isNonEmptyString14(objectUser)) {
     return objectUser;
   }
   const ownerUsername = (_a = object == null ? void 0 : object.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString13(ownerUsername) ? ownerUsername : void 0;
+  return isNonEmptyString14(ownerUsername) ? ownerUsername : void 0;
 }
 function isOwnedSnapshotObject(object, owner) {
   var _a;
@@ -14545,13 +15179,13 @@ function isOwnedSnapshotObject(object, owner) {
   }
   return object.user === owner || ((_a = object.owner) == null ? void 0 : _a.username) === owner;
 }
-function isRecord14(value) {
+function isRecord15(value) {
   return typeof value === "object" && value !== null;
 }
 function isFiniteNumber6(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isNonEmptyString13(value) {
+function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
 

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -11462,6 +11462,397 @@ function isNonEmptyString8(value) {
   return typeof value === "string" && value.length > 0;
 }
 
+// src/territory/multiRoomUpgrader.ts
+var MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO = 0.8;
+var MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP = 1;
+var REMOTE_UPGRADER_PATTERN = ["work", "carry", "move"];
+var REMOTE_UPGRADER_TRAVEL_PATTERN = ["work", "carry", "move", "move"];
+var RESERVED_CONTROLLER_BASE_BODY = ["claim", "move"];
+var REMOTE_UPGRADER_PATTERN_COST = 200;
+var MOVE_PART_COST = 50;
+var MAX_CREEP_PARTS2 = 50;
+var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
+var DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
+var ERR_NO_PATH_CODE4 = -2;
+var TERRITORY_ROUTE_DISTANCE_SEPARATOR3 = ">";
+var ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
+function recordPlannedMultiRoomUpgraderSpawn(memory) {
+  var _a, _b;
+  const sustain = memory.controllerSustain;
+  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString9(sustain.homeRoom) || !isNonEmptyString9(sustain.targetRoom)) {
+    return;
+  }
+  const cache = getActiveMultiRoomUpgraderCountCache();
+  const pendingByHome = (_a = cache.plannedByHomeRoom[sustain.homeRoom]) != null ? _a : {};
+  pendingByHome[sustain.targetRoom] = ((_b = pendingByHome[sustain.targetRoom]) != null ? _b : 0) + 1;
+  cache.plannedByHomeRoom[sustain.homeRoom] = pendingByHome;
+}
+function selectMultiRoomUpgradePlans(colony, options = {}) {
+  const config = normalizeMultiRoomUpgraderOptions(options);
+  if (config.perRoomUpgraderCap <= 0 || !hasPrimaryRoomStorageSurplus(colony, config.storageEnergyThresholdRatio)) {
+    return [];
+  }
+  const candidates = getVisibleMultiRoomUpgradeCandidates(colony, config);
+  if (candidates.length === 0) {
+    return [];
+  }
+  return candidates.sort(compareMultiRoomUpgradeCandidates).map(({ order: _order, ...plan }) => plan);
+}
+function buildMultiRoomUpgraderBody(energyAvailable, plan) {
+  const baseBody = plan.controllerState === "reserved" ? RESERVED_CONTROLLER_BASE_BODY : [];
+  const remainingEnergy = energyAvailable - getBodyCost2(baseBody);
+  if (remainingEnergy < REMOTE_UPGRADER_PATTERN_COST) {
+    return [];
+  }
+  const pattern = getRemoteUpgraderPattern(plan.routeDistance);
+  const patternCost = getBodyCost2(pattern);
+  const maxPatternCountByEnergy = Math.floor(remainingEnergy / patternCost);
+  const maxPatternCountBySize = Math.floor((MAX_CREEP_PARTS2 - baseBody.length) / pattern.length);
+  const patternCount = Math.min(
+    maxPatternCountByEnergy,
+    maxPatternCountBySize,
+    MAX_REMOTE_UPGRADER_PATTERN_COUNT
+  );
+  if (patternCount <= 0) {
+    return [];
+  }
+  const body = [
+    ...baseBody,
+    ...Array.from({ length: patternCount }).flatMap(() => pattern)
+  ];
+  const unusedEnergy = energyAvailable - getBodyCost2(body);
+  if (unusedEnergy >= MOVE_PART_COST && body.length < MAX_CREEP_PARTS2) {
+    return [...body, "move"];
+  }
+  return body;
+}
+function buildMultiRoomUpgraderMemory(plan) {
+  return {
+    role: "worker",
+    colony: plan.homeRoom,
+    territory: {
+      targetRoom: plan.targetRoom,
+      action: plan.controllerState === "reserved" ? "reserve" : "claim",
+      controllerId: plan.controllerId
+    },
+    controllerSustain: {
+      homeRoom: plan.homeRoom,
+      targetRoom: plan.targetRoom,
+      role: "upgrader"
+    }
+  };
+}
+function getVisibleMultiRoomUpgradeCandidates(colony, config) {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return [];
+  }
+  const homeRoom = colony.room.name;
+  const ownerUsername = getControllerOwnerUsername3(colony.room.controller);
+  const activeUpgraderCounts = getActiveMultiRoomUpgraderCountsByTarget(homeRoom);
+  const candidates = [];
+  let order = 0;
+  for (const room of Object.values(rooms)) {
+    const candidate = getVisibleMultiRoomUpgradeCandidate(
+      homeRoom,
+      ownerUsername,
+      room,
+      config.perRoomUpgraderCap,
+      activeUpgraderCounts,
+      order
+    );
+    order += 1;
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, perRoomUpgraderCap, activeUpgraderCounts, order) {
+  var _a;
+  if (!isNonEmptyString9(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
+    return null;
+  }
+  const controller = room.controller;
+  if (!controller || !isNonEmptyString9(controller.id)) {
+    return null;
+  }
+  const controllerState = getEligibleControllerState(controller, ownerUsername);
+  if (!controllerState) {
+    return null;
+  }
+  if (hasVisibleHostiles(room)) {
+    return null;
+  }
+  const routeDistance = getRouteDistance(homeRoom, room.name);
+  if (routeDistance === null) {
+    return null;
+  }
+  const activeUpgraderCount = (_a = activeUpgraderCounts[room.name]) != null ? _a : 0;
+  if (activeUpgraderCount >= perRoomUpgraderCap) {
+    return null;
+  }
+  return {
+    homeRoom,
+    targetRoom: room.name,
+    controllerId: controller.id,
+    controllerLevel: getControllerLevel(controller),
+    controllerState,
+    ...typeof routeDistance === "number" ? { routeDistance } : {},
+    activeUpgraderCount,
+    order
+  };
+}
+function getEligibleControllerState(controller, ownerUsername) {
+  if (controller.my === true) {
+    return controller.level < 8 ? "owned" : null;
+  }
+  const reservationUsername = getControllerReservationUsername2(controller);
+  if (ownerUsername && reservationUsername === ownerUsername) {
+    return "reserved";
+  }
+  return null;
+}
+function hasPrimaryRoomStorageSurplus(colony, storageEnergyThresholdRatio) {
+  const storage = colony.room.storage;
+  if (!storage) {
+    return false;
+  }
+  const storedEnergy = getStoredEnergy6(storage);
+  const storageCapacity = getStorageEnergyCapacity(storage);
+  return storageCapacity > 0 && storedEnergy > storageCapacity * storageEnergyThresholdRatio;
+}
+function normalizeMultiRoomUpgraderOptions(options) {
+  return {
+    storageEnergyThresholdRatio: normalizeRatio(
+      options.storageEnergyThresholdRatio,
+      MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO
+    ),
+    perRoomUpgraderCap: normalizePerRoomCap(options.perRoomUpgraderCap)
+  };
+}
+function normalizeRatio(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+function normalizePerRoomCap(value) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP;
+}
+function getRemoteUpgraderPattern(routeDistance) {
+  return typeof routeDistance === "number" && routeDistance > 1 ? REMOTE_UPGRADER_TRAVEL_PATTERN : REMOTE_UPGRADER_PATTERN;
+}
+function getBodyCost2(body) {
+  return body.reduce((total, part) => total + getBodyPartCost(part), 0);
+}
+function getBodyPartCost(part) {
+  switch (part) {
+    case "work":
+      return 100;
+    case "carry":
+    case "move":
+      return 50;
+    case "claim":
+      return 600;
+    case "attack":
+      return 80;
+    case "ranged_attack":
+      return 150;
+    case "heal":
+      return 250;
+    case "tough":
+      return 10;
+  }
+}
+function compareMultiRoomUpgradeCandidates(left, right) {
+  return left.controllerLevel - right.controllerLevel || compareOptionalNumbers3(left.routeDistance, right.routeDistance) || left.targetRoom.localeCompare(right.targetRoom) || left.order - right.order;
+}
+function compareOptionalNumbers3(left, right) {
+  return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
+}
+var activeMultiRoomUpgraderCountCache = null;
+function getActiveMultiRoomUpgraderCountsByTarget(homeRoom) {
+  var _a, _b;
+  const cache = getActiveMultiRoomUpgraderCountCache();
+  const activeByTarget = (_a = cache.countsByHomeRoom[homeRoom]) != null ? _a : {};
+  const plannedByTarget = (_b = cache.plannedByHomeRoom[homeRoom]) != null ? _b : {};
+  return combineCountMaps(activeByTarget, plannedByTarget);
+}
+function countActiveMultiRoomUpgradersByHomeRoom(creeps) {
+  var _a, _b, _c;
+  const countsByHomeRoom = {};
+  for (const creep of Object.values(creeps)) {
+    const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
+    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString9(sustain.homeRoom) || !isNonEmptyString9(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
+      continue;
+    }
+    const countsByTarget = (_b = countsByHomeRoom[sustain.homeRoom]) != null ? _b : {};
+    countsByTarget[sustain.targetRoom] = ((_c = countsByTarget[sustain.targetRoom]) != null ? _c : 0) + 1;
+    countsByHomeRoom[sustain.homeRoom] = countsByTarget;
+  }
+  return countsByHomeRoom;
+}
+function combineCountMaps(baseCounts, overlayCounts) {
+  var _a;
+  const combined = { ...baseCounts };
+  for (const [targetRoom, plannedCount] of Object.entries(overlayCounts)) {
+    combined[targetRoom] = ((_a = combined[targetRoom]) != null ? _a : 0) + plannedCount;
+  }
+  return combined;
+}
+function getActiveMultiRoomUpgraderCountCache() {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  const gameTime = getGameTime8();
+  if ((activeMultiRoomUpgraderCountCache == null ? void 0 : activeMultiRoomUpgraderCountCache.gameTime) !== gameTime || activeMultiRoomUpgraderCountCache.creeps !== creeps) {
+    activeMultiRoomUpgraderCountCache = {
+      gameTime,
+      creeps,
+      countsByHomeRoom: creeps ? countActiveMultiRoomUpgradersByHomeRoom(creeps) : {},
+      plannedByHomeRoom: {}
+    };
+  }
+  return activeMultiRoomUpgraderCountCache;
+}
+function isActiveMultiRoomUpgrader(creep) {
+  return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
+}
+function getControllerLevel(controller) {
+  return typeof controller.level === "number" ? controller.level : DEFAULT_RESERVED_CONTROLLER_LEVEL;
+}
+function getControllerOwnerUsername3(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  return isNonEmptyString9(username) ? username : null;
+}
+function getControllerReservationUsername2(controller) {
+  var _a;
+  const username = (_a = controller.reservation) == null ? void 0 : _a.username;
+  return isNonEmptyString9(username) ? username : null;
+}
+function getStoredEnergy6(storage) {
+  const storedEnergy = storage.store.getUsedCapacity(RESOURCE_ENERGY);
+  return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+function getStorageEnergyCapacity(storage) {
+  const capacity = storage.store.getCapacity(RESOURCE_ENERGY);
+  return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
+}
+function hasVisibleHostiles(room) {
+  const hostileCreepsFind = globalThis.FIND_HOSTILE_CREEPS;
+  const hostileStructuresFind = globalThis.FIND_HOSTILE_STRUCTURES;
+  return typeof hostileCreepsFind === "number" && room.find(hostileCreepsFind).length > 0 || typeof hostileStructuresFind === "number" && room.find(hostileStructuresFind).length > 0;
+}
+function getRouteDistance(fromRoom, targetRoom) {
+  var _a, _b;
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+  const gameTime = getGameTime8();
+  const cache = getTerritoryRouteDistanceCache2(gameTime);
+  const cacheKey = getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom);
+  const cachedRouteDistance = (_a = cache == null ? void 0 : cache.distances) == null ? void 0 : _a[cacheKey];
+  const cacheUpdatedAt = (_b = cache == null ? void 0 : cache.updatedAt) == null ? void 0 : _b[cacheKey];
+  if (typeof cacheUpdatedAt === "number" && !isRouteDistanceCacheStale(cacheUpdatedAt, gameTime)) {
+    if (cachedRouteDistance === null || typeof cachedRouteDistance === "number") {
+      return cachedRouteDistance;
+    }
+  } else if (cacheUpdatedAt !== void 0 && cache) {
+    delete cache.distances[cacheKey];
+    delete cache.updatedAt[cacheKey];
+  }
+  const routeDistance = getRouteDistanceFromGameMap(fromRoom, targetRoom);
+  if (routeDistance !== void 0) {
+    if (cache) {
+      cache.distances[cacheKey] = routeDistance;
+      cache.updatedAt[cacheKey] = gameTime;
+    }
+    return routeDistance;
+  }
+  return isAdjacentRoom(fromRoom, targetRoom) ? 1 : void 0;
+}
+function isRouteDistanceCacheStale(lastUpdatedAt, now) {
+  return lastUpdatedAt + ROUTE_DISTANCE_CACHE_TTL_TICKS < now;
+}
+function getTerritoryRouteDistanceCache2(gameTime) {
+  const memory = globalThis.Memory;
+  if (!memory) {
+    return void 0;
+  }
+  if (!isRecord9(memory.territory)) {
+    memory.territory = {};
+  }
+  if (!isRecord9(memory.territory.routeDistances)) {
+    memory.territory.routeDistances = {};
+  }
+  if (!isRecord9(memory.territory.routeDistancesUpdatedAt)) {
+    memory.territory.routeDistancesUpdatedAt = {};
+  }
+  const distances = memory.territory.routeDistances;
+  const updatedAt = memory.territory.routeDistancesUpdatedAt;
+  pruneStaleRouteDistanceEntries(updatedAt, distances, gameTime);
+  return {
+    distances,
+    updatedAt
+  };
+}
+function pruneStaleRouteDistanceEntries(updatedAt, distances, gameTime) {
+  for (const [cacheKey, lastUpdatedAt] of Object.entries(updatedAt)) {
+    if (typeof lastUpdatedAt !== "number") {
+      delete updatedAt[cacheKey];
+      delete distances[cacheKey];
+      continue;
+    }
+    if (isRouteDistanceCacheStale(lastUpdatedAt, gameTime)) {
+      delete updatedAt[cacheKey];
+      delete distances[cacheKey];
+    }
+  }
+}
+function getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom) {
+  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR3}${targetRoom}`;
+}
+function getRouteDistanceFromGameMap(fromRoom, targetRoom) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
+    return void 0;
+  }
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName) => isKnownDeadZoneRoom(roomName) ? Infinity : 1
+  });
+  if (route === getNoPathResultCode4()) {
+    return null;
+  }
+  return Array.isArray(route) ? route.length : void 0;
+}
+function isAdjacentRoom(fromRoom, targetRoom) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (!gameMap || typeof gameMap.describeExits !== "function") {
+    return false;
+  }
+  const exits = gameMap.describeExits(fromRoom);
+  if (!isRecord9(exits)) {
+    return false;
+  }
+  return Object.values(exits).some((roomName) => roomName === targetRoom);
+}
+function getNoPathResultCode4() {
+  const noPathCode = globalThis.ERR_NO_PATH;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE4;
+}
+function getGameTime8() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" ? gameTime : 0;
+}
+function isRecord9(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString9(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
 // src/spawn/spawnPlanner.ts
 var TERRITORY_SCOUT_BODY = ["move"];
 var TERRITORY_SCOUT_BODY_COST2 = 50;
@@ -11483,6 +11874,7 @@ var SPAWN_PRIORITY_TIERS = [
   "postClaimControllerSustain",
   "remoteEconomy",
   "territoryRemote",
+  "multiRoomControllerUpgrade",
   "controllerUpgradeSurplus"
 ];
 function planSpawn(colony, roleCounts, gameTime, options = {}) {
@@ -11522,6 +11914,8 @@ function planSpawnForPriorityTier(tier, context) {
       return planDefenseSpawn(context);
     case "territoryRemote":
       return planTerritoryRemoteSpawn(context);
+    case "multiRoomControllerUpgrade":
+      return planMultiRoomControllerUpgradeSpawn(context);
     case "controllerUpgradeSurplus":
       return planControllerUpgradeSurplusSpawn(context);
   }
@@ -11623,7 +12017,7 @@ function selectPostClaimControllerSustainPlan(colony) {
 function getPostClaimControllerSustainRecords(colonyName) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord9(records)) {
+  if (!isRecord10(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -11631,7 +12025,7 @@ function getPostClaimControllerSustainRecords(colonyName) {
   ).sort(comparePostClaimControllerSustainRecords);
 }
 function isPostClaimControllerSustainRecord(record, colonyName) {
-  return isRecord9(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString9(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord10(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString10(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function comparePostClaimControllerSustainRecords(left, right) {
   const leftHasSpawn = hasOperationalSpawnInRoom(left.roomName);
@@ -11848,6 +12242,35 @@ function planControllerUpgradeSurplusSpawn(context) {
   }
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
 }
+function planMultiRoomControllerUpgradeSpawn(context) {
+  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
+    return null;
+  }
+  const upgradePlans = selectMultiRoomUpgradePlans(context.colony);
+  if (upgradePlans.length === 0) {
+    return null;
+  }
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+  for (const upgradePlan of upgradePlans) {
+    const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
+    if (body.length === 0) {
+      continue;
+    }
+    return {
+      spawn,
+      body,
+      name: appendSpawnNameSuffix(
+        `worker-${context.colony.room.name}-${upgradePlan.targetRoom}-multiroom-upgrader-${context.gameTime}`,
+        context.options
+      ),
+      memory: buildMultiRoomUpgraderMemory(upgradePlan)
+    };
+  }
+  return null;
+}
 function shouldSpawnControllerUpgradeSurplusWorker(context) {
   if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
     return false;
@@ -11889,7 +12312,7 @@ function hasVisibleForeignReservedTerritoryTarget(colony) {
   if (!Array.isArray(targets)) {
     return false;
   }
-  const colonyOwnerUsername = getControllerOwnerUsername3(colony.room.controller);
+  const colonyOwnerUsername = getControllerOwnerUsername4(colony.room.controller);
   return targets.some((target) => {
     if (typeof target !== "object" || target === null) {
       return false;
@@ -11913,7 +12336,7 @@ function isForeignReservedController2(controller, colonyOwnerUsername) {
   const reservationUsername = (_a = controller == null ? void 0 : controller.reservation) == null ? void 0 : _a.username;
   return (controller == null ? void 0 : controller.my) !== true && typeof reservationUsername === "string" && reservationUsername.length > 0 && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername3(controller) {
+function getControllerOwnerUsername4(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return typeof username === "string" && username.length > 0 ? username : void 0;
@@ -11993,18 +12416,18 @@ function getVisibleRoom3(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function isRecord9(value) {
+function isRecord10(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString9(value) {
+function isNonEmptyString10(value) {
   return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/expansionScoring.ts
 var NEXT_EXPANSION_TARGET_CREATOR = "nextExpansionScoring";
 var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
-var TERRITORY_ROUTE_DISTANCE_SEPARATOR3 = ">";
-var ERR_NO_PATH_CODE4 = -2;
+var TERRITORY_ROUTE_DISTANCE_SEPARATOR4 = ">";
+var ERR_NO_PATH_CODE5 = -2;
 var MAX_NEARBY_EXPANSION_ROUTE_DISTANCE = 2;
 var TERRAIN_SCAN_MIN = 2;
 var TERRAIN_SCAN_MAX = 47;
@@ -12046,7 +12469,7 @@ function buildRuntimeExpansionScoringInput(colony) {
   var _a, _b;
   return {
     colonyName: colony.room.name,
-    ...getControllerOwnerUsername4(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername4(colony.room.controller) } : {},
+    ...getControllerOwnerUsername5(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername5(colony.room.controller) } : {},
     energyCapacityAvailable: colony.energyCapacityAvailable,
     ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
     ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
@@ -12060,13 +12483,13 @@ function buildRuntimeExpansionCandidates(colony) {
     return [];
   }
   const colonyName = colony.room.name;
-  const ownerUsername = getControllerOwnerUsername4(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername5(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames3(colonyName, ownerUsername);
   const adjacentRoomNames = getAdjacentRoomNamesByOwnedRoom(ownedRoomNames);
   const candidates = [];
   let order = 0;
   for (const room of Object.values(rooms)) {
-    if (!room || !isNonEmptyString10(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
+    if (!room || !isNonEmptyString11(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
       continue;
     }
     const routeDistance = getKnownRouteLength2(colonyName, room.name);
@@ -12344,7 +12767,7 @@ function upsertNextExpansionTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord10(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
+  if (isRecord11(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
     existingTarget.createdBy = NEXT_EXPANSION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -12374,7 +12797,7 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
     if (activeTarget && isSameTarget(target, activeTarget)) {
       return true;
     }
-    if (isRecord10(target) && isNonEmptyString10(target.roomName) && target.action === "claim") {
+    if (isRecord11(target) && isNonEmptyString11(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey(target.roomName, "claim"));
     }
     return false;
@@ -12387,16 +12810,16 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
   );
 }
 function isNextExpansionTarget(target, colony) {
-  return isRecord10(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
+  return isRecord11(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
 }
 function isSameTarget(left, right) {
-  return isRecord10(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord11(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey(roomName, action) {
   return `${roomName}:${action}`;
 }
 function compareExpansionCandidates(left, right) {
-  return getEvidenceStatusPriority2(left.evidenceStatus) - getEvidenceStatusPriority2(right.evidenceStatus) || right.score - left.score || compareOptionalNumbers3(left.nearestOwnedRoomDistance, right.nearestOwnedRoomDistance) || compareOptionalNumbers3(left.routeDistance, right.routeDistance) || left.roomName.localeCompare(right.roomName);
+  return getEvidenceStatusPriority2(left.evidenceStatus) - getEvidenceStatusPriority2(right.evidenceStatus) || right.score - left.score || compareOptionalNumbers4(left.nearestOwnedRoomDistance, right.nearestOwnedRoomDistance) || compareOptionalNumbers4(left.routeDistance, right.routeDistance) || left.roomName.localeCompare(right.roomName);
 }
 function getEvidenceStatusPriority2(status) {
   if (status === "sufficient") {
@@ -12404,7 +12827,7 @@ function getEvidenceStatusPriority2(status) {
   }
   return status === "insufficient-evidence" ? 1 : 2;
 }
-function compareOptionalNumbers3(left, right) {
+function compareOptionalNumbers4(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 function downgradeEvidenceStatus(current, downgrade) {
@@ -12428,7 +12851,7 @@ function getVisibleOwnedRoomNames3(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString10(room.name) && (!ownerUsername || getControllerOwnerUsername4(room.controller) === ownerUsername)) {
+    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString11(room.name) && (!ownerUsername || getControllerOwnerUsername5(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -12490,12 +12913,12 @@ function getAdjacentRoomNames3(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord10(exits)) {
+  if (!isRecord11(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER3.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString10(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString11(exitRoom) ? [exitRoom] : [];
   });
 }
 function getKnownRouteLength2(fromRoom, targetRoom) {
@@ -12503,8 +12926,8 @@ function getKnownRouteLength2(fromRoom, targetRoom) {
   if (fromRoom === targetRoom) {
     return 0;
   }
-  const cache = getTerritoryRouteDistanceCache2();
-  const cacheKey = getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom);
+  const cache = getTerritoryRouteDistanceCache3();
+  const cacheKey = getTerritoryRouteDistanceCacheKey3(fromRoom, targetRoom);
   const cachedRouteLength = cache == null ? void 0 : cache[cacheKey];
   if (cachedRouteLength === null || typeof cachedRouteLength === "number") {
     return cachedRouteLength;
@@ -12514,7 +12937,7 @@ function getKnownRouteLength2(fromRoom, targetRoom) {
     return void 0;
   }
   const route = gameMap.findRoute(fromRoom, targetRoom);
-  if (route === getNoPathResultCode4()) {
+  if (route === getNoPathResultCode5()) {
     if (cache) {
       cache[cacheKey] = null;
     }
@@ -12528,26 +12951,26 @@ function getKnownRouteLength2(fromRoom, targetRoom) {
   }
   return route.length;
 }
-function getTerritoryRouteDistanceCache2() {
+function getTerritoryRouteDistanceCache3() {
   const territoryMemory = getWritableTerritoryMemoryRecord3();
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord10(territoryMemory.routeDistances)) {
+  if (!isRecord11(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
 }
-function getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom) {
-  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR3}${targetRoom}`;
+function getTerritoryRouteDistanceCacheKey3(fromRoom, targetRoom) {
+  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR4}${targetRoom}`;
 }
-function getNoPathResultCode4() {
+function getNoPathResultCode5() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE4;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE5;
 }
 function summarizeExpansionController(controller) {
-  const ownerUsername = getControllerOwnerUsername4(controller);
-  const reservationUsername = getControllerReservationUsername2(controller);
+  const ownerUsername = getControllerOwnerUsername5(controller);
+  const reservationUsername = getControllerReservationUsername3(controller);
   const reservationTicksToEnd = getControllerReservationTicksToEnd2(controller);
   return {
     ...controller.my === true ? { my: true } : {},
@@ -12631,15 +13054,15 @@ function getFindConstant4(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getControllerOwnerUsername4(controller) {
+function getControllerOwnerUsername5(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString10(username) ? username : void 0;
+  return isNonEmptyString11(username) ? username : void 0;
 }
-function getControllerReservationUsername2(controller) {
+function getControllerReservationUsername3(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString10(username) ? username : void 0;
+  return isNonEmptyString11(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd2(controller) {
   var _a;
@@ -12649,11 +13072,11 @@ function getControllerReservationTicksToEnd2(controller) {
 function countActivePostClaimBootstraps() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord10(records)) {
+  if (!isRecord11(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord10(record) && record.status !== "ready"
+    (record) => isRecord11(record) && record.status !== "ready"
   ).length;
 }
 function getGameRooms2() {
@@ -12680,10 +13103,10 @@ function roundRatio2(numerator, denominator) {
 function toPercent(value) {
   return `${Math.round(value * 100)}%`;
 }
-function isRecord10(value) {
+function isRecord11(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString10(value) {
+function isNonEmptyString11(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -12696,14 +13119,14 @@ var ROOM_EDGE_MAX5 = 47;
 var DEFAULT_TERRAIN_WALL_MASK5 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
-  if (!isNonEmptyString11(input.colony) || !isNonEmptyString11(input.roomName)) {
+  if (!isNonEmptyString12(input.colony) || !isNonEmptyString12(input.roomName)) {
     return;
   }
   const bootstraps = getWritablePostClaimBootstrapRecords();
   if (!bootstraps) {
     return;
   }
-  const gameTime = getGameTime8();
+  const gameTime = getGameTime9();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
   bootstraps[input.roomName] = {
@@ -12814,7 +13237,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   return { active: true, spawnConstructionPending: true };
 }
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
-  if (!isNonEmptyString11(roomName)) {
+  if (!isNonEmptyString12(roomName)) {
     return;
   }
   const record = getPostClaimBootstrapRecord(roomName);
@@ -12823,7 +13246,7 @@ function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, res
   }
   updatePostClaimBootstrapRecord(roomName, {
     status: "spawningWorkers",
-    updatedAt: getGameTime8()
+    updatedAt: getGameTime9()
   });
   telemetryEvents.push({
     type: "postClaimBootstrap",
@@ -12988,14 +13411,14 @@ function findSources(room) {
   return room.find(findConstant);
 }
 function getRoomObjectPosition4(object) {
-  if (!isRecord11(object)) {
+  if (!isRecord12(object)) {
     return null;
   }
   if (isFiniteNumber6(object.x) && isFiniteNumber6(object.y)) {
     return { x: object.x, y: object.y };
   }
   const pos = object.pos;
-  if (isRecord11(pos) && isFiniteNumber6(pos.x) && isFiniteNumber6(pos.y)) {
+  if (isRecord12(pos) && isFiniteNumber6(pos.x) && isFiniteNumber6(pos.y)) {
     return { x: pos.x, y: pos.y };
   }
   return null;
@@ -13042,7 +13465,7 @@ function getWritablePostClaimBootstrapRecords() {
   return memory.territory.postClaimBootstraps;
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
-  return isRecord11(value) && value.roomName === expectedRoomName && isNonEmptyString11(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber6(value.claimedAt) && isFiniteNumber6(value.updatedAt);
+  return isRecord12(value) && value.roomName === expectedRoomName && isNonEmptyString12(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber6(value.claimedAt) && isFiniteNumber6(value.updatedAt);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
@@ -13097,15 +13520,15 @@ function getGlobalString(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getGameTime8() {
+function getGameTime9() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord11(value) {
+function isRecord12(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString11(value) {
+function isNonEmptyString12(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber6(value) {
@@ -13136,7 +13559,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return void 0;
   }
-  const tick = getGameTime9();
+  const tick = getGameTime10();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -13233,7 +13656,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime9());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime10());
   }
   return {
     roomName: colony.room.name,
@@ -13242,11 +13665,11 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime8()),
+    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime10()),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime9()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime9()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime9()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime10()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime10()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime10()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -13265,7 +13688,7 @@ function buildPostClaimBootstrapSummary(roomName) {
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime9());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime10());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -13400,7 +13823,7 @@ function isRecentWorkerTaskBehaviorSample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskBehaviorSample(value) {
-  return isRecord11(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord11(value.state) && isRecord11(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+  return isRecord13(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord13(value.state) && isRecord13(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
 }
 function isRecentWorkerTaskPolicyShadow(value, tick) {
   if (!isWorkerTaskPolicyShadow(value)) {
@@ -13409,7 +13832,7 @@ function isRecentWorkerTaskPolicyShadow(value, tick) {
   return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskPolicyShadow(value) {
-  return isRecord11(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
+  return isRecord13(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function shouldBuildStructureSnapshot(tick) {
   return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
@@ -13437,7 +13860,7 @@ function countConstructionSitesByType(constructionSites, globalName, fallback) {
   return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
 }
 function countOwnedRamparts(structures) {
-  return structures.filter((structure) => isRecord12(structure) && isObservedOwnedRampart(structure)).length;
+  return structures.filter((structure) => isRecord13(structure) && isObservedOwnedRampart(structure)).length;
 }
 function summarizeContainers(structures) {
   return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
@@ -13474,7 +13897,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   return [...repairCounts.entries()].sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId)).map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
 }
 function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
-  const structureRecord = isRecord12(structure) ? structure : {};
+  const structureRecord = isRecord13(structure) ? structure : {};
   const structureType = typeof structureRecord.structureType === "string" ? structureRecord.structureType : void 0;
   const hits = getFiniteNumber(structureRecord.hits);
   const hitsMax = getFiniteNumber(structureRecord.hitsMax);
@@ -13487,7 +13910,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord12(structure) && matchesStructureType8(structure.structureType, globalName, fallback);
+  return isRecord13(structure) && matchesStructureType8(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -13647,7 +14070,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord12(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord13(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio3(numerator, denominator) {
   if (denominator <= 0) {
@@ -13662,7 +14085,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord12(value)) {
+  if (!isRecord13(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -13703,7 +14126,7 @@ function isRecentSpawnCriticalRefillSample(sample, tick) {
   return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
 }
 function isSpawnCriticalRefillSample(value) {
-  return isRecord12(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
+  return isRecord13(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;
@@ -13786,7 +14209,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord12(constructionSite)) {
+  if (!isRecord13(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -13800,7 +14223,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord12(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord13(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -14022,10 +14445,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord12(entry) || typeof entry.event !== "number") {
+    if (!isRecord13(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord12(entry.data) ? entry.data : {};
+    const data = isRecord13(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -14091,7 +14514,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord12(structure) && (matchesStructureType8(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType8(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord13(structure) && (matchesStructureType8(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType8(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -14100,7 +14523,7 @@ function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
 function getObjectId2(value) {
-  return isRecord12(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+  return isRecord13(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects8(room, constantName) {
   const findConstant = getGlobalNumber5(constantName);
@@ -14131,7 +14554,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord12(object) || !isRecord12(object.store)) {
+  if (!isRecord13(object) || !isRecord13(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -14143,7 +14566,7 @@ function getEnergyInStore(object) {
   return typeof storedEnergy === "number" ? storedEnergy : 0;
 }
 function getEnergyCapacityInStore(object) {
-  if (!isRecord12(object) || !isRecord12(object.store)) {
+  if (!isRecord13(object) || !isRecord13(object.store)) {
     return 0;
   }
   const getCapacity = object.store.getCapacity;
@@ -14164,7 +14587,7 @@ function getEnergyCapacityInStore(object) {
 function sumDroppedEnergy2(droppedResources) {
   const energyResource = getEnergyResource5();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord12(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord13(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -14193,7 +14616,7 @@ function getEnergyResource5() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord12(value) {
+function isRecord13(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -14211,7 +14634,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime9() {
+function getGameTime10() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -14484,7 +14907,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime) {
   if (isControllerOwned2(controller)) {
     return { ...controllerEvaluation, reason: "controllerOwned" };
   }
-  if (isControllerReserved(controller, getControllerOwnerUsername5(colony.room.controller))) {
+  if (isControllerReserved(controller, getControllerOwnerUsername6(colony.room.controller))) {
     return { ...controllerEvaluation, reason: "controllerReserved" };
   }
   if (isExpansionClaimControllerOnCooldown(controller)) {
@@ -14548,7 +14971,7 @@ function upsertTerritoryTarget2(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord13(existingTarget)) {
+  if (isRecord14(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -14579,7 +15002,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord13(target) && isNonEmptyString12(target.roomName) && target.action === "claim") {
+    if (isRecord14(target) && isNonEmptyString13(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -14596,7 +15019,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord13(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord14(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime) {
@@ -14641,17 +15064,17 @@ function getControllerClaimCooldown(controller) {
   return typeof upgradeBlocked === "number" && upgradeBlocked > 0 ? upgradeBlocked : 0;
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord13(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord14(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isExistingAutonomousExpansionClaimTarget(colony, roomName) {
   var _a;
   const targets = (_a = getTerritoryMemoryRecord5()) == null ? void 0 : _a.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isAutonomousExpansionClaimTarget(target, colony) && isRecord13(target) && target.roomName === roomName
+    (target) => isAutonomousExpansionClaimTarget(target, colony) && isRecord14(target) && target.roomName === roomName
   ) : false;
 }
 function isSameTarget2(left, right) {
-  return isRecord13(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord14(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
@@ -14689,17 +15112,17 @@ function isControllerOwned2(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString12(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString13(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername5(controller) {
+function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString12(username) ? username : void 0;
+  return isNonEmptyString13(username) ? username : void 0;
 }
-function isRecord13(value) {
+function isRecord14(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString12(value) {
+function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -14805,7 +15228,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime10();
+  const gameTime = getGameTime11();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -14825,7 +15248,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime10());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime11());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -14905,7 +15328,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime10() {
+function getGameTime11() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -14999,6 +15422,7 @@ function runEconomy(preludeTelemetryEvents = []) {
       usedSpawns.add(outcome.spawn);
       availableEnergy = Math.max(0, availableEnergy - getBodyCost(spawnRequest.body));
       successfulSpawnCount += 1;
+      recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
       if (spawnRequest.memory.role !== "worker") {
         break;
       }
@@ -15079,17 +15503,17 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber7(refreshedAt) || !isRecord14(rawSelection) || !isNonEmptyString13(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber7(refreshedAt) || !isRecord15(rawSelection) || !isNonEmptyString14(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord14(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord15(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString13(rawSelection.targetRoom)) {
+    if (!isNonEmptyString14(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -15126,7 +15550,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord14(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord15(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -15144,17 +15568,17 @@ function getNextExpansionSelectionCacheStateKey(colony) {
 function countActivePostClaimBootstraps2() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord14(records)) {
+  if (!isRecord15(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord14(record) && record.status !== "ready"
+    (record) => isRecord15(record) && record.status !== "ready"
   ).length;
 }
-function isRecord14(value) {
+function isRecord15(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString13(value) {
+function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber7(value) {
@@ -15262,7 +15686,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime11())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime12())
     );
   }
 };
@@ -15334,7 +15758,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime11() {
+function getGameTime12() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -16164,10 +16588,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord15(rawReplay)) {
+  if (!isRecord16(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString14(rawReplay.replayId) || !isNonEmptyString14(rawReplay.room) || !isFiniteNumber7(rawReplay.startTick) || !isFiniteNumber7(rawReplay.endTick) || !isFiniteNumber7(rawReplay.finalScore) || !isRecord15(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString15(rawReplay.replayId) || !isNonEmptyString15(rawReplay.room) || !isFiniteNumber8(rawReplay.startTick) || !isFiniteNumber8(rawReplay.endTick) || !isFiniteNumber8(rawReplay.finalScore) || !isRecord16(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -16192,13 +16616,13 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord15(value) {
+function isRecord16(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString14(value) {
+function isNonEmptyString15(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isFiniteNumber7(value) {
+function isFiniteNumber8(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
 

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -36,6 +36,7 @@ import {
   TERRITORY_SCOUT_ROLE
 } from '../territory/territoryPlanner';
 import { runTerritoryControllerCreep } from '../territory/territoryRunner';
+import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgrader';
 import {
   recordPostClaimBootstrapWorkerSpawn,
   refreshPostClaimBootstrap
@@ -116,6 +117,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       usedSpawns.add(outcome.spawn);
       availableEnergy = Math.max(0, availableEnergy - getBodyCost(spawnRequest.body));
       successfulSpawnCount += 1;
+      recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
 
       if (spawnRequest.memory.role !== 'worker') {
         break;

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -37,7 +37,7 @@ import {
 import {
   buildMultiRoomUpgraderBody,
   buildMultiRoomUpgraderMemory,
-  selectMultiRoomUpgradePlan
+  selectMultiRoomUpgradePlans
 } from '../territory/multiRoomUpgrader';
 
 type SpawnPriorityTier =
@@ -615,8 +615,8 @@ function planMultiRoomControllerUpgradeSpawn(context: SpawnPlanningContext): Spa
     return null;
   }
 
-  const upgradePlan = selectMultiRoomUpgradePlan(context.colony);
-  if (!upgradePlan) {
+  const upgradePlans = selectMultiRoomUpgradePlans(context.colony);
+  if (upgradePlans.length === 0) {
     return null;
   }
 
@@ -625,20 +625,24 @@ function planMultiRoomControllerUpgradeSpawn(context: SpawnPlanningContext): Spa
     return null;
   }
 
-  const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
-  if (body.length === 0) {
-    return null;
+  for (const upgradePlan of upgradePlans) {
+    const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
+    if (body.length === 0) {
+      continue;
+    }
+
+    return {
+      spawn,
+      body,
+      name: appendSpawnNameSuffix(
+        `worker-${context.colony.room.name}-${upgradePlan.targetRoom}-multiroom-upgrader-${context.gameTime}`,
+        context.options
+      ),
+      memory: buildMultiRoomUpgraderMemory(upgradePlan)
+    };
   }
 
-  return {
-    spawn,
-    body,
-    name: appendSpawnNameSuffix(
-      `worker-${context.colony.room.name}-${upgradePlan.targetRoom}-multiroom-upgrader-${context.gameTime}`,
-      context.options
-    ),
-    memory: buildMultiRoomUpgraderMemory(upgradePlan)
-  };
+  return null;
 }
 
 function shouldSpawnControllerUpgradeSurplusWorker(context: SpawnPlanningContext): boolean {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -34,6 +34,11 @@ import {
   TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND,
   type TerritoryIntentPlan
 } from '../territory/territoryPlanner';
+import {
+  buildMultiRoomUpgraderBody,
+  buildMultiRoomUpgraderMemory,
+  selectMultiRoomUpgradePlan
+} from '../territory/multiRoomUpgrader';
 
 type SpawnPriorityTier =
   | 'emergencyBootstrap'
@@ -43,6 +48,7 @@ type SpawnPriorityTier =
   | 'postClaimControllerSustain'
   | 'remoteEconomy'
   | 'territoryRemote'
+  | 'multiRoomControllerUpgrade'
   | 'controllerUpgradeSurplus';
 
 interface SpawnPlanningContext {
@@ -90,6 +96,7 @@ const SPAWN_PRIORITY_TIERS: SpawnPriorityTier[] = [
   'postClaimControllerSustain',
   'remoteEconomy',
   'territoryRemote',
+  'multiRoomControllerUpgrade',
   'controllerUpgradeSurplus'
 ];
 
@@ -141,6 +148,8 @@ function planSpawnForPriorityTier(
       return planDefenseSpawn(context);
     case 'territoryRemote':
       return planTerritoryRemoteSpawn(context);
+    case 'multiRoomControllerUpgrade':
+      return planMultiRoomControllerUpgradeSpawn(context);
     case 'controllerUpgradeSurplus':
       return planControllerUpgradeSurplusSpawn(context);
   }
@@ -592,6 +601,44 @@ function planControllerUpgradeSurplusSpawn(context: SpawnPlanningContext): Spawn
   }
 
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
+}
+
+function planMultiRoomControllerUpgradeSpawn(context: SpawnPlanningContext): SpawnRequest | null {
+  if (
+    context.options.workersOnly ||
+    context.territoryIntentPending ||
+    context.survival.mode !== 'TERRITORY_READY' ||
+    hasControllerUpgradeBlockingTerritoryWork(context.colony) ||
+    context.workerCapacity < context.workerTarget ||
+    context.colony.energyAvailable < context.colony.energyCapacityAvailable
+  ) {
+    return null;
+  }
+
+  const upgradePlan = selectMultiRoomUpgradePlan(context.colony);
+  if (!upgradePlan) {
+    return null;
+  }
+
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+
+  const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
+  if (body.length === 0) {
+    return null;
+  }
+
+  return {
+    spawn,
+    body,
+    name: appendSpawnNameSuffix(
+      `worker-${context.colony.room.name}-${upgradePlan.targetRoom}-multiroom-upgrader-${context.gameTime}`,
+      context.options
+    ),
+    memory: buildMultiRoomUpgraderMemory(upgradePlan)
+  };
 }
 
 function shouldSpawnControllerUpgradeSurplusWorker(context: SpawnPlanningContext): boolean {

--- a/prod/src/territory/multiRoomUpgrader.ts
+++ b/prod/src/territory/multiRoomUpgrader.ts
@@ -1,0 +1,404 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { WORKER_REPLACEMENT_TICKS_TO_LIVE } from '../creeps/roleCounts';
+import { isKnownDeadZoneRoom } from '../defense/deadZone';
+
+export const MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO = 0.8;
+export const MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP = 1;
+
+const REMOTE_UPGRADER_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move'];
+const REMOTE_UPGRADER_TRAVEL_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move', 'move'];
+const RESERVED_CONTROLLER_BASE_BODY: BodyPartConstant[] = ['claim', 'move'];
+const REMOTE_UPGRADER_PATTERN_COST = 200;
+const MOVE_PART_COST = 50;
+const MAX_CREEP_PARTS = 50;
+const MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
+const DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
+
+export type MultiRoomUpgradeControllerState = 'owned' | 'reserved';
+
+export interface MultiRoomUpgraderOptions {
+  storageEnergyThresholdRatio?: number;
+  perRoomUpgraderCap?: number;
+}
+
+export interface MultiRoomUpgradePlan {
+  homeRoom: string;
+  targetRoom: string;
+  controllerId: Id<StructureController>;
+  controllerLevel: number;
+  controllerState: MultiRoomUpgradeControllerState;
+  routeDistance?: number;
+  activeUpgraderCount: number;
+}
+
+interface MultiRoomUpgradeCandidate extends MultiRoomUpgradePlan {
+  order: number;
+}
+
+interface MultiRoomUpgraderConfig {
+  storageEnergyThresholdRatio: number;
+  perRoomUpgraderCap: number;
+}
+
+export function selectMultiRoomUpgradePlan(
+  colony: ColonySnapshot,
+  options: MultiRoomUpgraderOptions = {}
+): MultiRoomUpgradePlan | null {
+  const config = normalizeMultiRoomUpgraderOptions(options);
+  if (config.perRoomUpgraderCap <= 0 || !hasPrimaryRoomStorageSurplus(colony, config.storageEnergyThresholdRatio)) {
+    return null;
+  }
+
+  const candidates = getVisibleMultiRoomUpgradeCandidates(colony, config);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const { order: _order, ...plan } = candidates.sort(compareMultiRoomUpgradeCandidates)[0];
+  return plan;
+}
+
+export function buildMultiRoomUpgraderBody(
+  energyAvailable: number,
+  plan: Pick<MultiRoomUpgradePlan, 'controllerState' | 'routeDistance'>
+): BodyPartConstant[] {
+  const baseBody = plan.controllerState === 'reserved' ? RESERVED_CONTROLLER_BASE_BODY : [];
+  const remainingEnergy = energyAvailable - getBodyCost(baseBody);
+  if (remainingEnergy < REMOTE_UPGRADER_PATTERN_COST) {
+    return [];
+  }
+
+  const pattern = getRemoteUpgraderPattern(plan.routeDistance);
+  const patternCost = getBodyCost(pattern);
+  const maxPatternCountByEnergy = Math.floor(remainingEnergy / patternCost);
+  const maxPatternCountBySize = Math.floor((MAX_CREEP_PARTS - baseBody.length) / pattern.length);
+  const patternCount = Math.min(
+    maxPatternCountByEnergy,
+    maxPatternCountBySize,
+    MAX_REMOTE_UPGRADER_PATTERN_COUNT
+  );
+  if (patternCount <= 0) {
+    return [];
+  }
+
+  const body = [
+    ...baseBody,
+    ...Array.from({ length: patternCount }).flatMap(() => pattern)
+  ];
+  const unusedEnergy = energyAvailable - getBodyCost(body);
+  if (unusedEnergy >= MOVE_PART_COST && body.length < MAX_CREEP_PARTS) {
+    return [...body, 'move'];
+  }
+
+  return body;
+}
+
+export function buildMultiRoomUpgraderMemory(plan: MultiRoomUpgradePlan): CreepMemory {
+  return {
+    role: 'worker',
+    colony: plan.targetRoom,
+    territory: {
+      targetRoom: plan.targetRoom,
+      action: plan.controllerState === 'reserved' ? 'reserve' : 'claim',
+      controllerId: plan.controllerId
+    },
+    controllerSustain: {
+      homeRoom: plan.homeRoom,
+      targetRoom: plan.targetRoom,
+      role: 'upgrader'
+    }
+  };
+}
+
+function getVisibleMultiRoomUpgradeCandidates(
+  colony: ColonySnapshot,
+  config: MultiRoomUpgraderConfig
+): MultiRoomUpgradeCandidate[] {
+  const rooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+  if (!rooms) {
+    return [];
+  }
+
+  const homeRoom = colony.room.name;
+  const ownerUsername = getControllerOwnerUsername(colony.room.controller);
+  const candidates: MultiRoomUpgradeCandidate[] = [];
+  let order = 0;
+
+  for (const room of Object.values(rooms)) {
+    const candidate = getVisibleMultiRoomUpgradeCandidate(
+      homeRoom,
+      ownerUsername,
+      room,
+      config.perRoomUpgraderCap,
+      order
+    );
+    order += 1;
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+
+  return candidates;
+}
+
+function getVisibleMultiRoomUpgradeCandidate(
+  homeRoom: string,
+  ownerUsername: string | null,
+  room: Room,
+  perRoomUpgraderCap: number,
+  order: number
+): MultiRoomUpgradeCandidate | null {
+  if (!isNonEmptyString(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
+    return null;
+  }
+
+  const controller = room.controller;
+  if (!controller || !isNonEmptyString(controller.id)) {
+    return null;
+  }
+
+  const controllerState = getEligibleControllerState(controller, ownerUsername);
+  if (!controllerState) {
+    return null;
+  }
+
+  const routeDistance = getRouteDistance(homeRoom, room.name);
+  if (routeDistance === null) {
+    return null;
+  }
+
+  const activeUpgraderCount = countActiveMultiRoomUpgraders(homeRoom, room.name);
+  if (activeUpgraderCount >= perRoomUpgraderCap) {
+    return null;
+  }
+
+  return {
+    homeRoom,
+    targetRoom: room.name,
+    controllerId: controller.id,
+    controllerLevel: getControllerLevel(controller),
+    controllerState,
+    ...(typeof routeDistance === 'number' ? { routeDistance } : {}),
+    activeUpgraderCount,
+    order
+  };
+}
+
+function getEligibleControllerState(
+  controller: StructureController,
+  ownerUsername: string | null
+): MultiRoomUpgradeControllerState | null {
+  if (controller.my === true) {
+    return controller.level < 8 ? 'owned' : null;
+  }
+
+  const reservationUsername = getControllerReservationUsername(controller);
+  if (ownerUsername && reservationUsername === ownerUsername) {
+    return 'reserved';
+  }
+
+  return null;
+}
+
+function hasPrimaryRoomStorageSurplus(colony: ColonySnapshot, storageEnergyThresholdRatio: number): boolean {
+  const storage = colony.room.storage;
+  if (!storage) {
+    return false;
+  }
+
+  const storedEnergy = getStoredEnergy(storage);
+  const storageCapacity = getStorageEnergyCapacity(storage);
+  return storageCapacity > 0 && storedEnergy > storageCapacity * storageEnergyThresholdRatio;
+}
+
+function normalizeMultiRoomUpgraderOptions(options: MultiRoomUpgraderOptions): MultiRoomUpgraderConfig {
+  return {
+    storageEnergyThresholdRatio: normalizeRatio(
+      options.storageEnergyThresholdRatio,
+      MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO
+    ),
+    perRoomUpgraderCap: normalizePerRoomCap(options.perRoomUpgraderCap)
+  };
+}
+
+function normalizeRatio(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function normalizePerRoomCap(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP;
+}
+
+function getRemoteUpgraderPattern(routeDistance: number | undefined): BodyPartConstant[] {
+  return typeof routeDistance === 'number' && routeDistance > 1
+    ? REMOTE_UPGRADER_TRAVEL_PATTERN
+    : REMOTE_UPGRADER_PATTERN;
+}
+
+function getBodyCost(body: BodyPartConstant[]): number {
+  return body.reduce((total, part) => total + getBodyPartCost(part), 0);
+}
+
+function getBodyPartCost(part: BodyPartConstant): number {
+  switch (part) {
+    case 'work':
+      return 100;
+    case 'carry':
+    case 'move':
+      return 50;
+    case 'claim':
+      return 600;
+    case 'attack':
+      return 80;
+    case 'ranged_attack':
+      return 150;
+    case 'heal':
+      return 250;
+    case 'tough':
+      return 10;
+  }
+}
+
+function compareMultiRoomUpgradeCandidates(
+  left: MultiRoomUpgradeCandidate,
+  right: MultiRoomUpgradeCandidate
+): number {
+  return (
+    left.controllerLevel - right.controllerLevel ||
+    compareOptionalNumbers(left.routeDistance, right.routeDistance) ||
+    left.targetRoom.localeCompare(right.targetRoom) ||
+    left.order - right.order
+  );
+}
+
+function compareOptionalNumbers(left: number | undefined, right: number | undefined): number {
+  return (left ?? Number.POSITIVE_INFINITY) - (right ?? Number.POSITIVE_INFINITY);
+}
+
+function countActiveMultiRoomUpgraders(homeRoom: string, targetRoom: string): number {
+  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  if (!creeps) {
+    return 0;
+  }
+
+  return Object.values(creeps).filter((creep) => isActiveMultiRoomUpgrader(creep, homeRoom, targetRoom)).length;
+}
+
+function isActiveMultiRoomUpgrader(creep: Creep, homeRoom: string, targetRoom: string): boolean {
+  const sustain = creep.memory?.controllerSustain;
+  return (
+    sustain?.role === 'upgrader' &&
+    sustain.homeRoom === homeRoom &&
+    sustain.targetRoom === targetRoom &&
+    (creep.ticksToLive === undefined || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE)
+  );
+}
+
+function getControllerLevel(controller: StructureController): number {
+  return typeof controller.level === 'number' ? controller.level : DEFAULT_RESERVED_CONTROLLER_LEVEL;
+}
+
+function getControllerOwnerUsername(controller: StructureController | undefined): string | null {
+  const username = (controller as (StructureController & { owner?: { username?: string } }) | undefined)?.owner
+    ?.username;
+  return isNonEmptyString(username) ? username : null;
+}
+
+function getControllerReservationUsername(controller: StructureController): string | null {
+  const username = (controller as StructureController & { reservation?: { username?: string } }).reservation?.username;
+  return isNonEmptyString(username) ? username : null;
+}
+
+function getStoredEnergy(storage: StructureStorage): number {
+  const storedEnergy = storage.store.getUsedCapacity(RESOURCE_ENERGY);
+  return typeof storedEnergy === 'number' && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+
+function getStorageEnergyCapacity(storage: StructureStorage): number {
+  const capacity = storage.store.getCapacity(RESOURCE_ENERGY);
+  return typeof capacity === 'number' && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
+}
+
+function getRouteDistance(fromRoom: string, targetRoom: string): number | null | undefined {
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+
+  const cachedRouteDistance = getCachedRouteDistance(fromRoom, targetRoom);
+  if (cachedRouteDistance !== undefined) {
+    return cachedRouteDistance;
+  }
+
+  const routeDistance = getRouteDistanceFromGameMap(fromRoom, targetRoom);
+  if (routeDistance !== undefined) {
+    return routeDistance;
+  }
+
+  return isAdjacentRoom(fromRoom, targetRoom) ? 1 : undefined;
+}
+
+function getCachedRouteDistance(fromRoom: string, targetRoom: string): number | null | undefined {
+  const routeDistances = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.routeDistances;
+  if (!isRecord(routeDistances)) {
+    return undefined;
+  }
+
+  const value = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`];
+  return typeof value === 'number' || value === null ? value : undefined;
+}
+
+function getRouteDistanceFromGameMap(fromRoom: string, targetRoom: string): number | null | undefined {
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map as
+    | (Partial<GameMap> & {
+        findRoute?: (
+          fromRoom: string,
+          toRoom: string,
+          opts?: { routeCallback?: (roomName: string, fromRoomName: string) => number }
+        ) => unknown;
+      })
+    | undefined;
+
+  if (typeof gameMap?.findRoute !== 'function') {
+    return undefined;
+  }
+
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName: string) => (isKnownDeadZoneRoom(roomName) ? Infinity : 1)
+  });
+  if (route === getNoPathResultCode()) {
+    return null;
+  }
+
+  return Array.isArray(route) ? route.length : undefined;
+}
+
+function isAdjacentRoom(fromRoom: string, targetRoom: string): boolean {
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map;
+  if (!gameMap || typeof gameMap.describeExits !== 'function') {
+    return false;
+  }
+
+  const exits = gameMap.describeExits(fromRoom) as ExitsInformation | null;
+  if (!isRecord(exits)) {
+    return false;
+  }
+
+  return Object.values(exits).some((roomName) => roomName === targetRoom);
+}
+
+function getNoPathResultCode(): ScreepsReturnCode {
+  const noPathCode = (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
+  return typeof noPathCode === 'number' ? noPathCode : ERR_NO_PATH_CODE;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/prod/src/territory/multiRoomUpgrader.ts
+++ b/prod/src/territory/multiRoomUpgrader.ts
@@ -15,7 +15,6 @@ const MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
 const DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
 const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
-const TERRITORY_ROUTE_DISTANCE_MEMORY_TTL_TICK_KEY = 'routeDistancesUpdatedAt';
 
 export type MultiRoomUpgradeControllerState = 'owned' | 'reserved';
 
@@ -41,6 +40,23 @@ interface MultiRoomUpgradeCandidate extends MultiRoomUpgradePlan {
 interface MultiRoomUpgraderConfig {
   storageEnergyThresholdRatio: number;
   perRoomUpgraderCap: number;
+}
+
+export function recordPlannedMultiRoomUpgraderSpawn(memory: CreepMemory): void {
+  const sustain = memory.controllerSustain;
+  if (
+    memory.role !== 'worker' ||
+    sustain?.role !== 'upgrader' ||
+    !isNonEmptyString(sustain.homeRoom) ||
+    !isNonEmptyString(sustain.targetRoom)
+  ) {
+    return;
+  }
+
+  const cache = getActiveMultiRoomUpgraderCountCache();
+  const pendingByHome = cache.plannedByHomeRoom[sustain.homeRoom] ?? {};
+  pendingByHome[sustain.targetRoom] = (pendingByHome[sustain.targetRoom] ?? 0) + 1;
+  cache.plannedByHomeRoom[sustain.homeRoom] = pendingByHome;
 }
 
 export function selectMultiRoomUpgradePlan(
@@ -105,7 +121,7 @@ export function buildMultiRoomUpgraderBody(
 export function buildMultiRoomUpgraderMemory(plan: MultiRoomUpgradePlan): CreepMemory {
   return {
     role: 'worker',
-    colony: plan.targetRoom,
+    colony: plan.homeRoom,
     territory: {
       targetRoom: plan.targetRoom,
       action: plan.controllerState === 'reserved' ? 'reserve' : 'claim',
@@ -174,12 +190,12 @@ function getVisibleMultiRoomUpgradeCandidate(
     return null;
   }
 
-  const routeDistance = getRouteDistance(homeRoom, room.name);
-  if (routeDistance === null) {
+  if (hasVisibleHostiles(room)) {
     return null;
   }
 
-  if (hasVisibleHostiles(room)) {
+  const routeDistance = getRouteDistance(homeRoom, room.name);
+  if (routeDistance === null) {
     return null;
   }
 
@@ -297,29 +313,16 @@ interface ActiveMultiRoomUpgraderCountCache {
   gameTime: number;
   creeps?: Game['creeps'];
   countsByHomeRoom: Record<string, Record<string, number>>;
+  plannedByHomeRoom: Record<string, Record<string, number>>;
 }
 
 let activeMultiRoomUpgraderCountCache: ActiveMultiRoomUpgraderCountCache | null = null;
 
 function getActiveMultiRoomUpgraderCountsByTarget(homeRoom: string): Record<string, number> {
-  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
-  if (!creeps) {
-    return {};
-  }
-
-  const gameTime = getGameTime();
-  if (
-    activeMultiRoomUpgraderCountCache?.gameTime !== gameTime ||
-    activeMultiRoomUpgraderCountCache.creeps !== creeps
-  ) {
-    activeMultiRoomUpgraderCountCache = {
-      gameTime,
-      creeps,
-      countsByHomeRoom: countActiveMultiRoomUpgradersByHomeRoom(creeps)
-    };
-  }
-
-  return activeMultiRoomUpgraderCountCache.countsByHomeRoom[homeRoom] ?? {};
+  const cache = getActiveMultiRoomUpgraderCountCache();
+  const activeByTarget = cache.countsByHomeRoom[homeRoom] ?? {};
+  const plannedByTarget = cache.plannedByHomeRoom[homeRoom] ?? {};
+  return combineCountMaps(activeByTarget, plannedByTarget);
 }
 
 function countActiveMultiRoomUpgradersByHomeRoom(
@@ -343,6 +346,36 @@ function countActiveMultiRoomUpgradersByHomeRoom(
   }
 
   return countsByHomeRoom;
+}
+
+function combineCountMaps(
+  baseCounts: Record<string, number>,
+  overlayCounts: Record<string, number>
+): Record<string, number> {
+  const combined = { ...baseCounts };
+  for (const [targetRoom, plannedCount] of Object.entries(overlayCounts)) {
+    combined[targetRoom] = (combined[targetRoom] ?? 0) + plannedCount;
+  }
+
+  return combined;
+}
+
+function getActiveMultiRoomUpgraderCountCache(): ActiveMultiRoomUpgraderCountCache {
+  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  const gameTime = getGameTime();
+  if (
+    activeMultiRoomUpgraderCountCache?.gameTime !== gameTime ||
+    activeMultiRoomUpgraderCountCache.creeps !== creeps
+  ) {
+    activeMultiRoomUpgraderCountCache = {
+      gameTime,
+      creeps,
+      countsByHomeRoom: creeps ? countActiveMultiRoomUpgradersByHomeRoom(creeps) : {},
+      plannedByHomeRoom: {}
+    };
+  }
+
+  return activeMultiRoomUpgraderCountCache;
 }
 
 function isActiveMultiRoomUpgrader(creep: Creep): boolean {
@@ -414,13 +447,6 @@ function getTerritoryRouteDistanceCache(): TerritoryMemory['routeDistances'] | u
 
   if (!isRecord(memory.territory)) {
     memory.territory = {};
-  }
-
-  const gameTime = getGameTime();
-  const territoryMemory = memory.territory as Record<string, unknown>;
-  if (territoryMemory[TERRITORY_ROUTE_DISTANCE_MEMORY_TTL_TICK_KEY] !== gameTime) {
-    territoryMemory[TERRITORY_ROUTE_DISTANCE_MEMORY_TTL_TICK_KEY] = gameTime;
-    territoryMemory.routeDistances = {};
   }
 
   if (!isRecord(memory.territory.routeDistances)) {

--- a/prod/src/territory/multiRoomUpgrader.ts
+++ b/prod/src/territory/multiRoomUpgrader.ts
@@ -15,6 +15,7 @@ const MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
 const DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
 const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
+const ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
 
 export type MultiRoomUpgradeControllerState = 'owned' | 'reserved';
 
@@ -317,6 +318,10 @@ interface ActiveMultiRoomUpgraderCountCache {
 }
 
 let activeMultiRoomUpgraderCountCache: ActiveMultiRoomUpgraderCountCache | null = null;
+interface RouteDistanceCacheState {
+  distances: Record<string, number | null>;
+  updatedAt: Record<string, number>;
+}
 
 function getActiveMultiRoomUpgraderCountsByTarget(homeRoom: string): Record<string, number> {
   const cache = getActiveMultiRoomUpgraderCountCache();
@@ -421,17 +426,25 @@ function getRouteDistance(fromRoom: string, targetRoom: string): number | null |
     return 0;
   }
 
-  const cache = getTerritoryRouteDistanceCache();
+  const gameTime = getGameTime();
+  const cache = getTerritoryRouteDistanceCache(gameTime);
   const cacheKey = getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom);
-  const cachedRouteDistance = cache?.[cacheKey];
-  if (cachedRouteDistance === null || typeof cachedRouteDistance === 'number') {
-    return cachedRouteDistance;
+  const cachedRouteDistance = cache?.distances?.[cacheKey];
+  const cacheUpdatedAt = cache?.updatedAt?.[cacheKey];
+  if (typeof cacheUpdatedAt === 'number' && !isRouteDistanceCacheStale(cacheUpdatedAt, gameTime)) {
+    if (cachedRouteDistance === null || typeof cachedRouteDistance === 'number') {
+      return cachedRouteDistance;
+    }
+  } else if (cacheUpdatedAt !== undefined && cache) {
+    delete cache.distances[cacheKey];
+    delete cache.updatedAt[cacheKey];
   }
 
   const routeDistance = getRouteDistanceFromGameMap(fromRoom, targetRoom);
   if (routeDistance !== undefined) {
     if (cache) {
-      cache[cacheKey] = routeDistance;
+      cache.distances[cacheKey] = routeDistance;
+      cache.updatedAt[cacheKey] = gameTime;
     }
     return routeDistance;
   }
@@ -439,7 +452,11 @@ function getRouteDistance(fromRoom: string, targetRoom: string): number | null |
   return isAdjacentRoom(fromRoom, targetRoom) ? 1 : undefined;
 }
 
-function getTerritoryRouteDistanceCache(): TerritoryMemory['routeDistances'] | undefined {
+function isRouteDistanceCacheStale(lastUpdatedAt: number, now: number): boolean {
+  return lastUpdatedAt + ROUTE_DISTANCE_CACHE_TTL_TICKS < now;
+}
+
+function getTerritoryRouteDistanceCache(gameTime: number): RouteDistanceCacheState | undefined {
   const memory = (globalThis as { Memory?: Partial<Memory> }).Memory;
   if (!memory) {
     return undefined;
@@ -453,7 +470,37 @@ function getTerritoryRouteDistanceCache(): TerritoryMemory['routeDistances'] | u
     memory.territory.routeDistances = {};
   }
 
-  return memory.territory.routeDistances as TerritoryMemory['routeDistances'];
+  if (!isRecord(memory.territory.routeDistancesUpdatedAt)) {
+    memory.territory.routeDistancesUpdatedAt = {};
+  }
+
+  const distances = memory.territory.routeDistances as Record<string, number | null>;
+  const updatedAt = memory.territory.routeDistancesUpdatedAt as Record<string, number>;
+  pruneStaleRouteDistanceEntries(updatedAt, distances, gameTime);
+
+  return {
+    distances,
+    updatedAt
+  };
+}
+
+function pruneStaleRouteDistanceEntries(
+  updatedAt: Record<string, unknown>,
+  distances: Record<string, number | null>,
+  gameTime: number
+): void {
+  for (const [cacheKey, lastUpdatedAt] of Object.entries(updatedAt)) {
+    if (typeof lastUpdatedAt !== 'number') {
+      delete updatedAt[cacheKey];
+      delete distances[cacheKey];
+      continue;
+    }
+
+    if (isRouteDistanceCacheStale(lastUpdatedAt, gameTime)) {
+      delete updatedAt[cacheKey];
+      delete distances[cacheKey];
+    }
+  }
 }
 
 function getTerritoryRouteDistanceCacheKey(fromRoom: string, targetRoom: string): string {

--- a/prod/src/territory/multiRoomUpgrader.ts
+++ b/prod/src/territory/multiRoomUpgrader.ts
@@ -46,18 +46,24 @@ export function selectMultiRoomUpgradePlan(
   colony: ColonySnapshot,
   options: MultiRoomUpgraderOptions = {}
 ): MultiRoomUpgradePlan | null {
+  return selectMultiRoomUpgradePlans(colony, options)[0] ?? null;
+}
+
+export function selectMultiRoomUpgradePlans(
+  colony: ColonySnapshot,
+  options: MultiRoomUpgraderOptions = {}
+): MultiRoomUpgradePlan[] {
   const config = normalizeMultiRoomUpgraderOptions(options);
   if (config.perRoomUpgraderCap <= 0 || !hasPrimaryRoomStorageSurplus(colony, config.storageEnergyThresholdRatio)) {
-    return null;
+    return [];
   }
 
   const candidates = getVisibleMultiRoomUpgradeCandidates(colony, config);
   if (candidates.length === 0) {
-    return null;
+    return [];
   }
 
-  const { order: _order, ...plan } = candidates.sort(compareMultiRoomUpgradeCandidates)[0];
-  return plan;
+  return candidates.sort(compareMultiRoomUpgradeCandidates).map(({ order: _order, ...plan }) => plan);
 }
 
 export function buildMultiRoomUpgraderBody(
@@ -123,6 +129,7 @@ function getVisibleMultiRoomUpgradeCandidates(
 
   const homeRoom = colony.room.name;
   const ownerUsername = getControllerOwnerUsername(colony.room.controller);
+  const activeUpgraderCounts = getActiveMultiRoomUpgraderCountsByTarget(homeRoom);
   const candidates: MultiRoomUpgradeCandidate[] = [];
   let order = 0;
 
@@ -132,6 +139,7 @@ function getVisibleMultiRoomUpgradeCandidates(
       ownerUsername,
       room,
       config.perRoomUpgraderCap,
+      activeUpgraderCounts,
       order
     );
     order += 1;
@@ -148,6 +156,7 @@ function getVisibleMultiRoomUpgradeCandidate(
   ownerUsername: string | null,
   room: Room,
   perRoomUpgraderCap: number,
+  activeUpgraderCounts: Record<string, number>,
   order: number
 ): MultiRoomUpgradeCandidate | null {
   if (!isNonEmptyString(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
@@ -164,12 +173,16 @@ function getVisibleMultiRoomUpgradeCandidate(
     return null;
   }
 
+  if (hasVisibleHostiles(room)) {
+    return null;
+  }
+
   const routeDistance = getRouteDistance(homeRoom, room.name);
   if (routeDistance === null) {
     return null;
   }
 
-  const activeUpgraderCount = countActiveMultiRoomUpgraders(homeRoom, room.name);
+  const activeUpgraderCount = activeUpgraderCounts[room.name] ?? 0;
   if (activeUpgraderCount >= perRoomUpgraderCap) {
     return null;
   }
@@ -279,23 +292,60 @@ function compareOptionalNumbers(left: number | undefined, right: number | undefi
   return (left ?? Number.POSITIVE_INFINITY) - (right ?? Number.POSITIVE_INFINITY);
 }
 
-function countActiveMultiRoomUpgraders(homeRoom: string, targetRoom: string): number {
-  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
-  if (!creeps) {
-    return 0;
-  }
-
-  return Object.values(creeps).filter((creep) => isActiveMultiRoomUpgrader(creep, homeRoom, targetRoom)).length;
+interface ActiveMultiRoomUpgraderCountCache {
+  gameTime: number;
+  creeps?: Game['creeps'];
+  countsByHomeRoom: Record<string, Record<string, number>>;
 }
 
-function isActiveMultiRoomUpgrader(creep: Creep, homeRoom: string, targetRoom: string): boolean {
-  const sustain = creep.memory?.controllerSustain;
-  return (
-    sustain?.role === 'upgrader' &&
-    sustain.homeRoom === homeRoom &&
-    sustain.targetRoom === targetRoom &&
-    (creep.ticksToLive === undefined || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE)
-  );
+let activeMultiRoomUpgraderCountCache: ActiveMultiRoomUpgraderCountCache | null = null;
+
+function getActiveMultiRoomUpgraderCountsByTarget(homeRoom: string): Record<string, number> {
+  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  if (!creeps) {
+    return {};
+  }
+
+  const gameTime = getGameTime();
+  if (
+    activeMultiRoomUpgraderCountCache?.gameTime !== gameTime ||
+    activeMultiRoomUpgraderCountCache.creeps !== creeps
+  ) {
+    activeMultiRoomUpgraderCountCache = {
+      gameTime,
+      creeps,
+      countsByHomeRoom: countActiveMultiRoomUpgradersByHomeRoom(creeps)
+    };
+  }
+
+  return activeMultiRoomUpgraderCountCache.countsByHomeRoom[homeRoom] ?? {};
+}
+
+function countActiveMultiRoomUpgradersByHomeRoom(
+  creeps: Game['creeps']
+): Record<string, Record<string, number>> {
+  const countsByHomeRoom: Record<string, Record<string, number>> = {};
+  for (const creep of Object.values(creeps)) {
+    const sustain = creep.memory?.controllerSustain;
+    if (
+      sustain?.role !== 'upgrader' ||
+      !isNonEmptyString(sustain.homeRoom) ||
+      !isNonEmptyString(sustain.targetRoom) ||
+      !isActiveMultiRoomUpgrader(creep)
+    ) {
+      continue;
+    }
+
+    const countsByTarget = countsByHomeRoom[sustain.homeRoom] ?? {};
+    countsByTarget[sustain.targetRoom] = (countsByTarget[sustain.targetRoom] ?? 0) + 1;
+    countsByHomeRoom[sustain.homeRoom] = countsByTarget;
+  }
+
+  return countsByHomeRoom;
+}
+
+function isActiveMultiRoomUpgrader(creep: Creep): boolean {
+  return creep.ticksToLive === undefined || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
 
 function getControllerLevel(controller: StructureController): number {
@@ -323,32 +373,57 @@ function getStorageEnergyCapacity(storage: StructureStorage): number {
   return typeof capacity === 'number' && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
 }
 
+function hasVisibleHostiles(room: Room): boolean {
+  const hostileCreepsFind = (globalThis as { FIND_HOSTILE_CREEPS?: FindConstant }).FIND_HOSTILE_CREEPS;
+  const hostileStructuresFind = (globalThis as { FIND_HOSTILE_STRUCTURES?: FindConstant }).FIND_HOSTILE_STRUCTURES;
+  return (
+    (typeof hostileCreepsFind === 'number' && room.find(hostileCreepsFind).length > 0) ||
+    (typeof hostileStructuresFind === 'number' && room.find(hostileStructuresFind).length > 0)
+  );
+}
+
 function getRouteDistance(fromRoom: string, targetRoom: string): number | null | undefined {
   if (fromRoom === targetRoom) {
     return 0;
   }
 
-  const cachedRouteDistance = getCachedRouteDistance(fromRoom, targetRoom);
-  if (cachedRouteDistance !== undefined) {
+  const cache = getTerritoryRouteDistanceCache();
+  const cacheKey = getTerritoryRouteDistanceCacheKey(fromRoom, targetRoom);
+  const cachedRouteDistance = cache?.[cacheKey];
+  if (cachedRouteDistance === null || typeof cachedRouteDistance === 'number') {
     return cachedRouteDistance;
   }
 
   const routeDistance = getRouteDistanceFromGameMap(fromRoom, targetRoom);
   if (routeDistance !== undefined) {
+    if (cache) {
+      cache[cacheKey] = routeDistance;
+    }
     return routeDistance;
   }
 
   return isAdjacentRoom(fromRoom, targetRoom) ? 1 : undefined;
 }
 
-function getCachedRouteDistance(fromRoom: string, targetRoom: string): number | null | undefined {
-  const routeDistances = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.routeDistances;
-  if (!isRecord(routeDistances)) {
+function getTerritoryRouteDistanceCache(): TerritoryMemory['routeDistances'] | undefined {
+  const memory = (globalThis as { Memory?: Partial<Memory> }).Memory;
+  if (!memory) {
     return undefined;
   }
 
-  const value = routeDistances[`${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`];
-  return typeof value === 'number' || value === null ? value : undefined;
+  if (!isRecord(memory.territory)) {
+    memory.territory = {};
+  }
+
+  if (!isRecord(memory.territory.routeDistances)) {
+    memory.territory.routeDistances = {};
+  }
+
+  return memory.territory.routeDistances as TerritoryMemory['routeDistances'];
+}
+
+function getTerritoryRouteDistanceCacheKey(fromRoom: string, targetRoom: string): string {
+  return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR}${targetRoom}`;
 }
 
 function getRouteDistanceFromGameMap(fromRoom: string, targetRoom: string): number | null | undefined {
@@ -393,6 +468,11 @@ function isAdjacentRoom(fromRoom: string, targetRoom: string): boolean {
 function getNoPathResultCode(): ScreepsReturnCode {
   const noPathCode = (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
   return typeof noPathCode === 'number' ? noPathCode : ERR_NO_PATH_CODE;
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof gameTime === 'number' ? gameTime : 0;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -187,7 +187,7 @@ declare global {
     executionHints?: TerritoryExecutionHintMemory[];
     postClaimBootstraps?: Record<string, TerritoryPostClaimBootstrapMemory>;
     reservations?: Record<string, TerritoryReservationMemory>;
-    routeDistancesUpdatedAt?: number;
+    routeDistancesUpdatedAt?: Record<string, number>;
     routeDistances?: Record<string, number | null>;
   }
 

--- a/prod/test/multiRoomUpgrader.test.ts
+++ b/prod/test/multiRoomUpgrader.test.ts
@@ -1,6 +1,7 @@
 import { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   buildMultiRoomUpgraderBody,
+  recordPlannedMultiRoomUpgraderSpawn,
   buildMultiRoomUpgraderMemory,
   selectMultiRoomUpgradePlan,
   selectMultiRoomUpgradePlans
@@ -118,12 +119,14 @@ describe('multi-room upgrader planner', () => {
     colony,
     rooms,
     creeps = {},
-    routeLengths = {}
+    routeLengths = {},
+    time = 0
   }: {
     colony: ColonySnapshot;
     rooms: Room[];
     creeps?: Record<string, Creep>;
     routeLengths?: Record<string, number | null>;
+    time?: number;
   }): jest.Mock {
     const findRoute = jest.fn((_fromRoom: string, toRoom: string) => {
       const configuredDistance = Object.prototype.hasOwnProperty.call(routeLengths, toRoom)
@@ -139,6 +142,7 @@ describe('multi-room upgrader planner', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: Object.fromEntries([[colony.room.name, colony.room], ...rooms.map((room) => [room.name, room])]),
       creeps,
+      time,
       map: { findRoute } as unknown as GameMap
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
@@ -222,6 +226,44 @@ describe('multi-room upgrader planner', () => {
     expect(selectMultiRoomUpgradePlan(colony)?.routeDistance).toBe(3);
     expect(findRoute).toHaveBeenCalledTimes(1);
     expect(Memory.territory?.routeDistances).toEqual({ 'W1N1>W3N1': 3 });
+    expect(Memory.territory?.routeDistancesUpdatedAt).toEqual({ 'W1N1>W3N1': 0 });
+  });
+
+  it('reuses cached route distances within the cache TTL', () => {
+    const colony = makeColony();
+    const findRoute = installGame({
+      colony,
+      rooms: [makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })],
+      routeLengths: { W3N1: 3 },
+      time: 1_000
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)?.routeDistance).toBe(3);
+    expect(selectMultiRoomUpgradePlan(colony)?.routeDistance).toBe(3);
+    expect(findRoute).toHaveBeenCalledTimes(1);
+    expect(selectMultiRoomUpgradePlan(colony)?.routeDistance).toBe(3);
+    expect(findRoute).toHaveBeenCalledTimes(1);
+  });
+
+  it('recomputes stale cached routes when the cache TTL expires', () => {
+    const colony = makeColony();
+    const findRoute = installGame({
+      colony,
+      rooms: [makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })],
+      routeLengths: { W3N1: 3 },
+      time: 1
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)?.routeDistance).toBe(3);
+    expect(findRoute).toHaveBeenCalledTimes(1);
+
+    if (Memory.territory) {
+      Memory.territory.routeDistancesUpdatedAt = { 'W1N1>W3N1': 0 };
+    }
+    (globalThis as unknown as { Game: Partial<Game> }).Game.time = 1_000;
+
+    expect(selectMultiRoomUpgradePlan(colony)?.routeDistance).toBe(3);
+    expect(findRoute).toHaveBeenCalledTimes(2);
   });
 
   it('uses extra move parts for longer remote upgrade routes', () => {
@@ -265,6 +307,35 @@ describe('multi-room upgrader planner', () => {
 
     expect(selectMultiRoomUpgradePlan(colony)?.targetRoom).toBe('W3N1');
     expect(selectMultiRoomUpgradePlan(colony, { perRoomUpgraderCap: 2 })?.targetRoom).toBe('W2N1');
+  });
+
+  it('counts planned and active multi-room upgrader creeps toward the per-room cap', () => {
+    const colony = makeColony();
+    const cacheTick = 1;
+    installGame({
+      colony,
+      rooms: [
+        makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 1) }),
+        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })
+      ],
+      creeps: { Existing: makeRemoteUpgrader('W2N1') },
+      routeLengths: { W2N1: 1, W3N1: 1 },
+      time: cacheTick
+    });
+
+    recordPlannedMultiRoomUpgraderSpawn({
+      role: 'worker',
+      controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' },
+      colony: 'W1N1'
+    } as CreepMemory);
+
+    const planWithCap1 = selectMultiRoomUpgradePlan(colony, { perRoomUpgraderCap: 1 });
+    const planWithCap2 = selectMultiRoomUpgradePlan(colony, { perRoomUpgraderCap: 2 });
+    const planWithCap3 = selectMultiRoomUpgradePlan(colony, { perRoomUpgraderCap: 3 });
+
+    expect(planWithCap1?.targetRoom).toBe('W3N1');
+    expect(planWithCap2?.targetRoom).toBe('W3N1');
+    expect(planWithCap3?.targetRoom).toBe('W2N1');
   });
 
   it('selects own reserved rooms and builds a reserve-capable sustain body', () => {

--- a/prod/test/multiRoomUpgrader.test.ts
+++ b/prod/test/multiRoomUpgrader.test.ts
@@ -2,7 +2,8 @@ import { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   buildMultiRoomUpgraderBody,
   buildMultiRoomUpgraderMemory,
-  selectMultiRoomUpgradePlan
+  selectMultiRoomUpgradePlan,
+  selectMultiRoomUpgradePlans
 } from '../src/territory/multiRoomUpgrader';
 
 describe('multi-room upgrader planner', () => {
@@ -193,6 +194,34 @@ describe('multi-room upgrader planner', () => {
     });
 
     expect(selectMultiRoomUpgradePlan(colony)?.targetRoom).toBe('W3N1');
+  });
+
+  it('returns all eligible plans in ranked order', () => {
+    const colony = makeColony();
+    installGame({
+      colony,
+      rooms: [
+        makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 3) }),
+        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })
+      ],
+      routeLengths: { W2N1: 1, W3N1: 3 }
+    });
+
+    expect(selectMultiRoomUpgradePlans(colony).map((plan) => plan.targetRoom)).toEqual(['W3N1', 'W2N1']);
+  });
+
+  it('caches computed route distances in memory', () => {
+    const colony = makeColony();
+    const findRoute = installGame({
+      colony,
+      rooms: [makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })],
+      routeLengths: { W3N1: 3 }
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)?.routeDistance).toBe(3);
+    expect(selectMultiRoomUpgradePlan(colony)?.routeDistance).toBe(3);
+    expect(findRoute).toHaveBeenCalledTimes(1);
+    expect(Memory.territory?.routeDistances).toEqual({ 'W1N1>W3N1': 3 });
   });
 
   it('uses extra move parts for longer remote upgrade routes', () => {

--- a/prod/test/multiRoomUpgrader.test.ts
+++ b/prod/test/multiRoomUpgrader.test.ts
@@ -1,0 +1,293 @@
+import { ColonySnapshot } from '../src/colony/colonyRegistry';
+import {
+  buildMultiRoomUpgraderBody,
+  buildMultiRoomUpgraderMemory,
+  selectMultiRoomUpgradePlan
+} from '../src/territory/multiRoomUpgrader';
+
+describe('multi-room upgrader planner', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 3;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 4;
+    (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  });
+
+  function makeColony({
+    roomName = 'W1N1',
+    storageEnergy = 850,
+    storageCapacity = 1_000
+  }: {
+    roomName?: string;
+    storageEnergy?: number;
+    storageCapacity?: number;
+  } = {}): ColonySnapshot {
+    const room = makeRoom({
+      roomName,
+      controller: {
+        id: `${roomName}-controller`,
+        my: true,
+        level: 4,
+        owner: { username: 'player' }
+      } as StructureController,
+      storage: makeStorage(storageEnergy, storageCapacity)
+    });
+    const spawn = { name: 'Spawn1', room } as StructureSpawn;
+    return {
+      room,
+      spawns: [spawn],
+      energyAvailable: 800,
+      energyCapacityAvailable: 800
+    };
+  }
+
+  function makeRoom({
+    roomName,
+    controller,
+    storage,
+    hostileCreeps = [],
+    hostileStructures = []
+  }: {
+    roomName: string;
+    controller?: StructureController;
+    storage?: StructureStorage;
+    hostileCreeps?: Creep[];
+    hostileStructures?: Structure[];
+  }): Room {
+    const find = jest.fn((type: number) => {
+      if (type === FIND_HOSTILE_CREEPS) {
+        return hostileCreeps;
+      }
+
+      if (type === FIND_HOSTILE_STRUCTURES) {
+        return hostileStructures;
+      }
+
+      return [];
+    });
+    return {
+      name: roomName,
+      find,
+      ...(controller ? { controller } : {}),
+      ...(storage ? { storage } : {})
+    } as unknown as Room;
+  }
+
+  function makeStorage(energy: number, capacity: number): StructureStorage {
+    return {
+      store: {
+        getUsedCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0)),
+        getCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? capacity : 0))
+      }
+    } as unknown as StructureStorage;
+  }
+
+  function makeOwnedController(roomName: string, level: number): StructureController {
+    return {
+      id: `${roomName}-controller`,
+      my: true,
+      level,
+      owner: { username: 'player' }
+    } as StructureController;
+  }
+
+  function makeReservedController(roomName: string): StructureController {
+    return {
+      id: `${roomName}-controller`,
+      my: false,
+      level: 0,
+      reservation: { username: 'player', ticksToEnd: 4_000 }
+    } as StructureController;
+  }
+
+  function makeRemoteUpgrader(targetRoom: string, ticksToLive = 1_000): Creep {
+    return {
+      ticksToLive,
+      memory: {
+        role: 'worker',
+        colony: targetRoom,
+        controllerSustain: { homeRoom: 'W1N1', targetRoom, role: 'upgrader' }
+      }
+    } as Creep;
+  }
+
+  function installGame({
+    colony,
+    rooms,
+    creeps = {},
+    routeLengths = {}
+  }: {
+    colony: ColonySnapshot;
+    rooms: Room[];
+    creeps?: Record<string, Creep>;
+    routeLengths?: Record<string, number | null>;
+  }): jest.Mock {
+    const findRoute = jest.fn((_fromRoom: string, toRoom: string) => {
+      const configuredDistance = Object.prototype.hasOwnProperty.call(routeLengths, toRoom)
+        ? routeLengths[toRoom]
+        : undefined;
+      if (configuredDistance === null) {
+        return ERR_NO_PATH;
+      }
+
+      const distance = configuredDistance ?? 1;
+      return Array.from({ length: distance }, (_value, index) => ({ exit: 3, room: `${toRoom}-${index}` }));
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: Object.fromEntries([[colony.room.name, colony.room], ...rooms.map((room) => [room.name, room])]),
+      creeps,
+      map: { findRoute } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    return findRoute;
+  }
+
+  it('does not select a remote controller when primary storage is below threshold', () => {
+    const colony = makeColony({ storageEnergy: 799, storageCapacity: 1_000 });
+    installGame({
+      colony,
+      rooms: [makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 1) })]
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)).toBeNull();
+  });
+
+  it('selects one adjacent owned controller when storage is above the surplus threshold', () => {
+    const colony = makeColony({ storageEnergy: 850, storageCapacity: 1_000 });
+    installGame({
+      colony,
+      rooms: [makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 1) })],
+      routeLengths: { W2N1: 1 }
+    });
+
+    const plan = selectMultiRoomUpgradePlan(colony);
+
+    expect(plan).toEqual({
+      homeRoom: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'W2N1-controller',
+      controllerLevel: 1,
+      controllerState: 'owned',
+      routeDistance: 1,
+      activeUpgraderCount: 0
+    });
+    expect(buildMultiRoomUpgraderMemory(plan!)).toEqual({
+      role: 'worker',
+      colony: 'W2N1',
+      territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'W2N1-controller' },
+      controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' }
+    });
+  });
+
+  it('ranks lower controller levels before proximity', () => {
+    const colony = makeColony();
+    installGame({
+      colony,
+      rooms: [
+        makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 3) }),
+        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })
+      ],
+      routeLengths: { W2N1: 1, W3N1: 3 }
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)?.targetRoom).toBe('W3N1');
+  });
+
+  it('uses extra move parts for longer remote upgrade routes', () => {
+    const colony = makeColony();
+    installGame({
+      colony,
+      rooms: [makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })],
+      routeLengths: { W3N1: 3 }
+    });
+
+    const plan = selectMultiRoomUpgradePlan(colony);
+
+    expect(buildMultiRoomUpgraderBody(800, plan!)).toEqual([
+      'work',
+      'carry',
+      'move',
+      'move',
+      'work',
+      'carry',
+      'move',
+      'move',
+      'work',
+      'carry',
+      'move',
+      'move',
+      'move'
+    ]);
+  });
+
+  it('handles multiple rooms while respecting the per-room upgrader cap', () => {
+    const colony = makeColony();
+    installGame({
+      colony,
+      rooms: [
+        makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 1) }),
+        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })
+      ],
+      creeps: { Existing: makeRemoteUpgrader('W2N1') },
+      routeLengths: { W2N1: 1, W3N1: 1 }
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)?.targetRoom).toBe('W3N1');
+    expect(selectMultiRoomUpgradePlan(colony, { perRoomUpgraderCap: 2 })?.targetRoom).toBe('W2N1');
+  });
+
+  it('selects own reserved rooms and builds a reserve-capable sustain body', () => {
+    const colony = makeColony({ storageEnergy: 900, storageCapacity: 1_000 });
+    installGame({
+      colony,
+      rooms: [makeRoom({ roomName: 'W2N1', controller: makeReservedController('W2N1') })],
+      routeLengths: { W2N1: 1 }
+    });
+
+    const plan = selectMultiRoomUpgradePlan(colony);
+
+    expect(plan).toEqual({
+      homeRoom: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'W2N1-controller',
+      controllerLevel: 0,
+      controllerState: 'reserved',
+      routeDistance: 1,
+      activeUpgraderCount: 0
+    });
+    expect(buildMultiRoomUpgraderMemory(plan!)).toEqual({
+      role: 'worker',
+      colony: 'W2N1',
+      territory: { targetRoom: 'W2N1', action: 'reserve', controllerId: 'W2N1-controller' },
+      controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' }
+    });
+    expect(buildMultiRoomUpgraderBody(1_000, plan!)).toEqual([
+      'claim',
+      'move',
+      'work',
+      'carry',
+      'move',
+      'move'
+    ]);
+  });
+
+  it('skips hostile and inaccessible rooms', () => {
+    const colony = makeColony();
+    installGame({
+      colony,
+      rooms: [
+        makeRoom({
+          roomName: 'W2N1',
+          controller: makeOwnedController('W2N1', 1),
+          hostileCreeps: [{ id: 'hostile1' } as Creep]
+        }),
+        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 1) })
+      ],
+      routeLengths: { W2N1: 1, W3N1: null }
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)).toBeNull();
+  });
+});

--- a/prod/test/multiRoomUpgrader.test.ts
+++ b/prod/test/multiRoomUpgrader.test.ts
@@ -176,7 +176,7 @@ describe('multi-room upgrader planner', () => {
     });
     expect(buildMultiRoomUpgraderMemory(plan!)).toEqual({
       role: 'worker',
-      colony: 'W2N1',
+      colony: 'W1N1',
       territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'W2N1-controller' },
       controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' }
     });
@@ -288,7 +288,7 @@ describe('multi-room upgrader planner', () => {
     });
     expect(buildMultiRoomUpgraderMemory(plan!)).toEqual({
       role: 'worker',
-      colony: 'W2N1',
+      colony: 'W1N1',
       territory: { targetRoom: 'W2N1', action: 'reserve', controllerId: 'W2N1-controller' },
       controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' }
     });

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -360,6 +360,50 @@ describe('planSpawn', () => {
     });
   });
 
+  it('tries the next ranked multi-room upgrade plan when the first body is unaffordable', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController(),
+      storageEnergy: 850,
+      storageCapacity: 1_000
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTerritoryRoom('W2N1', {
+          id: 'reservedController',
+          my: false,
+          level: 0,
+          reservation: { username: 'player', ticksToEnd: 4_000 }
+        } as StructureController),
+        W3N1: makeTerritoryRoom('W3N1', {
+          id: 'ownedController',
+          my: true,
+          level: 1
+        } as StructureController)
+      },
+      spawns: { Spawn1: spawn },
+      creeps: {},
+      map: {
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 3, room: toRoom }])
+      } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(planSpawn(colony, { worker: 3 }, 130)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
+      name: 'worker-W1N1-W3N1-multiroom-upgrader-130',
+      memory: {
+        role: 'worker',
+        colony: 'W3N1',
+        territory: { targetRoom: 'W3N1', action: 'claim', controllerId: 'ownedController' },
+        controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W3N1', role: 'upgrader' }
+      }
+    });
+  });
+
   it('uses the home spawn for a dedicated post-claim controller upgrader when the claimed room has no spawn', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -32,7 +32,9 @@ describe('planSpawn', () => {
     hostileCreeps = [],
     hostileStructures = [],
     spawning = null,
-    controller
+    controller,
+    storageEnergy,
+    storageCapacity
   }: {
     sourceCount?: number;
     energyAvailable?: number;
@@ -43,6 +45,8 @@ describe('planSpawn', () => {
     hostileStructures?: Structure[];
     spawning?: Spawning | null;
     controller?: StructureController;
+    storageEnergy?: number;
+    storageCapacity?: number;
   } = {}): { colony: ColonySnapshot; spawn: StructureSpawn; find: jest.Mock<unknown[], [number]> } {
     const sources = Array.from({ length: sourceCount }, (_, index) => ({ id: `source${index}` }) as Source);
     const constructionSites = Array.from(
@@ -75,7 +79,10 @@ describe('planSpawn', () => {
       energyAvailable,
       energyCapacityAvailable,
       find,
-      ...(controller ? { controller } : {})
+      ...(controller ? { controller } : {}),
+      ...(typeof storageEnergy === 'number' && typeof storageCapacity === 'number'
+        ? { storage: makeStorage(storageEnergy, storageCapacity) }
+        : {})
     } as unknown as Room;
     const spawn = { name: 'Spawn1', room, spawning } as StructureSpawn;
     const colony: ColonySnapshot = {
@@ -89,7 +96,16 @@ describe('planSpawn', () => {
   }
 
   function makeSafeOwnedController(): StructureController {
-    return { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController;
+    return { my: true, level: 3, ticksToDowngrade: 10_000, owner: { username: 'player' } } as StructureController;
+  }
+
+  function makeStorage(energy: number, capacity: number): StructureStorage {
+    return {
+      store: {
+        getUsedCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0)),
+        getCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? capacity : 0))
+      }
+    } as unknown as StructureStorage;
   }
 
   function installHostileFindGlobals(): void {
@@ -303,6 +319,45 @@ describe('planSpawn', () => {
     });
 
     expect(planSpawn(colony, { worker: 3 }, 128)).toBeNull();
+  });
+
+  it('dispatches a multi-room upgrader to an adjacent owned controller when storage has surplus energy', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController(),
+      storageEnergy: 850,
+      storageCapacity: 1_000
+    });
+    const targetController = {
+      id: 'controller2',
+      my: true,
+      level: 1
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTerritoryRoom('W2N1', targetController)
+      },
+      spawns: { Spawn1: spawn },
+      creeps: {},
+      map: {
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }])
+      } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(planSpawn(colony, { worker: 3 }, 129)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
+      name: 'worker-W1N1-W2N1-multiroom-upgrader-129',
+      memory: {
+        role: 'worker',
+        colony: 'W2N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller2' },
+        controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' }
+      }
+    });
   });
 
   it('uses the home spawn for a dedicated post-claim controller upgrader when the claimed room has no spawn', () => {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -353,7 +353,7 @@ describe('planSpawn', () => {
       name: 'worker-W1N1-W2N1-multiroom-upgrader-129',
       memory: {
         role: 'worker',
-        colony: 'W2N1',
+        colony: 'W1N1',
         territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller2' },
         controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' }
       }
@@ -397,7 +397,7 @@ describe('planSpawn', () => {
       name: 'worker-W1N1-W3N1-multiroom-upgrader-130',
       memory: {
         role: 'worker',
-        colony: 'W3N1',
+        colony: 'W1N1',
         territory: { targetRoom: 'W3N1', action: 'claim', controllerId: 'ownedController' },
         controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W3N1', role: 'upgrader' }
       }


### PR DESCRIPTION
## Summary
Implements multi-room controller upgrade sustain: when the colony has energy surplus and multiple owned rooms, spawn a dedicated upgrader creep for secondary rooms to sustain controller progress from surplus energy.

## Verification
- `npm run typecheck` — PASS
- `npm test -- --runInBand` — 785 tests, 31 suites PASS
- `npm run build` — PASS

## Changes
- `prod/src/spawn/spawnPlanner.ts` — Add multi-room upgrader spawn logic
- `prod/src/territory/multiRoomUpgrader.ts` — New module for multi-room upgrade sustain
- `prod/test/spawnPlanner.test.ts` — Tests for spawn planning with multi-room upgrades
- `prod/test/multiRoomUpgrader.test.ts` — Tests for multi-room upgrader behavior
- `prod/dist/main.js` — Build artifact

Refs #522
