### PR TITLE
feat(rl): behavioral cloning from heuristic traces for worker task policy (#508)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6463,6 +6463,326 @@ function matchesStructureType5(actual, globalName, fallback) {
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 
+// src/rl/workerTaskBehavior.ts
+var WORKER_TASK_BEHAVIOR_SCHEMA_VERSION = 1;
+var HEURISTIC_WORKER_TASK_POLICY_ID = "heuristic.worker-task.v1";
+var WORKER_TASK_BC_ACTION_TYPES = ["harvest", "transfer", "build", "repair", "upgrade"];
+var NEARBY_STRUCTURE_RANGE = 3;
+var NEARBY_TILE_COUNT = 49;
+var CURRENT_TASK_CODE = {
+  none: 0,
+  harvest: 1,
+  pickup: 2,
+  withdraw: 3,
+  transfer: 4,
+  build: 5,
+  repair: 6,
+  claim: 7,
+  reserve: 8,
+  upgrade: 9
+};
+function isWorkerTaskBehaviorActionType(value) {
+  return WORKER_TASK_BC_ACTION_TYPES.includes(value);
+}
+function recordWorkerTaskBehaviorTrace(creep, selectedTask) {
+  const memory = creep.memory;
+  if (!memory) {
+    return null;
+  }
+  if (!selectedTask || !isWorkerTaskBehaviorActionType(selectedTask.type)) {
+    delete memory.workerBehavior;
+    return null;
+  }
+  const sample = {
+    type: "workerTaskBehavior",
+    schemaVersion: WORKER_TASK_BEHAVIOR_SCHEMA_VERSION,
+    tick: getGameTick(),
+    policyId: HEURISTIC_WORKER_TASK_POLICY_ID,
+    liveEffect: false,
+    state: buildWorkerTaskBehaviorState(creep),
+    action: {
+      type: selectedTask.type,
+      targetId: String(selectedTask.targetId)
+    }
+  };
+  memory.workerBehavior = sample;
+  return sample;
+}
+function buildWorkerTaskBehaviorState(creep) {
+  var _a, _b, _c, _d, _e;
+  const room = creep.room;
+  const structures = findRoomObjects6(room, getFindConstant3("FIND_STRUCTURES"));
+  const myStructures = findRoomObjects6(room, getFindConstant3("FIND_MY_STRUCTURES"));
+  const constructionSites = findRoomObjects6(room, getFindConstant3("FIND_CONSTRUCTION_SITES"));
+  const droppedResources = findRoomObjects6(room, getFindConstant3("FIND_DROPPED_RESOURCES"));
+  const sources = findRoomObjects6(room, getFindConstant3("FIND_SOURCES"));
+  const hostileCreeps = findRoomObjects6(room, getFindConstant3("FIND_HOSTILE_CREEPS"));
+  const currentTask = (_c = (_b = (_a = creep.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) != null ? _c : "none";
+  const carriedEnergy = getUsedEnergy(creep);
+  const freeCapacity = getFreeEnergyCapacity(creep);
+  const energyCapacity = Math.max(0, carriedEnergy + freeCapacity);
+  const controller = room == null ? void 0 : room.controller;
+  const nearbyStructures = structures.filter((structure) => getRangeBetweenRoomObjects(creep, structure) <= NEARBY_STRUCTURE_RANGE);
+  const nearbyRoadCount = nearbyStructures.filter((structure) => isStructureType(structure, "STRUCTURE_ROAD", "road")).length;
+  const nearbyContainerCount = nearbyStructures.filter(
+    (structure) => isStructureType(structure, "STRUCTURE_CONTAINER", "container")
+  ).length;
+  const containerCount = structures.filter(
+    (structure) => isStructureType(structure, "STRUCTURE_CONTAINER", "container")
+  ).length;
+  const droppedEnergyAvailable = sumDroppedEnergy(droppedResources);
+  const spawnExtensionNeedCount = myStructures.filter(
+    (structure) => isStructureType(structure, "STRUCTURE_SPAWN", "spawn") || isStructureType(structure, "STRUCTURE_EXTENSION", "extension")
+  ).length;
+  const towerNeedCount = myStructures.filter(
+    (structure) => isStructureType(structure, "STRUCTURE_TOWER", "tower")
+  ).length;
+  return {
+    roomName: (_d = room == null ? void 0 : room.name) != null ? _d : "unknown",
+    ...buildPositionState(creep.pos),
+    carriedEnergy,
+    freeCapacity,
+    energyCapacity,
+    energyLoadRatio: roundRatio(carriedEnergy, energyCapacity),
+    currentTask,
+    currentTaskCode: (_e = CURRENT_TASK_CODE[currentTask]) != null ? _e : CURRENT_TASK_CODE.none,
+    ...numberField("roomEnergyAvailable", room == null ? void 0 : room.energyAvailable),
+    ...numberField("roomEnergyCapacity", room == null ? void 0 : room.energyCapacityAvailable),
+    workerCount: 0,
+    spawnExtensionNeedCount,
+    towerNeedCount,
+    constructionSiteCount: constructionSites.length,
+    repairTargetCount: countRepairTargets(structures),
+    sourceCount: sources.length,
+    hasContainerEnergy: containerCount > 0,
+    containerEnergyAvailable: 0,
+    droppedEnergyAvailable,
+    nearbyRoadCount,
+    nearbyContainerCount,
+    roadCoverage: roundRatio(nearbyRoadCount, NEARBY_TILE_COUNT),
+    hostileCreepCount: hostileCreeps.length,
+    ...buildControllerState(controller)
+  };
+}
+function buildPositionState(position) {
+  if (!position) {
+    return {};
+  }
+  return {
+    x: finiteNumber(position.x),
+    y: finiteNumber(position.y)
+  };
+}
+function buildControllerState(controller) {
+  if (!(controller == null ? void 0 : controller.my)) {
+    return {};
+  }
+  const progress = finiteNumber(controller.progress);
+  const progressTotal = finiteNumber(controller.progressTotal);
+  return {
+    ...numberField("controllerLevel", controller.level),
+    ...numberField("controllerTicksToDowngrade", controller.ticksToDowngrade),
+    ...progress !== void 0 && progressTotal !== void 0 && progressTotal > 0 ? { controllerProgressRatio: roundRatio(progress, progressTotal) } : {}
+  };
+}
+function countRepairTargets(structures) {
+  return structures.filter((structure) => {
+    const hits = finiteNumber(structure.hits);
+    const hitsMax = finiteNumber(structure.hitsMax);
+    if (hits === void 0 || hitsMax === void 0 || hits >= hitsMax) {
+      return false;
+    }
+    return isStructureType(structure, "STRUCTURE_ROAD", "road") || isStructureType(structure, "STRUCTURE_CONTAINER", "container") || isStructureType(structure, "STRUCTURE_RAMPART", "rampart") && structure.my !== false;
+  }).length;
+}
+function findRoomObjects6(room, findConstant) {
+  if (!room || typeof room.find !== "function" || typeof findConstant !== "number") {
+    return [];
+  }
+  try {
+    const objects = room.find(findConstant);
+    return Array.isArray(objects) ? objects : [];
+  } catch (_error) {
+    return [];
+  }
+}
+function getFindConstant3(name) {
+  const value = globalThis[name];
+  return typeof value === "number" && Number.isFinite(value) ? value : void 0;
+}
+function getUsedEnergy(target) {
+  var _a, _b, _c;
+  const value = (_b = (_a = target.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, getEnergyResourceConstant());
+  return Math.max(0, (_c = finiteNumber(value)) != null ? _c : 0);
+}
+function getFreeEnergyCapacity(target) {
+  var _a, _b, _c;
+  const value = (_b = (_a = target.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResourceConstant());
+  return Math.max(0, (_c = finiteNumber(value)) != null ? _c : 0);
+}
+function getEnergyResourceConstant() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function sumDroppedEnergy(resources) {
+  return resources.reduce((total, resource) => {
+    var _a;
+    if (resource.resourceType !== getEnergyResourceConstant()) {
+      return total;
+    }
+    return total + Math.max(0, (_a = finiteNumber(resource.amount)) != null ? _a : 0);
+  }, 0);
+}
+function isStructureType(structure, globalName, fallback) {
+  const globalValue = globalThis[globalName];
+  return structure.structureType === globalValue || structure.structureType === fallback;
+}
+function getRangeBetweenRoomObjects(left, right) {
+  var _a, _b;
+  const range = (_b = (_a = left.pos) == null ? void 0 : _a.getRangeTo) == null ? void 0 : _b.call(_a, right);
+  if (typeof range === "number" && Number.isFinite(range)) {
+    return range;
+  }
+  const leftPosition = left.pos;
+  const rightPosition = right.pos;
+  if (leftPosition && rightPosition && leftPosition.roomName === rightPosition.roomName && typeof leftPosition.x === "number" && typeof leftPosition.y === "number" && typeof rightPosition.x === "number" && typeof rightPosition.y === "number") {
+    return Math.max(Math.abs(leftPosition.x - rightPosition.x), Math.abs(leftPosition.y - rightPosition.y));
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
+function getGameTick() {
+  var _a;
+  const tick = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof tick === "number" && Number.isFinite(tick) ? tick : 0;
+}
+function numberField(key, value) {
+  const number = finiteNumber(value);
+  if (number === void 0) {
+    return {};
+  }
+  return { [key]: number };
+}
+function finiteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : void 0;
+}
+function roundRatio(numerator, denominator) {
+  if (denominator <= 0) {
+    return 0;
+  }
+  return Math.round(numerator / denominator * 1e3) / 1e3;
+}
+
+// src/rl/workerTaskBcModel.ts
+var WORKER_TASK_BC_MODEL = {
+  type: "worker-task-bc-decision-tree",
+  schemaVersion: 1,
+  policyId: "worker-task-bc.untrained.v1",
+  source: "placeholder",
+  liveEffect: false,
+  minConfidence: 0.9,
+  actionTypes: ["harvest", "transfer", "build", "repair", "upgrade"],
+  features: [],
+  root: null,
+  metadata: {
+    trainingSampleCount: 0,
+    evaluationSampleCount: 0,
+    evaluationMatchRate: null,
+    notes: "No trained artifact is bundled yet; runtime remains heuristic-only."
+  }
+};
+
+// src/rl/workerTaskPolicy.ts
+var testingModelOverride = null;
+function selectWorkerTaskWithBcFallback(creep, heuristicTask) {
+  var _a;
+  const memory = creep.memory;
+  const model = getActiveWorkerTaskBcModel();
+  const state = (_a = memory == null ? void 0 : memory.workerBehavior) == null ? void 0 : _a.state;
+  if (memory && !state) {
+    delete memory.workerTaskPolicyShadow;
+    return heuristicTask;
+  }
+  const prediction = state ? predictWorkerTaskAction(model, state) : null;
+  const heuristicAction = isWorkerTaskBehaviorActionType(heuristicTask == null ? void 0 : heuristicTask.type) ? heuristicTask.type : void 0;
+  if (memory) {
+    memory.workerTaskPolicyShadow = {
+      type: "workerTaskPolicyShadow",
+      schemaVersion: WORKER_TASK_BEHAVIOR_SCHEMA_VERSION,
+      tick: getGameTick2(),
+      policyId: model.policyId,
+      liveEffect: false,
+      ...prediction ? { predictedAction: prediction.action, confidence: prediction.confidence } : {},
+      ...heuristicAction ? { heuristicAction } : {},
+      matched: Boolean(prediction && heuristicAction && prediction.action === heuristicAction),
+      ...buildFallbackReason(model, prediction, heuristicAction)
+    };
+  }
+  return heuristicTask;
+}
+function predictWorkerTaskAction(model, state) {
+  if (!isUsableModel(model)) {
+    return null;
+  }
+  const leaf = evaluateNode(model.root, state);
+  if (!leaf || leaf.confidence < model.minConfidence) {
+    return null;
+  }
+  return {
+    policyId: model.policyId,
+    action: leaf.action,
+    confidence: leaf.confidence
+  };
+}
+function getActiveWorkerTaskBcModel() {
+  return testingModelOverride != null ? testingModelOverride : WORKER_TASK_BC_MODEL;
+}
+function isUsableModel(model) {
+  return model.type === "worker-task-bc-decision-tree" && model.schemaVersion === 1 && model.liveEffect === false && model.root !== null && model.actionTypes.every((action) => WORKER_TASK_BC_ACTION_TYPES.includes(action));
+}
+function evaluateNode(node, state) {
+  if (!node) {
+    return null;
+  }
+  if (node.type === "leaf") {
+    return node;
+  }
+  const featureValue = getFeatureValue(state, node.feature);
+  if (featureValue === null) {
+    return evaluateNode(node.missing === "left" ? node.left : node.right, state);
+  }
+  return evaluateNode(featureValue <= node.threshold ? node.left : node.right, state);
+}
+function getFeatureValue(state, feature) {
+  const value = state[feature];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "boolean") {
+    return value ? 1 : 0;
+  }
+  return null;
+}
+function buildFallbackReason(model, prediction, heuristicAction) {
+  if (!isUsableModel(model)) {
+    return { fallbackReason: "untrainedModel" };
+  }
+  if (!prediction) {
+    return { fallbackReason: "lowConfidence" };
+  }
+  if (!heuristicAction) {
+    return { fallbackReason: "unsupportedHeuristicAction" };
+  }
+  if (prediction.action !== heuristicAction) {
+    return { fallbackReason: "actionMismatch" };
+  }
+  return {};
+}
+function getGameTick2() {
+  var _a;
+  const tick = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof tick === "number" && Number.isFinite(tick) ? tick : 0;
+}
+
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS2 = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
@@ -6497,14 +6817,19 @@ var MAX_SURPLUS_CONTROLLER_PROGRESS_WORKERS = 3;
 var BASELINE_WORKER_THROUGHPUT_ENERGY_CAPACITY = 550;
 var nearTermSpawnExtensionRefillReserveCache = null;
 function selectWorkerTask(creep) {
-  var _a;
   clearWorkerEfficiencyTelemetry(creep);
+  const heuristicTask = selectHeuristicWorkerTask(creep);
+  recordWorkerTaskBehaviorTrace(creep, heuristicTask);
+  return selectWorkerTaskWithBcFallback(creep, heuristicTask);
+}
+function selectHeuristicWorkerTask(creep) {
+  var _a;
   const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
   const territoryWorkSuppressed = suppressesTerritoryWork(survivalAssessment);
   const bootstrapNonCriticalWorkSuppressed = suppressesBootstrapNonCriticalWork(survivalAssessment);
   const recoveryOnlyWorkSuppressed = bootstrapNonCriticalWorkSuppressed || territoryWorkSuppressed;
   const remoteProductiveSpendingSuppressed = recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep);
-  const carriedEnergy = getUsedEnergy(creep);
+  const carriedEnergy = getUsedEnergy2(creep);
   const urgentReservationRenewalTask = territoryWorkSuppressed ? null : selectUrgentVisibleReservationRenewalTask(creep);
   const territoryControllerTask = territoryWorkSuppressed ? null : selectVisibleTerritoryControllerTask(creep);
   if (carriedEnergy === 0) {
@@ -6515,7 +6840,7 @@ function selectWorkerTask(creep) {
       return territoryControllerTask;
     }
     let hasPriorityEnergySink = false;
-    if (getFreeEnergyCapacity(creep) > 0) {
+    if (getFreeEnergyCapacity2(creep) > 0) {
       const spawnRecoveryEnergySink = selectFillableEnergySink(creep);
       if (spawnRecoveryEnergySink) {
         hasPriorityEnergySink = true;
@@ -6834,8 +7159,8 @@ function hasEmergencySpawnExtensionRefillDemand(creep) {
   return energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 function getLowLoadWorkerEnergyContext(creep) {
-  const carriedEnergy = getUsedEnergy(creep);
-  const freeCapacity = getFreeEnergyCapacity(creep);
+  const carriedEnergy = getUsedEnergy2(creep);
+  const freeCapacity = getFreeEnergyCapacity2(creep);
   if (carriedEnergy <= 0 || freeCapacity <= 0) {
     return null;
   }
@@ -6871,9 +7196,9 @@ function recordSpawnCriticalRefillTelemetry(creep, spawn) {
   }
   memory.spawnCriticalRefill = {
     type: "spawnCriticalRefill",
-    tick: (_a = getGameTick()) != null ? _a : 0,
+    tick: (_a = getGameTick3()) != null ? _a : 0,
     targetId: String(spawn.id),
-    carriedEnergy: getUsedEnergy(creep),
+    carriedEnergy: getUsedEnergy2(creep),
     spawnEnergy: (_b = getKnownStoredEnergy(spawn)) != null ? _b : 0,
     freeCapacity: getFreeStoredEnergyCapacity(spawn),
     threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
@@ -6888,7 +7213,7 @@ function recordNearbyEnergyChoiceTelemetry(creep, candidate) {
   }
   memory.workerEfficiency = {
     type: "nearbyEnergyChoice",
-    tick: (_a = getGameTick()) != null ? _a : 0,
+    tick: (_a = getGameTick3()) != null ? _a : 0,
     carriedEnergy: context.carriedEnergy,
     freeCapacity: context.freeCapacity,
     selectedTask: candidate.task.type,
@@ -6906,7 +7231,7 @@ function recordLowLoadReturnTelemetry(creep, task, reason) {
   }
   memory.workerEfficiency = {
     type: "lowLoadReturn",
-    tick: (_a = getGameTick()) != null ? _a : 0,
+    tick: (_a = getGameTick3()) != null ? _a : 0,
     carriedEnergy: context.carriedEnergy,
     freeCapacity: context.freeCapacity,
     selectedTask: task.type,
@@ -6952,10 +7277,10 @@ function selectSpawnExtensionRecoveryEnergySink(energySinks, creep, reservedEner
   )[0];
 }
 function compareSpawnExtensionRecoveryEnergySinks(left, right, creep, reservedEnergyDeliveries, assignedTransferTargetId) {
-  const carriedEnergy = getUsedEnergy(creep);
+  const carriedEnergy = getUsedEnergy2(creep);
   const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(left, reservedEnergyDeliveries);
   const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(right, reservedEnergyDeliveries);
-  return compareCriticalSpawnPriority(left, right) || compareLowEnergySpawnPriority(left, right) || compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareAssignedTransferTarget(left, right, assignedTransferTargetId) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareEnergySinkId(left, right);
+  return compareCriticalSpawnPriority(left, right) || compareLowEnergySpawnPriority(left, right) || compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareAssignedTransferTarget(left, right, assignedTransferTargetId) || compareOptionalRanges(getRangeBetweenRoomObjects2(creep, left), getRangeBetweenRoomObjects2(creep, right)) || compareEnergySinkId(left, right);
 }
 function compareCriticalSpawnPriority(left, right) {
   if (isSpawnEnergySink(left) && isSpawnEnergySink(right)) {
@@ -7035,7 +7360,7 @@ function selectCloserReservedEnergySinkFallback(energySinks, creep, loadedWorker
   );
 }
 function isCloserThanReservedEnergyDelivery(creep, energySink, loadedWorkers) {
-  const creepRange = getRangeBetweenRoomObjects(creep, energySink);
+  const creepRange = getRangeBetweenRoomObjects2(creep, energySink);
   if (creepRange === null) {
     return false;
   }
@@ -7046,7 +7371,7 @@ function isCloserThanReservedEnergyDelivery(creep, energySink, loadedWorkers) {
       continue;
     }
     hasReservedDelivery = true;
-    const workerRange = getRangeBetweenRoomObjects(worker, energySink);
+    const workerRange = getRangeBetweenRoomObjects2(worker, energySink);
     if (workerRange === null) {
       continue;
     }
@@ -7074,7 +7399,7 @@ function getReservedEnergyDeliveriesBySinkId(creep, loadedWorkers) {
       continue;
     }
     const energySinkId = String(task.targetId);
-    reservedEnergyDeliveries.set(energySinkId, ((_b = reservedEnergyDeliveries.get(energySinkId)) != null ? _b : 0) + getUsedEnergy(worker));
+    reservedEnergyDeliveries.set(energySinkId, ((_b = reservedEnergyDeliveries.get(energySinkId)) != null ? _b : 0) + getUsedEnergy2(worker));
   }
   return reservedEnergyDeliveries;
 }
@@ -7298,7 +7623,7 @@ function createConstructionReservationContext(room) {
     const siteId = String(task.targetId);
     reservedProgressBySiteId.set(
       siteId,
-      ((_b = reservedProgressBySiteId.get(siteId)) != null ? _b : 0) + getUsedEnergy(worker) * getBuildPower()
+      ((_b = reservedProgressBySiteId.get(siteId)) != null ? _b : 0) + getUsedEnergy2(worker) * getBuildPower()
     );
   }
   return { reservedProgressBySiteId };
@@ -7329,7 +7654,7 @@ function selectNearTermCompletableConstructionSite(creep, constructionSites, con
   return candidates.sort(compareNearTermCompletableConstructionSites)[0];
 }
 function compareConstructionSiteCandidates(creep, left, right, constructionReservationContext, priorityContext) {
-  return getConstructionSiteImpactPriority(right, priorityContext) - getConstructionSiteImpactPriority(left, priorityContext) || compareConstructionSiteReasonableRange(creep, left, right) || compareConstructionSiteCompletion(creep, left, right, constructionReservationContext) || compareOptionalRanges(getRangeBetweenRoomObjects(creep, left), getRangeBetweenRoomObjects(creep, right)) || compareConstructionSiteId(left, right);
+  return getConstructionSiteImpactPriority(right, priorityContext) - getConstructionSiteImpactPriority(left, priorityContext) || compareConstructionSiteReasonableRange(creep, left, right) || compareConstructionSiteCompletion(creep, left, right, constructionReservationContext) || compareOptionalRanges(getRangeBetweenRoomObjects2(creep, left), getRangeBetweenRoomObjects2(creep, right)) || compareConstructionSiteId(left, right);
 }
 function compareConstructionSiteReasonableRange(creep, left, right) {
   const leftInRange = isConstructionSiteWithinReasonableRange(
@@ -7348,7 +7673,7 @@ function compareConstructionSiteReasonableRange(creep, left, right) {
   return leftInRange ? -1 : 1;
 }
 function isConstructionSiteWithinReasonableRange(creep, site, rangeLimit) {
-  const range = getRangeBetweenRoomObjects(creep, site);
+  const range = getRangeBetweenRoomObjects2(creep, site);
   return range === null || range <= rangeLimit;
 }
 function selectTopImpactConstructionSiteCandidates(candidates, priorityContext) {
@@ -7382,7 +7707,7 @@ function canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionR
     site,
     constructionReservationContext
   );
-  return remainingProgress > 0 && remainingProgress <= getUsedEnergy(creep) * getBuildPower();
+  return remainingProgress > 0 && remainingProgress <= getUsedEnergy2(creep) * getBuildPower();
 }
 function getUnreservedConstructionProgressForWorker(creep, site, constructionReservationContext) {
   const remainingProgress = getConstructionSiteRemainingProgress2(site);
@@ -7390,7 +7715,7 @@ function getUnreservedConstructionProgressForWorker(creep, site, constructionRes
     return remainingProgress;
   }
   const reservedProgress = getReservedConstructionProgress(site, constructionReservationContext);
-  const workerReservedProgress = isWorkerAssignedToConstructionSite(creep, site) ? getUsedEnergy(creep) * getBuildPower() : 0;
+  const workerReservedProgress = isWorkerAssignedToConstructionSite(creep, site) ? getUsedEnergy2(creep) * getBuildPower() : 0;
   return Math.max(0, remainingProgress - Math.max(0, reservedProgress - workerReservedProgress));
 }
 function getConstructionSiteRemainingProgress2(site) {
@@ -7421,7 +7746,7 @@ function selectCriticalRoadConstructionSite(creep, constructionSites, constructi
   );
 }
 function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller, constructionReservationContext) {
-  const controllerRange = getRangeBetweenRoomObjects(creep, controller);
+  const controllerRange = getRangeBetweenRoomObjects2(creep, controller);
   if (controllerRange === null) {
     return null;
   }
@@ -7452,7 +7777,7 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
   return candidates.sort(compareProductiveEnergySinkCandidates)[0].task;
 }
 function createProductiveEnergySinkCandidate(creep, target, task, taskPriority, canCompleteConstruction = false) {
-  const range = getRangeBetweenRoomObjects(creep, target);
+  const range = getRangeBetweenRoomObjects2(creep, target);
   if (range === null) {
     return null;
   }
@@ -7786,7 +8111,7 @@ function findLowLoadHarvestEnergyAcquisitionCandidates(creep) {
   ];
 }
 function getHarvestCandidateEnergy(creep, source) {
-  return typeof source.energy === "number" && Number.isFinite(source.energy) ? source.energy : getFreeEnergyCapacity(creep);
+  return typeof source.energy === "number" && Number.isFinite(source.energy) ? source.energy : getFreeEnergyCapacity2(creep);
 }
 function createLowLoadWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
@@ -7913,7 +8238,7 @@ function createUnreservedWorkerEnergyAcquisitionCandidate(creep, source, energy,
 }
 function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
-  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity(creep));
+  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity2(creep));
   return {
     energy,
     priority: getWorkerEnergyAcquisitionPriority(creep, source, energy, range),
@@ -7924,7 +8249,7 @@ function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   };
 }
 function getWorkerEnergyAcquisitionPriority(creep, source, energy, range) {
-  if (isContainerEnergySource(source) && range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE && energy >= Math.max(1, getFreeEnergyCapacity(creep))) {
+  if (isContainerEnergySource(source) && range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE && energy >= Math.max(1, getFreeEnergyCapacity2(creep))) {
     return 0;
   }
   return isDurableStoredEnergySource(source) ? 2 : 1;
@@ -7963,7 +8288,7 @@ function getReservedWorkerEnergyAcquisitionsBySourceId(creep) {
     if (!isWorkerEnergyAcquisitionReservationTask(task)) {
       continue;
     }
-    const freeCapacity = getFreeEnergyCapacity(worker);
+    const freeCapacity = getFreeEnergyCapacity2(worker);
     if (freeCapacity <= 0) {
       continue;
     }
@@ -7983,7 +8308,7 @@ function createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink) {
   if (candidate.range === null) {
     return null;
   }
-  const sourceToSinkRange = getRangeBetweenRoomObjects(candidate.source, energySink);
+  const sourceToSinkRange = getRangeBetweenRoomObjects2(candidate.source, energySink);
   if (sourceToSinkRange === null) {
     return null;
   }
@@ -8004,8 +8329,8 @@ function estimateHarvestDeliveryEtaFromSource(creep, source, energySink) {
   if (sourceAvailabilityDelay === null) {
     return null;
   }
-  const creepToSourceRange = getRangeBetweenRoomObjects(creep, source);
-  const sourceToSinkRange = getRangeBetweenRoomObjects(source, energySink);
+  const creepToSourceRange = getRangeBetweenRoomObjects2(creep, source);
+  const sourceToSinkRange = getRangeBetweenRoomObjects2(source, energySink);
   if (creepToSourceRange === null || sourceToSinkRange === null) {
     return null;
   }
@@ -8020,7 +8345,7 @@ function estimateHarvestTicks(creep, energySink) {
   return Math.ceil(energyNeeded / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
 }
 function getSpawnRecoveryHarvestEnergyTarget(creep, energySink) {
-  return Math.max(1, Math.min(getFreeEnergyCapacity(creep), getFreeStoredEnergyCapacity(energySink)));
+  return Math.max(1, Math.min(getFreeEnergyCapacity2(creep), getFreeStoredEnergyCapacity(energySink)));
 }
 function estimateHarvestSourceAvailabilityDelay(source) {
   if (typeof source.energy !== "number") {
@@ -8060,7 +8385,7 @@ function getBodyPartConstant3(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function getRangeBetweenRoomObjects(left, right) {
+function getRangeBetweenRoomObjects2(left, right) {
   const position = left.pos;
   if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
     return null;
@@ -8084,7 +8409,7 @@ function isReachable(creep, target) {
   if (typeof (position == null ? void 0 : position.findPathTo) !== "function") {
     return true;
   }
-  const range = getRangeBetweenRoomObjects(creep, target);
+  const range = getRangeBetweenRoomObjects2(creep, target);
   if (range !== null && range <= 1) {
     return true;
   }
@@ -8278,7 +8603,7 @@ function shouldRushRcl1Controller(controller) {
   return controller.my === true && controller.level === 1;
 }
 function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) {
-  const carriedEnergy = getUsedEnergy(creep);
+  const carriedEnergy = getUsedEnergy2(creep);
   if (carriedEnergy <= 0) {
     return false;
   }
@@ -8286,7 +8611,7 @@ function shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill(creep) {
   return reserveContext.refillReserve > 0 && isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, reserveContext);
 }
 function getNearTermSpawnExtensionRefillReserveContext(room) {
-  const gameTick = getGameTick();
+  const gameTick = getGameTick3();
   const roomName = getRoomName2(room);
   if (gameTick === null || roomName === null) {
     return createNearTermSpawnExtensionRefillReserveContext(room);
@@ -8321,7 +8646,7 @@ function createNearTermSpawnExtensionRefillReserveContext(room) {
     spawnExtensionEnergyStructures
   };
 }
-function getGameTick() {
+function getGameTick3() {
   var _a;
   const time = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof time === "number" && Number.isFinite(time) ? time : null;
@@ -8336,7 +8661,7 @@ function isWorkerEnergyNeededForNearTermSpawnExtensionRefillReserve(creep, reser
     if (isSameCreep(worker, creep)) {
       return reservedEnergy < reserveContext.refillReserve;
     }
-    reservedEnergy += getUsedEnergy(worker);
+    reservedEnergy += getUsedEnergy2(worker);
   }
   return true;
 }
@@ -8349,7 +8674,7 @@ function getNearTermRefillReserveLoadedWorkers(creep, reserveContext) {
   );
 }
 function compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures) {
-  return getUsedEnergy(right) - getUsedEnergy(left) || compareOptionalRanges(
+  return getUsedEnergy2(right) - getUsedEnergy2(left) || compareOptionalRanges(
     getClosestNearTermRefillRange(left, spawnExtensionEnergyStructures),
     getClosestNearTermRefillRange(right, spawnExtensionEnergyStructures)
   ) || getCreepStableSortKey(left).localeCompare(getCreepStableSortKey(right));
@@ -8377,7 +8702,7 @@ function dedupeCreepsByStableKey(creeps) {
 function getClosestNearTermRefillRange(creep, spawnExtensionEnergyStructures) {
   let closestRange = null;
   for (const structure of spawnExtensionEnergyStructures) {
-    const range = getRangeBetweenRoomObjects(creep, structure);
+    const range = getRangeBetweenRoomObjects2(creep, structure);
     if (range === null) {
       continue;
     }
@@ -8555,7 +8880,7 @@ function getRangeBetweenRoomObjectPositions(left, right) {
   if (!leftPosition || !rightPosition || !isSameRoomPosition5(leftPosition, rightPosition)) {
     return null;
   }
-  const rangeFromApi = getRangeBetweenRoomObjects(left, right);
+  const rangeFromApi = getRangeBetweenRoomObjects2(left, right);
   if (rangeFromApi !== null) {
     return rangeFromApi;
   }
@@ -8676,14 +9001,14 @@ function getSameRoomLoadedWorkersForRefillReservations(creep) {
 }
 function getSameRoomLoadedWorkersFromCandidates(creep, candidates) {
   const loadedWorkers = candidates.filter((candidate) => isSameRoomWorkerWithEnergy(candidate, creep.room));
-  if (!loadedWorkers.includes(creep) && getUsedEnergy(creep) > 0) {
+  if (!loadedWorkers.includes(creep) && getUsedEnergy2(creep) > 0) {
     loadedWorkers.push(creep);
   }
   return loadedWorkers;
 }
 function isSameRoomWorkerWithEnergy(creep, room) {
   var _a;
-  return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom(creep, room) && getUsedEnergy(creep) > 0;
+  return ((_a = creep.memory) == null ? void 0 : _a.role) === "worker" && isInRoom(creep, room) && getUsedEnergy2(creep) > 0;
 }
 function isInRoom(creep, room) {
   var _a;
@@ -8692,10 +9017,10 @@ function isInRoom(creep, room) {
   }
   return creep.room === room;
 }
-function getUsedEnergy(creep) {
+function getUsedEnergy2(creep) {
   return getStoredEnergy2(creep);
 }
-function getFreeEnergyCapacity(creep) {
+function getFreeEnergyCapacity2(creep) {
   return getFreeStoredEnergyCapacity(creep);
 }
 function getStoredEnergy2(object) {
@@ -8727,7 +9052,7 @@ function getFreeStoredEnergyCapacity(object) {
   const freeCapacity = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
   return typeof freeCapacity === "number" ? freeCapacity : 0;
 }
-function getEnergyCapacity(creep, carriedEnergy = getUsedEnergy(creep), freeCapacity = getFreeEnergyCapacity(creep)) {
+function getEnergyCapacity(creep, carriedEnergy = getUsedEnergy2(creep), freeCapacity = getFreeEnergyCapacity2(creep)) {
   var _a;
   const store = getStore(creep);
   const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
@@ -8958,8 +9283,8 @@ function getTerrainWallMask4() {
   return typeof terrainWallMask === "number" ? terrainWallMask : 1;
 }
 function isCloserHarvestSource(creep, candidate, selected) {
-  const candidateRange = getRangeBetweenRoomObjects(creep, candidate);
-  const selectedRange = getRangeBetweenRoomObjects(creep, selected);
+  const candidateRange = getRangeBetweenRoomObjects2(creep, candidate);
+  const selectedRange = getRangeBetweenRoomObjects2(creep, selected);
   return candidateRange !== null && selectedRange !== null && candidateRange < selectedRange;
 }
 function selectViableHarvestSources(sources, harvestEnergyTarget) {
@@ -8984,7 +9309,7 @@ function getHarvestSourceAvailableEnergy(source) {
   return getHarvestSourceEnergyCapacity(source);
 }
 function getHarvestEnergyTarget(creep) {
-  return Math.max(1, getFreeEnergyCapacity(creep));
+  return Math.max(1, getFreeEnergyCapacity2(creep));
 }
 function getSameRoomWorkerHarvestLoads(roomName, sources) {
   var _a, _b, _c, _d;
@@ -9782,7 +10107,7 @@ function runRemoteHarvester(creep) {
     }
     return;
   }
-  if (container && getFreeEnergyCapacity2(creep) <= 0 && getCarriedEnergy2(creep) > 0) {
+  if (container && getFreeEnergyCapacity3(creep) <= 0 && getCarriedEnergy2(creep) > 0) {
     transferToContainer(creep, container);
     return;
   }
@@ -9912,7 +10237,7 @@ function isSourceDepleted2(source) {
 function getCarriedEnergy2(creep) {
   return getStoredEnergy4(creep);
 }
-function getFreeEnergyCapacity2(creep) {
+function getFreeEnergyCapacity3(creep) {
   var _a, _b;
   const freeCapacity = (_b = (_a = creep.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource3());
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
@@ -10773,13 +11098,13 @@ function buildRuntimeExpansionCandidates(colony) {
 }
 function buildVisibleExpansionCandidateEvidence(room) {
   const controller = room.controller;
-  const sources = findRoomObjects6(room, getFindConstant3("FIND_SOURCES"));
+  const sources = findRoomObjects7(room, getFindConstant4("FIND_SOURCES"));
   const controllerSourceRange = calculateAverageControllerSourceRange(controller, sources);
   const terrain = summarizeRoomTerrain(room);
-  const hostileCreepCount = findRoomObjects6(room, getFindConstant3("FIND_HOSTILE_CREEPS")).length;
-  const hostileStructureCount = findRoomObjects6(
+  const hostileCreepCount = findRoomObjects7(room, getFindConstant4("FIND_HOSTILE_CREEPS")).length;
+  const hostileStructureCount = findRoomObjects7(
     room,
-    getFindConstant3("FIND_HOSTILE_STRUCTURES")
+    getFindConstant4("FIND_HOSTILE_STRUCTURES")
   ).length;
   return {
     ...controller ? { controller: summarizeExpansionController(controller) } : {},
@@ -11281,9 +11606,9 @@ function summarizeRoomTerrain(room) {
     return null;
   }
   return {
-    walkableRatio: roundRatio(plainCount + swampCount, total),
-    swampRatio: roundRatio(swampCount, total),
-    wallRatio: roundRatio(wallCount, total)
+    walkableRatio: roundRatio2(plainCount + swampCount, total),
+    swampRatio: roundRatio2(swampCount, total),
+    wallRatio: roundRatio2(wallCount, total)
   };
 }
 function getRoomTerrain4(room) {
@@ -11299,7 +11624,7 @@ function getTerrainMask(name, fallback) {
   const value = globalThis[name];
   return typeof value === "number" ? value : fallback;
 }
-function findRoomObjects6(room, findConstant) {
+function findRoomObjects7(room, findConstant) {
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return [];
   }
@@ -11310,7 +11635,7 @@ function findRoomObjects6(room, findConstant) {
     return [];
   }
 }
-function getFindConstant3(name) {
+function getFindConstant4(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -11357,7 +11682,7 @@ function getWritableTerritoryMemoryRecord3() {
   }
   return memory.territory;
 }
-function roundRatio(numerator, denominator) {
+function roundRatio2(numerator, denominator) {
   return denominator > 0 ? Math.round(numerator / denominator * 1e3) / 1e3 : 0;
 }
 function toPercent(value) {
@@ -11800,11 +12125,13 @@ var RUNTIME_SUMMARY_PREFIX = "#runtime-summary ";
 var RUNTIME_SUMMARY_INTERVAL = 20;
 var MAX_REPORTED_EVENTS = 10;
 var MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+var MAX_WORKER_BEHAVIOR_SAMPLES = 10;
 var MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 var MAX_REFILL_DELIVERY_SAMPLES = 5;
 var MAX_SPAWN_CRITICAL_REFILL_SAMPLES = 5;
 var MAX_TERRITORY_INTENT_SUMMARIES = 5;
 var WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
+var WORKER_BEHAVIOR_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var SPAWN_CRITICAL_REFILL_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 var OBSERVED_RAMPART_REPAIR_HITS_CEILING = 1e5;
@@ -11921,6 +12248,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
+    ...summarizeBehavior(colonyWorkers, getGameTime7()),
     ...summarizeWorkerEfficiency(colonyWorkers, getGameTime7()),
     ...summarizeRefillTelemetry(colonyWorkers, getGameTime7()),
     ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime7()),
@@ -11994,6 +12322,86 @@ function countWorkerTasks(workers) {
 }
 function isWorkerTaskType(taskType) {
   return WORKER_TASK_TYPES.includes(taskType);
+}
+function summarizeBehavior(workers, tick) {
+  const samples = workers.map((worker) => ({ creepName: getCreepName2(worker), sample: worker.memory.workerBehavior })).filter(
+    (entry) => isWorkerTaskBehaviorSample(entry.sample) && isRecentWorkerTaskBehaviorSample(entry.sample, tick)
+  ).sort(compareWorkerTaskBehaviorSampleEntries);
+  if (samples.length === 0) {
+    return {};
+  }
+  const reportedSamples = samples.slice(0, MAX_WORKER_BEHAVIOR_SAMPLES).map(toRuntimeWorkerTaskBehaviorSample);
+  return {
+    behavior: {
+      workerTaskPolicy: {
+        schemaVersion: 1,
+        sourcePolicyId: HEURISTIC_WORKER_TASK_POLICY_ID,
+        liveEffect: false,
+        sampleCount: samples.length,
+        actionCounts: countWorkerBehaviorActions(samples),
+        samples: reportedSamples,
+        ...samples.length > MAX_WORKER_BEHAVIOR_SAMPLES ? { omittedSampleCount: samples.length - MAX_WORKER_BEHAVIOR_SAMPLES } : {},
+        ...summarizeWorkerTaskPolicyShadow(workers, tick)
+      }
+    }
+  };
+}
+function countWorkerBehaviorActions(samples) {
+  const counts = Object.fromEntries(WORKER_TASK_BC_ACTION_TYPES.map((action) => [action, 0]));
+  for (const entry of samples) {
+    counts[entry.sample.action.type] += 1;
+  }
+  return counts;
+}
+function summarizeWorkerTaskPolicyShadow(workers, tick) {
+  const shadows = workers.map((worker) => worker.memory.workerTaskPolicyShadow).filter((shadow) => isRecentWorkerTaskPolicyShadow(shadow, tick));
+  if (shadows.length === 0) {
+    return {};
+  }
+  const matchedCount = shadows.filter((shadow) => shadow.matched).length;
+  const mismatchCount = shadows.filter((shadow) => shadow.fallbackReason === "actionMismatch").length;
+  const noPredictionCount = shadows.filter(
+    (shadow) => shadow.fallbackReason === "untrainedModel" || shadow.fallbackReason === "lowConfidence"
+  ).length;
+  return {
+    shadow: {
+      policyId: shadows[0].policyId,
+      liveEffect: false,
+      sampleCount: shadows.length,
+      matchedCount,
+      mismatchCount,
+      noPredictionCount,
+      matchRate: roundRatio3(matchedCount, shadows.length)
+    }
+  };
+}
+function compareWorkerTaskBehaviorSampleEntries(left, right) {
+  var _a, _b;
+  return right.sample.tick - left.sample.tick || ((_a = left.creepName) != null ? _a : "").localeCompare((_b = right.creepName) != null ? _b : "") || left.sample.action.type.localeCompare(right.sample.action.type) || left.sample.action.targetId.localeCompare(right.sample.action.targetId);
+}
+function toRuntimeWorkerTaskBehaviorSample(entry) {
+  return {
+    ...entry.creepName ? { creepName: entry.creepName } : {},
+    ...entry.sample
+  };
+}
+function isRecentWorkerTaskBehaviorSample(sample, tick) {
+  if (tick <= 0) {
+    return true;
+  }
+  return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
+}
+function isWorkerTaskBehaviorSample(value) {
+  return isRecord11(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord11(value.state) && isRecord11(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+}
+function isRecentWorkerTaskPolicyShadow(value, tick) {
+  if (!isWorkerTaskPolicyShadow(value)) {
+    return false;
+  }
+  return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
+}
+function isWorkerTaskPolicyShadow(value) {
+  return isRecord11(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function summarizeWorkerEfficiency(workers, tick) {
   const samples = workers.map((worker) => ({ creepName: getCreepName2(worker), sample: worker.memory.workerEfficiency })).filter(
@@ -12085,7 +12493,7 @@ function summarizeRefillDeliveryTicks(workers, tick) {
   return {
     refillDeliveryTicks: {
       completedCount,
-      averageTicks: roundRatio2(deliveryTicks.reduce((total, value) => total + value, 0), completedCount),
+      averageTicks: roundRatio3(deliveryTicks.reduce((total, value) => total + value, 0), completedCount),
       maxTicks: Math.max(...deliveryTicks),
       samples: reportedSamples,
       ...samples.length > MAX_REFILL_DELIVERY_SAMPLES ? { omittedSampleCount: samples.length - MAX_REFILL_DELIVERY_SAMPLES } : {}
@@ -12109,7 +12517,7 @@ function summarizeRefillWorkerUtilization(workers) {
       ...getCreepName2(worker) ? { creepName: getCreepName2(worker) } : {},
       refillActiveTicks: refillActiveTicks2,
       idleOrOtherTaskTicks: idleOrOtherTaskTicks2,
-      ratio: roundRatio2(refillActiveTicks2, totalTicks2)
+      ratio: roundRatio3(refillActiveTicks2, totalTicks2)
     };
   }).filter((summary) => summary !== null).sort(compareRefillWorkerUtilizationSummaries);
   if (workerSummaries.length === 0) {
@@ -12123,7 +12531,7 @@ function summarizeRefillWorkerUtilization(workers) {
       assignedWorkerCount: workerSummaries.length,
       refillActiveTicks,
       idleOrOtherTaskTicks,
-      ratio: roundRatio2(refillActiveTicks, totalTicks),
+      ratio: roundRatio3(refillActiveTicks, totalTicks),
       workers: workerSummaries
     }
   };
@@ -12148,7 +12556,7 @@ function isRecentRefillDeliverySample(sample, tick) {
 function isRefillDeliverySample(value) {
   return isRecord11(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
-function roundRatio2(numerator, denominator) {
+function roundRatio3(numerator, denominator) {
   if (denominator <= 0) {
     return 0;
   }
@@ -12229,14 +12637,14 @@ function buildControllerSummary(room) {
 }
 function summarizeResources(colony, colonyWorkers, events) {
   var _a, _b, _c, _d;
-  const roomStructures = (_a = findRoomObjects7(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const constructionSites = (_b = findRoomObjects7(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
-  const droppedResources = (_c = findRoomObjects7(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
-  const sources = (_d = findRoomObjects7(colony.room, "FIND_SOURCES")) != null ? _d : [];
+  const roomStructures = (_a = findRoomObjects8(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const constructionSites = (_b = findRoomObjects8(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
+  const droppedResources = (_c = findRoomObjects8(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
+  const sources = (_d = findRoomObjects8(colony.room, "FIND_SOURCES")) != null ? _d : [];
   return {
     storedEnergy: sumEnergyInStores(roomStructures),
     workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
-    droppedEnergy: sumDroppedEnergy(droppedResources),
+    droppedEnergy: sumDroppedEnergy2(droppedResources),
     sourceCount: sources.length,
     productiveEnergy: summarizeProductiveEnergy(colony.room, colonyWorkers, constructionSites, roomStructures),
     ...events ? { events } : {}
@@ -12330,8 +12738,8 @@ function buildControllerProgressRemaining(room) {
 }
 function summarizeCombat(room, events) {
   var _a, _b;
-  const hostileCreeps = (_a = findRoomObjects7(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
-  const hostileStructures = (_b = findRoomObjects7(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
+  const hostileCreeps = (_a = findRoomObjects8(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
+  const hostileStructures = (_b = findRoomObjects8(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
   return {
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -12576,7 +12984,7 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
 }
 function getSpawnExtensionEnergyStructureIds(room) {
   var _a, _b;
-  const structures = (_b = (_a = findRoomObjects7(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects7(room, "FIND_STRUCTURES")) != null ? _b : [];
+  const structures = (_b = (_a = findRoomObjects8(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects8(room, "FIND_STRUCTURES")) != null ? _b : [];
   const ids = /* @__PURE__ */ new Set();
   for (const structure of structures) {
     if (!isSpawnExtensionEnergyStructure2(structure)) {
@@ -12601,7 +13009,7 @@ function buildEventObjectId(entry) {
 function getObjectId2(value) {
   return isRecord11(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
-function findRoomObjects7(room, constantName) {
+function findRoomObjects8(room, constantName) {
   const findConstant = getGlobalNumber5(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
@@ -12641,7 +13049,7 @@ function getEnergyInStore(object) {
   const storedEnergy = object.store[getEnergyResource5()];
   return typeof storedEnergy === "number" ? storedEnergy : 0;
 }
-function sumDroppedEnergy(droppedResources) {
+function sumDroppedEnergy2(droppedResources) {
   const energyResource = getEnergyResource5();
   return droppedResources.reduce((total, droppedResource) => {
     if (!isRecord11(droppedResource) || droppedResource.resourceType !== energyResource) {

--- a/prod/src/rl/workerTaskBcModel.ts
+++ b/prod/src/rl/workerTaskBcModel.ts
@@ -1,0 +1,19 @@
+import type { WorkerTaskBcModel } from './workerTaskPolicy';
+
+export const WORKER_TASK_BC_MODEL: WorkerTaskBcModel = {
+  type: 'worker-task-bc-decision-tree',
+  schemaVersion: 1,
+  policyId: 'worker-task-bc.untrained.v1',
+  source: 'placeholder',
+  liveEffect: false,
+  minConfidence: 0.9,
+  actionTypes: ['harvest', 'transfer', 'build', 'repair', 'upgrade'],
+  features: [],
+  root: null,
+  metadata: {
+    trainingSampleCount: 0,
+    evaluationSampleCount: 0,
+    evaluationMatchRate: null,
+    notes: 'No trained artifact is bundled yet; runtime remains heuristic-only.'
+  }
+};

--- a/prod/src/rl/workerTaskBehavior.ts
+++ b/prod/src/rl/workerTaskBehavior.ts
@@ -1,0 +1,268 @@
+export const WORKER_TASK_BEHAVIOR_SCHEMA_VERSION = 1;
+export const HEURISTIC_WORKER_TASK_POLICY_ID = 'heuristic.worker-task.v1';
+export const WORKER_TASK_BC_ACTION_TYPES = ['harvest', 'transfer', 'build', 'repair', 'upgrade'] as const;
+
+const NEARBY_STRUCTURE_RANGE = 3;
+const NEARBY_TILE_COUNT = 49;
+const CURRENT_TASK_CODE: Record<string, number> = {
+  none: 0,
+  harvest: 1,
+  pickup: 2,
+  withdraw: 3,
+  transfer: 4,
+  build: 5,
+  repair: 6,
+  claim: 7,
+  reserve: 8,
+  upgrade: 9
+};
+
+type StoreOwner = {
+  store?: {
+    getUsedCapacity?: (resource?: ResourceConstant) => number | null;
+    getFreeCapacity?: (resource?: ResourceConstant) => number | null;
+  };
+};
+
+export type WorkerTaskBehaviorActionType = (typeof WORKER_TASK_BC_ACTION_TYPES)[number];
+
+export function isWorkerTaskBehaviorActionType(value: unknown): value is WorkerTaskBehaviorActionType {
+  return WORKER_TASK_BC_ACTION_TYPES.includes(value as WorkerTaskBehaviorActionType);
+}
+
+export function recordWorkerTaskBehaviorTrace(
+  creep: Creep,
+  selectedTask: CreepTaskMemory | null
+): WorkerTaskBehaviorSampleMemory | null {
+  const memory = creep.memory;
+  if (!memory) {
+    return null;
+  }
+
+  if (!selectedTask || !isWorkerTaskBehaviorActionType(selectedTask.type)) {
+    delete memory.workerBehavior;
+    return null;
+  }
+
+  const sample: WorkerTaskBehaviorSampleMemory = {
+    type: 'workerTaskBehavior',
+    schemaVersion: WORKER_TASK_BEHAVIOR_SCHEMA_VERSION,
+    tick: getGameTick(),
+    policyId: HEURISTIC_WORKER_TASK_POLICY_ID,
+    liveEffect: false,
+    state: buildWorkerTaskBehaviorState(creep),
+    action: {
+      type: selectedTask.type,
+      targetId: String(selectedTask.targetId)
+    }
+  };
+  memory.workerBehavior = sample;
+  return sample;
+}
+
+export function buildWorkerTaskBehaviorState(creep: Creep): WorkerTaskBehaviorStateMemory {
+  const room = creep.room;
+  const structures = findRoomObjects<AnyStructure>(room, getFindConstant('FIND_STRUCTURES'));
+  const myStructures = findRoomObjects<AnyOwnedStructure>(room, getFindConstant('FIND_MY_STRUCTURES'));
+  const constructionSites = findRoomObjects<ConstructionSite>(room, getFindConstant('FIND_CONSTRUCTION_SITES'));
+  const droppedResources = findRoomObjects<Resource<ResourceConstant>>(room, getFindConstant('FIND_DROPPED_RESOURCES'));
+  const sources = findRoomObjects<Source>(room, getFindConstant('FIND_SOURCES'));
+  const hostileCreeps = findRoomObjects<Creep>(room, getFindConstant('FIND_HOSTILE_CREEPS'));
+  const currentTask = creep.memory?.task?.type ?? 'none';
+  const carriedEnergy = getUsedEnergy(creep);
+  const freeCapacity = getFreeEnergyCapacity(creep);
+  const energyCapacity = Math.max(0, carriedEnergy + freeCapacity);
+  const controller = room?.controller;
+  const nearbyStructures = structures.filter((structure) => getRangeBetweenRoomObjects(creep, structure) <= NEARBY_STRUCTURE_RANGE);
+  const nearbyRoadCount = nearbyStructures.filter((structure) => isStructureType(structure, 'STRUCTURE_ROAD', 'road')).length;
+  const nearbyContainerCount = nearbyStructures.filter((structure) =>
+    isStructureType(structure, 'STRUCTURE_CONTAINER', 'container')
+  ).length;
+  const containerCount = structures.filter((structure) =>
+    isStructureType(structure, 'STRUCTURE_CONTAINER', 'container')
+  ).length;
+  const droppedEnergyAvailable = sumDroppedEnergy(droppedResources);
+  const spawnExtensionNeedCount = myStructures.filter(
+    (structure) =>
+      isStructureType(structure, 'STRUCTURE_SPAWN', 'spawn') ||
+      isStructureType(structure, 'STRUCTURE_EXTENSION', 'extension')
+  ).length;
+  const towerNeedCount = myStructures.filter(
+    (structure) => isStructureType(structure, 'STRUCTURE_TOWER', 'tower')
+  ).length;
+
+  return {
+    roomName: room?.name ?? 'unknown',
+    ...buildPositionState(creep.pos),
+    carriedEnergy,
+    freeCapacity,
+    energyCapacity,
+    energyLoadRatio: roundRatio(carriedEnergy, energyCapacity),
+    currentTask,
+    currentTaskCode: CURRENT_TASK_CODE[currentTask] ?? CURRENT_TASK_CODE.none,
+    ...numberField('roomEnergyAvailable', room?.energyAvailable),
+    ...numberField('roomEnergyCapacity', room?.energyCapacityAvailable),
+    workerCount: 0,
+    spawnExtensionNeedCount,
+    towerNeedCount,
+    constructionSiteCount: constructionSites.length,
+    repairTargetCount: countRepairTargets(structures),
+    sourceCount: sources.length,
+    hasContainerEnergy: containerCount > 0,
+    containerEnergyAvailable: 0,
+    droppedEnergyAvailable,
+    nearbyRoadCount,
+    nearbyContainerCount,
+    roadCoverage: roundRatio(nearbyRoadCount, NEARBY_TILE_COUNT),
+    hostileCreepCount: hostileCreeps.length,
+    ...buildControllerState(controller)
+  };
+}
+
+function buildPositionState(position: RoomPosition | undefined): Pick<WorkerTaskBehaviorStateMemory, 'x' | 'y'> {
+  if (!position) {
+    return {};
+  }
+
+  return {
+    x: finiteNumber(position.x),
+    y: finiteNumber(position.y)
+  };
+}
+
+function buildControllerState(
+  controller: StructureController | undefined
+): Pick<
+  WorkerTaskBehaviorStateMemory,
+  'controllerLevel' | 'controllerTicksToDowngrade' | 'controllerProgressRatio'
+> {
+  if (!controller?.my) {
+    return {};
+  }
+
+  const progress = finiteNumber(controller.progress);
+  const progressTotal = finiteNumber(controller.progressTotal);
+  return {
+    ...numberField('controllerLevel', controller.level),
+    ...numberField('controllerTicksToDowngrade', controller.ticksToDowngrade),
+    ...(progress !== undefined && progressTotal !== undefined && progressTotal > 0
+      ? { controllerProgressRatio: roundRatio(progress, progressTotal) }
+      : {})
+  };
+}
+
+function countRepairTargets(structures: AnyStructure[]): number {
+  return structures.filter((structure) => {
+    const hits = finiteNumber((structure as { hits?: unknown }).hits);
+    const hitsMax = finiteNumber((structure as { hitsMax?: unknown }).hitsMax);
+    if (hits === undefined || hitsMax === undefined || hits >= hitsMax) {
+      return false;
+    }
+
+    return (
+      isStructureType(structure, 'STRUCTURE_ROAD', 'road') ||
+      isStructureType(structure, 'STRUCTURE_CONTAINER', 'container') ||
+      (isStructureType(structure, 'STRUCTURE_RAMPART', 'rampart') &&
+        (structure as { my?: unknown }).my !== false)
+    );
+  }).length;
+}
+
+function findRoomObjects<T>(room: Room | undefined, findConstant: number | undefined): T[] {
+  if (!room || typeof room.find !== 'function' || typeof findConstant !== 'number') {
+    return [];
+  }
+
+  try {
+    const objects = room.find(findConstant as FindConstant) as unknown;
+    return Array.isArray(objects) ? (objects as T[]) : [];
+  } catch (_error) {
+    return [];
+  }
+}
+
+function getFindConstant(name: string): number | undefined {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function getUsedEnergy(target: StoreOwner): number {
+  const value = target.store?.getUsedCapacity?.(getEnergyResourceConstant());
+  return Math.max(0, finiteNumber(value) ?? 0);
+}
+
+function getFreeEnergyCapacity(target: StoreOwner): number {
+  const value = target.store?.getFreeCapacity?.(getEnergyResourceConstant());
+  return Math.max(0, finiteNumber(value) ?? 0);
+}
+
+function getEnergyResourceConstant(): ResourceConstant {
+  return ((globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
+}
+
+function sumDroppedEnergy(resources: Array<Resource<ResourceConstant>>): number {
+  return resources.reduce((total, resource) => {
+    if (resource.resourceType !== getEnergyResourceConstant()) {
+      return total;
+    }
+
+    return total + Math.max(0, finiteNumber(resource.amount) ?? 0);
+  }, 0);
+}
+
+function isStructureType(structure: { structureType?: unknown }, globalName: string, fallback: string): boolean {
+  const globalValue = (globalThis as Record<string, unknown>)[globalName];
+  return structure.structureType === globalValue || structure.structureType === fallback;
+}
+
+function getRangeBetweenRoomObjects(left: RoomObject, right: RoomObject): number {
+  const range = left.pos?.getRangeTo?.(right);
+  if (typeof range === 'number' && Number.isFinite(range)) {
+    return range;
+  }
+
+  const leftPosition = left.pos;
+  const rightPosition = right.pos;
+  if (
+    leftPosition &&
+    rightPosition &&
+    leftPosition.roomName === rightPosition.roomName &&
+    typeof leftPosition.x === 'number' &&
+    typeof leftPosition.y === 'number' &&
+    typeof rightPosition.x === 'number' &&
+    typeof rightPosition.y === 'number'
+  ) {
+    return Math.max(Math.abs(leftPosition.x - rightPosition.x), Math.abs(leftPosition.y - rightPosition.y));
+  }
+
+  return Number.MAX_SAFE_INTEGER;
+}
+
+function getGameTick(): number {
+  const tick = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof tick === 'number' && Number.isFinite(tick) ? tick : 0;
+}
+
+function numberField<Key extends keyof WorkerTaskBehaviorStateMemory>(
+  key: Key,
+  value: unknown
+): Pick<WorkerTaskBehaviorStateMemory, Key> {
+  const number = finiteNumber(value);
+  if (number === undefined) {
+    return {} as Pick<WorkerTaskBehaviorStateMemory, Key>;
+  }
+
+  return { [key]: number } as Pick<WorkerTaskBehaviorStateMemory, Key>;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function roundRatio(numerator: number, denominator: number): number {
+  if (denominator <= 0) {
+    return 0;
+  }
+
+  return Math.round((numerator / denominator) * 1_000) / 1_000;
+}

--- a/prod/src/rl/workerTaskPolicy.ts
+++ b/prod/src/rl/workerTaskPolicy.ts
@@ -1,0 +1,190 @@
+import { WORKER_TASK_BC_MODEL } from './workerTaskBcModel';
+import {
+  WORKER_TASK_BC_ACTION_TYPES,
+  WORKER_TASK_BEHAVIOR_SCHEMA_VERSION,
+  type WorkerTaskBehaviorActionType,
+  isWorkerTaskBehaviorActionType
+} from './workerTaskBehavior';
+
+export interface WorkerTaskBcModel {
+  type: 'worker-task-bc-decision-tree';
+  schemaVersion: 1;
+  policyId: string;
+  source: string;
+  liveEffect: false;
+  minConfidence: number;
+  actionTypes: WorkerTaskBehaviorActionType[];
+  features: string[];
+  root: WorkerTaskBcNode | null;
+  metadata?: {
+    trainingSampleCount?: number;
+    evaluationSampleCount?: number;
+    evaluationMatchRate?: number | null;
+    notes?: string;
+  };
+}
+
+export type WorkerTaskBcNode = WorkerTaskBcLeafNode | WorkerTaskBcBranchNode;
+
+export interface WorkerTaskBcLeafNode {
+  type: 'leaf';
+  action: WorkerTaskBehaviorActionType;
+  confidence: number;
+  sampleCount: number;
+  distribution: Partial<Record<WorkerTaskBehaviorActionType, number>>;
+}
+
+export interface WorkerTaskBcBranchNode {
+  type: 'branch';
+  feature: keyof WorkerTaskBehaviorStateMemory | string;
+  threshold: number;
+  missing: 'left' | 'right';
+  sampleCount: number;
+  distribution: Partial<Record<WorkerTaskBehaviorActionType, number>>;
+  left: WorkerTaskBcNode;
+  right: WorkerTaskBcNode;
+}
+
+export interface WorkerTaskBcPrediction {
+  policyId: string;
+  action: WorkerTaskBehaviorActionType;
+  confidence: number;
+}
+
+let testingModelOverride: WorkerTaskBcModel | null = null;
+
+export function selectWorkerTaskWithBcFallback(
+  creep: Creep,
+  heuristicTask: CreepTaskMemory | null
+): CreepTaskMemory | null {
+  const memory = creep.memory;
+  const model = getActiveWorkerTaskBcModel();
+  const state = memory?.workerBehavior?.state;
+  if (memory && !state) {
+    delete memory.workerTaskPolicyShadow;
+    return heuristicTask;
+  }
+
+  const prediction = state ? predictWorkerTaskAction(model, state) : null;
+  const heuristicAction = isWorkerTaskBehaviorActionType(heuristicTask?.type) ? heuristicTask.type : undefined;
+
+  if (memory) {
+    memory.workerTaskPolicyShadow = {
+      type: 'workerTaskPolicyShadow',
+      schemaVersion: WORKER_TASK_BEHAVIOR_SCHEMA_VERSION,
+      tick: getGameTick(),
+      policyId: model.policyId,
+      liveEffect: false,
+      ...(prediction ? { predictedAction: prediction.action, confidence: prediction.confidence } : {}),
+      ...(heuristicAction ? { heuristicAction } : {}),
+      matched: Boolean(prediction && heuristicAction && prediction.action === heuristicAction),
+      ...buildFallbackReason(model, prediction, heuristicAction)
+    };
+  }
+
+  return heuristicTask;
+}
+
+export function predictWorkerTaskAction(
+  model: WorkerTaskBcModel,
+  state: WorkerTaskBehaviorStateMemory
+): WorkerTaskBcPrediction | null {
+  if (!isUsableModel(model)) {
+    return null;
+  }
+
+  const leaf = evaluateNode(model.root, state);
+  if (!leaf || leaf.confidence < model.minConfidence) {
+    return null;
+  }
+
+  return {
+    policyId: model.policyId,
+    action: leaf.action,
+    confidence: leaf.confidence
+  };
+}
+
+export function setWorkerTaskBcModelForTesting(model: WorkerTaskBcModel): void {
+  testingModelOverride = model;
+}
+
+export function resetWorkerTaskBcModelForTesting(): void {
+  testingModelOverride = null;
+}
+
+function getActiveWorkerTaskBcModel(): WorkerTaskBcModel {
+  return testingModelOverride ?? WORKER_TASK_BC_MODEL;
+}
+
+function isUsableModel(model: WorkerTaskBcModel): boolean {
+  return (
+    model.type === 'worker-task-bc-decision-tree' &&
+    model.schemaVersion === 1 &&
+    model.liveEffect === false &&
+    model.root !== null &&
+    model.actionTypes.every((action) => WORKER_TASK_BC_ACTION_TYPES.includes(action))
+  );
+}
+
+function evaluateNode(
+  node: WorkerTaskBcNode | null,
+  state: WorkerTaskBehaviorStateMemory
+): WorkerTaskBcLeafNode | null {
+  if (!node) {
+    return null;
+  }
+
+  if (node.type === 'leaf') {
+    return node;
+  }
+
+  const featureValue = getFeatureValue(state, node.feature);
+  if (featureValue === null) {
+    return evaluateNode(node.missing === 'left' ? node.left : node.right, state);
+  }
+
+  return evaluateNode(featureValue <= node.threshold ? node.left : node.right, state);
+}
+
+function getFeatureValue(state: WorkerTaskBehaviorStateMemory, feature: string): number | null {
+  const value = (state as unknown as Record<string, unknown>)[feature];
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+
+  return null;
+}
+
+function buildFallbackReason(
+  model: WorkerTaskBcModel,
+  prediction: WorkerTaskBcPrediction | null,
+  heuristicAction: WorkerTaskBehaviorActionType | undefined
+): Pick<WorkerTaskPolicyShadowMemory, 'fallbackReason'> {
+  if (!isUsableModel(model)) {
+    return { fallbackReason: 'untrainedModel' };
+  }
+
+  if (!prediction) {
+    return { fallbackReason: 'lowConfidence' };
+  }
+
+  if (!heuristicAction) {
+    return { fallbackReason: 'unsupportedHeuristicAction' };
+  }
+
+  if (prediction.action !== heuristicAction) {
+    return { fallbackReason: 'actionMismatch' };
+  }
+
+  return {};
+}
+
+function getGameTick(): number {
+  const tick = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof tick === 'number' && Number.isFinite(tick) ? tick : 0;
+}

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -24,6 +24,8 @@ import {
   type ConstructionSiteImpactPriorityContext
 } from '../construction/constructionPriority';
 import { findSourceContainer } from '../economy/sourceContainers';
+import { recordWorkerTaskBehaviorTrace } from '../rl/workerTaskBehavior';
+import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
@@ -129,7 +131,12 @@ let nearTermSpawnExtensionRefillReserveCache: NearTermSpawnExtensionRefillReserv
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   clearWorkerEfficiencyTelemetry(creep);
+  const heuristicTask = selectHeuristicWorkerTask(creep);
+  recordWorkerTaskBehaviorTrace(creep, heuristicTask);
+  return selectWorkerTaskWithBcFallback(creep, heuristicTask);
+}
 
+function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   const survivalAssessment = getWorkerColonySurvivalAssessment(creep);
   const territoryWorkSuppressed = suppressesTerritoryWork(survivalAssessment);
   const bootstrapNonCriticalWorkSuppressed = suppressesBootstrapNonCriticalWork(survivalAssessment);

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -16,6 +16,12 @@ import {
   type ExpansionCandidateReport
 } from '../territory/expansionScoring';
 import {
+  HEURISTIC_WORKER_TASK_POLICY_ID,
+  WORKER_TASK_BC_ACTION_TYPES,
+  isWorkerTaskBehaviorActionType,
+  type WorkerTaskBehaviorActionType
+} from '../rl/workerTaskBehavior';
+import {
   getActiveTerritoryFollowUpExecutionHints,
   getSuspendedTerritoryIntentCountsByRoom,
   getTerritoryIntentProgressSummaries,
@@ -27,11 +33,13 @@ export const RUNTIME_SUMMARY_PREFIX = '#runtime-summary ';
 export const RUNTIME_SUMMARY_INTERVAL = 20;
 const MAX_REPORTED_EVENTS = 10;
 const MAX_WORKER_EFFICIENCY_SAMPLES = 5;
+const MAX_WORKER_BEHAVIOR_SAMPLES = 10;
 const MAX_WORKER_EFFICIENCY_REASON_SAMPLES = 5;
 const MAX_REFILL_DELIVERY_SAMPLES = 5;
 const MAX_SPAWN_CRITICAL_REFILL_SAMPLES = 5;
 const MAX_TERRITORY_INTENT_SUMMARIES = 5;
 const WORKER_EFFICIENCY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
+const WORKER_BEHAVIOR_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const REFILL_DELIVERY_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const SPAWN_CRITICAL_REFILL_SAMPLE_TTL = RUNTIME_SUMMARY_INTERVAL;
 const OBSERVED_RAMPART_REPAIR_HITS_CEILING = 100_000;
@@ -125,6 +133,7 @@ interface RuntimeRoomSummary {
   workerCount: number;
   spawnStatus: RuntimeSpawnStatus[];
   taskCounts: WorkerTaskCounts;
+  behavior?: RuntimeBehaviorSummary;
   workerEfficiency?: RuntimeWorkerEfficiencySummary;
   refillDeliveryTicks?: RuntimeRefillDeliveryTicksSummary;
   refillWorkerUtilization?: RuntimeRefillWorkerUtilizationSummary;
@@ -187,6 +196,40 @@ interface RuntimeWorkerEfficiencySummary {
   lowLoadReturnReasons?: RuntimeWorkerEfficiencyLowLoadReturnReasonSummary[];
   samples: RuntimeWorkerEfficiencySampleSummary[];
   omittedSampleCount?: number;
+}
+
+interface RuntimeBehaviorSummary {
+  workerTaskPolicy: RuntimeWorkerTaskBehaviorSummary;
+}
+
+interface RuntimeWorkerTaskBehaviorSummary {
+  schemaVersion: 1;
+  sourcePolicyId: string;
+  liveEffect: false;
+  sampleCount: number;
+  actionCounts: Record<WorkerTaskBehaviorActionType, number>;
+  samples: RuntimeWorkerTaskBehaviorSampleSummary[];
+  omittedSampleCount?: number;
+  shadow?: RuntimeWorkerTaskPolicyShadowSummary;
+}
+
+interface RuntimeWorkerTaskBehaviorSampleSummary extends WorkerTaskBehaviorSampleMemory {
+  creepName?: string;
+}
+
+interface RuntimeWorkerTaskBehaviorSampleEntry {
+  creepName: string | undefined;
+  sample: WorkerTaskBehaviorSampleMemory;
+}
+
+interface RuntimeWorkerTaskPolicyShadowSummary {
+  policyId: string;
+  liveEffect: false;
+  sampleCount: number;
+  matchedCount: number;
+  mismatchCount: number;
+  noPredictionCount: number;
+  matchRate: number;
 }
 
 interface RuntimeWorkerEfficiencySampleSummary extends WorkerEfficiencySampleMemory {
@@ -459,6 +502,7 @@ function summarizeRoom(
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
+    ...summarizeBehavior(colonyWorkers, getGameTime()),
     ...summarizeWorkerEfficiency(colonyWorkers, getGameTime()),
     ...summarizeRefillTelemetry(colonyWorkers, getGameTime()),
     ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime()),
@@ -554,6 +598,150 @@ function countWorkerTasks(workers: Creep[]): WorkerTaskCounts {
 
 function isWorkerTaskType(taskType: string | undefined): taskType is WorkerTaskType {
   return WORKER_TASK_TYPES.includes(taskType as WorkerTaskType);
+}
+
+function summarizeBehavior(workers: Creep[], tick: number): { behavior?: RuntimeBehaviorSummary } {
+  const samples = workers
+    .map((worker) => ({ creepName: getCreepName(worker), sample: worker.memory.workerBehavior }))
+    .filter(
+      (entry): entry is RuntimeWorkerTaskBehaviorSampleEntry =>
+        isWorkerTaskBehaviorSample(entry.sample) && isRecentWorkerTaskBehaviorSample(entry.sample, tick)
+    )
+    .sort(compareWorkerTaskBehaviorSampleEntries);
+
+  if (samples.length === 0) {
+    return {};
+  }
+
+  const reportedSamples = samples.slice(0, MAX_WORKER_BEHAVIOR_SAMPLES).map(toRuntimeWorkerTaskBehaviorSample);
+
+  return {
+    behavior: {
+      workerTaskPolicy: {
+        schemaVersion: 1,
+        sourcePolicyId: HEURISTIC_WORKER_TASK_POLICY_ID,
+        liveEffect: false,
+        sampleCount: samples.length,
+        actionCounts: countWorkerBehaviorActions(samples),
+        samples: reportedSamples,
+        ...(samples.length > MAX_WORKER_BEHAVIOR_SAMPLES
+          ? { omittedSampleCount: samples.length - MAX_WORKER_BEHAVIOR_SAMPLES }
+          : {}),
+        ...summarizeWorkerTaskPolicyShadow(workers, tick)
+      }
+    }
+  };
+}
+
+function countWorkerBehaviorActions(
+  samples: RuntimeWorkerTaskBehaviorSampleEntry[]
+): Record<WorkerTaskBehaviorActionType, number> {
+  const counts = Object.fromEntries(WORKER_TASK_BC_ACTION_TYPES.map((action) => [action, 0])) as Record<
+    WorkerTaskBehaviorActionType,
+    number
+  >;
+  for (const entry of samples) {
+    counts[entry.sample.action.type] += 1;
+  }
+
+  return counts;
+}
+
+function summarizeWorkerTaskPolicyShadow(
+  workers: Creep[],
+  tick: number
+): { shadow?: RuntimeWorkerTaskPolicyShadowSummary } {
+  const shadows = workers
+    .map((worker) => worker.memory.workerTaskPolicyShadow)
+    .filter((shadow): shadow is WorkerTaskPolicyShadowMemory => isRecentWorkerTaskPolicyShadow(shadow, tick));
+
+  if (shadows.length === 0) {
+    return {};
+  }
+
+  const matchedCount = shadows.filter((shadow) => shadow.matched).length;
+  const mismatchCount = shadows.filter((shadow) => shadow.fallbackReason === 'actionMismatch').length;
+  const noPredictionCount = shadows.filter(
+    (shadow) => shadow.fallbackReason === 'untrainedModel' || shadow.fallbackReason === 'lowConfidence'
+  ).length;
+
+  return {
+    shadow: {
+      policyId: shadows[0].policyId,
+      liveEffect: false,
+      sampleCount: shadows.length,
+      matchedCount,
+      mismatchCount,
+      noPredictionCount,
+      matchRate: roundRatio(matchedCount, shadows.length)
+    }
+  };
+}
+
+function compareWorkerTaskBehaviorSampleEntries(
+  left: RuntimeWorkerTaskBehaviorSampleEntry,
+  right: RuntimeWorkerTaskBehaviorSampleEntry
+): number {
+  return (
+    right.sample.tick - left.sample.tick ||
+    (left.creepName ?? '').localeCompare(right.creepName ?? '') ||
+    left.sample.action.type.localeCompare(right.sample.action.type) ||
+    left.sample.action.targetId.localeCompare(right.sample.action.targetId)
+  );
+}
+
+function toRuntimeWorkerTaskBehaviorSample(
+  entry: RuntimeWorkerTaskBehaviorSampleEntry
+): RuntimeWorkerTaskBehaviorSampleSummary {
+  return {
+    ...(entry.creepName ? { creepName: entry.creepName } : {}),
+    ...entry.sample
+  };
+}
+
+function isRecentWorkerTaskBehaviorSample(sample: WorkerTaskBehaviorSampleMemory, tick: number): boolean {
+  if (tick <= 0) {
+    return true;
+  }
+
+  return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
+}
+
+function isWorkerTaskBehaviorSample(value: unknown): value is WorkerTaskBehaviorSampleMemory {
+  return (
+    isRecord(value) &&
+    value.type === 'workerTaskBehavior' &&
+    value.schemaVersion === 1 &&
+    typeof value.tick === 'number' &&
+    Number.isFinite(value.tick) &&
+    typeof value.policyId === 'string' &&
+    value.liveEffect === false &&
+    isRecord(value.state) &&
+    isRecord(value.action) &&
+    isWorkerTaskBehaviorActionType(value.action.type) &&
+    typeof value.action.targetId === 'string'
+  );
+}
+
+function isRecentWorkerTaskPolicyShadow(value: unknown, tick: number): value is WorkerTaskPolicyShadowMemory {
+  if (!isWorkerTaskPolicyShadow(value)) {
+    return false;
+  }
+
+  return tick <= 0 || (value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL);
+}
+
+function isWorkerTaskPolicyShadow(value: unknown): value is WorkerTaskPolicyShadowMemory {
+  return (
+    isRecord(value) &&
+    value.type === 'workerTaskPolicyShadow' &&
+    value.schemaVersion === 1 &&
+    typeof value.tick === 'number' &&
+    Number.isFinite(value.tick) &&
+    typeof value.policyId === 'string' &&
+    value.liveEffect === false &&
+    typeof value.matched === 'boolean'
+  );
 }
 
 function summarizeWorkerEfficiency(

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -22,6 +22,8 @@ declare global {
     workerEfficiency?: WorkerEfficiencySampleMemory;
     refillTelemetry?: WorkerRefillTelemetryMemory;
     spawnCriticalRefill?: WorkerSpawnCriticalRefillMemory;
+    workerBehavior?: WorkerTaskBehaviorSampleMemory;
+    workerTaskPolicyShadow?: WorkerTaskPolicyShadowMemory;
   }
 
   type DefenseActionType =
@@ -307,6 +309,69 @@ declare global {
     spawnEnergy: number;
     freeCapacity: number;
     threshold: number;
+  }
+
+  type WorkerTaskBehaviorActionType = 'harvest' | 'transfer' | 'build' | 'repair' | 'upgrade';
+  type WorkerTaskPolicyShadowFallbackReason =
+    | 'untrainedModel'
+    | 'lowConfidence'
+    | 'unsupportedHeuristicAction'
+    | 'actionMismatch';
+
+  interface WorkerTaskBehaviorStateMemory {
+    roomName: string;
+    x?: number;
+    y?: number;
+    carriedEnergy: number;
+    freeCapacity: number;
+    energyCapacity: number;
+    energyLoadRatio: number;
+    currentTask: string;
+    currentTaskCode: number;
+    roomEnergyAvailable?: number;
+    roomEnergyCapacity?: number;
+    workerCount: number;
+    spawnExtensionNeedCount: number;
+    towerNeedCount: number;
+    constructionSiteCount: number;
+    repairTargetCount: number;
+    sourceCount: number;
+    hasContainerEnergy: boolean;
+    containerEnergyAvailable: number;
+    droppedEnergyAvailable: number;
+    nearbyRoadCount: number;
+    nearbyContainerCount: number;
+    roadCoverage: number;
+    hostileCreepCount: number;
+    controllerLevel?: number;
+    controllerTicksToDowngrade?: number;
+    controllerProgressRatio?: number;
+  }
+
+  interface WorkerTaskBehaviorSampleMemory {
+    type: 'workerTaskBehavior';
+    schemaVersion: 1;
+    tick: number;
+    policyId: string;
+    liveEffect: false;
+    state: WorkerTaskBehaviorStateMemory;
+    action: {
+      type: WorkerTaskBehaviorActionType;
+      targetId: string;
+    };
+  }
+
+  interface WorkerTaskPolicyShadowMemory {
+    type: 'workerTaskPolicyShadow';
+    schemaVersion: 1;
+    tick: number;
+    policyId: string;
+    liveEffect: false;
+    predictedAction?: WorkerTaskBehaviorActionType;
+    heuristicAction?: WorkerTaskBehaviorActionType;
+    confidence?: number;
+    matched: boolean;
+    fallbackReason?: WorkerTaskPolicyShadowFallbackReason;
   }
 
   type CreepTaskMemory =

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -540,6 +540,99 @@ describe('runtime telemetry summaries', () => {
     });
   });
 
+  it('reports worker behavior cloning traces with shadow-only policy metadata', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const recentWorker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        workerBehavior: makeWorkerBehaviorSample('transfer', 'spawn1', RUNTIME_SUMMARY_INTERVAL),
+        workerTaskPolicyShadow: {
+          type: 'workerTaskPolicyShadow',
+          schemaVersion: 1,
+          tick: RUNTIME_SUMMARY_INTERVAL,
+          policyId: 'worker-task-bc.test.v1',
+          liveEffect: false,
+          predictedAction: 'transfer',
+          confidence: 1,
+          heuristicAction: 'transfer',
+          matched: true
+        }
+      },
+      50,
+      'Carrier'
+    );
+    const mismatchWorker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        workerBehavior: makeWorkerBehaviorSample('build', 'site1', RUNTIME_SUMMARY_INTERVAL - 1),
+        workerTaskPolicyShadow: {
+          type: 'workerTaskPolicyShadow',
+          schemaVersion: 1,
+          tick: RUNTIME_SUMMARY_INTERVAL - 1,
+          policyId: 'worker-task-bc.test.v1',
+          liveEffect: false,
+          predictedAction: 'upgrade',
+          confidence: 1,
+          heuristicAction: 'build',
+          matched: false,
+          fallbackReason: 'actionMismatch'
+        }
+      },
+      50,
+      'Builder'
+    );
+    const staleWorker = makeWorker(
+      {
+        role: 'worker',
+        colony: 'W1N1',
+        workerBehavior: makeWorkerBehaviorSample('harvest', 'source1', 0)
+      },
+      0,
+      'Stale'
+    );
+
+    emitRuntimeSummary([colony], [recentWorker, mismatchWorker, staleWorker]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.behavior).toEqual({
+      workerTaskPolicy: {
+        schemaVersion: 1,
+        sourcePolicyId: 'heuristic.worker-task.v1',
+        liveEffect: false,
+        sampleCount: 2,
+        actionCounts: {
+          harvest: 0,
+          transfer: 1,
+          build: 1,
+          repair: 0,
+          upgrade: 0
+        },
+        samples: [
+          {
+            creepName: 'Carrier',
+            ...makeWorkerBehaviorSample('transfer', 'spawn1', RUNTIME_SUMMARY_INTERVAL)
+          },
+          {
+            creepName: 'Builder',
+            ...makeWorkerBehaviorSample('build', 'site1', RUNTIME_SUMMARY_INTERVAL - 1)
+          }
+        ],
+        shadow: {
+          policyId: 'worker-task-bc.test.v1',
+          liveEffect: false,
+          sampleCount: 2,
+          matchedCount: 1,
+          mismatchCount: 1,
+          noPredictionCount: 0,
+          matchRate: 0.5
+        }
+      }
+    });
+  });
+
   it('reports spawn-critical refill assignment telemetry', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
     const carrier = makeWorker(
@@ -1039,6 +1132,43 @@ function makeWorker(memory: CreepMemory, energy = 0, name?: string): Creep {
     memory,
     store: makeEnergyStore(energy)
   } as unknown as Creep;
+}
+
+function makeWorkerBehaviorSample(
+  action: WorkerTaskBehaviorActionType,
+  targetId: string,
+  tick: number
+): WorkerTaskBehaviorSampleMemory {
+  return {
+    type: 'workerTaskBehavior',
+    schemaVersion: 1,
+    tick,
+    policyId: 'heuristic.worker-task.v1',
+    liveEffect: false,
+    state: {
+      roomName: 'W1N1',
+      carriedEnergy: action === 'harvest' ? 0 : 50,
+      freeCapacity: action === 'harvest' ? 50 : 0,
+      energyCapacity: 50,
+      energyLoadRatio: action === 'harvest' ? 0 : 1,
+      currentTask: 'none',
+      currentTaskCode: 0,
+      workerCount: 2,
+      spawnExtensionNeedCount: action === 'transfer' ? 1 : 0,
+      towerNeedCount: 0,
+      constructionSiteCount: action === 'build' ? 1 : 0,
+      repairTargetCount: 0,
+      sourceCount: 2,
+      hasContainerEnergy: false,
+      containerEnergyAvailable: 0,
+      droppedEnergyAvailable: 0,
+      nearbyRoadCount: 0,
+      nearbyContainerCount: 0,
+      roadCoverage: 0,
+      hostileCreepCount: 0
+    },
+    action: { type: action, targetId }
+  };
 }
 
 function makeTrackedWorker(

--- a/prod/test/workerTaskPolicy.test.ts
+++ b/prod/test/workerTaskPolicy.test.ts
@@ -1,0 +1,216 @@
+import {
+  predictWorkerTaskAction,
+  resetWorkerTaskBcModelForTesting,
+  setWorkerTaskBcModelForTesting,
+  type WorkerTaskBcModel
+} from '../src/rl/workerTaskPolicy';
+import { selectWorkerTask } from '../src/tasks/workerTasks';
+
+const TEST_MODEL: WorkerTaskBcModel = {
+  type: 'worker-task-bc-decision-tree',
+  schemaVersion: 1,
+  policyId: 'worker-task-bc.test.v1',
+  source: 'test',
+  liveEffect: false,
+  minConfidence: 0.8,
+  actionTypes: ['harvest', 'transfer', 'build', 'repair', 'upgrade'],
+  features: ['carriedEnergy'],
+  root: {
+    type: 'branch',
+    feature: 'carriedEnergy',
+    threshold: 0,
+    missing: 'left',
+    sampleCount: 4,
+    distribution: { harvest: 2, transfer: 2 },
+    left: {
+      type: 'leaf',
+      action: 'harvest',
+      confidence: 1,
+      sampleCount: 2,
+      distribution: { harvest: 2 }
+    },
+    right: {
+      type: 'leaf',
+      action: 'transfer',
+      confidence: 1,
+      sampleCount: 2,
+      distribution: { transfer: 2 }
+    }
+  }
+};
+
+describe('worker task BC policy', () => {
+  afterEach(() => {
+    resetWorkerTaskBcModelForTesting();
+  });
+
+  it('predicts trained worker task actions from numeric state features', () => {
+    expect(
+      predictWorkerTaskAction(TEST_MODEL, {
+        ...baseState(),
+        carriedEnergy: 0
+      })
+    ).toEqual({
+      policyId: 'worker-task-bc.test.v1',
+      action: 'harvest',
+      confidence: 1
+    });
+
+    expect(
+      predictWorkerTaskAction(TEST_MODEL, {
+        ...baseState(),
+        carriedEnergy: 50
+      })
+    ).toMatchObject({
+      action: 'transfer',
+      confidence: 1
+    });
+  });
+
+  it('keeps heuristic transfer task while recording matching BC shadow metadata', () => {
+    setWorkerTaskBcModelForTesting(TEST_MODEL);
+    installWorkerTaskGlobals();
+    const spawn = {
+      id: 'spawn1',
+      structureType: 'spawn',
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(300)
+      }
+    } as unknown as StructureSpawn;
+    const creep = {
+      name: 'Carrier',
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: {
+        name: 'W1N1',
+        find: jest.fn((type: number, options?: { filter?: (structure: StructureSpawn) => boolean }) => {
+          if (type === FIND_MY_STRUCTURES) {
+            const structures = [spawn];
+            return options?.filter ? structures.filter(options.filter) : structures;
+          }
+
+          if (type === FIND_MY_CREEPS) {
+            return [creep];
+          }
+
+          return [];
+        })
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 123,
+      creeps: { Carrier: creep }
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerBehavior).toMatchObject({
+      type: 'workerTaskBehavior',
+      tick: 123,
+      liveEffect: false,
+      action: { type: 'transfer', targetId: 'spawn1' },
+      state: {
+        roomName: 'W1N1',
+        carriedEnergy: 50,
+        workerCount: 0,
+        spawnExtensionNeedCount: 1
+      }
+    });
+    expect(creep.memory.workerTaskPolicyShadow).toEqual({
+      type: 'workerTaskPolicyShadow',
+      schemaVersion: 1,
+      tick: 123,
+      policyId: 'worker-task-bc.test.v1',
+      liveEffect: false,
+      predictedAction: 'transfer',
+      confidence: 1,
+      heuristicAction: 'transfer',
+      matched: true
+    });
+  });
+
+  it('falls back to the heuristic when BC action disagrees', () => {
+    setWorkerTaskBcModelForTesting({
+      ...TEST_MODEL,
+      root: {
+        type: 'leaf',
+        action: 'upgrade',
+        confidence: 1,
+        sampleCount: 1,
+        distribution: { upgrade: 1 }
+      }
+    });
+    installWorkerTaskGlobals();
+    const source = { id: 'source1', energy: 300 } as Source;
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: {
+        name: 'W1N1',
+        find: jest.fn((type: number) => (type === FIND_SOURCES ? [source] : []))
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { time: 124, creeps: {} };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerTaskPolicyShadow).toMatchObject({
+      policyId: 'worker-task-bc.test.v1',
+      liveEffect: false,
+      predictedAction: 'upgrade',
+      heuristicAction: 'harvest',
+      matched: false,
+      fallbackReason: 'actionMismatch'
+    });
+  });
+});
+
+function baseState(): WorkerTaskBehaviorStateMemory {
+  return {
+    roomName: 'W1N1',
+    carriedEnergy: 0,
+    freeCapacity: 50,
+    energyCapacity: 50,
+    energyLoadRatio: 0,
+    currentTask: 'none',
+    currentTaskCode: 0,
+    workerCount: 1,
+    spawnExtensionNeedCount: 0,
+    towerNeedCount: 0,
+    constructionSiteCount: 0,
+    repairTargetCount: 0,
+    sourceCount: 1,
+    hasContainerEnergy: false,
+    containerEnergyAvailable: 0,
+    droppedEnergyAvailable: 0,
+    nearbyRoadCount: 0,
+    nearbyContainerCount: 0,
+    roadCoverage: 0,
+    hostileCreepCount: 0
+  };
+}
+
+function installWorkerTaskGlobals(): void {
+  (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+  (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
+  (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
+  (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
+  (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
+  (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
+  (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
+  (globalThis as unknown as { FIND_TOMBSTONES: number }).FIND_TOMBSTONES = 8;
+  (globalThis as unknown as { FIND_RUINS: number }).FIND_RUINS = 9;
+  (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 10;
+  (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+  (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+  (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+  (globalThis as unknown as { STRUCTURE_TOWER: StructureConstant }).STRUCTURE_TOWER = 'tower';
+  (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
+  (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+  (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
+}

--- a/scripts/screeps_worker_task_bc_train.py
+++ b/scripts/screeps_worker_task_bc_train.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+"""Train a shadow worker-task behavioral cloning policy from runtime summaries."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import shutil
+import sys
+import tempfile
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import screeps_rl_dataset_export as dataset_export
+
+
+SCHEMA_VERSION = 1
+MODEL_TYPE = "worker-task-bc-decision-tree"
+REPORT_TYPE = "worker-task-bc-evaluation-report"
+DEFAULT_OUT_DIR = Path("runtime-artifacts/worker-task-bc")
+DEFAULT_SAMPLE_LIMIT = 50_000
+DEFAULT_EVAL_RATIO = 0.2
+DEFAULT_MAX_DEPTH = 5
+DEFAULT_MIN_SAMPLES_SPLIT = 8
+DEFAULT_MIN_CONFIDENCE = 0.9
+ACTION_TYPES = ("harvest", "transfer", "build", "repair", "upgrade")
+FEATURES = (
+    "x",
+    "y",
+    "carriedEnergy",
+    "freeCapacity",
+    "energyCapacity",
+    "energyLoadRatio",
+    "currentTaskCode",
+    "roomEnergyAvailable",
+    "roomEnergyCapacity",
+    "workerCount",
+    "spawnExtensionNeedCount",
+    "towerNeedCount",
+    "constructionSiteCount",
+    "repairTargetCount",
+    "sourceCount",
+    "hasContainerEnergy",
+    "containerEnergyAvailable",
+    "droppedEnergyAvailable",
+    "nearbyRoadCount",
+    "nearbyContainerCount",
+    "roadCoverage",
+    "hostileCreepCount",
+    "controllerLevel",
+    "controllerTicksToDowngrade",
+    "controllerProgressRatio",
+)
+RUN_ID_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-")
+
+JsonObject = dict[str, Any]
+TreeNode = JsonObject
+
+
+@dataclass(frozen=True)
+class BehaviorSample:
+    sample_id: str
+    source_id: str
+    room_name: str
+    tick: int | None
+    creep_name: str | None
+    state: JsonObject
+    action: str
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def ratio(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a number") from error
+    if parsed < 0 or parsed >= 1:
+        raise argparse.ArgumentTypeError("must be at least 0 and less than 1")
+    return parsed
+
+
+def probability(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a number") from error
+    if parsed < 0 or parsed > 1:
+        raise argparse.ArgumentTypeError("must be between 0 and 1")
+    return parsed
+
+
+def extract_behavior_samples(
+    paths: Sequence[str],
+    max_file_bytes: int = dataset_export.DEFAULT_MAX_FILE_BYTES,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+) -> list[BehaviorSample]:
+    scan = dataset_export.collect_artifact_records(paths, max_file_bytes=max_file_bytes)
+    samples: list[BehaviorSample] = []
+
+    for record_index, record in enumerate(scan.records):
+        rooms = record.payload.get("rooms")
+        if not isinstance(rooms, list):
+            continue
+        for room in rooms:
+            if not isinstance(room, dict):
+                continue
+            room_name = room.get("roomName")
+            if not isinstance(room_name, str) or not room_name:
+                continue
+            samples.extend(extract_room_behavior_samples(record, record_index, room, room_name, sample_limit))
+            if len(samples) >= sample_limit:
+                return samples[:sample_limit]
+
+    return samples[:sample_limit]
+
+
+def extract_room_behavior_samples(
+    record: dataset_export.ArtifactRecord,
+    record_index: int,
+    room: JsonObject,
+    room_name: str,
+    sample_limit: int,
+) -> list[BehaviorSample]:
+    behavior = room.get("behavior")
+    if not isinstance(behavior, dict):
+        return []
+    worker_policy = behavior.get("workerTaskPolicy")
+    if not isinstance(worker_policy, dict):
+        return []
+    raw_samples = worker_policy.get("samples")
+    if not isinstance(raw_samples, list):
+        return []
+
+    samples: list[BehaviorSample] = []
+    for sample_index, raw_sample in enumerate(raw_samples):
+        parsed = parse_behavior_sample(
+            record=record,
+            record_index=record_index,
+            room_name=room_name,
+            sample_index=sample_index,
+            raw_sample=raw_sample,
+        )
+        if parsed is not None:
+            samples.append(parsed)
+        if len(samples) >= sample_limit:
+            break
+
+    return samples
+
+
+def parse_behavior_sample(
+    *,
+    record: dataset_export.ArtifactRecord,
+    record_index: int,
+    room_name: str,
+    sample_index: int,
+    raw_sample: Any,
+) -> BehaviorSample | None:
+    if not isinstance(raw_sample, dict) or raw_sample.get("liveEffect") is not False:
+        return None
+    state = raw_sample.get("state")
+    action = raw_sample.get("action")
+    if not isinstance(state, dict) or not isinstance(action, dict):
+        return None
+    action_type = action.get("type")
+    if action_type not in ACTION_TYPES:
+        return None
+    tick = raw_sample.get("tick")
+    creep_name = raw_sample.get("creepName")
+    sample_seed = {
+        "sourceId": record.source.source_id,
+        "recordIndex": record_index,
+        "lineNumber": record.line_number,
+        "roomName": room_name,
+        "sampleIndex": sample_index,
+        "tick": tick,
+        "creepName": creep_name,
+        "action": action_type,
+    }
+    return BehaviorSample(
+        sample_id=f"worker-bc-{canonical_hash(sample_seed)[:16]}",
+        source_id=record.source.source_id,
+        room_name=room_name,
+        tick=int(tick) if isinstance(tick, int) else None,
+        creep_name=creep_name if isinstance(creep_name, str) else None,
+        state=state,
+        action=action_type,
+    )
+
+
+def train_decision_tree(
+    samples: Sequence[BehaviorSample],
+    features: Sequence[str] = FEATURES,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    min_samples_split: int = DEFAULT_MIN_SAMPLES_SPLIT,
+) -> TreeNode | None:
+    if not samples:
+        return None
+    return build_tree(list(samples), tuple(features), max_depth, min_samples_split, depth=0)
+
+
+def build_tree(
+    samples: list[BehaviorSample],
+    features: tuple[str, ...],
+    max_depth: int,
+    min_samples_split: int,
+    depth: int,
+) -> TreeNode:
+    distribution = action_distribution(samples)
+    if depth >= max_depth or len(samples) < min_samples_split or len(distribution) <= 1:
+        return leaf_node(distribution)
+
+    split = find_best_split(samples, features)
+    if split is None:
+        return leaf_node(distribution)
+
+    feature, threshold, missing_side, left, right = split
+    return {
+        "type": "branch",
+        "feature": feature,
+        "threshold": round(threshold, 6),
+        "missing": missing_side,
+        "sampleCount": len(samples),
+        "distribution": dict(sorted(distribution.items())),
+        "left": build_tree(left, features, max_depth, min_samples_split, depth + 1),
+        "right": build_tree(right, features, max_depth, min_samples_split, depth + 1),
+    }
+
+
+def find_best_split(
+    samples: list[BehaviorSample],
+    features: tuple[str, ...],
+) -> tuple[str, float, str, list[BehaviorSample], list[BehaviorSample]] | None:
+    base_impurity = gini(samples)
+    best_gain = 0.0
+    best_split: tuple[str, float, str, list[BehaviorSample], list[BehaviorSample]] | None = None
+
+    for feature in features:
+        thresholds = candidate_thresholds(samples, feature)
+        for threshold in thresholds:
+            for missing_side in ("left", "right"):
+                left, right = partition_samples(samples, feature, threshold, missing_side)
+                if not left or not right:
+                    continue
+                impurity = weighted_gini(left, right)
+                gain = base_impurity - impurity
+                if gain > best_gain:
+                    best_gain = gain
+                    best_split = (feature, threshold, missing_side, left, right)
+
+    return best_split
+
+
+def candidate_thresholds(samples: Sequence[BehaviorSample], feature: str) -> list[float]:
+    values = sorted({value for sample in samples if (value := feature_value(sample.state, feature)) is not None})
+    if len(values) <= 1:
+        return []
+    mids = [(left + right) / 2 for left, right in zip(values, values[1:]) if left != right]
+    if len(mids) <= 32:
+        return mids
+    return [mids[round(index * (len(mids) - 1) / 31)] for index in range(32)]
+
+
+def partition_samples(
+    samples: Sequence[BehaviorSample],
+    feature: str,
+    threshold: float,
+    missing_side: str,
+) -> tuple[list[BehaviorSample], list[BehaviorSample]]:
+    left: list[BehaviorSample] = []
+    right: list[BehaviorSample] = []
+    for sample in samples:
+        value = feature_value(sample.state, feature)
+        if value is None:
+            (left if missing_side == "left" else right).append(sample)
+        elif value <= threshold:
+            left.append(sample)
+        else:
+            right.append(sample)
+    return left, right
+
+
+def feature_value(state: JsonObject, feature: str) -> float | None:
+    value = state.get(feature)
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)) and math.isfinite(value):
+        return float(value)
+    return None
+
+
+def weighted_gini(left: Sequence[BehaviorSample], right: Sequence[BehaviorSample]) -> float:
+    total = len(left) + len(right)
+    return (len(left) / total) * gini(left) + (len(right) / total) * gini(right)
+
+
+def gini(samples: Sequence[BehaviorSample]) -> float:
+    if not samples:
+        return 0.0
+    total = len(samples)
+    return 1.0 - sum((count / total) ** 2 for count in Counter(sample.action for sample in samples).values())
+
+
+def action_distribution(samples: Sequence[BehaviorSample]) -> Counter[str]:
+    return Counter(sample.action for sample in samples)
+
+
+def leaf_node(distribution: Counter[str]) -> TreeNode:
+    sample_count = sum(distribution.values())
+    action, count = max(distribution.items(), key=lambda item: (item[1], item[0]))
+    confidence = count / sample_count if sample_count else 0.0
+    return {
+        "type": "leaf",
+        "action": action,
+        "confidence": round(confidence, 6),
+        "sampleCount": sample_count,
+        "distribution": dict(sorted(distribution.items())),
+    }
+
+
+def evaluate_tree(root: TreeNode | None, samples: Sequence[BehaviorSample]) -> JsonObject:
+    if root is None or not samples:
+        return {
+            "sampleCount": len(samples),
+            "matchCount": 0,
+            "actionMatchRate": None,
+            "averageConfidence": None,
+            "byAction": {},
+        }
+
+    match_count = 0
+    confidence_total = 0.0
+    by_action: dict[str, Counter[str]] = {action: Counter() for action in ACTION_TYPES}
+    for sample in samples:
+        predicted_action, confidence = predict(root, sample.state)
+        confidence_total += confidence
+        if predicted_action == sample.action:
+            match_count += 1
+            by_action[sample.action]["match"] += 1
+        else:
+            by_action[sample.action]["mismatch"] += 1
+        by_action[sample.action]["total"] += 1
+
+    return {
+        "sampleCount": len(samples),
+        "matchCount": match_count,
+        "actionMatchRate": round(match_count / len(samples), 6),
+        "averageConfidence": round(confidence_total / len(samples), 6),
+        "byAction": {
+            action: {
+                "sampleCount": counts["total"],
+                "matchCount": counts["match"],
+                "mismatchCount": counts["mismatch"],
+                "matchRate": round(counts["match"] / counts["total"], 6) if counts["total"] else None,
+            }
+            for action, counts in by_action.items()
+            if counts["total"]
+        },
+    }
+
+
+def predict(node: TreeNode, state: JsonObject) -> tuple[str, float]:
+    current = node
+    while current.get("type") == "branch":
+        value = feature_value(state, str(current["feature"]))
+        if value is None:
+            current = current[current.get("missing", "left")]
+        else:
+            current = current["left"] if value <= float(current["threshold"]) else current["right"]
+    return str(current["action"]), float(current.get("confidence", 0))
+
+
+def assign_split(sample_id: str, split_seed: str, eval_ratio_value: float) -> str:
+    digest = hashlib.sha256(f"{split_seed}:{sample_id}".encode("utf-8")).hexdigest()
+    bucket = int(digest[:12], 16) / float(0xFFFFFFFFFFFF)
+    return "eval" if bucket < eval_ratio_value else "train"
+
+
+def split_samples(
+    samples: Sequence[BehaviorSample],
+    split_seed: str,
+    eval_ratio_value: float,
+) -> tuple[list[BehaviorSample], list[BehaviorSample]]:
+    train: list[BehaviorSample] = []
+    eval_samples: list[BehaviorSample] = []
+    for sample in samples:
+        if assign_split(sample.sample_id, split_seed, eval_ratio_value) == "eval":
+            eval_samples.append(sample)
+        else:
+            train.append(sample)
+
+    if not train and eval_samples:
+        train, eval_samples = eval_samples, []
+    return train, eval_samples
+
+
+def build_model(
+    run_id: str,
+    root: TreeNode | None,
+    train_samples: Sequence[BehaviorSample],
+    eval_samples: Sequence[BehaviorSample],
+    eval_report: JsonObject,
+    min_confidence: float,
+) -> JsonObject:
+    return {
+        "type": MODEL_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "policyId": f"worker-task-bc.{run_id}.v1",
+        "source": "runtime-summary behavior.workerTaskPolicy heuristic traces",
+        "liveEffect": False,
+        "minConfidence": min_confidence,
+        "actionTypes": list(ACTION_TYPES),
+        "features": list(FEATURES),
+        "root": root,
+        "metadata": {
+            "trainingSampleCount": len(train_samples),
+            "evaluationSampleCount": len(eval_samples),
+            "evaluationMatchRate": eval_report.get("actionMatchRate"),
+            "notes": "Shadow-only BC artifact; runtime integration keeps heuristic fallback and liveEffect=false.",
+        },
+    }
+
+
+def build_report(
+    run_id: str,
+    samples: Sequence[BehaviorSample],
+    train_samples: Sequence[BehaviorSample],
+    eval_samples: Sequence[BehaviorSample],
+    train_report: JsonObject,
+    eval_report: JsonObject,
+    max_depth: int,
+    min_samples_split: int,
+) -> JsonObject:
+    return {
+        "type": REPORT_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "runId": run_id,
+        "liveEffect": False,
+        "method": "stdlib-decision-tree-behavioral-cloning",
+        "features": list(FEATURES),
+        "sampleCount": len(samples),
+        "train": train_report,
+        "eval": eval_report,
+        "acceptance": {
+            "targetActionMatchRate": 0.9,
+            "actionMatchRate": eval_report.get("actionMatchRate") if eval_samples else train_report.get("actionMatchRate"),
+            "passesFidelityGate": bool(
+                (eval_report.get("actionMatchRate") if eval_samples else train_report.get("actionMatchRate")) is not None
+                and (eval_report.get("actionMatchRate") if eval_samples else train_report.get("actionMatchRate")) >= 0.9
+            ),
+            "simulatorStable": None,
+            "simulatorNotes": "Not evaluated by this offline trainer; consume this artifact in the simulator lane.",
+        },
+        "hyperparameters": {
+            "maxDepth": max_depth,
+            "minSamplesSplit": min_samples_split,
+        },
+        "actionCounts": dict(sorted(Counter(sample.action for sample in samples).items())),
+    }
+
+
+def build_run_id(samples: Sequence[BehaviorSample], max_depth: int, eval_ratio_value: float, split_seed: str) -> str:
+    seed = {
+        "schemaVersion": SCHEMA_VERSION,
+        "sampleIds": [sample.sample_id for sample in samples],
+        "actions": [sample.action for sample in samples],
+        "features": list(FEATURES),
+        "maxDepth": max_depth,
+        "evalRatio": eval_ratio_value,
+        "splitSeed": split_seed,
+    }
+    return f"worker-bc-{canonical_hash(seed)[:12]}"
+
+
+def validate_run_id(run_id: str) -> None:
+    if not run_id or run_id in {".", ".."} or any(char not in RUN_ID_CHARS for char in run_id):
+        raise ValueError("run id may contain only letters, numbers, dot, underscore, and hyphen")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def canonical_hash(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, value: str) -> None:
+    path.write_text(value, encoding="utf-8")
+
+
+def render_ts_model(model: JsonObject) -> str:
+    return "\n".join(
+        [
+            "import type { WorkerTaskBcModel } from './workerTaskPolicy';",
+            "",
+            f"export const WORKER_TASK_BC_MODEL: WorkerTaskBcModel = {json.dumps(model, indent=2, sort_keys=True)};",
+            "",
+        ]
+    )
+
+
+def train_policy(
+    paths: Sequence[str],
+    out_dir: Path,
+    run_id: str | None = None,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    eval_ratio_value: float = DEFAULT_EVAL_RATIO,
+    split_seed: str = "screeps-worker-bc-v1",
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    min_samples_split: int = DEFAULT_MIN_SAMPLES_SPLIT,
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    ts_out: Path | None = None,
+) -> JsonObject:
+    samples = extract_behavior_samples(paths, sample_limit=sample_limit)
+    resolved_run_id = run_id or build_run_id(samples, max_depth, eval_ratio_value, split_seed)
+    validate_run_id(resolved_run_id)
+    train_samples, eval_samples = split_samples(samples, split_seed, eval_ratio_value)
+    root = train_decision_tree(train_samples, max_depth=max_depth, min_samples_split=min_samples_split)
+    train_report = evaluate_tree(root, train_samples)
+    eval_report = evaluate_tree(root, eval_samples)
+    model = build_model(resolved_run_id, root, train_samples, eval_samples, eval_report, min_confidence)
+    report = build_report(
+        resolved_run_id,
+        samples,
+        train_samples,
+        eval_samples,
+        train_report,
+        eval_report,
+        max_depth,
+        min_samples_split,
+    )
+
+    run_dir = out_dir.expanduser() / resolved_run_id
+    out_dir.expanduser().mkdir(parents=True, exist_ok=True)
+    staging_dir = Path(tempfile.mkdtemp(prefix=f".{resolved_run_id}.", suffix=".staging", dir=str(out_dir.expanduser())))
+    try:
+        write_json(staging_dir / "worker_task_policy.json", model)
+        write_json(staging_dir / "evaluation_report.json", report)
+        if ts_out is not None:
+            write_text(staging_dir / "workerTaskBcModel.ts", render_ts_model(model))
+        run_dir.mkdir(parents=True, exist_ok=True)
+        os.replace(staging_dir / "worker_task_policy.json", run_dir / "worker_task_policy.json")
+        os.replace(staging_dir / "evaluation_report.json", run_dir / "evaluation_report.json")
+        if ts_out is not None:
+            ts_out.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(staging_dir / "workerTaskBcModel.ts", ts_out)
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+    return {
+        "ok": True,
+        "type": "worker-task-bc-training-run",
+        "schemaVersion": SCHEMA_VERSION,
+        "runId": resolved_run_id,
+        "outDir": dataset_export.display_path(run_dir),
+        "sampleCount": len(samples),
+        "trainSampleCount": len(train_samples),
+        "evalSampleCount": len(eval_samples),
+        "actionMatchRate": report["acceptance"]["actionMatchRate"],
+        "passesFidelityGate": report["acceptance"]["passesFidelityGate"],
+        "liveEffect": False,
+        "files": {
+            "model": "worker_task_policy.json",
+            "evaluationReport": "evaluation_report.json",
+            **({"tsModel": dataset_export.display_path(ts_out)} if ts_out is not None else {}),
+        },
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train a shadow worker task behavioral cloning policy from runtime-summary behavior samples."
+    )
+    parser.add_argument("paths", nargs="*", help="runtime artifact files or directories to scan")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--run-id")
+    parser.add_argument("--sample-limit", type=positive_int, default=DEFAULT_SAMPLE_LIMIT)
+    parser.add_argument("--eval-ratio", type=ratio, default=DEFAULT_EVAL_RATIO)
+    parser.add_argument("--split-seed", default="screeps-worker-bc-v1")
+    parser.add_argument("--max-depth", type=positive_int, default=DEFAULT_MAX_DEPTH)
+    parser.add_argument("--min-samples-split", type=positive_int, default=DEFAULT_MIN_SAMPLES_SPLIT)
+    parser.add_argument("--min-confidence", type=probability, default=DEFAULT_MIN_CONFIDENCE)
+    parser.add_argument("--ts-out", type=Path, help="optional generated TypeScript model export path")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    args.out_dir.expanduser().mkdir(parents=True, exist_ok=True)
+    summary = train_policy(
+        paths=args.paths,
+        out_dir=args.out_dir,
+        run_id=args.run_id,
+        sample_limit=args.sample_limit,
+        eval_ratio_value=args.eval_ratio,
+        split_seed=args.split_seed,
+        max_depth=args.max_depth,
+        min_samples_split=args.min_samples_split,
+        min_confidence=args.min_confidence,
+        ts_out=args.ts_out,
+    )
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_screeps_worker_task_bc_train.py
+++ b/scripts/test_screeps_worker_task_bc_train.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_worker_task_bc_train as trainer
+
+
+def runtime_line(payload: dict[str, object]) -> str:
+    return f"#runtime-summary {json.dumps(payload, sort_keys=True)}\n"
+
+
+def read_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class WorkerTaskBehavioralCloningTrainTest(unittest.TestCase):
+    def test_extracts_behavior_samples_and_trains_shadow_policy(self) -> None:
+        payload = {
+            "type": "runtime-summary",
+            "tick": 100,
+            "rooms": [
+                {
+                    "roomName": "W1N1",
+                    "behavior": {
+                        "workerTaskPolicy": {
+                            "liveEffect": False,
+                            "samples": [
+                                make_sample("HarvesterA", "harvest", "source1", 0, 100),
+                                make_sample("HarvesterB", "harvest", "source2", 0, 101),
+                                make_sample("CarrierA", "transfer", "spawn1", 50, 102),
+                                make_sample("CarrierB", "transfer", "spawn1", 50, 103),
+                            ],
+                        }
+                    },
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact = root / "runtime.log"
+            artifact.write_text(runtime_line(payload), encoding="utf-8")
+            out_dir = root / "bc"
+
+            summary = trainer.train_policy(
+                [str(artifact)],
+                out_dir,
+                run_id="test-run",
+                eval_ratio_value=0,
+                max_depth=2,
+                min_samples_split=2,
+            )
+            model = read_json(out_dir / "test-run" / "worker_task_policy.json")
+            report = read_json(out_dir / "test-run" / "evaluation_report.json")
+
+        self.assertTrue(summary["ok"])
+        self.assertEqual(summary["sampleCount"], 4)
+        self.assertEqual(summary["actionMatchRate"], 1.0)
+        self.assertTrue(summary["passesFidelityGate"])
+        self.assertFalse(model["liveEffect"])
+        self.assertEqual(model["type"], trainer.MODEL_TYPE)
+        self.assertEqual(model["root"]["type"], "branch")
+        self.assertFalse(report["liveEffect"])
+        self.assertEqual(report["acceptance"]["actionMatchRate"], 1.0)
+
+    def test_skips_unsupported_or_live_effect_samples(self) -> None:
+        supported = make_sample("Builder", "build", "site1", 50, 10)
+        unsupported = make_sample("Withdrawer", "withdraw", "container1", 0, 11)
+        live_effect = make_sample("Carrier", "transfer", "spawn1", 50, 12)
+        live_effect["liveEffect"] = True
+        payload = {
+            "type": "runtime-summary",
+            "tick": 12,
+            "rooms": [
+                {
+                    "roomName": "W1N1",
+                    "behavior": {
+                        "workerTaskPolicy": {
+                            "samples": [supported, unsupported, live_effect],
+                        }
+                    },
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact = Path(temp_dir) / "runtime.log"
+            artifact.write_text(runtime_line(payload), encoding="utf-8")
+            samples = trainer.extract_behavior_samples([str(artifact)])
+
+        self.assertEqual([sample.action for sample in samples], ["build"])
+
+
+def make_sample(
+    creep_name: str,
+    action: str,
+    target_id: str,
+    carried_energy: int,
+    tick: int,
+) -> dict[str, object]:
+    return {
+        "type": "workerTaskBehavior",
+        "schemaVersion": 1,
+        "tick": tick,
+        "creepName": creep_name,
+        "policyId": "heuristic.worker-task.v1",
+        "liveEffect": False,
+        "state": {
+            "roomName": "W1N1",
+            "carriedEnergy": carried_energy,
+            "freeCapacity": max(0, 50 - carried_energy),
+            "energyCapacity": 50,
+            "energyLoadRatio": carried_energy / 50,
+            "currentTaskCode": 0,
+            "spawnExtensionNeedCount": 1 if action == "transfer" else 0,
+            "constructionSiteCount": 1 if action == "build" else 0,
+            "sourceCount": 2,
+            "hasContainerEnergy": False,
+            "containerEnergyAvailable": 0,
+            "droppedEnergyAvailable": 0,
+            "nearbyRoadCount": 0,
+            "nearbyContainerCount": 0,
+            "roadCoverage": 0,
+            "hostileCreepCount": 0,
+        },
+        "action": {"type": action, "targetId": target_id},
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements behavioral cloning (BC) from heuristic worker task traces for worker task policy learning.

## Changes
- **prod/src/rl/**: New RL module with BC model, task behavior, and policy integration
- **prod/src/tasks/workerTasks.ts**: BC policy integration with conservative heuristic fallback
- **prod/src/telemetry/runtimeSummary.ts**: Trace collection telemetry for BC training data
- **prod/src/types.d.ts**: Type definitions for BC state/action/trace data structures
- **prod/test/workerTaskPolicy.test.ts**: Tests for BC policy matching and fallback behavior
- **prod/test/runtimeSummary.test.ts**: Updated tests for telemetry additions
- **scripts/**: BC training pipeline and test scripts

## Verification
```
npm run typecheck  # PASS
npm test -- --runInBand  # 31 suites, 777 tests PASS
npm run build  # PASS
```

Closes #508