### PR TITLE
feat(rl): historical MMO replay validator and RL rollout gate (#417)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -22,9 +22,13 @@ var main_exports = {};
 __export(main_exports, {
   DEFAULT_STRATEGY_REGISTRY: () => DEFAULT_STRATEGY_REGISTRY,
   DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG: () => DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG,
+  HistoricalReplayValidator: () => HistoricalReplayValidator,
+  RlRolloutGate: () => RlRolloutGate,
   STRATEGY_REGISTRY_SCHEMA_VERSION: () => STRATEGY_REGISTRY_SCHEMA_VERSION,
   evaluateStrategyShadowReplay: () => evaluateStrategyShadowReplay,
+  loadHistoricalReplays: () => loadHistoricalReplays,
   loop: () => loop,
+  validateRlStrategyRollout: () => validateRlStrategyRollout,
   validateStrategyRegistry: () => validateStrategyRegistry,
   validateStrategyRegistryEntry: () => validateStrategyRegistryEntry
 });
@@ -14919,6 +14923,169 @@ function isDamageableSnapshotStructure(object) {
   return object.type === "constructedWall" || object.type === "container" || object.type === "extension" || object.type === "rampart" || object.type === "road" || object.type === "spawn" || object.type === "storage" || object.type === "tower";
 }
 
+// src/strategy/historicalReplayValidator.ts
+var MIN_HISTORICAL_REPLAY_COUNT = 3;
+var MIN_HISTORICAL_REPLAY_CORRELATION = 0.5;
+var HistoricalReplayValidator = class {
+  validateStrategy(strategyId, historicalReplays) {
+    const scorePairs = historicalReplays.flatMap((replay) => {
+      const shadowScore = getLatestFiniteScore(replay.kpiHistory[strategyId]);
+      if (shadowScore === void 0 || !Number.isFinite(replay.finalScore)) {
+        return [];
+      }
+      return [{ shadowScore, finalScore: replay.finalScore }];
+    });
+    const correlation = scorePairs.length >= 2 ? calculatePearsonCorrelation(
+      scorePairs.map((pair) => pair.shadowScore),
+      scorePairs.map((pair) => pair.finalScore)
+    ) : 0;
+    const pass = scorePairs.length >= MIN_HISTORICAL_REPLAY_COUNT && correlation >= MIN_HISTORICAL_REPLAY_CORRELATION;
+    return {
+      pass,
+      correlation,
+      details: buildValidationDetails(strategyId, historicalReplays.length, scorePairs.length, correlation, pass)
+    };
+  }
+};
+function loadHistoricalReplays(room) {
+  var _a, _b;
+  const memory = globalThis;
+  const storedReplays = (_b = (_a = memory.Memory) == null ? void 0 : _a.strategyHistoricalReplays) == null ? void 0 : _b[room];
+  if (!Array.isArray(storedReplays)) {
+    return [];
+  }
+  return storedReplays.flatMap((replay) => {
+    const normalizedReplay = normalizeHistoricalReplay(replay);
+    return normalizedReplay ? [normalizedReplay] : [];
+  });
+}
+function buildValidationDetails(strategyId, availableReplayCount, usableReplayCount, correlation, pass) {
+  const formattedCorrelation = formatCorrelation(correlation);
+  if (usableReplayCount < MIN_HISTORICAL_REPLAY_COUNT) {
+    return `historical replay validation failed for ${strategyId}: ${usableReplayCount}/${availableReplayCount} usable replays, requires at least ${MIN_HISTORICAL_REPLAY_COUNT}; correlation=${formattedCorrelation}`;
+  }
+  if (!pass) {
+    return `historical replay validation failed for ${strategyId}: correlation=${formattedCorrelation} below ${MIN_HISTORICAL_REPLAY_CORRELATION.toFixed(
+      3
+    )} across ${usableReplayCount}/${availableReplayCount} usable replays`;
+  }
+  return `historical replay validation passed for ${strategyId}: correlation=${formattedCorrelation} across ${usableReplayCount}/${availableReplayCount} usable replays`;
+}
+function calculatePearsonCorrelation(left, right) {
+  if (left.length !== right.length || left.length === 0) {
+    return 0;
+  }
+  const leftMean = average(left);
+  const rightMean = average(right);
+  let covariance = 0;
+  let leftVariance = 0;
+  let rightVariance = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    const leftDelta = left[index] - leftMean;
+    const rightDelta = right[index] - rightMean;
+    covariance += leftDelta * rightDelta;
+    leftVariance += leftDelta * leftDelta;
+    rightVariance += rightDelta * rightDelta;
+  }
+  if (leftVariance === 0 || rightVariance === 0) {
+    return 0;
+  }
+  return clampCorrelation(covariance / Math.sqrt(leftVariance * rightVariance));
+}
+function average(values) {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+function clampCorrelation(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(-1, Math.min(1, value));
+}
+function getLatestFiniteScore(scores) {
+  if (!Array.isArray(scores)) {
+    return void 0;
+  }
+  for (let index = scores.length - 1; index >= 0; index -= 1) {
+    const score = scores[index];
+    if (Number.isFinite(score)) {
+      return score;
+    }
+  }
+  return void 0;
+}
+function normalizeHistoricalReplay(rawReplay) {
+  if (!isRecord15(rawReplay)) {
+    return null;
+  }
+  if (!isNonEmptyString14(rawReplay.replayId) || !isNonEmptyString14(rawReplay.room) || !isFiniteNumber7(rawReplay.startTick) || !isFiniteNumber7(rawReplay.endTick) || !isFiniteNumber7(rawReplay.finalScore) || !isRecord15(rawReplay.kpiHistory)) {
+    return null;
+  }
+  const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
+    (history, [kpiName, rawScores]) => {
+      if (!Array.isArray(rawScores)) {
+        return history;
+      }
+      history[kpiName] = rawScores.filter((score) => Number.isFinite(score));
+      return history;
+    },
+    {}
+  );
+  return {
+    replayId: rawReplay.replayId,
+    room: rawReplay.room,
+    startTick: rawReplay.startTick,
+    endTick: rawReplay.endTick,
+    finalScore: rawReplay.finalScore,
+    kpiHistory
+  };
+}
+function formatCorrelation(correlation) {
+  return correlation.toFixed(3);
+}
+function isRecord15(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString14(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function isFiniteNumber7(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+// src/strategy/rlRolloutGate.ts
+var RlRolloutGate = class {
+  constructor(historicalReplayValidator = new HistoricalReplayValidator()) {
+    this.historicalReplayValidator = historicalReplayValidator;
+  }
+  validateStrategyRollout(request) {
+    var _a, _b;
+    const prerequisiteResults = (_a = request.prerequisiteResults) != null ? _a : [];
+    const historicalReplays = (_b = request.historicalReplays) != null ? _b : loadHistoricalReplays(request.room);
+    const historicalReplay = this.historicalReplayValidator.validateStrategy(request.strategyId, historicalReplays);
+    const failedPrerequisites = prerequisiteResults.filter((result) => !result.pass);
+    const pass = failedPrerequisites.length === 0 && historicalReplay.pass;
+    return {
+      pass,
+      correlation: historicalReplay.correlation,
+      details: buildRolloutDetails(request.strategyId, historicalReplay, failedPrerequisites),
+      historicalReplay,
+      prerequisiteResults
+    };
+  }
+};
+function validateRlStrategyRollout(request) {
+  return new RlRolloutGate().validateStrategyRollout(request);
+}
+function buildRolloutDetails(strategyId, historicalReplay, failedPrerequisites) {
+  if (failedPrerequisites.length > 0) {
+    return `RL rollout blocked for ${strategyId}: ${failedPrerequisites.length} prerequisite gate(s) failed; ${historicalReplay.details}`;
+  }
+  if (!historicalReplay.pass) {
+    return `RL rollout blocked for ${strategyId}: ${historicalReplay.details}`;
+  }
+  return `RL rollout allowed for ${strategyId}: ${historicalReplay.details}`;
+}
+
 // src/main.ts
 var kernel = new Kernel();
 function loop() {
@@ -14928,9 +15095,13 @@ function loop() {
 0 && (module.exports = {
   DEFAULT_STRATEGY_REGISTRY,
   DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG,
+  HistoricalReplayValidator,
+  RlRolloutGate,
   STRATEGY_REGISTRY_SCHEMA_VERSION,
   evaluateStrategyShadowReplay,
+  loadHistoricalReplays,
   loop,
+  validateRlStrategyRollout,
   validateStrategyRegistry,
   validateStrategyRegistryEntry
 });

--- a/prod/src/main.ts
+++ b/prod/src/main.ts
@@ -6,6 +6,13 @@ export {
   validateStrategyRegistryEntry
 } from './strategy/strategyRegistry';
 export { DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG, evaluateStrategyShadowReplay } from './strategy/shadowEvaluator';
+export {
+  HistoricalReplayValidator,
+  loadHistoricalReplays,
+  type HistoricalReplay,
+  type ValidationResult
+} from './strategy/historicalReplayValidator';
+export { RlRolloutGate, validateRlStrategyRollout } from './strategy/rlRolloutGate';
 
 const kernel = new Kernel();
 

--- a/prod/src/strategy/historicalReplayValidator.ts
+++ b/prod/src/strategy/historicalReplayValidator.ts
@@ -1,0 +1,193 @@
+export interface HistoricalReplay {
+  replayId: string;
+  room: string;
+  startTick: number;
+  endTick: number;
+  finalScore: number;
+  kpiHistory: Record<string, number[]>;
+}
+
+export interface ValidationResult {
+  pass: boolean;
+  correlation: number;
+  details: string;
+}
+
+declare global {
+  interface Memory {
+    strategyHistoricalReplays?: Record<string, HistoricalReplay[]>;
+  }
+}
+
+const MIN_HISTORICAL_REPLAY_COUNT = 3;
+const MIN_HISTORICAL_REPLAY_CORRELATION = 0.5;
+
+export class HistoricalReplayValidator {
+  validateStrategy(strategyId: string, historicalReplays: HistoricalReplay[]): ValidationResult {
+    const scorePairs = historicalReplays.flatMap((replay) => {
+      const shadowScore = getLatestFiniteScore(replay.kpiHistory[strategyId]);
+      if (shadowScore === undefined || !Number.isFinite(replay.finalScore)) {
+        return [];
+      }
+
+      return [{ shadowScore, finalScore: replay.finalScore }];
+    });
+    const correlation =
+      scorePairs.length >= 2
+        ? calculatePearsonCorrelation(
+            scorePairs.map((pair) => pair.shadowScore),
+            scorePairs.map((pair) => pair.finalScore)
+          )
+        : 0;
+    const pass =
+      scorePairs.length >= MIN_HISTORICAL_REPLAY_COUNT && correlation >= MIN_HISTORICAL_REPLAY_CORRELATION;
+
+    return {
+      pass,
+      correlation,
+      details: buildValidationDetails(strategyId, historicalReplays.length, scorePairs.length, correlation, pass)
+    };
+  }
+}
+
+export function loadHistoricalReplays(room: string): HistoricalReplay[] {
+  const memory = globalThis as typeof globalThis & { Memory?: Partial<Memory> };
+  const storedReplays = memory.Memory?.strategyHistoricalReplays?.[room];
+
+  if (!Array.isArray(storedReplays)) {
+    return [];
+  }
+
+  return storedReplays.flatMap((replay) => {
+    const normalizedReplay = normalizeHistoricalReplay(replay);
+    return normalizedReplay ? [normalizedReplay] : [];
+  });
+}
+
+function buildValidationDetails(
+  strategyId: string,
+  availableReplayCount: number,
+  usableReplayCount: number,
+  correlation: number,
+  pass: boolean
+): string {
+  const formattedCorrelation = formatCorrelation(correlation);
+  if (usableReplayCount < MIN_HISTORICAL_REPLAY_COUNT) {
+    return `historical replay validation failed for ${strategyId}: ${usableReplayCount}/${availableReplayCount} usable replays, requires at least ${MIN_HISTORICAL_REPLAY_COUNT}; correlation=${formattedCorrelation}`;
+  }
+
+  if (!pass) {
+    return `historical replay validation failed for ${strategyId}: correlation=${formattedCorrelation} below ${MIN_HISTORICAL_REPLAY_CORRELATION.toFixed(
+      3
+    )} across ${usableReplayCount}/${availableReplayCount} usable replays`;
+  }
+
+  return `historical replay validation passed for ${strategyId}: correlation=${formattedCorrelation} across ${usableReplayCount}/${availableReplayCount} usable replays`;
+}
+
+function calculatePearsonCorrelation(left: number[], right: number[]): number {
+  if (left.length !== right.length || left.length === 0) {
+    return 0;
+  }
+
+  const leftMean = average(left);
+  const rightMean = average(right);
+  let covariance = 0;
+  let leftVariance = 0;
+  let rightVariance = 0;
+
+  for (let index = 0; index < left.length; index += 1) {
+    const leftDelta = left[index] - leftMean;
+    const rightDelta = right[index] - rightMean;
+    covariance += leftDelta * rightDelta;
+    leftVariance += leftDelta * leftDelta;
+    rightVariance += rightDelta * rightDelta;
+  }
+
+  if (leftVariance === 0 || rightVariance === 0) {
+    return 0;
+  }
+
+  return clampCorrelation(covariance / Math.sqrt(leftVariance * rightVariance));
+}
+
+function average(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function clampCorrelation(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(-1, Math.min(1, value));
+}
+
+function getLatestFiniteScore(scores: number[] | undefined): number | undefined {
+  if (!Array.isArray(scores)) {
+    return undefined;
+  }
+
+  for (let index = scores.length - 1; index >= 0; index -= 1) {
+    const score = scores[index];
+    if (Number.isFinite(score)) {
+      return score;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeHistoricalReplay(rawReplay: unknown): HistoricalReplay | null {
+  if (!isRecord(rawReplay)) {
+    return null;
+  }
+
+  if (
+    !isNonEmptyString(rawReplay.replayId) ||
+    !isNonEmptyString(rawReplay.room) ||
+    !isFiniteNumber(rawReplay.startTick) ||
+    !isFiniteNumber(rawReplay.endTick) ||
+    !isFiniteNumber(rawReplay.finalScore) ||
+    !isRecord(rawReplay.kpiHistory)
+  ) {
+    return null;
+  }
+
+  const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce<Record<string, number[]>>(
+    (history, [kpiName, rawScores]) => {
+      if (!Array.isArray(rawScores)) {
+        return history;
+      }
+
+      history[kpiName] = rawScores.filter((score): score is number => Number.isFinite(score));
+      return history;
+    },
+    {}
+  );
+
+  return {
+    replayId: rawReplay.replayId,
+    room: rawReplay.room,
+    startTick: rawReplay.startTick,
+    endTick: rawReplay.endTick,
+    finalScore: rawReplay.finalScore,
+    kpiHistory
+  };
+}
+
+function formatCorrelation(correlation: number): string {
+  return correlation.toFixed(3);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/prod/src/strategy/rlRolloutGate.ts
+++ b/prod/src/strategy/rlRolloutGate.ts
@@ -1,0 +1,59 @@
+import {
+  HistoricalReplayValidator,
+  loadHistoricalReplays,
+  type HistoricalReplay,
+  type ValidationResult
+} from './historicalReplayValidator';
+
+export interface RlRolloutGateRequest {
+  strategyId: string;
+  room: string;
+  historicalReplays?: HistoricalReplay[];
+  prerequisiteResults?: ValidationResult[];
+}
+
+export interface RlRolloutGateDecision extends ValidationResult {
+  historicalReplay: ValidationResult;
+  prerequisiteResults: ValidationResult[];
+}
+
+export class RlRolloutGate {
+  constructor(private readonly historicalReplayValidator = new HistoricalReplayValidator()) {}
+
+  validateStrategyRollout(request: RlRolloutGateRequest): RlRolloutGateDecision {
+    const prerequisiteResults = request.prerequisiteResults ?? [];
+    const historicalReplays = request.historicalReplays ?? loadHistoricalReplays(request.room);
+    const historicalReplay = this.historicalReplayValidator.validateStrategy(request.strategyId, historicalReplays);
+    const failedPrerequisites = prerequisiteResults.filter((result) => !result.pass);
+    const pass = failedPrerequisites.length === 0 && historicalReplay.pass;
+
+    return {
+      pass,
+      correlation: historicalReplay.correlation,
+      details: buildRolloutDetails(request.strategyId, historicalReplay, failedPrerequisites),
+      historicalReplay,
+      prerequisiteResults
+    };
+  }
+}
+
+export function validateRlStrategyRollout(request: RlRolloutGateRequest): RlRolloutGateDecision {
+  return new RlRolloutGate().validateStrategyRollout(request);
+}
+
+function buildRolloutDetails(
+  strategyId: string,
+  historicalReplay: ValidationResult,
+  failedPrerequisites: ValidationResult[]
+): string {
+  if (failedPrerequisites.length > 0) {
+    return `RL rollout blocked for ${strategyId}: ${failedPrerequisites.length} prerequisite gate(s) failed; ${historicalReplay.details}`;
+  }
+
+  if (!historicalReplay.pass) {
+    return `RL rollout blocked for ${strategyId}: ${historicalReplay.details}`;
+  }
+
+  return `RL rollout allowed for ${strategyId}: ${historicalReplay.details}`;
+}
+

--- a/prod/test/historicalReplayValidator.test.ts
+++ b/prod/test/historicalReplayValidator.test.ts
@@ -1,0 +1,103 @@
+import {
+  HistoricalReplayValidator,
+  loadHistoricalReplays,
+  type HistoricalReplay
+} from '../src/strategy/historicalReplayValidator';
+import { RlRolloutGate } from '../src/strategy/rlRolloutGate';
+
+const STRATEGY_ID = 'construction-priority.territory-shadow.v1';
+
+describe('historical replay validator', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { Memory: Memory }).Memory = {} as Memory;
+  });
+
+  it('passes when at least three replay shadow scores correlate with final scores', () => {
+    const validator = new HistoricalReplayValidator();
+
+    const result = validator.validateStrategy(STRATEGY_ID, [
+      replay('replay-1', 100, [8, 10]),
+      replay('replay-2', 200, [18, 20]),
+      replay('replay-3', 300, [26, 30])
+    ]);
+
+    expect(result.pass).toBe(true);
+    expect(result.correlation).toBeCloseTo(1);
+    expect(result.details).toContain('historical replay validation passed');
+  });
+
+  it('fails when fewer than three usable replay scores are available', () => {
+    const validator = new HistoricalReplayValidator();
+
+    const result = validator.validateStrategy(STRATEGY_ID, [
+      replay('replay-1', 100, [10]),
+      replay('replay-2', 200, [20]),
+      replay('replay-3', 300, [])
+    ]);
+
+    expect(result.pass).toBe(false);
+    expect(result.correlation).toBeCloseTo(1);
+    expect(result.details).toContain('2/3 usable replays');
+  });
+
+  it('fails when historical replay correlation is below the rollout threshold', () => {
+    const validator = new HistoricalReplayValidator();
+
+    const result = validator.validateStrategy(STRATEGY_ID, [
+      replay('replay-1', 100, [30]),
+      replay('replay-2', 200, [20]),
+      replay('replay-3', 300, [10])
+    ]);
+
+    expect(result.pass).toBe(false);
+    expect(result.correlation).toBeLessThan(0.5);
+    expect(result.details).toContain('below 0.500');
+  });
+
+  it('loads historical replay skeleton data from Memory by room', () => {
+    Memory.strategyHistoricalReplays = {
+      E26S49: [
+        replay('stored-1', 120, [12]),
+        {
+          replayId: 'invalid',
+          room: 'E26S49',
+          startTick: 1,
+          endTick: 2,
+          finalScore: 10,
+          kpiHistory: 'not-history'
+        } as unknown as HistoricalReplay
+      ],
+      E27S49: [replay('other-room', 900, [90], 'E27S49')]
+    };
+
+    expect(loadHistoricalReplays('E26S49')).toEqual([replay('stored-1', 120, [12])]);
+    expect(loadHistoricalReplays('W1N1')).toEqual([]);
+  });
+
+  it('blocks RL rollout when historical replay validation does not pass', () => {
+    const gate = new RlRolloutGate();
+
+    const decision = gate.validateStrategyRollout({
+      strategyId: STRATEGY_ID,
+      room: 'E26S49',
+      historicalReplays: [replay('replay-1', 100, [10]), replay('replay-2', 200, [20])]
+    });
+
+    expect(decision.pass).toBe(false);
+    expect(decision.historicalReplay.pass).toBe(false);
+    expect(decision.details).toContain('RL rollout blocked');
+  });
+});
+
+function replay(replayId: string, finalScore: number, strategyScores: number[], room = 'E26S49'): HistoricalReplay {
+  return {
+    replayId,
+    room,
+    startTick: 1,
+    endTick: 100,
+    finalScore,
+    kpiHistory: {
+      [STRATEGY_ID]: strategyScores
+    }
+  };
+}


### PR DESCRIPTION
## What

Adds the pre-rollout historical validation layer for RL-trained strategies:

- **HistoricalReplayValidator** — Pearson correlation gate between shadow eval scores and historical MMO replay final scores (≥3 replays, ≥0.5 correlation)
- **RlRolloutGate** — Aggregates prerequisite validation results + historical replay check into PASS/FAIL rollout decision
- **loadHistoricalReplays** — Normalize and load replay records from Screeps Memory

## Verification

```
npm run typecheck  # PASS
npm test -- --runInBand  # 31 suites, 778 tests PASS
npm run build  # PASS
```

Closes #417