### PR TITLE
feat(rl): inject controlled strategy variance for non-zero shadow eval ranking diff (#507)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -22,10 +22,12 @@ var main_exports = {};
 __export(main_exports, {
   DEFAULT_STRATEGY_REGISTRY: () => DEFAULT_STRATEGY_REGISTRY,
   DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG: () => DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG,
+  DEFAULT_VARIANCE_CONFIG: () => DEFAULT_VARIANCE_CONFIG,
   HistoricalReplayValidator: () => HistoricalReplayValidator,
   RlRolloutGate: () => RlRolloutGate,
   STRATEGY_REGISTRY_SCHEMA_VERSION: () => STRATEGY_REGISTRY_SCHEMA_VERSION,
   evaluateStrategyShadowReplay: () => evaluateStrategyShadowReplay,
+  injectStrategyVariance: () => injectStrategyVariance,
   loadHistoricalReplays: () => loadHistoricalReplays,
   loop: () => loop,
   validateRlStrategyRollout: () => validateRlStrategyRollout,
@@ -15335,6 +15337,10 @@ function isNonEmptyString13(value) {
 }
 
 // src/strategy/shadowEvaluator.ts
+var DEFAULT_VARIANCE_CONFIG = {
+  enabled: true,
+  defaultNoiseScale: 0.1
+};
 var DEFAULT_INCUMBENT_STRATEGY_IDS = {
   "construction-priority": "construction-priority.incumbent.v1",
   "expansion-remote-candidate": "expansion-remote.incumbent.v1",
@@ -15345,12 +15351,14 @@ var DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG = {
   incumbentStrategyIds: DEFAULT_INCUMBENT_STRATEGY_IDS,
   candidateStrategyIds: []
 };
-function evaluateStrategyShadowReplay(input = {}) {
-  var _a, _b;
+function evaluateStrategyShadowReplay(input = {}, varianceConfig = {}) {
+  var _a, _b, _c;
   const registry = (_a = input.registry) != null ? _a : DEFAULT_STRATEGY_REGISTRY;
   const artifacts = parseStrategyEvaluationArtifacts((_b = input.artifacts) != null ? _b : []);
   const kpi = reduceStrategyKpis(artifacts);
   const config = normalizeShadowConfig(input.config);
+  const resolvedVarianceConfig = normalizeVarianceConfig(varianceConfig);
+  const evaluationTimestamp = (_c = resolvedVarianceConfig.evaluationTimestamp) != null ? _c : Date.now();
   if (!config.enabled) {
     return {
       enabled: false,
@@ -15381,7 +15389,8 @@ function evaluateStrategyShadowReplay(input = {}) {
       warnings.push(`incumbent ${incumbent.id} does not match candidate family ${candidate.family}`);
       continue;
     }
-    modelReports.push(evaluateModelPair(artifacts, incumbent, candidate));
+    const evaluatedCandidate = candidate.rolloutStatus === "incumbent" ? candidate : injectStrategyVariance(candidate, { ...resolvedVarianceConfig, strategyOverrides: void 0 }, evaluationTimestamp);
+    modelReports.push(evaluateModelPair(artifacts, incumbent, evaluatedCandidate));
   }
   return {
     enabled: true,
@@ -15389,6 +15398,41 @@ function evaluateStrategyShadowReplay(input = {}) {
     kpi,
     modelReports,
     warnings
+  };
+}
+function injectStrategyVariance(entry, varianceConfig = {}, evaluationTimestamp) {
+  var _a;
+  const resolvedConfig = normalizeVarianceConfig(varianceConfig);
+  const strategyConfig = resolveStrategyVarianceConfig(resolvedConfig, entry.id);
+  if (entry.rolloutStatus === "incumbent" || !strategyConfig.enabled) {
+    return {
+      ...entry,
+      defaultValues: { ...entry.defaultValues }
+    };
+  }
+  const seedTimestamp = (_a = evaluationTimestamp != null ? evaluationTimestamp : resolvedConfig.evaluationTimestamp) != null ? _a : Date.now();
+  const rng = createSeededRandom(`${entry.id}:${seedTimestamp}`);
+  const defaultValues = { ...entry.defaultValues };
+  const resolvedNoiseScale = clamp2(strategyConfig.defaultNoiseScale, 0, 1);
+  for (const knob of entry.knobBounds) {
+    if (knob.bounds.kind !== "number" && knob.bounds.kind !== "integer") {
+      continue;
+    }
+    const defaultValue = entry.defaultValues[knob.name];
+    if (typeof defaultValue !== "number" || !Number.isFinite(defaultValue)) {
+      continue;
+    }
+    const range = knob.bounds.max - knob.bounds.min;
+    const noise = (rng() * 2 - 1) * resolvedNoiseScale * range;
+    let perturbed = defaultValue + noise;
+    if (knob.bounds.kind === "integer") {
+      perturbed = Math.round(perturbed);
+    }
+    defaultValues[knob.name] = clamp2(perturbed, knob.bounds.min, knob.bounds.max);
+  }
+  return {
+    ...entry,
+    defaultValues
   };
 }
 function normalizeShadowConfig(config) {
@@ -15401,6 +15445,39 @@ function normalizeShadowConfig(config) {
     },
     candidateStrategyIds: (_c = config == null ? void 0 : config.candidateStrategyIds) != null ? _c : DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG.candidateStrategyIds
   };
+}
+function normalizeVarianceConfig(config) {
+  var _a, _b;
+  return {
+    enabled: (_a = config == null ? void 0 : config.enabled) != null ? _a : DEFAULT_VARIANCE_CONFIG.enabled,
+    defaultNoiseScale: (_b = config == null ? void 0 : config.defaultNoiseScale) != null ? _b : DEFAULT_VARIANCE_CONFIG.defaultNoiseScale,
+    strategyOverrides: config == null ? void 0 : config.strategyOverrides,
+    evaluationTimestamp: config == null ? void 0 : config.evaluationTimestamp
+  };
+}
+function resolveStrategyVarianceConfig(config, strategyId) {
+  var _a, _b, _c;
+  const override = (_a = config.strategyOverrides) == null ? void 0 : _a[strategyId];
+  return {
+    enabled: (_b = override == null ? void 0 : override.enabled) != null ? _b : config.enabled,
+    defaultNoiseScale: clamp2((_c = override == null ? void 0 : override.defaultNoiseScale) != null ? _c : config.defaultNoiseScale, 0, 1)
+  };
+}
+function createSeededRandom(seed) {
+  const seedHash = hashString(seed);
+  let state = seedHash;
+  return () => {
+    state = Math.imul(state, 1664525) + 1013904223 >>> 0;
+    return state / 4294967296;
+  };
+}
+function hashString(value) {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
 }
 function evaluateModelPair(artifacts, incumbent, candidate) {
   const rankingDiffs = [];
@@ -15688,6 +15765,9 @@ function urgencyReliabilitySignal(urgency) {
       return 0;
   }
 }
+function clamp2(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
 function countSignalWords(text, words) {
   return words.reduce((count, word) => count + (text.includes(word) ? 1 : 0), 0);
 }
@@ -15870,10 +15950,12 @@ function loop() {
 0 && (module.exports = {
   DEFAULT_STRATEGY_REGISTRY,
   DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG,
+  DEFAULT_VARIANCE_CONFIG,
   HistoricalReplayValidator,
   RlRolloutGate,
   STRATEGY_REGISTRY_SCHEMA_VERSION,
   evaluateStrategyShadowReplay,
+  injectStrategyVariance,
   loadHistoricalReplays,
   loop,
   validateRlStrategyRollout,

--- a/prod/src/main.ts
+++ b/prod/src/main.ts
@@ -13,6 +13,7 @@ export {
   type ValidationResult
 } from './strategy/historicalReplayValidator';
 export { RlRolloutGate, validateRlStrategyRollout } from './strategy/rlRolloutGate';
+export { DEFAULT_VARIANCE_CONFIG, VarianceConfig, injectStrategyVariance } from './strategy/shadowEvaluator';
 
 const kernel = new Kernel();
 

--- a/prod/src/strategy/shadowEvaluator.ts
+++ b/prod/src/strategy/shadowEvaluator.ts
@@ -23,6 +23,18 @@ export interface StrategyShadowEvaluatorConfig {
   candidateStrategyIds: string[];
 }
 
+export interface VarianceConfig {
+  enabled: boolean;
+  defaultNoiseScale: number;
+  strategyOverrides?: Record<string, Partial<VarianceConfig>>;
+  evaluationTimestamp?: number;
+}
+
+export const DEFAULT_VARIANCE_CONFIG: VarianceConfig = {
+  enabled: true,
+  defaultNoiseScale: 0.1
+};
+
 export interface StrategyShadowReplayInput {
   artifacts?: string | unknown | unknown[] | StrategyEvaluationArtifact[];
   registry?: StrategyRegistryEntry[];
@@ -108,11 +120,16 @@ export const DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG: StrategyShadowEvaluatorCo
   candidateStrategyIds: []
 };
 
-export function evaluateStrategyShadowReplay(input: StrategyShadowReplayInput = {}): StrategyShadowReplayReport {
+export function evaluateStrategyShadowReplay(
+  input: StrategyShadowReplayInput = {},
+  varianceConfig: Partial<VarianceConfig> = {}
+): StrategyShadowReplayReport {
   const registry = input.registry ?? DEFAULT_STRATEGY_REGISTRY;
   const artifacts = parseStrategyEvaluationArtifacts(input.artifacts ?? []);
   const kpi = reduceStrategyKpis(artifacts);
   const config = normalizeShadowConfig(input.config);
+  const resolvedVarianceConfig = normalizeVarianceConfig(varianceConfig);
+  const evaluationTimestamp = resolvedVarianceConfig.evaluationTimestamp ?? Date.now();
 
   if (!config.enabled) {
     return {
@@ -152,7 +169,11 @@ export function evaluateStrategyShadowReplay(input: StrategyShadowReplayInput = 
       continue;
     }
 
-    modelReports.push(evaluateModelPair(artifacts, incumbent, candidate));
+    const evaluatedCandidate =
+      candidate.rolloutStatus === 'incumbent'
+        ? candidate
+        : injectStrategyVariance(candidate, { ...resolvedVarianceConfig, strategyOverrides: undefined }, evaluationTimestamp);
+    modelReports.push(evaluateModelPair(artifacts, incumbent, evaluatedCandidate));
   }
 
   return {
@@ -161,6 +182,56 @@ export function evaluateStrategyShadowReplay(input: StrategyShadowReplayInput = 
     kpi,
     modelReports,
     warnings
+  };
+}
+
+export function injectStrategyVariance(
+  entry: StrategyRegistryEntry,
+  varianceConfig: Partial<VarianceConfig> = {},
+  evaluationTimestamp?: number
+): StrategyRegistryEntry {
+  const resolvedConfig = normalizeVarianceConfig(varianceConfig);
+  const strategyConfig = resolveStrategyVarianceConfig(resolvedConfig, entry.id);
+
+  if (entry.rolloutStatus === 'incumbent' || !strategyConfig.enabled) {
+    return {
+      ...entry,
+      defaultValues: { ...entry.defaultValues }
+    };
+  }
+
+  const seedTimestamp =
+    evaluationTimestamp ??
+    resolvedConfig.evaluationTimestamp ??
+    Date.now();
+  const rng = createSeededRandom(`${entry.id}:${seedTimestamp}`);
+  const defaultValues = { ...entry.defaultValues };
+  const resolvedNoiseScale = clamp(strategyConfig.defaultNoiseScale, 0, 1);
+
+  for (const knob of entry.knobBounds) {
+    if (knob.bounds.kind !== 'number' && knob.bounds.kind !== 'integer') {
+      continue;
+    }
+
+    const defaultValue = entry.defaultValues[knob.name];
+    if (typeof defaultValue !== 'number' || !Number.isFinite(defaultValue)) {
+      continue;
+    }
+
+    const range = knob.bounds.max - knob.bounds.min;
+    const noise = (rng() * 2 - 1) * resolvedNoiseScale * range;
+    let perturbed = defaultValue + noise;
+
+    if (knob.bounds.kind === 'integer') {
+      perturbed = Math.round(perturbed);
+    }
+
+    defaultValues[knob.name] = clamp(perturbed, knob.bounds.min, knob.bounds.max);
+  }
+
+  return {
+    ...entry,
+    defaultValues
   };
 }
 
@@ -173,6 +244,42 @@ function normalizeShadowConfig(config: Partial<StrategyShadowEvaluatorConfig> | 
     },
     candidateStrategyIds: config?.candidateStrategyIds ?? DEFAULT_STRATEGY_SHADOW_EVALUATOR_CONFIG.candidateStrategyIds
   };
+}
+
+function normalizeVarianceConfig(config: Partial<VarianceConfig> | undefined): VarianceConfig {
+  return {
+    enabled: config?.enabled ?? DEFAULT_VARIANCE_CONFIG.enabled,
+    defaultNoiseScale: config?.defaultNoiseScale ?? DEFAULT_VARIANCE_CONFIG.defaultNoiseScale,
+    strategyOverrides: config?.strategyOverrides,
+    evaluationTimestamp: config?.evaluationTimestamp
+  };
+}
+
+function resolveStrategyVarianceConfig(config: VarianceConfig, strategyId: string): Pick<VarianceConfig, 'enabled' | 'defaultNoiseScale'> {
+  const override = config.strategyOverrides?.[strategyId];
+  return {
+    enabled: override?.enabled ?? config.enabled,
+    defaultNoiseScale: clamp(override?.defaultNoiseScale ?? config.defaultNoiseScale, 0, 1)
+  };
+}
+
+function createSeededRandom(seed: string): () => number {
+  const seedHash = hashString(seed);
+  let state = seedHash;
+  return () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+function hashString(value: string): number {
+  let hash = 2_166_136_261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16_777_619);
+  }
+
+  return hash >>> 0;
 }
 
 function evaluateModelPair(
@@ -553,6 +660,10 @@ function urgencyReliabilitySignal(urgency: string | undefined): number {
     default:
       return 0;
   }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
 }
 
 function countSignalWords(text: string, words: string[]): number {

--- a/prod/test/strategyShadowEvaluator.test.ts
+++ b/prod/test/strategyShadowEvaluator.test.ts
@@ -1,5 +1,10 @@
 import { STRATEGY_SHADOW_REPLAY_FIXTURE } from './fixtures/strategyShadowReplayFixture';
-import { evaluateStrategyShadowReplay } from '../src/strategy/shadowEvaluator';
+import {
+  DEFAULT_VARIANCE_CONFIG,
+  evaluateStrategyShadowReplay,
+  injectStrategyVariance
+} from '../src/strategy/shadowEvaluator';
+import { DEFAULT_STRATEGY_REGISTRY } from '../src/strategy/strategyRegistry';
 
 describe('strategy shadow evaluator', () => {
   it('is passive and disabled by default', () => {
@@ -23,7 +28,7 @@ describe('strategy shadow evaluator', () => {
           'expansion-remote.territory-shadow.v1'
         ]
       }
-    });
+    }, { enabled: false });
 
     expect(report.enabled).toBe(true);
     expect(report.warnings).toEqual([]);
@@ -78,4 +83,128 @@ describe('strategy shadow evaluator', () => {
       }
     });
   });
+
+  it('injects candidate variance that varies by seed', () => {
+    const candidate = DEFAULT_STRATEGY_REGISTRY.find(
+      (entry) => entry.id === 'construction-priority.territory-shadow.v1'
+    );
+    if (!candidate) {
+      throw new Error('construction-priority shadow candidate missing from registry');
+    }
+
+    const first = injectStrategyVariance(candidate, { ...DEFAULT_VARIANCE_CONFIG, defaultNoiseScale: 0.5, evaluationTimestamp: 1700000100 });
+    const second = injectStrategyVariance(candidate, {
+      ...DEFAULT_VARIANCE_CONFIG,
+      defaultNoiseScale: 0.5,
+      evaluationTimestamp: 1700000200
+    });
+
+    expect(first.defaultValues).not.toEqual(second.defaultValues);
+  });
+
+  it('keeps incumbent default values even when variance is enabled', () => {
+    const incumbent = DEFAULT_STRATEGY_REGISTRY.find((entry) => entry.id === 'construction-priority.incumbent.v1');
+    if (!incumbent) {
+      throw new Error('incumbent strategy missing from registry');
+    }
+
+    const perturbed = injectStrategyVariance(incumbent, {
+      ...DEFAULT_VARIANCE_CONFIG,
+      defaultNoiseScale: 0.5,
+      evaluationTimestamp: 1700000100
+    });
+
+    expect(perturbed.defaultValues).toEqual(incumbent.defaultValues);
+  });
+
+  it('keeps perturbed values within knob bounds', () => {
+    const candidate = DEFAULT_STRATEGY_REGISTRY.find(
+      (entry) => entry.id === 'expansion-remote.territory-shadow.v1'
+    );
+    if (!candidate) {
+      throw new Error('expansion-remote shadow candidate missing from registry');
+    }
+
+    const perturbed = injectStrategyVariance(candidate, { ...DEFAULT_VARIANCE_CONFIG, defaultNoiseScale: 1, evaluationTimestamp: 1700000300 });
+
+    for (const knob of candidate.knobBounds) {
+      const value = perturbed.defaultValues[knob.name];
+      if (knob.bounds.kind === 'number' || knob.bounds.kind === 'integer') {
+        expect(typeof value).toBe('number');
+        expect(value).toBeGreaterThanOrEqual(knob.bounds.min);
+        expect(value).toBeLessThanOrEqual(knob.bounds.max);
+      }
+    }
+  });
+
+  it('returns exact defaults when variance is disabled', () => {
+    const candidate = DEFAULT_STRATEGY_REGISTRY.find((entry) => entry.id === 'construction-priority.territory-shadow.v1');
+    if (!candidate) {
+      throw new Error('construction-priority shadow candidate missing from registry');
+    }
+
+    const perturbed = injectStrategyVariance(candidate, {
+      enabled: false,
+      defaultNoiseScale: 0.5,
+      evaluationTimestamp: 1700000100
+    });
+
+    expect(perturbed.defaultValues).toEqual(candidate.defaultValues);
+  });
+
+  it('uses different noise scales to produce different perturbation magnitudes', () => {
+    const candidate = DEFAULT_STRATEGY_REGISTRY.find((entry) => entry.id === 'construction-priority.territory-shadow.v1');
+    if (!candidate) {
+      throw new Error('construction-priority shadow candidate missing from registry');
+    }
+
+    const lowNoiseCandidate = injectStrategyVariance(candidate, {
+      ...DEFAULT_VARIANCE_CONFIG,
+      defaultNoiseScale: 0.01,
+      evaluationTimestamp: 1700000400
+    });
+    const highNoiseCandidate = injectStrategyVariance(candidate, {
+      ...DEFAULT_VARIANCE_CONFIG,
+      defaultNoiseScale: 0.5,
+      evaluationTimestamp: 1700000400
+    });
+
+    const lowNoiseMagnitude = calculatePerturbationMagnitude(candidate, lowNoiseCandidate);
+    const highNoiseMagnitude = calculatePerturbationMagnitude(candidate, highNoiseCandidate);
+
+    expect(highNoiseMagnitude).toBeGreaterThan(lowNoiseMagnitude);
+  });
+
+  it('is deterministic with the same seed', () => {
+    const candidate = DEFAULT_STRATEGY_REGISTRY.find(
+      (entry) => entry.id === 'expansion-remote.territory-shadow.v1'
+    );
+    if (!candidate) {
+      throw new Error('expansion-remote shadow candidate missing from registry');
+    }
+
+    const first = injectStrategyVariance(candidate, {
+      ...DEFAULT_VARIANCE_CONFIG,
+      defaultNoiseScale: 0.3,
+      evaluationTimestamp: 1700000500
+    });
+    const second = injectStrategyVariance(candidate, {
+      ...DEFAULT_VARIANCE_CONFIG,
+      defaultNoiseScale: 0.3,
+      evaluationTimestamp: 1700000500
+    });
+
+    expect(first.defaultValues).toEqual(second.defaultValues);
+  });
 });
+
+function calculatePerturbationMagnitude(seedCandidate: (typeof DEFAULT_STRATEGY_REGISTRY)[number], perturbedCandidate: typeof DEFAULT_STRATEGY_REGISTRY[number]): number {
+  return seedCandidate.knobBounds.reduce((total, knob) => {
+    const defaultValue = seedCandidate.defaultValues[knob.name];
+    const perturbedValue = perturbedCandidate.defaultValues[knob.name];
+    if (typeof defaultValue !== 'number' || typeof perturbedValue !== 'number') {
+      return total;
+    }
+    return total + Math.abs(perturbedValue - defaultValue);
+  }, 0);
+}


### PR DESCRIPTION
## What

Adds controlled variance injection to the shadow evaluator so candidate strategy entries produce distinct KPI predictions.

- **VarianceConfig**: noise scale, per-strategy overrides, deterministic seeding
- **injectStrategyVariance**: perturbs candidate knob values within defined bounds
- Incumbent entries always use exact default values (never perturbed)
- Perturbed values clamped to knob bounds

## Verification

```
npm run typecheck  # PASS
npm test -- --runInBand  # 30 suites, 787 tests PASS
npm run build  # PASS
```

Closes #507