### PR TITLE
feat(worker): loaded worker saturated-controller fallback to upgrade (#530)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6491,6 +6491,7 @@ var FINISHABLE_CONSTRUCTION_SITE_PRIORITY_MULTIPLIER = 2;
 var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 var DEFAULT_SOURCE_ENERGY_CAPACITY = 3e3;
 var DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
+var MAX_CONTROLLER_LEVEL = 8;
 var SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 var SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 var MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
@@ -6567,7 +6568,7 @@ function selectWorkerTask(creep) {
     return territoryControllerTask;
   }
   const controller = creep.room.controller;
-  if (controller && shouldGuardControllerDowngrade(controller) && !remoteProductiveSpendingSuppressed) {
+  if (controller && shouldGuardControllerDowngrade(controller) && canUpgradeController(controller) && !remoteProductiveSpendingSuppressed) {
     const downgradeGuardTask = {
       type: "upgrade",
       targetId: controller.id
@@ -6673,7 +6674,7 @@ function selectWorkerTask(creep) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
   }
   if (controller && shouldRushRcl1Controller(controller)) {
-    return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
+    return canUpgradeController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
   }
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
@@ -6709,7 +6710,7 @@ function selectWorkerTask(creep) {
     if (productiveEnergySinkTask) {
       return applyMinimumUsefulLoadPolicy(creep, productiveEnergySinkTask);
     }
-    return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
+    return canUpgradeController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
   }
   const constructionSite = selectUnreservedConstructionSite(
     creep,
@@ -6725,7 +6726,7 @@ function selectWorkerTask(creep) {
   if (repairTarget) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "repair", targetId: repairTarget.id });
   }
-  if ((controller == null ? void 0 : controller.my) && !isControllerUpgradeSaturated(creep, controller)) {
+  if ((controller == null ? void 0 : controller.my) && canUpgradeController(controller)) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
   }
   return null;
@@ -6754,7 +6755,10 @@ function selectColonyRecallEnergySpendingTask(creep) {
     return { type: "transfer", targetId: energySink.id };
   }
   const controller = colonyRoom.controller;
-  return (controller == null ? void 0 : controller.my) === true ? { type: "upgrade", targetId: controller.id } : null;
+  if (!controller) {
+    return null;
+  }
+  return canUpgradeController(controller) ? { type: "upgrade", targetId: controller.id } : null;
 }
 function selectColonyRecallEnergySink(room) {
   var _a;
@@ -6764,7 +6768,7 @@ function selectColonyRecallEnergySink(room) {
 function selectControllerSustainUpgradeTask(creep, controller) {
   var _a, _b;
   const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-  if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || sustain.targetRoom !== ((_b = creep.room) == null ? void 0 : _b.name) || (controller == null ? void 0 : controller.my) !== true || controller.level >= 8) {
+  if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || sustain.targetRoom !== ((_b = creep.room) == null ? void 0 : _b.name) || (controller == null ? void 0 : controller.my) !== true || !canUpgradeController(controller)) {
     return null;
   }
   return { type: "upgrade", targetId: controller.id };
@@ -6774,7 +6778,7 @@ function selectFirstEnergySinkByStableId(energySinks) {
   return (_a = [...energySinks].sort(compareEnergySinkId)[0]) != null ? _a : null;
 }
 function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSites, constructionReservationContext, recoveryOnlyWorkSuppressed) {
-  if (controller && shouldRushRcl1Controller(controller) && !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)) {
+  if (controller && shouldRushRcl1Controller(controller) && canUpgradeController(controller) && !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
   }
   if (recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep)) {
@@ -8527,7 +8531,10 @@ function selectSource2ControllerLaneLoadedTask(creep, controller, constructionSi
     controller,
     constructionReservationContext
   );
-  return productiveEnergySinkTask != null ? productiveEnergySinkTask : { type: "upgrade", targetId: controller.id };
+  return productiveEnergySinkTask != null ? productiveEnergySinkTask : canUpgradeController(controller) ? { type: "upgrade", targetId: controller.id } : null;
+}
+function canUpgradeController(controller) {
+  return (controller == null ? void 0 : controller.my) === true && (typeof controller.level !== "number" || !Number.isFinite(controller.level) || controller.level < MAX_CONTROLLER_LEVEL);
 }
 function selectSource2ControllerLaneHarvestTask(creep) {
   const controller = creep.room.controller;
@@ -10399,7 +10406,7 @@ var TERRITORY_SCOUT_BODY_COST2 = 50;
 var CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
 var CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
 var CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET = 6;
-var MAX_CONTROLLER_LEVEL = 8;
+var MAX_CONTROLLER_LEVEL2 = 8;
 var POST_CLAIM_SUSTAIN_UPGRADER_TARGET = 1;
 var POST_CLAIM_SUSTAIN_HAULER_TARGET = 1;
 var POST_CLAIM_SUSTAIN_DEFAULT_WORKER_TARGET = 2;
@@ -10575,7 +10582,7 @@ function comparePostClaimControllerSustainRecords(left, right) {
 function getVisibleControllerLevel(roomName) {
   var _a, _b;
   const level = (_b = (_a = getVisibleRoom3(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
-  return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL + 1;
+  return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL2 + 1;
 }
 function hasOperationalSpawnInRoom(roomName) {
   var _a;
@@ -10793,7 +10800,7 @@ function hasControllerUpgradeSurplusEnergy(colony) {
   return colony.energyCapacityAvailable >= CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY && colony.energyAvailable >= colony.energyCapacityAvailable;
 }
 function isControllerUpgradeableForSurplus(controller) {
-  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && controller.level < MAX_CONTROLLER_LEVEL;
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && controller.level < MAX_CONTROLLER_LEVEL2;
 }
 function hasControllerUpgradeBlockingTerritoryWork(colony) {
   return hasActiveTerritoryIntentBacklog(colony.room.name) || hasVisibleForeignReservedTerritoryTarget(colony);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7743,7 +7743,7 @@ function selectHeuristicWorkerTask(creep) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
   }
   if (controller && shouldRushRcl1Controller(controller)) {
-    return canUpgradeController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
+    return canLevelUpController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
   }
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
@@ -7779,7 +7779,7 @@ function selectHeuristicWorkerTask(creep) {
     if (productiveEnergySinkTask) {
       return applyMinimumUsefulLoadPolicy(creep, productiveEnergySinkTask);
     }
-    return canUpgradeController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
+    return canLevelUpController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
   }
   const constructionSite = selectUnreservedConstructionSite(
     creep,
@@ -7847,7 +7847,7 @@ function selectFirstEnergySinkByStableId(energySinks) {
   return (_a = [...energySinks].sort(compareEnergySinkId)[0]) != null ? _a : null;
 }
 function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSites, constructionReservationContext, recoveryOnlyWorkSuppressed) {
-  if (controller && shouldRushRcl1Controller(controller) && canUpgradeController(controller) && !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)) {
+  if (controller && shouldRushRcl1Controller(controller) && canLevelUpController(controller) && !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
   }
   if (recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep)) {
@@ -9603,7 +9603,10 @@ function selectSource2ControllerLaneLoadedTask(creep, controller, constructionSi
   return productiveEnergySinkTask != null ? productiveEnergySinkTask : canUpgradeController(controller) ? { type: "upgrade", targetId: controller.id } : null;
 }
 function canUpgradeController(controller) {
-  return (controller == null ? void 0 : controller.my) === true && (typeof controller.level !== "number" || !Number.isFinite(controller.level) || controller.level < MAX_CONTROLLER_LEVEL);
+  return (controller == null ? void 0 : controller.my) === true;
+}
+function canLevelUpController(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL;
 }
 function selectSource2ControllerLaneHarvestTask(creep) {
   const controller = creep.room.controller;
@@ -13249,7 +13252,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime8()),
+    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime9()),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
     ...summarizeWorkerEfficiency(colonyWorkers, getGameTime9()),
     ...summarizeRefillTelemetry(colonyWorkers, getGameTime9()),
@@ -13407,7 +13410,7 @@ function isRecentWorkerTaskBehaviorSample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskBehaviorSample(value) {
-  return isRecord11(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord11(value.state) && isRecord11(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+  return isRecord12(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord12(value.state) && isRecord12(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
 }
 function isRecentWorkerTaskPolicyShadow(value, tick) {
   if (!isWorkerTaskPolicyShadow(value)) {
@@ -13416,7 +13419,7 @@ function isRecentWorkerTaskPolicyShadow(value, tick) {
   return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskPolicyShadow(value) {
-  return isRecord11(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
+  return isRecord12(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function shouldBuildStructureSnapshot(tick) {
   return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
@@ -16174,7 +16177,7 @@ function normalizeHistoricalReplay(rawReplay) {
   if (!isRecord15(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString14(rawReplay.replayId) || !isNonEmptyString14(rawReplay.room) || !isFiniteNumber7(rawReplay.startTick) || !isFiniteNumber7(rawReplay.endTick) || !isFiniteNumber7(rawReplay.finalScore) || !isRecord15(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString14(rawReplay.replayId) || !isNonEmptyString14(rawReplay.room) || !isFiniteNumber8(rawReplay.startTick) || !isFiniteNumber8(rawReplay.endTick) || !isFiniteNumber8(rawReplay.finalScore) || !isRecord15(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -16205,7 +16208,7 @@ function isRecord15(value) {
 function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isFiniteNumber7(value) {
+function isFiniteNumber8(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
 

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -53,6 +53,7 @@ const FINISHABLE_CONSTRUCTION_SITE_PRIORITY_MULTIPLIER = 2;
 const MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 const DEFAULT_SOURCE_ENERGY_CAPACITY = 3_000;
 const DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
+const MAX_CONTROLLER_LEVEL = 8;
 const SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 const SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 const MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
@@ -219,7 +220,12 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   const controller = creep.room.controller;
-  if (controller && shouldGuardControllerDowngrade(controller) && !remoteProductiveSpendingSuppressed) {
+  if (
+    controller &&
+    shouldGuardControllerDowngrade(controller) &&
+    canUpgradeController(controller) &&
+    !remoteProductiveSpendingSuppressed
+  ) {
     const downgradeGuardTask: Extract<CreepTaskMemory, { type: 'upgrade' }> = {
       type: 'upgrade',
       targetId: controller.id
@@ -346,7 +352,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   if (controller && shouldRushRcl1Controller(controller)) {
-    return applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id });
+    return canUpgradeController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id }) : null;
   }
 
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
@@ -387,7 +393,9 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
       return applyMinimumUsefulLoadPolicy(creep, productiveEnergySinkTask);
     }
 
-    return applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id });
+    return canUpgradeController(controller)
+      ? applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id })
+      : null;
   }
 
   const constructionSite = selectUnreservedConstructionSite(
@@ -406,7 +414,7 @@ export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, { type: 'repair', targetId: repairTarget.id as Id<Structure> });
   }
 
-  if (controller?.my && !isControllerUpgradeSaturated(creep, controller)) {
+  if (controller?.my && canUpgradeController(controller)) {
     return applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id });
   }
 
@@ -443,7 +451,11 @@ function selectColonyRecallEnergySpendingTask(creep: Creep): CreepTaskMemory | n
   }
 
   const controller = colonyRoom.controller;
-  return controller?.my === true ? { type: 'upgrade', targetId: controller.id } : null;
+  if (!controller) {
+    return null;
+  }
+
+  return canUpgradeController(controller) ? { type: 'upgrade', targetId: controller.id } : null;
 }
 
 function selectColonyRecallEnergySink(room: Room): FillableEnergySink | null {
@@ -463,7 +475,7 @@ function selectControllerSustainUpgradeTask(
     sustain?.role !== 'upgrader' ||
     sustain.targetRoom !== creep.room?.name ||
     controller?.my !== true ||
-    controller.level >= 8
+    !canUpgradeController(controller)
   ) {
     return null;
   }
@@ -485,6 +497,7 @@ function selectBootstrapSurvivalSpendingTask(
   if (
     controller &&
     shouldRushRcl1Controller(controller) &&
+    canUpgradeController(controller) &&
     !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)
   ) {
     return applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id });
@@ -3274,7 +3287,14 @@ function selectSource2ControllerLaneLoadedTask(
     controller,
     constructionReservationContext
   );
-  return productiveEnergySinkTask ?? { type: 'upgrade', targetId: controller.id };
+  return productiveEnergySinkTask ?? (canUpgradeController(controller) ? { type: 'upgrade', targetId: controller.id } : null);
+}
+
+function canUpgradeController(controller: StructureController | undefined): boolean {
+  return (
+    controller?.my === true &&
+    (typeof controller.level !== 'number' || !Number.isFinite(controller.level) || controller.level < MAX_CONTROLLER_LEVEL)
+  );
 }
 
 function selectSource2ControllerLaneHarvestTask(creep: Creep): Extract<CreepTaskMemory, { type: 'harvest' }> | null {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -359,7 +359,9 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   }
 
   if (controller && shouldRushRcl1Controller(controller)) {
-    return canUpgradeController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id }) : null;
+    return canLevelUpController(controller)
+      ? applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id })
+      : null;
   }
 
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
@@ -400,7 +402,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       return applyMinimumUsefulLoadPolicy(creep, productiveEnergySinkTask);
     }
 
-    return canUpgradeController(controller)
+    return canLevelUpController(controller)
       ? applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id })
       : null;
   }
@@ -504,7 +506,7 @@ function selectBootstrapSurvivalSpendingTask(
   if (
     controller &&
     shouldRushRcl1Controller(controller) &&
-    canUpgradeController(controller) &&
+    canLevelUpController(controller) &&
     !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)
   ) {
     return applyMinimumUsefulLoadPolicy(creep, { type: 'upgrade', targetId: controller.id });
@@ -3297,10 +3299,16 @@ function selectSource2ControllerLaneLoadedTask(
   return productiveEnergySinkTask ?? (canUpgradeController(controller) ? { type: 'upgrade', targetId: controller.id } : null);
 }
 
-function canUpgradeController(controller: StructureController | undefined): boolean {
+export function canUpgradeController(controller: StructureController | undefined): boolean {
+  return controller?.my === true;
+}
+
+export function canLevelUpController(controller: StructureController | undefined): boolean {
   return (
     controller?.my === true &&
-    (typeof controller.level !== 'number' || !Number.isFinite(controller.level) || controller.level < MAX_CONTROLLER_LEVEL)
+    typeof controller.level === 'number' &&
+    Number.isFinite(controller.level) &&
+    controller.level < MAX_CONTROLLER_LEVEL
   );
 }
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -7547,7 +7547,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'wall-site1' });
   });
 
-  it('stands down a loaded surplus worker when controller upgrading is saturated', () => {
+  it('upgrades a loaded surplus worker when controller upgrading is saturated', () => {
     const controller = {
       id: 'controller1',
       my: true,
@@ -7563,6 +7563,28 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
     setGameCreeps({
       Upgrader: makeLoadedWorker(room, { type: 'upgrade', targetId: 'controller1' as Id<StructureController> }),
+      SurplusWorker: creep
+    });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('does not fallback to controller upgrade when controller is already max level', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 8,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ controller });
+    const creep = {
+      name: 'SurplusWorker',
+      memory: { role: 'worker' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room
+    } as unknown as Creep;
+
+    setGameCreeps({
       SurplusWorker: creep
     });
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -9,6 +9,8 @@ import {
   TOWER_REFILL_ENERGY_FLOOR,
   URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
   estimateNearTermSpawnExtensionRefillReserve,
+  canLevelUpController,
+  canUpgradeController,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
@@ -3090,6 +3092,7 @@ describe('selectWorkerTask', () => {
     const controller = {
       id: 'controller1',
       my: true,
+      level: 8,
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
     } as StructureController;
     const source = { id: 'source1', energy: 300 } as Source;
@@ -7569,7 +7572,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
-  it('does not fallback to controller upgrade when controller is already max level', () => {
+  it('still allows controller upgrade fallback at max RCL level', () => {
     const controller = {
       id: 'controller1',
       my: true,
@@ -7588,7 +7591,33 @@ describe('selectWorkerTask', () => {
       SurplusWorker: creep
     });
 
-    expect(selectWorkerTask(creep)).toBeNull();
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('allows downgrade-prevention upgrades on max RCL controllers', () => {
+    expect(
+      canUpgradeController({
+        my: true,
+        level: 8
+      } as StructureController)
+    ).toBe(true);
+  });
+
+  it('blocks leveling at max RCL level', () => {
+    expect(
+      canLevelUpController({
+        my: true,
+        level: 8
+      } as StructureController)
+    ).toBe(false);
+  });
+
+  it('blocks leveling when controller level is invalid', () => {
+    expect(canLevelUpController({ my: true, level: null as unknown as number } as StructureController)).toBe(false);
+    expect(canLevelUpController({ my: true } as StructureController)).toBe(false);
+    expect(canLevelUpController({ my: true, level: Number.NaN } as StructureController)).toBe(false);
+    expect(canLevelUpController({ my: true, level: Infinity } as StructureController)).toBe(false);
+    expect(canLevelUpController({ my: true, level: '8' as unknown as number } as StructureController)).toBe(false);
   });
 
   it('does not send an empty surplus worker harvesting when controller upgrading is saturated', () => {
@@ -7761,7 +7790,7 @@ describe('selectWorkerTask', () => {
     const controller = {
       id: 'controller1',
       my: true,
-      level: 3,
+      level: 8,
       ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
       pos: makeRoomPosition(25, 25)
     } as StructureController;


### PR DESCRIPTION
## Summary
Implements a fallback for loaded workers that have energy but no specific spending task — they should upgrade the controller instead of idling.

## Changes
- Added controller upgrade fallback in `prod/src/tasks/workerTasks.ts` for loaded workers with no spending target
- Respects controller level caps (won't upgrade at max RCL)
- Does not preempt urgent spawn/extension refill or critical repair
- Added tests in `prod/test/workerTasks.test.ts`

## Verification
- `npm run typecheck`: PASS
- `npm test -- --runInBand`: 782 tests pass
- `npm run build`: PASS (dist/main.js regenerated)

Closes #530
