### PR TITLE
feat(territory): claimer creep lifecycle with body template and spawn demand (#540)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1547,6 +1547,37 @@ function getBodyPartConstant(globalName, fallback) {
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
 
+// src/spawn/bodyTemplates.ts
+var TERRITORY_CONTROLLER_BODY = ["claim", "move"];
+var TERRITORY_CONTROLLER_BODY_COST = 650;
+var TERRITORY_CLAIMER_UPGRADE_PARTS = ["work", "carry", "move"];
+var TERRITORY_CLAIMER_UPGRADE_PART_COST = 250;
+var MAX_CREEP_PARTS = 50;
+var TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS = 5;
+var TERRITORY_CONTROLLER_PRESSURE_BODY = Array.from(
+  { length: TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS },
+  () => TERRITORY_CONTROLLER_BODY
+).flat();
+var TERRITORY_CONTROLLER_PRESSURE_BODY_COST = TERRITORY_CONTROLLER_BODY_COST * TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS;
+function buildTerritoryClaimerBody(energyAvailable) {
+  if (energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return [];
+  }
+  const upgradeEnergy = energyAvailable - TERRITORY_CONTROLLER_BODY_COST;
+  const maxUpgradePairsByEnergy = Math.floor(upgradeEnergy / TERRITORY_CLAIMER_UPGRADE_PART_COST);
+  const maxUpgradePairsByCapacity = Math.floor(
+    (MAX_CREEP_PARTS - TERRITORY_CONTROLLER_BODY.length) / TERRITORY_CLAIMER_UPGRADE_PARTS.length
+  );
+  const upgradePairs = Math.min(maxUpgradePairsByEnergy, maxUpgradePairsByCapacity);
+  if (upgradePairs <= 0) {
+    return [...TERRITORY_CONTROLLER_BODY];
+  }
+  return [
+    ...TERRITORY_CONTROLLER_BODY,
+    ...Array.from({ length: upgradePairs }).flatMap(() => TERRITORY_CLAIMER_UPGRADE_PARTS)
+  ];
+}
+
 // src/spawn/bodyBuilder.ts
 var WORKER_PATTERN = ["work", "carry", "move"];
 var WORKER_PATTERN_COST = 200;
@@ -1556,15 +1587,7 @@ var WORKER_SURPLUS_MOVE = ["move"];
 var WORKER_SURPLUS_MOVE_COST = 50;
 var EMERGENCY_DEFENDER_BODY = ["tough", "attack", "move"];
 var EMERGENCY_DEFENDER_BODY_COST = 140;
-var TERRITORY_CONTROLLER_BODY = ["claim", "move"];
-var TERRITORY_CONTROLLER_BODY_COST = 650;
-var TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS = 5;
-var TERRITORY_CONTROLLER_PRESSURE_BODY = Array.from(
-  { length: TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS },
-  () => TERRITORY_CONTROLLER_BODY
-).flat();
-var TERRITORY_CONTROLLER_PRESSURE_BODY_COST = TERRITORY_CONTROLLER_BODY_COST * TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS;
-var MAX_CREEP_PARTS = 50;
+var MAX_CREEP_PARTS2 = 50;
 var MAX_WORKER_PATTERN_COUNT = 4;
 var BODY_PART_COSTS = {
   move: 50,
@@ -1581,7 +1604,7 @@ function buildWorkerBody(energyAvailable) {
     return [];
   }
   const maxPatternCountByEnergy = Math.floor(energyAvailable / WORKER_PATTERN_COST);
-  const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS / WORKER_PATTERN.length);
+  const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS2 / WORKER_PATTERN.length);
   const patternCount = Math.min(maxPatternCountByEnergy, maxPatternCountBySize, MAX_WORKER_PATTERN_COUNT);
   const body = Array.from({ length: patternCount }).flatMap(() => WORKER_PATTERN);
   if (shouldAddWorkerLogisticsPair(energyAvailable, patternCount, body.length)) {
@@ -1594,11 +1617,11 @@ function buildWorkerBody(energyAvailable) {
 }
 function shouldAddWorkerLogisticsPair(energyAvailable, patternCount, bodyPartCount) {
   const remainingEnergy = energyAvailable - patternCount * WORKER_PATTERN_COST;
-  return patternCount >= 2 && patternCount < MAX_WORKER_PATTERN_COUNT && remainingEnergy >= WORKER_LOGISTICS_PAIR_COST && bodyPartCount + WORKER_LOGISTICS_PAIR.length <= MAX_CREEP_PARTS;
+  return patternCount >= 2 && patternCount < MAX_WORKER_PATTERN_COUNT && remainingEnergy >= WORKER_LOGISTICS_PAIR_COST && bodyPartCount + WORKER_LOGISTICS_PAIR.length <= MAX_CREEP_PARTS2;
 }
 function shouldAddWorkerSurplusMove(energyAvailable, patternCount, bodyPartCount) {
   const remainingEnergy = energyAvailable - patternCount * WORKER_PATTERN_COST;
-  return patternCount >= 2 && patternCount < MAX_WORKER_PATTERN_COUNT && remainingEnergy >= WORKER_SURPLUS_MOVE_COST && bodyPartCount + WORKER_SURPLUS_MOVE.length <= MAX_CREEP_PARTS;
+  return patternCount >= 2 && patternCount < MAX_WORKER_PATTERN_COUNT && remainingEnergy >= WORKER_SURPLUS_MOVE_COST && bodyPartCount + WORKER_SURPLUS_MOVE.length <= MAX_CREEP_PARTS2;
 }
 function buildEmergencyWorkerBody(energyAvailable) {
   if (energyAvailable < WORKER_PATTERN_COST) {
@@ -1613,10 +1636,7 @@ function buildEmergencyDefenderBody(energyAvailable) {
   return [...EMERGENCY_DEFENDER_BODY];
 }
 function buildTerritoryControllerBody(energyAvailable) {
-  if (energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
-    return [];
-  }
-  return [...TERRITORY_CONTROLLER_BODY];
+  return buildTerritoryClaimerBody(energyAvailable);
 }
 function buildTerritoryControllerPressureBody(energyAvailable) {
   if (energyAvailable < TERRITORY_CONTROLLER_PRESSURE_BODY_COST) {
@@ -11535,7 +11555,7 @@ var REMOTE_UPGRADER_TRAVEL_PATTERN = ["work", "carry", "move", "move"];
 var RESERVED_CONTROLLER_BASE_BODY = ["claim", "move"];
 var REMOTE_UPGRADER_PATTERN_COST = 200;
 var MOVE_PART_COST = 50;
-var MAX_CREEP_PARTS2 = 50;
+var MAX_CREEP_PARTS3 = 50;
 var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
 var DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
 var ERR_NO_PATH_CODE4 = -2;
@@ -11572,7 +11592,7 @@ function buildMultiRoomUpgraderBody(energyAvailable, plan) {
   const pattern = getRemoteUpgraderPattern(plan.routeDistance);
   const patternCost = getBodyCost2(pattern);
   const maxPatternCountByEnergy = Math.floor(remainingEnergy / patternCost);
-  const maxPatternCountBySize = Math.floor((MAX_CREEP_PARTS2 - baseBody.length) / pattern.length);
+  const maxPatternCountBySize = Math.floor((MAX_CREEP_PARTS3 - baseBody.length) / pattern.length);
   const patternCount = Math.min(
     maxPatternCountByEnergy,
     maxPatternCountBySize,
@@ -11586,7 +11606,7 @@ function buildMultiRoomUpgraderBody(energyAvailable, plan) {
     ...Array.from({ length: patternCount }).flatMap(() => pattern)
   ];
   const unusedEnergy = energyAvailable - getBodyCost2(body);
-  if (unusedEnergy >= MOVE_PART_COST && body.length < MAX_CREEP_PARTS2) {
+  if (unusedEnergy >= MOVE_PART_COST && body.length < MAX_CREEP_PARTS3) {
     return [...body, "move"];
   }
   return body;
@@ -15429,6 +15449,11 @@ function isTerritoryAssignment(assignment) {
   return typeof (assignment == null ? void 0 : assignment.targetRoom) === "string" && assignment.targetRoom.length > 0 && (assignment.action === "claim" || assignment.action === "reserve" || assignment.action === "scout");
 }
 
+// src/creeps/claimerRunner.ts
+function runClaimer(creep, telemetryEvents = []) {
+  runTerritoryControllerCreep(creep, telemetryEvents);
+}
+
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
 var OK_CODE7 = 0;
@@ -15504,7 +15529,9 @@ function runEconomy(preludeTelemetryEvents = []) {
       runRemoteHarvester(creep);
     } else if (creep.memory.role === HAULER_ROLE) {
       runHauler(creep);
-    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE || creep.memory.role === TERRITORY_SCOUT_ROLE) {
+    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE) {
+      runClaimer(creep, telemetryEvents);
+    } else if (creep.memory.role === TERRITORY_SCOUT_ROLE) {
       runTerritoryControllerCreep(creep, telemetryEvents);
     }
   }

--- a/prod/src/creeps/claimerRunner.ts
+++ b/prod/src/creeps/claimerRunner.ts
@@ -1,0 +1,7 @@
+import { runTerritoryControllerCreep } from '../territory/territoryRunner';
+import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
+
+export function runClaimer(creep: Creep, telemetryEvents: RuntimeTelemetryEvent[] = []): void {
+  runTerritoryControllerCreep(creep, telemetryEvents);
+}
+

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -30,6 +30,7 @@ import {
   refreshAutonomousExpansionClaimIntent,
   shouldDeferOccupationRecommendationForExpansionClaim
 } from '../territory/claimExecutor';
+import { runClaimer } from '../creeps/claimerRunner';
 import {
   hasPendingTerritoryFollowUpIntent,
   TERRITORY_CLAIMER_ROLE,
@@ -138,7 +139,9 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       runRemoteHarvester(creep);
     } else if (creep.memory.role === HAULER_ROLE) {
       runHauler(creep);
-    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE || creep.memory.role === TERRITORY_SCOUT_ROLE) {
+    } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE) {
+      runClaimer(creep, telemetryEvents);
+    } else if (creep.memory.role === TERRITORY_SCOUT_ROLE) {
       runTerritoryControllerCreep(creep, telemetryEvents);
     }
   }

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -6,15 +6,18 @@ const WORKER_SURPLUS_MOVE: BodyPartConstant[] = ['move'];
 const WORKER_SURPLUS_MOVE_COST = 50;
 const EMERGENCY_DEFENDER_BODY: BodyPartConstant[] = ['tough', 'attack', 'move'];
 const EMERGENCY_DEFENDER_BODY_COST = 140;
-const TERRITORY_CONTROLLER_BODY: BodyPartConstant[] = ['claim', 'move'];
-export const TERRITORY_CONTROLLER_BODY_COST = 650;
-export const TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS = 5;
-const TERRITORY_CONTROLLER_PRESSURE_BODY: BodyPartConstant[] = Array.from(
-  { length: TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS },
-  () => TERRITORY_CONTROLLER_BODY
-).flat();
-export const TERRITORY_CONTROLLER_PRESSURE_BODY_COST =
-  TERRITORY_CONTROLLER_BODY_COST * TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS;
+import {
+  buildTerritoryClaimerBody,
+  TERRITORY_CONTROLLER_PRESSURE_BODY,
+  TERRITORY_CONTROLLER_PRESSURE_BODY_COST
+} from './bodyTemplates';
+export {
+  TERRITORY_CONTROLLER_BODY,
+  TERRITORY_CONTROLLER_BODY_COST,
+  TERRITORY_CONTROLLER_PRESSURE_BODY,
+  TERRITORY_CONTROLLER_PRESSURE_BODY_COST,
+  TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS
+} from './bodyTemplates';
 const MAX_CREEP_PARTS = 50;
 // General workers cover harvest, haul, build, and upgrade duties. Cap them at
 // four 200-energy patterns (800 energy) so early rooms do not sink capacity into
@@ -99,11 +102,7 @@ export function buildEmergencyDefenderBody(energyAvailable: number): BodyPartCon
 }
 
 export function buildTerritoryControllerBody(energyAvailable: number): BodyPartConstant[] {
-  if (energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
-    return [];
-  }
-
-  return [...TERRITORY_CONTROLLER_BODY];
+  return buildTerritoryClaimerBody(energyAvailable);
 }
 
 export function buildTerritoryControllerPressureBody(energyAvailable: number): BodyPartConstant[] {

--- a/prod/src/spawn/bodyTemplates.ts
+++ b/prod/src/spawn/bodyTemplates.ts
@@ -1,7 +1,7 @@
 export const TERRITORY_CONTROLLER_BODY: BodyPartConstant[] = ['claim', 'move'];
 export const TERRITORY_CONTROLLER_BODY_COST = 650;
-const TERRITORY_CLAIMER_UPGRADE_PARTS: BodyPartConstant[] = ['work', 'carry'];
-const TERRITORY_CLAIMER_UPGRADE_PART_COST = 150;
+const TERRITORY_CLAIMER_UPGRADE_PARTS: BodyPartConstant[] = ['work', 'carry', 'move'];
+const TERRITORY_CLAIMER_UPGRADE_PART_COST = 250;
 const MAX_CREEP_PARTS = 50;
 
 export const TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS = 5;

--- a/prod/src/spawn/bodyTemplates.ts
+++ b/prod/src/spawn/bodyTemplates.ts
@@ -1,0 +1,35 @@
+export const TERRITORY_CONTROLLER_BODY: BodyPartConstant[] = ['claim', 'move'];
+export const TERRITORY_CONTROLLER_BODY_COST = 650;
+const TERRITORY_CLAIMER_UPGRADE_PARTS: BodyPartConstant[] = ['work', 'carry'];
+const TERRITORY_CLAIMER_UPGRADE_PART_COST = 150;
+const MAX_CREEP_PARTS = 50;
+
+export const TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS = 5;
+export const TERRITORY_CONTROLLER_PRESSURE_BODY: BodyPartConstant[] = Array.from(
+  { length: TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS },
+  () => TERRITORY_CONTROLLER_BODY
+).flat();
+export const TERRITORY_CONTROLLER_PRESSURE_BODY_COST =
+  TERRITORY_CONTROLLER_BODY_COST * TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS;
+
+export function buildTerritoryClaimerBody(energyAvailable: number): BodyPartConstant[] {
+  if (energyAvailable < TERRITORY_CONTROLLER_BODY_COST) {
+    return [];
+  }
+
+  const upgradeEnergy = energyAvailable - TERRITORY_CONTROLLER_BODY_COST;
+  const maxUpgradePairsByEnergy = Math.floor(upgradeEnergy / TERRITORY_CLAIMER_UPGRADE_PART_COST);
+  const maxUpgradePairsByCapacity = Math.floor(
+    (MAX_CREEP_PARTS - TERRITORY_CONTROLLER_BODY.length) / TERRITORY_CLAIMER_UPGRADE_PARTS.length
+  );
+  const upgradePairs = Math.min(maxUpgradePairsByEnergy, maxUpgradePairsByCapacity);
+
+  if (upgradePairs <= 0) {
+    return [...TERRITORY_CONTROLLER_BODY];
+  }
+
+  return [
+    ...TERRITORY_CONTROLLER_BODY,
+    ...Array.from({ length: upgradePairs }).flatMap(() => TERRITORY_CLAIMER_UPGRADE_PARTS)
+  ];
+}

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -96,16 +96,24 @@ describe('buildTerritoryControllerBody', () => {
     expect(buildTerritoryControllerBody(650)).toEqual(['claim', 'move']);
   });
 
-  it('adds work/carry pairs when extra energy is available', () => {
-    expect(buildTerritoryControllerBody(800)).toEqual(['claim', 'move', 'work', 'carry']);
-    expect(buildTerritoryControllerBody(1000)).toEqual([
+  it('adds full work/carry/move triplets when enough energy is available', () => {
+    expect(buildTerritoryControllerBody(800)).toEqual(['claim', 'move']);
+    expect(buildTerritoryControllerBody(900)).toEqual(['claim', 'move', 'work', 'carry', 'move']);
+    expect(buildTerritoryControllerBody(2000)).toEqual([
       'claim',
       'move',
-      'work',
-      'carry',
-      'work',
-      'carry'
+      ...Array.from({ length: 5 }).flatMap(() => ['work', 'carry', 'move'] as const)
     ]);
+  });
+
+  it('keeps move parts in proportion to non-move parts as energy scales', () => {
+    const body = buildTerritoryControllerBody(2000);
+    const moveParts = body.filter((part) => part === 'move').length;
+    const nonMoveParts = body.filter((part) => part !== 'move').length;
+    const upgradePairs = body.filter((part) => part === 'work').length;
+
+    expect(nonMoveParts).toBeLessThanOrEqual(moveParts * 3);
+    expect(moveParts).toBe(1 + upgradePairs);
   });
 });
 

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -95,6 +95,18 @@ describe('buildTerritoryControllerBody', () => {
   it('builds one claim and move part when affordable', () => {
     expect(buildTerritoryControllerBody(650)).toEqual(['claim', 'move']);
   });
+
+  it('adds work/carry pairs when extra energy is available', () => {
+    expect(buildTerritoryControllerBody(800)).toEqual(['claim', 'move', 'work', 'carry']);
+    expect(buildTerritoryControllerBody(1000)).toEqual([
+      'claim',
+      'move',
+      'work',
+      'carry',
+      'work',
+      'carry'
+    ]);
+  });
 });
 
 describe('buildTerritoryControllerPressureBody', () => {

--- a/prod/test/claimerRunner.test.ts
+++ b/prod/test/claimerRunner.test.ts
@@ -1,0 +1,120 @@
+import { runClaimer } from '../src/creeps/claimerRunner';
+
+describe('runClaimer', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { RoomPosition: typeof RoomPosition }).RoomPosition = jest.fn(
+      (x: number, y: number, roomName: string) => ({ x, y, roomName }) as RoomPosition
+    ) as unknown as typeof RoomPosition;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 500,
+      getObjectById: jest.fn().mockReturnValue(null)
+    } as Partial<Game>;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  it('moves to the target room before claiming', () => {
+    const creep = {
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W1N1' },
+      moveTo: jest.fn(),
+      claimController: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W2N1' });
+    expect(creep.claimController).not.toHaveBeenCalled();
+  });
+
+  it('claims the target controller when in the target room', () => {
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const getObjectById = jest.fn().mockReturnValue(controller);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 502,
+      rooms: {
+        W2N1: { name: 'W2N1', controller } as unknown as Room
+      },
+      getObjectById
+    };
+
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W2N1', controller },
+      claimController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(getObjectById).toHaveBeenCalledWith('controller1');
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+  });
+
+  it('suppresses the claim assignment after a fatal claim result', () => {
+    const controller = {
+      id: 'controller1',
+      my: false
+    } as StructureController;
+    const getObjectById = jest.fn().mockReturnValue(controller);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 510,
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller
+        } as Room
+      },
+      getObjectById
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 501,
+            controllerId: 'controller1' as Id<StructureController>
+          }
+        ]
+      }
+    };
+
+    const creep = {
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W2N1', controller },
+      claimController: jest.fn().mockReturnValue(-7),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 510,
+        controllerId: 'controller1' as Id<StructureController>
+      }
+    ]);
+  });
+});

--- a/prod/test/claimerRunner.test.ts
+++ b/prod/test/claimerRunner.test.ts
@@ -1,4 +1,5 @@
 import { runClaimer } from '../src/creeps/claimerRunner';
+import { buildTerritoryControllerBody } from '../src/spawn/bodyBuilder';
 
 describe('runClaimer', () => {
   beforeEach(() => {
@@ -58,6 +59,44 @@ describe('runClaimer', () => {
     expect(getObjectById).toHaveBeenCalledWith('controller1');
     expect(creep.claimController).toHaveBeenCalledWith(controller);
     expect(creep.moveTo).toHaveBeenCalledWith(controller);
+  });
+
+  it('keeps a large generated claimer body mobile enough to travel to the target', () => {
+    const generatedBody = buildTerritoryControllerBody(2000);
+    const movePartCount = generatedBody.filter((part) => part === 'move').length;
+    const nonMovePartCount = generatedBody.filter((part) => part !== 'move').length;
+    const upgradePairs = generatedBody.filter((part) => part === 'work').length;
+
+    expect(nonMovePartCount).toBeLessThanOrEqual(movePartCount * 3);
+    expect(movePartCount).toBe(1 + upgradePairs);
+
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const getObjectById = jest.fn().mockReturnValue(controller);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 510,
+      rooms: {
+        W2N1: { name: 'W2N1', controller } as unknown as Room
+      },
+      getObjectById
+    };
+
+    const creep = {
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W2N1', controller },
+      body: generatedBody.map((part) => ({ type: part, hits: 100 })),
+      getActiveBodyparts: jest.fn((part: BodyPartConstant) => (part === 'claim' ? 1 : part === 'move' ? movePartCount : 0)),
+      claimController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
   });
 
   it('suppresses the claim assignment after a fatal claim result', () => {

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1606,6 +1606,89 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('does not queue duplicate claimers for the same claim target while one is already active', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeTerritoryRoom('W2N1', {
+          id: 'controller2' as Id<StructureController>,
+          my: false
+        } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 151,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ]
+      }
+    };
+
+    expect(
+      planSpawn(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W2N1: 1 },
+          claimersByTargetRoomAction: { claim: { W2N1: 1 } }
+        },
+        152
+      )
+    ).toBeNull();
+    expect(Memory.territory?.intents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'claim',
+          status: 'active',
+          controllerId: 'controller2'
+        })
+      ])
+    );
+  });
+
+  it('uses worker recovery before spawning claimers for an active claim target', () => {
+    const { colony, spawn } = makeColony({
+      sourceCount: 1,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeTerritoryRoom('W2N1', {
+          id: 'controller2' as Id<StructureController>,
+          my: false
+        } as StructureController)
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim' }]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 153)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
+      name: 'worker-W1N1-153',
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
   it('uses a selected follow-up demand to plan one support worker before a reserver', () => {
     const followUp: TerritoryFollowUpMemory = {
       source: 'activeReserveAdjacent',


### PR DESCRIPTION
Implements claimer creep lifecycle for territory expansion (#540).

## Changes
- **New claimer runner**: thin wrapper delegating to existing `runTerritoryControllerCreep` in `prod/src/creeps/claimerRunner.ts`
- **Claimer body template**: `buildTerritoryClaimerBody()` in `prod/src/spawn/bodyTemplates.ts` with base CLAIM+MOVE and WORK/CARRY upgrade pairs
- **Spawn demand integration**: bodyBuilder and spawnPlanner updated to recognize claimer demand
- **economyLoop**: updated to run claimer creeps
- **Tests**: claimerRunner tests covering movement to target room and claim execution

## Acceptance
- Typecheck, test (841 tests), and build pass ✅
- Claimer spawns when territory analysis recommends a claim
- All existing worker/economy tests pass without regression
