### PR TITLE
feat(territory): expansion room reservation with controller reserve (#544)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3708,7 +3708,7 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
   removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
 function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString5(colony) || !isNonEmptyString5(assignment.targetRoom) || assignment.action !== "reserve") {
+  if (!isNonEmptyString5(colony) || !isNonEmptyString5(assignment.targetRoom) || assignment.action !== "reserve" || isTerritoryIntentSuppressed(colony, assignment.targetRoom, "reserve", gameTime)) {
     return null;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord2();
@@ -3761,7 +3761,7 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
   return reserveAssignment;
 }
 function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation, gameTime) {
-  if (evaluation.status !== "skipped" || evaluation.reason !== "gclInsufficient" && evaluation.reason !== "controllerCooldown" || !isNonEmptyString5(colony)) {
+  if (evaluation.status !== "skipped" || evaluation.reason !== "gclInsufficient" && evaluation.reason !== "controllerCooldown" || !isNonEmptyString5(colony) || !isNonEmptyString5(evaluation.targetRoom) || isTerritoryIntentSuppressed(colony, evaluation.targetRoom, "reserve", gameTime)) {
     return null;
   }
   const targetRoom = evaluation.targetRoom;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15011,11 +15011,11 @@ function isAutonomousExpansionClaimGclInsufficient() {
   if (!gcl || typeof gcl.level !== "number" || gcl.level <= 0) {
     return false;
   }
-  const gclOwnedRoomLimit = gcl.level;
-  if (!Number.isFinite(gclOwnedRoomLimit)) {
+  const maxClaimableRooms = gcl.level;
+  if (!Number.isFinite(maxClaimableRooms)) {
     return false;
   }
-  return getVisibleOwnedRoomCount() >= gclOwnedRoomLimit;
+  return getVisibleOwnedRoomCount() >= maxClaimableRooms;
 }
 function executeExpansionClaim(creep, controller, telemetryEvents = []) {
   var _a, _b, _c, _d, _e, _f, _g, _h;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15011,11 +15011,11 @@ function isAutonomousExpansionClaimGclInsufficient() {
   if (!gcl || typeof gcl.level !== "number" || gcl.level <= 0) {
     return false;
   }
-  const maxClaimableRooms = gcl.level;
-  if (!Number.isFinite(maxClaimableRooms)) {
+  const gclOwnedRoomLimit = gcl.level;
+  if (!Number.isFinite(gclOwnedRoomLimit)) {
     return false;
   }
-  return getVisibleOwnedRoomCount() >= maxClaimableRooms;
+  return getVisibleOwnedRoomCount() >= gclOwnedRoomLimit;
 }
 function executeExpansionClaim(creep, controller, telemetryEvents = []) {
   var _a, _b, _c, _d, _e, _f, _g, _h;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3311,8 +3311,10 @@ function signOccupiedControllerIfNeeded(creep, controller) {
 var TERRITORY_CLAIMER_ROLE = "claimer";
 var TERRITORY_SCOUT_ROLE = "scout";
 var TERRITORY_DOWNGRADE_GUARD_TICKS = 5e3;
-var TERRITORY_RESERVATION_RENEWAL_TICKS = 1e3;
-var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
+var GLOBAL_TERRITORY_RESERVATION_TICKS = globalThis.CONTROLLER_RESERVE_MAX;
+var TERRITORY_RESERVATION_TICKS = typeof GLOBAL_TERRITORY_RESERVATION_TICKS === "number" && GLOBAL_TERRITORY_RESERVATION_TICKS > 0 && Number.isFinite(GLOBAL_TERRITORY_RESERVATION_TICKS) ? Math.floor(GLOBAL_TERRITORY_RESERVATION_TICKS) : 5e3;
+var TERRITORY_RESERVATION_RENEWAL_TICKS = TERRITORY_RESERVATION_TICKS / 5;
+var TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = Math.min(500, TERRITORY_RESERVATION_RENEWAL_TICKS);
 var TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 var TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS = 50;
 var TERRITORY_SUPPRESSION_RETRY_TICKS2 = 1500;
@@ -3757,6 +3759,50 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
   recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
   return reserveAssignment;
+}
+function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation, gameTime) {
+  if (evaluation.status !== "skipped" || evaluation.reason !== "gclInsufficient" && evaluation.reason !== "controllerCooldown" || !isNonEmptyString5(colony)) {
+    return null;
+  }
+  const targetRoom = evaluation.targetRoom;
+  if (!isNonEmptyString5(targetRoom)) {
+    return null;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return null;
+  }
+  const colonyOwnerUsername = getVisibleColonyOwnerUsername2(colony);
+  if (!isNonEmptyString5(colonyOwnerUsername)) {
+    return null;
+  }
+  const controller = getVisibleController2(targetRoom, evaluation.controllerId);
+  if (!controller || isControllerOwned(controller) || isForeignReservedController(controller, colonyOwnerUsername)) {
+    return null;
+  }
+  if (isOwnReservedController(controller, colonyOwnerUsername)) {
+    const reservationTicksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+    if (reservationTicksToEnd === null || reservationTicksToEnd >= TERRITORY_RESERVATION_TICKS) {
+      return null;
+    }
+  }
+  updateTerritoryReservationMemory(
+    territoryMemory,
+    colony,
+    targetRoom,
+    evaluation.controllerId,
+    gameTime,
+    getOwnReservationTicksToEnd(controller, colonyOwnerUsername)
+  );
+  return recordTerritoryReserveFallbackIntent(
+    colony,
+    {
+      targetRoom,
+      action: "reserve",
+      ...evaluation.controllerId ? { controllerId: evaluation.controllerId } : {}
+    },
+    gameTime
+  );
 }
 function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   if (getWorkerCapacity(roleCounts) < workerTarget) {
@@ -6019,6 +6065,28 @@ function isForeignReservedController(controller, actorUsername) {
   }
   const reservation = controller.reservation;
   return isNonEmptyString5(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
+}
+function isOwnReservedController(controller, actorUsername) {
+  const reservation = controller.reservation;
+  return isNonEmptyString5(actorUsername) && isNonEmptyString5(reservation == null ? void 0 : reservation.username) && reservation.username === actorUsername;
+}
+function updateTerritoryReservationMemory(territoryMemory, colony, roomName, controllerId, gameTime, reservationTicksToEnd) {
+  if (reservationTicksToEnd === null) {
+    return;
+  }
+  const reservations = normalizeTerritoryReservations(territoryMemory.reservations);
+  const reservationKey = getTerritoryReservationMemoryKey(colony, roomName);
+  const nextReservation = {
+    colony,
+    roomName,
+    ticksToEnd: reservationTicksToEnd,
+    updatedAt: gameTime,
+    ...controllerId ? { controllerId } : {}
+  };
+  if (!isSameTerritoryReservation(reservations[reservationKey], nextReservation)) {
+    reservations[reservationKey] = nextReservation;
+    setTerritoryReservations(territoryMemory, reservations);
+  }
 }
 function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
   if (target.action !== "reserve" || colonyOwnerUsername === null) {
@@ -8772,11 +8840,7 @@ function selectWorkerEnergyAcquisitionTask(creep) {
   }
   return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
 }
-function selectWorkerEnergyFallbackTask(creep) {
-  const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
-  if (energyAcquisitionTask) {
-    return energyAcquisitionTask;
-  }
+function selectWorkerPreHarvestTask(creep) {
   const source = selectHarvestSource(creep);
   return source ? { type: "harvest", targetId: source.id } : null;
 }
@@ -10332,8 +10396,8 @@ function getGameTime7() {
 
 // src/creeps/workerRunner.ts
 var MAX_IMMEDIATE_RESELECT_EXECUTIONS = 1;
-var WORKER_NULL_LOOP_TICK_WINDOW = 5;
-var WORKER_NULL_LOOP_TRIGGER_COUNT = 3;
+var WORKER_NULL_LOOP_TICK_WINDOW = 10;
+var WORKER_STANDBY_IDLE_TIMEOUT_TICKS = 8;
 var WORKER_NULL_LOOP_FALLBACK_ATTEMPTS = 2;
 var OK_CODE3 = 0;
 var MIN_HAULER_DROPPED_ENERGY = 25;
@@ -10388,23 +10452,25 @@ function fallbackToEnergyOnNullSelectionLoop(creep, selectedTask) {
     return null;
   }
   const guardState = getWorkerTaskSelectionNullLoopState(creep, gameTime);
-  if (guardState.nullSelectionCount < WORKER_NULL_LOOP_TRIGGER_COUNT || guardState.fallbackAttempts >= WORKER_NULL_LOOP_FALLBACK_ATTEMPTS) {
+  const idleTicks = gameTime - guardState.idleStartTick + 1;
+  if (idleTicks <= WORKER_STANDBY_IDLE_TIMEOUT_TICKS || guardState.fallbackAttempts >= WORKER_NULL_LOOP_FALLBACK_ATTEMPTS) {
     return null;
   }
   guardState.fallbackAttempts += 1;
-  return selectWorkerEnergyFallbackTask(creep);
+  return selectWorkerPreHarvestTask(creep);
 }
 function getWorkerTaskSelectionNullLoopState(creep, gameTime) {
   const existing = creep.memory.workerTaskSelectionNullLoop;
   const isValidExistingState = Boolean(
-    existing && typeof existing.lastNullSelectionTick === "number" && Number.isFinite(existing.lastNullSelectionTick) && typeof existing.nullSelectionCount === "number" && Number.isFinite(existing.nullSelectionCount) && typeof existing.fallbackAttempts === "number" && Number.isFinite(existing.fallbackAttempts)
+    existing && typeof existing.lastNullSelectionTick === "number" && Number.isFinite(existing.lastNullSelectionTick) && typeof existing.nullSelectionCount === "number" && Number.isFinite(existing.nullSelectionCount) && typeof existing.fallbackAttempts === "number" && Number.isFinite(existing.fallbackAttempts) && typeof existing.idleStartTick === "number" && Number.isFinite(existing.idleStartTick)
   );
   const isInWindow = isValidExistingState && gameTime - existing.lastNullSelectionTick <= WORKER_NULL_LOOP_TICK_WINDOW;
   if (!isInWindow) {
     const state2 = {
       lastNullSelectionTick: gameTime,
       nullSelectionCount: 1,
-      fallbackAttempts: 0
+      fallbackAttempts: 0,
+      idleStartTick: gameTime
     };
     creep.memory.workerTaskSelectionNullLoop = state2;
     return state2;
@@ -14928,6 +14994,29 @@ function shouldDeferOccupationRecommendationForExpansionClaim(evaluation) {
 function shouldPruneAutonomousExpansionClaimTargets(reason) {
   return reason === "noAdjacentCandidate" || reason === "hostilePresence" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved";
 }
+function getVisibleOwnedRoomCount() {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return 0;
+  }
+  return Object.values(rooms).filter((room) => {
+    var _a2;
+    return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
+  }).length;
+}
+function isAutonomousExpansionClaimGclInsufficient() {
+  var _a;
+  const gcl = (_a = globalThis.Game) == null ? void 0 : _a.gcl;
+  if (!gcl || typeof gcl.level !== "number" || gcl.level <= 0) {
+    return false;
+  }
+  const maxClaimableRooms = gcl.level * gcl.level;
+  if (!Number.isFinite(maxClaimableRooms)) {
+    return false;
+  }
+  return getVisibleOwnedRoomCount() >= maxClaimableRooms;
+}
 function executeExpansionClaim(creep, controller, telemetryEvents = []) {
   var _a, _b, _c, _d, _e, _f, _g, _h;
   const result = typeof creep.claimController === "function" ? creep.claimController(controller) : OK_CODE5;
@@ -14994,6 +15083,9 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime) {
   }
   if (isControllerReserved(controller, getControllerOwnerUsername6(colony.room.controller))) {
     return { ...controllerEvaluation, reason: "controllerReserved" };
+  }
+  if (isAutonomousExpansionClaimGclInsufficient()) {
+    return { ...controllerEvaluation, reason: "gclInsufficient" };
   }
   if (isExpansionClaimControllerOnCooldown(controller)) {
     return { ...controllerEvaluation, reason: "controllerCooldown" };
@@ -15553,6 +15645,7 @@ function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady
       return;
     }
     const claimEvaluation = refreshAutonomousExpansionClaimIntent(colony, report, Game.time, telemetryEvents);
+    recordAutonomousExpansionClaimReserveFallbackIntent(colony.room.name, claimEvaluation, Game.time);
     if (shouldDeferOccupationRecommendationForExpansionClaim(claimEvaluation)) {
       return;
     }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15011,7 +15011,7 @@ function isAutonomousExpansionClaimGclInsufficient() {
   if (!gcl || typeof gcl.level !== "number" || gcl.level <= 0) {
     return false;
   }
-  const maxClaimableRooms = gcl.level * gcl.level;
+  const maxClaimableRooms = gcl.level;
   if (!Number.isFinite(maxClaimableRooms)) {
     return false;
   }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3707,6 +3707,27 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
   removeTerritoryFollowUpDemand(territoryMemory, colony, assignment.targetRoom, assignment.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
+function suppressSameRoomClaimTerritoryIntents(territoryMemory, intents, colony, targetRoom, gameTime) {
+  let hasSuppressedClaimIntent = false;
+  for (let i = 0; i < intents.length; i += 1) {
+    const intent = intents[i];
+    if (intent.colony !== colony || intent.targetRoom !== targetRoom || intent.action !== "claim") {
+      continue;
+    }
+    intents[i] = {
+      ...intent,
+      status: "suppressed",
+      updatedAt: gameTime
+    };
+    removeTerritoryFollowUpDemand(territoryMemory, colony, targetRoom, "claim");
+    removeTerritoryFollowUpExecutionHint(territoryMemory, colony, targetRoom, "claim");
+    hasSuppressedClaimIntent = true;
+  }
+  if (!hasSuppressedClaimIntent) {
+    return;
+  }
+  setTerritoryIntents(territoryMemory, intents);
+}
 function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
   if (!isNonEmptyString5(colony) || !isNonEmptyString5(assignment.targetRoom) || assignment.action !== "reserve" || isTerritoryIntentSuppressed(colony, assignment.targetRoom, "reserve", gameTime)) {
     return null;
@@ -3717,6 +3738,7 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
+  suppressSameRoomClaimTerritoryIntents(territoryMemory, intents, colony, assignment.targetRoom, gameTime);
   const followUp = getTerritoryReserveFallbackFollowUp(assignment, intents, colony, gameTime);
   const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
     intents,

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -34,7 +34,8 @@ import { runClaimer } from '../creeps/claimerRunner';
 import {
   hasPendingTerritoryFollowUpIntent,
   TERRITORY_CLAIMER_ROLE,
-  TERRITORY_SCOUT_ROLE
+  TERRITORY_SCOUT_ROLE,
+  recordAutonomousExpansionClaimReserveFallbackIntent
 } from '../territory/territoryPlanner';
 import { runTerritoryControllerCreep } from '../territory/territoryRunner';
 import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgrader';
@@ -171,6 +172,7 @@ function refreshExecutableTerritoryRecommendation(
     }
 
     const claimEvaluation = refreshAutonomousExpansionClaimIntent(colony, report, Game.time, telemetryEvents);
+    recordAutonomousExpansionClaimReserveFallbackIntent(colony.room.name, claimEvaluation, Game.time);
     if (shouldDeferOccupationRecommendationForExpansionClaim(claimEvaluation)) {
       return;
     }

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -75,6 +75,7 @@ export type RuntimeTerritoryClaimTelemetryReason =
   | 'controllerOwned'
   | 'controllerReserved'
   | 'controllerCooldown'
+  | 'gclInsufficient'
   | 'suppressed'
   | 'notInRange'
   | 'invalidTarget'

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -87,12 +87,12 @@ function isAutonomousExpansionClaimGclInsufficient(): boolean {
     return false;
   }
 
-  const maxClaimableRooms = gcl.level;
-  if (!Number.isFinite(maxClaimableRooms)) {
+  const gclOwnedRoomLimit = gcl.level;
+  if (!Number.isFinite(gclOwnedRoomLimit)) {
     return false;
   }
 
-  return getVisibleOwnedRoomCount() >= maxClaimableRooms;
+  return getVisibleOwnedRoomCount() >= gclOwnedRoomLimit;
 }
 
 export function executeExpansionClaim(

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -72,6 +72,29 @@ function shouldPruneAutonomousExpansionClaimTargets(
   );
 }
 
+function getVisibleOwnedRoomCount(): number {
+  const rooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+  if (!rooms) {
+    return 0;
+  }
+
+  return Object.values(rooms).filter((room) => room?.controller?.my === true).length;
+}
+
+function isAutonomousExpansionClaimGclInsufficient(): boolean {
+  const gcl = (globalThis as { Game?: Partial<Game> & { gcl?: { level?: number } } }).Game?.gcl;
+  if (!gcl || typeof gcl.level !== 'number' || gcl.level <= 0) {
+    return false;
+  }
+
+  const maxClaimableRooms = gcl.level * gcl.level;
+  if (!Number.isFinite(maxClaimableRooms)) {
+    return false;
+  }
+
+  return getVisibleOwnedRoomCount() >= maxClaimableRooms;
+}
+
 export function executeExpansionClaim(
   creep: Creep,
   controller: StructureController,
@@ -164,6 +187,10 @@ function evaluateAutonomousExpansionClaim(
 
   if (isControllerReserved(controller, getControllerOwnerUsername(colony.room.controller))) {
     return { ...controllerEvaluation, reason: 'controllerReserved' };
+  }
+
+  if (isAutonomousExpansionClaimGclInsufficient()) {
+    return { ...controllerEvaluation, reason: 'gclInsufficient' };
   }
 
   if (isExpansionClaimControllerOnCooldown(controller)) {

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -87,12 +87,12 @@ function isAutonomousExpansionClaimGclInsufficient(): boolean {
     return false;
   }
 
-  const gclOwnedRoomLimit = gcl.level;
-  if (!Number.isFinite(gclOwnedRoomLimit)) {
+  const maxClaimableRooms = gcl.level;
+  if (!Number.isFinite(maxClaimableRooms)) {
     return false;
   }
 
-  return getVisibleOwnedRoomCount() >= gclOwnedRoomLimit;
+  return getVisibleOwnedRoomCount() >= maxClaimableRooms;
 }
 
 export function executeExpansionClaim(

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -87,7 +87,7 @@ function isAutonomousExpansionClaimGclInsufficient(): boolean {
     return false;
   }
 
-  const maxClaimableRooms = gcl.level * gcl.level;
+  const maxClaimableRooms = gcl.level;
   if (!Number.isFinite(maxClaimableRooms)) {
     return false;
   }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -700,6 +700,37 @@ export function suppressTerritoryIntent(
   removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
 
+function suppressSameRoomClaimTerritoryIntents(
+  territoryMemory: TerritoryMemory,
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  targetRoom: string,
+  gameTime: number
+): void {
+  let hasSuppressedClaimIntent = false;
+  for (let i = 0; i < intents.length; i += 1) {
+    const intent = intents[i];
+    if (intent.colony !== colony || intent.targetRoom !== targetRoom || intent.action !== 'claim') {
+      continue;
+    }
+
+    intents[i] = {
+      ...intent,
+      status: 'suppressed',
+      updatedAt: gameTime
+    };
+    removeTerritoryFollowUpDemand(territoryMemory, colony, targetRoom, 'claim');
+    removeTerritoryFollowUpExecutionHint(territoryMemory, colony, targetRoom, 'claim');
+    hasSuppressedClaimIntent = true;
+  }
+
+  if (!hasSuppressedClaimIntent) {
+    return;
+  }
+
+  setTerritoryIntents(territoryMemory, intents);
+}
+
 export function recordTerritoryReserveFallbackIntent(
   colony: string | undefined,
   assignment: CreepTerritoryMemory,
@@ -721,6 +752,7 @@ export function recordTerritoryReserveFallbackIntent(
 
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
+  suppressSameRoomClaimTerritoryIntents(territoryMemory, intents, colony, assignment.targetRoom, gameTime);
   const followUp = getTerritoryReserveFallbackFollowUp(assignment, intents, colony, gameTime);
   const requiresControllerPressure = getPersistedTerritoryIntentPressureRequirement(
     intents,

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -5,6 +5,7 @@ import {
   TERRITORY_CONTROLLER_PRESSURE_BODY_COST,
   TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS
 } from '../spawn/bodyBuilder';
+import type { AutonomousExpansionClaimEvaluation } from './claimExecutor';
 import {
   scoreOccupationRecommendations,
   type OccupationControllerEvidence,
@@ -24,8 +25,15 @@ import {
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
 export const TERRITORY_DOWNGRADE_GUARD_TICKS = 5_000;
-export const TERRITORY_RESERVATION_RENEWAL_TICKS = 1_000;
-export const TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS / 4;
+const GLOBAL_TERRITORY_RESERVATION_TICKS = (globalThis as { CONTROLLER_RESERVE_MAX?: number }).CONTROLLER_RESERVE_MAX;
+export const TERRITORY_RESERVATION_TICKS =
+  typeof GLOBAL_TERRITORY_RESERVATION_TICKS === 'number' &&
+  GLOBAL_TERRITORY_RESERVATION_TICKS > 0 &&
+  Number.isFinite(GLOBAL_TERRITORY_RESERVATION_TICKS)
+    ? Math.floor(GLOBAL_TERRITORY_RESERVATION_TICKS)
+    : 5_000;
+export const TERRITORY_RESERVATION_RENEWAL_TICKS = TERRITORY_RESERVATION_TICKS / 5;
+export const TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS = Math.min(500, TERRITORY_RESERVATION_RENEWAL_TICKS);
 export const TERRITORY_RESERVATION_COMFORT_TICKS = TERRITORY_RESERVATION_RENEWAL_TICKS * 2;
 export const TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS = 50;
 export const TERRITORY_SUPPRESSION_RETRY_TICKS = 1_500;
@@ -751,6 +759,65 @@ export function recordTerritoryReserveFallbackIntent(
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
   recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime);
   return reserveAssignment;
+}
+
+export function recordAutonomousExpansionClaimReserveFallbackIntent(
+  colony: string | undefined,
+  evaluation: AutonomousExpansionClaimEvaluation,
+  gameTime: number
+): CreepTerritoryMemory | null {
+  if (
+    evaluation.status !== 'skipped' ||
+    (evaluation.reason !== 'gclInsufficient' && evaluation.reason !== 'controllerCooldown') ||
+    !isNonEmptyString(colony)
+  ) {
+    return null;
+  }
+
+  const targetRoom = evaluation.targetRoom;
+  if (!isNonEmptyString(targetRoom)) {
+    return null;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return null;
+  }
+
+  const colonyOwnerUsername = getVisibleColonyOwnerUsername(colony);
+  if (!isNonEmptyString(colonyOwnerUsername)) {
+    return null;
+  }
+
+  const controller = getVisibleController(targetRoom, evaluation.controllerId);
+  if (!controller || isControllerOwned(controller) || isForeignReservedController(controller, colonyOwnerUsername)) {
+    return null;
+  }
+
+  if (isOwnReservedController(controller, colonyOwnerUsername)) {
+    const reservationTicksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
+    if (reservationTicksToEnd === null || reservationTicksToEnd >= TERRITORY_RESERVATION_TICKS) {
+      return null;
+    }
+  }
+
+  updateTerritoryReservationMemory(
+    territoryMemory,
+    colony,
+    targetRoom,
+    evaluation.controllerId,
+    gameTime,
+    getOwnReservationTicksToEnd(controller, colonyOwnerUsername)
+  );
+  return recordTerritoryReserveFallbackIntent(
+    colony,
+    {
+      targetRoom,
+      action: 'reserve',
+      ...(evaluation.controllerId ? { controllerId: evaluation.controllerId } : {})
+    },
+    gameTime
+  );
 }
 
 export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {
@@ -4365,6 +4432,41 @@ function isForeignReservedController(
 
   const reservation = controller.reservation;
   return isNonEmptyString(reservation?.username) && reservation.username !== actorUsername;
+}
+
+function isOwnReservedController(
+  controller: StructureController,
+  actorUsername: string | null
+): boolean {
+  const reservation = controller.reservation;
+  return isNonEmptyString(actorUsername) && isNonEmptyString(reservation?.username) && reservation.username === actorUsername;
+}
+
+function updateTerritoryReservationMemory(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  roomName: string,
+  controllerId: Id<StructureController> | undefined,
+  gameTime: number,
+  reservationTicksToEnd: number | null
+): void {
+  if (reservationTicksToEnd === null) {
+    return;
+  }
+
+  const reservations = normalizeTerritoryReservations(territoryMemory.reservations);
+  const reservationKey = getTerritoryReservationMemoryKey(colony, roomName);
+  const nextReservation: TerritoryReservationMemory = {
+    colony,
+    roomName,
+    ticksToEnd: reservationTicksToEnd,
+    updatedAt: gameTime,
+    ...(controllerId ? { controllerId } : {})
+  };
+  if (!isSameTerritoryReservation(reservations[reservationKey], nextReservation)) {
+    reservations[reservationKey] = nextReservation;
+    setTerritoryReservations(territoryMemory, reservations);
+  }
 }
 
 function getConfiguredReserveRenewalTicksToEnd(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -705,7 +705,12 @@ export function recordTerritoryReserveFallbackIntent(
   assignment: CreepTerritoryMemory,
   gameTime: number
 ): CreepTerritoryMemory | null {
-  if (!isNonEmptyString(colony) || !isNonEmptyString(assignment.targetRoom) || assignment.action !== 'reserve') {
+  if (
+    !isNonEmptyString(colony) ||
+    !isNonEmptyString(assignment.targetRoom) ||
+    assignment.action !== 'reserve' ||
+    isTerritoryIntentSuppressed(colony, assignment.targetRoom, 'reserve', gameTime)
+  ) {
     return null;
   }
 
@@ -769,7 +774,9 @@ export function recordAutonomousExpansionClaimReserveFallbackIntent(
   if (
     evaluation.status !== 'skipped' ||
     (evaluation.reason !== 'gclInsufficient' && evaluation.reason !== 'controllerCooldown') ||
-    !isNonEmptyString(colony)
+    !isNonEmptyString(colony) ||
+    !isNonEmptyString(evaluation.targetRoom) ||
+    isTerritoryIntentSuppressed(colony, evaluation.targetRoom, 'reserve', gameTime)
   ) {
     return null;
   }

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -198,6 +198,32 @@ describe('autonomous expansion claim executor', () => {
     expect(shouldDeferOccupationRecommendationForExpansionClaim(evaluation)).toBe(true);
     expect(Memory.territory).toBeUndefined();
   });
+
+  it('marks and emits a gclInsufficient skip when expansion capacity is exceeded', () => {
+    const colony = makeColony();
+    (Game.rooms as Record<string, Room>) = {
+      W1N1: colony.room,
+      W2N1: makeTargetRoom('W2N1', {
+        controllerId: 'controller2' as Id<StructureController>
+      })
+    };
+    (Game as { gcl: { level: number } }).gcl = { level: 1 };
+
+    const evaluation = refreshAutonomousExpansionClaimIntent(
+      colony,
+      makeReport([makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })]),
+      104
+    );
+
+    expect(evaluation).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      reason: 'gclInsufficient'
+    });
+    expect(shouldDeferOccupationRecommendationForExpansionClaim(evaluation)).toBe(false);
+    expect(Memory.territory).toBeUndefined();
+  });
 });
 
 function makeColony({

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -201,13 +201,19 @@ describe('autonomous expansion claim executor', () => {
 
   it('marks and emits a gclInsufficient skip when expansion capacity is exceeded', () => {
     const colony = makeColony();
+    const ownedRoom = makeTargetRoom('W3N1', {
+      controllerId: 'controller3' as Id<StructureController>
+    });
+    (ownedRoom.controller as StructureController).my = true;
+    (ownedRoom.controller as StructureController).owner = { username: 'me' };
     (Game.rooms as Record<string, Room>) = {
       W1N1: colony.room,
+      W3N1: ownedRoom,
       W2N1: makeTargetRoom('W2N1', {
         controllerId: 'controller2' as Id<StructureController>
       })
     };
-    (Game as { gcl: { level: number } }).gcl = { level: 1 };
+    (Game as { gcl: { level: number } }).gcl = { level: 2 };
 
     const evaluation = refreshAutonomousExpansionClaimIntent(
       colony,

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -199,21 +199,29 @@ describe('autonomous expansion claim executor', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
-  it('marks and emits a gclInsufficient skip when expansion capacity is exceeded', () => {
+  it('marks and emits a gclInsufficient skip when GCL room cap is reached', () => {
     const colony = makeColony();
-    const ownedRoom = makeTargetRoom('W3N1', {
+    const firstOwnedRoom = makeTargetRoom('W3N1', {
       controllerId: 'controller3' as Id<StructureController>
     });
-    (ownedRoom.controller as StructureController).my = true;
-    (ownedRoom.controller as StructureController).owner = { username: 'me' };
+    const secondOwnedRoom = makeTargetRoom('W4N1', {
+      controllerId: 'controller3' as Id<StructureController>
+    });
+    const ownedController = firstOwnedRoom.controller as StructureController;
+    ownedController.my = true;
+    ownedController.owner = { username: 'me' };
+    const secondOwnedController = secondOwnedRoom.controller as StructureController;
+    secondOwnedController.my = true;
+    secondOwnedController.owner = { username: 'me' };
     (Game.rooms as Record<string, Room>) = {
       W1N1: colony.room,
-      W3N1: ownedRoom,
+      W3N1: firstOwnedRoom,
+      W4N1: secondOwnedRoom,
       W2N1: makeTargetRoom('W2N1', {
         controllerId: 'controller2' as Id<StructureController>
       })
     };
-    (Game as { gcl: { level: number } }).gcl = { level: 2 };
+    (Game as { gcl: { level: number } }).gcl = { level: 3 };
 
     const evaluation = refreshAutonomousExpansionClaimIntent(
       colony,

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -5435,6 +5435,34 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('does not overwrite a fresh suppressed reserve fallback intent', () => {
+    const colony = makeSafeColony({ energyAvailable: 3250, energyCapacityAvailable: 3250 });
+    const suppressedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: 543
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', { controller: { my: false } as StructureController })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }],
+        intents: [suppressedIntent]
+      }
+    };
+
+    expect(
+      recordTerritoryReserveFallbackIntent('W1N1', { targetRoom: 'W2N1', action: 'reserve' }, 544)
+    ).toBeNull();
+    expect(Memory.territory?.intents).toEqual([suppressedIntent]);
+  });
+
   it('records a reserve fallback intent when autonomous expansion is skipped due to gclInsufficient', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -5469,6 +5497,40 @@ describe('planTerritoryIntent', () => {
         controllerId: 'controller2'
       }
     ]);
+  });
+
+  it('does not overwrite a fresh suppressed reserve fallback intent from autonomous expansion fallback', () => {
+    const colony = makeSafeColony();
+    const suppressedIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      status: 'suppressed',
+      updatedAt: 543
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', { controller: { my: false } as StructureController })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }],
+        intents: [suppressedIntent]
+      }
+    };
+
+    const evaluation: AutonomousExpansionClaimEvaluation = {
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2' as Id<StructureController>,
+      reason: 'gclInsufficient'
+    };
+
+    expect(recordAutonomousExpansionClaimReserveFallbackIntent('W1N1', evaluation, 544)).toBeNull();
+    expect(Memory.territory?.intents).toEqual([suppressedIntent]);
   });
 
   it('records a reserve fallback intent when autonomous expansion is skipped due to controllerCooldown', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -3,6 +3,7 @@ import {
   buildTerritoryCreepMemory,
   getActiveTerritoryFollowUpExecutionHints,
   hasPendingTerritoryFollowUpIntent,
+  recordAutonomousExpansionClaimReserveFallbackIntent,
   planTerritoryIntent,
   recordTerritoryReserveFallbackIntent,
   recordRecoveredTerritoryFollowUpRetryCooldown,
@@ -17,6 +18,7 @@ import {
   TERRITORY_RESERVATION_RENEWAL_TICKS,
   TERRITORY_SUPPRESSION_RETRY_TICKS
 } from '../src/territory/territoryPlanner';
+import type { AutonomousExpansionClaimEvaluation } from '../src/territory/claimExecutor';
 
 describe('planTerritoryIntent', () => {
   beforeEach(() => {
@@ -5431,6 +5433,194 @@ describe('planTerritoryIntent', () => {
         updatedAt: 544
       }
     ]);
+  });
+
+  it('records a reserve fallback intent when autonomous expansion is skipped due to gclInsufficient', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', { controller: { my: false } as StructureController })
+      }
+    };
+
+    const evaluation: AutonomousExpansionClaimEvaluation = {
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2' as Id<StructureController>,
+      reason: 'gclInsufficient'
+    };
+
+    const assignment = recordAutonomousExpansionClaimReserveFallbackIntent('W1N1', evaluation, 544);
+
+    expect(assignment).toEqual({
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 544,
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
+  it('records a reserve fallback intent when autonomous expansion is skipped due to controllerCooldown', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', { controller: { my: false } as StructureController })
+      }
+    };
+
+    const evaluation: AutonomousExpansionClaimEvaluation = {
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2' as Id<StructureController>,
+      reason: 'controllerCooldown'
+    };
+
+    const assignment = recordAutonomousExpansionClaimReserveFallbackIntent('W1N1', evaluation, 544);
+
+    expect(assignment).toEqual({
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 544,
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
+  it('does not record an autonomous reserve fallback when the claim target is already reserved by us', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: 5_000 }
+          } as StructureController
+        })
+      }
+    };
+
+    const evaluation: AutonomousExpansionClaimEvaluation = {
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2' as Id<StructureController>,
+      reason: 'gclInsufficient'
+    };
+
+    const assignment = recordAutonomousExpansionClaimReserveFallbackIntent('W1N1', evaluation, 544);
+
+    expect(assignment).toBeNull();
+    expect(Memory.territory).toEqual({});
+  });
+
+  it('does not record an autonomous reserve fallback when the claim target is reserved by another player', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 2_000 }
+          } as StructureController
+        })
+      }
+    };
+
+    const evaluation: AutonomousExpansionClaimEvaluation = {
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2' as Id<StructureController>,
+      reason: 'controllerCooldown'
+    };
+
+    const assignment = recordAutonomousExpansionClaimReserveFallbackIntent('W1N1', evaluation, 544);
+
+    expect(assignment).toBeNull();
+    expect(Memory.territory).toEqual({});
+  });
+
+  it('plans re-reservation when an owned reservation drops below 500 ticks', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', {
+          controller: {
+            my: false,
+            reservation: { username: 'me', ticksToEnd: 499 }
+          } as StructureController
+        })
+      }
+    };
+
+    const evaluation: AutonomousExpansionClaimEvaluation = {
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2' as Id<StructureController>,
+      reason: 'gclInsufficient'
+    };
+
+    const assignment = recordAutonomousExpansionClaimReserveFallbackIntent('W1N1', evaluation, 544);
+
+    expect(assignment).toEqual({
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.reservations).toEqual({
+      'W1N1>W2N1': {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        ticksToEnd: 499,
+        updatedAt: 544,
+        controllerId: 'controller2'
+      }
+    });
+    expect(
+      shouldSpawnTerritoryControllerCreep(
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'reserve',
+          controllerId: 'controller2' as Id<StructureController>
+        },
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoomAction: {
+            reserve: {
+              W2N1: 1
+            }
+          }
+        },
+        545
+      )
+    ).toBe(true);
   });
 
   it('keeps foreign reservation pressure body requirements after target vision is lost', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -5499,6 +5499,88 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('suppresses same-room claim intent when emitting an autonomous reserve fallback', () => {
+    const colony = makeSafeColony();
+    const claimTarget: TerritoryTargetMemory = { colony: 'W1N1', roomName: 'W2N1', action: 'claim' };
+    const claimIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      status: 'active',
+      updatedAt: 543
+    };
+    const followUp = makeFollowUp('satisfiedClaimAdjacent', 'W1N1', 'claim');
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeRecommendationRoom('W2N1', { controller: { my: false } as StructureController })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [claimTarget],
+        intents: [claimIntent],
+        demands: [
+          {
+            type: 'followUpPreparation',
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            workerCount: 1,
+            updatedAt: 543,
+            followUp
+          }
+        ],
+        executionHints: [
+          {
+            type: 'activeFollowUpExecution',
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            reason: 'visibleControlEvidenceStillActionable',
+            updatedAt: 543,
+            followUp
+          }
+        ]
+      }
+    };
+
+    const evaluation: AutonomousExpansionClaimEvaluation = {
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2' as Id<StructureController>,
+      reason: 'gclInsufficient'
+    };
+
+    const assignment = recordAutonomousExpansionClaimReserveFallbackIntent('W1N1', evaluation, 544);
+
+    expect(assignment).toEqual({
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 544
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 544,
+        controllerId: 'controller2'
+      }
+    ]);
+    expect(Memory.territory?.demands).toBeUndefined();
+    expect(Memory.territory?.executionHints).toBeUndefined();
+  });
+
   it('does not overwrite a fresh suppressed reserve fallback intent from autonomous expansion fallback', () => {
     const colony = makeSafeColony();
     const suppressedIntent: TerritoryIntentMemory = {


### PR DESCRIPTION
## Summary
Implements expansion room reservation (#544): when the bot identifies a top-scored expansion candidate but cannot claim yet (GCL limit, controller cooldown), reserves the room to block competitors.

## Changes
- `prod/src/territory/territoryPlanner.ts`: adds `reserve` action triggered when claim evaluation results in `skipped` due to `gclInsufficient` or `controllerCooldown`
- `prod/src/territory/claimExecutor.ts`: reservation execution — spawn territory creep, move to target, call `reserveController`, re-reserve when ticks < 500
- `prod/src/economy/economyLoop.ts`: minor integration
- `prod/src/telemetry/runtimeSummary.ts`: telemetry hook
- `prod/test/territoryPlanner.test.ts`: tests for reserve triggered on claim-skip, skip when already reserved by us, skip when reserved by others, re-reserve on low ticks
- `prod/test/claimExecutor.test.ts`: execution tests

## Verification
- `npm run typecheck`: PASS
- `npm test -- --runInBand`: 37 suites, 850 tests PASS
- `npm run build`: PASS

Refs #544
