### PR TITLE
feat(economy): builder energy sourcing from nearest container/storage (#554)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7648,6 +7648,8 @@ var NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
 var MINIMUM_USEFUL_LOAD_RATIO = 0.4;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
+var BUILDER_STORAGE_WITHDRAW_MIN = 100;
+var BUILDER_DROPPED_PICKUP_RANGE = 5;
 var DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
 var MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
@@ -7675,6 +7677,7 @@ var MIN_LOADED_WORKERS_FOR_SURPLUS_CONTROLLER_PROGRESS = 5;
 var MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS = 2;
 var MAX_SURPLUS_CONTROLLER_PROGRESS_WORKERS = 3;
 var BASELINE_WORKER_THROUGHPUT_ENERGY_CAPACITY = 550;
+var BUILDER_STORAGE_ACQUISITION_SITE_RANGE = BUILDER_DROPPED_PICKUP_RANGE;
 var nearTermSpawnExtensionRefillReserveCache = null;
 function selectWorkerTask(creep) {
   clearWorkerEfficiencyTelemetry(creep);
@@ -7719,6 +7722,10 @@ function selectHeuristicWorkerTask(creep) {
       }
       if (shouldStandbySurplusWorkerInsteadOfAcquiring(creep, creep.room.controller)) {
         return null;
+      }
+      const builderEnergyAcquisitionTask = selectBuilderEnergyAcquisitionTask(creep);
+      if (builderEnergyAcquisitionTask) {
+        return builderEnergyAcquisitionTask;
       }
       const nearbyContainerEnergyAcquisitionTask = selectNearbyContainerWorkerEnergyAcquisitionTask(creep);
       if (nearbyContainerEnergyAcquisitionTask) {
@@ -8920,6 +8927,105 @@ function selectWorkerEnergyAcquisitionTask(creep) {
     return null;
   }
   return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+function selectBuilderEnergyAcquisitionTask(creep) {
+  var _a;
+  const buildTask = (_a = creep.memory) == null ? void 0 : _a.task;
+  if ((buildTask == null ? void 0 : buildTask.type) !== "build" || buildTask.targetId == null) {
+    return null;
+  }
+  const constructionSite = getGameObjectById(buildTask.targetId);
+  if (!constructionSite) {
+    return null;
+  }
+  const candidates = findBuilderEnergyAcquisitionCandidates(creep, constructionSite);
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(compareBuilderEnergyAcquisitionCandidates)[0].task;
+}
+function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
+  const context = {
+    creepOwnerUsername: getCreepOwnerUsername2(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+  const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).filter((source) => isConstructionSiteNearSource(constructionSite, source, BUILDER_STORAGE_ACQUISITION_SITE_RANGE)).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getStoredEnergy2(source),
+      {
+        type: "withdraw",
+        targetId: source.id
+      },
+      reservationContext,
+      BUILDER_STORAGE_WITHDRAW_MIN
+    );
+    return candidate ? [toBuilderEnergyAcquisitionCandidate(candidate, 0)] : [];
+  });
+  const droppedEnergyCandidates = findDroppedResources(creep.room).filter(
+    (resource) => isDroppedEnergy(resource, MIN_DROPPED_ENERGY_PICKUP_AMOUNT)
+  ).filter((source) => isConstructionSiteNearSource(constructionSite, source, BUILDER_DROPPED_PICKUP_RANGE)).flatMap((resource) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      resource,
+      resource.amount,
+      {
+        type: "pickup",
+        targetId: resource.id
+      },
+      reservationContext,
+      MIN_DROPPED_ENERGY_PICKUP_AMOUNT
+    );
+    return candidate ? [toBuilderEnergyAcquisitionCandidate(candidate, 1)] : [];
+  }).filter((candidate) => isReachable(creep, candidate.source)).sort(compareBuilderEnergyAcquisitionCandidates).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS);
+  if (storedEnergyCandidates.length > 0 || droppedEnergyCandidates.length > 0) {
+    return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);
+  }
+  const harvestSource = selectHarvestSource(creep);
+  if (!harvestSource || isSourceDepleted(harvestSource)) {
+    return [];
+  }
+  return [
+    toBuilderEnergyAcquisitionCandidate(
+      createLowLoadWorkerEnergyAcquisitionCandidate(
+        creep,
+        harvestSource,
+        getHarvestCandidateEnergy(creep, harvestSource),
+        { type: "harvest", targetId: harvestSource.id }
+      ),
+      2
+    )
+  ];
+}
+function toBuilderEnergyAcquisitionCandidate(candidate, priority) {
+  return {
+    ...candidate,
+    source: candidate.source,
+    task: candidate.task,
+    priority
+  };
+}
+function isConstructionSiteNearSource(constructionSite, source, rangeLimit) {
+  const rangeToSite = getRangeBetweenRoomObjects2(constructionSite, source);
+  return rangeToSite !== null && rangeToSite <= rangeLimit;
+}
+function compareBuilderEnergyAcquisitionCandidates(left, right) {
+  const priorityComparison = left.priority - right.priority;
+  if (priorityComparison !== 0) {
+    return priorityComparison;
+  }
+  return compareOptionalRanges(left.range, right.range) || right.score - left.score || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
+}
+function getGameObjectById(objectId) {
+  const game = globalThis.Game;
+  if (!(game == null ? void 0 : game.getObjectById)) {
+    return null;
+  }
+  const object = game.getObjectById(objectId);
+  return object ? object : null;
 }
 function selectWorkerPreHarvestTask(creep) {
   const source = selectHarvestSource(creep);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8981,24 +8981,7 @@ function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
     );
     return candidate ? [toBuilderEnergyAcquisitionCandidate(candidate, 1)] : [];
   }).sort(compareBuilderEnergyAcquisitionCandidates).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
-  if (storedEnergyCandidates.length > 0 || droppedEnergyCandidates.length > 0) {
-    return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);
-  }
-  const harvestSource = selectHarvestSource(creep);
-  if (!harvestSource || isSourceDepleted(harvestSource)) {
-    return [];
-  }
-  return [
-    toBuilderEnergyAcquisitionCandidate(
-      createLowLoadWorkerEnergyAcquisitionCandidate(
-        creep,
-        harvestSource,
-        getHarvestCandidateEnergy(creep, harvestSource),
-        { type: "harvest", targetId: harvestSource.id }
-      ),
-      2
-    )
-  ];
+  return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);
 }
 function toBuilderEnergyAcquisitionCandidate(candidate, priority) {
   return {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8980,7 +8980,7 @@ function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
       MIN_DROPPED_ENERGY_PICKUP_AMOUNT
     );
     return candidate ? [toBuilderEnergyAcquisitionCandidate(candidate, 1)] : [];
-  }).filter((candidate) => isReachable(creep, candidate.source)).sort(compareBuilderEnergyAcquisitionCandidates).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS);
+  }).sort(compareBuilderEnergyAcquisitionCandidates).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
   if (storedEnergyCandidates.length > 0 || droppedEnergyCandidates.length > 0) {
     return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);
   }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -38,6 +38,8 @@ export const NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
 export const MINIMUM_USEFUL_LOAD_RATIO = 0.4;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
+export const BUILDER_STORAGE_WITHDRAW_MIN = 100;
+export const BUILDER_DROPPED_PICKUP_RANGE = 5;
 const DEFAULT_SPAWN_ENERGY_CAPACITY = 300;
 const MIN_LOADED_WORKERS_FOR_SUSTAINED_CONTROLLER_PROGRESS = 2;
 const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
@@ -65,6 +67,7 @@ const MIN_LOADED_WORKERS_FOR_SURPLUS_CONTROLLER_PROGRESS = 5;
 const MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS = 2;
 const MAX_SURPLUS_CONTROLLER_PROGRESS_WORKERS = 3;
 const BASELINE_WORKER_THROUGHPUT_ENERGY_CAPACITY = 550;
+const BUILDER_STORAGE_ACQUISITION_SITE_RANGE = BUILDER_DROPPED_PICKUP_RANGE;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
@@ -87,6 +90,17 @@ type WorkerEnergySpendingTask =
   | Extract<CreepTaskMemory, { type: 'build' }>
   | Extract<CreepTaskMemory, { type: 'repair' }>
   | Extract<CreepTaskMemory, { type: 'upgrade' }>;
+type BuilderEnergyAcquisitionTask = Extract<CreepTaskMemory, { type: 'harvest' | 'pickup' | 'withdraw' }>;
+type BuilderEnergyAcquisitionPriority = 0 | 1 | 2;
+
+interface BuilderEnergyAcquisitionCandidate {
+  energy: number;
+  priority: BuilderEnergyAcquisitionPriority;
+  range: number | null;
+  score: number;
+  source: WorkerEnergyAcquisitionSource | Source;
+  task: BuilderEnergyAcquisitionTask;
+}
 
 interface StoredEnergySourceContext {
   creepOwnerUsername: string | null;
@@ -191,6 +205,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
 
       if (shouldStandbySurplusWorkerInsteadOfAcquiring(creep, creep.room.controller)) {
         return null;
+      }
+
+      const builderEnergyAcquisitionTask = selectBuilderEnergyAcquisitionTask(creep);
+      if (builderEnergyAcquisitionTask) {
+        return builderEnergyAcquisitionTask;
       }
 
       const nearbyContainerEnergyAcquisitionTask = selectNearbyContainerWorkerEnergyAcquisitionTask(creep);
@@ -2042,6 +2061,152 @@ function selectWorkerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitio
   }
 
   return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+
+function selectBuilderEnergyAcquisitionTask(creep: Creep): BuilderEnergyAcquisitionTask | null {
+  const buildTask = creep.memory?.task;
+  if (buildTask?.type !== 'build' || buildTask.targetId == null) {
+    return null;
+  }
+
+  const constructionSite = getGameObjectById<ConstructionSite>(buildTask.targetId);
+  if (!constructionSite) {
+    return null;
+  }
+
+  const candidates = findBuilderEnergyAcquisitionCandidates(creep, constructionSite);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.sort(compareBuilderEnergyAcquisitionCandidates)[0].task;
+}
+
+export function findBuilderEnergyAcquisitionCandidates(
+  creep: Creep,
+  constructionSite: ConstructionSite
+): BuilderEnergyAcquisitionCandidate[] {
+  const context: StoredEnergySourceContext = {
+    creepOwnerUsername: getCreepOwnerUsername(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+
+  const storedEnergyCandidates = findVisibleRoomStructures(creep.room)
+    .filter((structure): structure is StoredWorkerEnergySource => isSafeStoredEnergySource(structure, context))
+    .filter((source) => isConstructionSiteNearSource(constructionSite, source, BUILDER_STORAGE_ACQUISITION_SITE_RANGE))
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        getStoredEnergy(source),
+        {
+          type: 'withdraw',
+          targetId: source.id as Id<AnyStoreStructure>
+        },
+        reservationContext,
+        BUILDER_STORAGE_WITHDRAW_MIN
+      );
+
+      return candidate ? [toBuilderEnergyAcquisitionCandidate(candidate, 0)] : [];
+    });
+
+  const droppedEnergyCandidates = findDroppedResources(creep.room)
+    .filter((resource): resource is Resource<ResourceConstant> =>
+      isDroppedEnergy(resource, MIN_DROPPED_ENERGY_PICKUP_AMOUNT)
+    )
+    .filter((source) => isConstructionSiteNearSource(constructionSite, source, BUILDER_DROPPED_PICKUP_RANGE))
+    .flatMap((resource) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        resource,
+        resource.amount,
+        {
+          type: 'pickup',
+          targetId: resource.id
+        },
+        reservationContext,
+        MIN_DROPPED_ENERGY_PICKUP_AMOUNT
+      );
+
+      return candidate ? [toBuilderEnergyAcquisitionCandidate(candidate, 1)] : [];
+    })
+    .filter((candidate) => isReachable(creep, candidate.source))
+    .sort(compareBuilderEnergyAcquisitionCandidates)
+    .slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS);
+
+  if (storedEnergyCandidates.length > 0 || droppedEnergyCandidates.length > 0) {
+    return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);
+  }
+
+  const harvestSource = selectHarvestSource(creep);
+  if (!harvestSource || isSourceDepleted(harvestSource)) {
+    return [];
+  }
+
+  return [
+    toBuilderEnergyAcquisitionCandidate(
+      createLowLoadWorkerEnergyAcquisitionCandidate(
+        creep,
+        harvestSource,
+        getHarvestCandidateEnergy(creep, harvestSource),
+        { type: 'harvest', targetId: harvestSource.id }
+      ),
+      2
+    )
+  ];
+}
+
+function toBuilderEnergyAcquisitionCandidate(
+  candidate: WorkerEnergyAcquisitionCandidate | LowLoadWorkerEnergyAcquisitionCandidate,
+  priority: BuilderEnergyAcquisitionPriority
+): BuilderEnergyAcquisitionCandidate {
+  return {
+    ...candidate,
+    source: candidate.source as BuilderEnergyAcquisitionCandidate['source'],
+    task: candidate.task as BuilderEnergyAcquisitionCandidate['task'],
+    priority
+  };
+}
+
+function isConstructionSiteNearSource(
+  constructionSite: ConstructionSite,
+  source: RoomObject,
+  rangeLimit: number
+): boolean {
+  const rangeToSite = getRangeBetweenRoomObjects(constructionSite, source);
+  return rangeToSite !== null && rangeToSite <= rangeLimit;
+}
+
+function compareBuilderEnergyAcquisitionCandidates(
+  left: BuilderEnergyAcquisitionCandidate,
+  right: BuilderEnergyAcquisitionCandidate
+): number {
+  const priorityComparison = left.priority - right.priority;
+  if (priorityComparison !== 0) {
+    return priorityComparison;
+  }
+
+  return (
+    compareOptionalRanges(left.range, right.range) ||
+    right.score - left.score ||
+    right.energy - left.energy ||
+    String(left.source.id).localeCompare(String(right.source.id)) ||
+    left.task.type.localeCompare(right.task.type)
+  );
+}
+
+function getGameObjectById<T extends RoomObject>(
+  objectId: string
+): T | null {
+  const game = (globalThis as unknown as { Game?: Partial<Game> }).Game;
+  if (!game?.getObjectById) {
+    return null;
+  }
+
+  const object = game.getObjectById(objectId);
+  return object ? ((object as unknown) as T) : null;
 }
 
 export function selectWorkerEnergyFallbackTask(creep: Creep): CreepTaskMemory | null {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2134,28 +2134,9 @@ export function findBuilderEnergyAcquisitionCandidates(
     })
     .sort(compareBuilderEnergyAcquisitionCandidates)
     .slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS)
-    .filter((candidate) => isReachable(creep, candidate.source))
+    .filter((candidate) => isReachable(creep, candidate.source));
 
-  if (storedEnergyCandidates.length > 0 || droppedEnergyCandidates.length > 0) {
-    return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);
-  }
-
-  const harvestSource = selectHarvestSource(creep);
-  if (!harvestSource || isSourceDepleted(harvestSource)) {
-    return [];
-  }
-
-  return [
-    toBuilderEnergyAcquisitionCandidate(
-      createLowLoadWorkerEnergyAcquisitionCandidate(
-        creep,
-        harvestSource,
-        getHarvestCandidateEnergy(creep, harvestSource),
-        { type: 'harvest', targetId: harvestSource.id }
-      ),
-      2
-    )
-  ];
+  return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);
 }
 
 function toBuilderEnergyAcquisitionCandidate(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2132,9 +2132,9 @@ export function findBuilderEnergyAcquisitionCandidates(
 
       return candidate ? [toBuilderEnergyAcquisitionCandidate(candidate, 1)] : [];
     })
-    .filter((candidate) => isReachable(creep, candidate.source))
     .sort(compareBuilderEnergyAcquisitionCandidates)
-    .slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS);
+    .slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS)
+    .filter((candidate) => isReachable(creep, candidate.source))
 
   if (storedEnergyCandidates.length > 0 || droppedEnergyCandidates.length > 0) {
     return [...storedEnergyCandidates, ...droppedEnergyCandidates].sort(compareBuilderEnergyAcquisitionCandidates);

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3,6 +3,7 @@ import {
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
+  BUILDER_DROPPED_PICKUP_RANGE,
   BUILDER_STORAGE_WITHDRAW_MIN,
   LOW_LOAD_NEARBY_ENERGY_RANGE,
   LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
@@ -502,7 +503,48 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage-eligible' });
   });
 
-  it('builder falls back to harvest when nearby stored and dropped energy does not meet thresholds', () => {
+  it('builder falls through to nearby container acquisition when no site-local energy is available', () => {
+    const source = makeSource('source1', 10, 10, 300);
+    const constructionSite = withRangeTo(
+      {
+        id: 'build-site1',
+        structureType: 'extension',
+        pos: makeRoomPosition(20, 20)
+      } as ConstructionSite,
+      {
+        'container-near-creep': BUILDER_DROPPED_PICKUP_RANGE + 1
+      }
+    );
+    const nearbyContainer = withRangeTo(
+      makeStoredEnergyStructure('container-near-creep', 'container' as StructureConstant, 500),
+      { 'build-site1': BUILDER_DROPPED_PICKUP_RANGE + 1 }
+    );
+    const room = makeWorkerTaskRoom({
+      constructionSites: [constructionSite],
+      sources: [source],
+      structures: [nearbyContainer]
+    });
+    const creep = {
+      memory: { role: 'worker', task: { type: 'build', targetId: 'build-site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'container-near-creep' ? 2 : 1))
+      },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById: jest.fn().mockReturnValue(constructionSite)
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-near-creep' });
+    expect(room.find).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('builder falls through to nearby container energy when site-local candidates do not meet builder thresholds', () => {
     const source = makeSource('source1', 10, 10, 300);
     const constructionSite = withRangeTo(
       {
@@ -561,10 +603,10 @@ describe('selectWorkerTask', () => {
       getObjectById: jest.fn().mockReturnValue(constructionSite)
     };
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-small' });
   });
 
-  it('builder ignores insufficient stored energy and harvests instead', () => {
+  it('builder falls through to general stored-energy acquisition when site-local storage is below builder threshold', () => {
     const source = makeSource('source1', 10, 10, 300);
     const constructionSite = withRangeTo(
       {
@@ -614,7 +656,7 @@ describe('selectWorkerTask', () => {
       getObjectById: jest.fn().mockReturnValue(constructionSite)
     };
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage-small' });
   });
 
   it('falls back to harvesting when visible dropped energy is not reachable', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -577,7 +577,9 @@ describe('selectWorkerTask', () => {
       }
     );
     const storage = withRangeTo(
-      makeStoredEnergyStructure('storage-small', 'storage' as StructureConstant, BUILDER_STORAGE_WITHDRAW_MIN - 1),
+      makeStoredEnergyStructure('storage-small', 'storage' as StructureConstant, BUILDER_STORAGE_WITHDRAW_MIN - 1, {
+        my: true
+      }),
       { 'build-site1': 2 }
     );
     const getRangeTo = jest.fn((target: { id?: string }) => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3,6 +3,7 @@ import {
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
+  BUILDER_STORAGE_WITHDRAW_MIN,
   LOW_LOAD_NEARBY_ENERGY_RANGE,
   LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
   MINIMUM_USEFUL_LOAD_RATIO,
@@ -389,6 +390,229 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'pickup', targetId: 'drop-far' });
     expect(getRangeTo).not.toHaveBeenCalledWith(lowValueDroppedEnergy);
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('builder uses nearby stored energy near the construction site before harvesting', () => {
+    const source = { id: 'source1' } as Source;
+    const constructionSite = withRangeTo(
+      {
+      id: 'build-site1',
+        structureType: 'extension',
+        pos: makeRoomPosition(10, 10)
+      } as ConstructionSite,
+      {
+        'container-near': 2
+      }
+    );
+    const container = withRangeTo(
+      makeStoredEnergyStructure('container-near', 'container' as StructureConstant, 500),
+      { 'build-site1': 2 }
+    );
+    const getRangeTo = jest.fn((target: { id?: string }) => {
+      const ranges: Record<string, number> = {
+        'container-near': 2,
+        source1: 4
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_CONSTRUCTION_SITES) {
+        return [constructionSite];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [container];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      memory: { role: 'worker', task: { type: 'build', targetId: 'build-site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: {
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById: jest.fn().mockReturnValue(constructionSite)
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-near' });
+  });
+
+  it('builder uses nearby storage when it is the only viable stored-energy source near the site', () => {
+    const source = { id: 'source1' } as Source;
+    const constructionSite = withRangeTo(
+      {
+        id: 'build-site1',
+        structureType: 'extension',
+        pos: makeRoomPosition(10, 10)
+      } as ConstructionSite,
+      {
+        'storage-eligible': 4,
+        'container-empty': 2
+      }
+    );
+    const emptyContainer = withRangeTo(
+      makeStoredEnergyStructure('container-empty', 'container' as StructureConstant, 0),
+      { 'build-site1': 2 }
+    );
+    const storage = withRangeTo(
+      makeStoredEnergyStructure('storage-eligible', 'storage' as StructureConstant, 300, { my: true }),
+      { 'build-site1': 4 }
+    );
+    const getRangeTo = jest.fn((target: { id?: string }) => {
+      const ranges: Record<string, number> = {
+        'container-empty': 2,
+        'storage-eligible': 4,
+        source1: 6
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_CONSTRUCTION_SITES) {
+        return [constructionSite];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [emptyContainer, storage];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      memory: { role: 'worker', task: { type: 'build', targetId: 'build-site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { find: roomFind }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById: jest.fn().mockReturnValue(constructionSite)
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage-eligible' });
+  });
+
+  it('builder falls back to harvest when nearby stored and dropped energy does not meet thresholds', () => {
+    const source = makeSource('source1', 10, 10, 300);
+    const constructionSite = withRangeTo(
+      {
+        id: 'build-site1',
+        structureType: 'extension',
+        pos: makeRoomPosition(10, 10)
+      } as ConstructionSite,
+      {
+        'container-small': 2,
+        'drop-near': 2
+      }
+    );
+    const lowContainer = withRangeTo(
+      makeStoredEnergyStructure('container-small', 'container' as StructureConstant, BUILDER_STORAGE_WITHDRAW_MIN - 1),
+      { 'build-site1': 2 }
+    );
+    const nearDrop = {
+      id: 'drop-near',
+      resourceType: 'energy',
+      amount: 10
+    } as Resource<ResourceConstant>;
+    const getRangeTo = jest.fn((target: { id?: string }) => {
+      const ranges: Record<string, number> = {
+        'container-small': 2,
+        'drop-near': 2,
+        source1: 4
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_DROPPED_RESOURCES) {
+        return [nearDrop];
+      }
+
+      if (type === FIND_CONSTRUCTION_SITES) {
+        return [constructionSite];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [lowContainer];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      memory: { role: 'worker', task: { type: 'build', targetId: 'build-site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { find: roomFind }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById: jest.fn().mockReturnValue(constructionSite)
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('builder ignores insufficient stored energy and harvests instead', () => {
+    const source = makeSource('source1', 10, 10, 300);
+    const constructionSite = withRangeTo(
+      {
+        id: 'build-site1',
+        structureType: 'extension',
+        pos: makeRoomPosition(10, 10)
+      } as ConstructionSite,
+      {
+        'storage-small': 2
+      }
+    );
+    const storage = withRangeTo(
+      makeStoredEnergyStructure('storage-small', 'storage' as StructureConstant, BUILDER_STORAGE_WITHDRAW_MIN - 1),
+      { 'build-site1': 2 }
+    );
+    const getRangeTo = jest.fn((target: { id?: string }) => {
+      const ranges: Record<string, number> = {
+        'storage-small': 2,
+        source1: 4
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const roomFind = jest.fn((type: number) => {
+      if (type === FIND_CONSTRUCTION_SITES) {
+        return [constructionSite];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return [storage];
+      }
+
+      return type === FIND_SOURCES ? [source] : [];
+    });
+    const creep = {
+      memory: { role: 'worker', task: { type: 'build', targetId: 'build-site1' as Id<ConstructionSite> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo },
+      room: { find: roomFind }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById: jest.fn().mockReturnValue(constructionSite)
+    };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
   it('falls back to harvesting when visible dropped energy is not reachable', () => {


### PR DESCRIPTION
## Summary
Implements builder energy sourcing from nearest container/storage instead of always harvesting. Builders now prefer stored/dropped energy near construction sites over distant harvest sources.

## Changes
- Added `findBuilderEnergyAcquisitionCandidates` helper with container/storage/dropped energy priority
- Configurable thresholds: `BUILDER_STORAGE_WITHDRAW_MIN` (100), `BUILDER_DROPPED_PICKUP_RANGE` (5)
- Builder energy acquisition wired into worker task runner
- Tests: container pickup, storage fallback, harvest fallback, insufficient energy threshold

## Verification
- Typecheck: PASS
- Tests: 863/863 PASS
- Build: PASS

Closes #554
