### PR TITLE
feat(territory): enforce RCL-gated max room count to prevent low-RCL overexpansion (#559)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2697,6 +2697,7 @@ function persistOccupationRecommendationFollowUpIntent(report, gameTime = getGam
     action: followUpIntent.action,
     status: (existingIntent == null ? void 0 : existingIntent.status) === "active" ? "active" : "planned",
     updatedAt: gameTime,
+    createdBy: OCCUPATION_RECOMMENDATION_TARGET_CREATOR,
     ...controllerId ? { controllerId } : {},
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...followUp ? { followUp } : {},
@@ -5340,14 +5341,8 @@ function upsertTerritoryIntent2(intents, nextIntent) {
 }
 function findTerritoryIntentIndex(intents, nextIntent) {
   if (nextIntent.createdBy) {
-    const sourceOwnedIntentIndex = intents.findIndex(
-      (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === nextIntent.createdBy
-    );
-    if (sourceOwnedIntentIndex >= 0) {
-      return sourceOwnedIntentIndex;
-    }
     return intents.findIndex(
-      (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === void 0
+      (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === nextIntent.createdBy
     );
   }
   const unownedIntentIndex = intents.findIndex(
@@ -13190,7 +13185,7 @@ function getSelectionSkipReason(report) {
   if (report.candidates.length === 0) {
     return "noCandidate";
   }
-  if (report.candidates.every(isBlockedOnlyByRoomLimit)) {
+  if (report.candidates.some(hasRoomLimitPrecondition)) {
     return "roomLimitReached";
   }
   if (report.candidates.some((candidate) => candidate.preconditions.length > 0)) {
@@ -13201,8 +13196,10 @@ function getSelectionSkipReason(report) {
   }
   return "unavailable";
 }
-function isBlockedOnlyByRoomLimit(candidate) {
-  return candidate.preconditions.length === 1 && candidate.preconditions[0].startsWith(ROOM_LIMIT_PRECONDITION_PREFIX);
+function hasRoomLimitPrecondition(candidate) {
+  return candidate.preconditions.some(
+    (precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX)
+  );
 }
 function persistNextExpansionTarget(colony, candidate, gameTime) {
   const territoryMemory = getWritableTerritoryMemoryRecord3();
@@ -15464,7 +15461,7 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime) {
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const existingIntent = intents.find(
-    (intent) => intent.colony === colony && intent.targetRoom === target.roomName && intent.action === "claim"
+    (intent) => intent.colony === colony && intent.targetRoom === target.roomName && intent.action === "claim" && intent.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR
   );
   upsertTerritoryIntent4(intents, {
     colony,
@@ -15472,6 +15469,7 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime) {
     action: "claim",
     status: (existingIntent == null ? void 0 : existingIntent.status) === "active" ? "active" : "planned",
     updatedAt: gameTime,
+    createdBy: AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR,
     ...target.controllerId ? { controllerId: target.controllerId } : {}
   });
 }
@@ -15479,7 +15477,9 @@ function upsertTerritoryTarget2(territoryMemory, target) {
   if (!Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = [];
   }
-  const existingTarget = territoryMemory.targets.find((rawTarget) => isSameTarget2(rawTarget, target));
+  const existingTarget = territoryMemory.targets.find(
+    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord14(rawTarget) && rawTarget.createdBy === target.createdBy
+  );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
@@ -15495,7 +15495,7 @@ function upsertTerritoryTarget2(territoryMemory, target) {
 }
 function upsertTerritoryIntent4(intents, nextIntent) {
   const existingIndex = intents.findIndex(
-    (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action
+    (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action && intent.createdBy === nextIntent.createdBy
   );
   if (existingIndex >= 0) {
     intents[existingIndex] = nextIntent;
@@ -15524,7 +15524,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     return;
   }
   territoryMemory.intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
-    (intent) => intent.colony !== colony || !removedTargetKeys.has(getTargetKey2(intent.targetRoom, intent.action))
+    (intent) => intent.colony !== colony || intent.createdBy !== AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR || !removedTargetKeys.has(getTargetKey2(intent.targetRoom, intent.action))
   );
 }
 function pruneOccupationRecommendationTargets(territoryMemory, colony) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12803,6 +12803,7 @@ var DEFAULT_TERRAIN_SWAMP_MASK = 2;
 var DOWNGRADE_GUARD_TICKS2 = 5e3;
 var MIN_CONTROLLER_LEVEL = 2;
 var FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = "foreign reservation requires controller pressure";
+var ROOM_LIMIT_PRECONDITION_PREFIX = "limit expansion to ";
 var MAX_ROOM_COUNT_BY_RCL = {
   1: 1,
   2: 1,
@@ -13111,6 +13112,9 @@ function getSelectionSkipReason(report) {
   if (report.candidates.length === 0) {
     return "noCandidate";
   }
+  if (report.candidates.every(isBlockedOnlyByRoomLimit)) {
+    return "roomLimitReached";
+  }
   if (report.candidates.some((candidate) => candidate.preconditions.length > 0)) {
     return "unmetPreconditions";
   }
@@ -13118,6 +13122,9 @@ function getSelectionSkipReason(report) {
     return "insufficientEvidence";
   }
   return "unavailable";
+}
+function isBlockedOnlyByRoomLimit(candidate) {
+  return candidate.preconditions.length === 1 && candidate.preconditions[0].startsWith(ROOM_LIMIT_PRECONDITION_PREFIX);
 }
 function persistNextExpansionTarget(colony, candidate, gameTime) {
   const territoryMemory = getWritableTerritoryMemoryRecord3();
@@ -15888,6 +15895,9 @@ function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);
       return;
     }
+    if (expansionSelection.reason === "roomLimitReached") {
+      return;
+    }
     if (expansionSelection.reason === "unmetPreconditions") {
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);
       return;
@@ -15968,7 +15978,7 @@ function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
   };
 }
 function normalizeNextExpansionTargetSelectionReason(reason) {
-  return reason === "noCandidate" || reason === "unmetPreconditions" || reason === "insufficientEvidence" || reason === "unavailable" ? reason : void 0;
+  return reason === "noCandidate" || reason === "roomLimitReached" || reason === "unmetPreconditions" || reason === "insufficientEvidence" || reason === "unavailable" ? reason : void 0;
 }
 function isNextExpansionTargetSelectionCacheReusable(cachedSelection, colony, gameTime, stateKey) {
   if (cachedSelection.stateKey !== stateKey || gameTime < cachedSelection.refreshedAt || gameTime - cachedSelection.refreshedAt >= NEXT_EXPANSION_SCORING_REFRESH_INTERVAL) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12803,6 +12803,16 @@ var DEFAULT_TERRAIN_SWAMP_MASK = 2;
 var DOWNGRADE_GUARD_TICKS2 = 5e3;
 var MIN_CONTROLLER_LEVEL = 2;
 var FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = "foreign reservation requires controller pressure";
+var MAX_ROOM_COUNT_BY_RCL = {
+  1: 1,
+  2: 1,
+  3: 2,
+  4: 3,
+  5: 5,
+  6: 8,
+  7: 15,
+  8: 99
+};
 function buildRuntimeExpansionCandidateReport(colony) {
   return scoreExpansionCandidates(buildRuntimeExpansionScoringInput(colony));
 }
@@ -12839,10 +12849,18 @@ function buildRuntimeExpansionScoringInput(colony) {
     ...getControllerOwnerUsername5(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername5(colony.room.controller) } : {},
     energyCapacityAvailable: colony.energyCapacityAvailable,
     ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
+    ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername5(colony.room.controller)),
     ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
     activePostClaimBootstrapCount: countActivePostClaimBootstraps(),
     candidates: buildRuntimeExpansionCandidates(colony)
   };
+}
+function maxRoomsForRcl(controllerLevel) {
+  if (typeof controllerLevel !== "number" || !Number.isFinite(controllerLevel)) {
+    return MAX_ROOM_COUNT_BY_RCL[1];
+  }
+  const rcl = Math.min(8, Math.max(1, Math.floor(controllerLevel)));
+  return MAX_ROOM_COUNT_BY_RCL[rcl];
 }
 function buildRuntimeExpansionCandidates(colony) {
   const rooms = getGameRooms2();
@@ -13064,6 +13082,11 @@ function getExpansionPreconditions(input) {
   if (((_a = input.controllerLevel) != null ? _a : 0) < MIN_CONTROLLER_LEVEL) {
     preconditions.push("reach controller level 2 before expansion");
   }
+  const ownedRoomCount = getOwnedRoomCount(input);
+  const maxRoomCount = maxRoomsForRcl(input.controllerLevel);
+  if (ownedRoomCount >= maxRoomCount) {
+    preconditions.push(`limit expansion to ${maxRoomCount} owned rooms for current controller level`);
+  }
   if (typeof input.ticksToDowngrade === "number" && input.ticksToDowngrade <= DOWNGRADE_GUARD_TICKS2) {
     preconditions.push("stabilize home controller downgrade timer");
   }
@@ -13071,6 +13094,12 @@ function getExpansionPreconditions(input) {
     preconditions.push("finish active post-claim bootstrap before next expansion");
   }
   return preconditions;
+}
+function getOwnedRoomCount(input) {
+  if (typeof input.ownedRoomCount !== "number" || !Number.isFinite(input.ownedRoomCount)) {
+    return 1;
+  }
+  return Math.max(0, Math.floor(input.ownedRoomCount));
 }
 function selectPersistableExpansionCandidate(report) {
   var _a;
@@ -13223,6 +13252,9 @@ function getVisibleOwnedRoomNames3(colonyName, ownerUsername) {
     }
   }
   return ownedRoomNames;
+}
+function countVisibleOwnedRooms(colonyName, ownerUsername) {
+  return getVisibleOwnedRoomNames3(colonyName, ownerUsername).size;
 }
 function getAdjacentRoomNamesByOwnedRoom(ownedRoomNames) {
   const adjacentRoomNames = /* @__PURE__ */ new Map();
@@ -15962,9 +15994,21 @@ function getNextExpansionSelectionCacheStateKey(colony) {
     colony.room.name,
     colony.energyCapacityAvailable,
     controllerLevel,
+    countVisibleOwnedRooms2(),
     downgradeState,
     countActivePostClaimBootstraps2()
   ].join("|");
+}
+function countVisibleOwnedRooms2() {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return 0;
+  }
+  return Object.values(rooms).filter((room) => {
+    var _a2;
+    return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
+  }).length;
 }
 function countActivePostClaimBootstraps2() {
   var _a, _b;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2617,12 +2617,56 @@ function clearOccupationRecommendationFollowUpIntent(report) {
   report.followUpIntent = null;
   return report;
 }
+function suppressOccupationClaimRecommendation(report) {
+  var _a, _b, _c;
+  if (((_a = report.next) == null ? void 0 : _a.action) !== "occupy" && ((_b = report.followUpIntent) == null ? void 0 : _b.action) !== "claim") {
+    return report;
+  }
+  const next = (_c = report.candidates.find(
+    (candidate) => candidate.action !== "occupy" && candidate.evidenceStatus !== "unavailable"
+  )) != null ? _c : null;
+  report.next = next;
+  report.followUpIntent = isNonEmptyString4(report.colonyName) ? buildOccupationRecommendationFollowUpIntent(report.colonyName, next) : null;
+  return report;
+}
+function clearOccupationRecommendationClaimIntent(colony) {
+  if (!isNonEmptyString4(colony)) {
+    return;
+  }
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+  const removedTargetKeys = /* @__PURE__ */ new Set();
+  if (Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = territoryMemory.targets.filter((rawTarget) => {
+      const target = normalizeTerritoryTarget(rawTarget);
+      if ((target == null ? void 0 : target.colony) !== colony || target.action !== "claim" || target.createdBy !== OCCUPATION_RECOMMENDATION_TARGET_CREATOR) {
+        return true;
+      }
+      removedTargetKeys.add(getOccupationRecommendationTargetKey(target.roomName, target.action));
+      return false;
+    });
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  const nextIntents = intents.filter(
+    (intent) => !(intent.colony === colony && intent.action === "claim" && (intent.createdBy === OCCUPATION_RECOMMENDATION_TARGET_CREATOR || removedTargetKeys.has(getOccupationRecommendationTargetKey(intent.targetRoom, intent.action))))
+  );
+  if (nextIntents.length === intents.length) {
+    return;
+  }
+  if (nextIntents.length > 0) {
+    territoryMemory.intents = nextIntents;
+  } else {
+    delete territoryMemory.intents;
+  }
+}
 function scoreOccupationRecommendations(input) {
   var _a;
   const candidates = input.candidates.filter((candidate) => candidate.roomName !== input.colonyName).map((candidate) => scoreOccupationCandidate(input, candidate)).sort(compareOccupationRecommendationScores);
   const next = (_a = candidates.find((candidate) => candidate.evidenceStatus !== "unavailable")) != null ? _a : null;
   return attachOccupationRecommendationReportColony(
-    { candidates, next, followUpIntent: buildOccupationRecommendationFollowUpIntent(input, next) },
+    { candidates, next, followUpIntent: buildOccupationRecommendationFollowUpIntent(input.colonyName, next) },
     input.colonyName
   );
 }
@@ -2723,6 +2767,9 @@ function buildActiveOccupationRecommendationControlTarget(report) {
     return null;
   }
   return { roomName: recommendation.roomName, action };
+}
+function getOccupationRecommendationTargetKey(roomName, action) {
+  return `${roomName}:${action}`;
 }
 function revokeOccupationRecommendationTarget(territoryMemory, intent) {
   if (!isTerritoryControlAction(intent.action) || !Array.isArray(territoryMemory.targets)) {
@@ -2937,12 +2984,12 @@ function scoreOccupationCandidate(input, candidate) {
     ...candidate.hostileStructureCount !== void 0 ? { hostileStructureCount: candidate.hostileStructureCount } : {}
   };
 }
-function buildOccupationRecommendationFollowUpIntent(input, next) {
+function buildOccupationRecommendationFollowUpIntent(colonyName, next) {
   if (!next) {
     return null;
   }
   return {
-    colony: input.colonyName,
+    colony: colonyName,
     targetRoom: next.roomName,
     action: getTerritoryIntentAction(next.action),
     ...next.controllerId ? { controllerId: next.controllerId } : {},
@@ -5293,8 +5340,14 @@ function upsertTerritoryIntent2(intents, nextIntent) {
 }
 function findTerritoryIntentIndex(intents, nextIntent) {
   if (nextIntent.createdBy) {
-    return intents.findIndex(
+    const sourceOwnedIntentIndex = intents.findIndex(
       (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === nextIntent.createdBy
+    );
+    if (sourceOwnedIntentIndex >= 0) {
+      return sourceOwnedIntentIndex;
+    }
+    return intents.findIndex(
+      (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === void 0
     );
   }
   const unownedIntentIndex = intents.findIndex(
@@ -12865,6 +12918,9 @@ function refreshNextExpansionTargetSelection(colony, report, gameTime) {
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
   };
 }
+function clearNextExpansionTargetIntent(colony) {
+  pruneNextExpansionTargets(colony);
+}
 function buildRuntimeExpansionScoringInput(colony) {
   var _a, _b;
   return {
@@ -15268,6 +15324,9 @@ function refreshAutonomousExpansionClaimIntent(colony, report, gameTime, telemet
 function shouldDeferOccupationRecommendationForExpansionClaim(evaluation) {
   return evaluation.status === "planned" || evaluation.reason === "controllerCooldown";
 }
+function clearAutonomousExpansionClaimIntent(colony) {
+  pruneAutonomousExpansionClaimTargets(colony);
+}
 function shouldPruneAutonomousExpansionClaimTargets(reason) {
   return reason === "noAdjacentCandidate" || reason === "hostilePresence" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved";
 }
@@ -15910,7 +15969,7 @@ function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady
   const colonyWorkers = creeps.filter(
     (creep) => creep.memory.role === "worker" && creep.memory.colony === colony.room.name
   );
-  const report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
+  let report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   if (territoryReady) {
     const expansionSelection = refreshNextExpansionTargetSelectionIfDue(colony, Game.time);
     if (expansionSelection.status === "planned") {
@@ -15918,6 +15977,12 @@ function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady
       return;
     }
     if (expansionSelection.reason === "roomLimitReached") {
+      const colonyName = colony.room.name;
+      clearNextExpansionTargetIntent(colonyName);
+      clearAutonomousExpansionClaimIntent(colonyName);
+      clearOccupationRecommendationClaimIntent(colonyName);
+      report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
+      persistOccupationRecommendationFollowUpIntent(suppressOccupationClaimRecommendation(report), Game.time);
       return;
     }
     if (expansionSelection.reason === "unmetPreconditions") {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -17,16 +17,20 @@ import { emitRuntimeSummary, type RuntimeSummary, type RuntimeTelemetryEvent } f
 import { recordSourceWorkloads } from './sourceWorkload';
 import {
   buildRuntimeOccupationRecommendationReport,
+  clearOccupationRecommendationClaimIntent,
   clearOccupationRecommendationFollowUpIntent,
-  persistOccupationRecommendationFollowUpIntent
+  persistOccupationRecommendationFollowUpIntent,
+  suppressOccupationClaimRecommendation
 } from '../territory/occupationRecommendation';
 import {
   buildRuntimeExpansionCandidateReport,
+  clearNextExpansionTargetIntent,
   NEXT_EXPANSION_TARGET_CREATOR,
   type NextExpansionTargetSelection,
   refreshNextExpansionTargetSelection
 } from '../territory/expansionScoring';
 import {
+  clearAutonomousExpansionClaimIntent,
   refreshAutonomousExpansionClaimIntent,
   shouldDeferOccupationRecommendationForExpansionClaim
 } from '../territory/claimExecutor';
@@ -159,7 +163,7 @@ function refreshExecutableTerritoryRecommendation(
   const colonyWorkers = creeps.filter(
     (creep) => creep.memory.role === 'worker' && creep.memory.colony === colony.room.name
   );
-  const report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
+  let report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   if (territoryReady) {
     const expansionSelection = refreshNextExpansionTargetSelectionIfDue(colony, Game.time);
     if (expansionSelection.status === 'planned') {
@@ -167,6 +171,12 @@ function refreshExecutableTerritoryRecommendation(
       return;
     }
     if (expansionSelection.reason === 'roomLimitReached') {
+      const colonyName = colony.room.name;
+      clearNextExpansionTargetIntent(colonyName);
+      clearAutonomousExpansionClaimIntent(colonyName);
+      clearOccupationRecommendationClaimIntent(colonyName);
+      report = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
+      persistOccupationRecommendationFollowUpIntent(suppressOccupationClaimRecommendation(report), Game.time);
       return;
     }
     if (expansionSelection.reason === 'unmetPreconditions') {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -342,9 +342,19 @@ function getNextExpansionSelectionCacheStateKey(colony: ColonySnapshot): string 
     colony.room.name,
     colony.energyCapacityAvailable,
     controllerLevel,
+    countVisibleOwnedRooms(),
     downgradeState,
     countActivePostClaimBootstraps()
   ].join('|');
+}
+
+function countVisibleOwnedRooms(): number {
+  const rooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+  if (!rooms) {
+    return 0;
+  }
+
+  return Object.values(rooms).filter((room) => room?.controller?.my === true).length;
 }
 
 function countActivePostClaimBootstraps(): number {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -166,6 +166,9 @@ function refreshExecutableTerritoryRecommendation(
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);
       return;
     }
+    if (expansionSelection.reason === 'roomLimitReached') {
+      return;
+    }
     if (expansionSelection.reason === 'unmetPreconditions') {
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);
       return;
@@ -284,6 +287,7 @@ function normalizeNextExpansionTargetSelectionReason(
   reason: unknown
 ): NextExpansionTargetSelection['reason'] | undefined {
   return reason === 'noCandidate' ||
+    reason === 'roomLimitReached' ||
     reason === 'unmetPreconditions' ||
     reason === 'insufficientEvidence' ||
     reason === 'unavailable'

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -60,6 +60,10 @@ export function shouldDeferOccupationRecommendationForExpansionClaim(
   return evaluation.status === 'planned' || evaluation.reason === 'controllerCooldown';
 }
 
+export function clearAutonomousExpansionClaimIntent(colony: string): void {
+  pruneAutonomousExpansionClaimTargets(colony);
+}
+
 function shouldPruneAutonomousExpansionClaimTargets(
   reason: RuntimeTerritoryClaimTelemetryReason | undefined
 ): boolean {

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -256,7 +256,11 @@ function persistAutonomousExpansionClaimIntent(
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const existingIntent = intents.find(
-    (intent) => intent.colony === colony && intent.targetRoom === target.roomName && intent.action === 'claim'
+    (intent) =>
+      intent.colony === colony &&
+      intent.targetRoom === target.roomName &&
+      intent.action === 'claim' &&
+      intent.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR
   );
   upsertTerritoryIntent(intents, {
     colony,
@@ -264,6 +268,7 @@ function persistAutonomousExpansionClaimIntent(
     action: 'claim',
     status: existingIntent?.status === 'active' ? 'active' : 'planned',
     updatedAt: gameTime,
+    createdBy: AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR,
     ...(target.controllerId ? { controllerId: target.controllerId } : {})
   });
 }
@@ -273,7 +278,12 @@ function upsertTerritoryTarget(territoryMemory: TerritoryMemory, target: Territo
     territoryMemory.targets = [];
   }
 
-  const existingTarget = territoryMemory.targets.find((rawTarget) => isSameTarget(rawTarget, target));
+  const existingTarget = territoryMemory.targets.find(
+    (rawTarget) =>
+      isSameTarget(rawTarget, target) &&
+      isRecord(rawTarget) &&
+      rawTarget.createdBy === target.createdBy
+  );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
@@ -297,7 +307,8 @@ function upsertTerritoryIntent(
     (intent) =>
       intent.colony === nextIntent.colony &&
       intent.targetRoom === nextIntent.targetRoom &&
-      intent.action === nextIntent.action
+      intent.action === nextIntent.action &&
+      intent.createdBy === nextIntent.createdBy
   );
   if (existingIndex >= 0) {
     intents[existingIndex] = nextIntent;
@@ -338,7 +349,9 @@ function pruneAutonomousExpansionClaimTargets(
 
   territoryMemory.intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
     (intent) =>
-      intent.colony !== colony || !removedTargetKeys.has(getTargetKey(intent.targetRoom, intent.action))
+      intent.colony !== colony ||
+      intent.createdBy !== AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR ||
+      !removedTargetKeys.has(getTargetKey(intent.targetRoom, intent.action))
   );
 }
 

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -159,6 +159,10 @@ export function refreshNextExpansionTargetSelection(
   };
 }
 
+export function clearNextExpansionTargetIntent(colony: string): void {
+  pruneNextExpansionTargets(colony);
+}
+
 function buildRuntimeExpansionScoringInput(colony: ColonySnapshot): ExpansionScoringInput {
   return {
     colonyName: colony.room.name,

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -15,6 +15,16 @@ const DEFAULT_TERRAIN_SWAMP_MASK = 2;
 const DOWNGRADE_GUARD_TICKS = 5_000;
 const MIN_CONTROLLER_LEVEL = 2;
 const FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = 'foreign reservation requires controller pressure';
+const MAX_ROOM_COUNT_BY_RCL: Record<number, number> = {
+  1: 1,
+  2: 1,
+  3: 2,
+  4: 3,
+  5: 5,
+  6: 8,
+  7: 15,
+  8: 99
+};
 
 export type ExpansionCandidateEvidenceStatus = 'sufficient' | 'insufficient-evidence' | 'unavailable';
 
@@ -50,6 +60,7 @@ export interface ExpansionScoringInput {
   colonyOwnerUsername?: string;
   energyCapacityAvailable: number;
   controllerLevel?: number;
+  ownedRoomCount?: number;
   ticksToDowngrade?: number;
   activePostClaimBootstrapCount?: number;
   candidates: ExpansionCandidateInput[];
@@ -154,12 +165,22 @@ function buildRuntimeExpansionScoringInput(colony: ColonySnapshot): ExpansionSco
       : {}),
     energyCapacityAvailable: colony.energyCapacityAvailable,
     ...(typeof colony.room.controller?.level === 'number' ? { controllerLevel: colony.room.controller.level } : {}),
+    ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername(colony.room.controller)),
     ...(typeof colony.room.controller?.ticksToDowngrade === 'number'
       ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade }
       : {}),
     activePostClaimBootstrapCount: countActivePostClaimBootstraps(),
     candidates: buildRuntimeExpansionCandidates(colony)
   };
+}
+
+export function maxRoomsForRcl(controllerLevel: number | undefined): number {
+  if (typeof controllerLevel !== 'number' || !Number.isFinite(controllerLevel)) {
+    return MAX_ROOM_COUNT_BY_RCL[1];
+  }
+
+  const rcl = Math.min(8, Math.max(1, Math.floor(controllerLevel)));
+  return MAX_ROOM_COUNT_BY_RCL[rcl];
 }
 
 function buildRuntimeExpansionCandidates(colony: ColonySnapshot): ExpansionCandidateInput[] {
@@ -457,6 +478,12 @@ function getExpansionPreconditions(input: ExpansionScoringInput): string[] {
     preconditions.push('reach controller level 2 before expansion');
   }
 
+  const ownedRoomCount = getOwnedRoomCount(input);
+  const maxRoomCount = maxRoomsForRcl(input.controllerLevel);
+  if (ownedRoomCount >= maxRoomCount) {
+    preconditions.push(`limit expansion to ${maxRoomCount} owned rooms for current controller level`);
+  }
+
   if (typeof input.ticksToDowngrade === 'number' && input.ticksToDowngrade <= DOWNGRADE_GUARD_TICKS) {
     preconditions.push('stabilize home controller downgrade timer');
   }
@@ -466,6 +493,14 @@ function getExpansionPreconditions(input: ExpansionScoringInput): string[] {
   }
 
   return preconditions;
+}
+
+function getOwnedRoomCount(input: ExpansionScoringInput): number {
+  if (typeof input.ownedRoomCount !== 'number' || !Number.isFinite(input.ownedRoomCount)) {
+    return 1;
+  }
+
+  return Math.max(0, Math.floor(input.ownedRoomCount));
 }
 
 function selectPersistableExpansionCandidate(report: ExpansionCandidateReport): ExpansionCandidateScore | null {
@@ -697,6 +732,10 @@ function getVisibleOwnedRoomNames(colonyName: string, ownerUsername: string | un
   }
 
   return ownedRoomNames;
+}
+
+function countVisibleOwnedRooms(colonyName: string, ownerUsername: string | undefined): number {
+  return getVisibleOwnedRoomNames(colonyName, ownerUsername).size;
 }
 
 function getAdjacentRoomNamesByOwnedRoom(ownedRoomNames: Set<string>): Map<string, Set<string>> {

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -522,7 +522,7 @@ function getSelectionSkipReason(report: ExpansionCandidateReport): NextExpansion
     return 'noCandidate';
   }
 
-  if (report.candidates.every(isBlockedOnlyByRoomLimit)) {
+  if (report.candidates.some(hasRoomLimitPrecondition)) {
     return 'roomLimitReached';
   }
 
@@ -537,10 +537,9 @@ function getSelectionSkipReason(report: ExpansionCandidateReport): NextExpansion
   return 'unavailable';
 }
 
-function isBlockedOnlyByRoomLimit(candidate: ExpansionCandidateScore): boolean {
-  return (
-    candidate.preconditions.length === 1 &&
-    candidate.preconditions[0].startsWith(ROOM_LIMIT_PRECONDITION_PREFIX)
+function hasRoomLimitPrecondition(candidate: ExpansionCandidateScore): boolean {
+  return candidate.preconditions.some((precondition) =>
+    precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX)
   );
 }
 

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -15,6 +15,7 @@ const DEFAULT_TERRAIN_SWAMP_MASK = 2;
 const DOWNGRADE_GUARD_TICKS = 5_000;
 const MIN_CONTROLLER_LEVEL = 2;
 const FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = 'foreign reservation requires controller pressure';
+const ROOM_LIMIT_PRECONDITION_PREFIX = 'limit expansion to ';
 const MAX_ROOM_COUNT_BY_RCL: Record<number, number> = {
   1: 1,
   2: 1,
@@ -104,6 +105,7 @@ export interface ExpansionReservationEvidence {
 export type NextExpansionTargetSelectionStatus = 'planned' | 'skipped';
 export type NextExpansionTargetSelectionReason =
   | 'noCandidate'
+  | 'roomLimitReached'
   | 'unmetPreconditions'
   | 'insufficientEvidence'
   | 'unavailable';
@@ -516,6 +518,10 @@ function getSelectionSkipReason(report: ExpansionCandidateReport): NextExpansion
     return 'noCandidate';
   }
 
+  if (report.candidates.every(isBlockedOnlyByRoomLimit)) {
+    return 'roomLimitReached';
+  }
+
   if (report.candidates.some((candidate) => candidate.preconditions.length > 0)) {
     return 'unmetPreconditions';
   }
@@ -525,6 +531,13 @@ function getSelectionSkipReason(report: ExpansionCandidateReport): NextExpansion
   }
 
   return 'unavailable';
+}
+
+function isBlockedOnlyByRoomLimit(candidate: ExpansionCandidateScore): boolean {
+  return (
+    candidate.preconditions.length === 1 &&
+    candidate.preconditions[0].startsWith(ROOM_LIMIT_PRECONDITION_PREFIX)
+  );
 }
 
 function persistNextExpansionTarget(

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -111,6 +111,73 @@ export function clearOccupationRecommendationFollowUpIntent(
   return report;
 }
 
+export function suppressOccupationClaimRecommendation(
+  report: OccupationRecommendationReport
+): OccupationRecommendationReport {
+  if (report.next?.action !== 'occupy' && report.followUpIntent?.action !== 'claim') {
+    return report;
+  }
+
+  const next =
+    report.candidates.find(
+      (candidate) => candidate.action !== 'occupy' && candidate.evidenceStatus !== 'unavailable'
+    ) ?? null;
+  report.next = next;
+  report.followUpIntent = isNonEmptyString(report.colonyName)
+    ? buildOccupationRecommendationFollowUpIntent(report.colonyName, next)
+    : null;
+  return report;
+}
+
+export function clearOccupationRecommendationClaimIntent(colony: string): void {
+  if (!isNonEmptyString(colony)) {
+    return;
+  }
+
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const removedTargetKeys = new Set<string>();
+  if (Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = territoryMemory.targets.filter((rawTarget) => {
+      const target = normalizeTerritoryTarget(rawTarget);
+      if (
+        target?.colony !== colony ||
+        target.action !== 'claim' ||
+        target.createdBy !== OCCUPATION_RECOMMENDATION_TARGET_CREATOR
+      ) {
+        return true;
+      }
+
+      removedTargetKeys.add(getOccupationRecommendationTargetKey(target.roomName, target.action));
+      return false;
+    });
+  }
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  const nextIntents = intents.filter(
+    (intent) =>
+      !(
+        intent.colony === colony &&
+        intent.action === 'claim' &&
+        (intent.createdBy === OCCUPATION_RECOMMENDATION_TARGET_CREATOR ||
+          removedTargetKeys.has(getOccupationRecommendationTargetKey(intent.targetRoom, intent.action)))
+      )
+  );
+
+  if (nextIntents.length === intents.length) {
+    return;
+  }
+
+  if (nextIntents.length > 0) {
+    territoryMemory.intents = nextIntents;
+  } else {
+    delete territoryMemory.intents;
+  }
+}
+
 export function scoreOccupationRecommendations(
   input: OccupationRecommendationInput
 ): OccupationRecommendationReport {
@@ -121,7 +188,7 @@ export function scoreOccupationRecommendations(
   const next = candidates.find((candidate) => candidate.evidenceStatus !== 'unavailable') ?? null;
 
   return attachOccupationRecommendationReportColony(
-    { candidates, next, followUpIntent: buildOccupationRecommendationFollowUpIntent(input, next) },
+    { candidates, next, followUpIntent: buildOccupationRecommendationFollowUpIntent(input.colonyName, next) },
     input.colonyName
   );
 }
@@ -277,6 +344,10 @@ function buildActiveOccupationRecommendationControlTarget(
   }
 
   return { roomName: recommendation.roomName, action };
+}
+
+function getOccupationRecommendationTargetKey(roomName: string, action: TerritoryIntentAction): string {
+  return `${roomName}:${action}`;
 }
 
 function revokeOccupationRecommendationTarget(territoryMemory: TerritoryMemory, intent: TerritoryIntentMemory): void {
@@ -543,7 +614,7 @@ function scoreOccupationCandidate(
 }
 
 function buildOccupationRecommendationFollowUpIntent(
-  input: OccupationRecommendationInput,
+  colonyName: string,
   next: OccupationRecommendationScore | null
 ): OccupationRecommendationFollowUpIntent | null {
   if (!next) {
@@ -551,7 +622,7 @@ function buildOccupationRecommendationFollowUpIntent(
   }
 
   return {
-    colony: input.colonyName,
+    colony: colonyName,
     targetRoom: next.roomName,
     action: getTerritoryIntentAction(next.action),
     ...(next.controllerId ? { controllerId: next.controllerId } : {}),

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -234,6 +234,7 @@ export function persistOccupationRecommendationFollowUpIntent(
     action: followUpIntent.action,
     status: existingIntent?.status === 'active' ? 'active' : 'planned',
     updatedAt: gameTime,
+    createdBy: OCCUPATION_RECOMMENDATION_TARGET_CREATOR,
     ...(controllerId ? { controllerId } : {}),
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(followUp ? { followUp } : {}),

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -3133,8 +3133,15 @@ function findTerritoryIntentIndex(
   nextIntent: TerritoryIntentMemory
 ): number {
   if (nextIntent.createdBy) {
-    return intents.findIndex(
+    const sourceOwnedIntentIndex = intents.findIndex(
       (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === nextIntent.createdBy
+    );
+    if (sourceOwnedIntentIndex >= 0) {
+      return sourceOwnedIntentIndex;
+    }
+
+    return intents.findIndex(
+      (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === undefined
     );
   }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -3133,15 +3133,8 @@ function findTerritoryIntentIndex(
   nextIntent: TerritoryIntentMemory
 ): number {
   if (nextIntent.createdBy) {
-    const sourceOwnedIntentIndex = intents.findIndex(
-      (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === nextIntent.createdBy
-    );
-    if (sourceOwnedIntentIndex >= 0) {
-      return sourceOwnedIntentIndex;
-    }
-
     return intents.findIndex(
-      (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === undefined
+      (intent) => isSameTerritoryIntentRecord(intent, nextIntent) && intent.createdBy === nextIntent.createdBy
     );
   }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -162,6 +162,7 @@ declare global {
   type RoomExpansionSelectionStatus = 'planned' | 'skipped';
   type RoomExpansionSelectionReason =
     | 'noCandidate'
+    | 'roomLimitReached'
     | 'unmetPreconditions'
     | 'insufficientEvidence'
     | 'unavailable';

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -1,6 +1,7 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import type { RuntimeTelemetryEvent } from '../src/telemetry/runtimeSummary';
 import {
+  clearAutonomousExpansionClaimIntent,
   refreshAutonomousExpansionClaimIntent,
   shouldDeferOccupationRecommendationForExpansionClaim
 } from '../src/territory/claimExecutor';
@@ -58,6 +59,7 @@ describe('autonomous expansion claim executor', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 100,
+        createdBy: 'autonomousExpansionClaim',
         controllerId: 'controller2'
       }
     ]);
@@ -140,6 +142,120 @@ describe('autonomous expansion claim executor', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 104,
+        createdBy: 'autonomousExpansionClaim',
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
+  it('keeps non-autonomous claim intents when autonomous claims are cleared', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            action: 'claim',
+            createdBy: 'autonomousExpansionClaim',
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 105,
+            createdBy: 'autonomousExpansionClaim',
+            controllerId: 'controller2' as Id<StructureController>
+          },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 104,
+            controllerId: 'controller2' as Id<StructureController>
+          },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 103,
+            createdBy: 'occupationRecommendation',
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ]
+      }
+    };
+
+    clearAutonomousExpansionClaimIntent('W1N1');
+
+    expect(Memory.territory?.targets).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 104,
+        controllerId: 'controller2'
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 103,
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
+  it('adds a source-scoped autonomous claim intent without overwriting unowned claim progress', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 105,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ]
+      }
+    };
+    (Game.rooms as Record<string, Room>).W2N1 = makeTargetRoom('W2N1', {
+      controllerId: 'controller2' as Id<StructureController>
+    });
+
+    refreshAutonomousExpansionClaimIntent(
+      makeColony(),
+      makeReport([makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })]),
+      106
+    );
+
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'active',
+        updatedAt: 105,
+        controllerId: 'controller2'
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 106,
+        createdBy: 'autonomousExpansionClaim',
         controllerId: 'controller2'
       }
     ]);

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -874,6 +874,7 @@ describe('runEconomy', () => {
             action: 'claim',
             status: 'planned',
             updatedAt: 499,
+            createdBy: 'autonomousExpansionClaim',
             controllerId: 'controller2' as Id<StructureController>
           },
           {
@@ -1023,6 +1024,7 @@ describe('runEconomy', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: 323,
+        createdBy: 'occupationRecommendation',
         controllerId: 'controller2',
         requiresControllerPressure: true,
         followUp
@@ -1210,6 +1212,7 @@ describe('runEconomy', () => {
       action: 'claim',
       status: 'planned',
       updatedAt: 325,
+      createdBy: 'occupationRecommendation',
       controllerId: 'controller3'
     });
   });

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -753,19 +753,29 @@ describe('runEconomy', () => {
       colony: 'W1N1',
       reason: 'roomLimitReached'
     });
-    expect(Memory.territory?.targets).toEqual([{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]);
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
+      }
+    ]);
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
         targetRoom: 'W2N1',
         action: 'reserve',
         status: 'planned',
-        updatedAt: 502
+        updatedAt: 502,
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
       }
     ]);
   });
 
-  it('keeps recommendation reserve targets when the RCL room limit caps expansion claims', () => {
+  it('refreshes recommendation reserve targets when the RCL room limit caps expansion claims', () => {
     (globalThis as unknown as {
       FIND_SOURCES: number;
       FIND_HOSTILE_CREEPS: number;
@@ -814,7 +824,116 @@ describe('runEconomy', () => {
       colony: 'W1N1',
       reason: 'roomLimitReached'
     });
-    expect(Memory.territory?.targets).toContainEqual(recommendationTarget);
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
+      }
+    ]);
+    expect(Memory.territory?.targets).not.toContainEqual(recommendationTarget);
+  });
+
+  it('clears stale automated claim recommendations while preserving RCL-capped reserves', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_HOSTILE_CREEPS: number;
+      FIND_HOSTILE_STRUCTURES: number;
+      TERRAIN_MASK_WALL: number;
+      TERRAIN_MASK_SWAMP: number;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 2;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 3;
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { TERRAIN_MASK_SWAMP: number }).TERRAIN_MASK_SWAMP = 2;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            action: 'claim',
+            createdBy: 'autonomousExpansionClaim',
+            controllerId: 'controller2' as Id<StructureController>
+          },
+          {
+            colony: 'W1N1',
+            roomName: 'W4N1',
+            action: 'claim',
+            createdBy: 'occupationRecommendation',
+            controllerId: 'controller4' as Id<StructureController>
+          }
+        ],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 499,
+            controllerId: 'controller2' as Id<StructureController>
+          },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W4N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 499,
+            controllerId: 'controller4' as Id<StructureController>
+          }
+        ]
+      }
+    };
+    const room = makeTerritoryReadyEconomyRoom();
+    const targetRoom = makeVisibleExpansionScoringRoom('W2N1', 'controller2' as Id<StructureController>);
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 504,
+      rooms: { W1N1: room, W2N1: targetRoom, W3N1: makeOwnedEconomyRoom('W3N1') },
+      spawns: {},
+      creeps: workers,
+      getObjectById: jest.fn().mockReturnValue(null),
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' })),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain: jest.fn(() => ({ get: jest.fn().mockReturnValue(0) } as unknown as RoomTerrain))
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(room.memory.cachedExpansionSelection).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'roomLimitReached'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 504,
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
+      }
+    ]);
   });
 
   it('uses a second idle spawn for controller pressure after spawning follow-up support', () => {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -751,7 +751,7 @@ describe('runEconomy', () => {
     expect(room.memory.cachedExpansionSelection).toMatchObject({
       status: 'skipped',
       colony: 'W1N1',
-      reason: 'unmetPreconditions'
+      reason: 'roomLimitReached'
     });
     expect(Memory.territory?.targets).toEqual([{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]);
     expect(Memory.territory?.intents).toEqual([
@@ -763,6 +763,58 @@ describe('runEconomy', () => {
         updatedAt: 502
       }
     ]);
+  });
+
+  it('keeps recommendation reserve targets when the RCL room limit caps expansion claims', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_HOSTILE_CREEPS: number;
+      FIND_HOSTILE_STRUCTURES: number;
+      TERRAIN_MASK_WALL: number;
+      TERRAIN_MASK_SWAMP: number;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 2;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 3;
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { TERRAIN_MASK_SWAMP: number }).TERRAIN_MASK_SWAMP = 2;
+    const recommendationTarget: TerritoryTargetMemory = {
+      colony: 'W1N1',
+      roomName: 'W9N9',
+      action: 'reserve',
+      createdBy: 'occupationRecommendation'
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: { targets: [recommendationTarget] }
+    };
+    const room = makeTerritoryReadyEconomyRoom();
+    const targetRoom = makeVisibleExpansionScoringRoom('W2N1', 'controller2' as Id<StructureController>);
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 503,
+      rooms: { W1N1: room, W2N1: targetRoom, W3N1: makeOwnedEconomyRoom('W3N1') },
+      spawns: {},
+      creeps: workers,
+      getObjectById: jest.fn().mockReturnValue(null),
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' })),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain: jest.fn(() => ({ get: jest.fn().mockReturnValue(0) } as unknown as RoomTerrain))
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(room.memory.cachedExpansionSelection).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'roomLimitReached'
+    });
+    expect(Memory.territory?.targets).toContainEqual(recommendationTarget);
   });
 
   it('uses a second idle spawn for controller pressure after spawning follow-up support', () => {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -700,6 +700,71 @@ describe('runEconomy', () => {
     });
   });
 
+  it('refreshes next expansion scoring before the interval when owned room count reaches the RCL cap', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_HOSTILE_CREEPS: number;
+      FIND_HOSTILE_STRUCTURES: number;
+      TERRAIN_MASK_WALL: number;
+      TERRAIN_MASK_SWAMP: number;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 2;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 3;
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { TERRAIN_MASK_SWAMP: number }).TERRAIN_MASK_SWAMP = 2;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const room = makeTerritoryReadyEconomyRoom();
+    const targetRoom = makeVisibleExpansionScoringRoom('W2N1', 'controller2' as Id<StructureController>);
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    const getRoomTerrain = jest.fn(() => ({ get: jest.fn().mockReturnValue(0) } as unknown as RoomTerrain));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 501,
+      rooms: { W1N1: room, W2N1: targetRoom },
+      spawns: {},
+      creeps: workers,
+      getObjectById: jest.fn().mockReturnValue(null),
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' })),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game.rooms = {
+      W1N1: room,
+      W2N1: targetRoom,
+      W3N1: makeOwnedEconomyRoom('W3N1')
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game.time = 502;
+
+    runEconomy();
+
+    expect(getRoomTerrain).toHaveBeenCalledTimes(2);
+    expect(room.memory.lastExpansionScoreTime).toBe(502);
+    expect(room.memory.cachedExpansionSelection).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unmetPreconditions'
+    });
+    expect(Memory.territory?.targets).toEqual([{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 502
+      }
+    ]);
+  });
+
   it('uses a second idle spawn for controller pressure after spawning follow-up support', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     const followUp: TerritoryFollowUpMemory = {
@@ -1599,6 +1664,19 @@ function makeTerritoryReadyEconomyRoom({
       ticksToDowngrade: 10_000
     } as StructureController,
     find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: 'home-source' } as Source] : []))
+  } as unknown as Room;
+}
+
+function makeOwnedEconomyRoom(roomName: string): Room {
+  return {
+    name: roomName,
+    controller: {
+      my: true,
+      owner: { username: 'me' },
+      level: 3,
+      ticksToDowngrade: 10_000
+    } as StructureController,
+    find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
   } as unknown as Room;
 }
 

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -425,6 +425,29 @@ describe('next expansion scoring', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
+  it('reports the RCL room limit even when another expansion precondition is also unmet', () => {
+    const colony = makeSafeColony({ controllerLevel: 3 });
+    const report = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W3N1', sourceCount: 2 })], {
+        controllerLevel: 3,
+        ownedRoomCount: 2,
+        ticksToDowngrade: 100
+      })
+    );
+
+    expect(report.next?.preconditions).toEqual(
+      expect.arrayContaining([
+        'limit expansion to 2 owned rooms for current controller level',
+        'stabilize home controller downgrade timer'
+      ])
+    );
+    expect(refreshNextExpansionTargetSelection(colony, report, 213)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'roomLimitReached'
+    });
+  });
+
   it('leaves reserve intent planning available when the next expansion claim gate is at its room limit', () => {
     const colony = makeSafeColony({ controllerLevel: 2 });
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -1,6 +1,7 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import {
   buildRuntimeExpansionCandidateReport,
+  maxRoomsForRcl,
   refreshNextExpansionTargetSelection,
   scoreExpansionCandidates,
   type ExpansionCandidateInput,
@@ -376,6 +377,133 @@ describe('next expansion scoring', () => {
     ]);
   });
 
+  it.each([
+    [1, 1],
+    [2, 1],
+    [3, 2],
+    [4, 3],
+    [5, 5],
+    [6, 8],
+    [7, 15],
+    [8, 99]
+  ])('blocks next expansion claims at the RCL %i max room boundary', (controllerLevel, maxRoomCount) => {
+    expect(maxRoomsForRcl(controllerLevel)).toBe(maxRoomCount);
+
+    const atLimit = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: `W${controllerLevel + 1}N1` })], {
+        controllerLevel,
+        ownedRoomCount: maxRoomCount
+      })
+    );
+    const belowLimit = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: `W${controllerLevel + 2}N1` })], {
+        controllerLevel,
+        ownedRoomCount: maxRoomCount - 1
+      })
+    );
+    const roomLimitPrecondition = `limit expansion to ${maxRoomCount} owned rooms for current controller level`;
+
+    expect(atLimit.next?.preconditions).toContain(roomLimitPrecondition);
+    expect(belowLimit.next?.preconditions).not.toContain(roomLimitPrecondition);
+  });
+
+  it('does not persist next expansion claim intents when the RCL room limit is reached', () => {
+    const colony = makeSafeColony({ controllerLevel: 3 });
+    const report = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W3N1', sourceCount: 2 })], {
+        controllerLevel: 3,
+        ownedRoomCount: 2
+      })
+    );
+
+    expect(refreshNextExpansionTargetSelection(colony, report, 210)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unmetPreconditions'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toBeUndefined();
+  });
+
+  it('leaves reserve intent planning available when the next expansion claim gate is at its room limit', () => {
+    const colony = makeSafeColony({ controllerLevel: 2 });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'reserve' }]
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeVisibleExpansionRoom('W2N1', { sourceCount: 2 })
+      }
+    };
+
+    const report = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W3N1', sourceCount: 2 })], {
+        controllerLevel: 2,
+        ownedRoomCount: 1
+      })
+    );
+
+    expect(report.next?.preconditions).toContain(
+      'limit expansion to 1 owned rooms for current controller level'
+    );
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 211)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve'
+    });
+  });
+
+  it('preserves non-next-expansion claim intents when the RCL room limit prunes generated targets', () => {
+    const colony = makeSafeColony({ controllerLevel: 3 });
+    const activeClaimIntent: TerritoryIntentMemory = {
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      status: 'active',
+      updatedAt: 205,
+      createdBy: 'occupationRecommendation'
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          {
+            colony: 'W1N1',
+            roomName: 'W4N1',
+            action: 'claim',
+            createdBy: 'nextExpansionScoring'
+          }
+        ],
+        intents: [
+          activeClaimIntent,
+          {
+            colony: 'W1N1',
+            targetRoom: 'W4N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 206,
+            createdBy: 'nextExpansionScoring'
+          }
+        ]
+      }
+    };
+    const report = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W3N1', sourceCount: 2 })], {
+        controllerLevel: 3,
+        ownedRoomCount: 2
+      })
+    );
+
+    expect(refreshNextExpansionTargetSelection(colony, report, 212)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unmetPreconditions'
+    });
+    expect(Memory.territory?.targets).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([activeClaimIntent]);
+  });
+
   it('does not persist a next expansion target while post-claim bootstrap is active', () => {
     const colony = makeSafeColony();
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
@@ -424,6 +552,7 @@ function makeInput(
     colonyOwnerUsername: 'me',
     energyCapacityAvailable: 650,
     controllerLevel: 3,
+    ownedRoomCount: 1,
     ticksToDowngrade: 10_000,
     candidates,
     ...overrides
@@ -448,13 +577,17 @@ function makeCandidate(overrides: Partial<ExpansionCandidateInput> = {}): Expans
   };
 }
 
-function makeSafeColony(): ColonySnapshot {
+function makeSafeColony({
+  controllerLevel = 3
+}: {
+  controllerLevel?: number;
+} = {}): ColonySnapshot {
   const room = {
     name: 'W1N1',
     controller: {
       my: true,
       owner: { username: 'me' },
-      level: 3,
+      level: controllerLevel,
       ticksToDowngrade: 10_000
     } as StructureController,
     energyAvailable: 650,

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -419,7 +419,7 @@ describe('next expansion scoring', () => {
     expect(refreshNextExpansionTargetSelection(colony, report, 210)).toEqual({
       status: 'skipped',
       colony: 'W1N1',
-      reason: 'unmetPreconditions'
+      reason: 'roomLimitReached'
     });
     expect(Memory.territory?.targets).toBeUndefined();
     expect(Memory.territory?.intents).toBeUndefined();
@@ -498,7 +498,7 @@ describe('next expansion scoring', () => {
     expect(refreshNextExpansionTargetSelection(colony, report, 212)).toEqual({
       status: 'skipped',
       colony: 'W1N1',
-      reason: 'unmetPreconditions'
+      reason: 'roomLimitReached'
     });
     expect(Memory.territory?.targets).toEqual([]);
     expect(Memory.territory?.intents).toEqual([activeClaimIntent]);

--- a/prod/test/occupationRecommendation.test.ts
+++ b/prod/test/occupationRecommendation.test.ts
@@ -426,6 +426,7 @@ describe('occupation recommendation scoring', () => {
       action: 'claim',
       status: 'planned',
       updatedAt: 700,
+      createdBy: 'occupationRecommendation',
       controllerId: 'controller3'
     });
     expect(Memory.territory?.intents).toEqual([
@@ -436,6 +437,7 @@ describe('occupation recommendation scoring', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 700,
+        createdBy: 'occupationRecommendation',
         controllerId: 'controller3'
       }
     ]);
@@ -509,6 +511,7 @@ describe('occupation recommendation scoring', () => {
       action: 'claim',
       status: 'planned',
       updatedAt: 704,
+      createdBy: 'occupationRecommendation',
       controllerId: 'controller3'
     });
     expect(Memory.territory?.targets).toEqual([
@@ -560,6 +563,7 @@ describe('occupation recommendation scoring', () => {
       action: 'claim',
       status: 'planned',
       updatedAt: 705,
+      createdBy: 'occupationRecommendation',
       controllerId: 'controller3'
     });
     expect(Memory.territory?.targets).toEqual([
@@ -636,7 +640,8 @@ describe('occupation recommendation scoring', () => {
       targetRoom: 'W6N1',
       action: 'scout',
       status: 'planned',
-      updatedAt: 706
+      updatedAt: 706,
+      createdBy: 'occupationRecommendation'
     });
     expect(Memory.territory?.targets).toEqual([
       manualTarget,
@@ -698,6 +703,7 @@ describe('occupation recommendation scoring', () => {
       action: 'reserve',
       status: 'planned',
       updatedAt: 707,
+      createdBy: 'occupationRecommendation',
       controllerId: 'controller3'
     });
     expect(Memory.territory?.targets).toEqual([]);
@@ -738,7 +744,8 @@ describe('occupation recommendation scoring', () => {
       targetRoom: 'W2N1',
       action: 'reserve',
       status: 'planned',
-      updatedAt: 701
+      updatedAt: 701,
+      createdBy: 'occupationRecommendation'
     });
     expect(Memory.territory?.targets).toBeUndefined();
   });
@@ -819,6 +826,7 @@ describe('occupation recommendation scoring', () => {
       action: 'reserve',
       status: 'planned',
       updatedAt: 703,
+      createdBy: 'occupationRecommendation',
       controllerId: 'controller2'
     });
     expect(Memory.territory?.targets).toEqual([
@@ -1032,6 +1040,7 @@ describe('occupation recommendation scoring', () => {
       action: 'reserve',
       status: 'planned',
       updatedAt: 702,
+      createdBy: 'occupationRecommendation',
       controllerId: 'controller2'
     });
     expect(Memory.territory?.targets).toEqual([
@@ -1083,6 +1092,7 @@ describe('occupation recommendation scoring', () => {
       action: 'claim',
       status: 'active',
       updatedAt: 700,
+      createdBy: 'occupationRecommendation',
       controllerId: 'controller3',
       followUp
     });
@@ -1093,6 +1103,7 @@ describe('occupation recommendation scoring', () => {
         action: 'claim',
         status: 'active',
         updatedAt: 700,
+        createdBy: 'occupationRecommendation',
         controllerId: 'controller3',
         followUp
       }
@@ -1124,6 +1135,7 @@ describe('occupation recommendation scoring', () => {
       action: 'reserve',
       status: 'planned',
       updatedAt: 720,
+      createdBy: 'occupationRecommendation',
       controllerId: 'controller2',
       followUp
     });
@@ -1134,6 +1146,7 @@ describe('occupation recommendation scoring', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: 720,
+        createdBy: 'occupationRecommendation',
         controllerId: 'controller2',
         followUp
       }
@@ -1158,6 +1171,7 @@ describe('occupation recommendation scoring', () => {
       action: 'reserve',
       status: 'planned',
       updatedAt: 730,
+      createdBy: 'occupationRecommendation',
       requiresControllerPressure: true
     });
 
@@ -1169,6 +1183,7 @@ describe('occupation recommendation scoring', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: 730,
+        createdBy: 'occupationRecommendation',
         requiresControllerPressure: true
       }
     ]);
@@ -1207,7 +1222,8 @@ describe('occupation recommendation scoring', () => {
       targetRoom: 'W2N1',
       action: 'reserve',
       status: 'planned',
-      updatedAt: 731
+      updatedAt: 731,
+      createdBy: 'occupationRecommendation'
     });
     expect(Memory.territory?.intents).toEqual([
       {
@@ -1215,7 +1231,8 @@ describe('occupation recommendation scoring', () => {
         targetRoom: 'W2N1',
         action: 'reserve',
         status: 'planned',
-        updatedAt: 731
+        updatedAt: 731,
+        createdBy: 'occupationRecommendation'
       }
     ]);
   });
@@ -1247,6 +1264,7 @@ describe('occupation recommendation scoring', () => {
       action: 'reserve',
       status: 'planned',
       updatedAt: 731,
+      createdBy: 'occupationRecommendation',
       requiresControllerPressure: true
     });
     expect(Memory.territory?.intents).toEqual([
@@ -1256,6 +1274,7 @@ describe('occupation recommendation scoring', () => {
         action: 'reserve',
         status: 'planned',
         updatedAt: 731,
+        createdBy: 'occupationRecommendation',
         requiresControllerPressure: true
       }
     ]);
@@ -1288,6 +1307,7 @@ describe('occupation recommendation scoring', () => {
       action: 'claim',
       status: 'planned',
       updatedAt: 731,
+      createdBy: 'occupationRecommendation',
       requiresControllerPressure: true
     });
     expect(Memory.territory?.intents).toEqual([
@@ -1297,6 +1317,7 @@ describe('occupation recommendation scoring', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 731,
+        createdBy: 'occupationRecommendation',
         requiresControllerPressure: true
       }
     ]);
@@ -1344,6 +1365,7 @@ describe('occupation recommendation scoring', () => {
         action,
         status: 'planned',
         updatedAt: 731,
+        createdBy: 'occupationRecommendation',
         requiresControllerPressure: true
       });
       expect(Memory.territory?.intents).toEqual([
@@ -1353,6 +1375,7 @@ describe('occupation recommendation scoring', () => {
           action,
           status: 'planned',
           updatedAt: 731,
+          createdBy: 'occupationRecommendation',
           requiresControllerPressure: true
         }
       ]);
@@ -1386,7 +1409,8 @@ describe('occupation recommendation scoring', () => {
       targetRoom: 'W2N1',
       action: 'reserve',
       status: 'planned',
-      updatedAt: 731
+      updatedAt: 731,
+      createdBy: 'occupationRecommendation'
     });
     expect(Memory.territory?.intents).toEqual([
       {
@@ -1394,7 +1418,8 @@ describe('occupation recommendation scoring', () => {
         targetRoom: 'W2N1',
         action: 'reserve',
         status: 'planned',
-        updatedAt: 731
+        updatedAt: 731,
+        createdBy: 'occupationRecommendation'
       }
     ]);
   });

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -946,6 +946,7 @@ describe('runtime telemetry summaries', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: RUNTIME_SUMMARY_INTERVAL,
+        createdBy: 'occupationRecommendation',
         controllerId: 'controller2'
       }
     ]);

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1419,6 +1419,7 @@ describe('planSpawn', () => {
       action: 'claim',
       status: 'planned',
       updatedAt: 147,
+      createdBy: 'occupationRecommendation',
       requiresControllerPressure: true
     });
 
@@ -1441,6 +1442,7 @@ describe('planSpawn', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 148,
+        createdBy: 'occupationRecommendation',
         requiresControllerPressure: true
       }
     ]);

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -64,6 +64,70 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('keeps source-owned territory intents separate from unowned progress records', () => {
+    const colony = makeSafeColony();
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: {
+          name: 'W2N1',
+          controller: { id: 'controller2', my: false } as StructureController
+        } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            action: 'reserve',
+            createdBy: 'occupationRecommendation',
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'reserve',
+            status: 'active',
+            updatedAt: 599,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        ]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 600)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller2',
+      createdBy: 'occupationRecommendation'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 599,
+        controllerId: 'controller2'
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 600,
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
   it('seeds an adjacent reserve target when no configured targets exist', () => {
     const colony = makeSafeColony();
     const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));


### PR DESCRIPTION
## Summary
Enforce RCL-gated maximum room count to prevent low-RCL overexpansion.

## Changes
- Add RCL → maxRoomCount mapping in `expansionScoring.ts`
- Add preconditions check: when `ownedRoomCount >= maxRoomsForRcl(controllerLevel)`, block new claim/reserve intent generation
- Reserves are always allowed
- Does not affect already-claimed rooms' maintenance

## Verification
- Typecheck: PASS
- Tests: 37 suites, 881 tests, all passed
- Build: PASS

Closes #559