### PR TITLE
feat(defense): make rampart/tower construction proactive, not only reactive to hostile presence (#558)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7115,10 +7115,12 @@ function getTowerLimitForRcl(level) {
   return level ? (_a = TOWER_LIMITS_BY_RCL[level]) != null ? _a : 0 : 0;
 }
 function getExistingAndPendingBuildCount(state, globalName, fallback) {
-  var _a, _b, _c;
+  var _a, _b;
   const existingStructures = countStructuresByType(state.ownedStructures, globalName, fallback);
   const existingCount = existingStructures != null ? existingStructures : globalName === "STRUCTURE_TOWER" && fallback === "tower" ? (_a = state.towerCount) != null ? _a : 0 : 0;
-  const pendingCount = (_c = (_b = state.ownedConstructionSites) == null ? void 0 : _b.filter((site) => matchesStructureType5(String(site.structureType), globalName, fallback)).length) != null ? _c : 0;
+  const pendingCount = ((_b = state.ownedConstructionSites) != null ? _b : []).filter(
+    (site) => matchesStructureType5(String(site.structureType), globalName, fallback)
+  ).length;
   return existingCount + pendingCount;
 }
 function buildRemoteLogisticsCandidates(state) {
@@ -7170,8 +7172,8 @@ function createCandidateForBuildType(buildType, state) {
         risk: ["requires steady energy income to keep tower effective"],
         estimatedEnergyCost: STRUCTURE_BUILD_COSTS.tower,
         hostileExposure: "medium",
-        signals: { defense: Math.max(0.75, getDefensePressure(state)), enemyKillPotential: 0.7 },
-        vision: { survival: Math.max(0.75, getDefensePressure(state)), territory: 0.9, enemyKills: 0.5 }
+        signals: { defense: getDefensePressure(state), enemyKillPotential: 0.7 },
+        vision: { survival: getDefensePressure(state), territory: 0.9, enemyKills: 0.5 }
       };
     case "rampart":
       return {
@@ -7183,8 +7185,8 @@ function createCandidateForBuildType(buildType, state) {
         risk: ["decays without sustained repair budget"],
         estimatedEnergyCost: STRUCTURE_BUILD_COSTS.rampart,
         hostileExposure: "medium",
-        signals: { defense: Math.max(0.7, getDefensePressure(state)), repairDecay: getRepairDecayPressure(state) },
-        vision: { survival: Math.max(0.7, getDefensePressure(state)), territory: 0.8, enemyKills: 0.15 }
+        signals: { defense: getDefensePressure(state), repairDecay: getRepairDecayPressure(state) },
+        vision: { survival: getDefensePressure(state), territory: 0.8, enemyKills: 0.15 }
       };
     case "road":
       return {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6494,6 +6494,14 @@ var CONTROLLER_DOWNGRADE_WARNING_TICKS = 1e4;
 var EARLY_ENERGY_CAPACITY_TARGET = 550;
 var MIN_SAFE_WORKERS_FOR_EXPANSION = 3;
 var MIN_RCL_FOR_AUTOMATED_ROADS = 4;
+var TOWER_LIMITS_BY_RCL = {
+  3: 1,
+  4: 1,
+  5: 2,
+  6: 2,
+  7: 3,
+  8: 6
+};
 var DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE = 20;
 var MAX_SCORE = 100;
 var MAX_URGENCY_POINTS = 35;
@@ -6508,14 +6516,14 @@ var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var CONSTRUCTION_SITE_IMPACT_PRIORITY = {
   extension: 100,
   spawn: 95,
-  sourceContainer: 85,
-  criticalRoad: 75,
-  tower: 60,
-  container: 55,
-  protectedRampart: 50,
-  road: 45,
+  tower: 90,
+  protectedRampart: 90,
+  rampart: 85,
+  sourceContainer: 70,
+  criticalRoad: 80,
+  road: 55,
+  container: 45,
   other: 35,
-  rampart: 20,
   wall: 5
 };
 var STRUCTURE_BUILD_COSTS = {
@@ -7077,29 +7085,41 @@ function buildExistingSiteCandidates(state) {
   });
 }
 function buildPlannedLocalCandidates(state) {
-  var _a, _b, _c, _d, _e, _f;
+  var _a, _b, _c, _d, _e;
   const candidates = [];
   const rcl = (_a = state.rcl) != null ? _a : 0;
   const extensionLimit = getExtensionLimitForRcl(state.rcl);
+  const towerLimit = getTowerLimitForRcl(state.rcl);
   if (extensionLimit > 0 && ((_b = state.extensionCount) != null ? _b : 0) < extensionLimit) {
     candidates.push(createCandidateForBuildType("extension", state));
   }
-  if (rcl >= 2 && ((_c = state.sourceCount) != null ? _c : 0) > 0) {
-    candidates.push(createCandidateForBuildType("container", state));
-  }
-  if (rcl >= MIN_RCL_FOR_AUTOMATED_ROADS && ((_d = state.sourceCount) != null ? _d : 0) > 0) {
-    candidates.push(createCandidateForBuildType("road", state));
-  }
-  if (rcl >= 2 && getDefensePressure(state) > 0) {
-    candidates.push(createCandidateForBuildType("rampart", state));
-  }
-  if (rcl >= 3 && ((_e = state.towerCount) != null ? _e : 0) === 0) {
+  if (towerLimit > 0 && getExistingAndPendingBuildCount(state, "STRUCTURE_TOWER", "tower") < towerLimit) {
     candidates.push(createCandidateForBuildType("tower", state));
   }
-  if (((_f = state.spawnCount) != null ? _f : 1) === 0) {
+  if (rcl >= 2) {
+    candidates.push(createCandidateForBuildType("rampart", state));
+  }
+  if (rcl >= MIN_RCL_FOR_AUTOMATED_ROADS && ((_c = state.sourceCount) != null ? _c : 0) > 0) {
+    candidates.push(createCandidateForBuildType("road", state));
+  }
+  if (rcl >= 2 && ((_d = state.sourceCount) != null ? _d : 0) > 0) {
+    candidates.push(createCandidateForBuildType("container", state));
+  }
+  if (((_e = state.spawnCount) != null ? _e : 1) === 0) {
     candidates.push(createCandidateForBuildType("spawn", state));
   }
   return candidates;
+}
+function getTowerLimitForRcl(level) {
+  var _a;
+  return level ? (_a = TOWER_LIMITS_BY_RCL[level]) != null ? _a : 0 : 0;
+}
+function getExistingAndPendingBuildCount(state, globalName, fallback) {
+  var _a, _b, _c;
+  const existingStructures = countStructuresByType(state.ownedStructures, globalName, fallback);
+  const existingCount = existingStructures != null ? existingStructures : globalName === "STRUCTURE_TOWER" && fallback === "tower" ? (_a = state.towerCount) != null ? _a : 0 : 0;
+  const pendingCount = (_c = (_b = state.ownedConstructionSites) == null ? void 0 : _b.filter((site) => matchesStructureType5(String(site.structureType), globalName, fallback)).length) != null ? _c : 0;
+  return existingCount + pendingCount;
 }
 function buildRemoteLogisticsCandidates(state) {
   var _a, _b;
@@ -7145,26 +7165,26 @@ function createCandidateForBuildType(buildType, state) {
         buildItem: "build tower defense",
         buildType,
         minimumRcl: 3,
-        requiredObservations: ["room-controller", "hostile-presence", "energy-capacity", "worker-count"],
+        requiredObservations: ["room-controller", "energy-capacity", "worker-count"],
         expectedKpiMovement: ["improves room hold safety", "adds hostile damage and repair response capacity"],
         risk: ["requires steady energy income to keep tower effective"],
         estimatedEnergyCost: STRUCTURE_BUILD_COSTS.tower,
         hostileExposure: "medium",
         signals: { defense: Math.max(0.75, getDefensePressure(state)), enemyKillPotential: 0.7 },
-        vision: { survival: getDefensePressure(state), territory: 0.9, enemyKills: 0.5 }
+        vision: { survival: Math.max(0.75, getDefensePressure(state)), territory: 0.9, enemyKills: 0.5 }
       };
     case "rampart":
       return {
         buildItem: "build rampart defense",
         buildType,
         minimumRcl: 2,
-        requiredObservations: ["room-controller", "hostile-presence", "repair-decay", "worker-count"],
+        requiredObservations: ["room-controller", "repair-decay", "worker-count"],
         expectedKpiMovement: ["improves spawn/controller survivability under pressure"],
         risk: ["decays without sustained repair budget"],
         estimatedEnergyCost: STRUCTURE_BUILD_COSTS.rampart,
         hostileExposure: "medium",
-        signals: { defense: getDefensePressure(state), repairDecay: getRepairDecayPressure(state) },
-        vision: { survival: getDefensePressure(state), territory: 0.8, enemyKills: 0.15 }
+        signals: { defense: Math.max(0.7, getDefensePressure(state)), repairDecay: getRepairDecayPressure(state) },
+        vision: { survival: Math.max(0.7, getDefensePressure(state)), territory: 0.8, enemyKills: 0.15 }
       };
     case "road":
       return {
@@ -8883,7 +8903,7 @@ function isRampartConstructionSite(site) {
   return matchesStructureType6(site.structureType, "STRUCTURE_RAMPART", "rampart");
 }
 function isHighImpactConstructionSite(site, priorityContext) {
-  return isContainerConstructionSite2(site) || getConstructionSiteImpactPriority(site, priorityContext != null ? priorityContext : {}) >= CONSTRUCTION_SITE_IMPACT_PRIORITY.tower;
+  return isContainerConstructionSite2(site) || getConstructionSiteImpactPriority(site, priorityContext != null ? priorityContext : {}) >= CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad;
 }
 function matchesStructureType6(actual, globalName, fallback) {
   var _a;

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -169,6 +169,14 @@ const MIN_RCL_FOR_AUTOMATED_CONSTRUCTION = 2;
 const MIN_RCL_FOR_AUTOMATED_ROADS = 4;
 const DEFAULT_MAX_CONTAINER_SITES_PER_TICK = 1;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
+const TOWER_LIMITS_BY_RCL: Record<number, number> = {
+  3: 1,
+  4: 1,
+  5: 2,
+  6: 2,
+  7: 3,
+  8: 6
+};
 const ROOM_EDGE_MIN = 1;
 const ROOM_EDGE_MAX = 48;
 export const DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE = 20;
@@ -185,14 +193,14 @@ const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 export const CONSTRUCTION_SITE_IMPACT_PRIORITY = {
   extension: 100,
   spawn: 95,
-  sourceContainer: 85,
-  criticalRoad: 75,
-  tower: 60,
-  container: 55,
-  protectedRampart: 50,
-  road: 45,
+  tower: 90,
+  protectedRampart: 90,
+  rampart: 85,
+  sourceContainer: 70,
+  criticalRoad: 80,
+  road: 55,
+  container: 45,
   other: 35,
-  rampart: 20,
   wall: 5
 } as const;
 
@@ -1426,24 +1434,25 @@ function buildPlannedLocalCandidates(state: RuntimeConstructionPriorityState): C
   const candidates: ConstructionBuildCandidate[] = [];
   const rcl = state.rcl ?? 0;
   const extensionLimit = getExtensionLimitForRcl(state.rcl);
+  const towerLimit = getTowerLimitForRcl(state.rcl);
   if (extensionLimit > 0 && (state.extensionCount ?? 0) < extensionLimit) {
     candidates.push(createCandidateForBuildType('extension', state));
   }
 
-  if (rcl >= 2 && (state.sourceCount ?? 0) > 0) {
-    candidates.push(createCandidateForBuildType('container', state));
+  if (towerLimit > 0 && getExistingAndPendingBuildCount(state, 'STRUCTURE_TOWER', 'tower') < towerLimit) {
+    candidates.push(createCandidateForBuildType('tower', state));
+  }
+
+  if (rcl >= 2) {
+    candidates.push(createCandidateForBuildType('rampart', state));
   }
 
   if (rcl >= MIN_RCL_FOR_AUTOMATED_ROADS && (state.sourceCount ?? 0) > 0) {
     candidates.push(createCandidateForBuildType('road', state));
   }
 
-  if (rcl >= 2 && getDefensePressure(state) > 0) {
-    candidates.push(createCandidateForBuildType('rampart', state));
-  }
-
-  if (rcl >= 3 && (state.towerCount ?? 0) === 0) {
-    candidates.push(createCandidateForBuildType('tower', state));
+  if (rcl >= 2 && (state.sourceCount ?? 0) > 0) {
+    candidates.push(createCandidateForBuildType('container', state));
   }
 
   if ((state.spawnCount ?? 1) === 0) {
@@ -1451,6 +1460,26 @@ function buildPlannedLocalCandidates(state: RuntimeConstructionPriorityState): C
   }
 
   return candidates;
+}
+
+function getTowerLimitForRcl(level: number | undefined): number {
+  return level ? TOWER_LIMITS_BY_RCL[level] ?? 0 : 0;
+}
+
+function getExistingAndPendingBuildCount(
+  state: RuntimeConstructionPriorityState,
+  globalName: StructureConstantName,
+  fallback: string
+): number {
+  const existingStructures = countStructuresByType(state.ownedStructures, globalName, fallback);
+  const existingCount =
+    existingStructures ??
+    (globalName === 'STRUCTURE_TOWER' && fallback === 'tower' ? state.towerCount ?? 0 : 0);
+  const pendingCount =
+    state.ownedConstructionSites?.filter((site) => matchesStructureType(String(site.structureType), globalName, fallback))
+      .length ?? 0;
+
+  return existingCount + pendingCount;
 }
 
 function buildRemoteLogisticsCandidates(state: RuntimeConstructionPriorityState): ConstructionBuildCandidate[] {
@@ -1500,26 +1529,26 @@ function createCandidateForBuildType(
         buildItem: 'build tower defense',
         buildType,
         minimumRcl: 3,
-        requiredObservations: ['room-controller', 'hostile-presence', 'energy-capacity', 'worker-count'],
+        requiredObservations: ['room-controller', 'energy-capacity', 'worker-count'],
         expectedKpiMovement: ['improves room hold safety', 'adds hostile damage and repair response capacity'],
         risk: ['requires steady energy income to keep tower effective'],
         estimatedEnergyCost: STRUCTURE_BUILD_COSTS.tower,
         hostileExposure: 'medium',
         signals: { defense: Math.max(0.75, getDefensePressure(state)), enemyKillPotential: 0.7 },
-        vision: { survival: getDefensePressure(state), territory: 0.9, enemyKills: 0.5 }
+        vision: { survival: Math.max(0.75, getDefensePressure(state)), territory: 0.9, enemyKills: 0.5 }
       };
     case 'rampart':
       return {
         buildItem: 'build rampart defense',
         buildType,
         minimumRcl: 2,
-        requiredObservations: ['room-controller', 'hostile-presence', 'repair-decay', 'worker-count'],
+        requiredObservations: ['room-controller', 'repair-decay', 'worker-count'],
         expectedKpiMovement: ['improves spawn/controller survivability under pressure'],
         risk: ['decays without sustained repair budget'],
         estimatedEnergyCost: STRUCTURE_BUILD_COSTS.rampart,
         hostileExposure: 'medium',
-        signals: { defense: getDefensePressure(state), repairDecay: getRepairDecayPressure(state) },
-        vision: { survival: getDefensePressure(state), territory: 0.8, enemyKills: 0.15 }
+        signals: { defense: Math.max(0.7, getDefensePressure(state)), repairDecay: getRepairDecayPressure(state) },
+        vision: { survival: Math.max(0.7, getDefensePressure(state)), territory: 0.8, enemyKills: 0.15 }
       };
     case 'road':
       return {

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -1475,9 +1475,9 @@ function getExistingAndPendingBuildCount(
   const existingCount =
     existingStructures ??
     (globalName === 'STRUCTURE_TOWER' && fallback === 'tower' ? state.towerCount ?? 0 : 0);
-  const pendingCount =
-    state.ownedConstructionSites?.filter((site) => matchesStructureType(String(site.structureType), globalName, fallback))
-      .length ?? 0;
+  const pendingCount = (state.ownedConstructionSites ?? []).filter((site) =>
+    matchesStructureType(String(site.structureType), globalName, fallback)
+  ).length;
 
   return existingCount + pendingCount;
 }
@@ -1534,8 +1534,8 @@ function createCandidateForBuildType(
         risk: ['requires steady energy income to keep tower effective'],
         estimatedEnergyCost: STRUCTURE_BUILD_COSTS.tower,
         hostileExposure: 'medium',
-        signals: { defense: Math.max(0.75, getDefensePressure(state)), enemyKillPotential: 0.7 },
-        vision: { survival: Math.max(0.75, getDefensePressure(state)), territory: 0.9, enemyKills: 0.5 }
+        signals: { defense: getDefensePressure(state), enemyKillPotential: 0.7 },
+        vision: { survival: getDefensePressure(state), territory: 0.9, enemyKills: 0.5 }
       };
     case 'rampart':
       return {
@@ -1547,8 +1547,8 @@ function createCandidateForBuildType(
         risk: ['decays without sustained repair budget'],
         estimatedEnergyCost: STRUCTURE_BUILD_COSTS.rampart,
         hostileExposure: 'medium',
-        signals: { defense: Math.max(0.7, getDefensePressure(state)), repairDecay: getRepairDecayPressure(state) },
-        vision: { survival: Math.max(0.7, getDefensePressure(state)), territory: 0.8, enemyKills: 0.15 }
+        signals: { defense: getDefensePressure(state), repairDecay: getRepairDecayPressure(state) },
+        vision: { survival: getDefensePressure(state), territory: 0.8, enemyKills: 0.15 }
       };
     case 'road':
       return {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1873,7 +1873,7 @@ function isHighImpactConstructionSite(
 ): boolean {
   return (
     isContainerConstructionSite(site) ||
-    getConstructionSiteImpactPriority(site, priorityContext ?? {}) >= CONSTRUCTION_SITE_IMPACT_PRIORITY.tower
+    getConstructionSiteImpactPriority(site, priorityContext ?? {}) >= CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad
   );
 }
 

--- a/prod/test/constructionPriority.test.ts
+++ b/prod/test/constructionPriority.test.ts
@@ -246,6 +246,31 @@ describe('impact-weighted construction site selection', () => {
     );
   });
 
+  it('keeps tower and protected rampart construction above road/container logistics', () => {
+    const towerSite = makeConstructionSite('tower-site', 'tower', 20, 20);
+    const rampartSite = makeConstructionSite('protected-rampart-site', 'rampart', 21, 20);
+    const source = { id: 'source1', pos: makeRoomPosition(22, 20) } as Source;
+    const containerSite = makeConstructionSite('source-container-site', 'container', 22, 20);
+    const roadSite = makeConstructionSite('road-site', 'road', 23, 20);
+    const origin = makeSelectionOrigin({
+      'tower-site': 5,
+      'protected-rampart-site': 5,
+      'source-container-site': 5,
+      'road-site': 5
+    });
+    const context: ConstructionSiteImpactPriorityContext = {
+      protectedRampartAnchors: [makeRoomPosition(21, 20)],
+      sources: [source]
+    };
+
+    expect(selectImpactWeightedConstructionSite(origin, [roadSite, containerSite, towerSite], context)?.id).toBe(
+      'tower-site'
+    );
+    expect(selectImpactWeightedConstructionSite(origin, [roadSite, containerSite, rampartSite], context)?.id).toBe(
+      'protected-rampart-site'
+    );
+  });
+
   it('chooses the closest site when multiple sites have the same impact', () => {
     const farExtensionSite = makeConstructionSite('extension-far', 'extension', 20, 20);
     const nearExtensionSite = makeConstructionSite('extension-near', 'extension', 21, 20);
@@ -327,6 +352,79 @@ describe('runtime construction priority report', () => {
       missingObservations: ['remote-paths']
     });
   });
+
+  it('plans tower and rampart defense without hostile-presence observation', () => {
+    const { colony } = makeRuntimeColony({
+      controllerLevel: 3,
+      energyCapacityAvailable: 800,
+      ownedStructures: [makeOwnedStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 20, 20)]
+    });
+    const globals = globalThis as Record<string, unknown>;
+    delete globals.FIND_HOSTILE_CREEPS;
+    delete globals.FIND_HOSTILE_STRUCTURES;
+
+    const report = buildRuntimeConstructionPriorityReport(colony, [
+      { memory: { role: 'worker', colony: 'W1N1' } } as Creep,
+      { memory: { role: 'worker', colony: 'W1N1' } } as Creep,
+      { memory: { role: 'worker', colony: 'W1N1' } } as Creep
+    ]);
+
+    expect(scoreByName(report.candidates, 'build tower defense')).toMatchObject({
+      blocked: false,
+      missingObservations: []
+    });
+    expect(scoreByName(report.candidates, 'build rampart defense')).toMatchObject({
+      blocked: false,
+      missingObservations: []
+    });
+    expect(scoreFor(report.candidates, 'build tower defense')).toBeGreaterThanOrEqual(
+      scoreFor(report.candidates, 'build rampart defense')
+    );
+  });
+
+  it('plans additional towers until the current RCL tower cap is covered', () => {
+    const oneTower = buildRuntimeConstructionPriorityReport(
+      makeRuntimeColony({
+        controllerLevel: 5,
+        energyCapacityAvailable: 800,
+        ownedStructures: [
+          makeOwnedStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 20, 20),
+          makeOwnedStructure('tower1', TEST_GLOBALS.STRUCTURE_TOWER, 21, 20)
+        ]
+      }).colony,
+      [{ memory: { role: 'worker', colony: 'W1N1' } } as Creep]
+    );
+
+    const saturated = buildRuntimeConstructionPriorityReport(
+      makeRuntimeColony({
+        controllerLevel: 5,
+        energyCapacityAvailable: 800,
+        ownedStructures: [
+          makeOwnedStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 20, 20),
+          makeOwnedStructure('tower1', TEST_GLOBALS.STRUCTURE_TOWER, 21, 20),
+          makeOwnedStructure('tower2', TEST_GLOBALS.STRUCTURE_TOWER, 22, 20)
+        ]
+      }).colony,
+      [{ memory: { role: 'worker', colony: 'W1N1' } } as Creep]
+    );
+
+    const pendingSecondTower = buildRuntimeConstructionPriorityReport(
+      makeRuntimeColony({
+        controllerLevel: 5,
+        energyCapacityAvailable: 800,
+        ownedStructures: [
+          makeOwnedStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 20, 20),
+          makeOwnedStructure('tower1', TEST_GLOBALS.STRUCTURE_TOWER, 21, 20)
+        ],
+        ownedConstructionSites: [makeConstructionSite('tower-site', TEST_GLOBALS.STRUCTURE_TOWER, 22, 20)]
+      }).colony,
+      [{ memory: { role: 'worker', colony: 'W1N1' } } as Creep]
+    );
+
+    expect(hasBuildItem(oneTower.candidates, 'build tower defense')).toBe(true);
+    expect(hasBuildItem(saturated.candidates, 'build tower defense')).toBe(false);
+    expect(hasBuildItem(pendingSecondTower.candidates, 'build tower defense')).toBe(false);
+  });
 });
 
 function makeRoomState(overrides: Partial<ConstructionPriorityRoomState> = {}): ConstructionPriorityRoomState {
@@ -381,26 +479,54 @@ function makeTowerCandidate(): ConstructionBuildCandidate {
   };
 }
 
-function makeRuntimeColony(): { colony: ColonySnapshot; room: Room } {
+interface RuntimeColonyOptions {
+  controllerLevel?: number;
+  energyCapacityAvailable?: number;
+  ownedConstructionSites?: ConstructionSite[];
+  ownedStructures?: AnyOwnedStructure[];
+  sources?: Source[];
+  visibleStructures?: AnyStructure[];
+}
+
+function makeRuntimeColony(options: RuntimeColonyOptions = {}): { colony: ColonySnapshot; room: Room } {
+  const controllerPosition = makeRoomPosition(25, 25);
+  let ownedStructures: AnyOwnedStructure[] = [];
+  const ownedConstructionSites = options.ownedConstructionSites ?? [];
+  const sources = options.sources ?? ([{ id: 'source1' }, { id: 'source2' }] as Source[]);
   const room = {
     name: 'W1N1',
-    controller: { my: true, level: 2, ticksToDowngrade: 20_000 } as StructureController,
+    controller: {
+      my: true,
+      level: options.controllerLevel ?? 2,
+      ticksToDowngrade: 20_000,
+      pos: controllerPosition
+    } as StructureController,
     find: jest.fn((findType: number) => {
       switch (findType) {
         case TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES:
+          return ownedConstructionSites;
         case TEST_GLOBALS.FIND_MY_STRUCTURES:
+          return ownedStructures;
         case TEST_GLOBALS.FIND_STRUCTURES:
+          return options.visibleStructures ?? ownedStructures;
         case TEST_GLOBALS.FIND_HOSTILE_CREEPS:
         case TEST_GLOBALS.FIND_HOSTILE_STRUCTURES:
           return [];
         case TEST_GLOBALS.FIND_SOURCES:
-          return [{ id: 'source1' }, { id: 'source2' }] as Source[];
+          return sources;
         default:
           return [];
       }
     })
   } as unknown as Room;
-  const spawn = { structureType: TEST_GLOBALS.STRUCTURE_SPAWN, room } as unknown as StructureSpawn;
+  const spawn = {
+    id: 'spawn1',
+    name: 'Spawn1',
+    structureType: TEST_GLOBALS.STRUCTURE_SPAWN,
+    pos: makeRoomPosition(20, 20),
+    room
+  } as unknown as StructureSpawn;
+  ownedStructures = options.ownedStructures ?? ([spawn] as AnyOwnedStructure[]);
 
   return {
     room,
@@ -408,7 +534,7 @@ function makeRuntimeColony(): { colony: ColonySnapshot; room: Room } {
       room,
       spawns: [spawn],
       energyAvailable: 300,
-      energyCapacityAvailable: 550
+      energyCapacityAvailable: options.energyCapacityAvailable ?? 550
     }
   };
 }
@@ -446,6 +572,15 @@ function makeConstructionSite(
   } as unknown as ConstructionSite;
 }
 
+function makeOwnedStructure(id: string, structureType: string, x: number, y: number): AnyOwnedStructure {
+  return {
+    id,
+    structureType,
+    pos: makeRoomPosition(x, y),
+    my: true
+  } as unknown as AnyOwnedStructure;
+}
+
 function makeSelectionOrigin(rangesByTargetId: Record<string, number>): RoomObject {
   return {
     pos: {
@@ -465,4 +600,8 @@ function scoreByName<T extends { buildItem: string }>(candidates: T[], buildItem
   }
 
   return candidate;
+}
+
+function hasBuildItem(candidates: { buildItem: string }[], buildItem: string): boolean {
+  return candidates.some((candidate) => candidate.buildItem === buildItem);
 }


### PR DESCRIPTION
## Summary
Make rampart/tower construction proactive, not only reactive to hostile presence.

## Changes
- Tower: When RCL ≥ 3, always build a tower (minimum 1, up to MAX). Remove hostile-presence dependency
- Rampart: Claimed/owned rooms build protected rampart at spawn and controller positions regardless of hostile presence
- Construction priority: Extension > Tower ≥ Rampart > Road > Container

## Verification
- Typecheck: PASS
- Tests: 37 suites, 872 tests, all passed
- Build: PASS

Closes #558