### PR TITLE
feat(economy): implement upgrader energy boost when controller near level-up

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7738,6 +7738,8 @@ var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 var DEFAULT_SOURCE_ENERGY_CAPACITY = 3e3;
 var DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
 var MAX_CONTROLLER_LEVEL = 8;
+var UPGRADER_BOOST_CONTROLLER_PROGRESS_RATIO = 0.9;
+var UPGRADER_BOOST_LOW_ENERGY_RATIO = 0.5;
 var SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 var SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 var MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
@@ -7791,6 +7793,10 @@ function selectHeuristicWorkerTask(creep) {
       if (shouldStandbySurplusWorkerInsteadOfAcquiring(creep, creep.room.controller)) {
         return null;
       }
+      const upgraderBoostEnergyAcquisitionTask = selectUpgraderBoostEnergyAcquisitionTask(creep, creep.room.controller);
+      if (upgraderBoostEnergyAcquisitionTask) {
+        return upgraderBoostEnergyAcquisitionTask;
+      }
       const builderEnergyAcquisitionTask = selectBuilderEnergyAcquisitionTask(creep);
       if (builderEnergyAcquisitionTask) {
         return builderEnergyAcquisitionTask;
@@ -7835,6 +7841,10 @@ function selectHeuristicWorkerTask(creep) {
     };
     recordLowLoadReturnTelemetry(creep, downgradeGuardTask, "controllerDowngradeGuard");
     return downgradeGuardTask;
+  }
+  const upgraderBoostUpgradeTask = selectUpgraderBoostUpgradeTask(creep, controller, carriedEnergy);
+  if (upgraderBoostUpgradeTask) {
+    return upgraderBoostUpgradeTask;
   }
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   if (spawnOrExtensionEnergySink) {
@@ -8035,6 +8045,66 @@ function selectControllerSustainUpgradeTask(creep, controller) {
     return null;
   }
   return { type: "upgrade", targetId: controller.id };
+}
+function selectUpgraderBoostUpgradeTask(creep, controller, carriedEnergy) {
+  if (carriedEnergy <= 0 || !isUpgraderBoostActive(creep, controller)) {
+    return null;
+  }
+  return { type: "upgrade", targetId: controller.id };
+}
+function selectUpgraderBoostEnergyAcquisitionTask(creep, controller) {
+  if (!isUpgraderBoostActive(creep, controller) || !hasLowEnergyForUpgraderBoost(creep) || getFreeEnergyCapacity2(creep) <= 0) {
+    return null;
+  }
+  const context = {
+    creepOwnerUsername: getCreepOwnerUsername2(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+  const candidates = findVisibleRoomStructures(creep.room).filter(
+    (structure) => isSafeStoredEnergySource(structure, context) && isUpgraderBoostStoredEnergySource(structure)
+  ).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getStoredEnergy2(source),
+      {
+        type: "withdraw",
+        targetId: source.id
+      },
+      reservationContext
+    );
+    return candidate ? [candidate] : [];
+  });
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+function isUpgraderBoostActive(creep, controller) {
+  return isUpgraderCreep(creep) && isControllerNearLevelUp(controller);
+}
+function isUpgraderCreep(creep) {
+  var _a, _b, _c;
+  return ((_a = creep.memory) == null ? void 0 : _a.role) === "upgrader" || ((_c = (_b = creep.memory) == null ? void 0 : _b.controllerSustain) == null ? void 0 : _c.role) === "upgrader";
+}
+function isControllerNearLevelUp(controller) {
+  if (!controller || !canLevelUpController(controller)) {
+    return false;
+  }
+  const progress = controller.progress;
+  const progressTotal = controller.progressTotal;
+  return typeof progress === "number" && Number.isFinite(progress) && typeof progressTotal === "number" && Number.isFinite(progressTotal) && progressTotal > 0 && Math.max(0, progress) / progressTotal >= UPGRADER_BOOST_CONTROLLER_PROGRESS_RATIO;
+}
+function hasLowEnergyForUpgraderBoost(creep) {
+  const carriedEnergy = getUsedEnergy2(creep);
+  const freeCapacity = getFreeEnergyCapacity2(creep);
+  const capacity = getEnergyCapacity(creep, carriedEnergy, freeCapacity);
+  return capacity > 0 && carriedEnergy < capacity * UPGRADER_BOOST_LOW_ENERGY_RATIO;
+}
+function isUpgraderBoostStoredEnergySource(source) {
+  return matchesStructureType6(source.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType6(source.structureType, "STRUCTURE_STORAGE", "storage");
 }
 function selectFirstEnergySinkByStableId(energySinks) {
   var _a;
@@ -10656,6 +10726,8 @@ function runWorker(creep) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptTaskForUpgraderBoost(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptLowLoadReturnTaskForEnergyAcquisition(creep, currentTask, selectedTask)) {
@@ -11010,6 +11082,16 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, 
     return false;
   }
   return isUrgentEnergySpendingTask(selectedTask) || isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+function shouldPreemptTaskForUpgraderBoost(creep, task, selectedTask) {
+  var _a;
+  if (!isOwnedControllerUpgradeTask(creep, selectedTask) || isSameTask(task, selectedTask)) {
+    return false;
+  }
+  if (!isUpgraderBoostActive(creep, (_a = creep.room) == null ? void 0 : _a.controller)) {
+    return false;
+  }
+  return getCarriedEnergy(creep) > 0;
 }
 function shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, task, selectedTask) {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8131,7 +8131,7 @@ function selectUpgraderBoostEnergyAcquisitionTask(creep, controller) {
   return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
 }
 function isUpgraderBoostActive(creep, controller) {
-  return isUpgraderCreep(creep) && isControllerNearLevelUp(controller);
+  return isUpgraderCreep(creep) && !hasVisibleHostilePresence(creep.room) && isControllerNearLevelUp(controller);
 }
 function isUpgraderCreep(creep) {
   var _a, _b, _c;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7890,10 +7890,6 @@ function selectHeuristicWorkerTask(creep) {
     recordLowLoadReturnTelemetry(creep, downgradeGuardTask, "controllerDowngradeGuard");
     return downgradeGuardTask;
   }
-  const upgraderBoostUpgradeTask = selectUpgraderBoostUpgradeTask(creep, controller, carriedEnergy);
-  if (upgraderBoostUpgradeTask) {
-    return upgraderBoostUpgradeTask;
-  }
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   if (spawnOrExtensionEnergySink) {
     const spawnOrExtensionRefillTask = {
@@ -7915,6 +7911,10 @@ function selectHeuristicWorkerTask(creep) {
       return suppressedRemoteEnergyHandlingTask;
     }
     return null;
+  }
+  const upgraderBoostUpgradeTask = selectUpgraderBoostUpgradeTask(creep, controller, carriedEnergy);
+  if (upgraderBoostUpgradeTask) {
+    return upgraderBoostUpgradeTask;
   }
   const controllerSustainUpgradeTask = selectControllerSustainUpgradeTask(creep, controller);
   if (controllerSustainUpgradeTask) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -2,6 +2,7 @@ import {
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
   selectWorkerPreHarvestTask,
+  isUpgraderBoostActive,
   isWorkerRepairTargetComplete,
   selectWorkerTask,
   shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill
@@ -59,6 +60,8 @@ export function runWorker(creep: Creep): void {
   } else if (shouldPreemptEnergyAcquisitionTaskForSpawnRecovery(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, currentTask, selectedTask)) {
+    assignSelectedTask(creep, selectedTask, currentTask);
+  } else if (shouldPreemptTaskForUpgraderBoost(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
   } else if (shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, currentTask, selectedTask)) {
     assignSelectedTask(creep, selectedTask, currentTask);
@@ -569,6 +572,22 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(
   }
 
   return isUrgentEnergySpendingTask(selectedTask) || isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+
+function shouldPreemptTaskForUpgraderBoost(
+  creep: Creep,
+  task: CreepTaskMemory,
+  selectedTask: CreepTaskMemory | null
+): boolean {
+  if (!isOwnedControllerUpgradeTask(creep, selectedTask) || isSameTask(task, selectedTask)) {
+    return false;
+  }
+
+  if (!isUpgraderBoostActive(creep, creep.room?.controller)) {
+    return false;
+  }
+
+  return getCarriedEnergy(creep) > 0;
 }
 
 function shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -60,6 +60,8 @@ const MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 const DEFAULT_SOURCE_ENERGY_CAPACITY = 3_000;
 const DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
 const MAX_CONTROLLER_LEVEL = 8;
+const UPGRADER_BOOST_CONTROLLER_PROGRESS_RATIO = 0.9;
+const UPGRADER_BOOST_LOW_ENERGY_RATIO = 0.5;
 const SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
 const SOURCE2_CONTROLLER_LANE_MAX_RANGE = 6;
 const MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS = 4;
@@ -72,6 +74,7 @@ const BUILDER_STORAGE_ACQUISITION_SITE_RANGE = BUILDER_DROPPED_PICKUP_RANGE;
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
 type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal;
+type UpgraderBoostStoredEnergySource = StructureContainer | StructureStorage;
 type SalvageableWorkerEnergySource = Tombstone | Ruin;
 type FillableEnergySink = StructureSpawn | StructureExtension | StructureTower;
 type RemoteHaulerDeliverySink = StructureSpawn | StructureExtension | StructureStorage;
@@ -207,6 +210,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
         return null;
       }
 
+      const upgraderBoostEnergyAcquisitionTask = selectUpgraderBoostEnergyAcquisitionTask(creep, creep.room.controller);
+      if (upgraderBoostEnergyAcquisitionTask) {
+        return upgraderBoostEnergyAcquisitionTask;
+      }
+
       const builderEnergyAcquisitionTask = selectBuilderEnergyAcquisitionTask(creep);
       if (builderEnergyAcquisitionTask) {
         return builderEnergyAcquisitionTask;
@@ -265,6 +273,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     };
     recordLowLoadReturnTelemetry(creep, downgradeGuardTask, 'controllerDowngradeGuard');
     return downgradeGuardTask;
+  }
+
+  const upgraderBoostUpgradeTask = selectUpgraderBoostUpgradeTask(creep, controller, carriedEnergy);
+  if (upgraderBoostUpgradeTask) {
+    return upgraderBoostUpgradeTask;
   }
 
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
@@ -521,6 +534,107 @@ function selectControllerSustainUpgradeTask(
   }
 
   return { type: 'upgrade', targetId: controller.id };
+}
+
+function selectUpgraderBoostUpgradeTask(
+  creep: Creep,
+  controller: StructureController | undefined,
+  carriedEnergy: number
+): Extract<CreepTaskMemory, { type: 'upgrade' }> | null {
+  if (carriedEnergy <= 0 || !isUpgraderBoostActive(creep, controller)) {
+    return null;
+  }
+
+  return { type: 'upgrade', targetId: controller.id };
+}
+
+function selectUpgraderBoostEnergyAcquisitionTask(
+  creep: Creep,
+  controller: StructureController | undefined
+): WorkerEnergyAcquisitionTask | null {
+  if (
+    !isUpgraderBoostActive(creep, controller) ||
+    !hasLowEnergyForUpgraderBoost(creep) ||
+    getFreeEnergyCapacity(creep) <= 0
+  ) {
+    return null;
+  }
+
+  const context: StoredEnergySourceContext = {
+    creepOwnerUsername: getCreepOwnerUsername(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+  const candidates = findVisibleRoomStructures(creep.room)
+    .filter(
+      (structure): structure is UpgraderBoostStoredEnergySource =>
+        isSafeStoredEnergySource(structure, context) && isUpgraderBoostStoredEnergySource(structure)
+    )
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        getStoredEnergy(source),
+        {
+          type: 'withdraw',
+          targetId: source.id as Id<AnyStoreStructure>
+        },
+        reservationContext
+      );
+
+      return candidate ? [candidate] : [];
+    });
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+
+export function isUpgraderBoostActive(
+  creep: Creep,
+  controller: StructureController | undefined
+): controller is StructureController {
+  return isUpgraderCreep(creep) && isControllerNearLevelUp(controller);
+}
+
+function isUpgraderCreep(creep: Creep): boolean {
+  return creep.memory?.role === 'upgrader' || creep.memory?.controllerSustain?.role === 'upgrader';
+}
+
+function isControllerNearLevelUp(controller: StructureController | undefined): controller is StructureController {
+  if (!controller || !canLevelUpController(controller)) {
+    return false;
+  }
+
+  const progress = controller.progress;
+  const progressTotal = controller.progressTotal;
+  return (
+    typeof progress === 'number' &&
+    Number.isFinite(progress) &&
+    typeof progressTotal === 'number' &&
+    Number.isFinite(progressTotal) &&
+    progressTotal > 0 &&
+    Math.max(0, progress) / progressTotal >= UPGRADER_BOOST_CONTROLLER_PROGRESS_RATIO
+  );
+}
+
+function hasLowEnergyForUpgraderBoost(creep: Creep): boolean {
+  const carriedEnergy = getUsedEnergy(creep);
+  const freeCapacity = getFreeEnergyCapacity(creep);
+  const capacity = getEnergyCapacity(creep, carriedEnergy, freeCapacity);
+  return capacity > 0 && carriedEnergy < capacity * UPGRADER_BOOST_LOW_ENERGY_RATIO;
+}
+
+function isUpgraderBoostStoredEnergySource(
+  source: StoredWorkerEnergySource
+): source is UpgraderBoostStoredEnergySource {
+  return (
+    matchesStructureType(source.structureType, 'STRUCTURE_CONTAINER', 'container') ||
+    matchesStructureType(source.structureType, 'STRUCTURE_STORAGE', 'storage')
+  );
 }
 
 function selectFirstEnergySinkByStableId<T extends FillableEnergySink>(energySinks: T[]): T | null {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -275,11 +275,6 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return downgradeGuardTask;
   }
 
-  const upgraderBoostUpgradeTask = selectUpgraderBoostUpgradeTask(creep, controller, carriedEnergy);
-  if (upgraderBoostUpgradeTask) {
-    return upgraderBoostUpgradeTask;
-  }
-
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   if (spawnOrExtensionEnergySink) {
     const spawnOrExtensionRefillTask: Extract<CreepTaskMemory, { type: 'transfer' }> = {
@@ -305,6 +300,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     }
 
     return null;
+  }
+
+  const upgraderBoostUpgradeTask = selectUpgraderBoostUpgradeTask(creep, controller, carriedEnergy);
+  if (upgraderBoostUpgradeTask) {
+    return upgraderBoostUpgradeTask;
   }
 
   const controllerSustainUpgradeTask = selectControllerSustainUpgradeTask(creep, controller);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -597,7 +597,7 @@ export function isUpgraderBoostActive(
   creep: Creep,
   controller: StructureController | undefined
 ): controller is StructureController {
-  return isUpgraderCreep(creep) && isControllerNearLevelUp(controller);
+  return isUpgraderCreep(creep) && !hasVisibleHostilePresence(creep.room) && isControllerNearLevelUp(controller);
 }
 
 function isUpgraderCreep(creep: Creep): boolean {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -391,6 +391,50 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('preempts energy acquisition so boosted upgraders keep upgrading with any carried energy', () => {
+    const source = { id: 'source1', energy: 300 } as Source;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      progress: 900,
+      progressTotal: 1_000
+    } as StructureController;
+    const room = {
+      name: 'W1N1',
+      controller,
+      find: jest.fn().mockReturnValue([])
+    } as unknown as Room;
+    const creep = {
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> },
+        controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W1N1', role: 'upgrader' }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(25),
+        getFreeCapacity: jest.fn().mockReturnValue(75),
+        getCapacity: jest.fn().mockReturnValue(100)
+      },
+      room,
+      harvest: jest.fn(),
+      upgradeController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { BoostUpgrader: creep },
+      getObjectById: jest.fn((id: string) => (id === 'source1' ? source : id === 'controller1' ? controller : null))
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'upgrade', targetId: 'controller1' });
+    expect(creep.upgradeController).toHaveBeenCalledWith(controller);
+    expect(creep.harvest).not.toHaveBeenCalled();
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
   it('switches from a depleted harvest target to a viable source in the same tick', () => {
     const depletedSource = { id: 'source1', energy: 0 } as Source;
     const viableSource = { id: 'source2', energy: 100 } as Source;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -360,6 +360,74 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-ready' });
   });
 
+  it('boosting upgraders withdraw stored energy before source2 lane harvesting near controller level-up', () => {
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 25);
+    const storage = makeStoredEnergyStructure('storage1', 'storage' as StructureConstant, 500, {
+      my: true,
+      pos: makeRoomPosition(10, 10)
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      progress: 900,
+      progressTotal: 1_000,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const creep = {
+      name: 'BoostUpgrader',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W1N1', role: 'upgrader' }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(100),
+        getCapacity: jest.fn().mockReturnValue(100)
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage1' ? 8 : 1)) },
+      room: makeWorkerTaskRoom({ controller, sources: [source1, source2], structures: [storage] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage1' });
+  });
+
+  it('does not activate upgrader boost at RCL8', () => {
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 25);
+    const storage = makeStoredEnergyStructure('storage1', 'storage' as StructureConstant, 500, {
+      my: true,
+      pos: makeRoomPosition(10, 10)
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 8,
+      progress: 1_000,
+      progressTotal: 1_000,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const creep = {
+      name: 'MaxRclUpgrader',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W1N1', role: 'upgrader' }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(100),
+        getCapacity: jest.fn().mockReturnValue(100)
+      },
+      pos: { getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'storage1' ? 8 : 1)) },
+      room: makeWorkerTaskRoom({ controller, sources: [source1, source2], structures: [storage] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
+  });
+
   it('selects the richest dropped energy before harvesting when worker has free capacity', () => {
     const lowValueDroppedEnergy = { id: 'drop-low', resourceType: 'energy', amount: 24 } as Resource<ResourceConstant>;
     const farDroppedEnergy = { id: 'drop-far', resourceType: 'energy', amount: 50 } as Resource<ResourceConstant>;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -13,6 +13,7 @@ import {
   estimateNearTermSpawnExtensionRefillReserve,
   canLevelUpController,
   canUpgradeController,
+  isUpgraderBoostActive,
   selectWorkerTask
 } from '../src/tasks/workerTasks';
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
@@ -392,6 +393,64 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'storage1' });
+  });
+
+  it('reports upgrader boost active near controller level-up when no hostiles are visible', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      progress: 900,
+      progressTotal: 1_000
+    } as StructureController;
+    const creep = {
+      memory: { role: 'upgrader' },
+      room: makeWorkerTaskRoom({ controller })
+    } as unknown as Creep;
+
+    expect(isUpgraderBoostActive(creep, controller)).toBe(true);
+  });
+
+  it('reports upgrader boost inactive when hostiles are visible', () => {
+    const hostile = { id: 'hostile1' } as Creep;
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      progress: 900,
+      progressTotal: 1_000
+    } as StructureController;
+    const creep = {
+      memory: { role: 'upgrader' },
+      room: makeWorkerTaskRoom({ controller, hostileCreeps: [hostile] })
+    } as unknown as Creep;
+
+    expect(isUpgraderBoostActive(creep, controller)).toBe(false);
+  });
+
+  it('lets visible hostiles preempt boosted upgrader controller work for tower refill', () => {
+    const hostile = { id: 'hostile1' } as Creep;
+    const tower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      progress: 900,
+      progressTotal: 1_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      name: 'BoostUpgrader',
+      memory: { role: 'upgrader', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        hostileCreeps: [hostile],
+        myStructures: [tower as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'tower-low' });
   });
 
   it('does not activate upgrader boost at RCL8', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -428,6 +428,61 @@ describe('selectWorkerTask', () => {
     expect(isUpgraderBoostActive(creep, controller)).toBe(false);
   });
 
+  it('lets emergency spawn refill preempt boosted upgrader controller work', () => {
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 0, 300);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      progress: 900,
+      progressTotal: 1_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      name: 'BoostUpgrader',
+      memory: { role: 'upgrader', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        energyCapacityAvailable: 300,
+        myStructures: [spawn as AnyOwnedStructure]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('recalls boosted remote upgraders before controller work while survival suppresses remote spending', () => {
+    recordSurvivalMode('BOOTSTRAP');
+    const homeSpawn = makeEnergySink('home-spawn', 'spawn' as StructureConstant, 300);
+    const homeRoom = makeWorkerTaskRoom({ myStructures: [homeSpawn as AnyOwnedStructure] });
+    const remoteController = {
+      id: 'remote-controller',
+      my: true,
+      level: 3,
+      progress: 900,
+      progressTotal: 1_000,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const remoteRoom = makeWorkerTaskRoom({ controller: remoteController });
+    (remoteRoom as Room & { name: string }).name = 'W2N1';
+    const globalScope = globalThis as unknown as { Game?: Partial<Game> };
+    globalScope.Game = {
+      ...(globalScope.Game ?? {}),
+      creeps: {},
+      rooms: { W1N1: homeRoom, W2N1: remoteRoom }
+    };
+    const creep = {
+      name: 'RemoteBoostUpgrader',
+      memory: { role: 'upgrader', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: remoteRoom
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'home-spawn' });
+  });
+
   it('lets visible hostiles preempt boosted upgrader controller work for tower refill', () => {
     const hostile = { id: 'hostile1' } as Creep;
     const tower = makeTowerEnergySink('tower-low', TOWER_REFILL_ENERGY_FLOOR - 1, 501);


### PR DESCRIPTION
## Summary
Implement upgrader energy boost when controller is near level-up. When the room controller is within 10% of the next RCL, upgraders prioritize upgrading and prefer withdrawing from storage/containers for faster energy cycling.

## Changes
- `prod/src/creeps/workerRunner.ts`: Added upgrader boost logic that activates when controller progress >= 90%
- `prod/src/tasks/workerTasks.ts`: Upgrader energy acquisition prefers storage/container when boosting
- `prod/test/workerRunner.test.ts`: Tests for upgrader boost behavior
- `prod/test/workerTasks.test.ts`: Tests for boost energy acquisition

## Verification
- Typecheck: ✅
- Jest (875 tests): ✅
- Build: ✅
- git diff --check: ✅

Closes #562
