### PR TITLE
feat(territory): prioritize dual-source rooms and penalize foreign-controller rooms in expansion scoring (#565)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12870,6 +12870,8 @@ var TERRAIN_SCAN_MIN = 2;
 var TERRAIN_SCAN_MAX = 47;
 var DEFAULT_TERRAIN_WALL_MASK4 = 1;
 var DEFAULT_TERRAIN_SWAMP_MASK = 2;
+var DUAL_SOURCE_BONUS = 180;
+var FOREIGN_CONTROLLER_PENALTY = 300;
 var DOWNGRADE_GUARD_TICKS2 = 5e3;
 var MIN_CONTROLLER_LEVEL = 2;
 var FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = "foreign reservation requires controller pressure";
@@ -13073,20 +13075,28 @@ function scoreExpansionCandidate(input, candidate) {
   };
 }
 function calculateExpansionScore(input, candidate, evidenceStatus) {
-  var _a, _b;
+  var _a, _b, _c;
   const sourceScore = typeof candidate.sourceCount === "number" ? Math.min(candidate.sourceCount, 2) * 120 + Math.max(0, candidate.sourceCount - 2) * 20 : 0;
+  const dualSourceBonus = ((_a = candidate.sourceCount) != null ? _a : 0) >= 2 ? DUAL_SOURCE_BONUS : 0;
   const proximityScore = typeof candidate.controllerSourceRange === "number" ? Math.max(-80, 100 - candidate.controllerSourceRange * 6) : 0;
   const terrainScore = candidate.terrain ? Math.round(candidate.terrain.walkableRatio * 140 - candidate.terrain.swampRatio * 70) : 0;
   const reservationScore = getReservationScore(input, candidate.controller);
   const distanceScore = getDistanceScore(candidate);
   const adjacencyScore = candidate.adjacentToOwnedRoom ? 40 : 0;
-  const hostilePenalty = ((_a = candidate.hostileCreepCount) != null ? _a : 0) * 240 + ((_b = candidate.hostileStructureCount) != null ? _b : 0) * 140;
+  const foreignControllerPenalty = hasForeignControllerPresence(input, candidate.controller) ? FOREIGN_CONTROLLER_PENALTY : 0;
+  const hostilePenalty = ((_b = candidate.hostileCreepCount) != null ? _b : 0) * 240 + ((_c = candidate.hostileStructureCount) != null ? _c : 0) * 140;
   const unavailablePenalty = evidenceStatus === "unavailable" ? 2e3 : 0;
   const insufficientEvidencePenalty = evidenceStatus === "insufficient-evidence" ? 260 : 0;
   const preconditionPenalty = getExpansionPreconditions(input).length * 120;
   return Math.round(
-    500 + sourceScore + proximityScore + terrainScore + reservationScore + distanceScore + adjacencyScore - hostilePenalty - unavailablePenalty - insufficientEvidencePenalty - preconditionPenalty
+    500 + sourceScore + dualSourceBonus + proximityScore + terrainScore + reservationScore + distanceScore + adjacencyScore - foreignControllerPenalty - hostilePenalty - unavailablePenalty - insufficientEvidencePenalty - preconditionPenalty
   );
+}
+function hasForeignControllerPresence(input, controller) {
+  if (!controller) {
+    return false;
+  }
+  return isNonEmptyString11(controller.ownerUsername) && controller.ownerUsername !== input.colonyOwnerUsername || isNonEmptyString11(controller.reservationUsername) && controller.reservationUsername !== input.colonyOwnerUsername;
 }
 function getDistanceScore(candidate) {
   const nearestOwnedDistance = candidate.nearestOwnedRoomDistance;

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -12,6 +12,8 @@ const TERRAIN_SCAN_MIN = 2;
 const TERRAIN_SCAN_MAX = 47;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
 const DEFAULT_TERRAIN_SWAMP_MASK = 2;
+const DUAL_SOURCE_BONUS = 180;
+const FOREIGN_CONTROLLER_PENALTY = 300;
 const DOWNGRADE_GUARD_TICKS = 5_000;
 const MIN_CONTROLLER_LEVEL = 2;
 const FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = 'foreign reservation requires controller pressure';
@@ -361,6 +363,7 @@ function calculateExpansionScore(
   const sourceScore = typeof candidate.sourceCount === 'number'
     ? Math.min(candidate.sourceCount, 2) * 120 + Math.max(0, candidate.sourceCount - 2) * 20
     : 0;
+  const dualSourceBonus = (candidate.sourceCount ?? 0) >= 2 ? DUAL_SOURCE_BONUS : 0;
   const proximityScore = typeof candidate.controllerSourceRange === 'number'
     ? Math.max(-80, 100 - candidate.controllerSourceRange * 6)
     : 0;
@@ -370,6 +373,9 @@ function calculateExpansionScore(
   const reservationScore = getReservationScore(input, candidate.controller);
   const distanceScore = getDistanceScore(candidate);
   const adjacencyScore = candidate.adjacentToOwnedRoom ? 40 : 0;
+  const foreignControllerPenalty = hasForeignControllerPresence(input, candidate.controller)
+    ? FOREIGN_CONTROLLER_PENALTY
+    : 0;
   const hostilePenalty = (candidate.hostileCreepCount ?? 0) * 240 + (candidate.hostileStructureCount ?? 0) * 140;
   const unavailablePenalty = evidenceStatus === 'unavailable' ? 2_000 : 0;
   const insufficientEvidencePenalty = evidenceStatus === 'insufficient-evidence' ? 260 : 0;
@@ -378,15 +384,33 @@ function calculateExpansionScore(
   return Math.round(
     500 +
       sourceScore +
+      dualSourceBonus +
       proximityScore +
       terrainScore +
       reservationScore +
       distanceScore +
       adjacencyScore -
+      foreignControllerPenalty -
       hostilePenalty -
       unavailablePenalty -
       insufficientEvidencePenalty -
       preconditionPenalty
+  );
+}
+
+function hasForeignControllerPresence(
+  input: ExpansionScoringInput,
+  controller: ExpansionControllerEvidence | undefined
+): boolean {
+  if (!controller) {
+    return false;
+  }
+
+  return (
+    (isNonEmptyString(controller.ownerUsername) &&
+      controller.ownerUsername !== input.colonyOwnerUsername) ||
+    (isNonEmptyString(controller.reservationUsername) &&
+      controller.reservationUsername !== input.colonyOwnerUsername)
   );
 }
 

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -34,6 +34,93 @@ describe('next expansion scoring', () => {
     delete (globalThis as { TERRAIN_MASK_SWAMP?: number }).TERRAIN_MASK_SWAMP;
   });
 
+  it('adds a material score bonus for dual-source rooms', () => {
+    const report = scoreExpansionCandidates(
+      makeInput([
+        makeCandidate({ roomName: 'W2N1', order: 0, sourceCount: 1 }),
+        makeCandidate({ roomName: 'W3N1', order: 1, sourceCount: 2 })
+      ])
+    );
+    const singleSource = report.candidates.find((candidate) => candidate.roomName === 'W2N1');
+    const dualSource = report.candidates.find((candidate) => candidate.roomName === 'W3N1');
+
+    expect(report.next).toMatchObject({ roomName: 'W3N1', sourceCount: 2 });
+    expect(singleSource).toBeDefined();
+    expect(dualSource).toBeDefined();
+    expect((dualSource?.score ?? 0) - (singleSource?.score ?? 0)).toBeGreaterThanOrEqual(250);
+  });
+
+  it('penalizes foreign-owned and foreign-reserved controller presence', () => {
+    const report = scoreExpansionCandidates(
+      makeInput([
+        makeCandidate({ roomName: 'W2N1', order: 0 }),
+        makeCandidate({
+          roomName: 'W3N1',
+          order: 1,
+          controller: { ownerUsername: 'enemy' }
+        }),
+        makeCandidate({
+          roomName: 'W4N1',
+          order: 2,
+          controller: { reservationUsername: 'enemy', reservationTicksToEnd: 4_000 }
+        })
+      ])
+    );
+    const neutral = report.candidates.find((candidate) => candidate.roomName === 'W2N1');
+    const foreignOwned = report.candidates.find((candidate) => candidate.roomName === 'W3N1');
+    const foreignReserved = report.candidates.find((candidate) => candidate.roomName === 'W4N1');
+
+    expect(neutral).toBeDefined();
+    expect(foreignOwned).toMatchObject({
+      evidenceStatus: 'unavailable',
+      risks: ['enemy-owned controller cannot be claimed safely']
+    });
+    expect(foreignReserved).toMatchObject({
+      evidenceStatus: 'sufficient',
+      reservation: { username: 'enemy', relation: 'foreign', ticksToEnd: 4_000 },
+      requiresControllerPressure: true,
+      risks: ['foreign reservation requires controller pressure']
+    });
+    expect((neutral?.score ?? 0) - (foreignOwned?.score ?? 0)).toBeGreaterThanOrEqual(2_250);
+    expect((neutral?.score ?? 0) - (foreignReserved?.score ?? 0)).toBeGreaterThanOrEqual(400);
+  });
+
+  it('preserves ranking by proximity, terrain, and distance when resource and controller status match', () => {
+    const report = scoreExpansionCandidates(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          order: 0,
+          sourceCount: 2,
+          controllerSourceRange: 6,
+          terrain: { walkableRatio: 0.92, swampRatio: 0.05, wallRatio: 0.08 },
+          routeDistance: 1,
+          nearestOwnedRoomDistance: 1
+        }),
+        makeCandidate({
+          roomName: 'W3N1',
+          order: 1,
+          sourceCount: 2,
+          controllerSourceRange: 18,
+          terrain: { walkableRatio: 0.72, swampRatio: 0.22, wallRatio: 0.28 },
+          routeDistance: 2,
+          nearestOwnedRoomDistance: 2
+        })
+      ])
+    );
+
+    expect(report.candidates.map((candidate) => candidate.roomName)).toEqual(['W2N1', 'W3N1']);
+    expect(report.candidates[0].score).toBeGreaterThan(report.candidates[1].score);
+    expect(report.candidates[0].rationale).toEqual(
+      expect.arrayContaining([
+        'controller-source range 6',
+        'terrain walkable 92%',
+        'home route distance 1',
+        'nearest owned distance 1'
+      ])
+    );
+  });
+
   it('ranks claim candidates by sources, controller proximity, terrain, reserves, and distance', () => {
     const report = scoreExpansionCandidates(
       makeInput([


### PR DESCRIPTION
## Summary
Adds dual-source room bonus (+180) and foreign-controller penalty (-300) to expansion scoring, prioritizing rooms with two energy sources and deprioritizing rooms owned/reserved by other players.

## Changes
- `prod/src/territory/expansionScoring.ts`: Add `hasForeignControllerPresence()` utility and integrate `dualSourceBonus` / `foreignControllerPenalty` into `calculateExpansionScore()`
- `prod/test/expansionScoring.test.ts`: Comprehensive test coverage for dual-source bonus and foreign-controller penalty
- `prod/dist/main.js`: Rebuilt bundle

## Verification
- TypeScript typecheck: ✅
- Jest 893 tests: ✅
- Build: ✅

Closes #565