### PR TITLE
feat(territory): adjacent room expansion scoring for territory growth (#567)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4637,7 +4637,10 @@ function sortAdjacentRoomsByPersistedExpansionScore(roomNames, colonyName, terri
     return roomNames;
   }
   return roomNames.map((roomName, index) => ({ roomName, index })).sort(
-    (left, right) => compareOptionalNumbers2(scoredRoomRanks.get(left.roomName), scoredRoomRanks.get(right.roomName)) || left.index - right.index
+    (left, right) => {
+      var _a, _b;
+      return ((_a = scoredRoomRanks.get(left.roomName)) != null ? _a : Number.POSITIVE_INFINITY) - ((_b = scoredRoomRanks.get(right.roomName)) != null ? _b : Number.POSITIVE_INFINITY) || left.index - right.index;
+    }
   ).map(({ roomName }) => roomName);
 }
 function getPersistedExpansionCandidateRanks(colonyName, territoryMemory) {
@@ -13590,8 +13593,16 @@ function getNearestOwnedRoomDistance(ownedRoomNames, targetRoom, adjacentRoomNam
   let nearestDistance;
   for (const ownedRoomName of ownedRoomNames) {
     const adjacentDistance = ((_a = adjacentRoomNames.get(ownedRoomName)) == null ? void 0 : _a.has(targetRoom)) ? 1 : void 0;
-    const routeDistance = getKnownRouteLength2(ownedRoomName, targetRoom);
-    const distance = routeDistance != null ? routeDistance : adjacentDistance;
+    if (adjacentDistance !== void 0) {
+      nearestRoomName = ownedRoomName;
+      nearestDistance = adjacentDistance;
+      break;
+    }
+    const linearDistance = getLinearRoomDistance(ownedRoomName, targetRoom);
+    if (linearDistance !== void 0 && linearDistance > MAX_NEARBY_EXPANSION_ROUTE_DISTANCE) {
+      continue;
+    }
+    const distance = getKnownRouteLength2(ownedRoomName, targetRoom);
     if (distance === void 0) {
       continue;
     }
@@ -13611,6 +13622,15 @@ function getNearestOwnedRoomDistance(ownedRoomNames, targetRoom, adjacentRoomNam
     ...nearestRoomName ? { roomName: nearestRoomName } : {},
     ...nearestDistance !== void 0 ? { distance: nearestDistance } : {}
   };
+}
+function getLinearRoomDistance(fromRoom, targetRoom) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (gameMap == null ? void 0 : gameMap.getRoomLinearDistance) !== "function") {
+    return void 0;
+  }
+  const distance = gameMap.getRoomLinearDistance.call(gameMap, fromRoom, targetRoom);
+  return Number.isFinite(distance) ? distance : void 0;
 }
 function isNearbyExpansionCandidate(routeDistance, nearestOwnedDistance, adjacentToOwnedRoom) {
   if (routeDistance === null || nearestOwnedDistance.distance === null) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4578,7 +4578,11 @@ function isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts,
   return getVisibleTerritoryTargetState(target.roomName, "reserve", reserveIntent.controllerId, colonyOwnerUsername) !== "unavailable";
 }
 function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, source, orderOffset, routeDistanceLookupContext) {
-  const adjacentRooms = getAdjacentRoomNames2(originRoomName);
+  const adjacentRooms = sortAdjacentRoomsByPersistedExpansionScore(
+    getAdjacentRoomNames2(originRoomName),
+    colonyName,
+    territoryMemory
+  );
   if (adjacentRooms.length === 0) {
     return [];
   }
@@ -4623,6 +4627,34 @@ function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUse
     }
     return [];
   });
+}
+function sortAdjacentRoomsByPersistedExpansionScore(roomNames, colonyName, territoryMemory) {
+  if (roomNames.length <= 1) {
+    return roomNames;
+  }
+  const scoredRoomRanks = getPersistedExpansionCandidateRanks(colonyName, territoryMemory);
+  if (scoredRoomRanks.size === 0) {
+    return roomNames;
+  }
+  return roomNames.map((roomName, index) => ({ roomName, index })).sort(
+    (left, right) => compareOptionalNumbers2(scoredRoomRanks.get(left.roomName), scoredRoomRanks.get(right.roomName)) || left.index - right.index
+  ).map(({ roomName }) => roomName);
+}
+function getPersistedExpansionCandidateRanks(colonyName, territoryMemory) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.expansionCandidates)) {
+    return /* @__PURE__ */ new Map();
+  }
+  const ranks = /* @__PURE__ */ new Map();
+  for (const [index, rawCandidate] of territoryMemory.expansionCandidates.entries()) {
+    if (!isRecord4(rawCandidate)) {
+      continue;
+    }
+    if (rawCandidate.colony !== colonyName || !isNonEmptyString5(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || rawCandidate.recommendedAction !== "scout" && rawCandidate.recommendedAction !== "claim" || ranks.has(rawCandidate.roomName)) {
+      continue;
+    }
+    ranks.set(rawCandidate.roomName, index);
+  }
+  return ranks;
 }
 function getVisibleAdjacentReserveCandidates(colonyName, colonyOwnerUsername, territoryMemory, intents, gameTime, routeDistanceLookupContext) {
   return getAdjacentReserveCandidates(
@@ -12956,6 +12988,7 @@ var DUAL_SOURCE_BONUS = 180;
 var FOREIGN_CONTROLLER_PENALTY = 300;
 var DOWNGRADE_GUARD_TICKS2 = 5e3;
 var MIN_CONTROLLER_LEVEL = 2;
+var MAX_PERSISTED_EXPANSION_CANDIDATES = 5;
 var FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = "foreign reservation requires controller pressure";
 var ROOM_LIMIT_PRECONDITION_PREFIX = "limit expansion to ";
 var MAX_ROOM_COUNT_BY_RCL = {
@@ -12979,6 +13012,7 @@ function scoreExpansionCandidates(input) {
 }
 function refreshNextExpansionTargetSelection(colony, report, gameTime) {
   const colonyName = colony.room.name;
+  persistExpansionCandidateScores(colonyName, report, gameTime);
   const candidate = selectPersistableExpansionCandidate(report);
   if (!candidate) {
     pruneNextExpansionTargets(colonyName);
@@ -13021,18 +13055,32 @@ function maxRoomsForRcl(controllerLevel) {
   return MAX_ROOM_COUNT_BY_RCL[rcl];
 }
 function buildRuntimeExpansionCandidates(colony) {
-  const rooms = getGameRooms2();
-  if (!rooms) {
-    return [];
-  }
+  var _a;
+  const rooms = (_a = getGameRooms2()) != null ? _a : {};
   const colonyName = colony.room.name;
   const ownerUsername = getControllerOwnerUsername5(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames3(colonyName, ownerUsername);
   const adjacentRoomNames = getAdjacentRoomNamesByOwnedRoom(ownedRoomNames);
-  const candidates = [];
+  const candidateOrders = /* @__PURE__ */ new Map();
   let order = 0;
+  for (const ownedRoomName of ownedRoomNames) {
+    const adjacentRooms = adjacentRoomNames.get(ownedRoomName);
+    if (!adjacentRooms) {
+      continue;
+    }
+    for (const roomName of adjacentRooms) {
+      if (roomName === colonyName || ownedRoomNames.has(roomName) || candidateOrders.has(roomName)) {
+        continue;
+      }
+      candidateOrders.set(roomName, order);
+      order += 1;
+    }
+  }
   for (const room of Object.values(rooms)) {
     if (!room || !isNonEmptyString11(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
+      continue;
+    }
+    if (candidateOrders.has(room.name)) {
       continue;
     }
     const routeDistance = getKnownRouteLength2(colonyName, room.name);
@@ -13041,33 +13089,56 @@ function buildRuntimeExpansionCandidates(colony) {
     if (!isNearbyExpansionCandidate(routeDistance, nearestOwnedDistance, adjacentToOwnedRoom)) {
       continue;
     }
-    candidates.push({
-      roomName: room.name,
-      order,
-      adjacentToOwnedRoom,
-      ...routeDistance !== void 0 ? { routeDistance } : {},
-      ...nearestOwnedDistance.roomName ? { nearestOwnedRoom: nearestOwnedDistance.roomName } : {},
-      ...nearestOwnedDistance.distance !== void 0 ? { nearestOwnedRoomDistance: nearestOwnedDistance.distance } : {},
-      ...buildVisibleExpansionCandidateEvidence(room)
-    });
+    candidateOrders.set(room.name, order);
     order += 1;
   }
-  return candidates;
+  return Array.from(candidateOrders.entries()).flatMap(([roomName, candidateOrder]) => {
+    const routeDistance = getKnownRouteLength2(colonyName, roomName);
+    const nearestOwnedDistance = getNearestOwnedRoomDistance(ownedRoomNames, roomName, adjacentRoomNames);
+    const adjacentToOwnedRoom = isAdjacentToOwnedRoom(roomName, adjacentRoomNames);
+    if (!isNearbyExpansionCandidate(routeDistance, nearestOwnedDistance, adjacentToOwnedRoom)) {
+      return [];
+    }
+    const room = rooms[roomName];
+    return [
+      {
+        roomName,
+        order: candidateOrder,
+        visible: room != null,
+        adjacentToOwnedRoom,
+        ...routeDistance !== void 0 ? { routeDistance } : {},
+        ...nearestOwnedDistance.roomName ? { nearestOwnedRoom: nearestOwnedDistance.roomName } : {},
+        ...nearestOwnedDistance.distance !== void 0 ? { nearestOwnedRoomDistance: nearestOwnedDistance.distance } : {},
+        ...room ? buildVisibleExpansionCandidateEvidence(room) : buildUnseenExpansionCandidateEvidence(roomName)
+      }
+    ];
+  });
+}
+function buildUnseenExpansionCandidateEvidence(roomName) {
+  const terrain = summarizeRoomTerrain(roomName);
+  return {
+    visible: false,
+    ...terrain ? { terrain } : {}
+  };
 }
 function buildVisibleExpansionCandidateEvidence(room) {
   const controller = room.controller;
   const sources = findRoomObjects7(room, getFindConstant4("FIND_SOURCES"));
   const controllerSourceRange = calculateAverageControllerSourceRange(controller, sources);
-  const terrain = summarizeRoomTerrain(room);
+  const roomTerrain = getRoomTerrain4(room);
+  const terrain = summarizeRoomTerrainFromTerrain(roomTerrain);
+  const sourceAccessPoints = calculateAverageSourceAccessPoints(roomTerrain, sources);
   const hostileCreepCount = findRoomObjects7(room, getFindConstant4("FIND_HOSTILE_CREEPS")).length;
   const hostileStructureCount = findRoomObjects7(
     room,
     getFindConstant4("FIND_HOSTILE_STRUCTURES")
   ).length;
   return {
+    visible: true,
     ...controller ? { controller: summarizeExpansionController(controller) } : {},
     ...typeof (controller == null ? void 0 : controller.id) === "string" ? { controllerId: controller.id } : {},
     sourceCount: sources.length,
+    ...typeof sourceAccessPoints === "number" ? { sourceAccessPoints } : {},
     ...typeof controllerSourceRange === "number" ? { controllerSourceRange } : {},
     ...terrain ? { terrain } : {},
     hostileCreepCount,
@@ -13080,6 +13151,7 @@ function scoreExpansionCandidate(input, candidate) {
   const risks = [];
   const preconditions = getExpansionPreconditions(input);
   let evidenceStatus = "sufficient";
+  const visible = candidate.visible !== false;
   const routeDistance = candidate.routeDistance === null ? void 0 : candidate.routeDistance;
   const nearestOwnedRoomDistance = candidate.nearestOwnedRoomDistance === null ? void 0 : candidate.nearestOwnedRoomDistance;
   if (candidate.routeDistance === null || candidate.nearestOwnedRoomDistance === null) {
@@ -13087,8 +13159,14 @@ function scoreExpansionCandidate(input, candidate) {
     evidenceStatus = "unavailable";
   }
   if (!candidate.controller) {
-    risks.push("visible room has no controller");
-    evidenceStatus = "unavailable";
+    if (visible) {
+      risks.push("visible room has no controller");
+      evidenceStatus = "unavailable";
+    } else {
+      rationale.push("scout required for controller evidence");
+      risks.push("controller evidence missing until scout");
+      evidenceStatus = downgradeEvidenceStatus(evidenceStatus, "insufficient-evidence");
+    }
   } else {
     const controllerStatus = getControllerStatus(input, candidate.controller);
     rationale.push(controllerStatus.rationale);
@@ -13102,13 +13180,16 @@ function scoreExpansionCandidate(input, candidate) {
   if (typeof candidate.sourceCount === "number") {
     rationale.push(`${candidate.sourceCount} sources visible`);
   } else {
-    risks.push("source count evidence missing");
+    risks.push(visible ? "source count evidence missing" : "source count evidence missing until scout");
     evidenceStatus = downgradeEvidenceStatus(evidenceStatus, "insufficient-evidence");
+  }
+  if (typeof candidate.sourceAccessPoints === "number") {
+    rationale.push(`source access ${formatSourceAccessPoints(candidate.sourceAccessPoints)} open tiles`);
   }
   if (typeof candidate.controllerSourceRange === "number") {
     rationale.push(`controller-source range ${candidate.controllerSourceRange}`);
   } else {
-    risks.push("controller proximity evidence missing");
+    risks.push(visible ? "controller proximity evidence missing" : "controller proximity evidence missing until scout");
     evidenceStatus = downgradeEvidenceStatus(evidenceStatus, "insufficient-evidence");
   }
   if (candidate.terrain) {
@@ -13119,6 +13200,10 @@ function scoreExpansionCandidate(input, candidate) {
   }
   const hostileCreepCount = (_a = candidate.hostileCreepCount) != null ? _a : 0;
   const hostileStructureCount = (_b = candidate.hostileStructureCount) != null ? _b : 0;
+  if (!visible && (candidate.hostileCreepCount === void 0 || candidate.hostileStructureCount === void 0)) {
+    risks.push("hostile evidence missing until scout");
+    evidenceStatus = downgradeEvidenceStatus(evidenceStatus, "insufficient-evidence");
+  }
   if (hostileCreepCount > 0 || hostileStructureCount > 0) {
     risks.push("hostile presence visible");
     evidenceStatus = "unavailable";
@@ -13139,6 +13224,7 @@ function scoreExpansionCandidate(input, candidate) {
     roomName: candidate.roomName,
     score,
     evidenceStatus,
+    visible,
     rationale,
     preconditions,
     risks,
@@ -13148,6 +13234,7 @@ function scoreExpansionCandidate(input, candidate) {
     ...nearestOwnedRoomDistance !== void 0 ? { nearestOwnedRoomDistance } : {},
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {},
     ...candidate.sourceCount !== void 0 ? { sourceCount: candidate.sourceCount } : {},
+    ...candidate.sourceAccessPoints !== void 0 ? { sourceAccessPoints: candidate.sourceAccessPoints } : {},
     ...candidate.controllerSourceRange !== void 0 ? { controllerSourceRange: candidate.controllerSourceRange } : {},
     ...candidate.terrain ? { terrain: candidate.terrain } : {},
     ...candidate.hostileCreepCount !== void 0 ? { hostileCreepCount: candidate.hostileCreepCount } : {},
@@ -13160,6 +13247,7 @@ function calculateExpansionScore(input, candidate, evidenceStatus) {
   var _a, _b, _c;
   const sourceScore = typeof candidate.sourceCount === "number" ? Math.min(candidate.sourceCount, 2) * 120 + Math.max(0, candidate.sourceCount - 2) * 20 : 0;
   const dualSourceBonus = ((_a = candidate.sourceCount) != null ? _a : 0) >= 2 ? DUAL_SOURCE_BONUS : 0;
+  const sourceAccessScore = typeof candidate.sourceAccessPoints === "number" ? Math.round(candidate.sourceAccessPoints * 18) : 0;
   const proximityScore = typeof candidate.controllerSourceRange === "number" ? Math.max(-80, 100 - candidate.controllerSourceRange * 6) : 0;
   const terrainScore = candidate.terrain ? Math.round(candidate.terrain.walkableRatio * 140 - candidate.terrain.swampRatio * 70) : 0;
   const reservationScore = getReservationScore(input, candidate.controller);
@@ -13171,7 +13259,7 @@ function calculateExpansionScore(input, candidate, evidenceStatus) {
   const insufficientEvidencePenalty = evidenceStatus === "insufficient-evidence" ? 260 : 0;
   const preconditionPenalty = getExpansionPreconditions(input).length * 120;
   return Math.round(
-    500 + sourceScore + dualSourceBonus + proximityScore + terrainScore + reservationScore + distanceScore + adjacencyScore - foreignControllerPenalty - hostilePenalty - unavailablePenalty - insufficientEvidencePenalty - preconditionPenalty
+    500 + sourceScore + dualSourceBonus + sourceAccessScore + proximityScore + terrainScore + reservationScore + distanceScore + adjacencyScore - foreignControllerPenalty - hostilePenalty - unavailablePenalty - insufficientEvidencePenalty - preconditionPenalty
   );
 }
 function hasForeignControllerPresence(input, controller) {
@@ -13193,7 +13281,10 @@ function getDistanceScore(candidate) {
 }
 function getReservationScore(input, controller) {
   var _a;
-  if (!(controller == null ? void 0 : controller.reservationUsername)) {
+  if (!controller) {
+    return 0;
+  }
+  if (!controller.reservationUsername) {
     return 45;
   }
   if (controller.reservationUsername === input.colonyOwnerUsername) {
@@ -13292,6 +13383,54 @@ function hasRoomLimitPrecondition(candidate) {
   return candidate.preconditions.some(
     (precondition) => precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX)
   );
+}
+function persistExpansionCandidateScores(colony, report, gameTime) {
+  const territoryMemory = getWritableTerritoryMemoryRecord3();
+  if (!territoryMemory) {
+    return;
+  }
+  const existingCandidates = Array.isArray(territoryMemory.expansionCandidates) ? territoryMemory.expansionCandidates.filter(
+    (candidate) => isRecord11(candidate) && candidate.colony !== colony
+  ) : [];
+  const nextCandidates = report.candidates.slice(0, MAX_PERSISTED_EXPANSION_CANDIDATES).map((candidate) => toPersistedExpansionCandidateMemory(colony, candidate, gameTime));
+  if (existingCandidates.length === 0 && nextCandidates.length === 0) {
+    delete territoryMemory.expansionCandidates;
+    return;
+  }
+  territoryMemory.expansionCandidates = [...existingCandidates, ...nextCandidates];
+}
+function toPersistedExpansionCandidateMemory(colony, candidate, gameTime) {
+  const recommendedAction = getPersistedExpansionCandidateRecommendedAction(candidate);
+  return {
+    colony,
+    roomName: candidate.roomName,
+    score: candidate.score,
+    evidenceStatus: candidate.evidenceStatus,
+    visible: candidate.visible,
+    updatedAt: gameTime,
+    adjacentToOwnedRoom: candidate.adjacentToOwnedRoom,
+    ...recommendedAction ? { recommendedAction } : {},
+    ...candidate.routeDistance !== void 0 ? { routeDistance: candidate.routeDistance } : {},
+    ...candidate.nearestOwnedRoom ? { nearestOwnedRoom: candidate.nearestOwnedRoom } : {},
+    ...candidate.nearestOwnedRoomDistance !== void 0 ? { nearestOwnedRoomDistance: candidate.nearestOwnedRoomDistance } : {},
+    ...candidate.controllerId ? { controllerId: candidate.controllerId } : {},
+    ...candidate.sourceCount !== void 0 ? { sourceCount: candidate.sourceCount } : {},
+    ...candidate.sourceAccessPoints !== void 0 ? { sourceAccessPoints: candidate.sourceAccessPoints } : {},
+    ...candidate.controllerSourceRange !== void 0 ? { controllerSourceRange: candidate.controllerSourceRange } : {},
+    ...candidate.terrain ? { terrain: candidate.terrain } : {},
+    ...candidate.hostileCreepCount !== void 0 ? { hostileCreepCount: candidate.hostileCreepCount } : {},
+    ...candidate.hostileStructureCount !== void 0 ? { hostileStructureCount: candidate.hostileStructureCount } : {},
+    ...candidate.requiresControllerPressure ? { requiresControllerPressure: true } : {},
+    ...candidate.risks.length > 0 ? { risks: candidate.risks } : {},
+    ...candidate.preconditions.length > 0 ? { preconditions: candidate.preconditions } : {},
+    ...candidate.rationale.length > 0 ? { rationale: candidate.rationale } : {}
+  };
+}
+function getPersistedExpansionCandidateRecommendedAction(candidate) {
+  if (candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0) {
+    return "claim";
+  }
+  return candidate.evidenceStatus === "insufficient-evidence" && candidate.adjacentToOwnedRoom ? "scout" : void 0;
 }
 function persistNextExpansionTarget(colony, candidate, gameTime) {
   const territoryMemory = getWritableTerritoryMemoryRecord3();
@@ -13564,11 +13703,47 @@ function calculateAverageControllerSourceRange(controller, sources) {
   }
   return Math.round(ranges.reduce((total, range) => total + range, 0) / ranges.length);
 }
+function calculateAverageSourceAccessPoints(terrain, sources) {
+  if (sources.length === 0) {
+    return void 0;
+  }
+  if (!terrain || typeof terrain.get !== "function") {
+    return void 0;
+  }
+  const wallMask = getTerrainMask("TERRAIN_MASK_WALL", DEFAULT_TERRAIN_WALL_MASK4);
+  const accessCounts = sources.flatMap((source) => {
+    if (!source.pos) {
+      return [];
+    }
+    return [countWalkableAdjacentTiles(source.pos, terrain, wallMask)];
+  });
+  if (accessCounts.length === 0) {
+    return void 0;
+  }
+  const average2 = accessCounts.reduce((total, count) => total + count, 0) / accessCounts.length;
+  return Math.round(average2 * 10) / 10;
+}
+function countWalkableAdjacentTiles(pos, terrain, wallMask) {
+  let walkableCount = 0;
+  for (let x = Math.max(0, pos.x - 1); x <= Math.min(49, pos.x + 1); x += 1) {
+    for (let y = Math.max(0, pos.y - 1); y <= Math.min(49, pos.y + 1); y += 1) {
+      if (x === pos.x && y === pos.y) {
+        continue;
+      }
+      if ((terrain.get(x, y) & wallMask) === 0) {
+        walkableCount += 1;
+      }
+    }
+  }
+  return walkableCount;
+}
 function getRoomPositionRange(left, right) {
   return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
-function summarizeRoomTerrain(room) {
-  const terrain = getRoomTerrain4(room);
+function summarizeRoomTerrain(roomOrName) {
+  return summarizeRoomTerrainFromTerrain(getRoomTerrain4(roomOrName));
+}
+function summarizeRoomTerrainFromTerrain(terrain) {
   if (!terrain || typeof terrain.get !== "function") {
     return null;
   }
@@ -13599,14 +13774,17 @@ function summarizeRoomTerrain(room) {
     wallRatio: roundRatio2(wallCount, total)
   };
 }
-function getRoomTerrain4(room) {
+function getRoomTerrain4(roomOrName) {
   var _a;
-  const roomWithTerrain = room;
-  if (typeof roomWithTerrain.getTerrain === "function") {
-    return roomWithTerrain.getTerrain();
+  if (typeof roomOrName !== "string") {
+    const roomWithTerrain = roomOrName;
+    if (typeof roomWithTerrain.getTerrain === "function") {
+      return roomWithTerrain.getTerrain();
+    }
   }
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
-  return typeof (gameMap == null ? void 0 : gameMap.getRoomTerrain) === "function" ? gameMap.getRoomTerrain(room.name) : null;
+  const roomName = typeof roomOrName === "string" ? roomOrName : roomOrName.name;
+  return typeof (gameMap == null ? void 0 : gameMap.getRoomTerrain) === "function" ? gameMap.getRoomTerrain(roomName) : null;
 }
 function getTerrainMask(name, fallback) {
   const value = globalThis[name];
@@ -13675,6 +13853,9 @@ function roundRatio2(numerator, denominator) {
 }
 function toPercent(value) {
   return `${Math.round(value * 100)}%`;
+}
+function formatSourceAccessPoints(value) {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
 function isRecord11(value) {
   return typeof value === "object" && value !== null;

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -987,8 +987,18 @@ function getNearestOwnedRoomDistance(
   let nearestDistance: number | null | undefined;
   for (const ownedRoomName of ownedRoomNames) {
     const adjacentDistance = adjacentRoomNames.get(ownedRoomName)?.has(targetRoom) ? 1 : undefined;
-    const routeDistance = getKnownRouteLength(ownedRoomName, targetRoom);
-    const distance = routeDistance ?? adjacentDistance;
+    if (adjacentDistance !== undefined) {
+      nearestRoomName = ownedRoomName;
+      nearestDistance = adjacentDistance;
+      break;
+    }
+
+    const linearDistance = getLinearRoomDistance(ownedRoomName, targetRoom);
+    if (linearDistance !== undefined && linearDistance > MAX_NEARBY_EXPANSION_ROUTE_DISTANCE) {
+      continue;
+    }
+
+    const distance = getKnownRouteLength(ownedRoomName, targetRoom);
     if (distance === undefined) {
       continue;
     }
@@ -1011,6 +1021,18 @@ function getNearestOwnedRoomDistance(
     ...(nearestRoomName ? { roomName: nearestRoomName } : {}),
     ...(nearestDistance !== undefined ? { distance: nearestDistance } : {})
   };
+}
+
+function getLinearRoomDistance(fromRoom: string, targetRoom: string): number | undefined {
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map as
+    | (Partial<GameMap> & { getRoomLinearDistance?: (roomName1: string, roomName2: string) => number })
+    | undefined;
+  if (typeof gameMap?.getRoomLinearDistance !== 'function') {
+    return undefined;
+  }
+
+  const distance = gameMap.getRoomLinearDistance.call(gameMap, fromRoom, targetRoom);
+  return Number.isFinite(distance) ? distance : undefined;
 }
 
 function isNearbyExpansionCandidate(

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -16,6 +16,7 @@ const DUAL_SOURCE_BONUS = 180;
 const FOREIGN_CONTROLLER_PENALTY = 300;
 const DOWNGRADE_GUARD_TICKS = 5_000;
 const MIN_CONTROLLER_LEVEL = 2;
+const MAX_PERSISTED_EXPANSION_CANDIDATES = 5;
 const FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = 'foreign reservation requires controller pressure';
 const ROOM_LIMIT_PRECONDITION_PREFIX = 'limit expansion to ';
 const MAX_ROOM_COUNT_BY_RCL: Record<number, number> = {
@@ -41,6 +42,7 @@ export interface ExpansionCandidateScore {
   roomName: string;
   score: number;
   evidenceStatus: ExpansionCandidateEvidenceStatus;
+  visible: boolean;
   rationale: string[];
   preconditions: string[];
   risks: string[];
@@ -50,6 +52,7 @@ export interface ExpansionCandidateScore {
   adjacentToOwnedRoom: boolean;
   controllerId?: Id<StructureController>;
   sourceCount?: number;
+  sourceAccessPoints?: number;
   controllerSourceRange?: number;
   terrain?: ExpansionTerrainQuality;
   hostileCreepCount?: number;
@@ -73,12 +76,14 @@ export interface ExpansionCandidateInput {
   roomName: string;
   order: number;
   adjacentToOwnedRoom: boolean;
+  visible?: boolean;
   routeDistance?: number | null;
   nearestOwnedRoom?: string;
   nearestOwnedRoomDistance?: number | null;
   controller?: ExpansionControllerEvidence;
   controllerId?: Id<StructureController>;
   sourceCount?: number;
+  sourceAccessPoints?: number;
   controllerSourceRange?: number;
   terrain?: ExpansionTerrainQuality;
   hostileCreepCount?: number;
@@ -103,6 +108,37 @@ export interface ExpansionReservationEvidence {
   relation: 'own' | 'foreign';
   ticksToEnd?: number;
 }
+
+type PersistedExpansionCandidateRecommendedAction = 'claim' | 'scout';
+
+interface PersistedExpansionCandidateMemory {
+  colony: string;
+  roomName: string;
+  score: number;
+  evidenceStatus: ExpansionCandidateEvidenceStatus;
+  visible: boolean;
+  updatedAt: number;
+  adjacentToOwnedRoom: boolean;
+  recommendedAction?: PersistedExpansionCandidateRecommendedAction;
+  routeDistance?: number;
+  nearestOwnedRoom?: string;
+  nearestOwnedRoomDistance?: number;
+  controllerId?: Id<StructureController>;
+  sourceCount?: number;
+  sourceAccessPoints?: number;
+  controllerSourceRange?: number;
+  terrain?: ExpansionTerrainQuality;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  requiresControllerPressure?: boolean;
+  risks?: string[];
+  preconditions?: string[];
+  rationale?: string[];
+}
+
+type TerritoryMemoryWithExpansionCandidates = TerritoryMemory & {
+  expansionCandidates?: PersistedExpansionCandidateMemory[];
+};
 
 export type NextExpansionTargetSelectionStatus = 'planned' | 'skipped';
 export type NextExpansionTargetSelectionReason =
@@ -141,6 +177,7 @@ export function refreshNextExpansionTargetSelection(
   gameTime: number
 ): NextExpansionTargetSelection {
   const colonyName = colony.room.name;
+  persistExpansionCandidateScores(colonyName, report, gameTime);
   const candidate = selectPersistableExpansionCandidate(report);
   if (!candidate) {
     pruneNextExpansionTargets(colonyName);
@@ -192,20 +229,36 @@ export function maxRoomsForRcl(controllerLevel: number | undefined): number {
 }
 
 function buildRuntimeExpansionCandidates(colony: ColonySnapshot): ExpansionCandidateInput[] {
-  const rooms = getGameRooms();
-  if (!rooms) {
-    return [];
-  }
-
+  const rooms = getGameRooms() ?? {};
   const colonyName = colony.room.name;
   const ownerUsername = getControllerOwnerUsername(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames(colonyName, ownerUsername);
   const adjacentRoomNames = getAdjacentRoomNamesByOwnedRoom(ownedRoomNames);
-  const candidates: ExpansionCandidateInput[] = [];
+  const candidateOrders = new Map<string, number>();
   let order = 0;
+
+  for (const ownedRoomName of ownedRoomNames) {
+    const adjacentRooms = adjacentRoomNames.get(ownedRoomName);
+    if (!adjacentRooms) {
+      continue;
+    }
+
+    for (const roomName of adjacentRooms) {
+      if (roomName === colonyName || ownedRoomNames.has(roomName) || candidateOrders.has(roomName)) {
+        continue;
+      }
+
+      candidateOrders.set(roomName, order);
+      order += 1;
+    }
+  }
 
   for (const room of Object.values(rooms)) {
     if (!room || !isNonEmptyString(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
+      continue;
+    }
+
+    if (candidateOrders.has(room.name)) {
       continue;
     }
 
@@ -216,21 +269,44 @@ function buildRuntimeExpansionCandidates(colony: ColonySnapshot): ExpansionCandi
       continue;
     }
 
-    candidates.push({
-      roomName: room.name,
-      order,
-      adjacentToOwnedRoom,
-      ...(routeDistance !== undefined ? { routeDistance } : {}),
-      ...(nearestOwnedDistance.roomName ? { nearestOwnedRoom: nearestOwnedDistance.roomName } : {}),
-      ...(nearestOwnedDistance.distance !== undefined
-        ? { nearestOwnedRoomDistance: nearestOwnedDistance.distance }
-        : {}),
-      ...buildVisibleExpansionCandidateEvidence(room)
-    });
+    candidateOrders.set(room.name, order);
     order += 1;
   }
 
-  return candidates;
+  return Array.from(candidateOrders.entries()).flatMap(([roomName, candidateOrder]) => {
+    const routeDistance = getKnownRouteLength(colonyName, roomName);
+    const nearestOwnedDistance = getNearestOwnedRoomDistance(ownedRoomNames, roomName, adjacentRoomNames);
+    const adjacentToOwnedRoom = isAdjacentToOwnedRoom(roomName, adjacentRoomNames);
+    if (!isNearbyExpansionCandidate(routeDistance, nearestOwnedDistance, adjacentToOwnedRoom)) {
+      return [];
+    }
+
+    const room = rooms[roomName];
+    return [
+      {
+        roomName,
+        order: candidateOrder,
+        visible: room != null,
+        adjacentToOwnedRoom,
+        ...(routeDistance !== undefined ? { routeDistance } : {}),
+        ...(nearestOwnedDistance.roomName ? { nearestOwnedRoom: nearestOwnedDistance.roomName } : {}),
+        ...(nearestOwnedDistance.distance !== undefined
+          ? { nearestOwnedRoomDistance: nearestOwnedDistance.distance }
+          : {}),
+        ...(room ? buildVisibleExpansionCandidateEvidence(room) : buildUnseenExpansionCandidateEvidence(roomName))
+      }
+    ];
+  });
+}
+
+function buildUnseenExpansionCandidateEvidence(
+  roomName: string
+): Omit<ExpansionCandidateInput, 'roomName' | 'order' | 'adjacentToOwnedRoom'> {
+  const terrain = summarizeRoomTerrain(roomName);
+  return {
+    visible: false,
+    ...(terrain ? { terrain } : {})
+  };
 }
 
 function buildVisibleExpansionCandidateEvidence(
@@ -239,7 +315,9 @@ function buildVisibleExpansionCandidateEvidence(
   const controller = room.controller;
   const sources = findRoomObjects<Source>(room, getFindConstant('FIND_SOURCES'));
   const controllerSourceRange = calculateAverageControllerSourceRange(controller, sources);
-  const terrain = summarizeRoomTerrain(room);
+  const roomTerrain = getRoomTerrain(room);
+  const terrain = summarizeRoomTerrainFromTerrain(roomTerrain);
+  const sourceAccessPoints = calculateAverageSourceAccessPoints(roomTerrain, sources);
   const hostileCreepCount = findRoomObjects<Creep>(room, getFindConstant('FIND_HOSTILE_CREEPS')).length;
   const hostileStructureCount = findRoomObjects<AnyStructure>(
     room,
@@ -247,9 +325,11 @@ function buildVisibleExpansionCandidateEvidence(
   ).length;
 
   return {
+    visible: true,
     ...(controller ? { controller: summarizeExpansionController(controller) } : {}),
     ...(typeof controller?.id === 'string' ? { controllerId: controller.id as Id<StructureController> } : {}),
     sourceCount: sources.length,
+    ...(typeof sourceAccessPoints === 'number' ? { sourceAccessPoints } : {}),
     ...(typeof controllerSourceRange === 'number' ? { controllerSourceRange } : {}),
     ...(terrain ? { terrain } : {}),
     hostileCreepCount,
@@ -265,6 +345,7 @@ function scoreExpansionCandidate(
   const risks: string[] = [];
   const preconditions = getExpansionPreconditions(input);
   let evidenceStatus: ExpansionCandidateEvidenceStatus = 'sufficient';
+  const visible = candidate.visible !== false;
 
   const routeDistance = candidate.routeDistance === null ? undefined : candidate.routeDistance;
   const nearestOwnedRoomDistance =
@@ -275,8 +356,14 @@ function scoreExpansionCandidate(
   }
 
   if (!candidate.controller) {
-    risks.push('visible room has no controller');
-    evidenceStatus = 'unavailable';
+    if (visible) {
+      risks.push('visible room has no controller');
+      evidenceStatus = 'unavailable';
+    } else {
+      rationale.push('scout required for controller evidence');
+      risks.push('controller evidence missing until scout');
+      evidenceStatus = downgradeEvidenceStatus(evidenceStatus, 'insufficient-evidence');
+    }
   } else {
     const controllerStatus = getControllerStatus(input, candidate.controller);
     rationale.push(controllerStatus.rationale);
@@ -291,14 +378,18 @@ function scoreExpansionCandidate(
   if (typeof candidate.sourceCount === 'number') {
     rationale.push(`${candidate.sourceCount} sources visible`);
   } else {
-    risks.push('source count evidence missing');
+    risks.push(visible ? 'source count evidence missing' : 'source count evidence missing until scout');
     evidenceStatus = downgradeEvidenceStatus(evidenceStatus, 'insufficient-evidence');
+  }
+
+  if (typeof candidate.sourceAccessPoints === 'number') {
+    rationale.push(`source access ${formatSourceAccessPoints(candidate.sourceAccessPoints)} open tiles`);
   }
 
   if (typeof candidate.controllerSourceRange === 'number') {
     rationale.push(`controller-source range ${candidate.controllerSourceRange}`);
   } else {
-    risks.push('controller proximity evidence missing');
+    risks.push(visible ? 'controller proximity evidence missing' : 'controller proximity evidence missing until scout');
     evidenceStatus = downgradeEvidenceStatus(evidenceStatus, 'insufficient-evidence');
   }
 
@@ -311,6 +402,10 @@ function scoreExpansionCandidate(
 
   const hostileCreepCount = candidate.hostileCreepCount ?? 0;
   const hostileStructureCount = candidate.hostileStructureCount ?? 0;
+  if (!visible && (candidate.hostileCreepCount === undefined || candidate.hostileStructureCount === undefined)) {
+    risks.push('hostile evidence missing until scout');
+    evidenceStatus = downgradeEvidenceStatus(evidenceStatus, 'insufficient-evidence');
+  }
   if (hostileCreepCount > 0 || hostileStructureCount > 0) {
     risks.push('hostile presence visible');
     evidenceStatus = 'unavailable';
@@ -333,6 +428,7 @@ function scoreExpansionCandidate(
     roomName: candidate.roomName,
     score,
     evidenceStatus,
+    visible,
     rationale,
     preconditions,
     risks,
@@ -342,6 +438,7 @@ function scoreExpansionCandidate(
     ...(nearestOwnedRoomDistance !== undefined ? { nearestOwnedRoomDistance } : {}),
     ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
     ...(candidate.sourceCount !== undefined ? { sourceCount: candidate.sourceCount } : {}),
+    ...(candidate.sourceAccessPoints !== undefined ? { sourceAccessPoints: candidate.sourceAccessPoints } : {}),
     ...(candidate.controllerSourceRange !== undefined
       ? { controllerSourceRange: candidate.controllerSourceRange }
       : {}),
@@ -364,6 +461,8 @@ function calculateExpansionScore(
     ? Math.min(candidate.sourceCount, 2) * 120 + Math.max(0, candidate.sourceCount - 2) * 20
     : 0;
   const dualSourceBonus = (candidate.sourceCount ?? 0) >= 2 ? DUAL_SOURCE_BONUS : 0;
+  const sourceAccessScore =
+    typeof candidate.sourceAccessPoints === 'number' ? Math.round(candidate.sourceAccessPoints * 18) : 0;
   const proximityScore = typeof candidate.controllerSourceRange === 'number'
     ? Math.max(-80, 100 - candidate.controllerSourceRange * 6)
     : 0;
@@ -385,6 +484,7 @@ function calculateExpansionScore(
     500 +
       sourceScore +
       dualSourceBonus +
+      sourceAccessScore +
       proximityScore +
       terrainScore +
       reservationScore +
@@ -431,7 +531,11 @@ function getReservationScore(
   input: ExpansionScoringInput,
   controller: ExpansionControllerEvidence | undefined
 ): number {
-  if (!controller?.reservationUsername) {
+  if (!controller) {
+    return 0;
+  }
+
+  if (!controller.reservationUsername) {
     return 45;
   }
 
@@ -565,6 +669,83 @@ function hasRoomLimitPrecondition(candidate: ExpansionCandidateScore): boolean {
   return candidate.preconditions.some((precondition) =>
     precondition.startsWith(ROOM_LIMIT_PRECONDITION_PREFIX)
   );
+}
+
+function persistExpansionCandidateScores(
+  colony: string,
+  report: ExpansionCandidateReport,
+  gameTime: number
+): void {
+  const territoryMemory = getWritableTerritoryMemoryRecord() as TerritoryMemoryWithExpansionCandidates | null;
+  if (!territoryMemory) {
+    return;
+  }
+
+  const existingCandidates = Array.isArray(territoryMemory.expansionCandidates)
+    ? territoryMemory.expansionCandidates.filter(
+        (candidate) => isRecord(candidate) && candidate.colony !== colony
+      )
+    : [];
+  const nextCandidates = report.candidates
+    .slice(0, MAX_PERSISTED_EXPANSION_CANDIDATES)
+    .map((candidate) => toPersistedExpansionCandidateMemory(colony, candidate, gameTime));
+
+  if (existingCandidates.length === 0 && nextCandidates.length === 0) {
+    delete territoryMemory.expansionCandidates;
+    return;
+  }
+
+  territoryMemory.expansionCandidates = [...existingCandidates, ...nextCandidates];
+}
+
+function toPersistedExpansionCandidateMemory(
+  colony: string,
+  candidate: ExpansionCandidateScore,
+  gameTime: number
+): PersistedExpansionCandidateMemory {
+  const recommendedAction = getPersistedExpansionCandidateRecommendedAction(candidate);
+  return {
+    colony,
+    roomName: candidate.roomName,
+    score: candidate.score,
+    evidenceStatus: candidate.evidenceStatus,
+    visible: candidate.visible,
+    updatedAt: gameTime,
+    adjacentToOwnedRoom: candidate.adjacentToOwnedRoom,
+    ...(recommendedAction ? { recommendedAction } : {}),
+    ...(candidate.routeDistance !== undefined ? { routeDistance: candidate.routeDistance } : {}),
+    ...(candidate.nearestOwnedRoom ? { nearestOwnedRoom: candidate.nearestOwnedRoom } : {}),
+    ...(candidate.nearestOwnedRoomDistance !== undefined
+      ? { nearestOwnedRoomDistance: candidate.nearestOwnedRoomDistance }
+      : {}),
+    ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
+    ...(candidate.sourceCount !== undefined ? { sourceCount: candidate.sourceCount } : {}),
+    ...(candidate.sourceAccessPoints !== undefined ? { sourceAccessPoints: candidate.sourceAccessPoints } : {}),
+    ...(candidate.controllerSourceRange !== undefined
+      ? { controllerSourceRange: candidate.controllerSourceRange }
+      : {}),
+    ...(candidate.terrain ? { terrain: candidate.terrain } : {}),
+    ...(candidate.hostileCreepCount !== undefined ? { hostileCreepCount: candidate.hostileCreepCount } : {}),
+    ...(candidate.hostileStructureCount !== undefined
+      ? { hostileStructureCount: candidate.hostileStructureCount }
+      : {}),
+    ...(candidate.requiresControllerPressure ? { requiresControllerPressure: true } : {}),
+    ...(candidate.risks.length > 0 ? { risks: candidate.risks } : {}),
+    ...(candidate.preconditions.length > 0 ? { preconditions: candidate.preconditions } : {}),
+    ...(candidate.rationale.length > 0 ? { rationale: candidate.rationale } : {})
+  };
+}
+
+function getPersistedExpansionCandidateRecommendedAction(
+  candidate: ExpansionCandidateScore
+): PersistedExpansionCandidateRecommendedAction | undefined {
+  if (candidate.evidenceStatus === 'sufficient' && candidate.preconditions.length === 0) {
+    return 'claim';
+  }
+
+  return candidate.evidenceStatus === 'insufficient-evidence' && candidate.adjacentToOwnedRoom
+    ? 'scout'
+    : undefined;
 }
 
 function persistNextExpansionTarget(
@@ -956,12 +1137,60 @@ function calculateAverageControllerSourceRange(
   return Math.round(ranges.reduce((total, range) => total + range, 0) / ranges.length);
 }
 
+function calculateAverageSourceAccessPoints(
+  terrain: RoomTerrain | null,
+  sources: Source[]
+): number | undefined {
+  if (sources.length === 0) {
+    return undefined;
+  }
+
+  if (!terrain || typeof terrain.get !== 'function') {
+    return undefined;
+  }
+
+  const wallMask = getTerrainMask('TERRAIN_MASK_WALL', DEFAULT_TERRAIN_WALL_MASK);
+  const accessCounts = sources.flatMap((source) => {
+    if (!source.pos) {
+      return [];
+    }
+
+    return [countWalkableAdjacentTiles(source.pos, terrain, wallMask)];
+  });
+  if (accessCounts.length === 0) {
+    return undefined;
+  }
+
+  const average = accessCounts.reduce((total, count) => total + count, 0) / accessCounts.length;
+  return Math.round(average * 10) / 10;
+}
+
+function countWalkableAdjacentTiles(pos: RoomPosition, terrain: RoomTerrain, wallMask: number): number {
+  let walkableCount = 0;
+  for (let x = Math.max(0, pos.x - 1); x <= Math.min(49, pos.x + 1); x += 1) {
+    for (let y = Math.max(0, pos.y - 1); y <= Math.min(49, pos.y + 1); y += 1) {
+      if (x === pos.x && y === pos.y) {
+        continue;
+      }
+
+      if ((terrain.get(x, y) & wallMask) === 0) {
+        walkableCount += 1;
+      }
+    }
+  }
+
+  return walkableCount;
+}
+
 function getRoomPositionRange(left: RoomPosition, right: RoomPosition): number {
   return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
 
-function summarizeRoomTerrain(room: Room): ExpansionTerrainQuality | null {
-  const terrain = getRoomTerrain(room);
+function summarizeRoomTerrain(roomOrName: Room | string): ExpansionTerrainQuality | null {
+  return summarizeRoomTerrainFromTerrain(getRoomTerrain(roomOrName));
+}
+
+function summarizeRoomTerrainFromTerrain(terrain: RoomTerrain | null): ExpansionTerrainQuality | null {
   if (!terrain || typeof terrain.get !== 'function') {
     return null;
   }
@@ -996,16 +1225,19 @@ function summarizeRoomTerrain(room: Room): ExpansionTerrainQuality | null {
   };
 }
 
-function getRoomTerrain(room: Room): RoomTerrain | null {
-  const roomWithTerrain = room as Room & { getTerrain?: () => RoomTerrain };
-  if (typeof roomWithTerrain.getTerrain === 'function') {
-    return roomWithTerrain.getTerrain();
+function getRoomTerrain(roomOrName: Room | string): RoomTerrain | null {
+  if (typeof roomOrName !== 'string') {
+    const roomWithTerrain = roomOrName as Room & { getTerrain?: () => RoomTerrain };
+    if (typeof roomWithTerrain.getTerrain === 'function') {
+      return roomWithTerrain.getTerrain();
+    }
   }
 
   const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map as
     | (Partial<GameMap> & { getRoomTerrain?: (roomName: string) => RoomTerrain })
     | undefined;
-  return typeof gameMap?.getRoomTerrain === 'function' ? gameMap.getRoomTerrain(room.name) : null;
+  const roomName = typeof roomOrName === 'string' ? roomOrName : roomOrName.name;
+  return typeof gameMap?.getRoomTerrain === 'function' ? gameMap.getRoomTerrain(roomName) : null;
 }
 
 function getTerrainMask(name: 'TERRAIN_MASK_WALL' | 'TERRAIN_MASK_SWAMP', fallback: number): number {
@@ -1085,6 +1317,10 @@ function roundRatio(numerator: number, denominator: number): number {
 
 function toPercent(value: number): string {
   return `${Math.round(value * 100)}%`;
+}
+
+function formatSourceAccessPoints(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2029,7 +2029,8 @@ function sortAdjacentRoomsByPersistedExpansionScore(
     .map((roomName, index) => ({ roomName, index }))
     .sort(
       (left, right) =>
-        compareOptionalNumbers(scoredRoomRanks.get(left.roomName), scoredRoomRanks.get(right.roomName)) ||
+        (scoredRoomRanks.get(left.roomName) ?? Number.POSITIVE_INFINITY) -
+          (scoredRoomRanks.get(right.roomName) ?? Number.POSITIVE_INFINITY) ||
         left.index - right.index
     )
     .map(({ roomName }) => roomName);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1945,7 +1945,11 @@ function getAdjacentReserveCandidates(
   orderOffset: number,
   routeDistanceLookupContext: RouteDistanceLookupContext
 ): ScoredTerritoryTarget[] {
-  const adjacentRooms = getAdjacentRoomNames(originRoomName);
+  const adjacentRooms = sortAdjacentRoomsByPersistedExpansionScore(
+    getAdjacentRoomNames(originRoomName),
+    colonyName,
+    territoryMemory
+  );
   if (adjacentRooms.length === 0) {
     return [];
   }
@@ -2005,6 +2009,60 @@ function getAdjacentReserveCandidates(
 
     return [];
   });
+}
+
+function sortAdjacentRoomsByPersistedExpansionScore(
+  roomNames: string[],
+  colonyName: string,
+  territoryMemory: Record<string, unknown> | null
+): string[] {
+  if (roomNames.length <= 1) {
+    return roomNames;
+  }
+
+  const scoredRoomRanks = getPersistedExpansionCandidateRanks(colonyName, territoryMemory);
+  if (scoredRoomRanks.size === 0) {
+    return roomNames;
+  }
+
+  return roomNames
+    .map((roomName, index) => ({ roomName, index }))
+    .sort(
+      (left, right) =>
+        compareOptionalNumbers(scoredRoomRanks.get(left.roomName), scoredRoomRanks.get(right.roomName)) ||
+        left.index - right.index
+    )
+    .map(({ roomName }) => roomName);
+}
+
+function getPersistedExpansionCandidateRanks(
+  colonyName: string,
+  territoryMemory: Record<string, unknown> | null
+): Map<string, number> {
+  if (!territoryMemory || !Array.isArray(territoryMemory.expansionCandidates)) {
+    return new Map();
+  }
+
+  const ranks = new Map<string, number>();
+  for (const [index, rawCandidate] of territoryMemory.expansionCandidates.entries()) {
+    if (!isRecord(rawCandidate)) {
+      continue;
+    }
+
+    if (
+      rawCandidate.colony !== colonyName ||
+      !isNonEmptyString(rawCandidate.roomName) ||
+      rawCandidate.evidenceStatus === 'unavailable' ||
+      (rawCandidate.recommendedAction !== 'scout' && rawCandidate.recommendedAction !== 'claim') ||
+      ranks.has(rawCandidate.roomName)
+    ) {
+      continue;
+    }
+
+    ranks.set(rawCandidate.roomName, index);
+  }
+
+  return ranks;
 }
 
 function getVisibleAdjacentReserveCandidates(

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -247,6 +247,7 @@ describe('next expansion scoring', () => {
       nearestOwnedRoomDistance: 1,
       adjacentToOwnedRoom: true,
       sourceCount: 2,
+      sourceAccessPoints: 8,
       controllerSourceRange: 10,
       terrain: {
         walkableRatio: 0.9,
@@ -256,6 +257,112 @@ describe('next expansion scoring', () => {
     });
     expect(findRoute).toHaveBeenCalledWith('W1N1', 'W3N1');
     expect(findRoute).toHaveBeenCalledWith('W2N1', 'W3N1');
+  });
+
+  it('scores unseen adjacent rooms as scout-needed expansion candidates and the planner follows the persisted ranking', () => {
+    const colony = makeSafeColony();
+    const describeExits = jest.fn((roomName: string) =>
+      roomName === 'W1N1' ? { '1': 'W1N2', '3': 'W2N1' } : {}
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits,
+        findRoute: jest.fn(() => [{ exit: 3, room: 'next' }]),
+        getRoomTerrain: jest.fn((roomName: string) => makeTerrain(roomName === 'W2N1' ? 0.02 : 0.45))
+      } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room
+      }
+    };
+
+    const report = buildRuntimeExpansionCandidateReport(colony);
+
+    expect(report.candidates.map((candidate) => candidate.roomName)).toEqual(['W2N1', 'W1N2']);
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      evidenceStatus: 'insufficient-evidence',
+      visible: false,
+      terrain: {
+        walkableRatio: 0.98,
+        swampRatio: 0,
+        wallRatio: 0.02
+      },
+      risks: expect.arrayContaining([
+        'controller evidence missing until scout',
+        'source count evidence missing until scout',
+        'hostile evidence missing until scout'
+      ])
+    });
+
+    expect(refreshNextExpansionTargetSelection(colony, report, 400)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'insufficientEvidence'
+    });
+    expect(getExpansionCandidateMemory()).toEqual([
+      expect.objectContaining({
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        evidenceStatus: 'insufficient-evidence',
+        recommendedAction: 'scout',
+        visible: false,
+        updatedAt: 400
+      }),
+      expect.objectContaining({
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        evidenceStatus: 'insufficient-evidence',
+        recommendedAction: 'scout',
+        visible: false,
+        updatedAt: 400
+      })
+    ]);
+    expect(Memory.territory?.targets).toBeUndefined();
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 401)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'scout'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 401
+      }
+    ]);
+  });
+
+  it('records terrain-based source accessibility for visible expansion candidates', () => {
+    const colony = makeSafeColony();
+    const terrain = {
+      get: jest.fn((x: number, y: number) =>
+        x >= 14 && x <= 16 && y >= 24 && y <= 26 && !(x === 15 && y === 25) && y !== 24
+          ? TERRAIN_MASK_WALL
+          : 0
+      )
+    } as unknown as RoomTerrain;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' })),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain: jest.fn(() => terrain)
+      } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeVisibleExpansionRoom('W2N1')
+      }
+    };
+
+    const report = buildRuntimeExpansionCandidateReport(colony);
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      sourceAccessPoints: 3
+    });
+    expect(report.next?.rationale).toContain('source access 3 open tiles');
   });
 
   it('persists the selected claim target and the planner consumes it', () => {
@@ -679,6 +786,7 @@ function makeCandidate(overrides: Partial<ExpansionCandidateInput> = {}): Expans
     nearestOwnedRoomDistance: 1,
     controller: { },
     sourceCount: 1,
+    sourceAccessPoints: 6,
     controllerSourceRange: 8,
     terrain: { walkableRatio: 0.85, swampRatio: 0.1, wallRatio: 0.15 },
     hostileCreepCount: 0,
@@ -776,4 +884,11 @@ function makeTerrain(wallRatio: number): RoomTerrain {
       return normalized < wallRatio ? TERRAIN_MASK_WALL : 0;
     })
   } as unknown as RoomTerrain;
+}
+
+function getExpansionCandidateMemory(): Array<Record<string, unknown>> {
+  return (
+    ((Memory.territory ?? {}) as unknown as { expansionCandidates?: Array<Record<string, unknown>> })
+      .expansionCandidates ?? []
+  );
 }

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -227,6 +227,9 @@ describe('next expansion scoring', () => {
           roomName === 'W2N1' ? { '3': 'W3N1' } : { '3': 'W2N1' }
         ),
         findRoute,
+        getRoomLinearDistance: jest.fn((fromRoom: string, toRoom: string) =>
+          fromRoom === 'W2N1' && toRoom === 'W3N1' ? 1 : 8
+        ),
         getRoomTerrain: jest.fn((roomName: string) => makeTerrain(roomName === 'W3N1' ? 0.1 : 0.4))
       } as unknown as GameMap,
       rooms: {
@@ -256,7 +259,45 @@ describe('next expansion scoring', () => {
       }
     });
     expect(findRoute).toHaveBeenCalledWith('W1N1', 'W3N1');
-    expect(findRoute).toHaveBeenCalledWith('W2N1', 'W3N1');
+    expect(findRoute).not.toHaveBeenCalledWith('W2N1', 'W3N1');
+  });
+
+  it('filters distant owned rooms by linear distance before route lookup', () => {
+    const colony = makeSafeColony();
+    const findRoute = jest.fn((fromRoom: string, toRoom: string) =>
+      Array.from(
+        { length: fromRoom === 'W2N1' && toRoom === 'W4N1' ? 2 : 3 },
+        (_value, index) => ({ exit: 3, room: `${toRoom}-${index}` })
+      )
+    );
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: {
+        describeExits: jest.fn(() => ({})),
+        findRoute,
+        getRoomLinearDistance: jest.fn((fromRoom: string, toRoom: string) =>
+          fromRoom === 'W2N1' && toRoom === 'W4N1' ? 2 : 10
+        ),
+        getRoomTerrain: jest.fn(() => makeTerrain(0.1))
+      } as unknown as GameMap,
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeOwnedRoom('W2N1'),
+        W20N20: makeOwnedRoom('W20N20'),
+        W4N1: makeVisibleExpansionRoom('W4N1', { sourceCount: 2 })
+      }
+    };
+
+    const report = buildRuntimeExpansionCandidateReport(colony);
+
+    expect(report.next).toMatchObject({
+      roomName: 'W4N1',
+      routeDistance: 3,
+      nearestOwnedRoom: 'W2N1',
+      nearestOwnedRoomDistance: 2
+    });
+    expect(findRoute).toHaveBeenCalledWith('W1N1', 'W4N1');
+    expect(findRoute).toHaveBeenCalledWith('W2N1', 'W4N1');
+    expect(findRoute).not.toHaveBeenCalledWith('W20N20', 'W4N1');
   });
 
   it('scores unseen adjacent rooms as scout-needed expansion candidates and the planner follows the persisted ranking', () => {


### PR DESCRIPTION
## Summary
Implements adjacent room expansion scoring for territory growth in the Screeps bot.

## Changes
- `prod/src/territory/expansionScoring.ts`: Added adjacent room scoring logic
- `prod/src/territory/territoryPlanner.ts`: Integrated adjacent scoring into planner
- `prod/test/expansionScoring.test.ts`: Tests for adjacent room scoring
- `prod/dist/main.js`: Updated build artifact

## Verification
- TypeScript typecheck: PASS
- Jest test suite (903 tests): PASS
- Build (esbuild bundle): PASS

Closes #567
