### PR TITLE
feat(economy): optimize spawn body planning for RCL-appropriate worker efficiency (#568)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1651,9 +1651,6 @@ function buildLowRclWorkerBody(energyAvailable) {
   return body;
 }
 function buildProfileWorkerBody(energyAvailable, profile) {
-  if (energyAvailable < WORKER_PATTERN_COST) {
-    return [];
-  }
   if (energyAvailable < profile.patternCost) {
     return buildLowRclWorkerBody(energyAvailable);
   }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1585,12 +1585,24 @@ var WORKER_PATTERN = ["work", "carry", "move"];
 var WORKER_PATTERN_COST = 200;
 var WORKER_LOGISTICS_PAIR = ["carry", "move"];
 var WORKER_LOGISTICS_PAIR_COST = 100;
+var WORKER_WORK_MOVE_PAIR = ["work", "move"];
+var WORKER_WORK_MOVE_PAIR_COST = 150;
 var WORKER_SURPLUS_MOVE = ["move"];
 var WORKER_SURPLUS_MOVE_COST = 50;
+var MID_RCL_WORKER_PATTERN = ["work", "work", "carry", "move", "move"];
+var MID_RCL_WORKER_PATTERN_COST = 350;
+var HIGH_RCL_WORKER_PATTERN = ["work", "work", "work", "carry", "move", "move"];
+var HIGH_RCL_WORKER_PATTERN_COST = 450;
 var EMERGENCY_DEFENDER_BODY = ["tough", "attack", "move"];
 var EMERGENCY_DEFENDER_BODY_COST = 140;
 var MAX_CREEP_PARTS2 = 50;
 var MAX_WORKER_PATTERN_COUNT = 4;
+var MIN_MID_RCL = 4;
+var MIN_HIGH_RCL = 7;
+var MAX_MID_RCL_WORKER_PATTERN_COUNT = 5;
+var MAX_HIGH_RCL_WORKER_PATTERN_COUNT = 8;
+var MID_RCL_WORKER_MAX_COST = 1800;
+var HIGH_RCL_WORKER_MAX_COST = 3750;
 var BODY_PART_COSTS = {
   move: 50,
   work: 100,
@@ -1601,7 +1613,28 @@ var BODY_PART_COSTS = {
   claim: 600,
   tough: 10
 };
-function buildWorkerBody(energyAvailable) {
+var MID_RCL_WORKER_PROFILE = {
+  pattern: MID_RCL_WORKER_PATTERN,
+  patternCost: MID_RCL_WORKER_PATTERN_COST,
+  maxCost: MID_RCL_WORKER_MAX_COST,
+  maxPatternCount: MAX_MID_RCL_WORKER_PATTERN_COUNT
+};
+var HIGH_RCL_WORKER_PROFILE = {
+  pattern: HIGH_RCL_WORKER_PATTERN,
+  patternCost: HIGH_RCL_WORKER_PATTERN_COST,
+  maxCost: HIGH_RCL_WORKER_MAX_COST,
+  maxPatternCount: MAX_HIGH_RCL_WORKER_PATTERN_COUNT
+};
+function buildWorkerBody(energyAvailable, controllerLevel) {
+  if (isHighRcl(controllerLevel)) {
+    return buildProfileWorkerBody(energyAvailable, HIGH_RCL_WORKER_PROFILE);
+  }
+  if (isMidRcl(controllerLevel)) {
+    return buildProfileWorkerBody(energyAvailable, MID_RCL_WORKER_PROFILE);
+  }
+  return buildLowRclWorkerBody(energyAvailable);
+}
+function buildLowRclWorkerBody(energyAvailable) {
   if (energyAvailable < WORKER_PATTERN_COST) {
     return [];
   }
@@ -1616,6 +1649,46 @@ function buildWorkerBody(energyAvailable) {
     return [...body, ...WORKER_SURPLUS_MOVE];
   }
   return body;
+}
+function buildProfileWorkerBody(energyAvailable, profile) {
+  if (energyAvailable < WORKER_PATTERN_COST) {
+    return [];
+  }
+  if (energyAvailable < profile.patternCost) {
+    return buildLowRclWorkerBody(energyAvailable);
+  }
+  const energyBudget = Math.min(energyAvailable, profile.maxCost);
+  const maxPatternCountByEnergy = Math.floor(energyBudget / profile.patternCost);
+  const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS2 / profile.pattern.length);
+  const patternCount = Math.min(
+    maxPatternCountByEnergy,
+    maxPatternCountBySize,
+    profile.maxPatternCount
+  );
+  const body = Array.from({ length: patternCount }).flatMap(() => profile.pattern);
+  return addProfileWorkerRemainderParts(body, energyBudget, patternCount * profile.patternCost);
+}
+function addProfileWorkerRemainderParts(body, energyBudget, bodyCost) {
+  const additions = [
+    { parts: WORKER_WORK_MOVE_PAIR, cost: WORKER_WORK_MOVE_PAIR_COST },
+    { parts: WORKER_LOGISTICS_PAIR, cost: WORKER_LOGISTICS_PAIR_COST },
+    { parts: WORKER_SURPLUS_MOVE, cost: WORKER_SURPLUS_MOVE_COST }
+  ];
+  let nextBody = [...body];
+  let nextCost = bodyCost;
+  for (const addition of additions) {
+    if (nextCost + addition.cost <= energyBudget && nextBody.length + addition.parts.length <= MAX_CREEP_PARTS2) {
+      nextBody = [...nextBody, ...addition.parts];
+      nextCost += addition.cost;
+    }
+  }
+  return nextBody;
+}
+function isMidRcl(controllerLevel) {
+  return typeof controllerLevel === "number" && controllerLevel >= MIN_MID_RCL;
+}
+function isHighRcl(controllerLevel) {
+  return typeof controllerLevel === "number" && controllerLevel >= MIN_HIGH_RCL;
 }
 function shouldAddWorkerLogisticsPair(energyAvailable, patternCount, bodyPartCount) {
   const remainingEnergy = energyAvailable - patternCount * WORKER_PATTERN_COST;
@@ -12910,14 +12983,16 @@ function appendSpawnNameSuffix(baseName, options) {
   return options.nameSuffix ? `${baseName}-${options.nameSuffix}` : baseName;
 }
 function selectWorkerBody(colony, roleCounts) {
-  const normalBody = buildWorkerBody(colony.energyCapacityAvailable);
+  var _a;
+  const controllerLevel = (_a = colony.room.controller) == null ? void 0 : _a.level;
+  const normalBody = buildWorkerBody(colony.energyCapacityAvailable, controllerLevel);
   if (canAffordBody(normalBody, colony.energyAvailable)) {
     return normalBody;
   }
   if (roleCounts.worker === 0) {
     return buildEmergencyWorkerBody(colony.energyAvailable);
   }
-  return buildWorkerBody(colony.energyAvailable);
+  return buildWorkerBody(colony.energyAvailable, controllerLevel);
 }
 function canAffordBody(body, energyAvailable) {
   return body.length > 0 && getBodyCost(body) <= energyAvailable;

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -2,8 +2,14 @@ const WORKER_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move'];
 const WORKER_PATTERN_COST = 200;
 const WORKER_LOGISTICS_PAIR: BodyPartConstant[] = ['carry', 'move'];
 const WORKER_LOGISTICS_PAIR_COST = 100;
+const WORKER_WORK_MOVE_PAIR: BodyPartConstant[] = ['work', 'move'];
+const WORKER_WORK_MOVE_PAIR_COST = 150;
 const WORKER_SURPLUS_MOVE: BodyPartConstant[] = ['move'];
 const WORKER_SURPLUS_MOVE_COST = 50;
+const MID_RCL_WORKER_PATTERN: BodyPartConstant[] = ['work', 'work', 'carry', 'move', 'move'];
+const MID_RCL_WORKER_PATTERN_COST = 350;
+const HIGH_RCL_WORKER_PATTERN: BodyPartConstant[] = ['work', 'work', 'work', 'carry', 'move', 'move'];
+const HIGH_RCL_WORKER_PATTERN_COST = 450;
 const EMERGENCY_DEFENDER_BODY: BodyPartConstant[] = ['tough', 'attack', 'move'];
 const EMERGENCY_DEFENDER_BODY_COST = 140;
 import {
@@ -23,6 +29,12 @@ const MAX_CREEP_PARTS = 50;
 // four 200-energy patterns (800 energy) so early rooms do not sink capacity into
 // oversized unspecialized bodies before dedicated roles exist.
 const MAX_WORKER_PATTERN_COUNT = 4;
+const MIN_MID_RCL = 4;
+const MIN_HIGH_RCL = 7;
+const MAX_MID_RCL_WORKER_PATTERN_COUNT = 5;
+const MAX_HIGH_RCL_WORKER_PATTERN_COUNT = 8;
+const MID_RCL_WORKER_MAX_COST = 1800;
+const HIGH_RCL_WORKER_MAX_COST = 3750;
 const BODY_PART_COSTS: Record<BodyPartConstant, number> = {
   move: 50,
   work: 100,
@@ -34,7 +46,43 @@ const BODY_PART_COSTS: Record<BodyPartConstant, number> = {
   tough: 10
 };
 
-export function buildWorkerBody(energyAvailable: number): BodyPartConstant[] {
+interface WorkerBodyProfile {
+  pattern: BodyPartConstant[];
+  patternCost: number;
+  maxCost: number;
+  maxPatternCount: number;
+}
+
+const MID_RCL_WORKER_PROFILE: WorkerBodyProfile = {
+  pattern: MID_RCL_WORKER_PATTERN,
+  patternCost: MID_RCL_WORKER_PATTERN_COST,
+  maxCost: MID_RCL_WORKER_MAX_COST,
+  maxPatternCount: MAX_MID_RCL_WORKER_PATTERN_COUNT
+};
+
+const HIGH_RCL_WORKER_PROFILE: WorkerBodyProfile = {
+  pattern: HIGH_RCL_WORKER_PATTERN,
+  patternCost: HIGH_RCL_WORKER_PATTERN_COST,
+  maxCost: HIGH_RCL_WORKER_MAX_COST,
+  maxPatternCount: MAX_HIGH_RCL_WORKER_PATTERN_COUNT
+};
+
+export function buildWorkerBody(
+  energyAvailable: number,
+  controllerLevel?: number
+): BodyPartConstant[] {
+  if (isHighRcl(controllerLevel)) {
+    return buildProfileWorkerBody(energyAvailable, HIGH_RCL_WORKER_PROFILE);
+  }
+
+  if (isMidRcl(controllerLevel)) {
+    return buildProfileWorkerBody(energyAvailable, MID_RCL_WORKER_PROFILE);
+  }
+
+  return buildLowRclWorkerBody(energyAvailable);
+}
+
+function buildLowRclWorkerBody(energyAvailable: number): BodyPartConstant[] {
   if (energyAvailable < WORKER_PATTERN_COST) {
     return [];
   }
@@ -53,6 +101,65 @@ export function buildWorkerBody(energyAvailable: number): BodyPartConstant[] {
   }
 
   return body;
+}
+
+function buildProfileWorkerBody(
+  energyAvailable: number,
+  profile: WorkerBodyProfile
+): BodyPartConstant[] {
+  if (energyAvailable < WORKER_PATTERN_COST) {
+    return [];
+  }
+
+  if (energyAvailable < profile.patternCost) {
+    return buildLowRclWorkerBody(energyAvailable);
+  }
+
+  const energyBudget = Math.min(energyAvailable, profile.maxCost);
+  const maxPatternCountByEnergy = Math.floor(energyBudget / profile.patternCost);
+  const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS / profile.pattern.length);
+  const patternCount = Math.min(
+    maxPatternCountByEnergy,
+    maxPatternCountBySize,
+    profile.maxPatternCount
+  );
+  const body = Array.from({ length: patternCount }).flatMap(() => profile.pattern);
+
+  return addProfileWorkerRemainderParts(body, energyBudget, patternCount * profile.patternCost);
+}
+
+function addProfileWorkerRemainderParts(
+  body: BodyPartConstant[],
+  energyBudget: number,
+  bodyCost: number
+): BodyPartConstant[] {
+  const additions = [
+    { parts: WORKER_WORK_MOVE_PAIR, cost: WORKER_WORK_MOVE_PAIR_COST },
+    { parts: WORKER_LOGISTICS_PAIR, cost: WORKER_LOGISTICS_PAIR_COST },
+    { parts: WORKER_SURPLUS_MOVE, cost: WORKER_SURPLUS_MOVE_COST }
+  ];
+  let nextBody = [...body];
+  let nextCost = bodyCost;
+
+  for (const addition of additions) {
+    if (
+      nextCost + addition.cost <= energyBudget &&
+      nextBody.length + addition.parts.length <= MAX_CREEP_PARTS
+    ) {
+      nextBody = [...nextBody, ...addition.parts];
+      nextCost += addition.cost;
+    }
+  }
+
+  return nextBody;
+}
+
+function isMidRcl(controllerLevel: number | undefined): boolean {
+  return typeof controllerLevel === 'number' && controllerLevel >= MIN_MID_RCL;
+}
+
+function isHighRcl(controllerLevel: number | undefined): boolean {
+  return typeof controllerLevel === 'number' && controllerLevel >= MIN_HIGH_RCL;
 }
 
 function shouldAddWorkerLogisticsPair(

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -107,10 +107,6 @@ function buildProfileWorkerBody(
   energyAvailable: number,
   profile: WorkerBodyProfile
 ): BodyPartConstant[] {
-  if (energyAvailable < WORKER_PATTERN_COST) {
-    return [];
-  }
-
   if (energyAvailable < profile.patternCost) {
     return buildLowRclWorkerBody(energyAvailable);
   }

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -843,7 +843,8 @@ function appendSpawnNameSuffix(baseName: string, options: SpawnPlanningOptions):
 }
 
 function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyPartConstant[] {
-  const normalBody = buildWorkerBody(colony.energyCapacityAvailable);
+  const controllerLevel = colony.room.controller?.level;
+  const normalBody = buildWorkerBody(colony.energyCapacityAvailable, controllerLevel);
   if (canAffordBody(normalBody, colony.energyAvailable)) {
     return normalBody;
   }
@@ -852,7 +853,7 @@ function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyP
     return buildEmergencyWorkerBody(colony.energyAvailable);
   }
 
-  return buildWorkerBody(colony.energyAvailable);
+  return buildWorkerBody(colony.energyAvailable, controllerLevel);
 }
 
 function canAffordBody(body: BodyPartConstant[], energyAvailable: number): boolean {

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -9,6 +9,8 @@ import {
 import { TERRITORY_CONTROLLER_BODY, TERRITORY_CONTROLLER_BODY_COST } from '../src/spawn/creepBodies';
 
 const WORKER_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move'];
+const MID_RCL_WORKER_PATTERN: BodyPartConstant[] = ['work', 'work', 'carry', 'move', 'move'];
+const HIGH_RCL_WORKER_PATTERN: BodyPartConstant[] = ['work', 'work', 'work', 'carry', 'move', 'move'];
 
 const BODY_PART_COST_CASES: Array<[BodyPartConstant, number]> = [
   ['move', 50],
@@ -23,6 +25,10 @@ const BODY_PART_COST_CASES: Array<[BodyPartConstant, number]> = [
 
 function repeatWorkerPattern(patternCount: number): BodyPartConstant[] {
   return Array.from({ length: patternCount }).flatMap(() => WORKER_PATTERN);
+}
+
+function repeatPattern(pattern: BodyPartConstant[], patternCount: number): BodyPartConstant[] {
+  return Array.from({ length: patternCount }).flatMap(() => pattern);
 }
 
 describe('buildWorkerBody', () => {
@@ -45,7 +51,50 @@ describe('buildWorkerBody', () => {
   it('caps general-purpose worker bodies at 800 energy', () => {
     expect(buildWorkerBody(800)).toEqual(repeatWorkerPattern(4));
     expect(buildWorkerBody(10000)).toEqual(repeatWorkerPattern(4));
+    expect(buildWorkerBody(10000, 3)).toEqual(repeatWorkerPattern(4));
     expect(getBodyCost(buildWorkerBody(10000))).toBe(800);
+  });
+
+  it('keeps low RCL worker bodies compact and balanced', () => {
+    expect(buildWorkerBody(300, 1)).toEqual(WORKER_PATTERN);
+    expect(buildWorkerBody(650, 2)).toEqual([...repeatWorkerPattern(3), 'move']);
+    expect(buildWorkerBody(800, 3)).toEqual(repeatWorkerPattern(4));
+  });
+
+  it('uses mid RCL worker profiles with higher work capacity', () => {
+    expect(buildWorkerBody(300, 4)).toEqual(WORKER_PATTERN);
+    expect(buildWorkerBody(350, 4)).toEqual(MID_RCL_WORKER_PATTERN);
+    expect(buildWorkerBody(1300, 4)).toEqual([
+      ...repeatPattern(MID_RCL_WORKER_PATTERN, 3),
+      'work',
+      'move',
+      'carry',
+      'move'
+    ]);
+    expect(buildWorkerBody(2300, 6)).toEqual([...repeatPattern(MID_RCL_WORKER_PATTERN, 5), 'move']);
+    expect(getBodyCost(buildWorkerBody(2300, 6))).toBe(1800);
+  });
+
+  it('uses high RCL worker profiles for maximum throughput', () => {
+    expect(buildWorkerBody(800, 7)).toEqual([
+      ...HIGH_RCL_WORKER_PATTERN,
+      'work',
+      'move',
+      'carry',
+      'move',
+      'move'
+    ]);
+    expect(buildWorkerBody(3800, 8)).toEqual([
+      ...repeatPattern(HIGH_RCL_WORKER_PATTERN, 8),
+      'work',
+      'move'
+    ]);
+    expect(buildWorkerBody(5600, 8)).toEqual([
+      ...repeatPattern(HIGH_RCL_WORKER_PATTERN, 8),
+      'work',
+      'move'
+    ]);
+    expect(getBodyCost(buildWorkerBody(5600, 8))).toBe(3750);
   });
 
   it('returns an empty body when there is not enough energy for a worker set', () => {
@@ -63,6 +112,28 @@ describe('buildWorkerBody', () => {
       const completePatternPartCount = body.length - (body.length % WORKER_PATTERN.length);
       for (let i = 0; i < completePatternPartCount; i += WORKER_PATTERN.length) {
         expect(body.slice(i, i + WORKER_PATTERN.length)).toEqual(WORKER_PATTERN);
+      }
+    }
+  });
+
+  it('keeps RCL-aware worker bodies affordable within energy budgets and creep size limits', () => {
+    const cases: Array<{ controllerLevel: number; maxCost: number }> = [
+      { controllerLevel: 1, maxCost: 800 },
+      { controllerLevel: 3, maxCost: 800 },
+      { controllerLevel: 4, maxCost: 1800 },
+      { controllerLevel: 6, maxCost: 1800 },
+      { controllerLevel: 7, maxCost: 3750 },
+      { controllerLevel: 8, maxCost: 3750 }
+    ];
+    const energyBudgets = [0, 199, 200, 300, 350, 400, 600, 800, 1300, 1800, 2300, 3800, 5600, 10000];
+
+    for (const { controllerLevel, maxCost } of cases) {
+      for (const energyAvailable of energyBudgets) {
+        const body = buildWorkerBody(energyAvailable, controllerLevel);
+
+        expect(body.length).toBeLessThanOrEqual(50);
+        expect(getBodyCost(body)).toBeLessThanOrEqual(energyAvailable);
+        expect(getBodyCost(body)).toBeLessThanOrEqual(maxCost);
       }
     }
   });

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -75,6 +75,10 @@ describe('buildWorkerBody', () => {
     expect(getBodyCost(buildWorkerBody(2300, 6))).toBe(1800);
   });
 
+  it('falls back to a low-RCL worker body when high-RCL energy is below the profile pattern cost', () => {
+    expect(buildWorkerBody(400, 7)).toEqual(repeatWorkerPattern(2));
+  });
+
   it('uses high RCL worker profiles for maximum throughput', () => {
     expect(buildWorkerBody(800, 7)).toEqual([
       ...HIGH_RCL_WORKER_PATTERN,

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -12,6 +12,9 @@ import {
 } from '../src/territory/territoryPlanner';
 
 describe('planSpawn', () => {
+  const MID_RCL_WORKER_PATTERN: BodyPartConstant[] = ['work', 'work', 'carry', 'move', 'move'];
+  const HIGH_RCL_WORKER_PATTERN: BodyPartConstant[] = ['work', 'work', 'work', 'carry', 'move', 'move'];
+
   beforeEach(() => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
@@ -107,6 +110,10 @@ describe('planSpawn', () => {
         getCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? capacity : 0))
       }
     } as unknown as StructureStorage;
+  }
+
+  function repeatBodyPattern(pattern: BodyPartConstant[], patternCount: number): BodyPartConstant[] {
+    return Array.from({ length: patternCount }).flatMap(() => pattern);
   }
 
   function installHostileFindGlobals(): void {
@@ -285,6 +292,54 @@ describe('planSpawn', () => {
       body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'carry', 'move'],
       name: 'worker-W1N13-151',
       memory: { role: 'worker', colony: 'W1N13' }
+    });
+  });
+
+  it('uses the RCL4 medium worker profile when full capacity is affordable', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N19',
+      energyAvailable: 1300,
+      energyCapacityAvailable: 1300,
+      controller: { my: true, level: 4, ticksToDowngrade: 10_000 } as StructureController
+    });
+
+    expect(planSpawn(colony, { worker: 2 }, 152)).toEqual({
+      spawn,
+      body: [...repeatBodyPattern(MID_RCL_WORKER_PATTERN, 3), 'work', 'move', 'carry', 'move'],
+      name: 'worker-W1N19-152',
+      memory: { role: 'worker', colony: 'W1N19' }
+    });
+  });
+
+  it('falls back to an affordable RCL4 worker profile while room energy recovers', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N20',
+      energyAvailable: 600,
+      energyCapacityAvailable: 1300,
+      controller: { my: true, level: 4, ticksToDowngrade: 10_000 } as StructureController
+    });
+
+    expect(planSpawn(colony, { worker: 2 }, 153)).toEqual({
+      spawn,
+      body: [...MID_RCL_WORKER_PATTERN, 'work', 'move', 'carry', 'move'],
+      name: 'worker-W1N20-153',
+      memory: { role: 'worker', colony: 'W1N20' }
+    });
+  });
+
+  it('uses the high-RCL maximum-throughput worker profile', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N21',
+      energyAvailable: 5600,
+      energyCapacityAvailable: 5600,
+      controller: { my: true, level: 7, ticksToDowngrade: 10_000 } as StructureController
+    });
+
+    expect(planSpawn(colony, { worker: 2 }, 154)).toEqual({
+      spawn,
+      body: [...repeatBodyPattern(HIGH_RCL_WORKER_PATTERN, 8), 'work', 'move'],
+      name: 'worker-W1N21-154',
+      memory: { role: 'worker', colony: 'W1N21' }
     });
   });
 


### PR DESCRIPTION
## Summary
Optimizes spawn body planning to select RCL-appropriate worker body configurations for improved economy efficiency.

## Changes
- `prod/src/spawn/bodyBuilder.ts`: Body planning logic with RCL-gated worker configs
- `prod/src/spawn/spawnPlanner.ts`: Integration with spawn planner
- `prod/test/bodyBuilder.test.ts`: Tests for body planning
- `prod/test/spawnPlanner.test.ts`: Tests for spawn planner integration
- `prod/dist/main.js`: Updated build artifact

## Verification
- TypeScript typecheck: PASS
- Jest test suite (908 tests): PASS
- Build (esbuild bundle): PASS

Closes #568
