### PR TITLE
feat(economy): implement link energy transfer and storage management (#572)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7538,6 +7538,219 @@ function matchesStructureType5(actual, globalName, fallback) {
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 
+// src/economy/linkManager.ts
+var SOURCE_LINK_RANGE = 2;
+var CONTROLLER_LINK_RANGE = 3;
+var STORAGE_LINK_RANGE = 2;
+var OK_CODE3 = 0;
+function transferEnergy(room) {
+  var _a, _b, _c, _d;
+  const network = classifyLinks(room);
+  if (network.sourceLinks.length === 0) {
+    return [];
+  }
+  const destinationLinks = getDestinationLinks(network);
+  if (destinationLinks.length === 0) {
+    return [];
+  }
+  const projectedState = createProjectedLinkState(network.links);
+  const results = [];
+  for (const sourceLink of sortLinksByEnergy(network.sourceLinks, projectedState)) {
+    if (!canLinkSendEnergy(sourceLink, projectedState)) {
+      continue;
+    }
+    const destination = selectDestinationLink(sourceLink, destinationLinks, projectedState);
+    if (!destination) {
+      continue;
+    }
+    const sourceId = getObjectId2(sourceLink);
+    const destinationId = getObjectId2(destination.link);
+    const amount = Math.min(
+      (_a = projectedState.storedEnergyById.get(sourceId)) != null ? _a : 0,
+      (_b = projectedState.freeCapacityById.get(destinationId)) != null ? _b : 0
+    );
+    if (amount <= 0) {
+      continue;
+    }
+    const result = transferLinkEnergy(sourceLink, destination.link, amount);
+    results.push({
+      amount,
+      destinationId,
+      destinationRole: destination.role,
+      result,
+      sourceId
+    });
+    if (result === OK_CODE3) {
+      projectedState.storedEnergyById.set(sourceId, Math.max(0, ((_c = projectedState.storedEnergyById.get(sourceId)) != null ? _c : 0) - amount));
+      projectedState.freeCapacityById.set(
+        destinationId,
+        Math.max(0, ((_d = projectedState.freeCapacityById.get(destinationId)) != null ? _d : 0) - amount)
+      );
+    }
+  }
+  return results;
+}
+function classifyLinks(room) {
+  const links = findOwnedLinks(room);
+  const controllerLink = selectControllerLink(room, links);
+  const storageLink = selectStorageLink(room, links, controllerLink);
+  const destinationIds = new Set(
+    [controllerLink, storageLink].filter((link) => link !== null).map((link) => getObjectId2(link))
+  );
+  return {
+    links,
+    sourceLinks: selectSourceLinks(room, links, destinationIds),
+    controllerLink,
+    storageLink
+  };
+}
+function isSourceLink(room, link) {
+  const linkId = getObjectId2(link);
+  return linkId !== "" && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId2(sourceLink) === linkId);
+}
+function getDestinationLinks(network) {
+  const destinations = [];
+  if (network.controllerLink) {
+    destinations.push({ link: network.controllerLink, role: "controller" });
+  }
+  if (network.storageLink && getObjectId2(network.storageLink) !== getObjectId2(network.controllerLink)) {
+    destinations.push({ link: network.storageLink, role: "storage" });
+  }
+  return destinations;
+}
+function transferLinkEnergy(sourceLink, destinationLink, amount) {
+  return sourceLink.transfer(destinationLink, amount);
+}
+function selectDestinationLink(sourceLink, destinationLinks, projectedState) {
+  var _a;
+  const sourceId = getObjectId2(sourceLink);
+  return (_a = destinationLinks.find((destination) => {
+    var _a2;
+    const destinationId = getObjectId2(destination.link);
+    return destinationId !== sourceId && ((_a2 = projectedState.freeCapacityById.get(destinationId)) != null ? _a2 : 0) > 0;
+  })) != null ? _a : null;
+}
+function canLinkSendEnergy(link, projectedState) {
+  var _a;
+  return getLinkCooldown(link) <= 0 && ((_a = projectedState.storedEnergyById.get(getObjectId2(link))) != null ? _a : 0) > 0;
+}
+function createProjectedLinkState(links) {
+  return {
+    freeCapacityById: new Map(links.map((link) => [getObjectId2(link), getFreeEnergyCapacity(link)])),
+    storedEnergyById: new Map(links.map((link) => [getObjectId2(link), getStoredEnergy2(link)]))
+  };
+}
+function sortLinksByEnergy(links, projectedState) {
+  return [...links].sort(
+    (left, right) => {
+      var _a, _b;
+      return ((_a = projectedState.storedEnergyById.get(getObjectId2(right))) != null ? _a : 0) - ((_b = projectedState.storedEnergyById.get(getObjectId2(left))) != null ? _b : 0) || getObjectId2(left).localeCompare(getObjectId2(right));
+    }
+  );
+}
+function selectSourceLinks(room, links, destinationIds) {
+  const sources = findSources(room);
+  if (sources.length === 0) {
+    return [];
+  }
+  return links.filter((link) => !destinationIds.has(getObjectId2(link))).filter((link) => sources.some((source) => isNearRoomObject2(link, source, room.name, SOURCE_LINK_RANGE))).sort(compareObjectIds2);
+}
+function selectControllerLink(room, links) {
+  const controller = room.controller;
+  if (!controller) {
+    return null;
+  }
+  return selectClosestLink(links, controller, room.name, CONTROLLER_LINK_RANGE);
+}
+function selectStorageLink(room, links, controllerLink) {
+  var _a;
+  const storage = (_a = room.storage) != null ? _a : findStorage(room);
+  if (!storage) {
+    return null;
+  }
+  return selectClosestLink(
+    links.filter((link) => getObjectId2(link) !== getObjectId2(controllerLink)),
+    storage,
+    room.name,
+    STORAGE_LINK_RANGE
+  );
+}
+function selectClosestLink(links, target, roomName, range) {
+  var _a;
+  const targetPosition = getRoomObjectPosition(target);
+  if (!targetPosition || !isSameRoomPosition2(targetPosition, roomName)) {
+    return null;
+  }
+  return (_a = links.filter((link) => isNearRoomObject2(link, target, roomName, range)).sort(
+    (left, right) => compareRangeToPosition(targetPosition, left, right) || getObjectId2(left).localeCompare(getObjectId2(right))
+  )[0]) != null ? _a : null;
+}
+function isNearRoomObject2(left, right, roomName, range) {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return leftPosition !== null && rightPosition !== null && isSameRoomPosition2(leftPosition, roomName) && isSameRoomPosition2(rightPosition, roomName) && getRangeBetweenPositions2(leftPosition, rightPosition) <= range;
+}
+function compareRangeToPosition(position, left, right) {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return (leftPosition ? getRangeBetweenPositions2(position, leftPosition) : Number.POSITIVE_INFINITY) - (rightPosition ? getRangeBetweenPositions2(position, rightPosition) : Number.POSITIVE_INFINITY);
+}
+function findOwnedLinks(room) {
+  return findOwnedStructures2(room).filter((structure) => matchesStructureType6(structure.structureType, "STRUCTURE_LINK", "link")).sort(compareObjectIds2);
+}
+function findOwnedStructures2(room) {
+  if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const result = room.find(FIND_MY_STRUCTURES);
+  return Array.isArray(result) ? result : [];
+}
+function findStorage(room) {
+  var _a;
+  return (_a = findOwnedStructures2(room).filter(
+    (structure) => matchesStructureType6(structure.structureType, "STRUCTURE_STORAGE", "storage")
+  )[0]) != null ? _a : null;
+}
+function findSources(room) {
+  if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const result = room.find(FIND_SOURCES);
+  return Array.isArray(result) ? result : [];
+}
+function getStoredEnergy2(structure) {
+  var _a, _b;
+  const storedEnergy = (_b = (_a = structure.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, getEnergyResource3());
+  return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+function getFreeEnergyCapacity(structure) {
+  var _a, _b;
+  const freeCapacity = (_b = (_a = structure.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource3());
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+function getLinkCooldown(link) {
+  return typeof link.cooldown === "number" && Number.isFinite(link.cooldown) ? link.cooldown : 0;
+}
+function getEnergyResource3() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function compareObjectIds2(left, right) {
+  return getObjectId2(left).localeCompare(getObjectId2(right));
+}
+function getObjectId2(object) {
+  if (typeof object !== "object" || object === null) {
+    return "";
+  }
+  const id = object.id;
+  return typeof id === "string" ? id : "";
+}
+function matchesStructureType6(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+
 // src/rl/workerTaskBehavior.ts
 var WORKER_TASK_BEHAVIOR_SCHEMA_VERSION = 1;
 var HEURISTIC_WORKER_TASK_POLICY_ID = "heuristic.worker-task.v1";
@@ -7594,7 +7807,7 @@ function buildWorkerTaskBehaviorState(creep) {
   const hostileCreeps = findRoomObjects6(room, getFindConstant3("FIND_HOSTILE_CREEPS"));
   const currentTask = (_c = (_b = (_a = creep.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) != null ? _c : "none";
   const carriedEnergy = getUsedEnergy(creep);
-  const freeCapacity = getFreeEnergyCapacity(creep);
+  const freeCapacity = getFreeEnergyCapacity2(creep);
   const energyCapacity = Math.max(0, carriedEnergy + freeCapacity);
   const controller = room == null ? void 0 : room.controller;
   const nearbyStructures = structures.filter((structure) => getRangeBetweenRoomObjects(creep, structure) <= NEARBY_STRUCTURE_RANGE);
@@ -7690,7 +7903,7 @@ function getUsedEnergy(target) {
   const value = (_b = (_a = target.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, getEnergyResourceConstant());
   return Math.max(0, (_c = finiteNumber(value)) != null ? _c : 0);
 }
-function getFreeEnergyCapacity(target) {
+function getFreeEnergyCapacity2(target) {
   var _a, _b, _c;
   const value = (_b = (_a = target.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResourceConstant());
   return Math.max(0, (_c = finiteNumber(value)) != null ? _c : 0);
@@ -7926,7 +8139,7 @@ function selectHeuristicWorkerTask(creep) {
       return territoryControllerTask;
     }
     let hasPriorityEnergySink = false;
-    if (getFreeEnergyCapacity2(creep) > 0) {
+    if (getFreeEnergyCapacity3(creep) > 0) {
       const spawnRecoveryEnergySink = selectFillableEnergySink(creep);
       if (spawnRecoveryEnergySink) {
         hasPriorityEnergySink = true;
@@ -8206,7 +8419,7 @@ function selectUpgraderBoostUpgradeTask(creep, controller, carriedEnergy) {
   return { type: "upgrade", targetId: controller.id };
 }
 function selectUpgraderBoostEnergyAcquisitionTask(creep, controller) {
-  if (!isUpgraderBoostActive(creep, controller) || !hasLowEnergyForUpgraderBoost(creep) || getFreeEnergyCapacity2(creep) <= 0) {
+  if (!isUpgraderBoostActive(creep, controller) || !hasLowEnergyForUpgraderBoost(creep) || getFreeEnergyCapacity3(creep) <= 0) {
     return null;
   }
   const context = {
@@ -8221,7 +8434,7 @@ function selectUpgraderBoostEnergyAcquisitionTask(creep, controller) {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy2(source),
+      getStoredEnergy3(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -8252,12 +8465,12 @@ function isControllerNearLevelUp(controller) {
 }
 function hasLowEnergyForUpgraderBoost(creep) {
   const carriedEnergy = getUsedEnergy2(creep);
-  const freeCapacity = getFreeEnergyCapacity2(creep);
+  const freeCapacity = getFreeEnergyCapacity3(creep);
   const capacity = getEnergyCapacity(creep, carriedEnergy, freeCapacity);
   return capacity > 0 && carriedEnergy < capacity * UPGRADER_BOOST_LOW_ENERGY_RATIO;
 }
 function isUpgraderBoostStoredEnergySource(source) {
-  return matchesStructureType6(source.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType6(source.structureType, "STRUCTURE_STORAGE", "storage");
+  return matchesStructureType7(source.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType7(source.structureType, "STRUCTURE_STORAGE", "storage");
 }
 function selectFirstEnergySinkByStableId(energySinks) {
   var _a;
@@ -8328,7 +8541,7 @@ function hasEmergencySpawnExtensionRefillDemand(creep) {
 }
 function getLowLoadWorkerEnergyContext(creep) {
   const carriedEnergy = getUsedEnergy2(creep);
-  const freeCapacity = getFreeEnergyCapacity2(creep);
+  const freeCapacity = getFreeEnergyCapacity3(creep);
   if (carriedEnergy <= 0 || freeCapacity <= 0) {
     return null;
   }
@@ -8408,7 +8621,7 @@ function recordLowLoadReturnTelemetry(creep, task, reason) {
   };
 }
 function isFillableEnergySink(structure) {
-  return (matchesStructureType6(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType6(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType6(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
+  return (matchesStructureType7(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType7(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType7(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
 function selectFillableEnergySink(creep) {
   var _a;
@@ -8431,7 +8644,7 @@ function selectSpawnOrExtensionEnergySink(creep) {
   return unreservedEnergySink != null ? unreservedEnergySink : selectCloserReservedEnergySinkFallback(energySinks, creep, loadedWorkers, reservedEnergyDeliveries);
 }
 function selectStorageToSpawnExtensionRefillAcquisitionTask(creep) {
-  if (!isSpawnExtensionThroughputBottlenecked(creep.room) || getFreeEnergyCapacity2(creep) <= 0) {
+  if (!isSpawnExtensionThroughputBottlenecked(creep.room) || getFreeEnergyCapacity3(creep) <= 0) {
     return null;
   }
   const storage = selectStorageForSpawnExtensionRefill(creep);
@@ -8439,7 +8652,7 @@ function selectStorageToSpawnExtensionRefillAcquisitionTask(creep) {
     return null;
   }
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
-  const storageEnergy = getStoredEnergy2(storage);
+  const storageEnergy = getStoredEnergy3(storage);
   const availableStorageEnergy = getUnreservedWorkerEnergyAcquisitionAmount(storage, storageEnergy, reservationContext);
   const plannedWithdrawal = Math.min(
     storageEnergy,
@@ -8468,7 +8681,7 @@ function selectStorageForSpawnExtensionRefill(creep) {
     room: creep.room
   };
   const storageSources = findVisibleRoomStructures(creep.room).filter(
-    (structure) => isSafeStoredEnergySource(structure, context) && structure.structureType === "storage" && getStoredEnergy2(structure) > SPAWN_EXTENSION_THROUGHPUT_STORAGE_REFILL_RESERVE_FLOOR
+    (structure) => isSafeStoredEnergySource(structure, context) && structure.structureType === "storage" && getStoredEnergy3(structure) > SPAWN_EXTENSION_THROUGHPUT_STORAGE_REFILL_RESERVE_FLOOR
   );
   if (storageSources.length === 0) {
     return null;
@@ -8520,7 +8733,7 @@ function compareLowEnergySpawnPriority(left, right) {
   return leftLowEnergySpawn ? -1 : 1;
 }
 function isLowEnergySpawn(structure) {
-  return isSpawnEnergySink(structure) && getStoredEnergy2(structure) < getSpawnEnergyCapacity();
+  return isSpawnEnergySink(structure) && getStoredEnergy3(structure) < getSpawnEnergyCapacity();
 }
 function isCriticalSpawnEnergySink(structure) {
   const storedEnergy = getKnownStoredEnergy(structure);
@@ -8665,21 +8878,21 @@ function findRemoteHaulerStorageSinks(room) {
   );
 }
 function isRemoteHaulerStorageSink(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_STORAGE", "storage") && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
+  return matchesStructureType7(structure.structureType, "STRUCTURE_STORAGE", "storage") && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
 function selectFirstStorageSinkByStableId(storageSinks) {
   var _a;
   return (_a = [...storageSinks].sort((left, right) => String(left.id).localeCompare(String(right.id)))[0]) != null ? _a : null;
 }
 function isSpawnExtensionEnergyStructure(structure) {
-  return (matchesStructureType6(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType6(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;
+  return (matchesStructureType7(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType7(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;
 }
 function isSpawnEnergySink(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType7(structure.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isNearTermSpawningSpawn(structure) {
   var _a;
-  if (!matchesStructureType6(structure.structureType, "STRUCTURE_SPAWN", "spawn")) {
+  if (!matchesStructureType7(structure.structureType, "STRUCTURE_SPAWN", "spawn")) {
     return false;
   }
   const remainingTime = (_a = structure.spawning) == null ? void 0 : _a.remainingTime;
@@ -8689,13 +8902,13 @@ function isSpawnOrExtensionEnergySink(structure) {
   return isSpawnEnergySink(structure) || isExtensionEnergySink(structure);
 }
 function isExtensionEnergySink(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType7(structure.structureType, "STRUCTURE_EXTENSION", "extension");
 }
 function isTowerEnergySink(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_TOWER", "tower");
+  return matchesStructureType7(structure.structureType, "STRUCTURE_TOWER", "tower");
 }
 function isPriorityTowerEnergySink(structure) {
-  return isTowerEnergySink(structure) && getStoredEnergy2(structure) < TOWER_REFILL_ENERGY_FLOOR;
+  return isTowerEnergySink(structure) && getStoredEnergy3(structure) < TOWER_REFILL_ENERGY_FLOOR;
 }
 function selectClosestEnergySink(energySinks, creep) {
   var _a;
@@ -8790,7 +9003,7 @@ function findConstructionPriorityProtectedRampartAnchors(room) {
     anchors.push(room.controller.pos);
   }
   for (const structure of findConstructionPriorityOwnedStructures(room)) {
-    if (matchesStructureType6(structure.structureType, "STRUCTURE_SPAWN", "spawn") && structure.pos && isPositionInRoom(structure.pos, room.name)) {
+    if (matchesStructureType7(structure.structureType, "STRUCTURE_SPAWN", "spawn") && structure.pos && isPositionInRoom(structure.pos, room.name)) {
       anchors.push(structure.pos);
     }
   }
@@ -9113,24 +9326,24 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
   return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
 }
 function isSpawnConstructionSite(site) {
-  return matchesStructureType6(site.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType7(site.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isExtensionConstructionSite(site) {
-  return matchesStructureType6(site.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType7(site.structureType, "STRUCTURE_EXTENSION", "extension");
 }
 function isContainerConstructionSite2(site) {
-  return matchesStructureType6(site.structureType, "STRUCTURE_CONTAINER", "container");
+  return matchesStructureType7(site.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isRoadConstructionSite2(site) {
-  return matchesStructureType6(site.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType7(site.structureType, "STRUCTURE_ROAD", "road");
 }
 function isRampartConstructionSite(site) {
-  return matchesStructureType6(site.structureType, "STRUCTURE_RAMPART", "rampart");
+  return matchesStructureType7(site.structureType, "STRUCTURE_RAMPART", "rampart");
 }
 function isHighImpactConstructionSite(site, priorityContext) {
   return isContainerConstructionSite2(site) || getConstructionSiteImpactPriority(site, priorityContext != null ? priorityContext : {}) >= CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad;
 }
-function matchesStructureType6(actual, globalName, fallback) {
+function matchesStructureType7(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -9161,7 +9374,7 @@ function scoreStoredEnergySources(creep, sources) {
   }
   return sources.map((source) => {
     var _a, _b;
-    const energy = getStoredEnergy2(source);
+    const energy = getStoredEnergy3(source);
     const range = Math.max(0, (_b = (_a = position.getRangeTo) == null ? void 0 : _a.call(position, source)) != null ? _b : 0);
     return {
       energy,
@@ -9175,13 +9388,16 @@ function compareStoredEnergySourceScores(left, right) {
   return right.score - left.score || left.range - right.range || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id));
 }
 function isSafeStoredEnergySource(structure, context) {
-  return isStoredWorkerEnergySource(structure) && hasStoredEnergy2(structure) && isFriendlyStoredEnergySource(structure, context);
+  return isStoredWorkerEnergySource(structure, context.room) && hasStoredEnergy2(structure) && isFriendlyStoredEnergySource(structure, context);
 }
-function isStoredWorkerEnergySource(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType6(structure.structureType, "STRUCTURE_LINK", "link") || matchesStructureType6(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType6(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
+function isStoredWorkerEnergySource(structure, room) {
+  if (matchesStructureType7(structure.structureType, "STRUCTURE_LINK", "link")) {
+    return isSourceLink(room, structure);
+  }
+  return matchesStructureType7(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType7(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType7(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function hasStoredEnergy2(structure) {
-  return getStoredEnergy2(structure) > 0;
+  return getStoredEnergy3(structure) > 0;
 }
 function isFriendlyStoredEnergySource(structure, context) {
   var _a;
@@ -9192,7 +9408,7 @@ function isFriendlyStoredEnergySource(structure, context) {
   if (((_a = context.room.controller) == null ? void 0 : _a.my) === true) {
     return true;
   }
-  return matchesStructureType6(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
+  return matchesStructureType7(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
 }
 function isRoomSafeForUnownedContainerWithdrawal(context) {
   var _a;
@@ -9246,7 +9462,7 @@ function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy2(source),
+      getStoredEnergy3(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -9376,7 +9592,7 @@ function findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationCo
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy2(source),
+      getStoredEnergy3(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -9391,7 +9607,7 @@ function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationC
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy2(source),
+      getStoredEnergy3(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -9446,7 +9662,7 @@ function findLowLoadHarvestEnergyAcquisitionCandidates(creep) {
   ];
 }
 function getHarvestCandidateEnergy(creep, source) {
-  return typeof source.energy === "number" && Number.isFinite(source.energy) ? source.energy : getFreeEnergyCapacity2(creep);
+  return typeof source.energy === "number" && Number.isFinite(source.energy) ? source.energy : getFreeEnergyCapacity3(creep);
 }
 function createLowLoadWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
@@ -9517,7 +9733,7 @@ function findWorkerEnergyAcquisitionCandidates(creep, options = {}) {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy2(source),
+      getStoredEnergy3(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -9530,7 +9746,7 @@ function findWorkerEnergyAcquisitionCandidates(creep, options = {}) {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy2(source),
+      getStoredEnergy3(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -9573,7 +9789,7 @@ function createUnreservedWorkerEnergyAcquisitionCandidate(creep, source, energy,
 }
 function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
-  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity2(creep));
+  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity3(creep));
   return {
     energy,
     priority: getWorkerEnergyAcquisitionPriority(creep, source, energy, range),
@@ -9584,7 +9800,7 @@ function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   };
 }
 function getWorkerEnergyAcquisitionPriority(creep, source, energy, range) {
-  if (isContainerEnergySource(source) && range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE && energy >= Math.max(1, getFreeEnergyCapacity2(creep))) {
+  if (isContainerEnergySource(source) && range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE && energy >= Math.max(1, getFreeEnergyCapacity3(creep))) {
     return 0;
   }
   return isDurableStoredEnergySource(source) ? 2 : 1;
@@ -9597,7 +9813,7 @@ function isDurableStoredEnergySource(source) {
 }
 function isStructureEnergySourceType(source, globalName, fallback) {
   const structureType = source.structureType;
-  return matchesStructureType6(typeof structureType === "string" ? structureType : void 0, globalName, fallback);
+  return matchesStructureType7(typeof structureType === "string" ? structureType : void 0, globalName, fallback);
 }
 function scoreWorkerEnergyAcquisitionAmount(energy, freeCapacity) {
   if (freeCapacity <= 0) {
@@ -9623,7 +9839,7 @@ function getReservedWorkerEnergyAcquisitionsBySourceId(creep) {
     if (!isWorkerEnergyAcquisitionReservationTask(task)) {
       continue;
     }
-    const freeCapacity = getFreeEnergyCapacity2(worker);
+    const freeCapacity = getFreeEnergyCapacity3(worker);
     if (freeCapacity <= 0) {
       continue;
     }
@@ -9680,7 +9896,7 @@ function estimateHarvestTicks(creep, energySink) {
   return Math.ceil(energyNeeded / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
 }
 function getSpawnRecoveryHarvestEnergyTarget(creep, energySink) {
-  return Math.max(1, Math.min(getFreeEnergyCapacity2(creep), getFreeStoredEnergyCapacity(energySink)));
+  return Math.max(1, Math.min(getFreeEnergyCapacity3(creep), getFreeStoredEnergyCapacity(energySink)));
 }
 function estimateHarvestSourceAvailabilityDelay(source) {
   if (typeof source.energy !== "number") {
@@ -9806,7 +10022,7 @@ function findRuins(room) {
   return room.find(FIND_RUINS);
 }
 function hasSalvageableEnergy(source) {
-  return getStoredEnergy2(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
+  return getStoredEnergy3(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
 }
 function getCreepOwnerUsername2(creep) {
   var _a;
@@ -9884,7 +10100,7 @@ function isSafeRepairTarget(structure) {
   if (isRoadOrContainerRepairTarget(structure)) {
     return true;
   }
-  return matchesStructureType6(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+  return matchesStructureType7(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
 }
 function isCriticalInfrastructureRepairTarget(structure, criticalRoadContext, options) {
   if (!isSafeRepairTarget(structure) || !isRoadOrContainerRepairTarget(structure) || getHitsRatio(structure) > CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO) {
@@ -9899,16 +10115,16 @@ function isRoadOrContainerRepairTarget(structure) {
   return isRoadRepairTarget(structure) || isContainerRepairTarget(structure);
 }
 function isRoadRepairTarget(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType7(structure.structureType, "STRUCTURE_ROAD", "road");
 }
 function isContainerRepairTarget(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_CONTAINER", "container");
+  return matchesStructureType7(structure.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isWorkerRepairTargetComplete(structure) {
   return structure.hits >= getWorkerRepairHitsCeiling(structure);
 }
 function getWorkerRepairHitsCeiling(structure) {
-  if (matchesStructureType6(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
+  if (matchesStructureType7(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure)) {
     return Math.min(structure.hitsMax, IDLE_RAMPART_REPAIR_HITS_CEILING2);
   }
   return structure.hitsMax;
@@ -9920,10 +10136,10 @@ function compareRepairTargets(left, right) {
   return getRepairPriority(left) - getRepairPriority(right) || getHitsRatio(left) - getHitsRatio(right) || left.hits - right.hits || String(left.id).localeCompare(String(right.id));
 }
 function getRepairPriority(structure) {
-  if (matchesStructureType6(structure.structureType, "STRUCTURE_ROAD", "road")) {
+  if (matchesStructureType7(structure.structureType, "STRUCTURE_ROAD", "road")) {
     return 0;
   }
-  if (matchesStructureType6(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType7(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
     return 1;
   }
   return 2;
@@ -10359,12 +10575,12 @@ function isInRoom(creep, room) {
   return creep.room === room;
 }
 function getUsedEnergy2(creep) {
-  return getStoredEnergy2(creep);
+  return getStoredEnergy3(creep);
 }
-function getFreeEnergyCapacity2(creep) {
+function getFreeEnergyCapacity3(creep) {
   return getFreeStoredEnergyCapacity(creep);
 }
-function getStoredEnergy2(object) {
+function getStoredEnergy3(object) {
   var _a;
   return (_a = getKnownStoredEnergy(object)) != null ? _a : 0;
 }
@@ -10393,7 +10609,7 @@ function getFreeStoredEnergyCapacity(object) {
   const freeCapacity = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
   return typeof freeCapacity === "number" ? freeCapacity : 0;
 }
-function getEnergyCapacity(creep, carriedEnergy = getUsedEnergy2(creep), freeCapacity = getFreeEnergyCapacity2(creep)) {
+function getEnergyCapacity(creep, carriedEnergy = getUsedEnergy2(creep), freeCapacity = getFreeEnergyCapacity3(creep)) {
   var _a;
   const store = getStore(creep);
   const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
@@ -10459,7 +10675,7 @@ function selectSourceContainerHarvestTask(creep) {
 }
 function hasNonEmptySourceContainer(room, source) {
   const sourceContainer = findSourceContainer(room, source);
-  return sourceContainer !== null && getStoredEnergy2(sourceContainer) > 0;
+  return sourceContainer !== null && getStoredEnergy3(sourceContainer) > 0;
 }
 function hasVisiblePositionedContainer(room) {
   if (typeof FIND_STRUCTURES !== "number" || typeof room.find !== "function") {
@@ -10467,7 +10683,7 @@ function hasVisiblePositionedContainer(room) {
   }
   return room.find(FIND_STRUCTURES).some((structure) => {
     const position = getRoomObjectPosition3(structure);
-    return position !== null && matchesStructureType6(structure.structureType, "STRUCTURE_CONTAINER", "container");
+    return position !== null && matchesStructureType7(structure.structureType, "STRUCTURE_CONTAINER", "container");
   });
 }
 function selectHarvestSource(creep) {
@@ -10650,7 +10866,7 @@ function getHarvestSourceAvailableEnergy(source) {
   return getHarvestSourceEnergyCapacity(source);
 }
 function getHarvestEnergyTarget(creep) {
-  return Math.max(1, getFreeEnergyCapacity2(creep));
+  return Math.max(1, getFreeEnergyCapacity3(creep));
 }
 function getSameRoomWorkerHarvestLoads(roomName, sources) {
   var _a, _b, _c, _d;
@@ -10860,7 +11076,7 @@ var MAX_IMMEDIATE_RESELECT_EXECUTIONS = 1;
 var WORKER_NULL_LOOP_TICK_WINDOW = 10;
 var WORKER_STANDBY_IDLE_TIMEOUT_TICKS = 8;
 var WORKER_NULL_LOOP_FALLBACK_ATTEMPTS = 2;
-var OK_CODE3 = 0;
+var OK_CODE4 = 0;
 var MIN_HAULER_DROPPED_ENERGY = 25;
 function runWorker(creep) {
   if (runControllerSustainMovement(creep)) {
@@ -11038,7 +11254,7 @@ function selectControllerSustainHarvestTask(creep) {
 function isControllerSustainStoredEnergySource(structure) {
   const structureType = structure.structureType;
   const ownedState = structure.my;
-  return (structureType === STRUCTURE_CONTAINER || ownedState !== false) && (structureType === STRUCTURE_CONTAINER || structureType === STRUCTURE_STORAGE || structureType === STRUCTURE_TERMINAL) && getStoredEnergy3(structure) > 0;
+  return (structureType === STRUCTURE_CONTAINER || ownedState !== false) && (structureType === STRUCTURE_CONTAINER || structureType === STRUCTURE_STORAGE || structureType === STRUCTURE_TERMINAL) && getStoredEnergy4(structure) > 0;
 }
 function compareRoomObjectsByRangeAndId(creep, left, right) {
   return getRangeToRoomObject(creep, left) - getRangeToRoomObject(creep, right) || getStableId(left).localeCompare(getStableId(right));
@@ -11052,13 +11268,13 @@ function getStableId(object) {
   const id = object.id;
   return typeof id === "string" ? id : "";
 }
-function getStoredEnergy3(target) {
+function getStoredEnergy4(target) {
   var _a, _b;
   const storedEnergy = (_b = (_a = target.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY);
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
 function getCarriedEnergy(creep) {
-  return getStoredEnergy3(creep);
+  return getStoredEnergy4(creep);
 }
 function isControllerSustainMemory(value) {
   if (typeof value !== "object" || value === null) {
@@ -11550,10 +11766,10 @@ function executeHarvestTask(creep, source) {
   }
   if (!isInRangeToRoomObject(creep, source, 1)) {
     creep.moveTo(sourceContainer);
-    return { result: OK_CODE3, action: "move" };
+    return { result: OK_CODE4, action: "move" };
   }
   if (isDepletedHarvestSource(source)) {
-    return getUsedTransferEnergy(creep) > 0 ? transferDedicatedHarvestEnergy(creep, sourceContainer) : { result: OK_CODE3 };
+    return getUsedTransferEnergy(creep) > 0 ? transferDedicatedHarvestEnergy(creep, sourceContainer) : { result: OK_CODE4 };
   }
   if (getFreeTransferEnergyCapacity(creep) <= 0 && getUsedTransferEnergy(creep) > 0) {
     return transferDedicatedHarvestEnergy(creep, sourceContainer);
@@ -11562,24 +11778,24 @@ function executeHarvestTask(creep, source) {
   if ((result === ERR_FULL || result === ERR_NOT_ENOUGH_RESOURCES) && getUsedTransferEnergy(creep) > 0) {
     return transferDedicatedHarvestEnergy(creep, sourceContainer);
   }
-  return toTaskExecutionResult(result === ERR_NOT_ENOUGH_RESOURCES ? OK_CODE3 : result, "work");
+  return toTaskExecutionResult(result === ERR_NOT_ENOUGH_RESOURCES ? OK_CODE4 : result, "work");
 }
 function transferDedicatedHarvestEnergy(creep, sourceContainer) {
   if (typeof creep.transfer !== "function") {
-    return { result: OK_CODE3 };
+    return { result: OK_CODE4 };
   }
   const result = creep.transfer(sourceContainer, RESOURCE_ENERGY);
   if (result === ERR_NOT_IN_RANGE) {
     creep.moveTo(sourceContainer);
-    return { result: OK_CODE3, action: "move" };
+    return { result: OK_CODE4, action: "move" };
   }
   return toTaskExecutionResult(result, "work", { containerTransfer: true });
 }
 function toTaskExecutionResult(result, successAction, options = {}) {
   return {
     result,
-    ...result === OK_CODE3 ? { action: successAction } : {},
-    ...result === OK_CODE3 && options.containerTransfer ? { containerTransfer: true } : {}
+    ...result === OK_CODE4 ? { action: successAction } : {},
+    ...result === OK_CODE4 && options.containerTransfer ? { containerTransfer: true } : {}
   };
 }
 function recordTaskBehavior(creep, task, execution) {
@@ -11706,7 +11922,7 @@ function runRemoteHarvester(creep) {
   if (!container) {
     delete creep.memory.task;
     if (getCarriedEnergy2(creep) > 0) {
-      (_d = creep.drop) == null ? void 0 : _d.call(creep, getEnergyResource3());
+      (_d = creep.drop) == null ? void 0 : _d.call(creep, getEnergyResource4());
       return;
     }
   }
@@ -11726,7 +11942,7 @@ function runRemoteHarvester(creep) {
     }
     return;
   }
-  if (container && getFreeEnergyCapacity3(creep) <= 0 && getCarriedEnergy2(creep) > 0) {
+  if (container && getFreeEnergyCapacity4(creep) <= 0 && getCarriedEnergy2(creep) > 0) {
     transferToContainer(creep, container);
     return;
   }
@@ -11762,7 +11978,7 @@ function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
       targetRoom: room.name,
       sourceId: source.id,
       containerId: container.id,
-      containerEnergy: getStoredEnergy4(container)
+      containerEnergy: getStoredEnergy5(container)
     } : null;
   }).filter((assignment) => assignment !== null);
 }
@@ -11836,7 +12052,7 @@ function getAssignedContainer(assignment) {
 }
 function transferToContainer(creep, container) {
   var _a;
-  const result = (_a = creep.transfer) == null ? void 0 : _a.call(creep, container, getEnergyResource3());
+  const result = (_a = creep.transfer) == null ? void 0 : _a.call(creep, container, getEnergyResource4());
   if (result === getErrNotInRangeCode()) {
     moveTo(creep, container);
   }
@@ -11854,24 +12070,24 @@ function isSourceDepleted2(source) {
   return typeof source.energy === "number" && source.energy <= 0;
 }
 function getCarriedEnergy2(creep) {
-  return getStoredEnergy4(creep);
+  return getStoredEnergy5(creep);
 }
-function getFreeEnergyCapacity3(creep) {
+function getFreeEnergyCapacity4(creep) {
   var _a, _b;
-  const freeCapacity = (_b = (_a = creep.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource3());
+  const freeCapacity = (_b = (_a = creep.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4());
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
 }
-function getStoredEnergy4(target) {
+function getStoredEnergy5(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource3());
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource4());
   if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
     return Math.max(0, usedCapacity);
   }
-  const storedEnergy = store == null ? void 0 : store[getEnergyResource3()];
+  const storedEnergy = store == null ? void 0 : store[getEnergyResource4()];
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
-function getEnergyResource3() {
+function getEnergyResource4() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
@@ -11981,7 +12197,7 @@ function collectRemoteEnergy(creep, assignment) {
     delete creep.memory.task;
     return;
   }
-  if (getStoredEnergy5(container) <= 0) {
+  if (getStoredEnergy6(container) <= 0) {
     delete creep.memory.task;
     moveTo2(creep, container);
     return;
@@ -11991,7 +12207,7 @@ function collectRemoteEnergy(creep, assignment) {
     targetId: assignment.containerId
   };
   creep.memory.task = task;
-  const result = (_b = creep.withdraw) == null ? void 0 : _b.call(creep, container, getEnergyResource4());
+  const result = (_b = creep.withdraw) == null ? void 0 : _b.call(creep, container, getEnergyResource5());
   if (result === getErrNotInRangeCode2()) {
     moveTo2(creep, container);
   }
@@ -12014,7 +12230,7 @@ function deliverEnergy(creep, assignment) {
     delete creep.memory.task;
     return;
   }
-  const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, target, getEnergyResource4());
+  const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, target, getEnergyResource5());
   if (result === getErrNotInRangeCode2()) {
     moveTo2(creep, target);
   }
@@ -12052,19 +12268,19 @@ function moveTo2(creep, target) {
   (_a = creep.moveTo) == null ? void 0 : _a.call(creep, target, HAULER_MOVE_OPTS);
 }
 function getCarriedEnergy3(creep) {
-  return getStoredEnergy5(creep);
+  return getStoredEnergy6(creep);
 }
-function getStoredEnergy5(target) {
+function getStoredEnergy6(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource4());
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource5());
   if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
     return Math.max(0, usedCapacity);
   }
-  const storedEnergy = store == null ? void 0 : store[getEnergyResource4()];
+  const storedEnergy = store == null ? void 0 : store[getEnergyResource5()];
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
-function getEnergyResource4() {
+function getEnergyResource5() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
@@ -12246,7 +12462,7 @@ function hasPrimaryRoomStorageSurplus(colony, storageEnergyThresholdRatio) {
   if (!storage) {
     return false;
   }
-  const storedEnergy = getStoredEnergy6(storage);
+  const storedEnergy = getStoredEnergy7(storage);
   const storageCapacity = getStorageEnergyCapacity(storage);
   return storageCapacity > 0 && storedEnergy > storageCapacity * storageEnergyThresholdRatio;
 }
@@ -12356,7 +12572,7 @@ function getControllerReservationUsername2(controller) {
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
   return isNonEmptyString9(username) ? username : null;
 }
-function getStoredEnergy6(storage) {
+function getStoredEnergy7(storage) {
   const storedEnergy = storage.store.getUsedCapacity(RESOURCE_ENERGY);
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
@@ -13961,7 +14177,7 @@ function isNonEmptyString11(value) {
 
 // src/territory/postClaimBootstrap.ts
 var POST_CLAIM_BOOTSTRAP_WORKER_TARGET = 2;
-var OK_CODE4 = 0;
+var OK_CODE5 = 0;
 var ERR_INVALID_TARGET_CODE = -7;
 var ROOM_EDGE_MIN5 = 2;
 var ROOM_EDGE_MAX5 = 47;
@@ -14041,7 +14257,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
       updatedAt: gameTime,
       workerTarget,
       spawnSite,
-      lastResult: OK_CODE4
+      lastResult: OK_CODE5
     });
     if (shouldReportExistingSite) {
       telemetryEvents.push({
@@ -14050,7 +14266,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
         colony: record.colony,
         phase: "spawnSite",
         ...record.controllerId ? { controllerId: record.controllerId } : {},
-        result: OK_CODE4,
+        result: OK_CODE5,
         spawnSite,
         workerCount,
         workerTarget,
@@ -14060,7 +14276,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
     return { active: true, spawnConstructionPending: true };
   }
   const sitePlan = planInitialSpawnConstructionSite(colony.room);
-  const nextStatus = sitePlan.result === OK_CODE4 ? "spawnSitePending" : "spawnSiteBlocked";
+  const nextStatus = sitePlan.result === OK_CODE5 ? "spawnSitePending" : "spawnSiteBlocked";
   const shouldReportSitePlan = record.status !== nextStatus || record.lastResult !== sitePlan.result || sitePlan.position !== void 0 && !isSameSpawnSite(record.spawnSite, sitePlan.position);
   updatePostClaimBootstrapRecord(roomName, {
     status: nextStatus,
@@ -14136,7 +14352,7 @@ function planInitialSpawnConstructionSite(room) {
   let lastResult = ERR_INVALID_TARGET_CODE;
   for (const position of positions) {
     lastResult = room.createConstructionSite(position.x, position.y, getStructureConstant("STRUCTURE_SPAWN", "spawn"));
-    if (lastResult === OK_CODE4) {
+    if (lastResult === OK_CODE5) {
       return {
         result: lastResult,
         position: { ...position, roomName: room.name }
@@ -14173,7 +14389,7 @@ function selectInitialSpawnAnchor(room) {
   if (!controllerPosition) {
     return null;
   }
-  const sources = findSources(room).map(getRoomObjectPosition4).filter((position) => position !== null).sort((left, right) => getRange(controllerPosition, left) - getRange(controllerPosition, right));
+  const sources = findSources2(room).map(getRoomObjectPosition4).filter((position) => position !== null).sort((left, right) => getRange(controllerPosition, left) - getRange(controllerPosition, right));
   const nearestSourcePosition = sources[0];
   if (!nearestSourcePosition) {
     return clampPosition(controllerPosition);
@@ -14187,7 +14403,7 @@ function buildSpawnPlacementLookups(room, anchor, maximumScanRadius) {
   const blockingPositions = /* @__PURE__ */ new Set();
   for (const object of [
     room.controller,
-    ...findSources(room),
+    ...findSources2(room),
     ...lookForArea(room, "LOOK_STRUCTURES", anchor, maximumScanRadius),
     ...lookForArea(room, "LOOK_CONSTRUCTION_SITES", anchor, maximumScanRadius)
   ]) {
@@ -14248,11 +14464,11 @@ function findExistingSpawnConstructionSite(room) {
     return null;
   }
   const sites = room.find(findConstant, {
-    filter: (site) => matchesStructureType7(site.structureType, "STRUCTURE_SPAWN", "spawn")
+    filter: (site) => matchesStructureType8(site.structureType, "STRUCTURE_SPAWN", "spawn")
   });
   return (_a = sites[0]) != null ? _a : null;
 }
-function findSources(room) {
+function findSources2(room) {
   const findConstant = getGlobalNumber4("FIND_SOURCES");
   if (typeof room.find !== "function" || findConstant === null) {
     return [];
@@ -14353,7 +14569,7 @@ function getRoomTerrain5(roomName) {
 function getTerrainWallMask5() {
   return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK5;
 }
-function matchesStructureType7(actual, globalName, fallback) {
+function matchesStructureType8(actual, globalName, fallback) {
   return actual === getStructureConstant(globalName, fallback);
 }
 function getStructureConstant(globalName, fallback) {
@@ -14715,7 +14931,7 @@ function summarizeContainers(structures) {
   return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
 }
 function toRuntimeContainerSnapshot(structure) {
-  const id = getObjectId2(structure);
+  const id = getObjectId3(structure);
   if (!id) {
     return null;
   }
@@ -14738,7 +14954,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   }
   const structuresById = /* @__PURE__ */ new Map();
   for (const structure of roomStructures) {
-    const id = getObjectId2(structure);
+    const id = getObjectId3(structure);
     if (id) {
       structuresById.set(id, structure);
     }
@@ -14759,7 +14975,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord13(structure) && matchesStructureType8(structure.structureType, globalName, fallback);
+  return isRecord13(structure) && matchesStructureType9(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -15084,10 +15300,10 @@ function getRepairBacklogHits(structure) {
   return Math.max(0, Math.ceil(repairCeiling - hits));
 }
 function isObservableRepairBacklogStructure(structure) {
-  return matchesStructureType8(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType8(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
+  return matchesStructureType9(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType9(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
 }
 function isObservedOwnedRampart(structure) {
-  return matchesStructureType8(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
+  return matchesStructureType9(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
 }
 function buildControllerProgressRemaining(room) {
   const controller = room.controller;
@@ -15355,7 +15571,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
     if (!isSpawnExtensionEnergyStructure2(structure)) {
       continue;
     }
-    const id = getObjectId2(structure);
+    const id = getObjectId3(structure);
     if (id) {
       ids.add(id);
     }
@@ -15363,7 +15579,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord13(structure) && (matchesStructureType8(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType8(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord13(structure) && (matchesStructureType9(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType9(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -15371,7 +15587,7 @@ function getEventTargetId(data) {
 function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
-function getObjectId2(value) {
+function getObjectId3(value) {
   return isRecord13(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects8(room, constantName) {
@@ -15408,10 +15624,10 @@ function getEnergyInStore(object) {
   }
   const getUsedCapacity = object.store.getUsedCapacity;
   if (typeof getUsedCapacity === "function") {
-    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource5());
+    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource6());
     return typeof usedCapacity === "number" ? usedCapacity : 0;
   }
-  const storedEnergy = object.store[getEnergyResource5()];
+  const storedEnergy = object.store[getEnergyResource6()];
   return typeof storedEnergy === "number" ? storedEnergy : 0;
 }
 function getEnergyCapacityInStore(object) {
@@ -15420,12 +15636,12 @@ function getEnergyCapacityInStore(object) {
   }
   const getCapacity = object.store.getCapacity;
   if (typeof getCapacity === "function") {
-    const capacity2 = getCapacity.call(object.store, getEnergyResource5());
+    const capacity2 = getCapacity.call(object.store, getEnergyResource6());
     return typeof capacity2 === "number" && Number.isFinite(capacity2) ? Math.max(0, capacity2) : 0;
   }
   const getFreeCapacity = object.store.getFreeCapacity;
   if (typeof getFreeCapacity === "function") {
-    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource5());
+    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource6());
     if (typeof freeCapacity === "number" && Number.isFinite(freeCapacity)) {
       return Math.max(0, getEnergyInStore(object) + freeCapacity);
     }
@@ -15434,7 +15650,7 @@ function getEnergyCapacityInStore(object) {
   return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
 }
 function sumDroppedEnergy2(droppedResources) {
-  const energyResource = getEnergyResource5();
+  const energyResource = getEnergyResource6();
   return droppedResources.reduce((total, droppedResource) => {
     if (!isRecord13(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
@@ -15443,7 +15659,7 @@ function sumDroppedEnergy2(droppedResources) {
   }, 0);
 }
 function isEnergyEventData(data) {
-  return data.resourceType === void 0 || data.resourceType === getEnergyResource5();
+  return data.resourceType === void 0 || data.resourceType === getEnergyResource6();
 }
 function getNumericEventData(data, key) {
   const value = data[key];
@@ -15453,7 +15669,7 @@ function getGlobalNumber5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function matchesStructureType8(value, globalName, fallback) {
+function matchesStructureType9(value, globalName, fallback) {
   var _a;
   const expectedValue = (_a = globalThis[globalName]) != null ? _a : fallback;
   return value === expectedValue;
@@ -15461,7 +15677,7 @@ function matchesStructureType8(value, globalName, fallback) {
 function getFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function getEnergyResource5() {
+function getEnergyResource6() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
@@ -15499,7 +15715,7 @@ function recordSourceWorkloads(room, creeps, tick) {
   if (!memory || !roomName) {
     return;
   }
-  const sources = findSources2(room);
+  const sources = findSources3(room);
   if (sources.length === 0) {
     return;
   }
@@ -15512,7 +15728,7 @@ function recordSourceWorkloads(room, creeps, tick) {
     )
   };
 }
-function buildSourceWorkloadRecords(room, sources = findSources2(room), creeps = getGameCreeps4()) {
+function buildSourceWorkloadRecords(room, sources = findSources3(room), creeps = getGameCreeps4()) {
   const roomName = getRoomName3(room);
   const assignmentLoads = getSourceAssignmentLoads(roomName, sources, creeps);
   return sources.filter((source) => hasSourcePositionInRoom(source, room)).sort((left, right) => String(left.id).localeCompare(String(right.id))).map((source) => {
@@ -15566,7 +15782,7 @@ function getSourceAssignmentLoads(roomName, sources, creeps) {
 function createEmptySourceAssignmentLoad() {
   return { assignedHarvesters: 0, assignedWorkParts: 0 };
 }
-function findSources2(room) {
+function findSources3(room) {
   if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
     return [];
   }
@@ -15658,212 +15874,6 @@ function getRoomName3(room) {
   return typeof room.name === "string" && room.name.length > 0 ? room.name : null;
 }
 
-// src/economy/linkManager.ts
-var SOURCE_LINK_RANGE = 2;
-var CONTROLLER_LINK_RANGE = 3;
-var STORAGE_LINK_RANGE = 2;
-var OK_CODE5 = 0;
-function transferEnergy(room) {
-  var _a, _b, _c, _d;
-  const network = classifyLinks(room);
-  if (network.sourceLinks.length === 0) {
-    return [];
-  }
-  const destinationLinks = getDestinationLinks(network);
-  if (destinationLinks.length === 0) {
-    return [];
-  }
-  const projectedState = createProjectedLinkState(network.links);
-  const results = [];
-  for (const sourceLink of sortLinksByEnergy(network.sourceLinks, projectedState)) {
-    if (!canLinkSendEnergy(sourceLink, projectedState)) {
-      continue;
-    }
-    const destination = selectDestinationLink(sourceLink, destinationLinks, projectedState);
-    if (!destination) {
-      continue;
-    }
-    const sourceId = getObjectId3(sourceLink);
-    const destinationId = getObjectId3(destination.link);
-    const amount = Math.min(
-      (_a = projectedState.storedEnergyById.get(sourceId)) != null ? _a : 0,
-      (_b = projectedState.freeCapacityById.get(destinationId)) != null ? _b : 0
-    );
-    if (amount <= 0) {
-      continue;
-    }
-    const result = sourceLink.transferEnergy(destination.link, amount);
-    results.push({
-      amount,
-      destinationId,
-      destinationRole: destination.role,
-      result,
-      sourceId
-    });
-    if (result === OK_CODE5) {
-      projectedState.storedEnergyById.set(sourceId, Math.max(0, ((_c = projectedState.storedEnergyById.get(sourceId)) != null ? _c : 0) - amount));
-      projectedState.freeCapacityById.set(
-        destinationId,
-        Math.max(0, ((_d = projectedState.freeCapacityById.get(destinationId)) != null ? _d : 0) - amount)
-      );
-    }
-  }
-  return results;
-}
-function classifyLinks(room) {
-  const links = findOwnedLinks(room);
-  const controllerLink = selectControllerLink(room, links);
-  const storageLink = selectStorageLink(room, links, controllerLink);
-  const destinationIds = new Set(
-    [controllerLink, storageLink].filter((link) => link !== null).map((link) => getObjectId3(link))
-  );
-  return {
-    links,
-    sourceLinks: selectSourceLinks(room, links, destinationIds),
-    controllerLink,
-    storageLink
-  };
-}
-function getDestinationLinks(network) {
-  const destinations = [];
-  if (network.controllerLink) {
-    destinations.push({ link: network.controllerLink, role: "controller" });
-  }
-  if (network.storageLink && getObjectId3(network.storageLink) !== getObjectId3(network.controllerLink)) {
-    destinations.push({ link: network.storageLink, role: "storage" });
-  }
-  return destinations;
-}
-function selectDestinationLink(sourceLink, destinationLinks, projectedState) {
-  var _a;
-  const sourceId = getObjectId3(sourceLink);
-  return (_a = destinationLinks.find((destination) => {
-    var _a2;
-    const destinationId = getObjectId3(destination.link);
-    return destinationId !== sourceId && ((_a2 = projectedState.freeCapacityById.get(destinationId)) != null ? _a2 : 0) > 0;
-  })) != null ? _a : null;
-}
-function canLinkSendEnergy(link, projectedState) {
-  var _a;
-  return getLinkCooldown(link) <= 0 && ((_a = projectedState.storedEnergyById.get(getObjectId3(link))) != null ? _a : 0) > 0;
-}
-function createProjectedLinkState(links) {
-  return {
-    freeCapacityById: new Map(links.map((link) => [getObjectId3(link), getFreeEnergyCapacity4(link)])),
-    storedEnergyById: new Map(links.map((link) => [getObjectId3(link), getStoredEnergy7(link)]))
-  };
-}
-function sortLinksByEnergy(links, projectedState) {
-  return [...links].sort(
-    (left, right) => {
-      var _a, _b;
-      return ((_a = projectedState.storedEnergyById.get(getObjectId3(right))) != null ? _a : 0) - ((_b = projectedState.storedEnergyById.get(getObjectId3(left))) != null ? _b : 0) || getObjectId3(left).localeCompare(getObjectId3(right));
-    }
-  );
-}
-function selectSourceLinks(room, links, destinationIds) {
-  const sources = findSources3(room);
-  if (sources.length === 0) {
-    return [];
-  }
-  return links.filter((link) => !destinationIds.has(getObjectId3(link))).filter((link) => sources.some((source) => isNearRoomObject2(link, source, room.name, SOURCE_LINK_RANGE))).sort(compareObjectIds2);
-}
-function selectControllerLink(room, links) {
-  const controller = room.controller;
-  if (!controller) {
-    return null;
-  }
-  return selectClosestLink(links, controller, room.name, CONTROLLER_LINK_RANGE);
-}
-function selectStorageLink(room, links, controllerLink) {
-  var _a;
-  const storage = (_a = room.storage) != null ? _a : findStorage(room);
-  if (!storage) {
-    return null;
-  }
-  return selectClosestLink(
-    links.filter((link) => getObjectId3(link) !== getObjectId3(controllerLink)),
-    storage,
-    room.name,
-    STORAGE_LINK_RANGE
-  );
-}
-function selectClosestLink(links, target, roomName, range) {
-  var _a;
-  const targetPosition = getRoomObjectPosition(target);
-  if (!targetPosition || !isSameRoomPosition2(targetPosition, roomName)) {
-    return null;
-  }
-  return (_a = links.filter((link) => isNearRoomObject2(link, target, roomName, range)).sort(
-    (left, right) => compareRangeToPosition(targetPosition, left, right) || getObjectId3(left).localeCompare(getObjectId3(right))
-  )[0]) != null ? _a : null;
-}
-function isNearRoomObject2(left, right, roomName, range) {
-  const leftPosition = getRoomObjectPosition(left);
-  const rightPosition = getRoomObjectPosition(right);
-  return leftPosition !== null && rightPosition !== null && isSameRoomPosition2(leftPosition, roomName) && isSameRoomPosition2(rightPosition, roomName) && getRangeBetweenPositions2(leftPosition, rightPosition) <= range;
-}
-function compareRangeToPosition(position, left, right) {
-  const leftPosition = getRoomObjectPosition(left);
-  const rightPosition = getRoomObjectPosition(right);
-  return (leftPosition ? getRangeBetweenPositions2(position, leftPosition) : Number.POSITIVE_INFINITY) - (rightPosition ? getRangeBetweenPositions2(position, rightPosition) : Number.POSITIVE_INFINITY);
-}
-function findOwnedLinks(room) {
-  return findOwnedStructures2(room).filter((structure) => matchesStructureType9(structure.structureType, "STRUCTURE_LINK", "link")).sort(compareObjectIds2);
-}
-function findOwnedStructures2(room) {
-  if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
-    return [];
-  }
-  const result = room.find(FIND_MY_STRUCTURES);
-  return Array.isArray(result) ? result : [];
-}
-function findStorage(room) {
-  var _a;
-  return (_a = findOwnedStructures2(room).filter(
-    (structure) => matchesStructureType9(structure.structureType, "STRUCTURE_STORAGE", "storage")
-  )[0]) != null ? _a : null;
-}
-function findSources3(room) {
-  if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
-    return [];
-  }
-  const result = room.find(FIND_SOURCES);
-  return Array.isArray(result) ? result : [];
-}
-function getStoredEnergy7(structure) {
-  var _a, _b;
-  const storedEnergy = (_b = (_a = structure.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, getEnergyResource6());
-  return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
-}
-function getFreeEnergyCapacity4(structure) {
-  var _a, _b;
-  const freeCapacity = (_b = (_a = structure.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource6());
-  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
-}
-function getLinkCooldown(link) {
-  return typeof link.cooldown === "number" && Number.isFinite(link.cooldown) ? link.cooldown : 0;
-}
-function getEnergyResource6() {
-  var _a;
-  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
-}
-function compareObjectIds2(left, right) {
-  return getObjectId3(left).localeCompare(getObjectId3(right));
-}
-function getObjectId3(object) {
-  if (typeof object !== "object" || object === null) {
-    return "";
-  }
-  const id = object.id;
-  return typeof id === "string" ? id : "";
-}
-function matchesStructureType9(actual, globalName, fallback) {
-  var _a;
-  const constants = globalThis;
-  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
-}
-
 // src/economy/storageManager.ts
 var STORAGE_EMERGENCY_BUFFER = 1e3;
 var TOWER_REFILL_THRESHOLD = 500;
@@ -15904,10 +15914,13 @@ function transferStorageLinkEnergy(room) {
     {
       amount,
       destinationId: getObjectId4(controllerLink),
-      result: storageLink.transferEnergy(controllerLink, amount),
+      result: transferLinkEnergy2(storageLink, controllerLink, amount),
       sourceId: getObjectId4(storageLink)
     }
   ];
+}
+function transferLinkEnergy2(sourceLink, destinationLink, amount) {
+  return sourceLink.transfer(destinationLink, amount);
 }
 function buildEnergyDemandState(room) {
   const targets = [

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8848,9 +8848,9 @@ function createConstructionReservationContext(room) {
 }
 function getRoomOwnedCreeps(room) {
   var _a;
-  const findMyCreeps2 = globalThis.FIND_MY_CREEPS;
-  if (typeof findMyCreeps2 === "number") {
-    const roomCreeps = (_a = room.find) == null ? void 0 : _a.call(room, findMyCreeps2);
+  const findMyCreeps3 = globalThis.FIND_MY_CREEPS;
+  if (typeof findMyCreeps3 === "number") {
+    const roomCreeps = (_a = room.find) == null ? void 0 : _a.call(room, findMyCreeps3);
     if (Array.isArray(roomCreeps)) {
       return roomCreeps;
     }
@@ -9178,7 +9178,7 @@ function isSafeStoredEnergySource(structure, context) {
   return isStoredWorkerEnergySource(structure) && hasStoredEnergy2(structure) && isFriendlyStoredEnergySource(structure, context);
 }
 function isStoredWorkerEnergySource(structure) {
-  return matchesStructureType6(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType6(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType6(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
+  return matchesStructureType6(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType6(structure.structureType, "STRUCTURE_LINK", "link") || matchesStructureType6(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType6(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function hasStoredEnergy2(structure) {
   return getStoredEnergy2(structure) > 0;
@@ -11457,6 +11457,9 @@ function getTransferSinkPriority(target) {
   }
   if (matchesTransferSinkStructureType(structureType, "STRUCTURE_EXTENSION", "extension")) {
     return 2;
+  }
+  if (matchesTransferSinkStructureType(structureType, "STRUCTURE_LINK", "link")) {
+    return 0.5;
   }
   return matchesTransferSinkStructureType(structureType, "STRUCTURE_TOWER", "tower") ? 1 : 0;
 }
@@ -15655,9 +15658,542 @@ function getRoomName3(room) {
   return typeof room.name === "string" && room.name.length > 0 ? room.name : null;
 }
 
+// src/economy/linkManager.ts
+var SOURCE_LINK_RANGE = 2;
+var CONTROLLER_LINK_RANGE = 3;
+var STORAGE_LINK_RANGE = 2;
+var OK_CODE5 = 0;
+function transferEnergy(room) {
+  var _a, _b, _c, _d;
+  const network = classifyLinks(room);
+  if (network.sourceLinks.length === 0) {
+    return [];
+  }
+  const destinationLinks = getDestinationLinks(network);
+  if (destinationLinks.length === 0) {
+    return [];
+  }
+  const projectedState = createProjectedLinkState(network.links);
+  const results = [];
+  for (const sourceLink of sortLinksByEnergy(network.sourceLinks, projectedState)) {
+    if (!canLinkSendEnergy(sourceLink, projectedState)) {
+      continue;
+    }
+    const destination = selectDestinationLink(sourceLink, destinationLinks, projectedState);
+    if (!destination) {
+      continue;
+    }
+    const sourceId = getObjectId3(sourceLink);
+    const destinationId = getObjectId3(destination.link);
+    const amount = Math.min(
+      (_a = projectedState.storedEnergyById.get(sourceId)) != null ? _a : 0,
+      (_b = projectedState.freeCapacityById.get(destinationId)) != null ? _b : 0
+    );
+    if (amount <= 0) {
+      continue;
+    }
+    const result = sourceLink.transferEnergy(destination.link, amount);
+    results.push({
+      amount,
+      destinationId,
+      destinationRole: destination.role,
+      result,
+      sourceId
+    });
+    if (result === OK_CODE5) {
+      projectedState.storedEnergyById.set(sourceId, Math.max(0, ((_c = projectedState.storedEnergyById.get(sourceId)) != null ? _c : 0) - amount));
+      projectedState.freeCapacityById.set(
+        destinationId,
+        Math.max(0, ((_d = projectedState.freeCapacityById.get(destinationId)) != null ? _d : 0) - amount)
+      );
+    }
+  }
+  return results;
+}
+function classifyLinks(room) {
+  const links = findOwnedLinks(room);
+  const controllerLink = selectControllerLink(room, links);
+  const storageLink = selectStorageLink(room, links, controllerLink);
+  const destinationIds = new Set(
+    [controllerLink, storageLink].filter((link) => link !== null).map((link) => getObjectId3(link))
+  );
+  return {
+    links,
+    sourceLinks: selectSourceLinks(room, links, destinationIds),
+    controllerLink,
+    storageLink
+  };
+}
+function getDestinationLinks(network) {
+  const destinations = [];
+  if (network.controllerLink) {
+    destinations.push({ link: network.controllerLink, role: "controller" });
+  }
+  if (network.storageLink && getObjectId3(network.storageLink) !== getObjectId3(network.controllerLink)) {
+    destinations.push({ link: network.storageLink, role: "storage" });
+  }
+  return destinations;
+}
+function selectDestinationLink(sourceLink, destinationLinks, projectedState) {
+  var _a;
+  const sourceId = getObjectId3(sourceLink);
+  return (_a = destinationLinks.find((destination) => {
+    var _a2;
+    const destinationId = getObjectId3(destination.link);
+    return destinationId !== sourceId && ((_a2 = projectedState.freeCapacityById.get(destinationId)) != null ? _a2 : 0) > 0;
+  })) != null ? _a : null;
+}
+function canLinkSendEnergy(link, projectedState) {
+  var _a;
+  return getLinkCooldown(link) <= 0 && ((_a = projectedState.storedEnergyById.get(getObjectId3(link))) != null ? _a : 0) > 0;
+}
+function createProjectedLinkState(links) {
+  return {
+    freeCapacityById: new Map(links.map((link) => [getObjectId3(link), getFreeEnergyCapacity4(link)])),
+    storedEnergyById: new Map(links.map((link) => [getObjectId3(link), getStoredEnergy7(link)]))
+  };
+}
+function sortLinksByEnergy(links, projectedState) {
+  return [...links].sort(
+    (left, right) => {
+      var _a, _b;
+      return ((_a = projectedState.storedEnergyById.get(getObjectId3(right))) != null ? _a : 0) - ((_b = projectedState.storedEnergyById.get(getObjectId3(left))) != null ? _b : 0) || getObjectId3(left).localeCompare(getObjectId3(right));
+    }
+  );
+}
+function selectSourceLinks(room, links, destinationIds) {
+  const sources = findSources3(room);
+  if (sources.length === 0) {
+    return [];
+  }
+  return links.filter((link) => !destinationIds.has(getObjectId3(link))).filter((link) => sources.some((source) => isNearRoomObject2(link, source, room.name, SOURCE_LINK_RANGE))).sort(compareObjectIds2);
+}
+function selectControllerLink(room, links) {
+  const controller = room.controller;
+  if (!controller) {
+    return null;
+  }
+  return selectClosestLink(links, controller, room.name, CONTROLLER_LINK_RANGE);
+}
+function selectStorageLink(room, links, controllerLink) {
+  var _a;
+  const storage = (_a = room.storage) != null ? _a : findStorage(room);
+  if (!storage) {
+    return null;
+  }
+  return selectClosestLink(
+    links.filter((link) => getObjectId3(link) !== getObjectId3(controllerLink)),
+    storage,
+    room.name,
+    STORAGE_LINK_RANGE
+  );
+}
+function selectClosestLink(links, target, roomName, range) {
+  var _a;
+  const targetPosition = getRoomObjectPosition(target);
+  if (!targetPosition || !isSameRoomPosition2(targetPosition, roomName)) {
+    return null;
+  }
+  return (_a = links.filter((link) => isNearRoomObject2(link, target, roomName, range)).sort(
+    (left, right) => compareRangeToPosition(targetPosition, left, right) || getObjectId3(left).localeCompare(getObjectId3(right))
+  )[0]) != null ? _a : null;
+}
+function isNearRoomObject2(left, right, roomName, range) {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return leftPosition !== null && rightPosition !== null && isSameRoomPosition2(leftPosition, roomName) && isSameRoomPosition2(rightPosition, roomName) && getRangeBetweenPositions2(leftPosition, rightPosition) <= range;
+}
+function compareRangeToPosition(position, left, right) {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return (leftPosition ? getRangeBetweenPositions2(position, leftPosition) : Number.POSITIVE_INFINITY) - (rightPosition ? getRangeBetweenPositions2(position, rightPosition) : Number.POSITIVE_INFINITY);
+}
+function findOwnedLinks(room) {
+  return findOwnedStructures2(room).filter((structure) => matchesStructureType9(structure.structureType, "STRUCTURE_LINK", "link")).sort(compareObjectIds2);
+}
+function findOwnedStructures2(room) {
+  if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const result = room.find(FIND_MY_STRUCTURES);
+  return Array.isArray(result) ? result : [];
+}
+function findStorage(room) {
+  var _a;
+  return (_a = findOwnedStructures2(room).filter(
+    (structure) => matchesStructureType9(structure.structureType, "STRUCTURE_STORAGE", "storage")
+  )[0]) != null ? _a : null;
+}
+function findSources3(room) {
+  if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const result = room.find(FIND_SOURCES);
+  return Array.isArray(result) ? result : [];
+}
+function getStoredEnergy7(structure) {
+  var _a, _b;
+  const storedEnergy = (_b = (_a = structure.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, getEnergyResource6());
+  return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+function getFreeEnergyCapacity4(structure) {
+  var _a, _b;
+  const freeCapacity = (_b = (_a = structure.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource6());
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+function getLinkCooldown(link) {
+  return typeof link.cooldown === "number" && Number.isFinite(link.cooldown) ? link.cooldown : 0;
+}
+function getEnergyResource6() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function compareObjectIds2(left, right) {
+  return getObjectId3(left).localeCompare(getObjectId3(right));
+}
+function getObjectId3(object) {
+  if (typeof object !== "object" || object === null) {
+    return "";
+  }
+  const id = object.id;
+  return typeof id === "string" ? id : "";
+}
+function matchesStructureType9(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+
+// src/economy/storageManager.ts
+var STORAGE_EMERGENCY_BUFFER = 1e3;
+var TOWER_REFILL_THRESHOLD = 500;
+function manageStorage(room) {
+  const storage = getRoomStorage(room);
+  if (!storage) {
+    return { assignedTasks: 0, linkTransfers: [] };
+  }
+  const linkTransfers = transferStorageLinkEnergy(room);
+  const storageEnergy = getStoredEnergy8(storage);
+  if (storageEnergy <= 0) {
+    return { assignedTasks: 0, linkTransfers };
+  }
+  const demandState = buildEnergyDemandState(room);
+  if (!hasRemainingDemand(demandState)) {
+    return { assignedTasks: 0, linkTransfers };
+  }
+  const workers = findStorageManagementWorkers(room, storage, demandState);
+  const projectedStorageEnergy = reserveExistingAssignments(workers, storage, demandState, storageEnergy);
+  const assignedTasks = assignLoadedWorkers(workers, demandState) + assignStorageWithdrawals(workers, storage, demandState, projectedStorageEnergy);
+  return { assignedTasks, linkTransfers };
+}
+function transferStorageLinkEnergy(room) {
+  const { controllerLink, storageLink } = classifyLinks(room);
+  if (!controllerLink || !storageLink || getObjectId4(controllerLink) === getObjectId4(storageLink)) {
+    return [];
+  }
+  if (getLinkCooldown2(storageLink) > 0) {
+    return [];
+  }
+  const storedEnergy = getStoredEnergy8(storageLink);
+  const destinationFreeCapacity = getFreeEnergyCapacity5(controllerLink);
+  const amount = Math.min(storedEnergy, destinationFreeCapacity);
+  if (amount <= 0) {
+    return [];
+  }
+  return [
+    {
+      amount,
+      destinationId: getObjectId4(controllerLink),
+      result: storageLink.transferEnergy(controllerLink, amount),
+      sourceId: getObjectId4(storageLink)
+    }
+  ];
+}
+function buildEnergyDemandState(room) {
+  const targets = [
+    ...findSpawnExtensionRefillTargets(room),
+    ...findTowerRefillTargets(room),
+    ...findStorageLinkRefillTargets(room)
+  ].sort(compareDemandTargets);
+  return {
+    remainingCapacityById: new Map(targets.map((target) => [target.id, target.freeCapacity])),
+    targets
+  };
+}
+function findSpawnExtensionRefillTargets(room) {
+  const structures = findOwnedStructures3(room).filter(
+    (structure) => (matchesStructureType10(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType10(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity5(structure) > 0
+  );
+  if (!isRoomSpawnExtensionEnergyLow(room, structures)) {
+    return [];
+  }
+  return structures.map((target) => ({
+    freeCapacity: getFreeEnergyCapacity5(target),
+    id: getObjectId4(target),
+    priority: 3,
+    target
+  }));
+}
+function findTowerRefillTargets(room) {
+  return findOwnedStructures3(room).filter(
+    (structure) => matchesStructureType10(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy8(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity5(structure) > 0
+  ).map((target) => ({
+    freeCapacity: getFreeEnergyCapacity5(target),
+    id: getObjectId4(target),
+    priority: 2,
+    target
+  }));
+}
+function findStorageLinkRefillTargets(room) {
+  const { controllerLink, storageLink } = classifyLinks(room);
+  if (!controllerLink || !storageLink || getObjectId4(controllerLink) === getObjectId4(storageLink)) {
+    return [];
+  }
+  if (getFreeEnergyCapacity5(controllerLink) <= 0 || getFreeEnergyCapacity5(storageLink) <= 0) {
+    return [];
+  }
+  return [
+    {
+      freeCapacity: getFreeEnergyCapacity5(storageLink),
+      id: getObjectId4(storageLink),
+      priority: 1,
+      target: storageLink
+    }
+  ];
+}
+function isRoomSpawnExtensionEnergyLow(room, structures) {
+  if (structures.length === 0) {
+    return false;
+  }
+  const energyAvailable = room.energyAvailable;
+  const energyCapacityAvailable = room.energyCapacityAvailable;
+  if (typeof energyAvailable === "number" && Number.isFinite(energyAvailable) && typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable)) {
+    return energyAvailable < energyCapacityAvailable;
+  }
+  return structures.some((structure) => getFreeEnergyCapacity5(structure) > 0);
+}
+function findStorageManagementWorkers(room, storage, demandState) {
+  const storageId = getObjectId4(storage);
+  const demandTargetIds = new Set(demandState.targets.map((target) => target.id));
+  return findMyCreeps2(room).filter((creep) => isEligibleStorageManagementWorker(creep, room.name)).filter((creep) => isAssignableStorageManagementWorker(creep, storageId, demandTargetIds)).sort(compareWorkers);
+}
+function reserveExistingAssignments(workers, storage, demandState, storageEnergy) {
+  let projectedStorageEnergy = storageEnergy;
+  const storageId = getObjectId4(storage);
+  for (const worker of workers) {
+    const task = worker.memory.task;
+    if ((task == null ? void 0 : task.type) === "transfer") {
+      const targetId = String(task.targetId);
+      const remainingCapacity = demandState.remainingCapacityById.get(targetId);
+      if (typeof remainingCapacity === "number") {
+        demandState.remainingCapacityById.set(
+          targetId,
+          Math.max(0, remainingCapacity - getCarriedEnergy4(worker))
+        );
+      }
+    }
+    if ((task == null ? void 0 : task.type) === "withdraw" && String(task.targetId) === storageId) {
+      projectedStorageEnergy -= getFreeEnergyCapacity5(worker);
+    }
+  }
+  return Math.max(0, projectedStorageEnergy);
+}
+function assignLoadedWorkers(workers, demandState) {
+  let assignedTasks = 0;
+  for (const worker of workers) {
+    const carriedEnergy = getCarriedEnergy4(worker);
+    if (carriedEnergy <= 0) {
+      continue;
+    }
+    if (isExistingDemandTransfer(worker, demandState)) {
+      continue;
+    }
+    const target = selectDemandTarget(worker, demandState);
+    if (!target) {
+      continue;
+    }
+    if (setWorkerTask(worker, { type: "transfer", targetId: target.target.id })) {
+      assignedTasks += 1;
+    }
+    reserveDemandCapacity(demandState, target.id, carriedEnergy);
+  }
+  return assignedTasks;
+}
+function assignStorageWithdrawals(workers, storage, demandState, initialProjectedStorageEnergy) {
+  var _a;
+  let assignedTasks = 0;
+  let projectedStorageEnergy = initialProjectedStorageEnergy;
+  for (const worker of workers) {
+    if (!hasRemainingDemand(demandState) || getCarriedEnergy4(worker) > 0) {
+      continue;
+    }
+    if (((_a = worker.memory.task) == null ? void 0 : _a.type) === "withdraw" && String(worker.memory.task.targetId) === String(storage.id)) {
+      continue;
+    }
+    const freeCapacity = getFreeEnergyCapacity5(worker);
+    const plannedWithdrawal = Math.min(freeCapacity, projectedStorageEnergy);
+    if (plannedWithdrawal <= 0 || projectedStorageEnergy - plannedWithdrawal <= STORAGE_EMERGENCY_BUFFER) {
+      continue;
+    }
+    if (setWorkerTask(worker, { type: "withdraw", targetId: storage.id })) {
+      assignedTasks += 1;
+    }
+    projectedStorageEnergy -= plannedWithdrawal;
+  }
+  return assignedTasks;
+}
+function isExistingDemandTransfer(worker, demandState) {
+  const task = worker.memory.task;
+  return (task == null ? void 0 : task.type) === "transfer" && demandState.remainingCapacityById.has(String(task.targetId));
+}
+function selectDemandTarget(worker, demandState) {
+  var _a;
+  const availableTargets = demandState.targets.filter(
+    (target) => {
+      var _a2;
+      return ((_a2 = demandState.remainingCapacityById.get(target.id)) != null ? _a2 : 0) > 0;
+    }
+  );
+  if (availableTargets.length === 0) {
+    return null;
+  }
+  return (_a = [...availableTargets].sort((left, right) => compareDemandTargetsForWorker(worker, left, right))[0]) != null ? _a : null;
+}
+function reserveDemandCapacity(demandState, targetId, amount) {
+  var _a;
+  demandState.remainingCapacityById.set(
+    targetId,
+    Math.max(0, ((_a = demandState.remainingCapacityById.get(targetId)) != null ? _a : 0) - amount)
+  );
+}
+function hasRemainingDemand(demandState) {
+  return [...demandState.remainingCapacityById.values()].some((capacity) => capacity > 0);
+}
+function setWorkerTask(worker, task) {
+  var _a;
+  if (((_a = worker.memory.task) == null ? void 0 : _a.type) === task.type && String(worker.memory.task.targetId) === String(task.targetId)) {
+    return false;
+  }
+  worker.memory.task = task;
+  return true;
+}
+function isEligibleStorageManagementWorker(creep, roomName) {
+  var _a;
+  if (creep.memory.role !== "worker" || ((_a = creep.room) == null ? void 0 : _a.name) !== roomName) {
+    return false;
+  }
+  if (creep.memory.colony && creep.memory.colony !== roomName) {
+    return false;
+  }
+  return !creep.memory.controllerSustain && !creep.memory.territory;
+}
+function isAssignableStorageManagementWorker(creep, storageId, demandTargetIds) {
+  const task = creep.memory.task;
+  if (!task) {
+    return true;
+  }
+  if (task.type === "claim" || task.type === "reserve") {
+    return false;
+  }
+  if (task.type === "withdraw") {
+    return String(task.targetId) === storageId;
+  }
+  return task.type === "transfer" && demandTargetIds.has(String(task.targetId));
+}
+function compareDemandTargetsForWorker(worker, left, right) {
+  return right.priority - left.priority || compareOptionalRange(worker, left.target, right.target) || left.id.localeCompare(right.id);
+}
+function compareDemandTargets(left, right) {
+  return right.priority - left.priority || left.id.localeCompare(right.id);
+}
+function compareOptionalRange(worker, left, right) {
+  var _a;
+  const getRangeTo = (_a = worker.pos) == null ? void 0 : _a.getRangeTo;
+  if (typeof getRangeTo !== "function") {
+    return 0;
+  }
+  const leftRange = getRangeTo.call(worker.pos, left);
+  const rightRange = getRangeTo.call(worker.pos, right);
+  return normalizeRange(leftRange) - normalizeRange(rightRange);
+}
+function normalizeRange(range) {
+  return typeof range === "number" && Number.isFinite(range) ? range : Number.POSITIVE_INFINITY;
+}
+function compareWorkers(left, right) {
+  return getWorkerId(left).localeCompare(getWorkerId(right));
+}
+function getWorkerId(creep) {
+  const name = creep.name;
+  if (typeof name === "string" && name.length > 0) {
+    return name;
+  }
+  const id = creep.id;
+  return typeof id === "string" ? id : "";
+}
+function getRoomStorage(room) {
+  var _a;
+  if (room.storage) {
+    return room.storage;
+  }
+  return (_a = findOwnedStructures3(room).filter(
+    (structure) => matchesStructureType10(structure.structureType, "STRUCTURE_STORAGE", "storage")
+  )[0]) != null ? _a : null;
+}
+function findOwnedStructures3(room) {
+  if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const result = room.find(FIND_MY_STRUCTURES);
+  return Array.isArray(result) ? result : [];
+}
+function findMyCreeps2(room) {
+  if (typeof FIND_MY_CREEPS !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const result = room.find(FIND_MY_CREEPS);
+  return Array.isArray(result) ? result : [];
+}
+function getStoredEnergy8(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const storedEnergy = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource7());
+  return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+function getFreeEnergyCapacity5(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource7());
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+function getCarriedEnergy4(creep) {
+  return getStoredEnergy8(creep);
+}
+function getLinkCooldown2(link) {
+  return typeof link.cooldown === "number" && Number.isFinite(link.cooldown) ? link.cooldown : 0;
+}
+function getEnergyResource7() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function getObjectId4(object) {
+  if (typeof object !== "object" || object === null) {
+    return "";
+  }
+  const candidate = object;
+  if (typeof candidate.id === "string") {
+    return candidate.id;
+  }
+  return typeof candidate.name === "string" ? candidate.name : "";
+}
+function matchesStructureType10(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+
 // src/territory/claimExecutor.ts
 var AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR = "autonomousExpansionClaim";
-var OK_CODE5 = 0;
+var OK_CODE6 = 0;
 var ERR_NOT_IN_RANGE_CODE5 = -9;
 var ERR_INVALID_TARGET_CODE2 = -7;
 var ERR_NO_BODYPART_CODE = -12;
@@ -15717,7 +16253,7 @@ function isAutonomousExpansionClaimGclInsufficient() {
 }
 function executeExpansionClaim(creep, controller, telemetryEvents = []) {
   var _a, _b, _c, _d, _e, _f, _g, _h;
-  const result = typeof creep.claimController === "function" ? creep.claimController(controller) : OK_CODE5;
+  const result = typeof creep.claimController === "function" ? creep.claimController(controller) : OK_CODE6;
   const reason = getClaimResultReason(result);
   recordTerritoryClaimTelemetry(telemetryEvents, {
     colony: (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown",
@@ -15923,7 +16459,7 @@ function recordTerritoryClaimTelemetry(telemetryEvents, event) {
 }
 function getClaimResultReason(result) {
   switch (result) {
-    case OK_CODE5:
+    case OK_CODE6:
       return null;
     case ERR_NOT_IN_RANGE_CODE5:
       return "notInRange";
@@ -16009,7 +16545,7 @@ var ERR_NOT_IN_RANGE_CODE6 = -9;
 var ERR_INVALID_TARGET_CODE3 = -7;
 var ERR_NO_BODYPART_CODE2 = -12;
 var ERR_GCL_NOT_ENOUGH_CODE2 = -15;
-var OK_CODE6 = 0;
+var OK_CODE7 = 0;
 var CLAIM_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([
   ERR_INVALID_TARGET_CODE3,
   ERR_NO_BODYPART_CODE2,
@@ -16087,7 +16623,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   const result = assignment.action === "claim" ? executeExpansionClaim(creep, controller, telemetryEvents) : executeControllerAction(creep, controller, "reserveController");
-  if (assignment.action === "claim" && result === OK_CODE6) {
+  if (assignment.action === "claim" && result === OK_CODE7) {
     recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents);
   }
   if (result === ERR_NOT_IN_RANGE_CODE6 && typeof creep.moveTo === "function") {
@@ -16173,7 +16709,7 @@ function selectTargetController(creep, assignment) {
 function executeControllerAction(creep, controller, action) {
   const controllerAction = creep[action];
   if (typeof controllerAction !== "function") {
-    return OK_CODE6;
+    return OK_CODE7;
   }
   return controllerAction.call(creep, controller);
 }
@@ -16249,7 +16785,7 @@ function runClaimer(creep, telemetryEvents = []) {
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
-var OK_CODE7 = 0;
+var OK_CODE8 = 0;
 var NEXT_EXPANSION_SCORING_REFRESH_INTERVAL = 50;
 var NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS = 5e3;
 function runEconomy(preludeTelemetryEvents = []) {
@@ -16299,7 +16835,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         telemetryEvents,
         planningColony.spawns
       );
-      if (!outcome || outcome.result !== OK_CODE7) {
+      if (!outcome || outcome.result !== OK_CODE8) {
         break;
       }
       usedSpawns.add(outcome.spawn);
@@ -16314,6 +16850,8 @@ function runEconomy(preludeTelemetryEvents = []) {
       }
       roleCounts = addPlannedWorker(roleCounts);
     }
+    transferEnergy(colony.room);
+    manageStorage(colony.room);
   }
   for (const creep of creeps) {
     if (creep.memory.role === "worker") {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -19,7 +19,11 @@ import {
   recordCreepBehaviorWork
 } from '../telemetry/behaviorTelemetry';
 
-type TransferSinkStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION' | 'STRUCTURE_TOWER';
+type TransferSinkStructureConstantGlobal =
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_LINK'
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_TOWER';
 type CapacityConstructionStructureConstantGlobal = 'STRUCTURE_SPAWN' | 'STRUCTURE_EXTENSION';
 
 const MAX_IMMEDIATE_RESELECT_EXECUTIONS = 1;
@@ -913,6 +917,10 @@ function getTransferSinkPriority(target: unknown): number {
 
   if (matchesTransferSinkStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension')) {
     return 2;
+  }
+
+  if (matchesTransferSinkStructureType(structureType, 'STRUCTURE_LINK', 'link')) {
+    return 0.5;
   }
 
   return matchesTransferSinkStructureType(structureType, 'STRUCTURE_TOWER', 'tower') ? 1 : 0;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -15,6 +15,8 @@ import { getBodyCost, TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS } from '../spawn
 import { planSpawn, type SpawnPlanningOptions, type SpawnRequest } from '../spawn/spawnPlanner';
 import { emitRuntimeSummary, type RuntimeSummary, type RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 import { recordSourceWorkloads } from './sourceWorkload';
+import { transferEnergy as transferLinkEnergy } from './linkManager';
+import { manageStorage } from './storageManager';
 import {
   buildRuntimeOccupationRecommendationReport,
   clearOccupationRecommendationClaimIntent,
@@ -135,6 +137,9 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
 
       roleCounts = addPlannedWorker(roleCounts);
     }
+
+    transferLinkEnergy(colony.room);
+    manageStorage(colony.room);
   }
 
   for (const creep of creeps) {

--- a/prod/src/economy/linkManager.ts
+++ b/prod/src/economy/linkManager.ts
@@ -67,7 +67,7 @@ export function transferEnergy(room: Room): LinkTransferResult[] {
       continue;
     }
 
-    const result = sourceLink.transferEnergy(destination.link, amount);
+    const result = transferLinkEnergy(sourceLink, destination.link, amount);
     results.push({
       amount,
       destinationId,
@@ -106,6 +106,11 @@ export function classifyLinks(room: Room): LinkNetwork {
   };
 }
 
+export function isSourceLink(room: Room, link: StructureLink): boolean {
+  const linkId = getObjectId(link);
+  return linkId !== '' && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId(sourceLink) === linkId);
+}
+
 function getDestinationLinks(
   network: LinkNetwork
 ): Array<{ link: StructureLink; role: LinkDestinationRole }> {
@@ -118,6 +123,12 @@ function getDestinationLinks(
   }
 
   return destinations;
+}
+
+function transferLinkEnergy(sourceLink: StructureLink, destinationLink: StructureLink, amount: number): ScreepsReturnCode {
+  return (sourceLink as StructureLink & {
+    transfer: (target: StructureLink, amount?: number) => ScreepsReturnCode;
+  }).transfer(destinationLink, amount);
 }
 
 function selectDestinationLink(

--- a/prod/src/economy/linkManager.ts
+++ b/prod/src/economy/linkManager.ts
@@ -1,0 +1,308 @@
+import {
+  getRangeBetweenPositions,
+  getRoomObjectPosition,
+  isSameRoomPosition
+} from './sourceContainers';
+
+type LinkStructureConstantGlobal = 'STRUCTURE_LINK' | 'STRUCTURE_STORAGE';
+
+export const SOURCE_LINK_RANGE = 2;
+export const CONTROLLER_LINK_RANGE = 3;
+export const STORAGE_LINK_RANGE = 2;
+const OK_CODE = 0 as ScreepsReturnCode;
+
+export type LinkDestinationRole = 'controller' | 'storage';
+
+export interface LinkNetwork {
+  links: StructureLink[];
+  sourceLinks: StructureLink[];
+  controllerLink: StructureLink | null;
+  storageLink: StructureLink | null;
+}
+
+export interface LinkTransferResult {
+  amount: number;
+  destinationId: string;
+  destinationRole: LinkDestinationRole;
+  result: ScreepsReturnCode;
+  sourceId: string;
+}
+
+interface ProjectedLinkState {
+  freeCapacityById: Map<string, number>;
+  storedEnergyById: Map<string, number>;
+}
+
+export function transferEnergy(room: Room): LinkTransferResult[] {
+  const network = classifyLinks(room);
+  if (network.sourceLinks.length === 0) {
+    return [];
+  }
+
+  const destinationLinks = getDestinationLinks(network);
+  if (destinationLinks.length === 0) {
+    return [];
+  }
+
+  const projectedState = createProjectedLinkState(network.links);
+  const results: LinkTransferResult[] = [];
+
+  for (const sourceLink of sortLinksByEnergy(network.sourceLinks, projectedState)) {
+    if (!canLinkSendEnergy(sourceLink, projectedState)) {
+      continue;
+    }
+
+    const destination = selectDestinationLink(sourceLink, destinationLinks, projectedState);
+    if (!destination) {
+      continue;
+    }
+
+    const sourceId = getObjectId(sourceLink);
+    const destinationId = getObjectId(destination.link);
+    const amount = Math.min(
+      projectedState.storedEnergyById.get(sourceId) ?? 0,
+      projectedState.freeCapacityById.get(destinationId) ?? 0
+    );
+    if (amount <= 0) {
+      continue;
+    }
+
+    const result = sourceLink.transferEnergy(destination.link, amount);
+    results.push({
+      amount,
+      destinationId,
+      destinationRole: destination.role,
+      result,
+      sourceId
+    });
+
+    if (result === OK_CODE) {
+      projectedState.storedEnergyById.set(sourceId, Math.max(0, (projectedState.storedEnergyById.get(sourceId) ?? 0) - amount));
+      projectedState.freeCapacityById.set(
+        destinationId,
+        Math.max(0, (projectedState.freeCapacityById.get(destinationId) ?? 0) - amount)
+      );
+    }
+  }
+
+  return results;
+}
+
+export function classifyLinks(room: Room): LinkNetwork {
+  const links = findOwnedLinks(room);
+  const controllerLink = selectControllerLink(room, links);
+  const storageLink = selectStorageLink(room, links, controllerLink);
+  const destinationIds = new Set(
+    [controllerLink, storageLink]
+      .filter((link): link is StructureLink => link !== null)
+      .map((link) => getObjectId(link))
+  );
+
+  return {
+    links,
+    sourceLinks: selectSourceLinks(room, links, destinationIds),
+    controllerLink,
+    storageLink
+  };
+}
+
+function getDestinationLinks(
+  network: LinkNetwork
+): Array<{ link: StructureLink; role: LinkDestinationRole }> {
+  const destinations: Array<{ link: StructureLink; role: LinkDestinationRole }> = [];
+  if (network.controllerLink) {
+    destinations.push({ link: network.controllerLink, role: 'controller' });
+  }
+  if (network.storageLink && getObjectId(network.storageLink) !== getObjectId(network.controllerLink)) {
+    destinations.push({ link: network.storageLink, role: 'storage' });
+  }
+
+  return destinations;
+}
+
+function selectDestinationLink(
+  sourceLink: StructureLink,
+  destinationLinks: Array<{ link: StructureLink; role: LinkDestinationRole }>,
+  projectedState: ProjectedLinkState
+): { link: StructureLink; role: LinkDestinationRole } | null {
+  const sourceId = getObjectId(sourceLink);
+  return (
+    destinationLinks.find((destination) => {
+      const destinationId = getObjectId(destination.link);
+      return destinationId !== sourceId && (projectedState.freeCapacityById.get(destinationId) ?? 0) > 0;
+    }) ?? null
+  );
+}
+
+function canLinkSendEnergy(link: StructureLink, projectedState: ProjectedLinkState): boolean {
+  return getLinkCooldown(link) <= 0 && (projectedState.storedEnergyById.get(getObjectId(link)) ?? 0) > 0;
+}
+
+function createProjectedLinkState(links: StructureLink[]): ProjectedLinkState {
+  return {
+    freeCapacityById: new Map(links.map((link) => [getObjectId(link), getFreeEnergyCapacity(link)])),
+    storedEnergyById: new Map(links.map((link) => [getObjectId(link), getStoredEnergy(link)]))
+  };
+}
+
+function sortLinksByEnergy(links: StructureLink[], projectedState: ProjectedLinkState): StructureLink[] {
+  return [...links].sort(
+    (left, right) =>
+      (projectedState.storedEnergyById.get(getObjectId(right)) ?? 0) -
+        (projectedState.storedEnergyById.get(getObjectId(left)) ?? 0) ||
+      getObjectId(left).localeCompare(getObjectId(right))
+  );
+}
+
+function selectSourceLinks(room: Room, links: StructureLink[], destinationIds: Set<string>): StructureLink[] {
+  const sources = findSources(room);
+  if (sources.length === 0) {
+    return [];
+  }
+
+  return links
+    .filter((link) => !destinationIds.has(getObjectId(link)))
+    .filter((link) => sources.some((source) => isNearRoomObject(link, source, room.name, SOURCE_LINK_RANGE)))
+    .sort(compareObjectIds);
+}
+
+function selectControllerLink(room: Room, links: StructureLink[]): StructureLink | null {
+  const controller = room.controller;
+  if (!controller) {
+    return null;
+  }
+
+  return selectClosestLink(links, controller, room.name, CONTROLLER_LINK_RANGE);
+}
+
+function selectStorageLink(
+  room: Room,
+  links: StructureLink[],
+  controllerLink: StructureLink | null
+): StructureLink | null {
+  const storage = room.storage ?? findStorage(room);
+  if (!storage) {
+    return null;
+  }
+
+  return selectClosestLink(
+    links.filter((link) => getObjectId(link) !== getObjectId(controllerLink)),
+    storage,
+    room.name,
+    STORAGE_LINK_RANGE
+  );
+}
+
+function selectClosestLink(
+  links: StructureLink[],
+  target: RoomObject,
+  roomName: string,
+  range: number
+): StructureLink | null {
+  const targetPosition = getRoomObjectPosition(target);
+  if (!targetPosition || !isSameRoomPosition(targetPosition, roomName)) {
+    return null;
+  }
+
+  return (
+    links
+      .filter((link) => isNearRoomObject(link, target, roomName, range))
+      .sort(
+        (left, right) =>
+          compareRangeToPosition(targetPosition, left, right) || getObjectId(left).localeCompare(getObjectId(right))
+      )[0] ?? null
+  );
+}
+
+function isNearRoomObject(left: RoomObject, right: RoomObject, roomName: string, range: number): boolean {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return (
+    leftPosition !== null &&
+    rightPosition !== null &&
+    isSameRoomPosition(leftPosition, roomName) &&
+    isSameRoomPosition(rightPosition, roomName) &&
+    getRangeBetweenPositions(leftPosition, rightPosition) <= range
+  );
+}
+
+function compareRangeToPosition(position: RoomPosition, left: RoomObject, right: RoomObject): number {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return (
+    (leftPosition ? getRangeBetweenPositions(position, leftPosition) : Number.POSITIVE_INFINITY) -
+    (rightPosition ? getRangeBetweenPositions(position, rightPosition) : Number.POSITIVE_INFINITY)
+  );
+}
+
+function findOwnedLinks(room: Room): StructureLink[] {
+  return findOwnedStructures(room)
+    .filter((structure): structure is StructureLink => matchesStructureType(structure.structureType, 'STRUCTURE_LINK', 'link'))
+    .sort(compareObjectIds);
+}
+
+function findOwnedStructures(room: Room): AnyOwnedStructure[] {
+  if (typeof FIND_MY_STRUCTURES !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  const result = room.find(FIND_MY_STRUCTURES);
+  return Array.isArray(result) ? result : [];
+}
+
+function findStorage(room: Room): StructureStorage | null {
+  return (
+    findOwnedStructures(room).filter((structure): structure is StructureStorage =>
+      matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage')
+    )[0] ?? null
+  );
+}
+
+function findSources(room: Room): Source[] {
+  if (typeof FIND_SOURCES !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  const result = room.find(FIND_SOURCES);
+  return Array.isArray(result) ? result : [];
+}
+
+function getStoredEnergy(structure: StructureLink): number {
+  const storedEnergy = structure.store?.getUsedCapacity?.(getEnergyResource());
+  return typeof storedEnergy === 'number' && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+
+function getFreeEnergyCapacity(structure: StructureLink): number {
+  const freeCapacity = structure.store?.getFreeCapacity?.(getEnergyResource());
+  return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+
+function getLinkCooldown(link: StructureLink): number {
+  return typeof link.cooldown === 'number' && Number.isFinite(link.cooldown) ? link.cooldown : 0;
+}
+
+function getEnergyResource(): ResourceConstant {
+  return ((globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
+}
+
+function compareObjectIds(left: unknown, right: unknown): number {
+  return getObjectId(left).localeCompare(getObjectId(right));
+}
+
+function getObjectId(object: unknown): string {
+  if (typeof object !== 'object' || object === null) {
+    return '';
+  }
+
+  const id = (object as { id?: unknown }).id;
+  return typeof id === 'string' ? id : '';
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: LinkStructureConstantGlobal,
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<Record<LinkStructureConstantGlobal, string>>;
+  return actual === (constants[globalName] ?? fallback);
+}

--- a/prod/src/economy/storageManager.ts
+++ b/prod/src/economy/storageManager.ts
@@ -1,0 +1,473 @@
+import { classifyLinks } from './linkManager';
+
+type ManagedEnergyStructure = StructureSpawn | StructureExtension | StructureTower | StructureLink;
+type StorageStructureConstantGlobal =
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_LINK'
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_STORAGE'
+  | 'STRUCTURE_TOWER';
+
+export const STORAGE_EMERGENCY_BUFFER = 1_000;
+export const TOWER_REFILL_THRESHOLD = 500;
+
+export interface StorageLinkTransferResult {
+  amount: number;
+  destinationId: string;
+  result: ScreepsReturnCode;
+  sourceId: string;
+}
+
+export interface StorageManagementResult {
+  assignedTasks: number;
+  linkTransfers: StorageLinkTransferResult[];
+}
+
+interface EnergyDemandTarget {
+  freeCapacity: number;
+  id: string;
+  priority: number;
+  target: ManagedEnergyStructure;
+}
+
+interface EnergyDemandState {
+  remainingCapacityById: Map<string, number>;
+  targets: EnergyDemandTarget[];
+}
+
+export function manageStorage(room: Room): StorageManagementResult {
+  const storage = getRoomStorage(room);
+  if (!storage) {
+    return { assignedTasks: 0, linkTransfers: [] };
+  }
+
+  const linkTransfers = transferStorageLinkEnergy(room);
+  const storageEnergy = getStoredEnergy(storage);
+  if (storageEnergy <= 0) {
+    return { assignedTasks: 0, linkTransfers };
+  }
+
+  const demandState = buildEnergyDemandState(room);
+  if (!hasRemainingDemand(demandState)) {
+    return { assignedTasks: 0, linkTransfers };
+  }
+
+  const workers = findStorageManagementWorkers(room, storage, demandState);
+  const projectedStorageEnergy = reserveExistingAssignments(workers, storage, demandState, storageEnergy);
+  const assignedTasks =
+    assignLoadedWorkers(workers, demandState) +
+    assignStorageWithdrawals(workers, storage, demandState, projectedStorageEnergy);
+
+  return { assignedTasks, linkTransfers };
+}
+
+function transferStorageLinkEnergy(room: Room): StorageLinkTransferResult[] {
+  const { controllerLink, storageLink } = classifyLinks(room);
+  if (!controllerLink || !storageLink || getObjectId(controllerLink) === getObjectId(storageLink)) {
+    return [];
+  }
+
+  if (getLinkCooldown(storageLink) > 0) {
+    return [];
+  }
+
+  const storedEnergy = getStoredEnergy(storageLink);
+  const destinationFreeCapacity = getFreeEnergyCapacity(controllerLink);
+  const amount = Math.min(storedEnergy, destinationFreeCapacity);
+  if (amount <= 0) {
+    return [];
+  }
+
+  return [
+    {
+      amount,
+      destinationId: getObjectId(controllerLink),
+      result: storageLink.transferEnergy(controllerLink, amount),
+      sourceId: getObjectId(storageLink)
+    }
+  ];
+}
+
+function buildEnergyDemandState(room: Room): EnergyDemandState {
+  const targets = [
+    ...findSpawnExtensionRefillTargets(room),
+    ...findTowerRefillTargets(room),
+    ...findStorageLinkRefillTargets(room)
+  ].sort(compareDemandTargets);
+
+  return {
+    remainingCapacityById: new Map(targets.map((target) => [target.id, target.freeCapacity])),
+    targets
+  };
+}
+
+function findSpawnExtensionRefillTargets(room: Room): EnergyDemandTarget[] {
+  const structures = findOwnedStructures(room).filter(
+    (structure): structure is StructureSpawn | StructureExtension =>
+      (matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+        matchesStructureType(structure.structureType, 'STRUCTURE_EXTENSION', 'extension')) &&
+      getFreeEnergyCapacity(structure) > 0
+  );
+  if (!isRoomSpawnExtensionEnergyLow(room, structures)) {
+    return [];
+  }
+
+  return structures.map((target) => ({
+    freeCapacity: getFreeEnergyCapacity(target),
+    id: getObjectId(target),
+    priority: 3,
+    target
+  }));
+}
+
+function findTowerRefillTargets(room: Room): EnergyDemandTarget[] {
+  return findOwnedStructures(room)
+    .filter(
+      (structure): structure is StructureTower =>
+        matchesStructureType(structure.structureType, 'STRUCTURE_TOWER', 'tower') &&
+        getStoredEnergy(structure) < TOWER_REFILL_THRESHOLD &&
+        getFreeEnergyCapacity(structure) > 0
+    )
+    .map((target) => ({
+      freeCapacity: getFreeEnergyCapacity(target),
+      id: getObjectId(target),
+      priority: 2,
+      target
+    }));
+}
+
+function findStorageLinkRefillTargets(room: Room): EnergyDemandTarget[] {
+  const { controllerLink, storageLink } = classifyLinks(room);
+  if (!controllerLink || !storageLink || getObjectId(controllerLink) === getObjectId(storageLink)) {
+    return [];
+  }
+
+  if (getFreeEnergyCapacity(controllerLink) <= 0 || getFreeEnergyCapacity(storageLink) <= 0) {
+    return [];
+  }
+
+  return [
+    {
+      freeCapacity: getFreeEnergyCapacity(storageLink),
+      id: getObjectId(storageLink),
+      priority: 1,
+      target: storageLink
+    }
+  ];
+}
+
+function isRoomSpawnExtensionEnergyLow(
+  room: Room,
+  structures: Array<StructureSpawn | StructureExtension>
+): boolean {
+  if (structures.length === 0) {
+    return false;
+  }
+
+  const energyAvailable = room.energyAvailable;
+  const energyCapacityAvailable = room.energyCapacityAvailable;
+  if (
+    typeof energyAvailable === 'number' &&
+    Number.isFinite(energyAvailable) &&
+    typeof energyCapacityAvailable === 'number' &&
+    Number.isFinite(energyCapacityAvailable)
+  ) {
+    return energyAvailable < energyCapacityAvailable;
+  }
+
+  return structures.some((structure) => getFreeEnergyCapacity(structure) > 0);
+}
+
+function findStorageManagementWorkers(
+  room: Room,
+  storage: StructureStorage,
+  demandState: EnergyDemandState
+): Creep[] {
+  const storageId = getObjectId(storage);
+  const demandTargetIds = new Set(demandState.targets.map((target) => target.id));
+  return findMyCreeps(room)
+    .filter((creep) => isEligibleStorageManagementWorker(creep, room.name))
+    .filter((creep) => isAssignableStorageManagementWorker(creep, storageId, demandTargetIds))
+    .sort(compareWorkers);
+}
+
+function reserveExistingAssignments(
+  workers: Creep[],
+  storage: StructureStorage,
+  demandState: EnergyDemandState,
+  storageEnergy: number
+): number {
+  let projectedStorageEnergy = storageEnergy;
+  const storageId = getObjectId(storage);
+
+  for (const worker of workers) {
+    const task = worker.memory.task;
+    if (task?.type === 'transfer') {
+      const targetId = String(task.targetId);
+      const remainingCapacity = demandState.remainingCapacityById.get(targetId);
+      if (typeof remainingCapacity === 'number') {
+        demandState.remainingCapacityById.set(
+          targetId,
+          Math.max(0, remainingCapacity - getCarriedEnergy(worker))
+        );
+      }
+    }
+
+    if (task?.type === 'withdraw' && String(task.targetId) === storageId) {
+      projectedStorageEnergy -= getFreeEnergyCapacity(worker);
+    }
+  }
+
+  return Math.max(0, projectedStorageEnergy);
+}
+
+function assignLoadedWorkers(workers: Creep[], demandState: EnergyDemandState): number {
+  let assignedTasks = 0;
+  for (const worker of workers) {
+    const carriedEnergy = getCarriedEnergy(worker);
+    if (carriedEnergy <= 0) {
+      continue;
+    }
+
+    if (isExistingDemandTransfer(worker, demandState)) {
+      continue;
+    }
+
+    const target = selectDemandTarget(worker, demandState);
+    if (!target) {
+      continue;
+    }
+
+    if (setWorkerTask(worker, { type: 'transfer', targetId: target.target.id as Id<AnyStoreStructure> })) {
+      assignedTasks += 1;
+    }
+    reserveDemandCapacity(demandState, target.id, carriedEnergy);
+  }
+
+  return assignedTasks;
+}
+
+function assignStorageWithdrawals(
+  workers: Creep[],
+  storage: StructureStorage,
+  demandState: EnergyDemandState,
+  initialProjectedStorageEnergy: number
+): number {
+  let assignedTasks = 0;
+  let projectedStorageEnergy = initialProjectedStorageEnergy;
+
+  for (const worker of workers) {
+    if (!hasRemainingDemand(demandState) || getCarriedEnergy(worker) > 0) {
+      continue;
+    }
+
+    if (worker.memory.task?.type === 'withdraw' && String(worker.memory.task.targetId) === String(storage.id)) {
+      continue;
+    }
+
+    const freeCapacity = getFreeEnergyCapacity(worker);
+    const plannedWithdrawal = Math.min(freeCapacity, projectedStorageEnergy);
+    if (plannedWithdrawal <= 0 || projectedStorageEnergy - plannedWithdrawal <= STORAGE_EMERGENCY_BUFFER) {
+      continue;
+    }
+
+    if (setWorkerTask(worker, { type: 'withdraw', targetId: storage.id as Id<AnyStoreStructure> })) {
+      assignedTasks += 1;
+    }
+    projectedStorageEnergy -= plannedWithdrawal;
+  }
+
+  return assignedTasks;
+}
+
+function isExistingDemandTransfer(worker: Creep, demandState: EnergyDemandState): boolean {
+  const task = worker.memory.task;
+  return task?.type === 'transfer' && demandState.remainingCapacityById.has(String(task.targetId));
+}
+
+function selectDemandTarget(worker: Creep, demandState: EnergyDemandState): EnergyDemandTarget | null {
+  const availableTargets = demandState.targets.filter(
+    (target) => (demandState.remainingCapacityById.get(target.id) ?? 0) > 0
+  );
+  if (availableTargets.length === 0) {
+    return null;
+  }
+
+  return [...availableTargets].sort((left, right) => compareDemandTargetsForWorker(worker, left, right))[0] ?? null;
+}
+
+function reserveDemandCapacity(demandState: EnergyDemandState, targetId: string, amount: number): void {
+  demandState.remainingCapacityById.set(
+    targetId,
+    Math.max(0, (demandState.remainingCapacityById.get(targetId) ?? 0) - amount)
+  );
+}
+
+function hasRemainingDemand(demandState: EnergyDemandState): boolean {
+  return [...demandState.remainingCapacityById.values()].some((capacity) => capacity > 0);
+}
+
+function setWorkerTask(worker: Creep, task: CreepTaskMemory): boolean {
+  if (worker.memory.task?.type === task.type && String(worker.memory.task.targetId) === String(task.targetId)) {
+    return false;
+  }
+
+  worker.memory.task = task;
+  return true;
+}
+
+function isEligibleStorageManagementWorker(creep: Creep, roomName: string): boolean {
+  if (creep.memory.role !== 'worker' || creep.room?.name !== roomName) {
+    return false;
+  }
+
+  if (creep.memory.colony && creep.memory.colony !== roomName) {
+    return false;
+  }
+
+  return !creep.memory.controllerSustain && !creep.memory.territory;
+}
+
+function isAssignableStorageManagementWorker(
+  creep: Creep,
+  storageId: string,
+  demandTargetIds: Set<string>
+): boolean {
+  const task = creep.memory.task;
+  if (!task) {
+    return true;
+  }
+
+  if (task.type === 'claim' || task.type === 'reserve') {
+    return false;
+  }
+
+  if (task.type === 'withdraw') {
+    return String(task.targetId) === storageId;
+  }
+
+  return task.type === 'transfer' && demandTargetIds.has(String(task.targetId));
+}
+
+function compareDemandTargetsForWorker(
+  worker: Creep,
+  left: EnergyDemandTarget,
+  right: EnergyDemandTarget
+): number {
+  return (
+    right.priority - left.priority ||
+    compareOptionalRange(worker, left.target, right.target) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+function compareDemandTargets(left: EnergyDemandTarget, right: EnergyDemandTarget): number {
+  return right.priority - left.priority || left.id.localeCompare(right.id);
+}
+
+function compareOptionalRange(worker: Creep, left: RoomObject, right: RoomObject): number {
+  const getRangeTo = worker.pos?.getRangeTo;
+  if (typeof getRangeTo !== 'function') {
+    return 0;
+  }
+
+  const leftRange = getRangeTo.call(worker.pos, left);
+  const rightRange = getRangeTo.call(worker.pos, right);
+  return normalizeRange(leftRange) - normalizeRange(rightRange);
+}
+
+function normalizeRange(range: unknown): number {
+  return typeof range === 'number' && Number.isFinite(range) ? range : Number.POSITIVE_INFINITY;
+}
+
+function compareWorkers(left: Creep, right: Creep): number {
+  return getWorkerId(left).localeCompare(getWorkerId(right));
+}
+
+function getWorkerId(creep: Creep): string {
+  const name = (creep as Creep & { name?: unknown }).name;
+  if (typeof name === 'string' && name.length > 0) {
+    return name;
+  }
+
+  const id = (creep as Creep & { id?: unknown }).id;
+  return typeof id === 'string' ? id : '';
+}
+
+function getRoomStorage(room: Room): StructureStorage | null {
+  if (room.storage) {
+    return room.storage;
+  }
+
+  return (
+    findOwnedStructures(room).filter((structure): structure is StructureStorage =>
+      matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage')
+    )[0] ?? null
+  );
+}
+
+function findOwnedStructures(room: Room): AnyOwnedStructure[] {
+  if (typeof FIND_MY_STRUCTURES !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  const result = room.find(FIND_MY_STRUCTURES);
+  return Array.isArray(result) ? result : [];
+}
+
+function findMyCreeps(room: Room): Creep[] {
+  if (typeof FIND_MY_CREEPS !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  const result = room.find(FIND_MY_CREEPS);
+  return Array.isArray(result) ? result : [];
+}
+
+function getStoredEnergy(target: unknown): number {
+  const store = (target as { store?: { getUsedCapacity?: (resource?: ResourceConstant) => number | null } } | null)
+    ?.store;
+  const storedEnergy = store?.getUsedCapacity?.(getEnergyResource());
+  return typeof storedEnergy === 'number' && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+}
+
+function getFreeEnergyCapacity(target: unknown): number {
+  const store = (target as { store?: { getFreeCapacity?: (resource?: ResourceConstant) => number | null } } | null)
+    ?.store;
+  const freeCapacity = store?.getFreeCapacity?.(getEnergyResource());
+  return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+
+function getCarriedEnergy(creep: Creep): number {
+  return getStoredEnergy(creep);
+}
+
+function getLinkCooldown(link: StructureLink): number {
+  return typeof link.cooldown === 'number' && Number.isFinite(link.cooldown) ? link.cooldown : 0;
+}
+
+function getEnergyResource(): ResourceConstant {
+  return ((globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
+}
+
+function getObjectId(object: unknown): string {
+  if (typeof object !== 'object' || object === null) {
+    return '';
+  }
+
+  const candidate = object as { id?: unknown; name?: unknown };
+  if (typeof candidate.id === 'string') {
+    return candidate.id;
+  }
+
+  return typeof candidate.name === 'string' ? candidate.name : '';
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: StorageStructureConstantGlobal,
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<Record<StorageStructureConstantGlobal, string>>;
+  return actual === (constants[globalName] ?? fallback);
+}

--- a/prod/src/economy/storageManager.ts
+++ b/prod/src/economy/storageManager.ts
@@ -82,10 +82,16 @@ function transferStorageLinkEnergy(room: Room): StorageLinkTransferResult[] {
     {
       amount,
       destinationId: getObjectId(controllerLink),
-      result: storageLink.transferEnergy(controllerLink, amount),
+      result: transferLinkEnergy(storageLink, controllerLink, amount),
       sourceId: getObjectId(storageLink)
     }
   ];
+}
+
+function transferLinkEnergy(sourceLink: StructureLink, destinationLink: StructureLink, amount: number): ScreepsReturnCode {
+  return (sourceLink as StructureLink & {
+    transfer: (target: StructureLink, amount?: number) => ScreepsReturnCode;
+  }).transfer(destinationLink, amount);
 }
 
 function buildEnergyDemandState(room: Room): EnergyDemandState {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -24,6 +24,7 @@ import {
   type ConstructionSiteImpactPriorityContext
 } from '../construction/constructionPriority';
 import { findSourceContainer } from '../economy/sourceContainers';
+import { isSourceLink } from '../economy/linkManager';
 import { recordWorkerTaskBehaviorTrace } from '../rl/workerTaskBehavior';
 import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 
@@ -2072,13 +2073,16 @@ function isSafeStoredEnergySource(
   structure: AnyStructure,
   context: StoredEnergySourceContext
 ): structure is StoredWorkerEnergySource {
-  return isStoredWorkerEnergySource(structure) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, context);
+  return isStoredWorkerEnergySource(structure, context.room) && hasStoredEnergy(structure) && isFriendlyStoredEnergySource(structure, context);
 }
 
-function isStoredWorkerEnergySource(structure: AnyStructure): structure is StoredWorkerEnergySource {
+function isStoredWorkerEnergySource(structure: AnyStructure, room: Room): structure is StoredWorkerEnergySource {
+  if (matchesStructureType(structure.structureType, 'STRUCTURE_LINK', 'link')) {
+    return isSourceLink(room, structure as StructureLink);
+  }
+
   return (
     matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container') ||
-    matchesStructureType(structure.structureType, 'STRUCTURE_LINK', 'link') ||
     matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage') ||
     matchesStructureType(structure.structureType, 'STRUCTURE_TERMINAL', 'terminal')
   );

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -73,7 +73,7 @@ const BUILDER_STORAGE_ACQUISITION_SITE_RANGE = BUILDER_DROPPED_PICKUP_RANGE;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
-type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal;
+type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal | StructureLink;
 type UpgraderBoostStoredEnergySource = StructureContainer | StructureStorage;
 type SalvageableWorkerEnergySource = Tombstone | Ruin;
 type FillableEnergySink = StructureSpawn | StructureExtension | StructureTower;
@@ -1997,6 +1997,7 @@ type StructureConstantGlobal =
   | 'STRUCTURE_TOWER'
   | 'STRUCTURE_ROAD'
   | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_LINK'
   | 'STRUCTURE_STORAGE'
   | 'STRUCTURE_TERMINAL'
   | 'STRUCTURE_RAMPART';
@@ -2077,6 +2078,7 @@ function isSafeStoredEnergySource(
 function isStoredWorkerEnergySource(structure: AnyStructure): structure is StoredWorkerEnergySource {
   return (
     matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_LINK', 'link') ||
     matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage') ||
     matchesStructureType(structure.structureType, 'STRUCTURE_TERMINAL', 'terminal')
   );

--- a/prod/test/linkManager.test.ts
+++ b/prod/test/linkManager.test.ts
@@ -1,0 +1,187 @@
+import { classifyLinks, transferEnergy } from '../src/economy/linkManager';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+describe('linkManager', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, {
+      FIND_MY_STRUCTURES: 1,
+      FIND_SOURCES: 2,
+      RESOURCE_ENERGY: 'energy',
+      STRUCTURE_LINK: 'link',
+      STRUCTURE_STORAGE: 'storage'
+    });
+  });
+
+  it('handles rooms with no links', () => {
+    const room = makeRoom({ sources: [makeSource('source1', 10, 10)] });
+
+    expect(transferEnergy(room)).toEqual([]);
+  });
+
+  it('classifies source, controller, and storage links by room-local positions', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 400, 400);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 800);
+    const storageLink = makeLink('storage-link', 20, 21, 0, 800);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [storageLink, controllerLink, sourceLink],
+      sources: [makeSource('source1', 10, 10)],
+      storage: makeStorage('storage1', 20, 20, 5_000)
+    });
+
+    expect(classifyLinks(room)).toMatchObject({
+      sourceLinks: [{ id: 'source-link' }],
+      controllerLink: { id: 'controller-link' },
+      storageLink: { id: 'storage-link' }
+    });
+  });
+
+  it('transfers source link energy to the controller link first', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 400, 400);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 300);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLink, controllerLink],
+      sources: [makeSource('source1', 10, 10)]
+    });
+
+    expect(transferEnergy(room)).toEqual([
+      {
+        amount: 300,
+        destinationId: 'controller-link',
+        destinationRole: 'controller',
+        result: OK_CODE,
+        sourceId: 'source-link'
+      }
+    ]);
+    expect(sourceLink.transferEnergy).toHaveBeenCalledWith(controllerLink, 300);
+  });
+
+  it('falls back to the storage link when the controller link is full', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 250, 550);
+    const controllerLink = makeLink('controller-link', 25, 23, 800, 0);
+    const storageLink = makeLink('storage-link', 20, 21, 0, 200);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLink, controllerLink, storageLink],
+      sources: [makeSource('source1', 10, 10)],
+      storage: makeStorage('storage1', 20, 20, 5_000)
+    });
+
+    expect(transferEnergy(room)).toMatchObject([
+      {
+        amount: 200,
+        destinationId: 'storage-link',
+        destinationRole: 'storage',
+        sourceId: 'source-link'
+      }
+    ]);
+    expect(sourceLink.transferEnergy).toHaveBeenCalledWith(storageLink, 200);
+  });
+
+  it('respects source cooldown and empty or full link edge cases', () => {
+    const coolingSourceLink = makeLink('cooling-source', 11, 10, 400, 400, 3);
+    const emptySourceLink = makeLink('empty-source', 11, 12, 0, 800);
+    const fullControllerLink = makeLink('controller-link', 25, 23, 800, 0);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [coolingSourceLink, emptySourceLink, fullControllerLink],
+      sources: [makeSource('source1', 10, 10)]
+    });
+
+    expect(transferEnergy(room)).toEqual([]);
+    expect(coolingSourceLink.transferEnergy).not.toHaveBeenCalled();
+    expect(emptySourceLink.transferEnergy).not.toHaveBeenCalled();
+  });
+
+  it('tracks projected destination capacity across multiple source links', () => {
+    const sourceLinkA = makeLink('source-a', 11, 10, 400, 400);
+    const sourceLinkB = makeLink('source-b', 13, 10, 400, 400);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 500);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLinkB, controllerLink, sourceLinkA],
+      sources: [makeSource('source1', 10, 10), makeSource('source2', 14, 10)]
+    });
+
+    expect(transferEnergy(room)).toMatchObject([
+      { amount: 400, sourceId: 'source-a', destinationId: 'controller-link' },
+      { amount: 100, sourceId: 'source-b', destinationId: 'controller-link' }
+    ]);
+    expect(sourceLinkA.transferEnergy).toHaveBeenCalledWith(controllerLink, 400);
+    expect(sourceLinkB.transferEnergy).toHaveBeenCalledWith(controllerLink, 100);
+  });
+});
+
+function makeRoom({
+  controller = makeController(25, 25),
+  links = [],
+  sources = [],
+  storage
+}: {
+  controller?: StructureController;
+  links?: StructureLink[];
+  sources?: Source[];
+  storage?: StructureStorage;
+}): Room {
+  const structures = storage ? [...links, storage] : links;
+  return {
+    name: 'W1N1',
+    controller,
+    ...(storage ? { storage } : {}),
+    find: jest.fn((type: number) => {
+      if (type === FIND_MY_STRUCTURES) {
+        return structures;
+      }
+
+      if (type === FIND_SOURCES) {
+        return sources;
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+}
+
+function makeLink(
+  id: string,
+  x: number,
+  y: number,
+  energy: number,
+  freeCapacity: number,
+  cooldown = 0
+): StructureLink {
+  return {
+    id,
+    cooldown,
+    structureType: 'link',
+    pos: makeRoomPosition(x, y),
+    store: {
+      getFreeCapacity: jest.fn().mockReturnValue(freeCapacity),
+      getUsedCapacity: jest.fn().mockReturnValue(energy)
+    },
+    transferEnergy: jest.fn().mockReturnValue(OK_CODE)
+  } as unknown as StructureLink;
+}
+
+function makeStorage(id: string, x: number, y: number, energy: number): StructureStorage {
+  return {
+    id,
+    structureType: 'storage',
+    pos: makeRoomPosition(x, y),
+    store: { getUsedCapacity: jest.fn().mockReturnValue(energy) }
+  } as unknown as StructureStorage;
+}
+
+function makeSource(id: string, x: number, y: number): Source {
+  return { id, pos: makeRoomPosition(x, y) } as unknown as Source;
+}
+
+function makeController(x: number, y: number): StructureController {
+  return { id: 'controller1', my: true, pos: makeRoomPosition(x, y) } as unknown as StructureController;
+}
+
+function makeRoomPosition(x: number, y: number): RoomPosition {
+  return { x, y, roomName: 'W1N1' } as RoomPosition;
+}

--- a/prod/test/linkManager.test.ts
+++ b/prod/test/linkManager.test.ts
@@ -1,6 +1,7 @@
 import { classifyLinks, transferEnergy } from '../src/economy/linkManager';
 
 const OK_CODE = 0 as ScreepsReturnCode;
+type TestStructureLink = StructureLink & { transfer: jest.Mock };
 
 describe('linkManager', () => {
   beforeEach(() => {
@@ -55,7 +56,7 @@ describe('linkManager', () => {
         sourceId: 'source-link'
       }
     ]);
-    expect(sourceLink.transferEnergy).toHaveBeenCalledWith(controllerLink, 300);
+    expect(sourceLink.transfer).toHaveBeenCalledWith(controllerLink, 300);
   });
 
   it('falls back to the storage link when the controller link is full', () => {
@@ -77,7 +78,7 @@ describe('linkManager', () => {
         sourceId: 'source-link'
       }
     ]);
-    expect(sourceLink.transferEnergy).toHaveBeenCalledWith(storageLink, 200);
+    expect(sourceLink.transfer).toHaveBeenCalledWith(storageLink, 200);
   });
 
   it('respects source cooldown and empty or full link edge cases', () => {
@@ -91,8 +92,8 @@ describe('linkManager', () => {
     });
 
     expect(transferEnergy(room)).toEqual([]);
-    expect(coolingSourceLink.transferEnergy).not.toHaveBeenCalled();
-    expect(emptySourceLink.transferEnergy).not.toHaveBeenCalled();
+    expect(coolingSourceLink.transfer).not.toHaveBeenCalled();
+    expect(emptySourceLink.transfer).not.toHaveBeenCalled();
   });
 
   it('tracks projected destination capacity across multiple source links', () => {
@@ -109,8 +110,8 @@ describe('linkManager', () => {
       { amount: 400, sourceId: 'source-a', destinationId: 'controller-link' },
       { amount: 100, sourceId: 'source-b', destinationId: 'controller-link' }
     ]);
-    expect(sourceLinkA.transferEnergy).toHaveBeenCalledWith(controllerLink, 400);
-    expect(sourceLinkB.transferEnergy).toHaveBeenCalledWith(controllerLink, 100);
+    expect(sourceLinkA.transfer).toHaveBeenCalledWith(controllerLink, 400);
+    expect(sourceLinkB.transfer).toHaveBeenCalledWith(controllerLink, 100);
   });
 });
 
@@ -121,7 +122,7 @@ function makeRoom({
   storage
 }: {
   controller?: StructureController;
-  links?: StructureLink[];
+  links?: TestStructureLink[];
   sources?: Source[];
   storage?: StructureStorage;
 }): Room {
@@ -151,7 +152,7 @@ function makeLink(
   energy: number,
   freeCapacity: number,
   cooldown = 0
-): StructureLink {
+): TestStructureLink {
   return {
     id,
     cooldown,
@@ -161,8 +162,8 @@ function makeLink(
       getFreeCapacity: jest.fn().mockReturnValue(freeCapacity),
       getUsedCapacity: jest.fn().mockReturnValue(energy)
     },
-    transferEnergy: jest.fn().mockReturnValue(OK_CODE)
-  } as unknown as StructureLink;
+    transfer: jest.fn().mockReturnValue(OK_CODE)
+  } as unknown as TestStructureLink;
 }
 
 function makeStorage(id: string, x: number, y: number, energy: number): StructureStorage {

--- a/prod/test/storageManager.test.ts
+++ b/prod/test/storageManager.test.ts
@@ -1,0 +1,264 @@
+import {
+  manageStorage,
+  STORAGE_EMERGENCY_BUFFER,
+  TOWER_REFILL_THRESHOLD
+} from '../src/economy/storageManager';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+describe('storageManager', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, {
+      FIND_MY_CREEPS: 1,
+      FIND_MY_STRUCTURES: 2,
+      FIND_SOURCES: 3,
+      RESOURCE_ENERGY: 'energy',
+      STRUCTURE_EXTENSION: 'extension',
+      STRUCTURE_LINK: 'link',
+      STRUCTURE_SPAWN: 'spawn',
+      STRUCTURE_STORAGE: 'storage',
+      STRUCTURE_TOWER: 'tower'
+    });
+  });
+
+  it('handles rooms without storage', () => {
+    const worker = makeWorker('Worker1', 0, 50);
+    const room = makeRoom({ creeps: [worker], structures: [makeTower('tower1', 100, 900)] });
+
+    expect(manageStorage(room)).toEqual({ assignedTasks: 0, linkTransfers: [] });
+    expect(worker.memory.task).toBeUndefined();
+  });
+
+  it('assigns tower refill delivery and storage withdrawal when tower energy is low', () => {
+    const storage = makeStorage(2_000);
+    const tower = makeTower('tower1', TOWER_REFILL_THRESHOLD - 1, 501);
+    const loadedWorker = makeWorker('Loaded', 50, 0);
+    const emptyWorker = makeWorker('Empty', 0, 50);
+    const room = makeRoom({
+      creeps: [emptyWorker, loadedWorker],
+      storage,
+      structures: [storage, tower]
+    });
+
+    expect(manageStorage(room).assignedTasks).toBe(2);
+    expect(loadedWorker.memory.task).toEqual({ type: 'transfer', targetId: 'tower1' });
+    expect(emptyWorker.memory.task).toEqual({ type: 'withdraw', targetId: 'storage1' });
+  });
+
+  it('keeps storage above the emergency buffer before assigning withdrawals', () => {
+    const storage = makeStorage(STORAGE_EMERGENCY_BUFFER + 20);
+    const spawn = makeSpawn('spawn1', 200);
+    const worker = makeWorker('Worker1', 0, 50);
+    const room = makeRoom({
+      creeps: [worker],
+      energyAvailable: 100,
+      energyCapacityAvailable: 300,
+      storage,
+      structures: [storage, spawn]
+    });
+
+    expect(manageStorage(room).assignedTasks).toBe(0);
+    expect(worker.memory.task).toBeUndefined();
+  });
+
+  it('distributes storage energy to spawn and extensions when room energy is low', () => {
+    const storage = makeStorage(2_000);
+    const spawn = makeSpawn('spawn1', 200);
+    const extension = makeExtension('extension1', 50);
+    const worker = makeWorker('Worker1', 50, 0, {
+      getRangeTo: jest.fn((target: RoomObject) =>
+        (target as { id?: string }).id === 'extension1' ? 1 : 5
+      )
+    });
+    const room = makeRoom({
+      creeps: [worker],
+      energyAvailable: 100,
+      energyCapacityAvailable: 350,
+      storage,
+      structures: [storage, spawn, extension]
+    });
+
+    manageStorage(room);
+
+    expect(worker.memory.task).toEqual({ type: 'transfer', targetId: 'extension1' });
+  });
+
+  it('feeds controller links from storage links when possible', () => {
+    const storage = makeStorage(0);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 300);
+    const storageLink = makeLink('storage-link', 20, 21, 400, 400);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      storage,
+      structures: [storage, controllerLink, storageLink],
+      sources: [makeSource('source1', 10, 10)]
+    });
+
+    expect(manageStorage(room).linkTransfers).toEqual([
+      {
+        amount: 300,
+        destinationId: 'controller-link',
+        result: OK_CODE,
+        sourceId: 'storage-link'
+      }
+    ]);
+    expect(storageLink.transferEnergy).toHaveBeenCalledWith(controllerLink, 300);
+  });
+
+  it('does not feed controller links when the storage link is cooling down or the destination is full', () => {
+    const storage = makeStorage(2_000);
+    const controllerLink = makeLink('controller-link', 25, 23, 800, 0);
+    const storageLink = makeLink('storage-link', 20, 21, 400, 400, 2);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      storage,
+      structures: [storage, controllerLink, storageLink]
+    });
+
+    expect(manageStorage(room).linkTransfers).toEqual([]);
+    expect(storageLink.transferEnergy).not.toHaveBeenCalled();
+  });
+
+  it('assigns workers to fill the storage link when the controller link can receive energy', () => {
+    const storage = makeStorage(2_000);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 400);
+    const storageLink = makeLink('storage-link', 20, 21, 0, 400);
+    const loadedWorker = makeWorker('Loaded', 50, 0);
+    const emptyWorker = makeWorker('Empty', 0, 50);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      creeps: [emptyWorker, loadedWorker],
+      storage,
+      structures: [storage, controllerLink, storageLink]
+    });
+
+    expect(manageStorage(room).assignedTasks).toBe(2);
+    expect(loadedWorker.memory.task).toEqual({ type: 'transfer', targetId: 'storage-link' });
+    expect(emptyWorker.memory.task).toEqual({ type: 'withdraw', targetId: 'storage1' });
+  });
+});
+
+function makeRoom({
+  controller = makeController(25, 25),
+  creeps = [],
+  energyAvailable,
+  energyCapacityAvailable,
+  sources = [],
+  storage,
+  structures = []
+}: {
+  controller?: StructureController;
+  creeps?: Creep[];
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
+  sources?: Source[];
+  storage?: StructureStorage;
+  structures?: AnyOwnedStructure[];
+}): Room {
+  return {
+    name: 'W1N1',
+    controller,
+    ...(energyAvailable === undefined ? {} : { energyAvailable }),
+    ...(energyCapacityAvailable === undefined ? {} : { energyCapacityAvailable }),
+    ...(storage ? { storage } : {}),
+    find: jest.fn((type: number) => {
+      if (type === FIND_MY_CREEPS) {
+        return creeps;
+      }
+
+      if (type === FIND_MY_STRUCTURES) {
+        return structures;
+      }
+
+      if (type === FIND_SOURCES) {
+        return sources;
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+}
+
+function makeWorker(
+  name: string,
+  carriedEnergy: number,
+  freeCapacity: number,
+  pos: { getRangeTo?: (target: RoomObject) => number } = {}
+): Creep {
+  return {
+    name,
+    memory: { role: 'worker', colony: 'W1N1' },
+    pos,
+    room: { name: 'W1N1' } as Room,
+    store: {
+      getFreeCapacity: jest.fn().mockReturnValue(freeCapacity),
+      getUsedCapacity: jest.fn().mockReturnValue(carriedEnergy)
+    }
+  } as unknown as Creep;
+}
+
+function makeStorage(energy: number): StructureStorage {
+  return {
+    id: 'storage1',
+    structureType: 'storage',
+    pos: makeRoomPosition(20, 20),
+    store: { getUsedCapacity: jest.fn().mockReturnValue(energy) }
+  } as unknown as StructureStorage;
+}
+
+function makeTower(id: string, energy: number, freeCapacity: number): StructureTower {
+  return makeEnergyStructure(id, 'tower', energy, freeCapacity) as StructureTower;
+}
+
+function makeSpawn(id: string, freeCapacity: number): StructureSpawn {
+  return makeEnergyStructure(id, 'spawn', 0, freeCapacity) as StructureSpawn;
+}
+
+function makeExtension(id: string, freeCapacity: number): StructureExtension {
+  return makeEnergyStructure(id, 'extension', 0, freeCapacity) as StructureExtension;
+}
+
+function makeLink(
+  id: string,
+  x: number,
+  y: number,
+  energy: number,
+  freeCapacity: number,
+  cooldown = 0
+): StructureLink {
+  return {
+    ...makeEnergyStructure(id, 'link', energy, freeCapacity),
+    cooldown,
+    pos: makeRoomPosition(x, y),
+    transferEnergy: jest.fn().mockReturnValue(OK_CODE)
+  } as unknown as StructureLink;
+}
+
+function makeEnergyStructure(
+  id: string,
+  structureType: StructureConstant,
+  energy: number,
+  freeCapacity: number
+): AnyOwnedStructure {
+  return {
+    id,
+    structureType,
+    pos: makeRoomPosition(20, 20),
+    store: {
+      getFreeCapacity: jest.fn().mockReturnValue(freeCapacity),
+      getUsedCapacity: jest.fn().mockReturnValue(energy)
+    }
+  } as unknown as AnyOwnedStructure;
+}
+
+function makeSource(id: string, x: number, y: number): Source {
+  return { id, pos: makeRoomPosition(x, y) } as unknown as Source;
+}
+
+function makeController(x: number, y: number): StructureController {
+  return { id: 'controller1', my: true, pos: makeRoomPosition(x, y) } as unknown as StructureController;
+}
+
+function makeRoomPosition(x: number, y: number): RoomPosition {
+  return { x, y, roomName: 'W1N1' } as RoomPosition;
+}

--- a/prod/test/storageManager.test.ts
+++ b/prod/test/storageManager.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../src/economy/storageManager';
 
 const OK_CODE = 0 as ScreepsReturnCode;
+type TestStructureLink = StructureLink & { transfer: jest.Mock };
 
 describe('storageManager', () => {
   beforeEach(() => {
@@ -102,7 +103,7 @@ describe('storageManager', () => {
         sourceId: 'storage-link'
       }
     ]);
-    expect(storageLink.transferEnergy).toHaveBeenCalledWith(controllerLink, 300);
+    expect(storageLink.transfer).toHaveBeenCalledWith(controllerLink, 300);
   });
 
   it('does not feed controller links when the storage link is cooling down or the destination is full', () => {
@@ -116,7 +117,7 @@ describe('storageManager', () => {
     });
 
     expect(manageStorage(room).linkTransfers).toEqual([]);
-    expect(storageLink.transferEnergy).not.toHaveBeenCalled();
+    expect(storageLink.transfer).not.toHaveBeenCalled();
   });
 
   it('assigns workers to fill the storage link when the controller link can receive energy', () => {
@@ -225,13 +226,13 @@ function makeLink(
   energy: number,
   freeCapacity: number,
   cooldown = 0
-): StructureLink {
+): TestStructureLink {
   return {
     ...makeEnergyStructure(id, 'link', energy, freeCapacity),
     cooldown,
     pos: makeRoomPosition(x, y),
-    transferEnergy: jest.fn().mockReturnValue(OK_CODE)
-  } as unknown as StructureLink;
+    transfer: jest.fn().mockReturnValue(OK_CODE)
+  } as unknown as TestStructureLink;
 }
 
 function makeEnergyStructure(

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -19,7 +19,7 @@ function withRangeTo<T extends { id: string }>(object: T, rangesByTargetId: Reco
 
 describe('runWorker', () => {
   beforeEach(() => {
-    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; ERR_NOT_ENOUGH_RESOURCES: number; ERR_INVALID_TARGET: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).ERR_NOT_IN_RANGE = -9;
+    (globalThis as unknown as { ERR_NOT_IN_RANGE: number; ERR_FULL: number; ERR_NOT_ENOUGH_RESOURCES: number; ERR_INVALID_TARGET: number; RESOURCE_ENERGY: ResourceConstant; FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_LINK: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).ERR_NOT_IN_RANGE = -9;
     (globalThis as unknown as { ERR_FULL: number }).ERR_FULL = -8;
     (globalThis as unknown as { ERR_NOT_ENOUGH_RESOURCES: number }).ERR_NOT_ENOUGH_RESOURCES = -6;
     (globalThis as unknown as { ERR_INVALID_TARGET: number }).ERR_INVALID_TARGET = -7;
@@ -34,6 +34,7 @@ describe('runWorker', () => {
     (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { STRUCTURE_LINK: StructureConstant }).STRUCTURE_LINK = 'link';
     (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
     (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
     (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
@@ -2545,6 +2546,58 @@ describe('runWorker', () => {
 
     expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
     expect(creep.transfer).toHaveBeenCalledWith(spawn, 'energy');
+  });
+
+  it('withdraws from a link when assigned a link energy task', () => {
+    const link = {
+      id: 'link1',
+      structureType: 'link',
+      store: { getUsedCapacity: jest.fn().mockReturnValue(200) }
+    } as unknown as StructureLink;
+    const creep = {
+      memory: { task: { type: 'withdraw', targetId: 'link1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: { find: jest.fn().mockReturnValue([]) },
+      withdraw: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(link)
+    };
+
+    runWorker(creep);
+
+    expect(creep.withdraw).toHaveBeenCalledWith(link, 'energy');
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+
+  it('transfers into a link when assigned a link energy task', () => {
+    const link = {
+      id: 'link1',
+      structureType: 'link',
+      store: { getFreeCapacity: jest.fn().mockReturnValue(400) }
+    } as unknown as StructureLink;
+    const creep = {
+      memory: { task: { type: 'transfer', targetId: 'link1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: { find: jest.fn().mockReturnValue([]) },
+      transfer: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      getObjectById: jest.fn().mockReturnValue(link)
+    };
+
+    runWorker(creep);
+
+    expect(creep.transfer).toHaveBeenCalledWith(link, 'energy');
+    expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
   it('falls back to pre-harvest when standby idle exceeds timeout', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -152,6 +152,16 @@ function makeStoredEnergyStructure(
   } as unknown as StructureContainer | StructureStorage | StructureTerminal;
 }
 
+function makeStoredEnergyLink(id: string, x: number, y: number, energy: number): StructureLink {
+  return {
+    id,
+    my: true,
+    structureType: 'link',
+    pos: makeRoomPosition(x, y),
+    store: { getUsedCapacity: jest.fn().mockReturnValue(energy) }
+  } as unknown as StructureLink;
+}
+
 function makeSalvageEnergySource(
   id: string,
   energy: number,
@@ -308,7 +318,7 @@ function recordSurvivalMode(
 describe('selectWorkerTask', () => {
   beforeEach(() => {
     clearColonySurvivalAssessmentCache();
-    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; FIND_HOSTILE_CREEPS: number; FIND_HOSTILE_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_TOWER: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_SOURCES: number; FIND_CONSTRUCTION_SITES: number; FIND_MY_STRUCTURES: number; FIND_DROPPED_RESOURCES: number; FIND_STRUCTURES: number; FIND_HOSTILE_CREEPS: number; FIND_HOSTILE_STRUCTURES: number; RESOURCE_ENERGY: ResourceConstant; STRUCTURE_SPAWN: StructureConstant; STRUCTURE_EXTENSION: StructureConstant; STRUCTURE_TOWER: StructureConstant; STRUCTURE_ROAD: StructureConstant; STRUCTURE_CONTAINER: StructureConstant; STRUCTURE_LINK: StructureConstant; STRUCTURE_STORAGE: StructureConstant; STRUCTURE_TERMINAL: StructureConstant; STRUCTURE_RAMPART: StructureConstant }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 3;
     (globalThis as unknown as { FIND_DROPPED_RESOURCES: number }).FIND_DROPPED_RESOURCES = 4;
@@ -323,6 +333,7 @@ describe('selectWorkerTask', () => {
     (globalThis as unknown as { STRUCTURE_TOWER: StructureConstant }).STRUCTURE_TOWER = 'tower';
     (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
     (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { STRUCTURE_LINK: StructureConstant }).STRUCTURE_LINK = 'link';
     (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
     (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
     (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
@@ -1543,6 +1554,35 @@ describe('selectWorkerTask', () => {
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-tiny' });
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
+  });
+
+  it('withdraws only from source links and ignores controller links', () => {
+    const source = makeSource('source1', 10, 10);
+    const sourceLink = makeStoredEnergyLink('source-link', 11, 10, 300);
+    const controllerLink = makeStoredEnergyLink('controller-link', 25, 23, 800);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      controller,
+      myStructures: [sourceLink, controllerLink],
+      sources: [source],
+      structures: [controllerLink, sourceLink]
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'controller-link' ? 1 : 10))
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'source-link' });
   });
 
   it('prefers a nearby full-load pickup over distant surplus stored energy', () => {


### PR DESCRIPTION
## Summary
Implements link energy transfer and storage management for improved colony energy efficiency.

## Verification
- Controller: `npm run typecheck` ✅
- Controller: `npm test -- --runInBand` — 39 suites, 927 tests all passed ✅  
- Controller: `npm run build` ✅
- Controller: `git diff --check` clean ✅

## Changes
- `prod/src/economy/linkManager.ts` — new: link energy transfer logic
- `prod/src/economy/storageManager.ts` — new: storage energy management
- `prod/src/creeps/workerRunner.ts` — integrate link/storage into worker energy flow
- `prod/src/economy/economyLoop.ts` — register link/storage managers
- `prod/src/tasks/workerTasks.ts` — worker task support for link/storage
- `prod/test/linkManager.test.ts` — new: link manager tests
- `prod/test/storageManager.test.ts` — new: storage manager tests
- `prod/test/workerRunner.test.ts` — updated tests
- `prod/dist/main.js` — generated bundle

Refs #572