### PR TITLE
feat(territory): implement remote mining logistics for claimed expansion rooms (#571)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1596,6 +1596,9 @@ var HIGH_RCL_WORKER_PATTERN_COST = 450;
 var EMERGENCY_DEFENDER_BODY = ["tough", "attack", "move"];
 var EMERGENCY_DEFENDER_BODY_COST = 140;
 var MAX_CREEP_PARTS2 = 50;
+var MAX_REMOTE_HARVESTER_WORK_PARTS = 5;
+var MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS = 10;
+var MIN_REMOTE_HAULER_CARRY_MOVE_PAIRS = 6;
 var MAX_WORKER_PATTERN_COUNT = 4;
 var MIN_MID_RCL = 4;
 var MIN_HIGH_RCL = 7;
@@ -1716,8 +1719,43 @@ function buildTerritoryControllerPressureBody(energyAvailable) {
   }
   return [...TERRITORY_CONTROLLER_PRESSURE_BODY];
 }
+function buildRemoteHarvesterBody(energyAvailable) {
+  const workParts = Math.min(
+    MAX_REMOTE_HARVESTER_WORK_PARTS,
+    Math.floor(
+      (Math.max(0, energyAvailable) - getBodyPartCost("carry") - getBodyPartCost("move")) / getBodyPartCost("work")
+    )
+  );
+  if (workParts <= 0) {
+    return [];
+  }
+  return [...Array.from({ length: workParts }, () => "work"), "carry", "move"];
+}
+function buildRemoteHaulerBody(energyAvailable, routeDistance = 1) {
+  const pairCount = Math.min(
+    getRemoteHaulerCarryMovePairLimit(routeDistance),
+    Math.floor(Math.max(0, energyAvailable) / (getBodyPartCost("carry") + getBodyPartCost("move"))),
+    Math.floor(MAX_CREEP_PARTS2 / 2)
+  );
+  if (pairCount <= 0) {
+    return [];
+  }
+  return Array.from({ length: pairCount }).flatMap(() => ["carry", "move"]);
+}
 function getBodyCost(body) {
   return body.reduce((cost, part) => cost + BODY_PART_COSTS[part], 0);
+}
+function getRemoteHaulerCarryMovePairLimit(routeDistance) {
+  if (!Number.isFinite(routeDistance) || routeDistance <= 0) {
+    return MIN_REMOTE_HAULER_CARRY_MOVE_PAIRS;
+  }
+  return Math.min(
+    MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS,
+    Math.max(MIN_REMOTE_HAULER_CARRY_MOVE_PAIRS, Math.ceil(routeDistance) * 2)
+  );
+}
+function getBodyPartCost(part) {
+  return BODY_PART_COSTS[part];
 }
 
 // src/colony/survivalMode.ts
@@ -2382,6 +2420,21 @@ function findSourceContainer(room, source) {
   });
   return (_a = containers.sort((left, right) => compareSourceContainers(sourcePosition, left, right))[0]) != null ? _a : null;
 }
+function findSourceContainerConstructionSite(room, source) {
+  var _a;
+  if (typeof FIND_CONSTRUCTION_SITES !== "number" || typeof room.find !== "function") {
+    return null;
+  }
+  const sourcePosition = getRoomObjectPosition(source);
+  if (!sourcePosition || !isSameRoomPosition2(sourcePosition, room.name)) {
+    return null;
+  }
+  const sites = room.find(FIND_CONSTRUCTION_SITES).filter((site) => isContainerConstructionSite(site)).filter((site) => {
+    const sitePosition = getRoomObjectPosition(site);
+    return sitePosition !== null && isSameRoomPosition2(sitePosition, room.name) && getRangeBetweenPositions2(sourcePosition, sitePosition) <= 1;
+  });
+  return (_a = sites.sort((left, right) => compareSourceContainerSites(sourcePosition, left, right))[0]) != null ? _a : null;
+}
 function isContainerStructure(structure) {
   return matchesStructureType3(structure.structureType, "STRUCTURE_CONTAINER", "container");
 }
@@ -2406,6 +2459,14 @@ function compareSourceContainers(sourcePosition, left, right) {
     rightPosition ? getRangeBetweenPositions2(sourcePosition, rightPosition) : Number.POSITIVE_INFINITY
   ) || String(left.id).localeCompare(String(right.id));
 }
+function compareSourceContainerSites(sourcePosition, left, right) {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return compareNumbers(
+    leftPosition ? getRangeBetweenPositions2(sourcePosition, leftPosition) : Number.POSITIVE_INFINITY,
+    rightPosition ? getRangeBetweenPositions2(sourcePosition, rightPosition) : Number.POSITIVE_INFINITY
+  ) || String(left.id).localeCompare(String(right.id));
+}
 function compareNumbers(left, right) {
   return left - right;
 }
@@ -2417,23 +2478,26 @@ function matchesStructureType3(actual, globalName, fallback) {
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
+function isContainerConstructionSite(site) {
+  return matchesStructureType3(site.structureType, "STRUCTURE_CONTAINER", "container");
+}
 
 // src/construction/sourceContainerPlanner.ts
 var MIN_CONTROLLER_LEVEL_FOR_SOURCE_CONTAINERS = 2;
 var ROOM_EDGE_MIN3 = 1;
 var ROOM_EDGE_MAX3 = 48;
 var DEFAULT_TERRAIN_WALL_MASK3 = 1;
-function planSourceContainerConstruction(colony) {
+function planSourceContainerConstruction(colony, options = {}) {
   var _a, _b;
   const room = colony.room;
-  if (((_b = (_a = room.controller) == null ? void 0 : _a.level) != null ? _b : 0) < MIN_CONTROLLER_LEVEL_FOR_SOURCE_CONTAINERS || !hasRequiredRoomApis2(room) || typeof FIND_SOURCES !== "number") {
+  if (((_b = (_a = room.controller) == null ? void 0 : _a.level) != null ? _b : 0) < getMinimumControllerLevel(options) || !hasRequiredRoomApis2(room) || typeof FIND_SOURCES !== "number") {
     return null;
   }
   const lookups = createSourceContainerPlannerLookups(room);
   if (!lookups) {
     return null;
   }
-  const anchor = selectContainerAnchor(colony);
+  const anchor = options.anchor === void 0 ? selectContainerAnchor(colony) : options.anchor;
   for (const source of getSortedSources2(room)) {
     if (findSourceContainer(room, source) || hasPendingSourceContainerSite(source, lookups)) {
       continue;
@@ -2450,6 +2514,10 @@ function planSourceContainerConstruction(colony) {
     return result;
   }
   return null;
+}
+function getMinimumControllerLevel(options) {
+  var _a;
+  return (_a = options.minimumControllerLevel) != null ? _a : MIN_CONTROLLER_LEVEL_FOR_SOURCE_CONTAINERS;
 }
 function hasRequiredRoomApis2(room) {
   const partialRoom = room;
@@ -2481,7 +2549,7 @@ function createSourceContainerPlannerLookups(room) {
     }
     const key = getPositionKey3(position);
     lookups.blockedPositions.add(key);
-    if (isContainerConstructionSite(site)) {
+    if (isContainerConstructionSite2(site)) {
       lookups.pendingContainerPositions.add(key);
     }
   }
@@ -2564,7 +2632,7 @@ function getTerrainWallMask3() {
   const terrainWallMask = globalThis.TERRAIN_MASK_WALL;
   return typeof terrainWallMask === "number" ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK3;
 }
-function isContainerConstructionSite(site) {
+function isContainerConstructionSite2(site) {
   return site.structureType === getContainerStructureType();
 }
 function getContainerStructureType() {
@@ -3460,6 +3528,7 @@ var TERRITORY_ROUTE_DISTANCE_SEPARATOR2 = ">";
 var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 var TERRITORY_SCOUT_BODY_COST = 50;
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 = "occupationRecommendation";
+var REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 var recoveredTerritoryFollowUpRetryMetadata = /* @__PURE__ */ new WeakMap();
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options = {}) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
@@ -3948,6 +4017,107 @@ function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation,
     },
     gameTime
   );
+}
+function refreshRemoteMiningSetup(colony, gameTime = getGameTime6()) {
+  var _a, _b, _c, _d;
+  const territoryMemory = getWritableTerritoryMemoryRecord2();
+  if (!territoryMemory) {
+    return;
+  }
+  const colonyName = colony.room.name;
+  const records = getRemoteMiningBootstrapRecords(territoryMemory, colonyName);
+  const storedRemoteMining = territoryMemory.remoteMining;
+  if (storedRemoteMining === void 0 && records.length === 0) {
+    return;
+  }
+  const remoteMining = isRecord4(storedRemoteMining) && !Array.isArray(storedRemoteMining) ? storedRemoteMining : {};
+  territoryMemory.remoteMining = remoteMining;
+  const activeKeys = /* @__PURE__ */ new Set();
+  for (const record of records) {
+    const key = getRemoteMiningMemoryKey(record.colony, record.roomName);
+    activeKeys.add(key);
+    const room = getVisibleRoom(record.roomName);
+    if (!room) {
+      const previous = remoteMining[key];
+      updateRemoteMiningRoomMemoryIfChanged(
+        remoteMining,
+        key,
+        {
+          colony: record.colony,
+          roomName: record.roomName,
+          status: (_a = previous == null ? void 0 : previous.status) != null ? _a : "containerPending",
+          sources: (_b = previous == null ? void 0 : previous.sources) != null ? _b : {}
+        },
+        gameTime
+      );
+      continue;
+    }
+    if (isHostileOwnedController(room.controller)) {
+      updateRemoteMiningRoomMemoryIfChanged(
+        remoteMining,
+        key,
+        {
+          colony: record.colony,
+          roomName: record.roomName,
+          status: "unclaimed",
+          sources: {}
+        },
+        gameTime
+      );
+      continue;
+    }
+    const suspended = isRemoteMiningSuspended(territoryMemory, record.colony, record.roomName, gameTime);
+    if (!suspended) {
+      planSourceContainerConstruction(
+        {
+          room,
+          spawns: [],
+          energyAvailable: room.energyAvailable,
+          energyCapacityAvailable: room.energyCapacityAvailable
+        },
+        {
+          anchor: (_d = (_c = room.controller) == null ? void 0 : _c.pos) != null ? _d : null,
+          minimumControllerLevel: REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL
+        }
+      );
+    }
+    const sources = getRemoteMiningSources(room);
+    const assignedCreeps = getRemoteMiningAssignedCreeps(record.colony, record.roomName);
+    const sourceStates = Object.fromEntries(
+      sources.map((source) => {
+        const container = findSourceContainer(room, source);
+        const pendingSite = findSourceContainerConstructionSite(room, source);
+        const sourceId = String(source.id);
+        const state = {
+          sourceId,
+          ...container ? { containerId: String(container.id) } : {},
+          containerBuilt: container !== null,
+          containerSitePending: pendingSite !== null,
+          harvesterAssigned: hasAssignedRemoteHarvester(assignedCreeps, record.colony, record.roomName, sourceId),
+          haulerAssigned: hasAssignedRemoteHauler(assignedCreeps, record.colony, record.roomName, sourceId, container),
+          energyAvailable: container ? getStoredEnergy(container) : 0,
+          energyFlowing: container !== null && hasRemoteEnergyFlow(container, assignedCreeps, record, sourceId)
+        };
+        return [sourceId, state];
+      })
+    );
+    updateRemoteMiningRoomMemoryIfChanged(
+      remoteMining,
+      key,
+      {
+        colony: record.colony,
+        roomName: record.roomName,
+        status: suspended ? "suspended" : getRemoteMiningStatus(Object.values(sourceStates)),
+        sources: sourceStates
+      },
+      gameTime
+    );
+  }
+  for (const key of Object.keys(remoteMining)) {
+    if (key.startsWith(`${colonyName}:`) && !activeKeys.has(key)) {
+      delete remoteMining[key];
+    }
+  }
 }
 function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   if (getWorkerCapacity(roleCounts) < workerTarget) {
@@ -6263,6 +6433,9 @@ function isVisibleRoomMissingController(targetRoom) {
 function isControllerOwned(controller) {
   return controller.owner != null || controller.my === true;
 }
+function isHostileOwnedController(controller) {
+  return (controller == null ? void 0 : controller.owner) != null && controller.my !== true;
+}
 function isControllerOwnedByColony2(controller, colonyOwnerUsername) {
   const ownerUsername = getControllerOwnerUsername2(controller);
   return controller.my === true || isNonEmptyString5(ownerUsername) && ownerUsername === colonyOwnerUsername;
@@ -6371,6 +6544,133 @@ function getGameTime6() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
+}
+function getRemoteMiningBootstrapRecords(territoryMemory, colonyName) {
+  const records = territoryMemory.postClaimBootstraps;
+  if (!isRecord4(records)) {
+    return [];
+  }
+  return Object.values(records).filter((record) => isRemoteMiningBootstrapRecord(record, colonyName)).sort(compareRemoteMiningBootstrapRecords);
+}
+function isRemoteMiningBootstrapRecord(record, colonyName) {
+  return isRecord4(record) && record.colony === colonyName && isNonEmptyString5(record.roomName) && record.roomName !== colonyName && isPostClaimRemoteMiningStatus(record.status);
+}
+function isPostClaimRemoteMiningStatus(status) {
+  return status === "detected" || status === "spawnSitePending" || status === "spawnSiteBlocked" || status === "spawningWorkers" || status === "ready";
+}
+function compareRemoteMiningBootstrapRecords(left, right) {
+  return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
+}
+function getRemoteMiningMemoryKey(colony, roomName) {
+  return `${colony}:${roomName}`;
+}
+function updateRemoteMiningRoomMemoryIfChanged(remoteMining, key, nextState, gameTime) {
+  var _a;
+  const previous = remoteMining[key];
+  const candidate = {
+    ...nextState,
+    updatedAt: (_a = previous == null ? void 0 : previous.updatedAt) != null ? _a : gameTime
+  };
+  if (isSameRemoteMiningRoomMemory(previous, candidate)) {
+    return;
+  }
+  remoteMining[key] = {
+    ...nextState,
+    updatedAt: gameTime
+  };
+}
+function isSameRemoteMiningRoomMemory(left, right) {
+  return left != null && left.colony === right.colony && left.roomName === right.roomName && left.status === right.status && left.updatedAt === right.updatedAt && isSameRemoteMiningSources(left.sources, right.sources);
+}
+function isSameRemoteMiningSources(left, right) {
+  if (!isRecord4(left)) {
+    return false;
+  }
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+  return rightKeys.every((key) => isSameRemoteMiningSource(left[key], right[key]));
+}
+function isSameRemoteMiningSource(left, right) {
+  return left != null && left.sourceId === right.sourceId && left.containerId === right.containerId && left.containerBuilt === right.containerBuilt && left.containerSitePending === right.containerSitePending && left.harvesterAssigned === right.harvesterAssigned && left.haulerAssigned === right.haulerAssigned && left.energyAvailable === right.energyAvailable && left.energyFlowing === right.energyFlowing;
+}
+function isRemoteMiningSuspended(territoryMemory, colony, roomName, gameTime) {
+  if (isKnownDeadZoneRoom(roomName)) {
+    return true;
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  return intents.some(
+    (intent) => intent.colony === colony && intent.targetRoom === roomName && isTerritoryIntentSuspensionActive(intent, gameTime)
+  );
+}
+function getRemoteMiningSources(room) {
+  if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  return room.find(FIND_SOURCES).sort(
+    (left, right) => String(left.id).localeCompare(String(right.id))
+  );
+}
+function getRemoteMiningAssignedCreeps(homeRoom, targetRoom) {
+  const findMyCreeps3 = globalThis.FIND_MY_CREEPS;
+  if (typeof findMyCreeps3 !== "number") {
+    return [];
+  }
+  const seen = /* @__PURE__ */ new Set();
+  const creeps = [];
+  for (const roomName of [homeRoom, targetRoom]) {
+    const room = getVisibleRoom(roomName);
+    if (!room || typeof room.find !== "function") {
+      continue;
+    }
+    const roomCreeps = room.find(findMyCreeps3);
+    if (!Array.isArray(roomCreeps)) {
+      continue;
+    }
+    for (const creep of roomCreeps) {
+      const key = getRemoteMiningCreepKey(creep);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      creeps.push(creep);
+    }
+  }
+  return creeps;
+}
+function getRemoteMiningCreepKey(creep) {
+  var _a, _b, _c, _d, _e, _f;
+  return (_f = creep.name) != null ? _f : `${(_b = (_a = creep.memory) == null ? void 0 : _a.role) != null ? _b : "creep"}:${(_d = (_c = creep.memory) == null ? void 0 : _c.colony) != null ? _d : ""}:${(_e = creep.ticksToLive) != null ? _e : ""}`;
+}
+function hasAssignedRemoteHarvester(creeps, homeRoom, targetRoom, sourceId) {
+  return creeps.some(
+    (creep) => {
+      var _a, _b, _c, _d;
+      return ((_a = creep.memory) == null ? void 0 : _a.role) === "remoteHarvester" && ((_b = creep.memory.remoteHarvester) == null ? void 0 : _b.homeRoom) === homeRoom && ((_c = creep.memory.remoteHarvester) == null ? void 0 : _c.targetRoom) === targetRoom && String((_d = creep.memory.remoteHarvester) == null ? void 0 : _d.sourceId) === sourceId;
+    }
+  );
+}
+function hasAssignedRemoteHauler(creeps, homeRoom, targetRoom, sourceId, container) {
+  return creeps.some(
+    (creep) => {
+      var _a, _b, _c, _d, _e;
+      return ((_a = creep.memory) == null ? void 0 : _a.role) === "hauler" && ((_b = creep.memory.remoteHauler) == null ? void 0 : _b.homeRoom) === homeRoom && ((_c = creep.memory.remoteHauler) == null ? void 0 : _c.targetRoom) === targetRoom && String((_d = creep.memory.remoteHauler) == null ? void 0 : _d.sourceId) === sourceId && (container === null || String((_e = creep.memory.remoteHauler) == null ? void 0 : _e.containerId) === String(container.id));
+    }
+  );
+}
+function hasRemoteEnergyFlow(container, creeps, record, sourceId) {
+  return getStoredEnergy(container) > 0 || hasAssignedRemoteHauler(creeps, record.colony, record.roomName, sourceId, container);
+}
+function getRemoteMiningStatus(sources) {
+  if (sources.length === 0 || sources.some((source) => !source.containerBuilt)) {
+    return "containerPending";
+  }
+  if (sources.some((source) => source.harvesterAssigned || source.energyFlowing)) {
+    return "active";
+  }
+  return "containerReady";
 }
 function getWritableTerritoryMemoryRecord2() {
   const memory = getMemoryRecord();
@@ -8865,9 +9165,9 @@ function findSpawnExtensionEnergyStructures(room) {
   return room.find(FIND_MY_STRUCTURES).filter((structure) => isSpawnExtensionEnergyStructure(structure));
 }
 function selectRemoteHaulerDeliverySink(room) {
-  var _a;
+  var _a, _b;
   const fillableSinks = findFillableEnergySinksInRoom(room);
-  return (_a = selectFirstEnergySinkByStableId(fillableSinks.filter(isSpawnOrExtensionEnergySink))) != null ? _a : selectFirstStorageSinkByStableId(findRemoteHaulerStorageSinks(room));
+  return (_b = (_a = selectFirstEnergySinkByStableId(fillableSinks.filter(isSpawnOrExtensionEnergySink))) != null ? _a : selectFirstStorageSinkByStableId(findRemoteHaulerStorageSinks(room))) != null ? _b : selectFirstEnergySinkByStableId(fillableSinks.filter(isTowerEnergySink));
 }
 function findRemoteHaulerStorageSinks(room) {
   if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
@@ -8977,7 +9277,7 @@ function buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSit
   if (constructionSites.some(isRoadConstructionSite2)) {
     context.criticalRoadContext = buildWorkerCriticalRoadLogisticsContext(creep);
   }
-  if (constructionSites.some(isContainerConstructionSite2)) {
+  if (constructionSites.some(isContainerConstructionSite3)) {
     context.sources = findConstructionPrioritySources(creep.room);
   }
   if (constructionSites.some(isRampartConstructionSite)) {
@@ -9285,7 +9585,7 @@ function selectBaselineLogisticsConstructionSiteBeforeAdditionalExtension(creep,
     creep,
     constructionSites,
     constructionReservationContext,
-    isContainerConstructionSite2,
+    isContainerConstructionSite3,
     { priorityContext: priorityContext != null ? priorityContext : {}, requireReasonableRange: true }
   );
 }
@@ -9331,7 +9631,7 @@ function isSpawnConstructionSite(site) {
 function isExtensionConstructionSite(site) {
   return matchesStructureType7(site.structureType, "STRUCTURE_EXTENSION", "extension");
 }
-function isContainerConstructionSite2(site) {
+function isContainerConstructionSite3(site) {
   return matchesStructureType7(site.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isRoadConstructionSite2(site) {
@@ -9341,7 +9641,7 @@ function isRampartConstructionSite(site) {
   return matchesStructureType7(site.structureType, "STRUCTURE_RAMPART", "rampart");
 }
 function isHighImpactConstructionSite(site, priorityContext) {
-  return isContainerConstructionSite2(site) || getConstructionSiteImpactPriority(site, priorityContext != null ? priorityContext : {}) >= CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad;
+  return isContainerConstructionSite3(site) || getConstructionSiteImpactPriority(site, priorityContext != null ? priorityContext : {}) >= CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad;
 }
 function matchesStructureType7(actual, globalName, fallback) {
   var _a;
@@ -11853,21 +12153,11 @@ function isInRangeToRoomObject(creep, target, range) {
 var REMOTE_HARVESTER_ROLE = "remoteHarvester";
 var REMOTE_CREEP_REPLACEMENT_TICKS = 100;
 var MAX_REMOTE_HARVESTERS_PER_SOURCE = 1;
-var MAX_REMOTE_HARVESTER_WORK_PARTS = 5;
 var REMOTE_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var ERR_FULL_CODE = -8;
 var ERR_NOT_ENOUGH_RESOURCES_CODE = -6;
 var ERR_NOT_IN_RANGE_CODE3 = -9;
-function buildRemoteHarvesterBody(energyAvailable) {
-  const workParts = Math.min(
-    MAX_REMOTE_HARVESTER_WORK_PARTS,
-    Math.floor((Math.max(0, energyAvailable) - 100) / 100)
-  );
-  if (workParts <= 0) {
-    return [];
-  }
-  return [...Array.from({ length: workParts }, () => "work"), "carry", "move"];
-}
+var DEFAULT_REMOTE_ROOM_DISTANCE = 1;
 function selectRemoteHarvesterAssignment(homeRoom) {
   var _a;
   return (_a = getRemoteSourceAssignments(homeRoom).find(
@@ -11907,7 +12197,7 @@ function runRemoteHarvester(creep) {
   if (!assignment) {
     return;
   }
-  if (isRemoteOperationSuspended(assignment.homeRoom, assignment.targetRoom)) {
+  if (shouldRetreatFromRemote(creep, assignment)) {
     delete creep.memory.task;
     moveTowardRoom2(creep, assignment.homeRoom);
     return;
@@ -11967,6 +12257,16 @@ function moveTowardRoom2(creep, roomName, target) {
     moveTo(creep, new RoomPositionCtor(25, 25, roomName));
   }
 }
+function shouldRetreatFromRemote(creep, assignment) {
+  if (isRemoteOperationSuspended(assignment.homeRoom, assignment.targetRoom)) {
+    return true;
+  }
+  const targetRoom = getVisibleRoom2(assignment.targetRoom);
+  if (isHostileOwnedRemoteController(targetRoom == null ? void 0 : targetRoom.controller)) {
+    return true;
+  }
+  return isVisibleRemoteThreatened(creep.room, assignment.targetRoom);
+}
 function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
   if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
     return [];
@@ -11978,7 +12278,8 @@ function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
       targetRoom: room.name,
       sourceId: source.id,
       containerId: container.id,
-      containerEnergy: getStoredEnergy5(container)
+      containerEnergy: getStoredEnergy5(container),
+      routeDistance: estimateRemoteRoomDistance(homeRoom, room.name)
     } : null;
   }).filter((assignment) => assignment !== null);
 }
@@ -12000,11 +12301,13 @@ function compareRemoteSourceAssignments(left, right) {
   return left.targetRoom.localeCompare(right.targetRoom) || String(left.sourceId).localeCompare(String(right.sourceId));
 }
 function isUsableRemoteRoom(room) {
-  var _a;
-  return ((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && typeof room.find === "function";
+  return room != null && !isHostileOwnedRemoteController(room.controller) && typeof room.find === "function";
+}
+function isHostileOwnedRemoteController(controller) {
+  return (controller == null ? void 0 : controller.owner) != null && controller.my !== true;
 }
 function countRemoteHarvestersForSource(assignment) {
-  return getGameCreeps2().filter(
+  return getRemoteOperationCreeps(assignment.homeRoom, assignment.targetRoom).filter(
     (creep) => {
       var _a, _b, _c, _d;
       return ((_a = creep.memory) == null ? void 0 : _a.role) === REMOTE_HARVESTER_ROLE && canSatisfyRemoteCreepCapacity(creep) && ((_b = creep.memory.remoteHarvester) == null ? void 0 : _b.homeRoom) === assignment.homeRoom && ((_c = creep.memory.remoteHarvester) == null ? void 0 : _c.targetRoom) === assignment.targetRoom && String((_d = creep.memory.remoteHarvester) == null ? void 0 : _d.sourceId) === String(assignment.sourceId);
@@ -12100,10 +12403,33 @@ function getVisibleRoom2(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameCreeps2() {
-  var _a;
-  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  return creeps ? Object.values(creeps) : [];
+function getRemoteOperationCreeps(homeRoom, targetRoom) {
+  const findMyCreeps3 = globalThis.FIND_MY_CREEPS;
+  if (typeof findMyCreeps3 !== "number") {
+    return [];
+  }
+  const seen = /* @__PURE__ */ new Set();
+  const creeps = [];
+  for (const roomName of [homeRoom, targetRoom]) {
+    const room = getVisibleRoom2(roomName);
+    const roomCreeps = typeof (room == null ? void 0 : room.find) === "function" ? room.find(findMyCreeps3) : void 0;
+    if (!Array.isArray(roomCreeps)) {
+      continue;
+    }
+    for (const creep of roomCreeps) {
+      const key = getCreepStableKey2(creep);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      creeps.push(creep);
+    }
+  }
+  return creeps;
+}
+function getCreepStableKey2(creep) {
+  var _a, _b, _c, _d, _e, _f;
+  return (_f = creep.name) != null ? _f : `${(_b = (_a = creep.memory) == null ? void 0 : _a.role) != null ? _b : "creep"}:${(_d = (_c = creep.memory) == null ? void 0 : _c.colony) != null ? _d : ""}:${(_e = creep.ticksToLive) != null ? _e : ""}`;
 }
 function isAdjacentRoomOrUnknown(homeRoom, targetRoom) {
   const home = parseRoomCoordinates2(homeRoom);
@@ -12129,6 +12455,21 @@ function parseRoomCoordinates2(roomName) {
     y: match[3] === "S" ? verticalValue : -verticalValue - 1
   };
 }
+function estimateRemoteRoomDistance(homeRoom, targetRoom) {
+  const home = parseRoomCoordinates2(homeRoom);
+  const target = parseRoomCoordinates2(targetRoom);
+  if (!home || !target) {
+    return DEFAULT_REMOTE_ROOM_DISTANCE;
+  }
+  return Math.max(DEFAULT_REMOTE_ROOM_DISTANCE, Math.max(Math.abs(home.x - target.x), Math.abs(home.y - target.y)));
+}
+function isVisibleRemoteThreatened(room, targetRoom) {
+  if ((room == null ? void 0 : room.name) !== targetRoom || typeof FIND_HOSTILE_CREEPS !== "number" || typeof room.find !== "function") {
+    return false;
+  }
+  const hostiles = room.find(FIND_HOSTILE_CREEPS);
+  return Array.isArray(hostiles) && hostiles.length > 0;
+}
 function getErrFullCode() {
   var _a;
   return (_a = globalThis.ERR_FULL) != null ? _a : ERR_FULL_CODE;
@@ -12152,29 +12493,30 @@ function isNonEmptyString7(value) {
 var HAULER_ROLE = "hauler";
 var REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD = 500;
 var MAX_REMOTE_HAULERS_PER_CONTAINER = 1;
-var MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS = 10;
 var HAULER_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var ERR_NOT_IN_RANGE_CODE4 = -9;
-function buildRemoteHaulerBody(energyAvailable) {
-  const pairCount = Math.min(MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS, Math.floor(Math.max(0, energyAvailable) / 100));
-  if (pairCount <= 0) {
-    return [];
-  }
-  return Array.from({ length: pairCount }).flatMap(() => ["carry", "move"]);
-}
 function selectRemoteHaulerAssignment(homeRoom) {
   var _a;
+  if (!hasRemoteHaulerDeliveryDemand(homeRoom)) {
+    return null;
+  }
   return (_a = getRemoteSourceAssignments(homeRoom).filter((assignment) => assignment.containerEnergy > REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD).filter((assignment) => countRemoteHaulersForContainer(assignment) < MAX_REMOTE_HAULERS_PER_CONTAINER).sort(compareRemoteHaulerAssignments)[0]) != null ? _a : null;
 }
+function hasRemoteHaulerDeliveryDemand(homeRoom) {
+  const room = getVisibleRoom3(homeRoom);
+  return room !== void 0 && selectRemoteHaulerDeliveryTask(room) !== null;
+}
 function runHauler(creep) {
-  var _a, _b;
+  var _a, _b, _c;
   const assignment = normalizeRemoteHaulerMemory((_a = creep.memory) == null ? void 0 : _a.remoteHauler);
   if (!assignment) {
     return;
   }
-  if (isRemoteOperationSuspended(assignment.homeRoom, assignment.targetRoom)) {
+  if (shouldRetreatFromRemote(creep, assignment)) {
     delete creep.memory.task;
-    if (((_b = creep.room) == null ? void 0 : _b.name) !== assignment.homeRoom || getCarriedEnergy3(creep) > 0) {
+    if (getCarriedEnergy3(creep) > 0 && ((_b = creep.room) == null ? void 0 : _b.name) === assignment.homeRoom) {
+      deliverEnergy(creep, assignment);
+    } else if (((_c = creep.room) == null ? void 0 : _c.name) !== assignment.homeRoom || getCarriedEnergy3(creep) > 0) {
       moveTowardRoom2(creep, assignment.homeRoom);
     }
     return;
@@ -12239,7 +12581,7 @@ function compareRemoteHaulerAssignments(left, right) {
   return right.containerEnergy - left.containerEnergy || left.targetRoom.localeCompare(right.targetRoom) || String(left.sourceId).localeCompare(String(right.sourceId));
 }
 function countRemoteHaulersForContainer(assignment) {
-  return getGameCreeps3().filter(
+  return getRemoteOperationCreeps2(assignment.homeRoom, assignment.targetRoom).filter(
     (creep) => {
       var _a, _b, _c, _d;
       return ((_a = creep.memory) == null ? void 0 : _a.role) === HAULER_ROLE && canSatisfyRemoteCreepCapacity2(creep) && ((_b = creep.memory.remoteHauler) == null ? void 0 : _b.homeRoom) === assignment.homeRoom && ((_c = creep.memory.remoteHauler) == null ? void 0 : _c.targetRoom) === assignment.targetRoom && String((_d = creep.memory.remoteHauler) == null ? void 0 : _d.containerId) === String(assignment.containerId);
@@ -12289,10 +12631,37 @@ function getObjectById2(id) {
   const getObjectById3 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
   return typeof getObjectById3 === "function" ? getObjectById3(String(id)) : null;
 }
-function getGameCreeps3() {
-  var _a;
-  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  return creeps ? Object.values(creeps) : [];
+function getRemoteOperationCreeps2(homeRoom, targetRoom) {
+  const findMyCreeps3 = globalThis.FIND_MY_CREEPS;
+  if (typeof findMyCreeps3 !== "number") {
+    return [];
+  }
+  const seen = /* @__PURE__ */ new Set();
+  const creeps = [];
+  for (const roomName of [homeRoom, targetRoom]) {
+    const room = getVisibleRoom3(roomName);
+    const roomCreeps = typeof (room == null ? void 0 : room.find) === "function" ? room.find(findMyCreeps3) : void 0;
+    if (!Array.isArray(roomCreeps)) {
+      continue;
+    }
+    for (const creep of roomCreeps) {
+      const key = getCreepStableKey3(creep);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      creeps.push(creep);
+    }
+  }
+  return creeps;
+}
+function getVisibleRoom3(roomName) {
+  var _a, _b;
+  return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+}
+function getCreepStableKey3(creep) {
+  var _a, _b, _c, _d, _e, _f;
+  return (_f = creep.name) != null ? _f : `${(_b = (_a = creep.memory) == null ? void 0 : _a.role) != null ? _b : "creep"}:${(_d = (_c = creep.memory) == null ? void 0 : _c.colony) != null ? _d : ""}:${(_e = creep.ticksToLive) != null ? _e : ""}`;
 }
 function getErrNotInRangeCode2() {
   var _a;
@@ -12485,9 +12854,9 @@ function getRemoteUpgraderPattern(routeDistance) {
   return typeof routeDistance === "number" && routeDistance > 1 ? REMOTE_UPGRADER_TRAVEL_PATTERN : REMOTE_UPGRADER_PATTERN;
 }
 function getBodyCost2(body) {
-  return body.reduce((total, part) => total + getBodyPartCost(part), 0);
+  return body.reduce((total, part) => total + getBodyPartCost2(part), 0);
 }
-function getBodyPartCost(part) {
+function getBodyPartCost2(part) {
   switch (part) {
     case "work":
       return 100;
@@ -12833,7 +13202,7 @@ function selectPostClaimControllerSustainPlan(colony) {
   var _a;
   const records = getPostClaimControllerSustainRecords(colony.room.name);
   for (const record of records) {
-    const targetRoom = getVisibleRoom3(record.roomName);
+    const targetRoom = getVisibleRoom4(record.roomName);
     if (((_a = targetRoom == null ? void 0 : targetRoom.controller) == null ? void 0 : _a.my) !== true) {
       continue;
     }
@@ -12880,7 +13249,7 @@ function comparePostClaimControllerSustainRecords(left, right) {
 }
 function getVisibleControllerLevel(roomName) {
   var _a, _b;
-  const level = (_b = (_a = getVisibleRoom3(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
+  const level = (_b = (_a = getVisibleRoom4(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
   return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL2 + 1;
 }
 function hasOperationalSpawnInRoom(roomName) {
@@ -13000,7 +13369,7 @@ function planRemoteEconomySpawn(context) {
   if (!remoteHaulerAssignment) {
     return null;
   }
-  const body = buildRemoteHaulerBody(context.colony.energyAvailable);
+  const body = buildRemoteHaulerBody(context.colony.energyAvailable, remoteHaulerAssignment.routeDistance);
   if (body.length === 0) {
     return null;
   }
@@ -13257,7 +13626,7 @@ function buildTerritorySpawnBody(energyAvailable, intent) {
   }
   return buildTerritoryControllerBody(energyAvailable);
 }
-function getVisibleRoom3(roomName) {
+function getVisibleRoom4(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -15728,7 +16097,7 @@ function recordSourceWorkloads(room, creeps, tick) {
     )
   };
 }
-function buildSourceWorkloadRecords(room, sources = findSources3(room), creeps = getGameCreeps4()) {
+function buildSourceWorkloadRecords(room, sources = findSources3(room), creeps = getGameCreeps2()) {
   const roomName = getRoomName3(room);
   const assignmentLoads = getSourceAssignmentLoads(roomName, sources, creeps);
   return sources.filter((source) => hasSourcePositionInRoom(source, room)).sort((left, right) => String(left.id).localeCompare(String(right.id))).map((source) => {
@@ -15865,7 +16234,7 @@ function getBodyPartConstant4(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function getGameCreeps4() {
+function getGameCreeps2() {
   var _a;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
   return creeps ? Object.values(creeps) : [];
@@ -16309,7 +16678,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime) {
   if (colony.energyCapacityAvailable < TERRITORY_CONTROLLER_BODY_COST) {
     return { ...baseEvaluation, reason: "energyCapacityLow" };
   }
-  const room = getVisibleRoom4(candidate.roomName);
+  const room = getVisibleRoom5(candidate.roomName);
   if (!room) {
     return { ...baseEvaluation, reason: "roomNotVisible" };
   }
@@ -16506,7 +16875,7 @@ function isSameTarget2(left, right) {
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
 }
-function getVisibleRoom4(roomName) {
+function getVisibleRoom5(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -16817,6 +17186,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         planEarlyRoadConstruction(colony);
       }
     }
+    refreshRemoteMiningSetup(colony, Game.time);
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4030,8 +4030,13 @@ function refreshRemoteMiningSetup(colony, gameTime = getGameTime6()) {
   if (storedRemoteMining === void 0 && records.length === 0) {
     return;
   }
-  const remoteMining = isRecord4(storedRemoteMining) && !Array.isArray(storedRemoteMining) ? storedRemoteMining : {};
-  territoryMemory.remoteMining = remoteMining;
+  let remoteMining;
+  if (isRecord4(storedRemoteMining) && !Array.isArray(storedRemoteMining)) {
+    remoteMining = storedRemoteMining;
+  } else {
+    remoteMining = {};
+    territoryMemory.remoteMining = remoteMining;
+  }
   const activeKeys = /* @__PURE__ */ new Set();
   for (const record of records) {
     const key = getRemoteMiningMemoryKey(record.colony, record.roomName);
@@ -6434,7 +6439,10 @@ function isControllerOwned(controller) {
   return controller.owner != null || controller.my === true;
 }
 function isHostileOwnedController(controller) {
-  return (controller == null ? void 0 : controller.owner) != null && controller.my !== true;
+  if ((controller == null ? void 0 : controller.owner) == null) {
+    return false;
+  }
+  return controller.my !== true;
 }
 function isControllerOwnedByColony2(controller, colonyOwnerUsername) {
   const ownerUsername = getControllerOwnerUsername2(controller);
@@ -12262,7 +12270,7 @@ function shouldRetreatFromRemote(creep, assignment) {
     return true;
   }
   const targetRoom = getVisibleRoom2(assignment.targetRoom);
-  if (isHostileOwnedRemoteController(targetRoom == null ? void 0 : targetRoom.controller)) {
+  if (isForeignOwnedRemoteController(targetRoom == null ? void 0 : targetRoom.controller)) {
     return true;
   }
   return isVisibleRemoteThreatened(targetRoom, assignment.targetRoom);
@@ -12301,10 +12309,13 @@ function compareRemoteSourceAssignments(left, right) {
   return left.targetRoom.localeCompare(right.targetRoom) || String(left.sourceId).localeCompare(String(right.sourceId));
 }
 function isUsableRemoteRoom(room) {
-  return room != null && !isHostileOwnedRemoteController(room.controller) && typeof room.find === "function";
+  return room != null && !isForeignOwnedRemoteController(room.controller) && typeof room.find === "function";
 }
-function isHostileOwnedRemoteController(controller) {
-  return (controller == null ? void 0 : controller.owner) != null && controller.my !== true;
+function isForeignOwnedRemoteController(controller) {
+  if ((controller == null ? void 0 : controller.owner) == null) {
+    return false;
+  }
+  return controller.my !== true;
 }
 function countRemoteHarvestersForSource(assignment) {
   return getRemoteOperationCreeps(assignment.homeRoom, assignment.targetRoom).filter(

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12265,7 +12265,7 @@ function shouldRetreatFromRemote(creep, assignment) {
   if (isHostileOwnedRemoteController(targetRoom == null ? void 0 : targetRoom.controller)) {
     return true;
   }
-  return isVisibleRemoteThreatened(creep.room, assignment.targetRoom);
+  return isVisibleRemoteThreatened(targetRoom, assignment.targetRoom);
 }
 function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
   if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {

--- a/prod/src/construction/sourceContainerPlanner.ts
+++ b/prod/src/construction/sourceContainerPlanner.ts
@@ -24,10 +24,18 @@ interface SourceContainerPlannerLookups {
   pendingContainerPositions: Set<string>;
 }
 
-export function planSourceContainerConstruction(colony: ColonySnapshot): ScreepsReturnCode | null {
+export interface SourceContainerPlanningOptions {
+  anchor?: RoomPosition | null;
+  minimumControllerLevel?: number;
+}
+
+export function planSourceContainerConstruction(
+  colony: ColonySnapshot,
+  options: SourceContainerPlanningOptions = {}
+): ScreepsReturnCode | null {
   const room = colony.room;
   if (
-    (room.controller?.level ?? 0) < MIN_CONTROLLER_LEVEL_FOR_SOURCE_CONTAINERS ||
+    (room.controller?.level ?? 0) < getMinimumControllerLevel(options) ||
     !hasRequiredRoomApis(room) ||
     typeof FIND_SOURCES !== 'number'
   ) {
@@ -39,7 +47,7 @@ export function planSourceContainerConstruction(colony: ColonySnapshot): Screeps
     return null;
   }
 
-  const anchor = selectContainerAnchor(colony);
+  const anchor = options.anchor === undefined ? selectContainerAnchor(colony) : options.anchor;
   for (const source of getSortedSources(room)) {
     if (findSourceContainer(room, source) || hasPendingSourceContainerSite(source, lookups)) {
       continue;
@@ -60,6 +68,10 @@ export function planSourceContainerConstruction(colony: ColonySnapshot): Screeps
   }
 
   return null;
+}
+
+function getMinimumControllerLevel(options: SourceContainerPlanningOptions): number {
+  return options.minimumControllerLevel ?? MIN_CONTROLLER_LEVEL_FOR_SOURCE_CONTAINERS;
 }
 
 function hasRequiredRoomApis(room: Room): boolean {

--- a/prod/src/creeps/hauler.ts
+++ b/prod/src/creeps/hauler.ts
@@ -200,8 +200,8 @@ function getRemoteOperationCreeps(homeRoom: string, targetRoom: string): Creep[]
   const creeps: Creep[] = [];
   for (const roomName of [homeRoom, targetRoom]) {
     const room = getVisibleRoom(roomName);
-    const find = room?.find as ((type: number) => Creep[]) | undefined;
-    const roomCreeps = find?.(findMyCreeps);
+    const roomCreeps =
+      typeof room?.find === 'function' ? (room.find(findMyCreeps as FindConstant) as Creep[]) : undefined;
     if (!Array.isArray(roomCreeps)) {
       continue;
     }

--- a/prod/src/creeps/hauler.ts
+++ b/prod/src/creeps/hauler.ts
@@ -1,30 +1,27 @@
 import { selectRemoteHaulerDeliveryTask } from '../tasks/workerTasks';
 import {
   getRemoteSourceAssignments,
-  isRemoteOperationSuspended,
   moveTowardRoom,
   REMOTE_CREEP_REPLACEMENT_TICKS,
+  shouldRetreatFromRemote,
   type RemoteSourceAssignment
 } from './remoteHarvester';
+import { buildRemoteHaulerBody } from '../spawn/bodyBuilder';
 
 export const HAULER_ROLE = 'hauler';
 export const REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD = 500;
 
 const MAX_REMOTE_HAULERS_PER_CONTAINER = 1;
-const MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS = 10;
 const HAULER_MOVE_OPTS: MoveToOpts = { reusePath: 20, ignoreRoads: false };
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 
-export function buildRemoteHaulerBody(energyAvailable: number): BodyPartConstant[] {
-  const pairCount = Math.min(MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS, Math.floor(Math.max(0, energyAvailable) / 100));
-  if (pairCount <= 0) {
-    return [];
-  }
-
-  return Array.from({ length: pairCount }).flatMap(() => ['carry', 'move'] as BodyPartConstant[]);
-}
+export { buildRemoteHaulerBody };
 
 export function selectRemoteHaulerAssignment(homeRoom: string): RemoteSourceAssignment | null {
+  if (!hasRemoteHaulerDeliveryDemand(homeRoom)) {
+    return null;
+  }
+
   return (
     getRemoteSourceAssignments(homeRoom)
       .filter((assignment) => assignment.containerEnergy > REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD)
@@ -33,15 +30,22 @@ export function selectRemoteHaulerAssignment(homeRoom: string): RemoteSourceAssi
   );
 }
 
+function hasRemoteHaulerDeliveryDemand(homeRoom: string): boolean {
+  const room = getVisibleRoom(homeRoom);
+  return room !== undefined && selectRemoteHaulerDeliveryTask(room) !== null;
+}
+
 export function runHauler(creep: Creep): void {
   const assignment = normalizeRemoteHaulerMemory(creep.memory?.remoteHauler);
   if (!assignment) {
     return;
   }
 
-  if (isRemoteOperationSuspended(assignment.homeRoom, assignment.targetRoom)) {
+  if (shouldRetreatFromRemote(creep, assignment)) {
     delete creep.memory.task;
-    if (creep.room?.name !== assignment.homeRoom || getCarriedEnergy(creep) > 0) {
+    if (getCarriedEnergy(creep) > 0 && creep.room?.name === assignment.homeRoom) {
+      deliverEnergy(creep, assignment);
+    } else if (creep.room?.name !== assignment.homeRoom || getCarriedEnergy(creep) > 0) {
       moveTowardRoom(creep, assignment.homeRoom);
     }
     return;
@@ -120,7 +124,7 @@ function compareRemoteHaulerAssignments(left: RemoteSourceAssignment, right: Rem
 }
 
 function countRemoteHaulersForContainer(assignment: RemoteSourceAssignment): number {
-  return getGameCreeps().filter(
+  return getRemoteOperationCreeps(assignment.homeRoom, assignment.targetRoom).filter(
     (creep) =>
       creep.memory?.role === HAULER_ROLE &&
       canSatisfyRemoteCreepCapacity(creep) &&
@@ -186,9 +190,42 @@ function getObjectById<T>(id: string): T | null {
   return typeof getObjectById === 'function' ? getObjectById(String(id)) : null;
 }
 
-function getGameCreeps(): Creep[] {
-  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
-  return creeps ? Object.values(creeps) : [];
+function getRemoteOperationCreeps(homeRoom: string, targetRoom: string): Creep[] {
+  const findMyCreeps = (globalThis as { FIND_MY_CREEPS?: number }).FIND_MY_CREEPS;
+  if (typeof findMyCreeps !== 'number') {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const creeps: Creep[] = [];
+  for (const roomName of [homeRoom, targetRoom]) {
+    const room = getVisibleRoom(roomName);
+    const find = room?.find as ((type: number) => Creep[]) | undefined;
+    const roomCreeps = find?.(findMyCreeps);
+    if (!Array.isArray(roomCreeps)) {
+      continue;
+    }
+
+    for (const creep of roomCreeps) {
+      const key = getCreepStableKey(creep);
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      creeps.push(creep);
+    }
+  }
+
+  return creeps;
+}
+
+function getVisibleRoom(roomName: string): Room | undefined {
+  return (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName];
+}
+
+function getCreepStableKey(creep: Creep): string {
+  return creep.name ?? `${creep.memory?.role ?? 'creep'}:${creep.memory?.colony ?? ''}:${creep.ticksToLive ?? ''}`;
 }
 
 function getErrNotInRangeCode(): ScreepsReturnCode {

--- a/prod/src/creeps/remoteHarvester.ts
+++ b/prod/src/creeps/remoteHarvester.ts
@@ -164,7 +164,7 @@ export function shouldRetreatFromRemote(
     return true;
   }
 
-  return isVisibleRemoteThreatened(creep.room, assignment.targetRoom);
+  return isVisibleRemoteThreatened(targetRoom, assignment.targetRoom);
 }
 
 function getRemoteSourceAssignmentsInRoom(homeRoom: string, room: Room): RemoteSourceAssignment[] {

--- a/prod/src/creeps/remoteHarvester.ts
+++ b/prod/src/creeps/remoteHarvester.ts
@@ -369,8 +369,8 @@ function getRemoteOperationCreeps(homeRoom: string, targetRoom: string): Creep[]
   const creeps: Creep[] = [];
   for (const roomName of [homeRoom, targetRoom]) {
     const room = getVisibleRoom(roomName);
-    const find = room?.find as ((type: number) => Creep[]) | undefined;
-    const roomCreeps = find?.(findMyCreeps);
+    const roomCreeps =
+      typeof room?.find === 'function' ? (room.find(findMyCreeps as FindConstant) as Creep[]) : undefined;
     if (!Array.isArray(roomCreeps)) {
       continue;
     }

--- a/prod/src/creeps/remoteHarvester.ts
+++ b/prod/src/creeps/remoteHarvester.ts
@@ -1,15 +1,16 @@
 import { hasSafeRouteAvoidingDeadZones, isKnownDeadZoneRoom } from '../defense/deadZone';
 import { findSourceContainer } from '../economy/sourceContainers';
+import { buildRemoteHarvesterBody } from '../spawn/bodyBuilder';
 
 export const REMOTE_HARVESTER_ROLE = 'remoteHarvester';
 export const REMOTE_CREEP_REPLACEMENT_TICKS = 100;
 
 const MAX_REMOTE_HARVESTERS_PER_SOURCE = 1;
-const MAX_REMOTE_HARVESTER_WORK_PARTS = 5;
 const REMOTE_MOVE_OPTS: MoveToOpts = { reusePath: 20, ignoreRoads: false };
 const ERR_FULL_CODE = -8 as ScreepsReturnCode;
 const ERR_NOT_ENOUGH_RESOURCES_CODE = -6 as ScreepsReturnCode;
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+const DEFAULT_REMOTE_ROOM_DISTANCE = 1;
 
 export interface RemoteSourceAssignment {
   homeRoom: string;
@@ -17,19 +18,10 @@ export interface RemoteSourceAssignment {
   sourceId: Id<Source>;
   containerId: Id<StructureContainer>;
   containerEnergy: number;
+  routeDistance: number;
 }
 
-export function buildRemoteHarvesterBody(energyAvailable: number): BodyPartConstant[] {
-  const workParts = Math.min(
-    MAX_REMOTE_HARVESTER_WORK_PARTS,
-    Math.floor((Math.max(0, energyAvailable) - 100) / 100)
-  );
-  if (workParts <= 0) {
-    return [];
-  }
-
-  return [...Array.from({ length: workParts }, () => 'work' as BodyPartConstant), 'carry', 'move'];
-}
+export { buildRemoteHarvesterBody };
 
 export function selectRemoteHarvesterAssignment(homeRoom: string): RemoteSourceAssignment | null {
   return (
@@ -84,7 +76,7 @@ export function runRemoteHarvester(creep: Creep): void {
     return;
   }
 
-  if (isRemoteOperationSuspended(assignment.homeRoom, assignment.targetRoom)) {
+  if (shouldRetreatFromRemote(creep, assignment)) {
     delete creep.memory.task;
     moveTowardRoom(creep, assignment.homeRoom);
     return;
@@ -159,6 +151,22 @@ export function moveTowardRoom(creep: Creep, roomName: string, target?: RoomObje
   }
 }
 
+export function shouldRetreatFromRemote(
+  creep: Creep,
+  assignment: CreepRemoteHarvesterMemory | CreepRemoteHaulerMemory
+): boolean {
+  if (isRemoteOperationSuspended(assignment.homeRoom, assignment.targetRoom)) {
+    return true;
+  }
+
+  const targetRoom = getVisibleRoom(assignment.targetRoom);
+  if (targetRoom?.controller && targetRoom.controller.my !== true) {
+    return true;
+  }
+
+  return isVisibleRemoteThreatened(creep.room, assignment.targetRoom);
+}
+
 function getRemoteSourceAssignmentsInRoom(homeRoom: string, room: Room): RemoteSourceAssignment[] {
   if (typeof FIND_SOURCES !== 'number' || typeof room.find !== 'function') {
     return [];
@@ -173,7 +181,8 @@ function getRemoteSourceAssignmentsInRoom(homeRoom: string, room: Room): RemoteS
             targetRoom: room.name,
             sourceId: source.id,
             containerId: container.id,
-            containerEnergy: getStoredEnergy(container)
+            containerEnergy: getStoredEnergy(container),
+            routeDistance: estimateRemoteRoomDistance(homeRoom, room.name)
           }
         : null;
     })
@@ -221,7 +230,7 @@ function isUsableRemoteRoom(room: Room | undefined): room is Room {
 }
 
 function countRemoteHarvestersForSource(assignment: RemoteSourceAssignment): number {
-  return getGameCreeps().filter(
+  return getRemoteOperationCreeps(assignment.homeRoom, assignment.targetRoom).filter(
     (creep) =>
       creep.memory?.role === REMOTE_HARVESTER_ROLE &&
       canSatisfyRemoteCreepCapacity(creep) &&
@@ -346,9 +355,38 @@ function getVisibleRoom(roomName: string): Room | undefined {
   return (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName];
 }
 
-function getGameCreeps(): Creep[] {
-  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
-  return creeps ? Object.values(creeps) : [];
+function getRemoteOperationCreeps(homeRoom: string, targetRoom: string): Creep[] {
+  const findMyCreeps = (globalThis as { FIND_MY_CREEPS?: number }).FIND_MY_CREEPS;
+  if (typeof findMyCreeps !== 'number') {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const creeps: Creep[] = [];
+  for (const roomName of [homeRoom, targetRoom]) {
+    const room = getVisibleRoom(roomName);
+    const find = room?.find as ((type: number) => Creep[]) | undefined;
+    const roomCreeps = find?.(findMyCreeps);
+    if (!Array.isArray(roomCreeps)) {
+      continue;
+    }
+
+    for (const creep of roomCreeps) {
+      const key = getCreepStableKey(creep);
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      creeps.push(creep);
+    }
+  }
+
+  return creeps;
+}
+
+function getCreepStableKey(creep: Creep): string {
+  return creep.name ?? `${creep.memory?.role ?? 'creep'}:${creep.memory?.colony ?? ''}:${creep.ticksToLive ?? ''}`;
 }
 
 function isAdjacentRoomOrUnknown(homeRoom: string, targetRoom: string): boolean {
@@ -378,6 +416,25 @@ function parseRoomCoordinates(roomName: string): { x: number; y: number } | null
     x: match[1] === 'E' ? horizontalValue : -horizontalValue - 1,
     y: match[3] === 'S' ? verticalValue : -verticalValue - 1
   };
+}
+
+function estimateRemoteRoomDistance(homeRoom: string, targetRoom: string): number {
+  const home = parseRoomCoordinates(homeRoom);
+  const target = parseRoomCoordinates(targetRoom);
+  if (!home || !target) {
+    return DEFAULT_REMOTE_ROOM_DISTANCE;
+  }
+
+  return Math.max(DEFAULT_REMOTE_ROOM_DISTANCE, Math.max(Math.abs(home.x - target.x), Math.abs(home.y - target.y)));
+}
+
+function isVisibleRemoteThreatened(room: Room | undefined, targetRoom: string): boolean {
+  if (room?.name !== targetRoom || typeof FIND_HOSTILE_CREEPS !== 'number' || typeof room.find !== 'function') {
+    return false;
+  }
+
+  const hostiles = room.find(FIND_HOSTILE_CREEPS) as Creep[];
+  return Array.isArray(hostiles) && hostiles.length > 0;
 }
 
 function getErrFullCode(): ScreepsReturnCode {

--- a/prod/src/creeps/remoteHarvester.ts
+++ b/prod/src/creeps/remoteHarvester.ts
@@ -160,7 +160,7 @@ export function shouldRetreatFromRemote(
   }
 
   const targetRoom = getVisibleRoom(assignment.targetRoom);
-  if (isHostileOwnedRemoteController(targetRoom?.controller)) {
+  if (isForeignOwnedRemoteController(targetRoom?.controller)) {
     return true;
   }
 
@@ -226,11 +226,15 @@ function compareRemoteSourceAssignments(left: RemoteSourceAssignment, right: Rem
 }
 
 function isUsableRemoteRoom(room: Room | undefined): room is Room {
-  return room != null && !isHostileOwnedRemoteController(room.controller) && typeof room.find === 'function';
+  return room != null && !isForeignOwnedRemoteController(room.controller) && typeof room.find === 'function';
 }
 
-function isHostileOwnedRemoteController(controller: StructureController | undefined): boolean {
-  return controller?.owner != null && controller.my !== true;
+function isForeignOwnedRemoteController(controller: StructureController | undefined): boolean {
+  if (controller?.owner == null) {
+    return false;
+  }
+
+  return controller.my !== true;
 }
 
 function countRemoteHarvestersForSource(assignment: RemoteSourceAssignment): number {

--- a/prod/src/creeps/remoteHarvester.ts
+++ b/prod/src/creeps/remoteHarvester.ts
@@ -160,7 +160,7 @@ export function shouldRetreatFromRemote(
   }
 
   const targetRoom = getVisibleRoom(assignment.targetRoom);
-  if (targetRoom?.controller && targetRoom.controller.my !== true) {
+  if (isHostileOwnedRemoteController(targetRoom?.controller)) {
     return true;
   }
 
@@ -226,7 +226,11 @@ function compareRemoteSourceAssignments(left: RemoteSourceAssignment, right: Rem
 }
 
 function isUsableRemoteRoom(room: Room | undefined): room is Room {
-  return room?.controller?.my === true && typeof room.find === 'function';
+  return room != null && !isHostileOwnedRemoteController(room.controller) && typeof room.find === 'function';
+}
+
+function isHostileOwnedRemoteController(controller: StructureController | undefined): boolean {
+  return controller?.owner != null && controller.my !== true;
 }
 
 function countRemoteHarvestersForSource(assignment: RemoteSourceAssignment): number {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -41,7 +41,8 @@ import {
   hasPendingTerritoryFollowUpIntent,
   TERRITORY_CLAIMER_ROLE,
   TERRITORY_SCOUT_ROLE,
-  recordAutonomousExpansionClaimReserveFallbackIntent
+  recordAutonomousExpansionClaimReserveFallbackIntent,
+  refreshRemoteMiningSetup
 } from '../territory/territoryPlanner';
 import { runTerritoryControllerCreep } from '../territory/territoryRunner';
 import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgrader';
@@ -83,6 +84,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
         planEarlyRoadConstruction(colony);
       }
     }
+    refreshRemoteMiningSetup(colony, Game.time);
 
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);

--- a/prod/src/economy/sourceContainers.ts
+++ b/prod/src/economy/sourceContainers.ts
@@ -31,6 +31,31 @@ export function findSourceContainer(room: Room, source: Source): StructureContai
   return containers.sort((left, right) => compareSourceContainers(sourcePosition, left, right))[0] ?? null;
 }
 
+export function findSourceContainerConstructionSite(room: Room, source: Source): ConstructionSite | null {
+  if (typeof FIND_CONSTRUCTION_SITES !== 'number' || typeof room.find !== 'function') {
+    return null;
+  }
+
+  const sourcePosition = getRoomObjectPosition(source);
+  if (!sourcePosition || !isSameRoomPosition(sourcePosition, room.name)) {
+    return null;
+  }
+
+  const sites = room
+    .find(FIND_CONSTRUCTION_SITES)
+    .filter((site): site is ConstructionSite => isContainerConstructionSite(site))
+    .filter((site) => {
+      const sitePosition = getRoomObjectPosition(site);
+      return (
+        sitePosition !== null &&
+        isSameRoomPosition(sitePosition, room.name) &&
+        getRangeBetweenPositions(sourcePosition, sitePosition) <= 1
+      );
+    });
+
+  return sites.sort((left, right) => compareSourceContainerSites(sourcePosition, left, right))[0] ?? null;
+}
+
 export function isContainerStructure(structure: AnyStructure): structure is StructureContainer {
   return matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container');
 }
@@ -65,6 +90,23 @@ function compareSourceContainers(sourcePosition: RoomPosition, left: StructureCo
   );
 }
 
+function compareSourceContainerSites(
+  sourcePosition: RoomPosition,
+  left: ConstructionSite,
+  right: ConstructionSite
+): number {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+
+  return (
+    compareNumbers(
+      leftPosition ? getRangeBetweenPositions(sourcePosition, leftPosition) : Number.POSITIVE_INFINITY,
+      rightPosition ? getRangeBetweenPositions(sourcePosition, rightPosition) : Number.POSITIVE_INFINITY
+    ) ||
+    String(left.id).localeCompare(String(right.id))
+  );
+}
+
 function compareNumbers(left: number, right: number): number {
   return left - right;
 }
@@ -87,4 +129,8 @@ function matchesStructureType(
 ): boolean {
   const constants = globalThis as unknown as Partial<Record<SourceContainerStructureConstantGlobal, string>>;
   return actual === (constants[globalName] ?? fallback);
+}
+
+function isContainerConstructionSite(site: ConstructionSite): boolean {
+  return matchesStructureType(site.structureType, 'STRUCTURE_CONTAINER', 'container');
 }

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -25,6 +25,9 @@ export {
   TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS
 } from './bodyTemplates';
 const MAX_CREEP_PARTS = 50;
+const MAX_REMOTE_HARVESTER_WORK_PARTS = 5;
+const MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS = 10;
+const MIN_REMOTE_HAULER_CARRY_MOVE_PAIRS = 6;
 // General workers cover harvest, haul, build, and upgrade duties. Cap them at
 // four 200-energy patterns (800 energy) so early rooms do not sink capacity into
 // oversized unspecialized bodies before dedicated roles exist.
@@ -216,6 +219,49 @@ export function buildTerritoryControllerPressureBody(energyAvailable: number): B
   return [...TERRITORY_CONTROLLER_PRESSURE_BODY];
 }
 
+export function buildRemoteHarvesterBody(energyAvailable: number): BodyPartConstant[] {
+  const workParts = Math.min(
+    MAX_REMOTE_HARVESTER_WORK_PARTS,
+    Math.floor(
+      (Math.max(0, energyAvailable) - getBodyPartCost('carry') - getBodyPartCost('move')) /
+        getBodyPartCost('work')
+    )
+  );
+  if (workParts <= 0) {
+    return [];
+  }
+
+  return [...Array.from({ length: workParts }, () => 'work' as BodyPartConstant), 'carry', 'move'];
+}
+
+export function buildRemoteHaulerBody(energyAvailable: number, routeDistance = 1): BodyPartConstant[] {
+  const pairCount = Math.min(
+    getRemoteHaulerCarryMovePairLimit(routeDistance),
+    Math.floor(Math.max(0, energyAvailable) / (getBodyPartCost('carry') + getBodyPartCost('move'))),
+    Math.floor(MAX_CREEP_PARTS / 2)
+  );
+  if (pairCount <= 0) {
+    return [];
+  }
+
+  return Array.from({ length: pairCount }).flatMap(() => ['carry', 'move'] as BodyPartConstant[]);
+}
+
 export function getBodyCost(body: BodyPartConstant[]): number {
   return body.reduce((cost, part) => cost + BODY_PART_COSTS[part], 0);
+}
+
+function getRemoteHaulerCarryMovePairLimit(routeDistance: number): number {
+  if (!Number.isFinite(routeDistance) || routeDistance <= 0) {
+    return MIN_REMOTE_HAULER_CARRY_MOVE_PAIRS;
+  }
+
+  return Math.min(
+    MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS,
+    Math.max(MIN_REMOTE_HAULER_CARRY_MOVE_PAIRS, Math.ceil(routeDistance) * 2)
+  );
+}
+
+function getBodyPartCost(part: BodyPartConstant): number {
+  return BODY_PART_COSTS[part];
 }

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -6,12 +6,10 @@ import {
 } from '../colony/survivalMode';
 import { getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import {
-  buildRemoteHarvesterBody,
   REMOTE_HARVESTER_ROLE,
   selectRemoteHarvesterAssignment
 } from '../creeps/remoteHarvester';
 import {
-  buildRemoteHaulerBody,
   HAULER_ROLE,
   selectRemoteHaulerAssignment
 } from '../creeps/hauler';
@@ -19,6 +17,8 @@ import { DEFENDER_ROLE } from '../defense/defenseLoop';
 import {
   buildEmergencyDefenderBody,
   buildEmergencyWorkerBody,
+  buildRemoteHarvesterBody,
+  buildRemoteHaulerBody,
   buildTerritoryControllerBody,
   buildTerritoryControllerPressureBody,
   buildWorkerBody,
@@ -500,7 +500,7 @@ function planRemoteEconomySpawn(context: SpawnPlanningContext): SpawnRequest | n
     return null;
   }
 
-  const body = buildRemoteHaulerBody(context.colony.energyAvailable);
+  const body = buildRemoteHaulerBody(context.colony.energyAvailable, remoteHaulerAssignment.routeDistance);
   if (body.length === 0) {
     return null;
   }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -78,7 +78,7 @@ type StoredWorkerEnergySource = StructureContainer | StructureStorage | Structur
 type UpgraderBoostStoredEnergySource = StructureContainer | StructureStorage;
 type SalvageableWorkerEnergySource = Tombstone | Ruin;
 type FillableEnergySink = StructureSpawn | StructureExtension | StructureTower;
-type RemoteHaulerDeliverySink = StructureSpawn | StructureExtension | StructureStorage;
+type RemoteHaulerDeliverySink = StructureSpawn | StructureExtension | StructureStorage | StructureTower;
 type SpawnExtensionEnergyStructure = StructureSpawn | StructureExtension;
 type WorkerEnergyAcquisitionSource =
   | StoredWorkerEnergySource
@@ -1231,7 +1231,8 @@ function selectRemoteHaulerDeliverySink(room: Room): RemoteHaulerDeliverySink | 
   const fillableSinks = findFillableEnergySinksInRoom(room);
   return (
     selectFirstEnergySinkByStableId(fillableSinks.filter(isSpawnOrExtensionEnergySink)) ??
-    selectFirstStorageSinkByStableId(findRemoteHaulerStorageSinks(room))
+    selectFirstStorageSinkByStableId(findRemoteHaulerStorageSinks(room)) ??
+    selectFirstEnergySinkByStableId(fillableSinks.filter(isTowerEnergySink))
   );
 }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -890,11 +890,13 @@ export function refreshRemoteMiningSetup(colony: ColonySnapshot, gameTime = getG
     return;
   }
 
-  const remoteMining =
-    isRecord(storedRemoteMining) && !Array.isArray(storedRemoteMining)
-      ? (storedRemoteMining as Record<string, TerritoryRemoteMiningRoomMemory>)
-      : {};
-  territoryMemory.remoteMining = remoteMining;
+  let remoteMining: Record<string, TerritoryRemoteMiningRoomMemory>;
+  if (isRecord(storedRemoteMining) && !Array.isArray(storedRemoteMining)) {
+    remoteMining = storedRemoteMining as Record<string, TerritoryRemoteMiningRoomMemory>;
+  } else {
+    remoteMining = {};
+    territoryMemory.remoteMining = remoteMining;
+  }
   const activeKeys = new Set<string>();
 
   for (const record of records) {
@@ -4676,7 +4678,11 @@ function isControllerOwned(controller: StructureController): boolean {
 }
 
 function isHostileOwnedController(controller: StructureController | undefined): boolean {
-  return controller?.owner != null && controller.my !== true;
+  if (controller?.owner == null) {
+    return false;
+  }
+
+  return controller.my !== true;
 }
 
 function isControllerOwnedByColony(controller: StructureController, colonyOwnerUsername: string | null): boolean {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -72,7 +72,7 @@ const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
 const TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 const TERRITORY_SCOUT_BODY_COST = 50;
 const OCCUPATION_RECOMMENDATION_TARGET_CREATOR: TerritoryTargetMemory['createdBy'] = 'occupationRecommendation';
-const REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 1;
+const REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -885,11 +885,15 @@ export function refreshRemoteMiningSetup(colony: ColonySnapshot, gameTime = getG
 
   const colonyName = colony.room.name;
   const records = getRemoteMiningBootstrapRecords(territoryMemory, colonyName);
-  if (!territoryMemory.remoteMining && records.length === 0) {
+  const storedRemoteMining = territoryMemory.remoteMining;
+  if (storedRemoteMining === undefined && records.length === 0) {
     return;
   }
 
-  const remoteMining = territoryMemory.remoteMining ?? {};
+  const remoteMining =
+    isRecord(storedRemoteMining) && !Array.isArray(storedRemoteMining)
+      ? (storedRemoteMining as Record<string, TerritoryRemoteMiningRoomMemory>)
+      : {};
   territoryMemory.remoteMining = remoteMining;
   const activeKeys = new Set<string>();
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -164,6 +164,8 @@ interface RecoveredTerritoryFollowUpRetryMetadata {
   suppressedAt: number;
 }
 
+type RemoteMiningRoomState = Omit<TerritoryRemoteMiningRoomMemory, 'updatedAt'>;
+
 const recoveredTerritoryFollowUpRetryMetadata = new WeakMap<
   TerritoryIntentPlan,
   RecoveredTerritoryFollowUpRetryMetadata
@@ -881,36 +883,49 @@ export function refreshRemoteMiningSetup(colony: ColonySnapshot, gameTime = getG
     return;
   }
 
+  const colonyName = colony.room.name;
+  const records = getRemoteMiningBootstrapRecords(territoryMemory, colonyName);
+  if (!territoryMemory.remoteMining && records.length === 0) {
+    return;
+  }
+
   const remoteMining = territoryMemory.remoteMining ?? {};
   territoryMemory.remoteMining = remoteMining;
-  const colonyName = colony.room.name;
   const activeKeys = new Set<string>();
 
-  for (const record of getRemoteMiningBootstrapRecords(territoryMemory, colonyName)) {
+  for (const record of records) {
     const key = getRemoteMiningMemoryKey(record.colony, record.roomName);
     activeKeys.add(key);
 
     const room = getVisibleRoom(record.roomName);
     if (!room) {
       const previous = remoteMining[key];
-      remoteMining[key] = {
-        colony: record.colony,
-        roomName: record.roomName,
-        status: previous?.status ?? 'containerPending',
-        updatedAt: gameTime,
-        sources: previous?.sources ?? {}
-      };
+      updateRemoteMiningRoomMemoryIfChanged(
+        remoteMining,
+        key,
+        {
+          colony: record.colony,
+          roomName: record.roomName,
+          status: previous?.status ?? 'containerPending',
+          sources: previous?.sources ?? {}
+        },
+        gameTime
+      );
       continue;
     }
 
-    if (room.controller?.my !== true) {
-      remoteMining[key] = {
-        colony: record.colony,
-        roomName: record.roomName,
-        status: 'unclaimed',
-        updatedAt: gameTime,
-        sources: {}
-      };
+    if (isHostileOwnedController(room.controller)) {
+      updateRemoteMiningRoomMemoryIfChanged(
+        remoteMining,
+        key,
+        {
+          colony: record.colony,
+          roomName: record.roomName,
+          status: 'unclaimed',
+          sources: {}
+        },
+        gameTime
+      );
       continue;
     }
 
@@ -951,13 +966,17 @@ export function refreshRemoteMiningSetup(colony: ColonySnapshot, gameTime = getG
       })
     );
 
-    remoteMining[key] = {
-      colony: record.colony,
-      roomName: record.roomName,
-      status: suspended ? 'suspended' : getRemoteMiningStatus(Object.values(sourceStates)),
-      updatedAt: gameTime,
-      sources: sourceStates
-    };
+    updateRemoteMiningRoomMemoryIfChanged(
+      remoteMining,
+      key,
+      {
+        colony: record.colony,
+        roomName: record.roomName,
+        status: suspended ? 'suspended' : getRemoteMiningStatus(Object.values(sourceStates)),
+        sources: sourceStates
+      },
+      gameTime
+    );
   }
 
   for (const key of Object.keys(remoteMining)) {
@@ -4652,6 +4671,10 @@ function isControllerOwned(controller: StructureController): boolean {
   return controller.owner != null || controller.my === true;
 }
 
+function isHostileOwnedController(controller: StructureController | undefined): boolean {
+  return controller?.owner != null && controller.my !== true;
+}
+
 function isControllerOwnedByColony(controller: StructureController, colonyOwnerUsername: string | null): boolean {
   const ownerUsername = getControllerOwnerUsername(controller);
   return controller.my === true || (isNonEmptyString(ownerUsername) && ownerUsername === colonyOwnerUsername);
@@ -4868,6 +4891,76 @@ function getRemoteMiningMemoryKey(colony: string, roomName: string): string {
   return `${colony}:${roomName}`;
 }
 
+function updateRemoteMiningRoomMemoryIfChanged(
+  remoteMining: Record<string, TerritoryRemoteMiningRoomMemory>,
+  key: string,
+  nextState: RemoteMiningRoomState,
+  gameTime: number
+): void {
+  const previous = remoteMining[key];
+  const candidate: TerritoryRemoteMiningRoomMemory = {
+    ...nextState,
+    updatedAt: previous?.updatedAt ?? gameTime
+  };
+
+  if (isSameRemoteMiningRoomMemory(previous, candidate)) {
+    return;
+  }
+
+  remoteMining[key] = {
+    ...nextState,
+    updatedAt: gameTime
+  };
+}
+
+function isSameRemoteMiningRoomMemory(
+  left: TerritoryRemoteMiningRoomMemory | undefined,
+  right: TerritoryRemoteMiningRoomMemory
+): boolean {
+  return (
+    left != null &&
+    left.colony === right.colony &&
+    left.roomName === right.roomName &&
+    left.status === right.status &&
+    left.updatedAt === right.updatedAt &&
+    isSameRemoteMiningSources(left.sources, right.sources)
+  );
+}
+
+function isSameRemoteMiningSources(
+  left: Record<string, TerritoryRemoteMiningSourceMemory> | undefined,
+  right: Record<string, TerritoryRemoteMiningSourceMemory>
+): boolean {
+  if (!isRecord(left)) {
+    return false;
+  }
+
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+
+  return rightKeys.every((key) => isSameRemoteMiningSource(left[key], right[key]));
+}
+
+function isSameRemoteMiningSource(
+  left: TerritoryRemoteMiningSourceMemory | undefined,
+  right: TerritoryRemoteMiningSourceMemory
+): boolean {
+  return (
+    left != null &&
+    left.sourceId === right.sourceId &&
+    left.containerId === right.containerId &&
+    left.containerBuilt === right.containerBuilt &&
+    left.containerSitePending === right.containerSitePending &&
+    left.harvesterAssigned === right.harvesterAssigned &&
+    left.haulerAssigned === right.haulerAssigned &&
+    left.energyAvailable === right.energyAvailable &&
+    left.energyFlowing === right.energyFlowing
+  );
+}
+
 function isRemoteMiningSuspended(
   territoryMemory: TerritoryMemory,
   colony: string,
@@ -4907,8 +5000,11 @@ function getRemoteMiningAssignedCreeps(homeRoom: string, targetRoom: string): Cr
   const creeps: Creep[] = [];
   for (const roomName of [homeRoom, targetRoom]) {
     const room = getVisibleRoom(roomName);
-    const find = room?.find as ((type: number) => Creep[]) | undefined;
-    const roomCreeps = find?.(findMyCreeps);
+    if (!room || typeof room.find !== 'function') {
+      continue;
+    }
+
+    const roomCreeps = room.find(findMyCreeps as FindConstant) as Creep[];
     if (!Array.isArray(roomCreeps)) {
       continue;
     }

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -21,6 +21,11 @@ import {
   isRouteBlockedByKnownDeadZone,
   refreshVisibleRoomDeadZoneMemory
 } from '../defense/deadZone';
+import { planSourceContainerConstruction } from '../construction/sourceContainerPlanner';
+import {
+  findSourceContainer,
+  findSourceContainerConstructionSite
+} from '../economy/sourceContainers';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
@@ -67,6 +72,7 @@ const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
 const TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 const TERRITORY_SCOUT_BODY_COST = 50;
 const OCCUPATION_RECOMMENDATION_TARGET_CREATOR: TerritoryTargetMemory['createdBy'] = 'occupationRecommendation';
+const REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 1;
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -867,6 +873,98 @@ export function recordAutonomousExpansionClaimReserveFallbackIntent(
     },
     gameTime
   );
+}
+
+export function refreshRemoteMiningSetup(colony: ColonySnapshot, gameTime = getGameTime()): void {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const remoteMining = territoryMemory.remoteMining ?? {};
+  territoryMemory.remoteMining = remoteMining;
+  const colonyName = colony.room.name;
+  const activeKeys = new Set<string>();
+
+  for (const record of getRemoteMiningBootstrapRecords(territoryMemory, colonyName)) {
+    const key = getRemoteMiningMemoryKey(record.colony, record.roomName);
+    activeKeys.add(key);
+
+    const room = getVisibleRoom(record.roomName);
+    if (!room) {
+      const previous = remoteMining[key];
+      remoteMining[key] = {
+        colony: record.colony,
+        roomName: record.roomName,
+        status: previous?.status ?? 'containerPending',
+        updatedAt: gameTime,
+        sources: previous?.sources ?? {}
+      };
+      continue;
+    }
+
+    if (room.controller?.my !== true) {
+      remoteMining[key] = {
+        colony: record.colony,
+        roomName: record.roomName,
+        status: 'unclaimed',
+        updatedAt: gameTime,
+        sources: {}
+      };
+      continue;
+    }
+
+    const suspended = isRemoteMiningSuspended(territoryMemory, record.colony, record.roomName, gameTime);
+    if (!suspended) {
+      planSourceContainerConstruction(
+        {
+          room,
+          spawns: [],
+          energyAvailable: room.energyAvailable,
+          energyCapacityAvailable: room.energyCapacityAvailable
+        },
+        {
+          anchor: room.controller?.pos ?? null,
+          minimumControllerLevel: REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL
+        }
+      );
+    }
+
+    const sources = getRemoteMiningSources(room);
+    const assignedCreeps = getRemoteMiningAssignedCreeps(record.colony, record.roomName);
+    const sourceStates = Object.fromEntries(
+      sources.map((source) => {
+        const container = findSourceContainer(room, source);
+        const pendingSite = findSourceContainerConstructionSite(room, source);
+        const sourceId = String(source.id);
+        const state: TerritoryRemoteMiningSourceMemory = {
+          sourceId,
+          ...(container ? { containerId: String(container.id) } : {}),
+          containerBuilt: container !== null,
+          containerSitePending: pendingSite !== null,
+          harvesterAssigned: hasAssignedRemoteHarvester(assignedCreeps, record.colony, record.roomName, sourceId),
+          haulerAssigned: hasAssignedRemoteHauler(assignedCreeps, record.colony, record.roomName, sourceId, container),
+          energyAvailable: container ? getStoredEnergy(container) : 0,
+          energyFlowing: container !== null && hasRemoteEnergyFlow(container, assignedCreeps, record, sourceId)
+        };
+        return [sourceId, state];
+      })
+    );
+
+    remoteMining[key] = {
+      colony: record.colony,
+      roomName: record.roomName,
+      status: suspended ? 'suspended' : getRemoteMiningStatus(Object.values(sourceStates)),
+      updatedAt: gameTime,
+      sources: sourceStates
+    };
+  }
+
+  for (const key of Object.keys(remoteMining)) {
+    if (key.startsWith(`${colonyName}:`) && !activeKeys.has(key)) {
+      delete remoteMining[key];
+    }
+  }
 }
 
 export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {
@@ -4720,6 +4818,175 @@ function getVisibleController(targetRoom: string, controllerId?: Id<StructureCon
 function getGameTime(): number {
   const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
   return typeof gameTime === 'number' ? gameTime : 0;
+}
+
+function getRemoteMiningBootstrapRecords(
+  territoryMemory: TerritoryMemory,
+  colonyName: string
+): TerritoryPostClaimBootstrapMemory[] {
+  const records = territoryMemory.postClaimBootstraps;
+  if (!isRecord(records)) {
+    return [];
+  }
+
+  return Object.values(records)
+    .filter((record): record is TerritoryPostClaimBootstrapMemory => isRemoteMiningBootstrapRecord(record, colonyName))
+    .sort(compareRemoteMiningBootstrapRecords);
+}
+
+function isRemoteMiningBootstrapRecord(
+  record: unknown,
+  colonyName: string
+): record is TerritoryPostClaimBootstrapMemory {
+  return (
+    isRecord(record) &&
+    record.colony === colonyName &&
+    isNonEmptyString(record.roomName) &&
+    record.roomName !== colonyName &&
+    isPostClaimRemoteMiningStatus(record.status)
+  );
+}
+
+function isPostClaimRemoteMiningStatus(status: unknown): status is TerritoryPostClaimBootstrapStatus {
+  return (
+    status === 'detected' ||
+    status === 'spawnSitePending' ||
+    status === 'spawnSiteBlocked' ||
+    status === 'spawningWorkers' ||
+    status === 'ready'
+  );
+}
+
+function compareRemoteMiningBootstrapRecords(
+  left: TerritoryPostClaimBootstrapMemory,
+  right: TerritoryPostClaimBootstrapMemory
+): number {
+  return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
+}
+
+function getRemoteMiningMemoryKey(colony: string, roomName: string): string {
+  return `${colony}:${roomName}`;
+}
+
+function isRemoteMiningSuspended(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  roomName: string,
+  gameTime: number
+): boolean {
+  if (isKnownDeadZoneRoom(roomName)) {
+    return true;
+  }
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  return intents.some(
+    (intent) =>
+      intent.colony === colony &&
+      intent.targetRoom === roomName &&
+      isTerritoryIntentSuspensionActive(intent, gameTime)
+  );
+}
+
+function getRemoteMiningSources(room: Room): Source[] {
+  if (typeof FIND_SOURCES !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  return (room.find(FIND_SOURCES) as Source[]).sort((left, right) =>
+    String(left.id).localeCompare(String(right.id))
+  );
+}
+
+function getRemoteMiningAssignedCreeps(homeRoom: string, targetRoom: string): Creep[] {
+  const findMyCreeps = (globalThis as { FIND_MY_CREEPS?: number }).FIND_MY_CREEPS;
+  if (typeof findMyCreeps !== 'number') {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const creeps: Creep[] = [];
+  for (const roomName of [homeRoom, targetRoom]) {
+    const room = getVisibleRoom(roomName);
+    const find = room?.find as ((type: number) => Creep[]) | undefined;
+    const roomCreeps = find?.(findMyCreeps);
+    if (!Array.isArray(roomCreeps)) {
+      continue;
+    }
+
+    for (const creep of roomCreeps) {
+      const key = getRemoteMiningCreepKey(creep);
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      creeps.push(creep);
+    }
+  }
+
+  return creeps;
+}
+
+function getRemoteMiningCreepKey(creep: Creep): string {
+  return creep.name ?? `${creep.memory?.role ?? 'creep'}:${creep.memory?.colony ?? ''}:${creep.ticksToLive ?? ''}`;
+}
+
+function hasAssignedRemoteHarvester(
+  creeps: Creep[],
+  homeRoom: string,
+  targetRoom: string,
+  sourceId: string
+): boolean {
+  return creeps.some(
+    (creep) =>
+      creep.memory?.role === 'remoteHarvester' &&
+      creep.memory.remoteHarvester?.homeRoom === homeRoom &&
+      creep.memory.remoteHarvester?.targetRoom === targetRoom &&
+      String(creep.memory.remoteHarvester?.sourceId) === sourceId
+  );
+}
+
+function hasAssignedRemoteHauler(
+  creeps: Creep[],
+  homeRoom: string,
+  targetRoom: string,
+  sourceId: string,
+  container: StructureContainer | null
+): boolean {
+  return creeps.some(
+    (creep) =>
+      creep.memory?.role === 'hauler' &&
+      creep.memory.remoteHauler?.homeRoom === homeRoom &&
+      creep.memory.remoteHauler?.targetRoom === targetRoom &&
+      String(creep.memory.remoteHauler?.sourceId) === sourceId &&
+      (container === null || String(creep.memory.remoteHauler?.containerId) === String(container.id))
+  );
+}
+
+function hasRemoteEnergyFlow(
+  container: StructureContainer,
+  creeps: Creep[],
+  record: TerritoryPostClaimBootstrapMemory,
+  sourceId: string
+): boolean {
+  return (
+    getStoredEnergy(container) > 0 ||
+    hasAssignedRemoteHauler(creeps, record.colony, record.roomName, sourceId, container)
+  );
+}
+
+function getRemoteMiningStatus(
+  sources: TerritoryRemoteMiningSourceMemory[]
+): TerritoryRemoteMiningStatus {
+  if (sources.length === 0 || sources.some((source) => !source.containerBuilt)) {
+    return 'containerPending';
+  }
+
+  if (sources.some((source) => source.harvesterAssigned || source.energyFlowing)) {
+    return 'active';
+  }
+
+  return 'containerReady';
 }
 
 function getWritableTerritoryMemoryRecord(): TerritoryMemory | null {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -188,6 +188,7 @@ declare global {
     demands?: TerritoryFollowUpDemandMemory[];
     executionHints?: TerritoryExecutionHintMemory[];
     postClaimBootstraps?: Record<string, TerritoryPostClaimBootstrapMemory>;
+    remoteMining?: Record<string, TerritoryRemoteMiningRoomMemory>;
     reservations?: Record<string, TerritoryReservationMemory>;
     routeDistancesUpdatedAt?: Record<string, number>;
     routeDistances?: Record<string, number | null>;
@@ -274,6 +275,32 @@ declare global {
     controllerId?: Id<StructureController>;
     spawnSite?: TerritoryPostClaimBootstrapSpawnSiteMemory;
     lastResult?: ScreepsReturnCode;
+  }
+
+  type TerritoryRemoteMiningStatus =
+    | 'unclaimed'
+    | 'containerPending'
+    | 'containerReady'
+    | 'active'
+    | 'suspended';
+
+  interface TerritoryRemoteMiningRoomMemory {
+    colony: string;
+    roomName: string;
+    status: TerritoryRemoteMiningStatus;
+    updatedAt: number;
+    sources: Record<string, TerritoryRemoteMiningSourceMemory>;
+  }
+
+  interface TerritoryRemoteMiningSourceMemory {
+    sourceId: string;
+    containerId?: string;
+    containerBuilt: boolean;
+    containerSitePending: boolean;
+    harvesterAssigned: boolean;
+    haulerAssigned: boolean;
+    energyAvailable: number;
+    energyFlowing: boolean;
   }
 
   interface CreepTerritoryMemory {

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -1,6 +1,8 @@
 import {
   buildEmergencyDefenderBody,
   buildEmergencyWorkerBody,
+  buildRemoteHarvesterBody,
+  buildRemoteHaulerBody,
   buildTerritoryControllerBody,
   buildTerritoryControllerPressureBody,
   buildWorkerBody,
@@ -218,6 +220,38 @@ describe('buildTerritoryControllerPressureBody', () => {
       'claim',
       'move'
     ]);
+  });
+});
+
+describe('buildRemoteHarvesterBody', () => {
+  it('builds a work-heavy remote miner with carry and move support', () => {
+    expect(buildRemoteHarvesterBody(199)).toEqual([]);
+    expect(buildRemoteHarvesterBody(200)).toEqual(['work', 'carry', 'move']);
+    expect(buildRemoteHarvesterBody(650)).toEqual(['work', 'work', 'work', 'work', 'work', 'carry', 'move']);
+    expect(getBodyCost(buildRemoteHarvesterBody(650))).toBeLessThanOrEqual(650);
+  });
+});
+
+describe('buildRemoteHaulerBody', () => {
+  it('builds carry and move logistics bodies within the energy and distance budget', () => {
+    expect(buildRemoteHaulerBody(99)).toEqual([]);
+    expect(buildRemoteHaulerBody(300, 1)).toEqual(['carry', 'move', 'carry', 'move', 'carry', 'move']);
+    expect(buildRemoteHaulerBody(1_000, 1)).toEqual([
+      'carry',
+      'move',
+      'carry',
+      'move',
+      'carry',
+      'move',
+      'carry',
+      'move',
+      'carry',
+      'move',
+      'carry',
+      'move'
+    ]);
+    expect(buildRemoteHaulerBody(1_000, 5).length).toBeGreaterThan(buildRemoteHaulerBody(1_000, 1).length);
+    expect(getBodyCost(buildRemoteHaulerBody(1_000, 5))).toBeLessThanOrEqual(1_000);
   });
 });
 

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1650,6 +1650,94 @@ describe('runEconomy', () => {
     );
   });
 
+  it('refreshes remote mining setup for claimed expansion rooms during the economy tick', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_CREEPS: number;
+      STRUCTURE_CONTAINER: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      OK: ScreepsReturnCode;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 2;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 3;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 4;
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { OK: ScreepsReturnCode }).OK = OK_CODE;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'ready',
+            claimedAt: 420,
+            updatedAt: 421,
+            workerTarget: 2
+          }
+        }
+      }
+    };
+    const homeRoom = makeTerritoryReadyEconomyRoom();
+    const constructionSites: ConstructionSite[] = [];
+    const remoteRoom = {
+      name: 'W2N1',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: {
+        my: true,
+        level: 1,
+        pos: { x: 25, y: 25, roomName: 'W2N1' } as RoomPosition
+      } as StructureController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_SOURCES) {
+          return [{ id: 'remote-source', pos: { x: 10, y: 10, roomName: 'W2N1' } as RoomPosition } as Source];
+        }
+
+        if (type === FIND_CONSTRUCTION_SITES) {
+          return constructionSites;
+        }
+
+        return [];
+      }),
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        constructionSites.push({
+          id: `site-${x}-${y}`,
+          structureType,
+          pos: { x, y, roomName: 'W2N1' } as RoomPosition
+        } as ConstructionSite);
+        return OK_CODE;
+      })
+    } as unknown as Room & { createConstructionSite: jest.Mock };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 422,
+      rooms: { W1N1: homeRoom, W2N1: remoteRoom },
+      spawns: {},
+      creeps: {},
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(remoteRoom.createConstructionSite).toHaveBeenCalledWith(11, 11, STRUCTURE_CONTAINER);
+    expect(Memory.territory?.remoteMining?.['W1N1:W2N1']).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'containerPending',
+      sources: {
+        'remote-source': {
+          sourceId: 'remote-source',
+          containerSitePending: true
+        }
+      }
+    });
+  });
+
   it('keeps unsafe occupation recommendations on worker recovery before territory spawn pressure', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};

--- a/prod/test/hauler.test.ts
+++ b/prod/test/hauler.test.ts
@@ -1,0 +1,149 @@
+import { runHauler } from '../src/creeps/hauler';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+
+describe('runHauler', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 1;
+    (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 2;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
+    (globalThis as unknown as { STRUCTURE_TOWER: StructureConstant }).STRUCTURE_TOWER = 'tower';
+    (globalThis as unknown as { ERR_NOT_IN_RANGE: ScreepsReturnCode }).ERR_NOT_IN_RANGE = ERR_NOT_IN_RANGE_CODE;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  });
+
+  it('withdraws energy from the assigned remote container', () => {
+    const container = makeStoreStructure('container1', 'container' as StructureConstant, 700, 0);
+    const remoteRoom = makeRoom('W2N1', true, [], []);
+    const creep = makeHauler(remoteRoom, 0);
+    creep.withdraw = jest.fn().mockReturnValue(ERR_NOT_IN_RANGE_CODE);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W2N1: remoteRoom },
+      getObjectById: jest.fn((id: string) => (id === 'container1' ? container : null))
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'withdraw', targetId: 'container1' });
+    expect(creep.withdraw).toHaveBeenCalledWith(container, RESOURCE_ENERGY);
+    expect(creep.moveTo).toHaveBeenCalledWith(container, { reusePath: 20, ignoreRoads: false });
+  });
+
+  it('delivers carried remote energy to spawn and extension sinks before storage', () => {
+    const spawn = makeStoreStructure('spawn1', STRUCTURE_SPAWN, 100, 200);
+    const storage = makeStoreStructure('storage1', STRUCTURE_STORAGE, 1_000, 5_000);
+    const homeRoom = makeRoom('W1N1', true, [storage, spawn], []);
+    const creep = makeHauler(homeRoom, 100);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W1N1: homeRoom },
+      getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : id === 'storage1' ? storage : null))
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.transfer).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY);
+  });
+
+  it('uses tower capacity when spawn, extension, and storage sinks are unavailable', () => {
+    const tower = makeStoreStructure('tower1', STRUCTURE_TOWER, 200, 800);
+    const homeRoom = makeRoom('W1N1', true, [tower], []);
+    const creep = makeHauler(homeRoom, 100);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W1N1: homeRoom },
+      getObjectById: jest.fn((id: string) => (id === 'tower1' ? tower : null))
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'tower1' });
+    expect(creep.transfer).toHaveBeenCalledWith(tower, RESOURCE_ENERGY);
+  });
+
+  it('delivers carried energy after a remote room becomes unclaimed', () => {
+    const spawn = makeStoreStructure('spawn1', STRUCTURE_SPAWN, 100, 200);
+    const homeRoom = makeRoom('W1N1', true, [spawn], []);
+    const unclaimedRemoteRoom = makeRoom('W2N1', false, [], []);
+    const creep = makeHauler(homeRoom, 100);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W1N1: homeRoom, W2N1: unclaimedRemoteRoom },
+      getObjectById: jest.fn((id: string) => (id === 'spawn1' ? spawn : null))
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.transfer).toHaveBeenCalledWith(spawn, RESOURCE_ENERGY);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+});
+
+function makeHauler(room: Room, carriedEnergy: number): Creep {
+  return {
+    memory: {
+      role: 'hauler',
+      colony: 'W1N1',
+      remoteHauler: {
+        homeRoom: 'W1N1',
+        targetRoom: 'W2N1',
+        sourceId: 'source1' as Id<Source>,
+        containerId: 'container1' as Id<StructureContainer>
+      }
+    },
+    room,
+    store: {
+      getUsedCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? carriedEnergy : 0))
+    },
+    withdraw: jest.fn().mockReturnValue(OK_CODE),
+    transfer: jest.fn().mockReturnValue(OK_CODE),
+    moveTo: jest.fn()
+  } as unknown as Creep;
+}
+
+function makeRoom(
+  roomName: string,
+  owned: boolean,
+  structures: AnyOwnedStructure[],
+  hostiles: Creep[]
+): Room {
+  return {
+    name: roomName,
+    controller: { my: owned } as StructureController,
+    find: jest.fn((type: number, options?: { filter?: (structure: AnyOwnedStructure) => boolean }) => {
+      if (type === FIND_HOSTILE_CREEPS) {
+        return hostiles;
+      }
+
+      if (type === FIND_MY_STRUCTURES) {
+        return options?.filter ? structures.filter(options.filter) : structures;
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+}
+
+function makeStoreStructure(
+  id: string,
+  structureType: StructureConstant,
+  usedEnergy: number,
+  freeEnergy: number
+): AnyOwnedStructure {
+  return {
+    id,
+    structureType,
+    store: {
+      getUsedCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? usedEnergy : 0)),
+      getFreeCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? freeEnergy : 0))
+    }
+  } as unknown as AnyOwnedStructure;
+}

--- a/prod/test/remoteHarvester.test.ts
+++ b/prod/test/remoteHarvester.test.ts
@@ -1,0 +1,135 @@
+import { runRemoteHarvester } from '../src/creeps/remoteHarvester';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+describe('runRemoteHarvester', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 1;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { ERR_NOT_IN_RANGE: ScreepsReturnCode }).ERR_NOT_IN_RANGE = -9 as ScreepsReturnCode;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  });
+
+  it('deposits carried source energy into the assigned remote container', () => {
+    const source = makeSource('source1');
+    const container = makeContainer('container1');
+    const room = makeRoom('W2N1', true, []);
+    const creep = makeRemoteHarvester(room, {
+      usedEnergy: 50,
+      freeEnergy: 0,
+      range: 1
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W2N1: room },
+      getObjectById: jest.fn((id: string) => (id === source.id ? source : id === container.id ? container : null))
+    };
+
+    runRemoteHarvester(creep);
+
+    expect(creep.transfer).toHaveBeenCalledWith(container, RESOURCE_ENERGY);
+    expect(creep.harvest).not.toHaveBeenCalled();
+  });
+
+  it('retreats home when the assigned remote room is no longer claimed', () => {
+    const homeController = { id: 'controller1' } as StructureController;
+    const homeRoom = { name: 'W1N1', controller: homeController } as Room;
+    const remoteRoom = makeRoom('W2N1', false, []);
+    const creep = makeRemoteHarvester(remoteRoom, {
+      usedEnergy: 0,
+      freeEnergy: 50,
+      range: 1
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W1N1: homeRoom, W2N1: remoteRoom },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    runRemoteHarvester(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith(homeController, { reusePath: 20, ignoreRoads: false });
+    expect(creep.harvest).not.toHaveBeenCalled();
+  });
+
+  it('retreats home when hostiles threaten the remote room', () => {
+    const homeController = { id: 'controller1' } as StructureController;
+    const homeRoom = { name: 'W1N1', controller: homeController } as Room;
+    const hostile = { id: 'hostile1' } as Creep;
+    const remoteRoom = makeRoom('W2N1', true, [hostile]);
+    const creep = makeRemoteHarvester(remoteRoom, {
+      usedEnergy: 0,
+      freeEnergy: 50,
+      range: 1
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W1N1: homeRoom, W2N1: remoteRoom },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    runRemoteHarvester(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith(homeController, { reusePath: 20, ignoreRoads: false });
+    expect(creep.harvest).not.toHaveBeenCalled();
+  });
+});
+
+function makeRemoteHarvester(
+  room: Room,
+  {
+    usedEnergy,
+    freeEnergy,
+    range
+  }: {
+    usedEnergy: number;
+    freeEnergy: number;
+    range: number;
+  }
+): Creep {
+  return {
+    memory: {
+      role: 'remoteHarvester',
+      colony: 'W1N1',
+      remoteHarvester: {
+        homeRoom: 'W1N1',
+        targetRoom: 'W2N1',
+        sourceId: 'source1' as Id<Source>,
+        containerId: 'container1' as Id<StructureContainer>
+      }
+    },
+    room,
+    pos: { getRangeTo: jest.fn().mockReturnValue(range) } as unknown as RoomPosition,
+    store: {
+      getUsedCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? usedEnergy : 0)),
+      getFreeCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? freeEnergy : 0))
+    },
+    harvest: jest.fn().mockReturnValue(OK_CODE),
+    transfer: jest.fn().mockReturnValue(OK_CODE),
+    moveTo: jest.fn()
+  } as unknown as Creep;
+}
+
+function makeRoom(roomName: string, owned: boolean, hostiles: Creep[]): Room {
+  return {
+    name: roomName,
+    controller: { my: owned } as StructureController,
+    find: jest.fn((type: number) => (type === FIND_HOSTILE_CREEPS ? hostiles : []))
+  } as unknown as Room;
+}
+
+function makeSource(id: string): Source {
+  return { id, energy: 300 } as Source;
+}
+
+function makeContainer(id: string): StructureContainer {
+  return {
+    id,
+    structureType: 'container',
+    store: {
+      getUsedCapacity: jest.fn().mockReturnValue(0)
+    }
+  } as unknown as StructureContainer;
+}

--- a/prod/test/remoteHarvester.test.ts
+++ b/prod/test/remoteHarvester.test.ts
@@ -94,6 +94,27 @@ describe('runRemoteHarvester', () => {
     expect(creep.moveTo).toHaveBeenCalledWith(homeController, { reusePath: 20, ignoreRoads: false });
     expect(creep.harvest).not.toHaveBeenCalled();
   });
+
+  it('retreats home while in transit when hostiles threaten the visible target room', () => {
+    const homeController = { id: 'controller1' } as StructureController;
+    const homeRoom = { name: 'W1N1', controller: homeController } as Room;
+    const hostile = { id: 'hostile1' } as Creep;
+    const remoteRoom = makeRoom('W2N1', false, [hostile]);
+    const creep = makeRemoteHarvester(homeRoom, {
+      usedEnergy: 0,
+      freeEnergy: 50,
+      range: 20
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W1N1: homeRoom, W2N1: remoteRoom },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    runRemoteHarvester(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith(homeController, { reusePath: 20, ignoreRoads: false });
+    expect(creep.harvest).not.toHaveBeenCalled();
+  });
 });
 
 function makeRemoteHarvester(

--- a/prod/test/remoteHarvester.test.ts
+++ b/prod/test/remoteHarvester.test.ts
@@ -35,10 +35,10 @@ describe('runRemoteHarvester', () => {
     expect(creep.harvest).not.toHaveBeenCalled();
   });
 
-  it('retreats home when the assigned remote room is no longer claimed', () => {
+  it('retreats home when the assigned remote room is hostile owned', () => {
     const homeController = { id: 'controller1' } as StructureController;
     const homeRoom = { name: 'W1N1', controller: homeController } as Room;
-    const remoteRoom = makeRoom('W2N1', false, []);
+    const remoteRoom = makeRoom('W2N1', false, [], { username: 'enemy' });
     const creep = makeRemoteHarvester(remoteRoom, {
       usedEnergy: 0,
       freeEnergy: 50,
@@ -53,6 +53,25 @@ describe('runRemoteHarvester', () => {
 
     expect(creep.moveTo).toHaveBeenCalledWith(homeController, { reusePath: 20, ignoreRoads: false });
     expect(creep.harvest).not.toHaveBeenCalled();
+  });
+
+  it('harvests in neutral assigned remote rooms', () => {
+    const source = makeSource('source1');
+    const remoteRoom = makeRoom('W2N1', false, []);
+    const creep = makeRemoteHarvester(remoteRoom, {
+      usedEnergy: 0,
+      freeEnergy: 50,
+      range: 1
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W2N1: remoteRoom },
+      getObjectById: jest.fn((id: string) => (id === source.id ? source : null))
+    };
+
+    runRemoteHarvester(creep);
+
+    expect(creep.harvest).toHaveBeenCalledWith(source);
+    expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
   it('retreats home when hostiles threaten the remote room', () => {
@@ -112,10 +131,15 @@ function makeRemoteHarvester(
   } as unknown as Creep;
 }
 
-function makeRoom(roomName: string, owned: boolean, hostiles: Creep[]): Room {
+function makeRoom(
+  roomName: string,
+  owned: boolean,
+  hostiles: Creep[],
+  owner = owned ? { username: 'me' } : undefined
+): Room {
   return {
     name: roomName,
-    controller: { my: owned } as StructureController,
+    controller: { my: owned, ...(owner ? { owner } : {}) } as StructureController,
     find: jest.fn((type: number) => (type === FIND_HOSTILE_CREEPS ? hostiles : []))
   } as unknown as Room;
 }

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -19,6 +19,8 @@ describe('planSpawn', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 5;
+    (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 6;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 10;
     (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     delete (globalThis as { FIND_HOSTILE_CREEPS?: number }).FIND_HOSTILE_CREEPS;
@@ -38,7 +40,8 @@ describe('planSpawn', () => {
     spawning = null,
     controller,
     storageEnergy,
-    storageCapacity
+    storageCapacity,
+    ownedStructures = []
   }: {
     sourceCount?: number;
     energyAvailable?: number;
@@ -51,6 +54,7 @@ describe('planSpawn', () => {
     controller?: StructureController;
     storageEnergy?: number;
     storageCapacity?: number;
+    ownedStructures?: AnyOwnedStructure[];
   } = {}): { colony: ColonySnapshot; spawn: StructureSpawn; find: jest.Mock<unknown[], [number]> } {
     const sources = Array.from({ length: sourceCount }, (_, index) => ({ id: `source${index}` }) as Source);
     const constructionSites = Array.from(
@@ -64,6 +68,14 @@ describe('planSpawn', () => {
 
       if (type === FIND_MY_CONSTRUCTION_SITES) {
         return constructionSites;
+      }
+
+      if (type === FIND_MY_CREEPS) {
+        return findMockCreepsInRoom(roomName);
+      }
+
+      if (type === FIND_MY_STRUCTURES) {
+        return ownedStructures;
       }
 
       const hostileCreepsFind = (globalThis as Record<string, unknown>).FIND_HOSTILE_CREEPS;
@@ -110,6 +122,16 @@ describe('planSpawn', () => {
         getCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? capacity : 0))
       }
     } as unknown as StructureStorage;
+  }
+
+  function makeRemoteHaulerStorageSink(id: string): AnyOwnedStructure {
+    return {
+      id,
+      structureType: 'storage',
+      store: {
+        getFreeCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? 5_000 : 0))
+      }
+    } as unknown as AnyOwnedStructure;
   }
 
   function repeatBodyPattern(pattern: BodyPartConstant[], patternCount: number): BodyPartConstant[] {
@@ -187,6 +209,10 @@ describe('planSpawn', () => {
           return [container];
         }
 
+        if (type === FIND_MY_CREEPS) {
+          return findMockCreepsInRoom(roomName);
+        }
+
         return [];
       })
     } as unknown as Room;
@@ -226,8 +252,14 @@ describe('planSpawn', () => {
           containerId: containerId as Id<StructureContainer>
         }
       },
+      room: { name: 'W2N1' } as Room,
       ticksToLive: 1_000
     } as Creep;
+  }
+
+  function findMockCreepsInRoom(roomName: string): Creep[] {
+    const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+    return creeps ? Object.values(creeps).filter((creep) => creep.room?.name === roomName) : [];
   }
 
   it('plans a worker when the colony has no workers and an idle spawn', () => {
@@ -741,7 +773,8 @@ describe('planSpawn', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,
       energyCapacityAvailable: 650,
-      controller: makeSafeOwnedController()
+      controller: makeSafeOwnedController(),
+      ownedStructures: [makeRemoteHaulerStorageSink('storage1')]
     });
     const source = makeRemoteSource('W2N1-source0');
     const belowThresholdRoom = makeRemoteEconomyRoom({
@@ -796,6 +829,34 @@ describe('planSpawn', () => {
         }
       }
     });
+  });
+
+  it('waits on remote haulers when the home colony has no known delivery demand', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    const remoteRoom = makeRemoteEconomyRoom({
+      container: makeRemoteContainer('W2N1-container0', 700)
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 506,
+      rooms: { W1N1: colony.room, W2N1: remoteRoom },
+      spawns: { Spawn1: spawn },
+      creeps: {
+        RemoteUpgrader: makePostClaimSustainUpgrader(),
+        RemoteHarvester: makeRemoteHarvester()
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: { W2N1: makeSatisfiedPostClaimRemoteMemory() }
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 4 }, 507)).toBeNull();
   });
 
   it('does not spawn remote harvesters while the target has a hostile territory suspension', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -6153,6 +6153,128 @@ describe('planTerritoryIntent', () => {
       }
     });
   });
+
+  it('records neutral visible remote rooms as usable remote mining targets', () => {
+    (globalThis as unknown as {
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_CREEPS: number;
+      STRUCTURE_CONTAINER: StructureConstant;
+      RESOURCE_ENERGY: ResourceConstant;
+    }).FIND_STRUCTURES = 10;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 11;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 12;
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    const colony = makeSafeColony();
+    const container = makeRemoteMiningContainer('container1', 0);
+    const remoteRoom = makeRemoteMiningRoom({
+      controller: {
+        id: 'controller2',
+        my: false,
+        level: 0,
+        pos: { x: 25, y: 25, roomName: 'W2N1' } as RoomPosition
+      } as StructureController,
+      structures: [container]
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: makeRemoteMiningBootstrap()
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 702,
+      rooms: { W1N1: colony.room, W2N1: remoteRoom }
+    };
+
+    refreshRemoteMiningSetup(colony, 702);
+
+    expect(Memory.territory?.remoteMining?.['W1N1:W2N1']).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'containerReady',
+      sources: {
+        source1: {
+          sourceId: 'source1',
+          containerId: 'container1',
+          containerBuilt: true
+        }
+      }
+    });
+  });
+
+  it('does not rewrite unchanged remote mining memory on later economy ticks', () => {
+    (globalThis as unknown as {
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_CREEPS: number;
+      STRUCTURE_CONTAINER: StructureConstant;
+      RESOURCE_ENERGY: ResourceConstant;
+    }).FIND_STRUCTURES = 10;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 11;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 12;
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    const colony = makeSafeColony();
+    const container = makeRemoteMiningContainer('container1', 0);
+    const remoteRoom = makeRemoteMiningRoom({ structures: [container] });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: makeRemoteMiningBootstrap()
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 703,
+      rooms: { W1N1: colony.room, W2N1: remoteRoom }
+    };
+
+    refreshRemoteMiningSetup(colony, 703);
+    const previous = Memory.territory?.remoteMining?.['W1N1:W2N1'];
+    refreshRemoteMiningSetup(colony, 704);
+
+    expect(Memory.territory?.remoteMining?.['W1N1:W2N1']).toBe(previous);
+    expect(Memory.territory?.remoteMining?.['W1N1:W2N1']?.updatedAt).toBe(703);
+  });
+
+  it('keeps Room.find bound while collecting assigned remote mining creeps', () => {
+    (globalThis as unknown as {
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_CREEPS: number;
+      STRUCTURE_CONTAINER: StructureConstant;
+      RESOURCE_ENERGY: ResourceConstant;
+    }).FIND_STRUCTURES = 10;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 11;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 12;
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    const colony = makeSafeColony();
+    const container = makeRemoteMiningContainer('container1', 0);
+    const remoteHarvester = makeAssignedRemoteMiningCreep('remoteHarvester', 'W2N1');
+    const remoteRoom = makeRemoteMiningRoom({
+      structures: [container],
+      creeps: [remoteHarvester],
+      requireFindReceiver: true
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: makeRemoteMiningBootstrap()
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 705,
+      rooms: { W1N1: colony.room, W2N1: remoteRoom }
+    };
+
+    expect(() => refreshRemoteMiningSetup(colony, 705)).not.toThrow();
+    expect(Memory.territory?.remoteMining?.['W1N1:W2N1']?.sources.source1.harvesterAssigned).toBe(true);
+  });
 });
 
 function makeFollowUp(
@@ -6220,44 +6342,53 @@ function makeRemoteMiningRoom({
   structures = [],
   constructionSites = [],
   creeps = [],
-  createConstructionSite = jest.fn().mockReturnValue(0 as ScreepsReturnCode)
+  createConstructionSite = jest.fn().mockReturnValue(0 as ScreepsReturnCode),
+  controller = {
+    id: 'controller2',
+    my: true,
+    level: 1,
+    pos: { x: 25, y: 25, roomName: 'W2N1' } as RoomPosition
+  } as StructureController,
+  requireFindReceiver = false
 }: {
   structures?: AnyStructure[];
   constructionSites?: ConstructionSite[];
   creeps?: Creep[];
   createConstructionSite?: jest.Mock;
+  controller?: StructureController;
+  requireFindReceiver?: boolean;
 } = {}): Room & { createConstructionSite: jest.Mock } {
-  return {
+  const room = {
     name: 'W2N1',
     energyAvailable: 0,
     energyCapacityAvailable: 0,
-    controller: {
-      id: 'controller2',
-      my: true,
-      level: 1,
-      pos: { x: 25, y: 25, roomName: 'W2N1' } as RoomPosition
-    } as StructureController,
-    find: jest.fn((type: number) => {
-      if (type === FIND_SOURCES) {
-        return [{ id: 'source1', pos: { x: 10, y: 10, roomName: 'W2N1' } as RoomPosition } as Source];
-      }
-
-      if (type === FIND_STRUCTURES) {
-        return structures;
-      }
-
-      if (type === FIND_CONSTRUCTION_SITES) {
-        return constructionSites;
-      }
-
-      if (type === FIND_MY_CREEPS) {
-        return creeps;
-      }
-
-      return [];
-    }),
+    controller,
     createConstructionSite
-  } as unknown as Room & { createConstructionSite: jest.Mock };
+  } as unknown as Room & { createConstructionSite: jest.Mock; find: jest.Mock };
+  room.find = jest.fn(function (this: Room | undefined, type: number) {
+    if (requireFindReceiver && this !== room) {
+      throw new Error('Room.find called without a Room receiver');
+    }
+
+    if (type === FIND_SOURCES) {
+      return [{ id: 'source1', pos: { x: 10, y: 10, roomName: 'W2N1' } as RoomPosition } as Source];
+    }
+
+    if (type === FIND_STRUCTURES) {
+      return structures;
+    }
+
+    if (type === FIND_CONSTRUCTION_SITES) {
+      return constructionSites;
+    }
+
+    if (type === FIND_MY_CREEPS) {
+      return creeps;
+    }
+
+    return [];
+  }) as unknown as jest.Mock;
+  return room;
 }
 
 function makeRemoteMiningContainer(id: string, energy: number): StructureContainer {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -7,6 +7,7 @@ import {
   planTerritoryIntent,
   recordTerritoryReserveFallbackIntent,
   recordRecoveredTerritoryFollowUpRetryCooldown,
+  refreshRemoteMiningSetup,
   requiresTerritoryControllerPressure,
   shouldSpawnTerritoryControllerCreep,
   suppressTerritoryIntent,
@@ -6034,6 +6035,124 @@ describe('planTerritoryIntent', () => {
       }
     });
   });
+
+  it('plans remote source container construction and records pending remote mining state', () => {
+    (globalThis as unknown as {
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_CREEPS: number;
+      STRUCTURE_CONTAINER: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      OK: ScreepsReturnCode;
+    }).FIND_STRUCTURES = 10;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 11;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 12;
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { OK: ScreepsReturnCode }).OK = 0 as ScreepsReturnCode;
+    const colony = makeSafeColony();
+    const constructionSites: ConstructionSite[] = [];
+    const remoteRoom = makeRemoteMiningRoom({
+      constructionSites,
+      createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+        constructionSites.push({
+          id: `site-${x}-${y}`,
+          structureType,
+          pos: { x, y, roomName: 'W2N1' } as RoomPosition
+        } as ConstructionSite);
+        return 0 as ScreepsReturnCode;
+      })
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: makeRemoteMiningBootstrap()
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 700,
+      rooms: { W1N1: colony.room, W2N1: remoteRoom },
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    refreshRemoteMiningSetup(colony, 700);
+
+    expect(remoteRoom.createConstructionSite).toHaveBeenCalledWith(11, 11, STRUCTURE_CONTAINER);
+    expect(Memory.territory?.remoteMining?.['W1N1:W2N1']).toEqual({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'containerPending',
+      updatedAt: 700,
+      sources: {
+        source1: {
+          sourceId: 'source1',
+          containerBuilt: false,
+          containerSitePending: true,
+          harvesterAssigned: false,
+          haulerAssigned: false,
+          energyAvailable: 0,
+          energyFlowing: false
+        }
+      }
+    });
+  });
+
+  it('records active remote mining state from source containers and room-local assigned creeps', () => {
+    (globalThis as unknown as {
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_CREEPS: number;
+      STRUCTURE_CONTAINER: StructureConstant;
+      RESOURCE_ENERGY: ResourceConstant;
+    }).FIND_STRUCTURES = 10;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 11;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 12;
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    const colony = makeSafeColony();
+    const container = makeRemoteMiningContainer('container1', 700);
+    const remoteHarvester = makeAssignedRemoteMiningCreep('remoteHarvester', 'W2N1');
+    const remoteHauler = makeAssignedRemoteMiningCreep('hauler', 'W2N1');
+    const remoteRoom = makeRemoteMiningRoom({
+      structures: [container],
+      creeps: [remoteHarvester, remoteHauler]
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: makeRemoteMiningBootstrap()
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 701,
+      rooms: { W1N1: colony.room, W2N1: remoteRoom }
+    };
+
+    refreshRemoteMiningSetup(colony, 701);
+
+    expect(Memory.territory?.remoteMining?.['W1N1:W2N1']).toEqual({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'active',
+      updatedAt: 701,
+      sources: {
+        source1: {
+          sourceId: 'source1',
+          containerId: 'container1',
+          containerBuilt: true,
+          containerSitePending: false,
+          harvesterAssigned: true,
+          haulerAssigned: true,
+          energyAvailable: 700,
+          energyFlowing: true
+        }
+      }
+    });
+  });
 });
 
 function makeFollowUp(
@@ -6083,6 +6202,102 @@ function makeRecommendationRoom(
       }
     })
   } as unknown as Room;
+}
+
+function makeRemoteMiningBootstrap(): TerritoryPostClaimBootstrapMemory {
+  return {
+    colony: 'W1N1',
+    roomName: 'W2N1',
+    status: 'ready',
+    claimedAt: 650,
+    updatedAt: 651,
+    workerTarget: 2,
+    controllerId: 'controller2' as Id<StructureController>
+  };
+}
+
+function makeRemoteMiningRoom({
+  structures = [],
+  constructionSites = [],
+  creeps = [],
+  createConstructionSite = jest.fn().mockReturnValue(0 as ScreepsReturnCode)
+}: {
+  structures?: AnyStructure[];
+  constructionSites?: ConstructionSite[];
+  creeps?: Creep[];
+  createConstructionSite?: jest.Mock;
+} = {}): Room & { createConstructionSite: jest.Mock } {
+  return {
+    name: 'W2N1',
+    energyAvailable: 0,
+    energyCapacityAvailable: 0,
+    controller: {
+      id: 'controller2',
+      my: true,
+      level: 1,
+      pos: { x: 25, y: 25, roomName: 'W2N1' } as RoomPosition
+    } as StructureController,
+    find: jest.fn((type: number) => {
+      if (type === FIND_SOURCES) {
+        return [{ id: 'source1', pos: { x: 10, y: 10, roomName: 'W2N1' } as RoomPosition } as Source];
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return structures;
+      }
+
+      if (type === FIND_CONSTRUCTION_SITES) {
+        return constructionSites;
+      }
+
+      if (type === FIND_MY_CREEPS) {
+        return creeps;
+      }
+
+      return [];
+    }),
+    createConstructionSite
+  } as unknown as Room & { createConstructionSite: jest.Mock };
+}
+
+function makeRemoteMiningContainer(id: string, energy: number): StructureContainer {
+  return {
+    id,
+    structureType: 'container',
+    pos: { x: 10, y: 11, roomName: 'W2N1' } as RoomPosition,
+    store: {
+      getUsedCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0))
+    }
+  } as unknown as StructureContainer;
+}
+
+function makeAssignedRemoteMiningCreep(role: 'remoteHarvester' | 'hauler', roomName: string): Creep {
+  return {
+    name: `${role}1`,
+    room: { name: roomName } as Room,
+    ticksToLive: 1_000,
+    memory: {
+      role,
+      colony: 'W1N1',
+      ...(role === 'remoteHarvester'
+        ? {
+            remoteHarvester: {
+              homeRoom: 'W1N1',
+              targetRoom: 'W2N1',
+              sourceId: 'source1' as Id<Source>,
+              containerId: 'container1' as Id<StructureContainer>
+            }
+          }
+        : {
+            remoteHauler: {
+              homeRoom: 'W1N1',
+              targetRoom: 'W2N1',
+              sourceId: 'source1' as Id<Source>,
+              containerId: 'container1' as Id<StructureContainer>
+            }
+          })
+    }
+  } as Creep;
 }
 
 function makeSafeColony({

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -6240,6 +6240,70 @@ describe('planTerritoryIntent', () => {
     expect(Memory.territory?.remoteMining?.['W1N1:W2N1']?.updatedAt).toBe(703);
   });
 
+  it('does not reassign normalized remote mining memory when setup is unchanged', () => {
+    (globalThis as unknown as {
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_CREEPS: number;
+      STRUCTURE_CONTAINER: StructureConstant;
+      RESOURCE_ENERGY: ResourceConstant;
+    }).FIND_STRUCTURES = 10;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 11;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 12;
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    const colony = makeSafeColony();
+    const container = makeRemoteMiningContainer('container1', 0);
+    const remoteRoom = makeRemoteMiningRoom({ structures: [container] });
+    const existingEntry: TerritoryRemoteMiningRoomMemory = {
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'containerReady',
+      updatedAt: 703,
+      sources: {
+        source1: {
+          sourceId: 'source1',
+          containerId: 'container1',
+          containerBuilt: true,
+          containerSitePending: false,
+          harvesterAssigned: false,
+          haulerAssigned: false,
+          energyAvailable: 0,
+          energyFlowing: false
+        }
+      }
+    };
+    let remoteMining: Record<string, TerritoryRemoteMiningRoomMemory> = {
+      'W1N1:W2N1': existingEntry
+    };
+    const territoryMemory: TerritoryMemory = {
+      postClaimBootstraps: {
+        W2N1: makeRemoteMiningBootstrap()
+      }
+    };
+    const remoteMiningSetter = jest.fn((next: Record<string, TerritoryRemoteMiningRoomMemory>) => {
+      remoteMining = next;
+    });
+    Object.defineProperty(territoryMemory, 'remoteMining', {
+      configurable: true,
+      enumerable: true,
+      get: () => remoteMining,
+      set: remoteMiningSetter
+    });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: territoryMemory
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 704,
+      rooms: { W1N1: colony.room, W2N1: remoteRoom }
+    };
+
+    refreshRemoteMiningSetup(colony, 704);
+
+    expect(remoteMiningSetter).not.toHaveBeenCalled();
+    expect(Memory.territory?.remoteMining?.['W1N1:W2N1']).toBe(existingEntry);
+  });
+
   it('keeps Room.find bound while collecting assigned remote mining creeps', () => {
     (globalThis as unknown as {
       FIND_STRUCTURES: number;


### PR DESCRIPTION
## Summary
Implements remote mining logistics for claimed expansion rooms: remote harvester creep role, hauler logistics, expansion-optimized spawn body planning, and territory planner integration.

## Verification
- Controller: `npm run typecheck` ✅
- Controller: `npm test -- --runInBand` — 39 suites, 925 tests all passed ✅
- Controller: `npm run build` ✅
- Controller: `git diff --check` clean ✅

## Changes
- `prod/src/creeps/remoteHarvester.ts` — new remote harvester creep role
- `prod/src/creeps/hauler.ts` — hauler logistics for remote mining
- `prod/src/spawn/bodyBuilder.ts` — expansion-optimized body planning
- `prod/src/spawn/spawnPlanner.ts` — remote mining spawn integration
- `prod/src/construction/sourceContainerPlanner.ts` — remote source container planning
- `prod/src/economy/sourceContainers.ts` — remote source access
- `prod/src/economy/economyLoop.ts` — register remote mining module
- `prod/src/territory/territoryPlanner.ts` — territory integration for remote mining
- `prod/src/types.d.ts` — type definitions
- `prod/src/tasks/workerTasks.ts` — worker task support
- `prod/test/remoteHarvester.test.ts` — new
- `prod/test/hauler.test.ts` — new
- `prod/test/bodyBuilder.test.ts`, `prod/test/economyLoop.test.ts`, `prod/test/spawnPlanner.test.ts`, `prod/test/territoryPlanner.test.ts` — updated
- `prod/dist/main.js` — generated bundle

Refs #571