### PR TITLE
feat(rl): update RL domain roadmap, training reward workflow, and add training runner script (#549)

### DIFF
--- a/docs/ops/rl-domain-roadmap.md
+++ b/docs/ops/rl-domain-roadmap.md
@@ -35,13 +35,13 @@ Until then, outputs are offline/shadow/high-level recommendation only: construct
 | L1 Data substrate | Convert saved runtime/monitor artifacts into train/eval-ready samples | #409, #415 | `runtime-artifacts/rl-datasets/<run-id>/` with card/manifests | export after new artifact windows and before experiments |
 | L2 Shadow evaluator automation | Run passive strategy comparisons over saved artifacts | #409, #417 | bounded strategy-shadow reports indexed by dataset exporter | scheduled/offline; must become recurring |
 | L3 Simulator harness | Self-hosted accelerated parallel environment | #414, #413 | resettable scenario runner and throughput report toward 100x aggregate official tick speed | implementation lane until usable |
-| L4 Training/reward framework | Select RL/bandit/evolutionary method and tune objective safely | #416, #266 | experiment config, reward card, baseline-vs-candidate report | per experiment |
+| L4 Training/reward framework | Select RL/bandit/evolutionary method and tune objective safely | #416, #266, #549 | experiment config, reward card, private-simulator training report | per experiment |
 | L5 Historical validation | Test candidates against official-MMO historical windows before rollout | #417 | pass/fail validation report with OOD/reliability rejection | before any live influence |
 | L6 KPI rollout/rollback | Deploy only gated high-level strategy changes, monitor, and revert on degradation | #418 | rollout decision, rollback plan, post-rollout KPI report | per candidate release |
 
 ## Implementation status
 
-- L4: Training framework — implemented 2026-05-03 — scripts/screeps_rl_experiment_card.py, docs/ops/rl-training-reward-workflow.md, docs/research/2026-05-03-rl-training-approaches.md
+- L4: Training framework — implemented 2026-05-03 — `scripts/screeps_rl_training_runner.py` runs JSON/YAML experiment cards through the private simulator harness, computes lexicographic territory/resources/kills rewards with expansion-survival penalties, emits shadow-compatible JSON reports, and is covered by `scripts/test_screeps_rl_training_runner.py`. Supporting artifacts: `scripts/screeps_rl_experiment_card.py`, `docs/ops/rl-training-reward-workflow.md`, `docs/research/2026-05-03-rl-training-approaches.md`.
 
 ## Current issue map
 
@@ -59,6 +59,7 @@ Active/next P1 roadmap:
 - #409 — dataset/evaluation gate; bridge from artifacts to executable experiments.
 - #414 — accelerated self-hosted simulator harness.
 - #416 — training framework and reward workflow.
+- #549 — real RL training runner implementation with lexicographic reward and private-simulator orchestration.
 - #417 — historical official-MMO validation.
 - #418 — KPI-gated rollout, rollback, online feedback ingestion.
 - #266 — offline RL / hierarchical recommendation prototype; must wait for enough L1-L5 evidence and must remain offline-only initially.
@@ -182,11 +183,15 @@ Deliverables:
 - produce one offline high-level recommendation baseline.
 - durable workflow: `docs/ops/rl-training-reward-workflow.md`;
 - executable offline experiment-card helper: `scripts/screeps_rl_experiment_card.py`.
+- executable training runner: `scripts/screeps_rl_training_runner.py`;
+- unit coverage for lexicographic reward, expansion survival, card loading, ranking, and JSON report shape.
 
 Verification:
 
 - experiment card links dataset run ID and code commit;
 - generated/validated cards preserve `liveEffect:false`, `officialMmoWrites:false`, and `officialMmoWritesAllowed:false`;
+- training runner reports preserve `liveEffect:false`, `officialMmoWrites:false`, and `officialMmoWritesAllowed:false`;
+- expansion rooms count as territory only when they survive with spawns and creeps at the end of simulation;
 - candidate cannot advance without #417 historical validation.
 
 ## Reporting format

--- a/docs/ops/rl-training-reward-workflow.md
+++ b/docs/ops/rl-training-reward-workflow.md
@@ -6,6 +6,8 @@ Roadmap link: `docs/ops/rl-domain-roadmap.md` L4, Slice C.
 
 Primary artifacts:
 
+- `scripts/screeps_rl_training_runner.py`
+- `scripts/test_screeps_rl_training_runner.py`
 - `scripts/screeps_rl_experiment_card.py`
 - `docs/research/2026-05-03-rl-training-approaches.md`
 - `scripts/screeps_rl_dataset_export.py`
@@ -38,6 +40,14 @@ python3 scripts/screeps_rl_experiment_card.py --validate --input runtime-artifac
 python3 scripts/screeps_rl_experiment_card.py self-test
 ```
 
+Run a real offline/private-simulator training experiment:
+
+```bash
+python3 scripts/screeps_rl_training_runner.py \
+  --experiment-card runtime-artifacts/rl-experiment-cards/<card>.json \
+  --out-dir runtime-artifacts/rl-training
+```
+
 The card is deterministic JSON. `card_id` is derived from `dataset_run_id` plus the first 12 hex characters of `code_commit`. Output goes to stdout unless `--output <path>` is provided.
 
 ## Experiment Card Contract
@@ -48,7 +58,9 @@ Every experiment card records exactly the offline decision surface:
 - `dataset_run_id`
 - `code_commit`
 - `training_approach`: `bandit`, `evolutionary`, or `policy_gradient`
-- `reward_model`: lexicographic component order and dominance weights
+- `reward_model`: lexicographic component order and dominance metadata
+- `simulation`: tick count, worker count, room, shard, code bundle, map fixture, and repetition count
+- `strategy_variants`: registry IDs or inline parameter sets for expansion aggressiveness, worker allocation ratio, construction priority, and defense posture
 - `safety`
 - `created_at`
 - `status`: always `shadow`
@@ -69,62 +81,87 @@ Validation fails if `liveEffect`, `officialMmoWrites`, or `officialMmoWritesAllo
 
 ## Reward Definition
 
-The reward function is lexicographic. The expression below is documentation for dominance order, not permission to let a later component compensate for an earlier failure:
+The implemented training runner computes a lexicographic tuple, not a scalar weighted sum:
 
 ```text
-R = α·R_reliability + β·R_territory + γ·R_resources + δ·R_kills
-where α ≫ β ≫ γ ≫ δ
+R = (T, E, K)
+T = rooms_gained - rooms_lost
+E = (stored_energy_delta + collected_energy) / resource_normalizer
+K = hostile_kills - own_losses
 ```
 
-Interpretation:
+Comparison is strict lexicographic order:
 
-- `R_reliability` dominates every other component.
-- `R_territory` is evaluated only after reliability passes.
-- `R_resources` is evaluated only after reliability and territory pass.
-- `R_kills` is last and cannot justify losses in reliability, territory, or economy.
+- `T` territory is compared first.
+- `E` resources/economy is compared only when `T` ties.
+- `K` combat outcome is compared only when both `T` and `E` tie.
+- A variant that loses territory cannot outscore one that holds territory because of resources or kills.
 
-The experiment card encodes dominance weights as:
+The runner accepts cards whose component order is either:
 
-```json
-{
-  "alpha_reliability": 1000000000,
-  "beta_territory": 1000000,
-  "gamma_resources": 1000,
-  "delta_kills": 1
-}
+```text
+territory -> resources -> kills
 ```
 
-These are guardrail weights for auditability. They are not a scalar weighted-sum approval.
+or the older card-helper order:
+
+```text
+reliability -> territory -> resources -> kills
+```
+
+In the older order, reliability remains a safety/audit gate. It is not allowed to make later reward components compensate for a territory loss.
 
 ## Reward Components
 
-`R_reliability`:
-
-- owned spawns remain `owned_spawns > 0`;
-- owned creeps remain `owned_creeps >= 3`;
-- no controller downgrade risk window is introduced or hidden;
-- no loop exceptions, uncaught errors, telemetry silence, memory corruption, or CPU bucket collapse.
-
-`R_territory`:
+`T` territory:
 
 - owned room count delta;
 - RCL progression and controller progress;
 - controller reservation uptime for remote rooms;
 - safe expansion, reserve, and remote target quality.
+- expansion survival rule: a claimed room counts as held only if it has at least one spawn and at least one owned creep at the end of the simulator run.
+- claimed rooms that do not survive count as `rooms_lost`, even if they were newly claimed during the run.
 
-`R_resources`:
+Concrete implemented territory calculation:
+
+```text
+initial_held = rooms with an owned controller or owned spawn at the first observation
+claimed = rooms claimed/owned at any observation, plus explicit claimedRooms metrics
+survived_end = claimed rooms with spawns > 0 and owned_creeps > 0 at the final observation
+rooms_gained = count(survived_end - initial_held)
+rooms_lost = count(initial_held - survived_end) + count((claimed - survived_end) - initial_held)
+T = rooms_gained - rooms_lost
+```
+
+`E` resources:
 
 - stored energy plus carried energy delta;
 - source utilization and harvested energy;
 - useful transfer/logistics throughput;
 - GCL progress and sustainable economy conversion.
 
-`R_kills`:
+Concrete implemented resource calculation:
+
+```text
+stored_energy_delta = final_room_energy - initial_room_energy
+collected_energy = sum(harvestedEnergy + collectedEnergy + pickupEnergy events)
+E = (stored_energy_delta + collected_energy) / resource_normalizer
+```
+
+Default `resource_normalizer` is `1000` unless the card overrides it.
+
+`K` kills:
 
 - hostile creep destruction delta;
 - hostile structure destruction delta;
 - hostile objective denial;
 - own creep, structure, and room-loss penalties.
+
+Concrete implemented combat calculation:
+
+```text
+K = hostile_kills - own_losses
+```
 
 ## OOD And Conservative Rejection
 
@@ -147,7 +184,7 @@ OOD detection:
 Shadow evidence gate:
 
 - Shadow evaluation must show at least one full 8h Gameplay Evolution review cycle with positive KPI delta before any recommendation reaches `consider for manual review`.
-- Positive KPI delta must respect lexicographic order: reliability non-regression first, then territory, then resources, then kills.
+- Positive KPI delta must respect lexicographic order: safety/reliability non-regression as a gate, then territory, then resources, then kills.
 - Missing historical validation from the #417 lane blocks promotion beyond offline/shadow analysis.
 
 ## Baseline Experiment
@@ -232,8 +269,10 @@ Local checks:
 
 ```bash
 python3 -m py_compile scripts/screeps_rl_experiment_card.py
+python3 -m py_compile scripts/screeps_rl_training_runner.py
 python3 scripts/screeps_rl_experiment_card.py self-test
 python3 scripts/screeps_rl_experiment_card.py --dry-run --dataset-run-id rl-000000000000
 python3 scripts/screeps_rl_experiment_card.py --dry-run --dataset-run-id rl-000000000000 --output /tmp/test-card.json
 python3 scripts/screeps_rl_experiment_card.py --validate --input /tmp/test-card.json
+python3 -m unittest scripts/test_screeps_rl_training_runner.py -v
 ```

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -461,6 +461,7 @@ def _build_tick_entry(
     overview: Any,
     terrain: Any,
     room_overviews: Any,
+    visible_rooms: Sequence[str] | None = None,
 ) -> JsonObject:
     overview_payload: JsonObject = {"roomCount": 0, "rooms": []}
     if isinstance(overview, dict):
@@ -474,7 +475,11 @@ def _build_tick_entry(
                     "gametime": selected.get("gametime"),
                     "gametimes": selected.get("gametimes"),
                 }
-    room_names = _visible_room_names(overview, shard, room)
+    room_names = (
+        _dedupe_room_names(visible_rooms)
+        if visible_rooms is not None
+        else _visible_room_names(overview, shard, room)
+    )
     room_payloads = _room_overview_payloads(room_overviews, room_names, room)
     room_summaries = {
         room_name: _summarize_room_state(room_payloads.get(room_name, {}), room_name)
@@ -488,6 +493,14 @@ def _build_tick_entry(
         "overview": overview_payload,
         "terrain": _terrain_summary(terrain),
     }
+
+
+def _dedupe_room_names(room_names: Sequence[str]) -> list[str]:
+    ordered: list[str] = []
+    for room_name in room_names:
+        if isinstance(room_name, str) and room_name not in ordered:
+            ordered.append(room_name)
+    return ordered
 
 
 def _visible_room_names(overview: Any, shard: str, anchor_room: str) -> list[str]:
@@ -594,6 +607,7 @@ def _run_one_tick(
                 overview_result.payload,
                 terrain_result.payload,
                 room_overviews,
+                visible_rooms,
             )
             return token, current_tick, tick_entry
         time.sleep(RUN_TICK_POLL_SECONDS)

--- a/scripts/screeps_rl_simulator_harness.py
+++ b/scripts/screeps_rl_simulator_harness.py
@@ -460,7 +460,7 @@ def _build_tick_entry(
     tick: int | None,
     overview: Any,
     terrain: Any,
-    room_overview: Any,
+    room_overviews: Any,
 ) -> JsonObject:
     overview_payload: JsonObject = {"roomCount": 0, "rooms": []}
     if isinstance(overview, dict):
@@ -474,15 +474,42 @@ def _build_tick_entry(
                     "gametime": selected.get("gametime"),
                     "gametimes": selected.get("gametimes"),
                 }
-    room_summary = _summarize_room_state(_extract_room_payload(room_overview, room), room)
+    room_names = _visible_room_names(overview, shard, room)
+    room_payloads = _room_overview_payloads(room_overviews, room_names, room)
+    room_summaries = {
+        room_name: _summarize_room_state(room_payloads.get(room_name, {}), room_name)
+        for room_name in room_names
+    }
     return {
         "tick": tick if isinstance(tick, int) else None,
         "shard": shard,
         "room": room,
-        "rooms": {room: room_summary},
+        "rooms": room_summaries,
         "overview": overview_payload,
         "terrain": _terrain_summary(terrain),
     }
+
+
+def _visible_room_names(overview: Any, shard: str, anchor_room: str) -> list[str]:
+    ordered: list[str] = []
+    for room_name in runtime_monitor.overview_rooms(overview, shard):
+        if room_name not in ordered:
+            ordered.append(room_name)
+    if anchor_room not in ordered:
+        ordered.insert(0, anchor_room)
+    return ordered
+
+
+def _room_overview_payloads(room_overviews: Any, room_names: Sequence[str], anchor_room: str) -> dict[str, Any]:
+    if not isinstance(room_overviews, dict):
+        return {}
+    if any(isinstance(room_overviews.get(room_name), dict) for room_name in room_names):
+        return {
+            room_name: payload
+            for room_name, payload in room_overviews.items()
+            if isinstance(room_name, str) and isinstance(payload, dict)
+        }
+    return {anchor_room: room_overviews}
 
 
 def _wait_for_http_with_smoke(cfg: Any, smoke: Any, timeout_seconds: int = RUN_PHASE_TIMEOUT_SECONDS) -> None:
@@ -500,6 +527,33 @@ def _read_gametime_from_overview(payload: Any, shard: str) -> int | None:
 
 def _safe_redact_smoke_payload(payload: Any) -> JsonObject:
     return {"ok": True, "payload": dataset_export.redact_text(json.dumps(payload, sort_keys=True, ensure_ascii=True))[:2000]}
+
+
+def _fetch_room_overviews(
+    cfg: Any,
+    smoke: Any,
+    token: str,
+    rooms: Sequence[str],
+    shard: str,
+) -> tuple[str, dict[str, Any]]:
+    payloads: dict[str, Any] = {}
+    for room_name in rooms:
+        room_overview = smoke.http_json(
+            "GET",
+            cfg.server_url,
+            "/api/game/room-overview",
+            params={"room": room_name, "shard": shard},
+            headers=smoke.token_headers(token),
+            timeout=RUN_API_TIMEOUT_SECONDS,
+        )
+        token = smoke.update_token_from_headers(token, room_overview.headers)
+        if isinstance(room_overview.payload, dict) and not smoke.api_dict_succeeded(room_overview):
+            raise RuntimeError(
+                f"/api/game/room-overview returned unusable payload for {room_name}: "
+                f"{_safe_redact_smoke_payload(room_overview.payload)}"
+            )
+        payloads[room_name] = room_overview.payload
+    return token, payloads
 
 
 def _run_one_tick(
@@ -524,33 +578,22 @@ def _run_one_tick(
             timeout=RUN_API_TIMEOUT_SECONDS,
         )
         token = smoke.update_token_from_headers(token, terrain_result.headers)
-        room_overview = smoke.http_json(
-            "GET",
-            cfg.server_url,
-            "/api/game/room-overview",
-            params={"room": room, "shard": shard},
-            headers=smoke.token_headers(token),
-            timeout=RUN_API_TIMEOUT_SECONDS,
-        )
-        token = smoke.update_token_from_headers(token, room_overview.headers)
         current_tick = _read_gametime_from_overview(overview_result.payload, shard)
         if isinstance(overview_result.payload, dict) and not smoke.api_dict_succeeded(overview_result):
             raise RuntimeError(f"/api/user/overview returned unusable payload: {_safe_redact_smoke_payload(overview_result.payload)}")
-        if isinstance(room_overview.payload, dict) and not smoke.api_dict_succeeded(room_overview):
-            raise RuntimeError(
-                f"/api/game/room-overview returned unusable payload: {_safe_redact_smoke_payload(room_overview.payload)}"
-            )
         if current_tick is None:
             time.sleep(RUN_TICK_POLL_SECONDS)
             continue
         if previous_tick is None or current_tick > previous_tick:
+            visible_rooms = _visible_room_names(overview_result.payload, shard, room)
+            token, room_overviews = _fetch_room_overviews(cfg, smoke, token, visible_rooms, shard)
             tick_entry = _build_tick_entry(
                 shard,
                 room,
                 current_tick,
                 overview_result.payload,
                 terrain_result.payload,
-                room_overview.payload,
+                room_overviews,
             )
             return token, current_tick, tick_entry
         time.sleep(RUN_TICK_POLL_SECONDS)

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -257,8 +257,7 @@ def load_strategy_registry(path: Path) -> dict[str, StrategyVariant]:
     except OSError:
         return {}
 
-    text = re.sub(r"//.*", "", text)
-    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    text = mask_ts_comments_outside_strings(text)
     registry: dict[str, StrategyVariant] = {}
     for block in iter_registry_entry_blocks(text):
         variant_id = regex_group(r"\bid:\s*['\"]([^'\"]+)['\"]", block)
@@ -274,6 +273,53 @@ def load_strategy_registry(path: Path) -> dict[str, StrategyVariant]:
             source="registry",
         )
     return registry
+
+
+def mask_ts_comments_outside_strings(text: str) -> str:
+    """Replace TypeScript comments with whitespace without touching quoted content."""
+    masked: list[str] = []
+    index = 0
+    quote: str | None = None
+    escaped = False
+    while index < len(text):
+        char = text[index]
+        next_char = text[index + 1] if index + 1 < len(text) else ""
+        if quote:
+            masked.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in ("'", '"', "`"):
+            quote = char
+            masked.append(char)
+            index += 1
+            continue
+        if char == "/" and next_char == "/":
+            masked.extend((" ", " "))
+            index += 2
+            while index < len(text) and text[index] not in "\r\n":
+                masked.append(" ")
+                index += 1
+            continue
+        if char == "/" and next_char == "*":
+            masked.extend((" ", " "))
+            index += 2
+            while index < len(text):
+                if text[index] == "*" and index + 1 < len(text) and text[index + 1] == "/":
+                    masked.extend((" ", " "))
+                    index += 2
+                    break
+                masked.append(text[index] if text[index] in "\r\n" else " ")
+                index += 1
+            continue
+        masked.append(char)
+        index += 1
+    return "".join(masked)
 
 
 def iter_registry_entry_blocks(text: str) -> list[str]:
@@ -300,7 +346,7 @@ def find_matching_brace(text: str, start: int) -> int | None:
             elif char == quote:
                 quote = None
             continue
-        if char in ("'", '"'):
+        if char in ("'", '"', "`"):
             quote = char
             continue
         if char == "{":
@@ -476,7 +522,8 @@ def run_training_experiment(
         report_id=resolved_report_id,
         generated_at=generated_at or utc_now_iso(),
     )
-    assert_no_secret_leak(report, dataset_export.configured_secret_values())
+    report_secret_values = dataset_export.configured_secret_values() + [os.environ.get("STEAM_KEY", "")]
+    assert_no_secret_leak(report, report_secret_values)
     report_path = out_dir.expanduser() / f"{resolved_report_id}.json"
     write_json_atomic(report_path, report)
     report["reportPath"] = dataset_export.display_path(report_path)

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -1,0 +1,1427 @@
+#!/usr/bin/env python3
+"""Run offline Screeps RL strategy experiments against the private simulator harness."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import statistics
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence, TextIO
+
+import screeps_rl_dataset_export as dataset_export
+import screeps_rl_simulator_harness as simulator_harness
+
+
+SCHEMA_VERSION = 1
+REPORT_TYPE = "screeps-rl-training-report"
+SUMMARY_TYPE = "screeps-rl-training-generation"
+DEFAULT_OUT_DIR = Path("runtime-artifacts/rl-training")
+DEFAULT_RESOURCE_NORMALIZER = 1000.0
+DEFAULT_RUN_REPETITIONS = 1
+REWARD_TIERS = ("territory", "resources", "kills")
+REPORT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+STRATEGY_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
+JsonObject = dict[str, Any]
+SimulatorRunner = Callable[..., JsonObject]
+
+
+class TrainingCardError(ValueError):
+    """Raised when an experiment card is unsafe or structurally invalid."""
+
+
+@dataclass(frozen=True)
+class StrategyVariant:
+    """Strategy candidate metadata consumed by the simulator and report."""
+
+    id: str
+    parameters: JsonObject
+    family: str | None = None
+    rollout_status: str | None = None
+    source: str = "inline"
+    title: str | None = None
+
+    def to_json(self) -> JsonObject:
+        payload: JsonObject = {
+            "id": self.id,
+            "parameters": self.parameters,
+            "source": self.source,
+        }
+        if self.family:
+            payload["family"] = self.family
+        if self.rollout_status:
+            payload["rolloutStatus"] = self.rollout_status
+        if self.title:
+            payload["title"] = self.title
+        return payload
+
+
+@dataclass(frozen=True)
+class SimulationConfig:
+    """Private simulator run settings shared across all variants."""
+
+    ticks: int
+    workers: int
+    repetitions: int
+    room: str
+    shard: str
+    branch: str
+    code_path: Path
+    map_source_file: Path
+    simulator_out_dir: Path
+
+    def to_json(self) -> JsonObject:
+        return {
+            "ticks": self.ticks,
+            "workers": self.workers,
+            "repetitions": self.repetitions,
+            "room": self.room,
+            "shard": self.shard,
+            "branch": self.branch,
+            "codePath": str(self.code_path),
+            "mapSourceFile": str(self.map_source_file),
+            "simulatorOutDir": str(self.simulator_out_dir),
+        }
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+
+
+def canonical_hash(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    ).hexdigest()
+
+
+def load_experiment_card(path: Path) -> JsonObject:
+    """Load a JSON or YAML experiment card from disk."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise TrainingCardError(f"could not read experiment card {path}: {error}") from error
+
+    parsed: Any
+    if path.suffix.lower() == ".json":
+        parsed = parse_json_card(text, path)
+    else:
+        stripped = text.lstrip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            parsed = parse_json_card(text, path)
+        else:
+            parsed = parse_yaml_card(text, path)
+
+    if not isinstance(parsed, dict):
+        raise TrainingCardError("experiment card must be a JSON/YAML object")
+    validate_experiment_card(parsed)
+    return parsed
+
+
+def parse_json_card(text: str, path: Path) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as error:
+        raise TrainingCardError(f"{path} is not valid JSON: {error}") from error
+
+
+def parse_yaml_card(text: str, path: Path) -> Any:
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ModuleNotFoundError as error:
+        raise TrainingCardError(f"{path} is YAML, but PyYAML is not installed") from error
+    try:
+        return yaml.safe_load(text)
+    except Exception as error:  # noqa: BLE001 - PyYAML exposes several parse exception classes
+        raise TrainingCardError(f"{path} is not valid YAML: {error}") from error
+
+
+def validate_experiment_card(card: JsonObject) -> None:
+    status = card.get("status", "shadow")
+    if status != "shadow":
+        raise TrainingCardError("status must be shadow")
+
+    safety = card.get("safety")
+    if not isinstance(safety, dict):
+        raise TrainingCardError("safety must be present and must be an object")
+    for field in ("liveEffect", "officialMmoWrites", "officialMmoWritesAllowed"):
+        if safety.get(field) is not False:
+            raise TrainingCardError(f"safety.{field} must be false")
+        if field in card and card[field] is not False:
+            raise TrainingCardError(f"{field} must be false when present")
+
+    reward_model = card.get("reward_model", card.get("rewardModel"))
+    if not isinstance(reward_model, dict):
+        raise TrainingCardError("reward_model must be present and must be an object")
+    order = reward_model.get("component_order", reward_model.get("componentOrder"))
+    if order not in (list(REWARD_TIERS), ["reliability", *REWARD_TIERS]):
+        raise TrainingCardError("reward_model.component_order must preserve territory, resources, kills")
+    if reward_model.get("scalar_weighted_sum_authorized", reward_model.get("scalarWeightedSumAuthorized", False)) is True:
+        raise TrainingCardError("reward_model.scalar_weighted_sum_authorized must be false")
+
+    raw_variants = raw_variant_definitions(card)
+    if not isinstance(raw_variants, list) or len(raw_variants) == 0:
+        raise TrainingCardError("experiment card must define at least one strategy variant")
+
+    simulation = raw_mapping(card.get("simulation", card.get("simulator", {})), "simulation")
+    if "ticks" in simulation and positive_int_value(simulation["ticks"]) is None:
+        raise TrainingCardError("simulation.ticks must be a positive integer")
+    if "workers" in simulation and positive_int_value(simulation["workers"]) is None:
+        raise TrainingCardError("simulation.workers must be a positive integer")
+    if "repetitions" in simulation and positive_int_value(simulation["repetitions"]) is None:
+        raise TrainingCardError("simulation.repetitions must be a positive integer")
+
+
+def raw_variant_definitions(card: JsonObject) -> Any:
+    for key in ("strategy_variants", "strategyVariants", "variants"):
+        if key in card:
+            return card[key]
+    return None
+
+
+def raw_mapping(value: Any, label: str) -> JsonObject:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TrainingCardError(f"{label} must be an object")
+    return value
+
+
+def load_strategy_variants(card: JsonObject, registry_path: Path | None = None) -> list[StrategyVariant]:
+    """Resolve strategy variants from the TS registry and inline card definitions."""
+    registry = load_strategy_registry(registry_path or simulator_harness.DEFAULT_STRATEGY_REGISTRY_PATH)
+    variants: list[StrategyVariant] = []
+    seen: set[str] = set()
+    for raw in raw_variant_definitions(card):
+        variant = normalize_variant(raw, registry)
+        if variant.id in seen:
+            raise TrainingCardError(f"duplicate strategy variant id: {variant.id}")
+        seen.add(variant.id)
+        variants.append(variant)
+    return variants
+
+
+def normalize_variant(raw: Any, registry: dict[str, StrategyVariant]) -> StrategyVariant:
+    if isinstance(raw, str):
+        variant_id = validate_strategy_id(raw)
+        registry_variant = registry.get(variant_id)
+        if registry_variant is None:
+            raise TrainingCardError(f"strategy variant {variant_id!r} is not inline and was not found in registry")
+        return registry_variant
+
+    if not isinstance(raw, dict):
+        raise TrainingCardError("strategy variant entries must be strings or objects")
+    variant_id = validate_strategy_id(require_text(raw, "id"))
+    registry_variant = registry.get(variant_id)
+    source = "inline"
+    parameters = first_mapping(raw, ("parameters", "params", "defaultValues", "default_values"))
+    if parameters is None and registry_variant is not None:
+        parameters = registry_variant.parameters
+        source = registry_variant.source
+    if parameters is None:
+        parameters = {}
+    family = text_or_none(raw.get("family")) or (registry_variant.family if registry_variant else None)
+    rollout_status = (
+        text_or_none(raw.get("rolloutStatus"))
+        or text_or_none(raw.get("rollout_status"))
+        or (registry_variant.rollout_status if registry_variant else None)
+    )
+    title = text_or_none(raw.get("title")) or (registry_variant.title if registry_variant else None)
+    return StrategyVariant(
+        id=variant_id,
+        parameters=dict(sorted(parameters.items())),
+        family=family,
+        rollout_status=rollout_status,
+        source=source,
+        title=title,
+    )
+
+
+def load_strategy_registry(path: Path) -> dict[str, StrategyVariant]:
+    """Parse the existing TypeScript registry enough to recover ids and default parameter sets."""
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    registry: dict[str, StrategyVariant] = {}
+    for block in iter_registry_entry_blocks(text):
+        variant_id = regex_group(r"\bid:\s*['\"]([^'\"]+)['\"]", block)
+        if not variant_id:
+            continue
+        parameters = parse_ts_default_values(block)
+        registry[variant_id] = StrategyVariant(
+            id=variant_id,
+            parameters=parameters,
+            family=regex_group(r"\bfamily:\s*['\"]([^'\"]+)['\"]", block),
+            rollout_status=regex_group(r"\brolloutStatus:\s*['\"]([^'\"]+)['\"]", block),
+            title=regex_group(r"\btitle:\s*['\"]([^'\"]+)['\"]", block),
+            source="registry",
+        )
+    return registry
+
+
+def iter_registry_entry_blocks(text: str) -> list[str]:
+    blocks: list[str] = []
+    for match in re.finditer(r"^\s*\{\s*\n\s*id:\s*['\"][^'\"]+['\"]", text, re.MULTILINE):
+        start = match.start()
+        end = find_matching_brace(text, start)
+        if end is not None:
+            blocks.append(text[start : end + 1])
+    return blocks
+
+
+def find_matching_brace(text: str, start: int) -> int | None:
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index in range(start, len(text)):
+        char = text[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in ("'", '"'):
+            quote = char
+            continue
+        if char == "{":
+            depth += 1
+            continue
+        if char == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def parse_ts_default_values(block: str) -> JsonObject:
+    match = re.search(r"\bdefaultValues:\s*\{", block)
+    if not match:
+        return {}
+    start = block.find("{", match.start())
+    end = find_matching_brace(block, start)
+    if end is None:
+        return {}
+    body = block[start + 1 : end]
+    values: JsonObject = {}
+    for item in re.finditer(r"([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^,\n}]+)", body):
+        values[item.group(1)] = parse_ts_scalar(item.group(2).strip())
+    return dict(sorted(values.items()))
+
+
+def parse_ts_scalar(raw: str) -> Any:
+    stripped = raw.rstrip(",").strip()
+    if stripped in {"true", "false"}:
+        return stripped == "true"
+    if (stripped.startswith("'") and stripped.endswith("'")) or (stripped.startswith('"') and stripped.endswith('"')):
+        return stripped[1:-1]
+    try:
+        parsed = float(stripped) if "." in stripped else int(stripped)
+    except ValueError:
+        return stripped
+    return parsed
+
+
+def regex_group(pattern: str, text: str) -> str | None:
+    match = re.search(pattern, text)
+    return match.group(1) if match else None
+
+
+def require_text(raw: JsonObject, field: str) -> str:
+    value = raw.get(field)
+    if not isinstance(value, str) or not value:
+        raise TrainingCardError(f"strategy variant {field} must be a non-empty string")
+    return value
+
+
+def validate_strategy_id(value: str) -> str:
+    if not STRATEGY_ID_RE.fullmatch(value) or value in {".", ".."}:
+        raise TrainingCardError("strategy variant id may contain only letters, numbers, dot, colon, underscore, and hyphen")
+    return value
+
+
+def first_mapping(raw: JsonObject, keys: Sequence[str]) -> JsonObject | None:
+    for key in keys:
+        value = raw.get(key)
+        if isinstance(value, dict):
+            return value
+    return None
+
+
+def simulation_config_from_card(card: JsonObject) -> SimulationConfig:
+    simulation = raw_mapping(card.get("simulation", card.get("simulator", {})), "simulation")
+    return SimulationConfig(
+        ticks=positive_int_value(simulation.get("ticks")) or simulator_harness.DEFAULT_RUN_TICKS,
+        workers=positive_int_value(simulation.get("workers")) or simulator_harness.DEFAULT_RUN_WORKERS,
+        repetitions=positive_int_value(simulation.get("repetitions")) or DEFAULT_RUN_REPETITIONS,
+        room=text_or_none(simulation.get("room")) or simulator_harness.DEFAULT_SIM_ROOM,
+        shard=text_or_none(simulation.get("shard")) or simulator_harness.DEFAULT_SIM_SHARD,
+        branch=text_or_none(simulation.get("branch")) or simulator_harness.DEFAULT_ACTIVE_WORLD_BRANCH,
+        code_path=Path(text_or_none(simulation.get("code_path")) or text_or_none(simulation.get("codePath")) or simulator_harness.DEFAULT_CODE_PATH),
+        map_source_file=Path(
+            text_or_none(simulation.get("map_source_file"))
+            or text_or_none(simulation.get("mapSourceFile"))
+            or simulator_harness.DEFAULT_MAP_SOURCE_FILE
+        ),
+        simulator_out_dir=Path(
+            text_or_none(simulation.get("simulator_out_dir"))
+            or text_or_none(simulation.get("simulatorOutDir"))
+            or simulator_harness.DEFAULT_RUN_OUT_DIR
+        ),
+    )
+
+
+def positive_int_value(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = int(value)
+        except ValueError:
+            return None
+        return parsed if parsed > 0 else None
+    return None
+
+
+def text_or_none(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def reward_options_from_card(card: JsonObject) -> JsonObject:
+    reward_model = raw_mapping(card.get("reward_model", card.get("rewardModel", {})), "reward_model")
+    weights = reward_model.get("component_weights", reward_model.get("componentWeights"))
+    if not isinstance(weights, dict):
+        weights = {}
+    normalizers = reward_model.get("normalizers")
+    if not isinstance(normalizers, dict):
+        normalizers = {}
+    return {
+        "componentOrder": list(REWARD_TIERS),
+        "weights": weights,
+        "resourceNormalizer": positive_float_value(
+            reward_model.get("resource_normalizer", reward_model.get("resourceNormalizer", normalizers.get("resources")))
+        )
+        or DEFAULT_RESOURCE_NORMALIZER,
+    }
+
+
+def positive_float_value(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(value) and value > 0:
+        return float(value)
+    if isinstance(value, str):
+        try:
+            parsed = float(value)
+        except ValueError:
+            return None
+        return parsed if math.isfinite(parsed) and parsed > 0 else None
+    return None
+
+
+def run_training_experiment(
+    card_path: Path,
+    out_dir: Path = DEFAULT_OUT_DIR,
+    *,
+    report_id: str | None = None,
+    generated_at: str | None = None,
+    registry_path: Path | None = None,
+    simulator_runner: SimulatorRunner = simulator_harness.run_simulator,
+    stdout: TextIO | None = None,
+) -> JsonObject:
+    """Run all card variants through the simulator harness and write a JSON report."""
+    card = load_experiment_card(card_path)
+    variants = load_strategy_variants(card, registry_path=registry_path)
+    config = simulation_config_from_card(card)
+    reward_options = reward_options_from_card(card)
+    resolved_report_id = report_id or default_report_id(card, variants, config)
+    validate_report_id(resolved_report_id)
+
+    simulator_runs = execute_simulator_runs(
+        simulator_runner=simulator_runner,
+        variants=variants,
+        config=config,
+        card=card,
+        report_id=resolved_report_id,
+    )
+    report = build_training_report(
+        card=card,
+        card_path=card_path,
+        variants=variants,
+        config=config,
+        simulator_runs=simulator_runs,
+        reward_options=reward_options,
+        report_id=resolved_report_id,
+        generated_at=generated_at or utc_now_iso(),
+    )
+    assert_no_secret_leak(report, dataset_export.configured_secret_values())
+    report_path = out_dir.expanduser() / f"{resolved_report_id}.json"
+    write_json_atomic(report_path, report)
+    report["reportPath"] = dataset_export.display_path(report_path)
+    if stdout is not None:
+        stdout.write(canonical_json(build_generation_summary(report)))
+    return report
+
+
+def execute_simulator_runs(
+    *,
+    simulator_runner: SimulatorRunner,
+    variants: Sequence[StrategyVariant],
+    config: SimulationConfig,
+    card: JsonObject,
+    report_id: str,
+) -> list[JsonObject]:
+    variant_ids = [variant.id for variant in variants]
+    base_run_id = text_or_none(card.get("run_id")) or text_or_none(card.get("runId")) or report_id
+    runs: list[JsonObject] = []
+    for repetition in range(config.repetitions):
+        run_id = base_run_id if config.repetitions == 1 else f"{base_run_id}-r{repetition + 1:02d}"
+        runs.append(
+            simulator_runner(
+                ticks=config.ticks,
+                workers=config.workers,
+                variants=variant_ids,
+                out_dir=config.simulator_out_dir,
+                run_id=run_id,
+                room=config.room,
+                shard=config.shard,
+                branch=config.branch,
+                code_path=config.code_path,
+                map_source_file=config.map_source_file,
+            )
+        )
+    return runs
+
+
+def build_training_report(
+    *,
+    card: JsonObject,
+    card_path: Path,
+    variants: Sequence[StrategyVariant],
+    config: SimulationConfig,
+    simulator_runs: Sequence[JsonObject],
+    reward_options: JsonObject,
+    report_id: str,
+    generated_at: str,
+) -> JsonObject:
+    per_variant_runs = collect_variant_runs(simulator_runs)
+    results = [
+        summarize_variant(variant, per_variant_runs.get(variant.id, []), reward_options)
+        for variant in variants
+    ]
+    ranking = rank_variant_results(results)
+    incumbent_ids = incumbent_strategy_ids(variants)
+    model_reports = build_shadow_compatible_model_reports(ranking, incumbent_ids)
+    pairwise = build_pairwise_comparisons(results)
+    changed_top_count = 1 if ranking and incumbent_ids and ranking[0]["variantId"] not in incumbent_ids else 0
+    ranking_diff_count = sum(1 for item in pairwise if item.get("winner") and item["winner"] not in incumbent_ids)
+    warnings = build_report_warnings(results, simulator_runs)
+
+    return {
+        "type": REPORT_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "reportId": report_id,
+        "generatedAt": generated_at,
+        "owningIssue": "#549",
+        "status": "shadow",
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "safety": safety_metadata(),
+        "experimentCard": summarize_card(card, card_path),
+        "simulation": config.to_json(),
+        "source": {
+            "experimentCardPath": dataset_export.display_path(card_path),
+            "simulatorHarness": "scripts/screeps_rl_simulator_harness.py",
+            "simulatorRunCount": len(simulator_runs),
+            "simulatorRunIds": [
+                run.get("runId")
+                for run in simulator_runs
+                if isinstance(run, dict) and isinstance(run.get("runId"), str)
+            ],
+            "initialConditions": {
+                "ticks": config.ticks,
+                "room": config.room,
+                "shard": config.shard,
+                "branch": config.branch,
+                "mapSourceFile": str(config.map_source_file),
+            },
+        },
+        "rewardModel": {
+            "type": "lexicographic",
+            "componentOrder": list(REWARD_TIERS),
+            "resourceNormalizer": reward_options["resourceNormalizer"],
+            "formula": (
+                "compare (roomsGained - roomsLost, "
+                "(storedEnergyDelta + collectedEnergy) / resourceNormalizer, "
+                "hostileKills - ownLosses) lexicographically"
+            ),
+            "scalarWeightedSumAuthorized": False,
+            "expansionSurvival": "claimed rooms count as held only with at least one spawn and one owned creep at end",
+        },
+        "strategyVariants": [variant.to_json() for variant in variants],
+        "candidateStrategyIds": [variant.id for variant in variants],
+        "incumbentStrategyIds": incumbent_ids,
+        "artifactCount": sum(result["sampleCount"] for result in results),
+        "variantResults": results,
+        "ranking": ranking,
+        "statisticalComparison": {
+            "method": "per-variant deterministic simulator samples with lexicographic mean comparison",
+            "sampleCountByVariant": {result["variantId"]: result["sampleCount"] for result in results},
+            "componentMeans": {
+                result["variantId"]: result["reward"]["tuple"]
+                for result in results
+            },
+            "pairwise": pairwise,
+        },
+        "modelReportCount": len(model_reports),
+        "rankingDiffCount": ranking_diff_count,
+        "changedTopCount": changed_top_count,
+        "modelFamilies": sorted({text for text in (result.get("family") for result in results) if isinstance(text, str)}),
+        "modelReports": model_reports,
+        "kpiSummary": build_kpi_summary(results),
+        "warnings": warnings,
+    }
+
+
+def collect_variant_runs(simulator_runs: Sequence[JsonObject]) -> dict[str, list[JsonObject]]:
+    collected: dict[str, list[JsonObject]] = {}
+    for run in simulator_runs:
+        if not isinstance(run, dict):
+            continue
+        raw_variants = run.get("variants")
+        if not isinstance(raw_variants, list):
+            continue
+        for raw_variant in raw_variants:
+            if not isinstance(raw_variant, dict):
+                continue
+            variant_id = raw_variant.get("variant_id", raw_variant.get("variantId"))
+            if isinstance(variant_id, str):
+                collected.setdefault(variant_id, []).append(raw_variant)
+    return collected
+
+
+def summarize_variant(
+    variant: StrategyVariant,
+    runs: Sequence[JsonObject],
+    reward_options: JsonObject,
+) -> JsonObject:
+    run_metrics = [compute_run_metrics(run, reward_options) for run in runs]
+    reward_tuple = mean_reward_tuple(run_metrics)
+    return {
+        "variantId": variant.id,
+        "family": variant.family,
+        "rolloutStatus": variant.rollout_status,
+        "sampleCount": len(run_metrics),
+        "ok": bool(runs) and all(run.get("ok", True) is True for run in runs),
+        "parameters": variant.parameters,
+        "reward": {
+            "type": "lexicographic",
+            "componentOrder": list(REWARD_TIERS),
+            "tuple": reward_tuple,
+            "samples": [metrics["rewardTuple"] for metrics in run_metrics],
+            "sampleStdDev": reward_stddev(run_metrics),
+        },
+        "metrics": aggregate_metrics(run_metrics),
+        "runs": [
+            {
+                "variantRunId": run.get("variant_run_id", run.get("variantRunId")),
+                "ticksRun": number_or_none(run.get("ticks_run", run.get("ticksRun"))),
+                "ok": run.get("ok", True) is True,
+                "error": text_or_none(run.get("error")),
+            }
+            for run in runs
+        ],
+    }
+
+
+def compute_run_metrics(run: JsonObject, reward_options: JsonObject) -> JsonObject:
+    explicit_metrics = run.get("metrics") if isinstance(run.get("metrics"), dict) else {}
+    tick_log = run.get("tick_log", run.get("tickLog"))
+    ticks = tick_log if isinstance(tick_log, list) else []
+    initial_rooms = normalize_room_map(explicit_metrics.get("initialRooms", explicit_metrics.get("initial_rooms")))
+    final_rooms = normalize_room_map(explicit_metrics.get("finalRooms", explicit_metrics.get("final_rooms")))
+    if ticks:
+        if not initial_rooms:
+            initial_rooms = rooms_from_tick(ticks[0])
+        if not final_rooms:
+            final_rooms = rooms_from_tick(ticks[-1])
+
+    claimed_rooms = string_set(
+        explicit_metrics.get(
+            "claimedRooms",
+            explicit_metrics.get("claimed_rooms", explicit_metrics.get("roomsClaimed", explicit_metrics.get("rooms_claimed"))),
+        )
+    )
+    claimed_rooms.update(room for tick in ticks for room in rooms_from_tick(tick) if is_claimed_room(rooms_from_tick(tick)[room]))
+    claimed_rooms.update(room for room, summary in initial_rooms.items() if is_claimed_room(summary))
+    claimed_rooms.update(room for room, summary in final_rooms.items() if is_claimed_room(summary))
+
+    initial_held = {
+        room
+        for room, summary in initial_rooms.items()
+        if is_claimed_room(summary) or spawn_count(summary) > 0
+    }
+    survived_end = {
+        room
+        for room, summary in final_rooms.items()
+        if room in claimed_rooms and room_survived(summary)
+    }
+    collapsed = claimed_rooms - survived_end
+    initial_lost = initial_held - survived_end
+    collapsed_expansion_loss = collapsed - initial_held
+    rooms_gained = len(survived_end - initial_held)
+    rooms_lost = len(initial_lost) + len(collapsed_expansion_loss)
+    territory_delta = explicit_number(
+        explicit_metrics,
+        ("territoryDelta", "territory_delta"),
+        default=rooms_gained - rooms_lost,
+    )
+
+    initial_energy = rooms_energy(initial_rooms)
+    final_energy = rooms_energy(final_rooms)
+    collected_energy = explicit_number(
+        explicit_metrics,
+        ("collectedEnergy", "collected_energy", "collectionDelta", "collection_delta"),
+        default=sum(extract_collected_energy(tick) for tick in ticks),
+    )
+    stored_energy_delta = explicit_number(
+        explicit_metrics,
+        ("storedEnergyDelta", "stored_energy_delta", "energyStoredDelta", "energy_stored_delta"),
+        default=final_energy - initial_energy,
+    )
+    resource_raw = stored_energy_delta + collected_energy
+    resources_delta = explicit_number(
+        explicit_metrics,
+        ("resourceDelta", "resource_delta", "resourcesDelta", "resources_delta"),
+        default=resource_raw / reward_options["resourceNormalizer"],
+    )
+
+    hostile_kills = explicit_number(
+        explicit_metrics,
+        ("hostileKills", "hostile_kills"),
+        default=sum(extract_hostile_kills(tick) for tick in ticks),
+    )
+    own_losses = explicit_number(
+        explicit_metrics,
+        ("ownLosses", "own_losses"),
+        default=sum(extract_own_losses(tick) for tick in ticks),
+    )
+    combat_delta = explicit_number(
+        explicit_metrics,
+        ("combatDelta", "combat_delta", "killsDelta", "kills_delta"),
+        default=hostile_kills - own_losses,
+    )
+
+    reward_tuple = [round_float(territory_delta), round_float(resources_delta), round_float(combat_delta)]
+    return {
+        "rewardTuple": reward_tuple,
+        "territory": {
+            "delta": round_float(territory_delta),
+            "ownedRoomCount": len(survived_end),
+            "roomsGained": rooms_gained,
+            "roomsLost": rooms_lost,
+            "roomGainLoss": {"gained": rooms_gained, "lost": rooms_lost},
+            "initialHeldRooms": sorted(initial_held),
+            "survivedEndRooms": sorted(survived_end),
+            "claimedRooms": sorted(claimed_rooms),
+            "collapsedClaimedRooms": sorted(collapsed),
+            "rclLevels": {
+                room: controller_level(summary)
+                for room, summary in sorted(final_rooms.items())
+                if room in claimed_rooms or room in survived_end
+            },
+            "rclDelta": round_float(rooms_rcl(final_rooms) - rooms_rcl(initial_rooms)),
+        },
+        "resources": {
+            "delta": round_float(resources_delta),
+            "raw": round_float(resource_raw),
+            "storedEnergyDelta": round_float(stored_energy_delta),
+            "collectedEnergy": round_float(collected_energy),
+            "spawnUtilization": round_float(spawn_utilization(ticks)),
+            "normalizer": reward_options["resourceNormalizer"],
+        },
+        "kills": {
+            "delta": round_float(combat_delta),
+            "hostileKills": round_float(hostile_kills),
+            "ownLosses": round_float(own_losses),
+        },
+    }
+
+
+def rooms_from_tick(tick: Any) -> dict[str, JsonObject]:
+    if not isinstance(tick, dict):
+        return {}
+    for key in ("rooms", "roomStates", "room_states"):
+        rooms = normalize_room_map(tick.get(key))
+        if rooms:
+            return rooms
+    return {}
+
+
+def normalize_room_map(raw: Any) -> dict[str, JsonObject]:
+    rooms: dict[str, JsonObject] = {}
+    if isinstance(raw, dict):
+        for key, value in raw.items():
+            if isinstance(value, dict):
+                room_name = text_or_none(value.get("roomName")) or text_or_none(value.get("room")) or str(key)
+                rooms[room_name] = value
+        return rooms
+    if isinstance(raw, list):
+        for value in raw:
+            if isinstance(value, dict):
+                room_name = text_or_none(value.get("roomName")) or text_or_none(value.get("room"))
+                if room_name:
+                    rooms[room_name] = value
+    return rooms
+
+
+def is_claimed_room(summary: JsonObject) -> bool:
+    if summary.get("claimed") is True or summary.get("owned") is True or summary.get("my") is True:
+        return True
+    controller = summary.get("controller")
+    if isinstance(controller, dict):
+        if controller.get("my") is True or controller.get("owned") is True:
+            return True
+        owner = controller.get("owner")
+        if isinstance(owner, str) and owner:
+            return True
+        if isinstance(owner, dict) and owner:
+            return True
+    if spawn_count(summary) > 0 and controller_level(summary) > 0:
+        return True
+    return False
+
+
+def room_survived(summary: JsonObject) -> bool:
+    return spawn_count(summary) > 0 and creep_count(summary) > 0
+
+
+def spawn_count(summary: JsonObject) -> int:
+    for key in ("owned_spawns", "ownedSpawnCount", "spawnCount", "spawns"):
+        value = int_or_none(summary.get(key))
+        if value is not None:
+            return value
+    structures = summary.get("structures")
+    if isinstance(structures, dict):
+        for key in ("spawn", "STRUCTURE_SPAWN"):
+            value = int_or_none(structures.get(key))
+            if value is not None:
+                return value
+    return 0
+
+
+def creep_count(summary: JsonObject) -> int:
+    for key in ("owned_creeps", "ownedCreeps", "ownedCreepCount", "creeps", "workerCount"):
+        value = int_or_none(summary.get(key))
+        if value is not None:
+            return value
+    return 0
+
+
+def controller_level(summary: JsonObject) -> int:
+    controller = summary.get("controller")
+    if isinstance(controller, dict):
+        value = int_or_none(controller.get("level"))
+        if value is not None:
+            return value
+    value = int_or_none(summary.get("rcl", summary.get("controllerLevel")))
+    return value or 0
+
+
+def rooms_rcl(rooms: dict[str, JsonObject]) -> float:
+    return sum(controller_level(summary) for summary in rooms.values())
+
+
+def rooms_energy(rooms: dict[str, JsonObject]) -> float:
+    return sum(room_energy(summary) for summary in rooms.values())
+
+
+def room_energy(summary: JsonObject) -> float:
+    total = 0.0
+    for key in ("storedEnergy", "stored_energy", "energy", "energyAvailable"):
+        value = number_or_none(summary.get(key))
+        if value is not None:
+            total += value
+            break
+    resources = summary.get("resources")
+    if isinstance(resources, dict):
+        for key in ("storedEnergy", "workerCarriedEnergy", "droppedEnergy"):
+            value = number_or_none(resources.get(key))
+            if value is not None:
+                total += value
+    storage = summary.get("storage")
+    if isinstance(storage, dict):
+        store = storage.get("store")
+        if isinstance(store, dict):
+            total += float(number_or_none(store.get("energy")) or 0)
+        else:
+            total += float(number_or_none(storage.get("energy")) or 0)
+    terminal = summary.get("terminal")
+    if isinstance(terminal, dict):
+        store = terminal.get("store")
+        if isinstance(store, dict):
+            total += float(number_or_none(store.get("energy")) or 0)
+    return total
+
+
+def extract_collected_energy(tick: Any) -> float:
+    total = 0.0
+    for room in rooms_from_tick(tick).values():
+        resources = room.get("resources")
+        if isinstance(resources, dict):
+            events = resources.get("events")
+            if isinstance(events, dict):
+                for key in ("harvestedEnergy", "collectedEnergy", "pickupEnergy"):
+                    total += float(number_or_none(events.get(key)) or 0)
+        events = room.get("events")
+        if isinstance(events, dict):
+            for key in ("harvestedEnergy", "collectedEnergy", "pickupEnergy"):
+                total += float(number_or_none(events.get(key)) or 0)
+    return total
+
+
+def extract_hostile_kills(tick: Any) -> float:
+    total = 0.0
+    for room in rooms_from_tick(tick).values():
+        combat = room.get("combat")
+        if isinstance(combat, dict):
+            for key in ("hostileKills", "hostileCreepKills", "hostileStructureKills"):
+                total += float(number_or_none(combat.get(key)) or 0)
+            events = combat.get("events")
+            if isinstance(events, dict):
+                for key in ("hostileCreepDestroyedCount", "hostileStructureDestroyedCount", "objectDestroyedCount"):
+                    total += float(number_or_none(events.get(key)) or 0)
+    return total
+
+
+def extract_own_losses(tick: Any) -> float:
+    total = 0.0
+    for room in rooms_from_tick(tick).values():
+        combat = room.get("combat")
+        if isinstance(combat, dict):
+            for key in ("ownLosses", "ownCreepLosses", "ownStructureLosses"):
+                total += float(number_or_none(combat.get(key)) or 0)
+            events = combat.get("events")
+            if isinstance(events, dict):
+                for key in ("ownCreepDestroyedCount", "ownStructureDestroyedCount"):
+                    total += float(number_or_none(events.get(key)) or 0)
+    return total
+
+
+def spawn_utilization(ticks: Sequence[Any]) -> float:
+    busy = 0
+    total = 0
+    for tick in ticks:
+        for room in rooms_from_tick(tick).values():
+            status = room.get("spawnStatus")
+            if isinstance(status, list):
+                for item in status:
+                    if not isinstance(item, dict):
+                        continue
+                    total += 1
+                    item_status = str(item.get("status", "")).lower()
+                    if item_status and item_status not in {"idle", "available"}:
+                        busy += 1
+            utilization = number_or_none(room.get("spawnUtilization"))
+            if utilization is not None:
+                return float(utilization)
+    return busy / total if total > 0 else 0.0
+
+
+def explicit_number(raw: JsonObject, keys: Sequence[str], *, default: float) -> float:
+    for key in keys:
+        value = number_or_none(raw.get(key))
+        if value is not None:
+            return float(value)
+    return float(default)
+
+
+def string_set(raw: Any) -> set[str]:
+    if isinstance(raw, list):
+        return {item for item in raw if isinstance(item, str) and item}
+    if isinstance(raw, dict):
+        return {str(key) for key, value in raw.items() if value}
+    return set()
+
+
+def int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def number_or_none(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and math.isfinite(value):
+        return value
+    return None
+
+
+def round_float(value: float | int) -> float | int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return round(float(value), 6)
+
+
+def mean_reward_tuple(metrics: Sequence[JsonObject]) -> list[float | int]:
+    if not metrics:
+        return [0, 0, 0]
+    columns = list(zip(*(metric["rewardTuple"] for metric in metrics)))
+    return [round_float(statistics.fmean(float(value) for value in column)) for column in columns]
+
+
+def reward_stddev(metrics: Sequence[JsonObject]) -> list[float | int]:
+    if len(metrics) <= 1:
+        return [0, 0, 0]
+    columns = list(zip(*(metric["rewardTuple"] for metric in metrics)))
+    return [round_float(statistics.pstdev(float(value) for value in column)) for column in columns]
+
+
+def aggregate_metrics(metrics: Sequence[JsonObject]) -> JsonObject:
+    if not metrics:
+        return {
+            "territory": empty_territory_metrics(),
+            "resources": empty_resource_metrics(),
+            "kills": empty_kill_metrics(),
+        }
+    return {
+        "territory": {
+            "delta": mean_component(metrics, "territory", "delta"),
+            "ownedRoomCount": mean_component(metrics, "territory", "ownedRoomCount"),
+            "roomsGained": mean_component(metrics, "territory", "roomsGained"),
+            "roomsLost": mean_component(metrics, "territory", "roomsLost"),
+            "roomGainLoss": {
+                "gained": mean_component(metrics, "territory", "roomsGained"),
+                "lost": mean_component(metrics, "territory", "roomsLost"),
+            },
+            "rclDelta": mean_component(metrics, "territory", "rclDelta"),
+            "rclLevels": aggregate_rcl_levels(metrics),
+            "collapsedClaimedRooms": sorted(
+                {
+                    room
+                    for metric in metrics
+                    for room in metric["territory"].get("collapsedClaimedRooms", [])
+                    if isinstance(room, str)
+                }
+            ),
+            "survivedEndRooms": sorted(
+                {
+                    room
+                    for metric in metrics
+                    for room in metric["territory"].get("survivedEndRooms", [])
+                    if isinstance(room, str)
+                }
+            ),
+        },
+        "resources": {
+            "delta": mean_component(metrics, "resources", "delta"),
+            "raw": mean_component(metrics, "resources", "raw"),
+            "storedEnergyDelta": mean_component(metrics, "resources", "storedEnergyDelta"),
+            "collectedEnergy": mean_component(metrics, "resources", "collectedEnergy"),
+            "spawnUtilization": mean_component(metrics, "resources", "spawnUtilization"),
+            "normalizer": metrics[0]["resources"]["normalizer"],
+        },
+        "kills": {
+            "delta": mean_component(metrics, "kills", "delta"),
+            "hostileKills": mean_component(metrics, "kills", "hostileKills"),
+            "ownLosses": mean_component(metrics, "kills", "ownLosses"),
+        },
+    }
+
+
+def empty_territory_metrics() -> JsonObject:
+    return {
+        "delta": 0,
+        "ownedRoomCount": 0,
+        "roomsGained": 0,
+        "roomsLost": 0,
+        "roomGainLoss": {"gained": 0, "lost": 0},
+        "rclDelta": 0,
+        "rclLevels": {},
+        "collapsedClaimedRooms": [],
+        "survivedEndRooms": [],
+    }
+
+
+def empty_resource_metrics() -> JsonObject:
+    return {
+        "delta": 0,
+        "raw": 0,
+        "storedEnergyDelta": 0,
+        "collectedEnergy": 0,
+        "spawnUtilization": 0,
+        "normalizer": DEFAULT_RESOURCE_NORMALIZER,
+    }
+
+
+def empty_kill_metrics() -> JsonObject:
+    return {"delta": 0, "hostileKills": 0, "ownLosses": 0}
+
+
+def mean_component(metrics: Sequence[JsonObject], component: str, field: str) -> float | int:
+    values = [float(metric[component].get(field, 0)) for metric in metrics]
+    return round_float(statistics.fmean(values)) if values else 0
+
+
+def aggregate_rcl_levels(metrics: Sequence[JsonObject]) -> JsonObject:
+    levels_by_room: dict[str, list[float]] = {}
+    for metric in metrics:
+        levels = metric["territory"].get("rclLevels")
+        if not isinstance(levels, dict):
+            continue
+        for room, level in levels.items():
+            numeric = number_or_none(level)
+            if isinstance(room, str) and numeric is not None:
+                levels_by_room.setdefault(room, []).append(float(numeric))
+    return {
+        room: round_float(statistics.fmean(values))
+        for room, values in sorted(levels_by_room.items())
+    }
+
+
+def rank_variant_results(results: Sequence[JsonObject]) -> list[JsonObject]:
+    sorted_results = sorted(
+        results,
+        key=lambda item: (
+            float(item["reward"]["tuple"][0]),
+            float(item["reward"]["tuple"][1]),
+            float(item["reward"]["tuple"][2]),
+            item["variantId"],
+        ),
+        reverse=True,
+    )
+    ranking: list[JsonObject] = []
+    previous_tuple: list[Any] | None = None
+    previous_rank = 0
+    for index, result in enumerate(sorted_results):
+        reward_tuple = list(result["reward"]["tuple"])
+        rank = previous_rank if reward_tuple == previous_tuple else index + 1
+        previous_tuple = reward_tuple
+        previous_rank = rank
+        ranking.append(
+            {
+                "rank": rank,
+                "variantId": result["variantId"],
+                "rewardTuple": reward_tuple,
+                "sampleCount": result["sampleCount"],
+                "ok": result["ok"],
+            }
+        )
+    return ranking
+
+
+def build_pairwise_comparisons(results: Sequence[JsonObject]) -> list[JsonObject]:
+    comparisons: list[JsonObject] = []
+    for left_index, left in enumerate(results):
+        for right in results[left_index + 1 :]:
+            comparison = compare_reward_tuples(left["reward"]["tuple"], right["reward"]["tuple"])
+            if comparison > 0:
+                winner = left["variantId"]
+            elif comparison < 0:
+                winner = right["variantId"]
+            else:
+                winner = None
+            comparisons.append(
+                {
+                    "left": left["variantId"],
+                    "right": right["variantId"],
+                    "winner": winner,
+                    "firstDifferingTier": first_differing_tier(left["reward"]["tuple"], right["reward"]["tuple"]),
+                    "delta": {
+                        "territory": round_float(float(left["reward"]["tuple"][0]) - float(right["reward"]["tuple"][0])),
+                        "resources": round_float(float(left["reward"]["tuple"][1]) - float(right["reward"]["tuple"][1])),
+                        "kills": round_float(float(left["reward"]["tuple"][2]) - float(right["reward"]["tuple"][2])),
+                    },
+                }
+            )
+    return comparisons
+
+
+def compare_reward_tuples(left: Sequence[Any], right: Sequence[Any]) -> int:
+    for left_value, right_value in zip(left, right):
+        left_float = float(left_value)
+        right_float = float(right_value)
+        if left_float > right_float:
+            return 1
+        if left_float < right_float:
+            return -1
+    return 0
+
+
+def first_differing_tier(left: Sequence[Any], right: Sequence[Any]) -> str | None:
+    for index, tier in enumerate(REWARD_TIERS):
+        if float(left[index]) != float(right[index]):
+            return tier
+    return None
+
+
+def incumbent_strategy_ids(variants: Sequence[StrategyVariant]) -> list[str]:
+    incumbents = [variant.id for variant in variants if variant.rollout_status == "incumbent"]
+    return incumbents or ([variants[0].id] if variants else [])
+
+
+def build_shadow_compatible_model_reports(ranking: Sequence[JsonObject], incumbent_ids: Sequence[str]) -> list[JsonObject]:
+    incumbent = incumbent_ids[0] if incumbent_ids else None
+    reports: list[JsonObject] = []
+    rank_by_variant = {item["variantId"]: item["rank"] for item in ranking}
+    incumbent_rank = rank_by_variant.get(incumbent) if incumbent else None
+    for item in ranking:
+        variant_id = item["variantId"]
+        if variant_id == incumbent:
+            continue
+        changed_top = item["rank"] == 1 and variant_id != incumbent
+        reports.append(
+            {
+                "family": "rl-training",
+                "incumbentStrategyId": incumbent,
+                "candidateStrategyId": variant_id,
+                "rankingDiffCount": 1 if incumbent_rank is not None and item["rank"] != incumbent_rank else 0,
+                "changedTopCount": 1 if changed_top else 0,
+                "rankingDiffsTruncated": False,
+                "rankingDiffs": [
+                    {
+                        "artifactIndex": 0,
+                        "context": "rl-training-lexicographic-reward",
+                        "changedTop": changed_top,
+                        "incumbentTop": {
+                            "itemId": incumbent,
+                            "rank": incumbent_rank,
+                            "score": None,
+                        }
+                        if incumbent
+                        else None,
+                        "candidateTop": {
+                            "itemId": variant_id,
+                            "rank": item["rank"],
+                            "score": None,
+                        },
+                        "rankChangeCount": 1,
+                        "rankChangeSamples": [
+                            {
+                                "itemId": variant_id,
+                                "incumbentRank": incumbent_rank,
+                                "candidateRank": item["rank"],
+                                "delta": None,
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    return reports
+
+
+def build_kpi_summary(results: Sequence[JsonObject]) -> JsonObject:
+    if not results:
+        return {}
+    best = rank_variant_results(results)[0]
+    return {
+        "territory": {
+            "score": best["rewardTuple"][0],
+            "components": {
+                result["variantId"]: result["metrics"]["territory"]["delta"]
+                for result in results
+            },
+        },
+        "resources": {
+            "score": best["rewardTuple"][1],
+            "components": {
+                result["variantId"]: result["metrics"]["resources"]["delta"]
+                for result in results
+            },
+        },
+        "kills": {
+            "score": best["rewardTuple"][2],
+            "components": {
+                result["variantId"]: result["metrics"]["kills"]["delta"]
+                for result in results
+            },
+        },
+    }
+
+
+def build_report_warnings(results: Sequence[JsonObject], simulator_runs: Sequence[JsonObject]) -> list[str]:
+    warnings: list[str] = []
+    for result in results:
+        if result["sampleCount"] == 0:
+            warnings.append(f"variant {result['variantId']} produced no simulator result")
+        elif not result["ok"]:
+            warnings.append(f"variant {result['variantId']} had simulator errors")
+    for run in simulator_runs:
+        if isinstance(run, dict) and run.get("liveEffect") is True:
+            warnings.append("simulator run unexpectedly reported liveEffect=true")
+        if isinstance(run, dict) and run.get("officialMmoWrites") is True:
+            warnings.append("simulator run unexpectedly reported officialMmoWrites=true")
+    return warnings[:20]
+
+
+def summarize_card(card: JsonObject, path: Path) -> JsonObject:
+    return {
+        "path": dataset_export.display_path(path),
+        "cardId": card.get("card_id", card.get("cardId")),
+        "datasetRunId": card.get("dataset_run_id", card.get("datasetRunId")),
+        "codeCommit": card.get("code_commit", card.get("codeCommit")),
+        "trainingApproach": card.get("training_approach", card.get("trainingApproach")),
+        "status": card.get("status", "shadow"),
+        "safety": card.get("safety"),
+    }
+
+
+def safety_metadata() -> JsonObject:
+    return {
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "officialMmoWritesAllowed": False,
+        "officialMmoControl": False,
+        "inputMode": "experiment card plus local private-server simulator harness output",
+        "simulatorOnly": True,
+        "liveApiCalls": False,
+        "liveSecretsRequired": False,
+        "memoryWritesAllowed": False,
+        "rawMemoryWritesAllowed": False,
+        "rawCreepIntentControl": False,
+        "spawnIntentControl": False,
+        "constructionIntentControl": False,
+        "marketIntentControl": False,
+        "allowedUse": "offline/private simulator analysis and shadow reports only",
+    }
+
+
+def default_report_id(card: JsonObject, variants: Sequence[StrategyVariant], config: SimulationConfig) -> str:
+    seed = {
+        "card": summarize_card(card, Path("<card>")),
+        "variants": [variant.to_json() for variant in variants],
+        "simulation": config.to_json(),
+    }
+    card_id = text_or_none(card.get("card_id", card.get("cardId"))) or "rl-training"
+    safe_card_id = re.sub(r"[^A-Za-z0-9_.-]", "-", card_id).strip(".-") or "rl-training"
+    return f"{safe_card_id}-{canonical_hash(seed)[:12]}"
+
+
+def validate_report_id(report_id: str) -> None:
+    if not REPORT_ID_RE.fullmatch(report_id) or report_id in {".", ".."}:
+        raise TrainingCardError("report id may contain only letters, numbers, dot, underscore, and hyphen")
+
+
+def assert_no_secret_leak(payload: JsonObject, secrets: Sequence[str]) -> None:
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=True)
+    for secret in secrets:
+        if secret and len(secret) >= 6 and secret in encoded:
+            raise RuntimeError("refusing to persist RL training report containing a configured secret")
+
+
+def write_json_atomic(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
+            temp_fd = -1
+            handle.write(canonical_json(payload))
+        os.replace(temp_path, path)
+    finally:
+        if temp_fd != -1:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def build_generation_summary(report: JsonObject) -> JsonObject:
+    return {
+        "ok": True,
+        "type": SUMMARY_TYPE,
+        "schemaVersion": SCHEMA_VERSION,
+        "reportId": report["reportId"],
+        "reportPath": report.get("reportPath"),
+        "liveEffect": False,
+        "officialMmoWrites": False,
+        "candidateStrategyIds": report["candidateStrategyIds"],
+        "incumbentStrategyIds": report["incumbentStrategyIds"],
+        "topVariantId": report["ranking"][0]["variantId"] if report["ranking"] else None,
+        "artifactCount": report["artifactCount"],
+        "changedTopCount": report["changedTopCount"],
+        "warnings": report["warnings"],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run offline Screeps RL strategy experiments through the private simulator harness.",
+    )
+    parser.add_argument("--experiment-card", required=True, type=Path, help="Experiment card JSON/YAML path.")
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help=f"Training report output directory. Default: {DEFAULT_OUT_DIR}.",
+    )
+    parser.add_argument("--report-id", help="Optional report file stem. Defaults to card/config hash.")
+    parser.add_argument(
+        "--registry-path",
+        type=Path,
+        default=simulator_harness.DEFAULT_STRATEGY_REGISTRY_PATH,
+        help="Strategy registry TypeScript source. Inline variant parameters still work if this is missing.",
+    )
+    parser.add_argument(
+        "--print-report",
+        action="store_true",
+        help="Print the full report instead of the compact generation summary.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None, stdout: TextIO = sys.stdout, stderr: TextIO = sys.stderr) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report = run_training_experiment(
+            args.experiment_card,
+            args.out_dir,
+            report_id=args.report_id,
+            registry_path=args.registry_path,
+        )
+        stdout.write(canonical_json(report if args.print_report else build_generation_summary(report)))
+        return 0
+    except (RuntimeError, TrainingCardError, OSError) as error:
+        stderr.write(f"error: {error}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -567,10 +567,11 @@ def build_training_report(
         summarize_variant(variant, per_variant_runs.get(variant.id, []), reward_options)
         for variant in variants
     ]
-    ranking = rank_variant_results(results)
+    scored_results = [result for result in results if result["sampleCount"] > 0]
+    ranking = rank_variant_results(scored_results)
     incumbent_ids = incumbent_strategy_ids(variants)
     model_reports = build_shadow_compatible_model_reports(ranking, incumbent_ids)
-    pairwise = build_pairwise_comparisons(results)
+    pairwise = build_pairwise_comparisons(scored_results)
     changed_top_count = 1 if ranking and incumbent_ids and ranking[0]["variantId"] not in incumbent_ids else 0
     ranking_diff_count = sum(1 for item in pairwise if item.get("winner") and item["winner"] not in incumbent_ids)
     warnings = build_report_warnings(results, simulator_runs)
@@ -628,7 +629,7 @@ def build_training_report(
             "sampleCountByVariant": {result["variantId"]: result["sampleCount"] for result in results},
             "componentMeans": {
                 result["variantId"]: result["reward"]["tuple"]
-                for result in results
+                for result in scored_results
             },
             "pairwise": pairwise,
         },
@@ -637,7 +638,7 @@ def build_training_report(
         "changedTopCount": changed_top_count,
         "modelFamilies": sorted({text for text in (result.get("family") for result in results) if isinstance(text, str)}),
         "modelReports": model_reports,
-        "kpiSummary": build_kpi_summary(results),
+        "kpiSummary": build_kpi_summary(scored_results),
         "warnings": warnings,
     }
 
@@ -664,14 +665,17 @@ def summarize_variant(
     runs: Sequence[JsonObject],
     reward_options: JsonObject,
 ) -> JsonObject:
-    run_metrics = [compute_run_metrics(run, reward_options) for run in runs]
+    scored_runs = [run for run in runs if run.get("ok") is True]
+    excluded_run_count = len(runs) - len(scored_runs)
+    run_metrics = [compute_run_metrics(run, reward_options) for run in scored_runs]
     reward_tuple = mean_reward_tuple(run_metrics)
     return {
         "variantId": variant.id,
         "family": variant.family,
         "rolloutStatus": variant.rollout_status,
         "sampleCount": len(run_metrics),
-        "ok": bool(runs) and all(run.get("ok", True) is True for run in runs),
+        "excludedRunCount": excluded_run_count,
+        "ok": bool(scored_runs) and excluded_run_count == 0,
         "parameters": variant.parameters,
         "reward": {
             "type": "lexicographic",
@@ -685,7 +689,7 @@ def summarize_variant(
             {
                 "variantRunId": run.get("variant_run_id", run.get("variantRunId")),
                 "ticksRun": number_or_none(run.get("ticks_run", run.get("ticksRun"))),
-                "ok": run.get("ok", True) is True,
+                "ok": run.get("ok") is True,
                 "error": text_or_none(run.get("error")),
             }
             for run in runs
@@ -1314,7 +1318,12 @@ def build_kpi_summary(results: Sequence[JsonObject]) -> JsonObject:
 def build_report_warnings(results: Sequence[JsonObject], simulator_runs: Sequence[JsonObject]) -> list[str]:
     warnings: list[str] = []
     for result in results:
-        if result["sampleCount"] == 0:
+        excluded_run_count = int(result.get("excludedRunCount", 0))
+        if excluded_run_count > 0:
+            warnings.append(
+                f"variant {result['variantId']} excluded {excluded_run_count} failed simulator run(s) from reward scoring"
+            )
+        elif result["sampleCount"] == 0:
             warnings.append(f"variant {result['variantId']} produced no simulator result")
         elif not result["ok"]:
             warnings.append(f"variant {result['variantId']} had simulator errors")

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -257,6 +257,7 @@ def load_strategy_registry(path: Path) -> dict[str, StrategyVariant]:
     except OSError:
         return {}
 
+    text = strip_ts_comments(text)
     registry: dict[str, StrategyVariant] = {}
     for block in iter_registry_entry_blocks(text):
         variant_id = regex_group(r"\bid:\s*['\"]([^'\"]+)['\"]", block)
@@ -272,6 +273,11 @@ def load_strategy_registry(path: Path) -> dict[str, StrategyVariant]:
             source="registry",
         )
     return registry
+
+
+def strip_ts_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    return re.sub(r"//.*", "", text)
 
 
 def iter_registry_entry_blocks(text: str) -> list[str]:
@@ -463,6 +469,7 @@ def run_training_experiment(
         card=card,
         report_id=resolved_report_id,
     )
+    assert_simulator_runs_shadow_safe(simulator_runs)
     report = build_training_report(
         card=card,
         card_path=card_path,
@@ -491,7 +498,8 @@ def execute_simulator_runs(
     report_id: str,
 ) -> list[JsonObject]:
     variant_ids = [variant.id for variant in variants]
-    base_run_id = text_or_none(card.get("run_id")) or text_or_none(card.get("runId")) or report_id
+    raw_run_id = text_or_none(card.get("run_id")) or text_or_none(card.get("runId")) or report_id
+    base_run_id = normalize_simulator_run_id(raw_run_id)
     runs: list[JsonObject] = []
     for repetition in range(config.repetitions):
         run_id = base_run_id if config.repetitions == 1 else f"{base_run_id}-r{repetition + 1:02d}"
@@ -510,6 +518,41 @@ def execute_simulator_runs(
             )
         )
     return runs
+
+
+def normalize_simulator_run_id(raw: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_-]+", "_", raw)
+    normalized = re.sub(r"_+", "_", normalized).strip("_-")
+    if not normalized:
+        normalized = "rl_training"
+    simulator_harness.validate_run_id_token(normalized)
+    return normalized
+
+
+def assert_simulator_runs_shadow_safe(simulator_runs: Sequence[JsonObject]) -> None:
+    unsafe: list[str] = []
+    for index, run in enumerate(simulator_runs):
+        if not isinstance(run, dict):
+            continue
+        unsafe.extend(unsafe_simulator_flags(run, f"run[{index}]"))
+        variants = run.get("variants")
+        if isinstance(variants, list):
+            for variant_index, variant in enumerate(variants):
+                if isinstance(variant, dict):
+                    unsafe.extend(unsafe_simulator_flags(variant, f"run[{index}].variants[{variant_index}]"))
+    if unsafe:
+        raise RuntimeError("refusing to persist unsafe RL training report: " + "; ".join(unsafe))
+
+
+def unsafe_simulator_flags(payload: JsonObject, label: str) -> list[str]:
+    unsafe: list[str] = []
+    for field in ("liveEffect", "live_effect"):
+        if payload.get(field) is True:
+            unsafe.append(f"{label}.{field}=true")
+    for field in ("officialMmoWrites", "official_mmo_writes"):
+        if payload.get(field) is True:
+            unsafe.append(f"{label}.{field}=true")
+    return unsafe
 
 
 def build_training_report(

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -570,9 +570,13 @@ def build_training_report(
     scored_results = [result for result in results if result["sampleCount"] > 0]
     ranking = rank_variant_results(scored_results)
     incumbent_ids = incumbent_strategy_ids(variants)
-    model_reports = build_shadow_compatible_model_reports(ranking, incumbent_ids)
+    best_incumbent_reward_tuple = best_incumbent_reward_tuple_from_ranking(ranking, incumbent_ids)
+    model_reports = build_shadow_compatible_model_reports(ranking, incumbent_ids, best_incumbent_reward_tuple)
     pairwise = build_pairwise_comparisons(scored_results)
-    changed_top_count = 1 if ranking and incumbent_ids and ranking[0]["variantId"] not in incumbent_ids else 0
+    changed_top = bool(
+        ranking and variant_strictly_beats_best_incumbent(ranking[0], incumbent_ids, best_incumbent_reward_tuple)
+    )
+    changed_top_count = 1 if changed_top else 0
     ranking_diff_count = sum(1 for item in pairwise if item.get("winner") and item["winner"] not in incumbent_ids)
     warnings = build_report_warnings(results, simulator_runs)
 
@@ -1212,6 +1216,27 @@ def build_pairwise_comparisons(results: Sequence[JsonObject]) -> list[JsonObject
     return comparisons
 
 
+def best_incumbent_reward_tuple_from_ranking(
+    ranking: Sequence[JsonObject], incumbent_ids: Sequence[str]
+) -> Sequence[Any] | None:
+    best_tuple: Sequence[Any] | None = None
+    for item in ranking:
+        if item["variantId"] not in incumbent_ids:
+            continue
+        reward_tuple = item["rewardTuple"]
+        if best_tuple is None or compare_reward_tuples(reward_tuple, best_tuple) > 0:
+            best_tuple = reward_tuple
+    return best_tuple
+
+
+def variant_strictly_beats_best_incumbent(
+    item: JsonObject, incumbent_ids: Sequence[str], best_incumbent_reward_tuple: Sequence[Any] | None
+) -> bool:
+    if item["variantId"] in incumbent_ids or best_incumbent_reward_tuple is None:
+        return False
+    return compare_reward_tuples(item["rewardTuple"], best_incumbent_reward_tuple) > 0
+
+
 def compare_reward_tuples(left: Sequence[Any], right: Sequence[Any]) -> int:
     for left_value, right_value in zip(left, right):
         left_float = float(left_value)
@@ -1235,8 +1260,14 @@ def incumbent_strategy_ids(variants: Sequence[StrategyVariant]) -> list[str]:
     return incumbents or ([variants[0].id] if variants else [])
 
 
-def build_shadow_compatible_model_reports(ranking: Sequence[JsonObject], incumbent_ids: Sequence[str]) -> list[JsonObject]:
+def build_shadow_compatible_model_reports(
+    ranking: Sequence[JsonObject],
+    incumbent_ids: Sequence[str],
+    best_incumbent_reward_tuple: Sequence[Any] | None = None,
+) -> list[JsonObject]:
     incumbent = incumbent_ids[0] if incumbent_ids else None
+    if best_incumbent_reward_tuple is None:
+        best_incumbent_reward_tuple = best_incumbent_reward_tuple_from_ranking(ranking, incumbent_ids)
     reports: list[JsonObject] = []
     rank_by_variant = {item["variantId"]: item["rank"] for item in ranking}
     incumbent_rank = rank_by_variant.get(incumbent) if incumbent else None
@@ -1244,7 +1275,9 @@ def build_shadow_compatible_model_reports(ranking: Sequence[JsonObject], incumbe
         variant_id = item["variantId"]
         if variant_id == incumbent:
             continue
-        changed_top = item["rank"] == 1 and variant_id != incumbent
+        changed_top = item["rank"] == 1 and variant_strictly_beats_best_incumbent(
+            item, incumbent_ids, best_incumbent_reward_tuple
+        )
         reports.append(
             {
                 "family": "rl-training",

--- a/scripts/screeps_rl_training_runner.py
+++ b/scripts/screeps_rl_training_runner.py
@@ -257,7 +257,8 @@ def load_strategy_registry(path: Path) -> dict[str, StrategyVariant]:
     except OSError:
         return {}
 
-    text = strip_ts_comments(text)
+    text = re.sub(r"//.*", "", text)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
     registry: dict[str, StrategyVariant] = {}
     for block in iter_registry_entry_blocks(text):
         variant_id = regex_group(r"\bid:\s*['\"]([^'\"]+)['\"]", block)
@@ -273,11 +274,6 @@ def load_strategy_registry(path: Path) -> dict[str, StrategyVariant]:
             source="registry",
         )
     return registry
-
-
-def strip_ts_comments(text: str) -> str:
-    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
-    return re.sub(r"//.*", "", text)
 
 
 def iter_registry_entry_blocks(text: str) -> list[str]:

--- a/scripts/test_screeps_rl_simulator_harness.py
+++ b/scripts/test_screeps_rl_simulator_harness.py
@@ -460,6 +460,50 @@ class RlSimulatorHarnessTest(unittest.TestCase):
         with self.assertRaisesRegex(argparse.ArgumentTypeError, "letters, numbers"):
             harness.parse_run_id_token("run.1")
 
+    def test_build_tick_entry_includes_all_visible_room_summaries(self) -> None:
+        overview = {
+            "shards": {
+                "shardX": {
+                    "rooms": ["E26S49", "E26S50"],
+                    "gametime": 12,
+                    "gametimes": [12],
+                }
+            }
+        }
+        room_overviews = {
+            "E26S49": {
+                "room": "E26S49",
+                "roomData": {
+                    "controller": {"level": 1},
+                    "objects": [{"type": "spawn"}],
+                    "creeps": 2,
+                    "energy": 300,
+                },
+            },
+            "E26S50": {
+                "room": "E26S50",
+                "roomData": {
+                    "controller": {"level": 2},
+                    "objects": [{"type": "spawn"}],
+                    "creeps": 1,
+                    "energy": 200,
+                },
+            },
+        }
+
+        tick_entry = harness._build_tick_entry(
+            "shardX",
+            "E26S49",
+            12,
+            overview,
+            {"terrain": [{"room": "E26S49", "terrain": "0" * 2500}]},
+            room_overviews,
+        )
+
+        self.assertEqual(sorted(tick_entry["rooms"]), ["E26S49", "E26S50"])
+        self.assertEqual(tick_entry["rooms"]["E26S49"]["structures"]["spawn"], 1)
+        self.assertEqual(tick_entry["rooms"]["E26S50"]["controller"]["level"], 2)
+
     def test_run_variant_initializes_frozen_smoke_config_with_http_server_url(self) -> None:
         captured_server_urls: list[str] = []
 

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -309,6 +309,38 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["ranking"][0]["rewardTuple"][0], 0)
         self.assertEqual(report["statisticalComparison"]["pairwise"][0]["firstDifferingTier"], "resources")
 
+    def test_failed_variant_runs_are_excluded_from_reward_ranking(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        negative_baseline = variant_result(
+            "baseline",
+            [
+                start,
+                tick(2, [room("W1N1", spawns=0, creeps=0, energy=0, claimed=True)]),
+            ],
+        )
+        failed_candidate = variant_result("candidate", [])
+        failed_candidate["ok"] = False
+        failed_candidate["error"] = "simulator failed"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, base_card())
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="failed-run-excluded",
+                simulator_runner=MockSimulator({"baseline": negative_baseline, "candidate": failed_candidate}),
+            )
+
+        candidate_result = next(result for result in report["variantResults"] if result["variantId"] == "candidate")
+        self.assertEqual(candidate_result["sampleCount"], 0)
+        self.assertEqual(candidate_result["excludedRunCount"], 1)
+        self.assertEqual(candidate_result["reward"]["samples"], [])
+        self.assertEqual([item["variantId"] for item in report["ranking"]], ["baseline"])
+        self.assertNotIn("candidate", report["statisticalComparison"]["componentMeans"])
+        self.assertTrue(any("excluded 1 failed simulator run" in warning for warning in report["warnings"]))
+
     def test_json_report_output_format_is_shadow_report_compatible(self) -> None:
         start = tick(1, [room("W1N1", energy=100, spawn_status="idle")])
         baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200, spawn_status="spawning")])])

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -289,6 +291,28 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(list(registry), ["candidate"])
         self.assertEqual(registry["candidate"].parameters["expansion_aggressiveness"], 1)
 
+    def test_strategy_registry_loader_preserves_comment_markers_inside_strings(self) -> None:
+        registry_text = """
+export const STRATEGY_REGISTRY = [
+  {
+    id: 'candidate',
+    title: 'https://planner.example/variants/*literal*/',
+    defaultValues: {
+      construction_priority: 'https://planner.example/queues',
+      defense_posture: 'hold /* literal comment marker */',
+    },
+  },
+];
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "strategyRegistry.ts"
+            registry_path.write_text(registry_text, encoding="utf-8")
+            registry = runner.load_strategy_registry(registry_path)
+
+        self.assertEqual(registry["candidate"].title, "https://planner.example/variants/*literal*/")
+        self.assertEqual(registry["candidate"].parameters["construction_priority"], "https://planner.example/queues")
+        self.assertEqual(registry["candidate"].parameters["defense_posture"], "hold /* literal comment marker */")
+
     def test_variant_ranking_uses_resources_when_territory_ties(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         lower_resource = variant_result("baseline", [start, tick(2, [room("W1N1", energy=300, harvested=100)])])
@@ -446,6 +470,33 @@ export const STRATEGY_REGISTRY = [
                 )
 
             self.assertFalse((out_dir / "unsafe-flags.json").exists())
+
+    def test_final_report_secret_scan_includes_steam_key_variant_errors(self) -> None:
+        secret = "steam-secret-token-123456"
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        failed_candidate = variant_result("candidate", [])
+        failed_candidate["ok"] = False
+        failed_candidate["error"] = f"simulator echoed {secret}"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, base_card())
+            with (
+                mock.patch.dict(os.environ, {"STEAM_KEY": secret}),
+                mock.patch.object(runner.dataset_export, "configured_secret_values", return_value=[]),
+                self.assertRaisesRegex(RuntimeError, "configured secret"),
+            ):
+                runner.run_training_experiment(
+                    card_path,
+                    out_dir,
+                    report_id="steam-key-error-leak",
+                    simulator_runner=MockSimulator({"baseline": baseline, "candidate": failed_candidate}),
+                )
+
+            self.assertFalse((out_dir / "steam-key-error-leak.json").exists())
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -259,6 +259,36 @@ strategy_variants:
         self.assertEqual(variants[0].parameters["construction_priority"], "balanced")
         self.assertEqual(config.ticks, 5)
 
+    def test_strategy_registry_loader_ignores_commented_entries(self) -> None:
+        registry_text = """
+export const STRATEGY_REGISTRY = [
+  // { id: 'commented-line', defaultValues: { expansion_aggressiveness: 9 } },
+  {
+    id: 'candidate',
+    family: 'test-family',
+    rolloutStatus: 'shadow',
+    title: 'Candidate',
+    defaultValues: {
+      expansion_aggressiveness: 1,
+      worker_allocation_ratio: 0.5,
+    },
+  },
+  /*
+  {
+    id: 'commented-block',
+    defaultValues: { expansion_aggressiveness: 10 },
+  },
+  */
+];
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry_path = Path(temp_dir) / "strategyRegistry.ts"
+            registry_path.write_text(registry_text, encoding="utf-8")
+            registry = runner.load_strategy_registry(registry_path)
+
+        self.assertEqual(list(registry), ["candidate"])
+        self.assertEqual(registry["candidate"].parameters["expansion_aggressiveness"], 1)
+
     def test_variant_ranking_uses_resources_when_territory_ties(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         lower_resource = variant_result("baseline", [start, tick(2, [room("W1N1", energy=300, harvested=100)])])
@@ -311,6 +341,51 @@ strategy_variants:
         self.assertTrue(str(report["reportPath"]).endswith("reports/format-check.json"))
         self.assertEqual(simulator.calls[0]["ticks"], 2)
         self.assertEqual(simulator.calls[0]["variants"], ["baseline", "candidate"])
+
+    def test_report_id_with_dots_is_normalized_for_simulator_run_id(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250)])])
+        simulator = MockSimulator({"baseline": baseline, "candidate": candidate})
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, base_card())
+            runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="rl.exp.with.dots",
+                simulator_runner=simulator,
+            )
+
+        self.assertEqual(simulator.calls[0]["run_id"], "rl_exp_with_dots")
+
+    def test_unsafe_simulator_flags_fail_before_report_is_persisted(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200)])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250)])])
+
+        class UnsafeSimulator(MockSimulator):
+            def __call__(self, **kwargs: Any) -> JsonObject:
+                result = super().__call__(**kwargs)
+                result["liveEffect"] = True
+                return result
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, base_card())
+            with self.assertRaisesRegex(RuntimeError, "liveEffect=true"):
+                runner.run_training_experiment(
+                    card_path,
+                    out_dir,
+                    report_id="unsafe-flags",
+                    simulator_runner=UnsafeSimulator({"baseline": baseline, "candidate": candidate}),
+                )
+
+            self.assertFalse((out_dir / "unsafe-flags.json").exists())
 
 
 if __name__ == "__main__":

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import screeps_rl_training_runner as runner
+
+
+JsonObject = dict[str, Any]
+
+
+def write_json(path: Path, payload: JsonObject) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def read_json(path: Path) -> JsonObject:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def base_card(variant_ids: list[str] | None = None) -> JsonObject:
+    ids = variant_ids or ["baseline", "candidate"]
+    return {
+        "card_id": "rl-exp-test-000000000000",
+        "dataset_run_id": "rl-test-dataset",
+        "code_commit": "a" * 40,
+        "created_at": "2026-05-03T00:00:00Z",
+        "status": "shadow",
+        "training_approach": "bandit",
+        "safety": {
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "officialMmoWritesAllowed": False,
+            "ood_rejection": True,
+            "conservative_actions_only": True,
+        },
+        "reward_model": {
+            "type": "lexicographic",
+            "component_order": ["territory", "resources", "kills"],
+            "component_weights": {
+                "territory": 1000000,
+                "resources": 1000,
+                "kills": 1,
+            },
+            "resource_normalizer": 1000,
+            "scalar_weighted_sum_authorized": False,
+        },
+        "simulation": {
+            "ticks": 2,
+            "workers": 1,
+            "room": "W1N1",
+            "shard": "shardX",
+            "branch": "activeWorld",
+            "code_path": "prod/dist/main.js",
+            "map_source_file": "/root/screeps/maps/map-0b6758af.json",
+            "simulator_out_dir": "runtime-artifacts/rl-simulator-test",
+        },
+        "strategy_variants": [
+            {
+                "id": variant_id,
+                "rolloutStatus": "incumbent" if index == 0 else "shadow",
+                "family": "test-family",
+                "parameters": {
+                    "expansion_aggressiveness": index,
+                    "worker_allocation_ratio": 0.5,
+                    "construction_priority": "balanced",
+                    "defense_posture": "hold",
+                },
+            }
+            for index, variant_id in enumerate(ids)
+        ],
+    }
+
+
+def room(
+    room_name: str,
+    *,
+    spawns: int = 1,
+    creeps: int = 3,
+    energy: int = 100,
+    rcl: int = 1,
+    claimed: bool = True,
+    harvested: int = 0,
+    hostile_kills: int = 0,
+    own_losses: int = 0,
+    spawn_status: str | None = None,
+) -> JsonObject:
+    payload: JsonObject = {
+        "roomName": room_name,
+        "controller": {"level": rcl, "my": claimed},
+        "structures": {"spawn": spawns},
+        "creeps": creeps,
+        "resources": {
+            "storedEnergy": energy,
+            "events": {"harvestedEnergy": harvested},
+        },
+        "combat": {
+            "events": {
+                "hostileCreepDestroyedCount": hostile_kills,
+                "ownCreepDestroyedCount": own_losses,
+            }
+        },
+    }
+    if spawn_status is not None:
+        payload["spawnStatus"] = [{"name": "Spawn1", "status": spawn_status}]
+    return payload
+
+
+def tick(tick_number: int, rooms: list[JsonObject]) -> JsonObject:
+    return {
+        "tick": tick_number,
+        "rooms": {str(room_payload["roomName"]): room_payload for room_payload in rooms},
+    }
+
+
+def variant_result(variant_id: str, ticks: list[JsonObject]) -> JsonObject:
+    return {
+        "variant_id": variant_id,
+        "variant_run_id": f"run-{variant_id}",
+        "ticks_run": len(ticks),
+        "wall_clock_seconds": 0.01,
+        "ok": True,
+        "tick_log": ticks,
+    }
+
+
+class MockSimulator:
+    def __init__(self, results_by_variant: dict[str, JsonObject]) -> None:
+        self.results_by_variant = results_by_variant
+        self.calls: list[JsonObject] = []
+
+    def __call__(self, **kwargs: Any) -> JsonObject:
+        self.calls.append(dict(kwargs))
+        return {
+            "type": "screeps-rl-simulator-run",
+            "runId": kwargs["run_id"],
+            "liveEffect": False,
+            "officialMmoWrites": False,
+            "variants": [self.results_by_variant[variant_id] for variant_id in kwargs["variants"]],
+        }
+
+
+class RlTrainingRunnerTest(unittest.TestCase):
+    def test_lexicographic_reward_makes_territory_win_beat_resource_win(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        resource_win = variant_result(
+            "baseline",
+            [
+                start,
+                tick(2, [room("W1N1", energy=12000, harvested=9000)]),
+            ],
+        )
+        territory_win = variant_result(
+            "candidate",
+            [
+                start,
+                tick(2, [room("W1N1", energy=50), room("W1N2", energy=50)]),
+            ],
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, base_card())
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="territory-beats-resources",
+                simulator_runner=MockSimulator({"baseline": resource_win, "candidate": territory_win}),
+            )
+
+        self.assertEqual(report["ranking"][0]["variantId"], "candidate")
+        self.assertEqual(report["variantResults"][1]["reward"]["tuple"][0], 1)
+        self.assertGreater(report["variantResults"][0]["reward"]["tuple"][1], report["variantResults"][1]["reward"]["tuple"][1])
+        comparison = report["statisticalComparison"]["pairwise"][0]
+        self.assertEqual(comparison["winner"], "candidate")
+        self.assertEqual(comparison["firstDifferingTier"], "territory")
+
+    def test_expansion_survival_marks_claimed_but_collapsed_room_as_loss(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        collapsed_expansion = variant_result(
+            "candidate",
+            [
+                start,
+                tick(
+                    2,
+                    [
+                        room("W1N1", energy=100),
+                        room("W1N2", spawns=0, creeps=0, energy=0, claimed=True),
+                    ],
+                ),
+            ],
+        )
+        metrics = runner.compute_run_metrics(collapsed_expansion, {"resourceNormalizer": 1000})
+
+        self.assertEqual(metrics["territory"]["delta"], -1)
+        self.assertEqual(metrics["territory"]["roomsLost"], 1)
+        self.assertEqual(metrics["territory"]["collapsedClaimedRooms"], ["W1N2"])
+        self.assertEqual(metrics["rewardTuple"][0], -1)
+
+    def test_experiment_card_loading_and_validation_accepts_yaml_inline_variants(self) -> None:
+        yaml_text = """
+card_id: rl-exp-yaml-000000000000
+dataset_run_id: rl-yaml-dataset
+code_commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+created_at: "2026-05-03T00:00:00Z"
+status: shadow
+training_approach: bandit
+safety:
+  liveEffect: false
+  officialMmoWrites: false
+  officialMmoWritesAllowed: false
+  ood_rejection: true
+  conservative_actions_only: true
+reward_model:
+  type: lexicographic
+  component_order:
+    - territory
+    - resources
+    - kills
+  scalar_weighted_sum_authorized: false
+simulation:
+  ticks: 5
+  workers: 1
+  repetitions: 1
+  room: W1N1
+strategy_variants:
+  - id: yaml-baseline
+    rolloutStatus: incumbent
+    parameters:
+      expansion_aggressiveness: 0.4
+      worker_allocation_ratio: 0.6
+      construction_priority: balanced
+      defense_posture: hold
+  - id: yaml-candidate
+    rolloutStatus: shadow
+    parameters:
+      expansion_aggressiveness: 0.7
+      worker_allocation_ratio: 0.5
+      construction_priority: territory
+      defense_posture: hold
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            card_path = Path(temp_dir) / "card.yaml"
+            card_path.write_text(yaml_text, encoding="utf-8")
+            card = runner.load_experiment_card(card_path)
+            variants = runner.load_strategy_variants(card, registry_path=Path(temp_dir) / "missing-registry.ts")
+            config = runner.simulation_config_from_card(card)
+
+        self.assertEqual(card["status"], "shadow")
+        self.assertEqual([variant.id for variant in variants], ["yaml-baseline", "yaml-candidate"])
+        self.assertEqual(variants[0].parameters["construction_priority"], "balanced")
+        self.assertEqual(config.ticks, 5)
+
+    def test_variant_ranking_uses_resources_when_territory_ties(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        lower_resource = variant_result("baseline", [start, tick(2, [room("W1N1", energy=300, harvested=100)])])
+        higher_resource = variant_result("candidate", [start, tick(2, [room("W1N1", energy=900, harvested=100)])])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, base_card())
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="resource-tiebreak",
+                simulator_runner=MockSimulator({"baseline": lower_resource, "candidate": higher_resource}),
+            )
+
+        self.assertEqual(report["ranking"][0]["variantId"], "candidate")
+        self.assertEqual(report["ranking"][0]["rewardTuple"][0], 0)
+        self.assertEqual(report["statisticalComparison"]["pairwise"][0]["firstDifferingTier"], "resources")
+
+    def test_json_report_output_format_is_shadow_report_compatible(self) -> None:
+        start = tick(1, [room("W1N1", energy=100, spawn_status="idle")])
+        baseline = variant_result("baseline", [start, tick(2, [room("W1N1", energy=200, spawn_status="spawning")])])
+        candidate = variant_result("candidate", [start, tick(2, [room("W1N1", energy=250, hostile_kills=2)])])
+        simulator = MockSimulator({"baseline": baseline, "candidate": candidate})
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            out_dir = root / "reports"
+            write_json(card_path, base_card())
+            report = runner.run_training_experiment(
+                card_path,
+                out_dir,
+                report_id="format-check",
+                simulator_runner=simulator,
+            )
+            persisted = read_json(out_dir / "format-check.json")
+
+        self.assertEqual(persisted["type"], "screeps-rl-training-report")
+        self.assertEqual(persisted["schemaVersion"], 1)
+        self.assertFalse(persisted["liveEffect"])
+        self.assertFalse(persisted["officialMmoWrites"])
+        self.assertFalse(persisted["safety"]["liveApiCalls"])
+        self.assertEqual(persisted["candidateStrategyIds"], ["baseline", "candidate"])
+        self.assertEqual(persisted["incumbentStrategyIds"], ["baseline"])
+        self.assertIn("modelReports", persisted)
+        self.assertIn("kpiSummary", persisted)
+        self.assertIn("statisticalComparison", persisted)
+        self.assertTrue(str(report["reportPath"]).endswith("reports/format-check.json"))
+        self.assertEqual(simulator.calls[0]["ticks"], 2)
+        self.assertEqual(simulator.calls[0]["variants"], ["baseline", "candidate"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_screeps_rl_training_runner.py
+++ b/scripts/test_screeps_rl_training_runner.py
@@ -309,6 +309,34 @@ export const STRATEGY_REGISTRY = [
         self.assertEqual(report["ranking"][0]["rewardTuple"][0], 0)
         self.assertEqual(report["statisticalComparison"]["pairwise"][0]["firstDifferingTier"], "resources")
 
+    def test_equal_reward_tuple_does_not_count_as_top_change(self) -> None:
+        start = tick(1, [room("W1N1", energy=100)])
+        finish = tick(2, [room("W1N1", energy=300, harvested=100)])
+        baseline = variant_result("baseline", [start, finish])
+        candidate = variant_result("candidate", [start, finish])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            card_path = root / "card.json"
+            write_json(card_path, base_card())
+            report = runner.run_training_experiment(
+                card_path,
+                root / "reports",
+                report_id="equal-reward-tie",
+                simulator_runner=MockSimulator({"baseline": baseline, "candidate": candidate}),
+            )
+
+        self.assertEqual(report["ranking"][0]["variantId"], "candidate")
+        self.assertEqual([item["rank"] for item in report["ranking"]], [1, 1])
+        self.assertIsNone(report["statisticalComparison"]["pairwise"][0]["winner"])
+        self.assertEqual(report["changedTopCount"], 0)
+        self.assertEqual(report["rankingDiffCount"], 0)
+
+        model_report = next(item for item in report["modelReports"] if item["candidateStrategyId"] == "candidate")
+        self.assertEqual(model_report["changedTopCount"], 0)
+        self.assertFalse(model_report["rankingDiffs"][0]["changedTop"])
+        self.assertEqual(runner.build_generation_summary(report)["changedTopCount"], 0)
+
     def test_failed_variant_runs_are_excluded_from_reward_ranking(self) -> None:
         start = tick(1, [room("W1N1", energy=100)])
         negative_baseline = variant_result(


### PR DESCRIPTION
## Summary
Updates RL domain roadmap and training reward workflow documentation, and adds the RL training runner script with tests.

## Changes
- `docs/ops/rl-domain-roadmap.md`: Updated RL strategy flywheel roadmap entries
- `docs/ops/rl-training-reward-workflow.md`: Expanded training reward workflow specifications
- `scripts/screeps_rl_training_runner.py`: New RL training runner script
- `scripts/test_screeps_rl_training_runner.py`: New tests for the training runner

Part of #549
