### PR TITLE
feat(telemetry): emit behavior telemetry (idle/stuck/move/work ticks) in runtime summary console output (#528)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -11216,6 +11216,7 @@ var BEHAVIOR_COUNTER_KEYS = [
   { key: "containerTransfers" },
   { key: "pathLength" }
 ];
+var TOP_IDLE_WORKER_COUNT = 3;
 function observeCreepBehaviorTick(creep, tick = getGameTime7()) {
   var _a, _b;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -11282,7 +11283,8 @@ function summarizeAndResetCreepBehaviorTelemetry(workers) {
   return {
     behavior: {
       creeps: creepSummaries,
-      totals: summarizeBehaviorTotals(creepSummaries)
+      totals: summarizeBehaviorTotals(creepSummaries),
+      ...summarizeTopIdleWorkers(creepSummaries)
     }
   };
 }
@@ -11346,9 +11348,16 @@ function summarizeBehaviorTotals(creeps) {
     }
   );
 }
+function summarizeTopIdleWorkers(creeps) {
+  const topIdleWorkers = creeps.filter((creep) => creep.idleTicks > 0).sort(compareRuntimeIdleWorkerSummaries).slice(0, TOP_IDLE_WORKER_COUNT);
+  return topIdleWorkers.length > 0 ? { topIdleWorkers } : {};
+}
 function compareRuntimeCreepBehaviorSummaries(left, right) {
   var _a, _b;
   return ((_a = left.creepName) != null ? _a : "").localeCompare((_b = right.creepName) != null ? _b : "");
+}
+function compareRuntimeIdleWorkerSummaries(left, right) {
+  return right.idleTicks - left.idleTicks || compareRuntimeCreepBehaviorSummaries(left, right);
 }
 function buildCreepNameSummary(creep) {
   const name = creep.name;

--- a/prod/src/telemetry/behaviorTelemetry.ts
+++ b/prod/src/telemetry/behaviorTelemetry.ts
@@ -12,6 +12,7 @@ export interface RuntimeCreepBehaviorSummary {
 export interface RuntimeBehaviorSummary {
   creeps: RuntimeCreepBehaviorSummary[];
   totals: RuntimeBehaviorTotals;
+  topIdleWorkers?: RuntimeCreepBehaviorSummary[];
 }
 
 interface RuntimeBehaviorTotals {
@@ -38,6 +39,7 @@ const BEHAVIOR_COUNTER_KEYS: CreepBehaviorCounterKey[] = [
   { key: 'containerTransfers' },
   { key: 'pathLength' }
 ];
+const TOP_IDLE_WORKER_COUNT = 3;
 
 export function observeCreepBehaviorTick(creep: Creep, tick: number = getGameTime()): void {
   const telemetry = ensureCreepBehaviorTelemetry(creep);
@@ -117,7 +119,8 @@ export function summarizeAndResetCreepBehaviorTelemetry(workers: Creep[]): { beh
   return {
     behavior: {
       creeps: creepSummaries,
-      totals: summarizeBehaviorTotals(creepSummaries)
+      totals: summarizeBehaviorTotals(creepSummaries),
+      ...summarizeTopIdleWorkers(creepSummaries)
     }
   };
 }
@@ -196,11 +199,29 @@ function summarizeBehaviorTotals(creeps: RuntimeCreepBehaviorSummary[]): Runtime
   );
 }
 
+function summarizeTopIdleWorkers(
+  creeps: RuntimeCreepBehaviorSummary[]
+): { topIdleWorkers?: RuntimeCreepBehaviorSummary[] } {
+  const topIdleWorkers = creeps
+    .filter((creep) => creep.idleTicks > 0)
+    .sort(compareRuntimeIdleWorkerSummaries)
+    .slice(0, TOP_IDLE_WORKER_COUNT);
+
+  return topIdleWorkers.length > 0 ? { topIdleWorkers } : {};
+}
+
 function compareRuntimeCreepBehaviorSummaries(
   left: RuntimeCreepBehaviorSummary,
   right: RuntimeCreepBehaviorSummary
 ): number {
   return (left.creepName ?? '').localeCompare(right.creepName ?? '');
+}
+
+function compareRuntimeIdleWorkerSummaries(
+  left: RuntimeCreepBehaviorSummary,
+  right: RuntimeCreepBehaviorSummary
+): number {
+  return right.idleTicks - left.idleTicks || compareRuntimeCreepBehaviorSummaries(left, right);
 }
 
 function buildCreepNameSummary(creep: Creep): { creepName?: string } {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -234,6 +234,7 @@ interface RuntimeBehaviorSummary {
   workerTaskPolicy?: RuntimeWorkerTaskBehaviorSummary;
   creeps?: RuntimeCreepBehaviorSummary[];
   totals?: RuntimeBehaviorTotals;
+  topIdleWorkers?: RuntimeCreepBehaviorSummary[];
 }
 
 interface RuntimeCreepBehaviorSummary {

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -6,6 +6,7 @@ import {
   shouldEmitRuntimeSummary,
   type RuntimeTelemetryEvent
 } from '../src/telemetry/runtimeSummary';
+import { recordCreepBehaviorIdle } from '../src/telemetry/behaviorTelemetry';
 import { CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD } from '../src/tasks/workerTasks';
 
 const TEST_GLOBALS = {
@@ -257,13 +258,67 @@ describe('runtime telemetry summaries', () => {
         stuckTicks: 1,
         containerTransfers: 1,
         pathLength: 2
-      }
+      },
+      topIdleWorkers: [
+        {
+          creepName: 'RepairWorker',
+          idleTicks: 1,
+          moveTicks: 3,
+          workTicks: 2,
+          stuckTicks: 1,
+          containerTransfers: 1,
+          pathLength: 2,
+          repairTargetId: 'road-damaged'
+        }
+      ]
     });
     expect(worker.memory.behaviorTelemetry).toEqual({
       lastPosition: { x: 10, y: 12, roomName: 'W1N1' },
       lastMoveTick: RUNTIME_SUMMARY_INTERVAL,
       lastObservedTick: RUNTIME_SUMMARY_INTERVAL
     });
+  });
+
+  it('populates behavior summary after simulateWorkerIdle and reports the top idle workers', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    const workers = [
+      makeWorker({ role: 'worker', colony: 'W1N1' }, 0, 'IdleA'),
+      makeWorker({ role: 'worker', colony: 'W1N1' }, 0, 'IdleB'),
+      makeWorker({ role: 'worker', colony: 'W1N1' }, 0, 'IdleC'),
+      makeWorker({ role: 'worker', colony: 'W1N1' }, 0, 'IdleD')
+    ];
+
+    simulateWorkerIdle(workers[0], 4);
+    simulateWorkerIdle(workers[1], 2);
+    simulateWorkerIdle(workers[2], 3);
+    simulateWorkerIdle(workers[3], 1);
+
+    emitRuntimeSummary([colony], workers);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.behavior).toEqual({
+      creeps: [
+        makeIdleBehaviorSummary('IdleA', 4),
+        makeIdleBehaviorSummary('IdleB', 2),
+        makeIdleBehaviorSummary('IdleC', 3),
+        makeIdleBehaviorSummary('IdleD', 1)
+      ],
+      totals: {
+        idleTicks: 10,
+        moveTicks: 0,
+        workTicks: 0,
+        stuckTicks: 0,
+        containerTransfers: 0,
+        pathLength: 0
+      },
+      topIdleWorkers: [
+        makeIdleBehaviorSummary('IdleA', 4),
+        makeIdleBehaviorSummary('IdleC', 3),
+        makeIdleBehaviorSummary('IdleB', 2)
+      ]
+    });
+    expect(workers.map((worker) => worker.memory.behaviorTelemetry)).toEqual([undefined, undefined, undefined, undefined]);
   });
 
   it('reports cadence structure snapshots with defenses, containers, repairs, and road coverage', () => {
@@ -1160,6 +1215,24 @@ describe('runtime telemetry summaries', () => {
     return JSON.parse((message as string).slice(RUNTIME_SUMMARY_PREFIX.length)) as Record<string, unknown>;
   }
 });
+
+function simulateWorkerIdle(worker: Creep, idleTicks: number): void {
+  for (let tick = 1; tick <= idleTicks; tick += 1) {
+    recordCreepBehaviorIdle(worker, tick);
+  }
+}
+
+function makeIdleBehaviorSummary(creepName: string, idleTicks: number): Record<string, unknown> {
+  return {
+    creepName,
+    idleTicks,
+    moveTicks: 0,
+    workTicks: 0,
+    stuckTicks: 0,
+    containerTransfers: 0,
+    pathLength: 0
+  };
+}
 
 function installRuntimeTelemetryGlobals(): void {
   const globals = globalThis as Record<string, unknown>;


### PR DESCRIPTION
## Summary
Instruments behavior telemetry in the #runtime-summary console output so idle/stuck/move/work ticks are visible in runtime monitoring.

## Changes
- `prod/src/telemetry/behaviorTelemetry.ts`: Added top-N idle worker summary export
- `prod/src/telemetry/runtimeSummary.ts`: Wire behavior summary into console emission
- `prod/test/runtimeSummary.test.ts`: Tests for behavior telemetry in runtime summary
- `prod/dist/main.js`: Regenerated build artifact

## Verification
- `npm run typecheck`: PASS
- `npm test -- --runInBand`: 41 suites / 948 tests PASS
- `npm run build`: OK, dist/main.js regenerated

## Linked issue
Closes #528

## Roadmap category
roadmap:phase-c-telemetry / kind:code