### PR TITLE
feat(territory): prioritize spawn construction and RCL acceleration in claimed rooms

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -6975,6 +6975,7 @@ var CRITICAL_REPAIR_HITS_RATIO = 0.5;
 var DECAYING_REPAIR_HITS_RATIO = 0.8;
 var IDLE_RAMPART_REPAIR_HITS_CEILING = 1e5;
 var CONSTRUCTION_SITE_IMPACT_PRIORITY = {
+  claimedRoomSpawn: 110,
   extension: 100,
   spawn: 95,
   tower: 90,
@@ -7091,7 +7092,7 @@ function getConstructionSiteImpactPriority(site, context = {}) {
     return CONSTRUCTION_SITE_IMPACT_PRIORITY.extension;
   }
   if (matchesStructureType5(site.structureType, "STRUCTURE_SPAWN", "spawn")) {
-    return CONSTRUCTION_SITE_IMPACT_PRIORITY.spawn;
+    return isClaimedRoomConstructionSite(site, context) ? CONSTRUCTION_SITE_IMPACT_PRIORITY.claimedRoomSpawn : CONSTRUCTION_SITE_IMPACT_PRIORITY.spawn;
   }
   if (matchesStructureType5(site.structureType, "STRUCTURE_CONTAINER", "container")) {
     return isSourceContainerConstructionSite(site, context) ? CONSTRUCTION_SITE_IMPACT_PRIORITY.sourceContainer : CONSTRUCTION_SITE_IMPACT_PRIORITY.container;
@@ -7125,6 +7126,14 @@ function isSourceContainerConstructionSite(site, context) {
     return false;
   }
   return context.sources.some((source) => isNearRoomObject(source, sitePosition));
+}
+function isClaimedRoomConstructionSite(site, context) {
+  var _a;
+  const siteRoom = site.room;
+  if (((_a = siteRoom == null ? void 0 : siteRoom.controller) == null ? void 0 : _a.my) === true) {
+    return true;
+  }
+  return context.claimedRoomName !== void 0 && isSameRoomPosition4(getRoomObjectPosition2(site), context.claimedRoomName);
 }
 function isProtectedRampartConstructionSite(site, context) {
   const sitePosition = getRoomObjectPosition2(site);
@@ -9281,7 +9290,8 @@ function selectUnreservedConstructionSite(creep, constructionSites, construction
   );
 }
 function buildWorkerConstructionSiteImpactPriorityContext(creep, constructionSites) {
-  const context = {};
+  var _a;
+  const context = ((_a = creep.room.controller) == null ? void 0 : _a.my) === true ? { claimedRoomName: creep.room.name } : {};
   if (constructionSites.some(isRoadConstructionSite2)) {
     context.criticalRoadContext = buildWorkerCriticalRoadLogisticsContext(creep);
   }
@@ -12697,6 +12707,7 @@ function isNonEmptyString8(value) {
 // src/territory/multiRoomUpgrader.ts
 var MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO = 0.8;
 var MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP = 1;
+var SPAWN_CONSTRUCTION_UPGRADER_CAP_BONUS = 1;
 var REMOTE_UPGRADER_PATTERN = ["work", "carry", "move"];
 var REMOTE_UPGRADER_TRAVEL_PATTERN = ["work", "carry", "move", "move"];
 var RESERVED_CONTROLLER_BASE_BODY = ["claim", "move"];
@@ -12790,7 +12801,7 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
       homeRoom,
       ownerUsername,
       room,
-      config.perRoomUpgraderCap,
+      config,
       activeUpgraderCounts,
       order
     );
@@ -12801,7 +12812,7 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
   }
   return candidates;
 }
-function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, perRoomUpgraderCap, activeUpgraderCounts, order) {
+function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, config, activeUpgraderCounts, order) {
   var _a;
   if (!isNonEmptyString9(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
     return null;
@@ -12822,6 +12833,7 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, perR
     return null;
   }
   const activeUpgraderCount = (_a = activeUpgraderCounts[room.name]) != null ? _a : 0;
+  const perRoomUpgraderCap = getEffectivePerRoomUpgraderCap(room, config);
   if (activeUpgraderCount >= perRoomUpgraderCap) {
     return null;
   }
@@ -12869,6 +12881,45 @@ function normalizeRatio(value, fallback) {
 }
 function normalizePerRoomCap(value) {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP;
+}
+function getEffectivePerRoomUpgraderCap(room, config) {
+  return hasActiveClaimedRoomSpawnConstructionSite(room) ? config.perRoomUpgraderCap + SPAWN_CONSTRUCTION_UPGRADER_CAP_BONUS : config.perRoomUpgraderCap;
+}
+function hasActiveClaimedRoomSpawnConstructionSite(room) {
+  var _a;
+  if (((_a = room.controller) == null ? void 0 : _a.my) !== true || typeof room.find !== "function") {
+    return false;
+  }
+  const findConstant = getFindConstant4("FIND_MY_CONSTRUCTION_SITES");
+  if (findConstant === null) {
+    return false;
+  }
+  try {
+    const sites = room.find(findConstant);
+    return Array.isArray(sites) && sites.some(isActiveSpawnConstructionSite);
+  } catch {
+    return false;
+  }
+}
+function isActiveSpawnConstructionSite(site) {
+  return isRecord9(site) && matchesStructureType8(site.structureType, "STRUCTURE_SPAWN", "spawn") && hasIncompleteConstructionSiteProgress(site);
+}
+function hasIncompleteConstructionSiteProgress(site) {
+  const progress = site.progress;
+  const progressTotal = site.progressTotal;
+  if (typeof progress !== "number" || typeof progressTotal !== "number" || !Number.isFinite(progress) || !Number.isFinite(progressTotal)) {
+    return true;
+  }
+  return progress < progressTotal;
+}
+function getFindConstant4(constantName) {
+  const findConstant = globalThis[constantName];
+  return typeof findConstant === "number" ? findConstant : null;
+}
+function matchesStructureType8(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return typeof actual === "string" && actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 function getRemoteUpgraderPattern(routeDistance) {
   return typeof routeDistance === "number" && routeDistance > 1 ? REMOTE_UPGRADER_TRAVEL_PATTERN : REMOTE_UPGRADER_PATTERN;
@@ -13806,15 +13857,15 @@ function buildUnseenExpansionCandidateEvidence(roomName) {
 }
 function buildVisibleExpansionCandidateEvidence(room) {
   const controller = room.controller;
-  const sources = findRoomObjects7(room, getFindConstant4("FIND_SOURCES"));
+  const sources = findRoomObjects7(room, getFindConstant5("FIND_SOURCES"));
   const controllerSourceRange = calculateAverageControllerSourceRange(controller, sources);
   const roomTerrain = getRoomTerrain4(room);
   const terrain = summarizeRoomTerrainFromTerrain(roomTerrain);
   const sourceAccessPoints = calculateAverageSourceAccessPoints(roomTerrain, sources);
-  const hostileCreepCount = findRoomObjects7(room, getFindConstant4("FIND_HOSTILE_CREEPS")).length;
+  const hostileCreepCount = findRoomObjects7(room, getFindConstant5("FIND_HOSTILE_CREEPS")).length;
   const hostileStructureCount = findRoomObjects7(
     room,
-    getFindConstant4("FIND_HOSTILE_STRUCTURES")
+    getFindConstant5("FIND_HOSTILE_STRUCTURES")
   ).length;
   return {
     visible: true,
@@ -14501,7 +14552,7 @@ function findRoomObjects7(room, findConstant) {
     return [];
   }
 }
-function getFindConstant4(name) {
+function getFindConstant5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -14661,6 +14712,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
         workerTarget,
         spawnCount
       });
+      recordSpawnSitePlacedTelemetry(record, spawnSite, OK_CODE5, telemetryEvents, true);
     }
     return { active: true, spawnConstructionPending: true };
   }
@@ -14687,6 +14739,9 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
       workerTarget,
       spawnCount
     });
+    if (sitePlan.result === OK_CODE5 && sitePlan.position) {
+      recordSpawnSitePlacedTelemetry(record, sitePlan.position, sitePlan.result, telemetryEvents);
+    }
   }
   return { active: true, spawnConstructionPending: true };
 }
@@ -14729,6 +14784,17 @@ function getPostClaimBootstrapSummary(roomName) {
     ...record.spawnSite ? { spawnSite: record.spawnSite } : {},
     ...record.lastResult !== void 0 ? { lastResult: record.lastResult } : {}
   };
+}
+function recordSpawnSitePlacedTelemetry(record, spawnSite, result, telemetryEvents, existing = false) {
+  telemetryEvents.push({
+    type: "spawnSitePlaced",
+    roomName: record.roomName,
+    colony: record.colony,
+    ...record.controllerId ? { controllerId: record.controllerId } : {},
+    result,
+    spawnSite,
+    ...existing ? { existing } : {}
+  });
 }
 function planInitialSpawnConstructionSite(room) {
   if (typeof room.createConstructionSite !== "function") {
@@ -14853,7 +14919,7 @@ function findExistingSpawnConstructionSite(room) {
     return null;
   }
   const sites = room.find(findConstant, {
-    filter: (site) => matchesStructureType8(site.structureType, "STRUCTURE_SPAWN", "spawn")
+    filter: (site) => matchesStructureType9(site.structureType, "STRUCTURE_SPAWN", "spawn")
   });
   return (_a = sites[0]) != null ? _a : null;
 }
@@ -14958,7 +15024,7 @@ function getRoomTerrain5(roomName) {
 function getTerrainWallMask5() {
   return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK5;
 }
-function matchesStructureType8(actual, globalName, fallback) {
+function matchesStructureType9(actual, globalName, fallback) {
   return actual === getStructureConstant(globalName, fallback);
 }
 function getStructureConstant(globalName, fallback) {
@@ -15364,7 +15430,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord13(structure) && matchesStructureType9(structure.structureType, globalName, fallback);
+  return isRecord13(structure) && matchesStructureType10(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -15689,10 +15755,10 @@ function getRepairBacklogHits(structure) {
   return Math.max(0, Math.ceil(repairCeiling - hits));
 }
 function isObservableRepairBacklogStructure(structure) {
-  return matchesStructureType9(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType9(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
+  return matchesStructureType10(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType10(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
 }
 function isObservedOwnedRampart(structure) {
-  return matchesStructureType9(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
+  return matchesStructureType10(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
 }
 function buildControllerProgressRemaining(room) {
   const controller = room.controller;
@@ -15968,7 +16034,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord13(structure) && (matchesStructureType9(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType9(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord13(structure) && (matchesStructureType10(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType10(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -16058,7 +16124,7 @@ function getGlobalNumber5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function matchesStructureType9(value, globalName, fallback) {
+function matchesStructureType10(value, globalName, fallback) {
   var _a;
   const expectedValue = (_a = globalThis[globalName]) != null ? _a : fallback;
   return value === expectedValue;
@@ -16324,7 +16390,7 @@ function buildEnergyDemandState(room) {
 }
 function findSpawnExtensionRefillTargets(room) {
   const structures = findOwnedStructures3(room).filter(
-    (structure) => (matchesStructureType10(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType10(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity5(structure) > 0
+    (structure) => (matchesStructureType11(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType11(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity5(structure) > 0
   );
   if (!isRoomSpawnExtensionEnergyLow(room, structures)) {
     return [];
@@ -16338,7 +16404,7 @@ function findSpawnExtensionRefillTargets(room) {
 }
 function findTowerRefillTargets(room) {
   return findOwnedStructures3(room).filter(
-    (structure) => matchesStructureType10(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy8(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity5(structure) > 0
+    (structure) => matchesStructureType11(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy8(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity5(structure) > 0
   ).map((target) => ({
     freeCapacity: getFreeEnergyCapacity5(target),
     id: getObjectId4(target),
@@ -16538,7 +16604,7 @@ function getRoomStorage(room) {
     return room.storage;
   }
   return (_a = findOwnedStructures3(room).filter(
-    (structure) => matchesStructureType10(structure.structureType, "STRUCTURE_STORAGE", "storage")
+    (structure) => matchesStructureType11(structure.structureType, "STRUCTURE_STORAGE", "storage")
   )[0]) != null ? _a : null;
 }
 function findOwnedStructures3(room) {
@@ -16587,7 +16653,7 @@ function getObjectId4(object) {
   }
   return typeof candidate.name === "string" ? candidate.name : "";
 }
-function matchesStructureType10(actual, globalName, fallback) {
+function matchesStructureType11(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -134,6 +134,7 @@ export interface ConstructionPriorityPlanningResult {
 
 export interface ConstructionSiteImpactPriorityContext {
   criticalRoadContext?: CriticalRoadLogisticsContext;
+  claimedRoomName?: string;
   protectedRampartAnchors?: RoomPosition[];
   sources?: Source[];
 }
@@ -191,6 +192,7 @@ const CRITICAL_REPAIR_HITS_RATIO = 0.5;
 const DECAYING_REPAIR_HITS_RATIO = 0.8;
 const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 export const CONSTRUCTION_SITE_IMPACT_PRIORITY = {
+  claimedRoomSpawn: 110,
   extension: 100,
   spawn: 95,
   tower: 90,
@@ -336,6 +338,7 @@ export function buildConstructionSiteImpactPriorityContext(
 
   return {
     criticalRoadContext: buildCriticalRoadLogisticsContext(room),
+    ...(room.controller?.my === true ? { claimedRoomName: room.name } : {}),
     protectedRampartAnchors: getProtectedRampartAnchorPositions(room, ownedStructures),
     ...(sources === null ? {} : { sources })
   };
@@ -350,7 +353,9 @@ export function getConstructionSiteImpactPriority(
   }
 
   if (matchesStructureType(site.structureType, 'STRUCTURE_SPAWN', 'spawn')) {
-    return CONSTRUCTION_SITE_IMPACT_PRIORITY.spawn;
+    return isClaimedRoomConstructionSite(site, context)
+      ? CONSTRUCTION_SITE_IMPACT_PRIORITY.claimedRoomSpawn
+      : CONSTRUCTION_SITE_IMPACT_PRIORITY.spawn;
   }
 
   if (matchesStructureType(site.structureType, 'STRUCTURE_CONTAINER', 'container')) {
@@ -768,6 +773,18 @@ function isSourceContainerConstructionSite(
   }
 
   return context.sources.some((source) => isNearRoomObject(source, sitePosition));
+}
+
+function isClaimedRoomConstructionSite(
+  site: ConstructionSite,
+  context: ConstructionSiteImpactPriorityContext
+): boolean {
+  const siteRoom = (site as ConstructionSite & { room?: Room }).room;
+  if (siteRoom?.controller?.my === true) {
+    return true;
+  }
+
+  return context.claimedRoomName !== undefined && isSameRoomPosition(getRoomObjectPosition(site), context.claimedRoomName);
 }
 
 function isProtectedRampartConstructionSite(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1403,7 +1403,8 @@ function buildWorkerConstructionSiteImpactPriorityContext(
   creep: Creep,
   constructionSites: ConstructionSite[]
 ): ConstructionSiteImpactPriorityContext {
-  const context: ConstructionSiteImpactPriorityContext = {};
+  const context: ConstructionSiteImpactPriorityContext =
+    creep.room.controller?.my === true ? { claimedRoomName: creep.room.name } : {};
   if (constructionSites.some(isRoadConstructionSite)) {
     context.criticalRoadContext = buildWorkerCriticalRoadLogisticsContext(creep);
   }

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -64,7 +64,8 @@ export type RuntimeTelemetryEvent =
   | RuntimeSpawnTelemetryEvent
   | RuntimeDefenseTelemetryEvent
   | RuntimeTerritoryClaimTelemetryEvent
-  | RuntimePostClaimBootstrapTelemetryEvent;
+  | RuntimePostClaimBootstrapTelemetryEvent
+  | RuntimeSpawnSitePlacedTelemetryEvent;
 
 export type RuntimeTerritoryClaimTelemetryReason =
   | 'noAdjacentCandidate'
@@ -124,6 +125,16 @@ export interface RuntimePostClaimBootstrapTelemetryEvent {
   workerTarget?: number;
   spawnCount?: number;
   spawnSite?: TerritoryPostClaimBootstrapSpawnSiteMemory;
+}
+
+export interface RuntimeSpawnSitePlacedTelemetryEvent {
+  type: 'spawnSitePlaced';
+  roomName: string;
+  colony: string;
+  controllerId?: Id<StructureController>;
+  result: ScreepsReturnCode;
+  spawnSite: TerritoryPostClaimBootstrapSpawnSiteMemory;
+  existing?: boolean;
 }
 
 interface RuntimeSpawnStatus {

--- a/prod/src/territory/multiRoomUpgrader.ts
+++ b/prod/src/territory/multiRoomUpgrader.ts
@@ -5,6 +5,7 @@ import { isKnownDeadZoneRoom } from '../defense/deadZone';
 export const MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO = 0.8;
 export const MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP = 1;
 
+const SPAWN_CONSTRUCTION_UPGRADER_CAP_BONUS = 1;
 const REMOTE_UPGRADER_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move'];
 const REMOTE_UPGRADER_TRAVEL_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move', 'move'];
 const RESERVED_CONTROLLER_BASE_BODY: BodyPartConstant[] = ['claim', 'move'];
@@ -42,6 +43,9 @@ interface MultiRoomUpgraderConfig {
   storageEnergyThresholdRatio: number;
   perRoomUpgraderCap: number;
 }
+
+type FindConstantGlobal = 'FIND_MY_CONSTRUCTION_SITES';
+type StructureConstantGlobal = 'STRUCTURE_SPAWN';
 
 export function recordPlannedMultiRoomUpgraderSpawn(memory: CreepMemory): void {
   const sustain = memory.controllerSustain;
@@ -156,7 +160,7 @@ function getVisibleMultiRoomUpgradeCandidates(
       homeRoom,
       ownerUsername,
       room,
-      config.perRoomUpgraderCap,
+      config,
       activeUpgraderCounts,
       order
     );
@@ -173,7 +177,7 @@ function getVisibleMultiRoomUpgradeCandidate(
   homeRoom: string,
   ownerUsername: string | null,
   room: Room,
-  perRoomUpgraderCap: number,
+  config: MultiRoomUpgraderConfig,
   activeUpgraderCounts: Record<string, number>,
   order: number
 ): MultiRoomUpgradeCandidate | null {
@@ -201,6 +205,7 @@ function getVisibleMultiRoomUpgradeCandidate(
   }
 
   const activeUpgraderCount = activeUpgraderCounts[room.name] ?? 0;
+  const perRoomUpgraderCap = getEffectivePerRoomUpgraderCap(room, config);
   if (activeUpgraderCount >= perRoomUpgraderCap) {
     return null;
   }
@@ -262,6 +267,67 @@ function normalizePerRoomCap(value: number | undefined): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP;
+}
+
+function getEffectivePerRoomUpgraderCap(room: Room, config: MultiRoomUpgraderConfig): number {
+  return hasActiveClaimedRoomSpawnConstructionSite(room)
+    ? config.perRoomUpgraderCap + SPAWN_CONSTRUCTION_UPGRADER_CAP_BONUS
+    : config.perRoomUpgraderCap;
+}
+
+function hasActiveClaimedRoomSpawnConstructionSite(room: Room): boolean {
+  if (room.controller?.my !== true || typeof room.find !== 'function') {
+    return false;
+  }
+
+  const findConstant = getFindConstant('FIND_MY_CONSTRUCTION_SITES');
+  if (findConstant === null) {
+    return false;
+  }
+
+  try {
+    const sites = room.find(findConstant);
+    return Array.isArray(sites) && sites.some(isActiveSpawnConstructionSite);
+  } catch {
+    return false;
+  }
+}
+
+function isActiveSpawnConstructionSite(site: unknown): site is ConstructionSite {
+  return (
+    isRecord(site) &&
+    matchesStructureType(site.structureType, 'STRUCTURE_SPAWN', 'spawn') &&
+    hasIncompleteConstructionSiteProgress(site)
+  );
+}
+
+function hasIncompleteConstructionSiteProgress(site: Record<string, unknown>): boolean {
+  const progress = site.progress;
+  const progressTotal = site.progressTotal;
+  if (
+    typeof progress !== 'number' ||
+    typeof progressTotal !== 'number' ||
+    !Number.isFinite(progress) ||
+    !Number.isFinite(progressTotal)
+  ) {
+    return true;
+  }
+
+  return progress < progressTotal;
+}
+
+function getFindConstant(constantName: FindConstantGlobal): FindConstant | null {
+  const findConstant = (globalThis as unknown as Partial<Record<FindConstantGlobal, number>>)[constantName];
+  return typeof findConstant === 'number' ? (findConstant as FindConstant) : null;
+}
+
+function matchesStructureType(
+  actual: unknown,
+  globalName: StructureConstantGlobal,
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, string>>;
+  return typeof actual === 'string' && actual === (constants[globalName] ?? fallback);
 }
 
 function getRemoteUpgraderPattern(routeDistance: number | undefined): BodyPartConstant[] {

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -155,6 +155,7 @@ export function refreshPostClaimBootstrap(
         workerTarget,
         spawnCount
       });
+      recordSpawnSitePlacedTelemetry(record, spawnSite, OK_CODE, telemetryEvents, true);
     }
     return { active: true, spawnConstructionPending: true };
   }
@@ -185,6 +186,9 @@ export function refreshPostClaimBootstrap(
       workerTarget,
       spawnCount
     });
+    if (sitePlan.result === OK_CODE && sitePlan.position) {
+      recordSpawnSitePlacedTelemetry(record, sitePlan.position, sitePlan.result, telemetryEvents);
+    }
   }
 
   return { active: true, spawnConstructionPending: true };
@@ -239,6 +243,24 @@ export function getPostClaimBootstrapSummary(roomName: string): PostClaimBootstr
     ...(record.spawnSite ? { spawnSite: record.spawnSite } : {}),
     ...(record.lastResult !== undefined ? { lastResult: record.lastResult } : {})
   };
+}
+
+function recordSpawnSitePlacedTelemetry(
+  record: TerritoryPostClaimBootstrapMemory,
+  spawnSite: TerritoryPostClaimBootstrapSpawnSiteMemory,
+  result: ScreepsReturnCode,
+  telemetryEvents: RuntimeTelemetryEvent[],
+  existing = false
+): void {
+  telemetryEvents.push({
+    type: 'spawnSitePlaced',
+    roomName: record.roomName,
+    colony: record.colony,
+    ...(record.controllerId ? { controllerId: record.controllerId } : {}),
+    result,
+    spawnSite,
+    ...(existing ? { existing } : {})
+  });
 }
 
 function planInitialSpawnConstructionSite(room: Room): SpawnSitePlanResult {

--- a/prod/test/constructionPriority.test.ts
+++ b/prod/test/constructionPriority.test.ts
@@ -231,6 +231,21 @@ describe('impact-weighted construction site selection', () => {
     expect(selectImpactWeightedConstructionSite(origin, [rampartSite, extensionSite])?.id).toBe('extension-site');
   });
 
+  it('prioritizes a claimed-room spawn site over extension construction', () => {
+    const spawnSite = makeConstructionSite('spawn-site', 'spawn', 20, 20);
+    const extensionSite = makeConstructionSite('extension-site', 'extension', 21, 20);
+    const origin = makeSelectionOrigin({
+      'spawn-site': 5,
+      'extension-site': 5
+    });
+
+    expect(
+      selectImpactWeightedConstructionSite(origin, [extensionSite, spawnSite], {
+        claimedRoomName: 'W1N1'
+      })?.id
+    ).toBe('spawn-site');
+  });
+
   it('prioritizes a source container over a generic road', () => {
     const source = { id: 'source1', pos: makeRoomPosition(10, 10) } as Source;
     const containerSite = makeConstructionSite('source-container-site', 'container', 11, 10);

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1300,20 +1300,32 @@ describe('runEconomy', () => {
     });
     expect(logSpy).toHaveBeenCalledTimes(1);
     const [message] = logSpy.mock.calls[0];
-    expect(JSON.parse((message as string).slice(RUNTIME_SUMMARY_PREFIX.length))).toMatchObject({
-      events: [
+    const payload = JSON.parse((message as string).slice(RUNTIME_SUMMARY_PREFIX.length));
+    expect(payload.events).toEqual(
+      expect.arrayContaining([
         {
           type: 'postClaimBootstrap',
           roomName: 'W2N1',
           colony: 'W1N1',
           phase: 'spawnSite',
+          controllerId: 'controller2',
           result: OK_CODE,
           spawnSite: { roomName: 'W2N1', x: 23, y: 23 },
           workerCount: 0,
           workerTarget: 2,
           spawnCount: 0
+        },
+        {
+          type: 'spawnSitePlaced',
+          roomName: 'W2N1',
+          colony: 'W1N1',
+          controllerId: 'controller2',
+          result: OK_CODE,
+          spawnSite: { roomName: 'W2N1', x: 23, y: 23 }
         }
-      ],
+      ])
+    );
+    expect(payload).toMatchObject({
       rooms: [
         {
           roomName: 'W2N1',
@@ -1326,6 +1338,82 @@ describe('runEconomy', () => {
         }
       ]
     });
+  });
+
+  it('emits spawn-site telemetry when a claimed room already has an active spawn site', () => {
+    (globalThis as unknown as {
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_SOURCES: number;
+      STRUCTURE_SPAWN: StructureConstant;
+      Memory: Partial<Memory>;
+    }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'detected',
+            claimedAt: 406,
+            updatedAt: 406,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        }
+      }
+    };
+    const spawnSite = {
+      id: 'spawn-site-existing',
+      structureType: 'spawn',
+      progress: 100,
+      progressTotal: 15_000,
+      pos: { x: 24, y: 24, roomName: 'W2N1' }
+    } as ConstructionSite;
+    const room = {
+      name: 'W2N1',
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: { id: 'controller2', my: true, level: 1 } as StructureController,
+      find: jest.fn((type: number) => {
+        if (type === FIND_MY_CONSTRUCTION_SITES) {
+          return [spawnSite];
+        }
+
+        if (type === FIND_SOURCES) {
+          return [{ id: 'source1' } as Source];
+        }
+
+        return [];
+      }),
+      createConstructionSite: jest.fn()
+    } as unknown as Room;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 407,
+      rooms: { W2N1: room },
+      spawns: {},
+      creeps: {}
+    };
+
+    runEconomy();
+
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+    const [message] = logSpy.mock.calls[0];
+    const payload = JSON.parse((message as string).slice(RUNTIME_SUMMARY_PREFIX.length));
+    expect(payload.events).toEqual(
+      expect.arrayContaining([
+        {
+          type: 'spawnSitePlaced',
+          roomName: 'W2N1',
+          colony: 'W1N1',
+          controllerId: 'controller2',
+          result: OK_CODE,
+          spawnSite: { roomName: 'W2N1', x: 24, y: 24 },
+          existing: true
+        }
+      ])
+    );
   });
 
   it('plans an initial spawn construction site beyond radius 6 when nearer tiles are blocked', () => {

--- a/prod/test/multiRoomUpgrader.test.ts
+++ b/prod/test/multiRoomUpgrader.test.ts
@@ -12,6 +12,8 @@ describe('multi-room upgrader planner', () => {
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
     (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 3;
     (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 4;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 5;
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;
     delete (globalThis as { Game?: Partial<Game> }).Game;
     delete (globalThis as { Memory?: Partial<Memory> }).Memory;
@@ -50,13 +52,15 @@ describe('multi-room upgrader planner', () => {
     controller,
     storage,
     hostileCreeps = [],
-    hostileStructures = []
+    hostileStructures = [],
+    constructionSites = []
   }: {
     roomName: string;
     controller?: StructureController;
     storage?: StructureStorage;
     hostileCreeps?: Creep[];
     hostileStructures?: Structure[];
+    constructionSites?: ConstructionSite[];
   }): Room {
     const find = jest.fn((type: number) => {
       if (type === FIND_HOSTILE_CREEPS) {
@@ -65,6 +69,10 @@ describe('multi-room upgrader planner', () => {
 
       if (type === FIND_HOSTILE_STRUCTURES) {
         return hostileStructures;
+      }
+
+      if (type === FIND_MY_CONSTRUCTION_SITES) {
+        return constructionSites;
       }
 
       return [];
@@ -113,6 +121,15 @@ describe('multi-room upgrader planner', () => {
         controllerSustain: { homeRoom: 'W1N1', targetRoom, role: 'upgrader' }
       }
     } as Creep;
+  }
+
+  function makeSpawnConstructionSite(id = 'spawn-site', progress = 0, progressTotal = 15_000): ConstructionSite {
+    return {
+      id,
+      structureType: 'spawn',
+      progress,
+      progressTotal
+    } as ConstructionSite;
   }
 
   function installGame({
@@ -336,6 +353,45 @@ describe('multi-room upgrader planner', () => {
     expect(planWithCap1?.targetRoom).toBe('W3N1');
     expect(planWithCap2?.targetRoom).toBe('W3N1');
     expect(planWithCap3?.targetRoom).toBe('W2N1');
+  });
+
+  it('temporarily allows an extra upgrader for claimed rooms with active spawn construction', () => {
+    const colony = makeColony();
+    installGame({
+      colony,
+      rooms: [
+        makeRoom({
+          roomName: 'W2N1',
+          controller: makeOwnedController('W2N1', 1),
+          constructionSites: [makeSpawnConstructionSite()]
+        })
+      ],
+      creeps: { Existing: makeRemoteUpgrader('W2N1') },
+      routeLengths: { W2N1: 1 }
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)).toMatchObject({
+      targetRoom: 'W2N1',
+      activeUpgraderCount: 1
+    });
+  });
+
+  it('keeps the normal cap when the claimed-room spawn site is complete', () => {
+    const colony = makeColony();
+    installGame({
+      colony,
+      rooms: [
+        makeRoom({
+          roomName: 'W2N1',
+          controller: makeOwnedController('W2N1', 1),
+          constructionSites: [makeSpawnConstructionSite('spawn-site-complete', 15_000, 15_000)]
+        })
+      ],
+      creeps: { Existing: makeRemoteUpgrader('W2N1') },
+      routeLengths: { W2N1: 1 }
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)).toBeNull();
   });
 
   it('selects own reserved rooms and builds a reserve-capable sustain body', () => {


### PR DESCRIPTION
Closes #581

## Summary
Prioritize spawn construction in claimed rooms and accelerate RCL progression via multi-room upgrader assignment.

## Changes
- Add spawn construction priority in `constructionPriority.ts`
- Extend `multiRoomUpgrader.ts` for aggressive multi-room RCL acceleration
- Add post-claim bootstrap spawn construction support in `postClaimBootstrap.ts`
- Add worker task reservation for construction sites
- Extend runtime summary telemetry fields for territory construction tracking

## Verification
- `npm run typecheck`: PASS
- `npm test -- --runInBand`: 41 suites, 955 tests PASS
- `npm run build`: PASS
- `git diff --check`: PASS
