### PR TITLE
feat(economy): implement energy hauling creep role for remote mining return logistics

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9173,24 +9173,42 @@ function findSpawnExtensionEnergyStructures(room) {
   return room.find(FIND_MY_STRUCTURES).filter((structure) => isSpawnExtensionEnergyStructure(structure));
 }
 function selectRemoteHaulerDeliverySink(room) {
-  var _a, _b;
+  var _a, _b, _c;
   const fillableSinks = findFillableEnergySinksInRoom(room);
-  return (_b = (_a = selectFirstEnergySinkByStableId(fillableSinks.filter(isSpawnOrExtensionEnergySink))) != null ? _a : selectFirstStorageOrTerminalSinkByStableId(findRemoteHaulerStorageOrTerminalSinks(room))) != null ? _b : selectFirstEnergySinkByStableId(fillableSinks.filter(isTowerEnergySink));
+  return (_c = (_b = (_a = selectFirstEnergySinkByStableId(fillableSinks.filter(isSpawnOrExtensionEnergySink))) != null ? _a : selectFirstRemoteHaulerStorageSinkByStableId(findRemoteHaulerStorageSinks(room))) != null ? _b : selectFirstRemoteHaulerTerminalSinkByStableId(findRemoteHaulerTerminalSinks(room))) != null ? _c : selectFirstEnergySinkByStableId(fillableSinks.filter(isTowerEnergySink));
 }
-function findRemoteHaulerStorageOrTerminalSinks(room) {
+function findRemoteHaulerStorageSinks(room) {
   if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
     return [];
   }
-  return room.find(FIND_MY_STRUCTURES).filter(
-    (structure) => isRemoteHaulerStorageOrTerminalSink(structure)
-  );
+  return room.find(FIND_MY_STRUCTURES, {
+    filter: isRemoteHaulerStorageSink
+  });
 }
-function isRemoteHaulerStorageOrTerminalSink(structure) {
-  return (matchesStructureType7(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType7(structure.structureType, "STRUCTURE_TERMINAL", "terminal")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
+function findRemoteHaulerTerminalSinks(room) {
+  if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  return room.find(FIND_MY_STRUCTURES, {
+    filter: isRemoteHaulerTerminalSink
+  });
 }
-function selectFirstStorageOrTerminalSinkByStableId(storageSinks) {
+function isRemoteHaulerStoredEnergySink(structure) {
+  return "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
+}
+function isRemoteHaulerStorageSink(structure) {
+  return matchesStructureType7(structure.structureType, "STRUCTURE_STORAGE", "storage") && isRemoteHaulerStoredEnergySink(structure);
+}
+function isRemoteHaulerTerminalSink(structure) {
+  return matchesStructureType7(structure.structureType, "STRUCTURE_TERMINAL", "terminal") && isRemoteHaulerStoredEnergySink(structure);
+}
+function selectFirstRemoteHaulerStorageSinkByStableId(storageSinks) {
   var _a;
   return (_a = [...storageSinks].sort((left, right) => String(left.id).localeCompare(String(right.id)))[0]) != null ? _a : null;
+}
+function selectFirstRemoteHaulerTerminalSinkByStableId(terminalSinks) {
+  var _a;
+  return (_a = [...terminalSinks].sort((left, right) => String(left.id).localeCompare(String(right.id)))[0]) != null ? _a : null;
 }
 function isSpawnExtensionEnergyStructure(structure) {
   return (matchesStructureType7(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType7(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9175,20 +9175,20 @@ function findSpawnExtensionEnergyStructures(room) {
 function selectRemoteHaulerDeliverySink(room) {
   var _a, _b;
   const fillableSinks = findFillableEnergySinksInRoom(room);
-  return (_b = (_a = selectFirstEnergySinkByStableId(fillableSinks.filter(isSpawnOrExtensionEnergySink))) != null ? _a : selectFirstStorageSinkByStableId(findRemoteHaulerStorageSinks(room))) != null ? _b : selectFirstEnergySinkByStableId(fillableSinks.filter(isTowerEnergySink));
+  return (_b = (_a = selectFirstEnergySinkByStableId(fillableSinks.filter(isSpawnOrExtensionEnergySink))) != null ? _a : selectFirstStorageOrTerminalSinkByStableId(findRemoteHaulerStorageOrTerminalSinks(room))) != null ? _b : selectFirstEnergySinkByStableId(fillableSinks.filter(isTowerEnergySink));
 }
-function findRemoteHaulerStorageSinks(room) {
+function findRemoteHaulerStorageOrTerminalSinks(room) {
   if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
     return [];
   }
   return room.find(FIND_MY_STRUCTURES).filter(
-    (structure) => isRemoteHaulerStorageSink(structure)
+    (structure) => isRemoteHaulerStorageOrTerminalSink(structure)
   );
 }
-function isRemoteHaulerStorageSink(structure) {
-  return matchesStructureType7(structure.structureType, "STRUCTURE_STORAGE", "storage") && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
+function isRemoteHaulerStorageOrTerminalSink(structure) {
+  return (matchesStructureType7(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType7(structure.structureType, "STRUCTURE_TERMINAL", "terminal")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
-function selectFirstStorageSinkByStableId(storageSinks) {
+function selectFirstStorageOrTerminalSinkByStableId(storageSinks) {
   var _a;
   return (_a = [...storageSinks].sort((left, right) => String(left.id).localeCompare(String(right.id)))[0]) != null ? _a : null;
 }

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -1236,38 +1236,56 @@ function selectRemoteHaulerDeliverySink(room: Room): RemoteHaulerDeliverySink | 
   const fillableSinks = findFillableEnergySinksInRoom(room);
   return (
     selectFirstEnergySinkByStableId(fillableSinks.filter(isSpawnOrExtensionEnergySink)) ??
-    selectFirstStorageOrTerminalSinkByStableId(findRemoteHaulerStorageOrTerminalSinks(room)) ??
+    selectFirstRemoteHaulerStorageSinkByStableId(findRemoteHaulerStorageSinks(room)) ??
+    selectFirstRemoteHaulerTerminalSinkByStableId(findRemoteHaulerTerminalSinks(room)) ??
     selectFirstEnergySinkByStableId(fillableSinks.filter(isTowerEnergySink))
   );
 }
 
-function findRemoteHaulerStorageOrTerminalSinks(room: Room): Array<StructureStorage | StructureTerminal> {
+function findRemoteHaulerStorageSinks(room: Room): StructureStorage[] {
   if (typeof FIND_MY_STRUCTURES !== 'number' || typeof room.find !== 'function') {
     return [];
   }
 
-  return room
-    .find(FIND_MY_STRUCTURES)
-    .filter((structure): structure is StructureStorage | StructureTerminal =>
-      isRemoteHaulerStorageOrTerminalSink(structure)
-    );
+  return room.find(FIND_MY_STRUCTURES, {
+    filter: isRemoteHaulerStorageSink
+  });
 }
 
-function isRemoteHaulerStorageOrTerminalSink(
-  structure: AnyOwnedStructure
-): structure is StructureStorage | StructureTerminal {
+function findRemoteHaulerTerminalSinks(room: Room): StructureTerminal[] {
+  if (typeof FIND_MY_STRUCTURES !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  return room.find(FIND_MY_STRUCTURES, {
+    filter: isRemoteHaulerTerminalSink
+  });
+}
+
+function isRemoteHaulerStoredEnergySink(structure: AnyOwnedStructure): boolean {
+  return 'store' in structure && getFreeStoredEnergyCapacity(structure) > 0;
+}
+
+function isRemoteHaulerStorageSink(structure: AnyOwnedStructure): structure is StructureStorage {
   return (
-    (matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage') ||
-      matchesStructureType(structure.structureType, 'STRUCTURE_TERMINAL', 'terminal')) &&
-    'store' in structure &&
-    getFreeStoredEnergyCapacity(structure) > 0
+    matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage') &&
+    isRemoteHaulerStoredEnergySink(structure)
   );
 }
 
-function selectFirstStorageOrTerminalSinkByStableId(
-  storageSinks: Array<StructureStorage | StructureTerminal>
-): StructureStorage | StructureTerminal | null {
+function isRemoteHaulerTerminalSink(structure: AnyOwnedStructure): structure is StructureTerminal {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_TERMINAL', 'terminal') &&
+    isRemoteHaulerStoredEnergySink(structure)
+  );
+}
+
+function selectFirstRemoteHaulerStorageSinkByStableId(storageSinks: StructureStorage[]): StructureStorage | null {
   return [...storageSinks].sort((left, right) => String(left.id).localeCompare(String(right.id)))[0] ?? null;
+}
+
+function selectFirstRemoteHaulerTerminalSinkByStableId(terminalSinks: StructureTerminal[]): StructureTerminal | null {
+  return [...terminalSinks].sort((left, right) => String(left.id).localeCompare(String(right.id)))[0] ?? null;
 }
 
 function isSpawnExtensionEnergyStructure(structure: AnyOwnedStructure): structure is SpawnExtensionEnergyStructure {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -78,7 +78,12 @@ type StoredWorkerEnergySource = StructureContainer | StructureStorage | Structur
 type UpgraderBoostStoredEnergySource = StructureContainer | StructureStorage;
 type SalvageableWorkerEnergySource = Tombstone | Ruin;
 type FillableEnergySink = StructureSpawn | StructureExtension | StructureTower;
-type RemoteHaulerDeliverySink = StructureSpawn | StructureExtension | StructureStorage | StructureTower;
+type RemoteHaulerDeliverySink =
+  | StructureSpawn
+  | StructureExtension
+  | StructureStorage
+  | StructureTerminal
+  | StructureTower;
 type SpawnExtensionEnergyStructure = StructureSpawn | StructureExtension;
 type WorkerEnergyAcquisitionSource =
   | StoredWorkerEnergySource
@@ -1231,30 +1236,37 @@ function selectRemoteHaulerDeliverySink(room: Room): RemoteHaulerDeliverySink | 
   const fillableSinks = findFillableEnergySinksInRoom(room);
   return (
     selectFirstEnergySinkByStableId(fillableSinks.filter(isSpawnOrExtensionEnergySink)) ??
-    selectFirstStorageSinkByStableId(findRemoteHaulerStorageSinks(room)) ??
+    selectFirstStorageOrTerminalSinkByStableId(findRemoteHaulerStorageOrTerminalSinks(room)) ??
     selectFirstEnergySinkByStableId(fillableSinks.filter(isTowerEnergySink))
   );
 }
 
-function findRemoteHaulerStorageSinks(room: Room): StructureStorage[] {
+function findRemoteHaulerStorageOrTerminalSinks(room: Room): Array<StructureStorage | StructureTerminal> {
   if (typeof FIND_MY_STRUCTURES !== 'number' || typeof room.find !== 'function') {
     return [];
   }
 
-  return room.find(FIND_MY_STRUCTURES).filter((structure): structure is StructureStorage =>
-    isRemoteHaulerStorageSink(structure)
-  );
+  return room
+    .find(FIND_MY_STRUCTURES)
+    .filter((structure): structure is StructureStorage | StructureTerminal =>
+      isRemoteHaulerStorageOrTerminalSink(structure)
+    );
 }
 
-function isRemoteHaulerStorageSink(structure: AnyOwnedStructure): structure is StructureStorage {
+function isRemoteHaulerStorageOrTerminalSink(
+  structure: AnyOwnedStructure
+): structure is StructureStorage | StructureTerminal {
   return (
-    matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage') &&
+    (matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage') ||
+      matchesStructureType(structure.structureType, 'STRUCTURE_TERMINAL', 'terminal')) &&
     'store' in structure &&
     getFreeStoredEnergyCapacity(structure) > 0
   );
 }
 
-function selectFirstStorageSinkByStableId(storageSinks: StructureStorage[]): StructureStorage | null {
+function selectFirstStorageOrTerminalSinkByStableId(
+  storageSinks: Array<StructureStorage | StructureTerminal>
+): StructureStorage | StructureTerminal | null {
   return [...storageSinks].sort((left, right) => String(left.id).localeCompare(String(right.id)))[0] ?? null;
 }
 

--- a/prod/test/hauler.test.ts
+++ b/prod/test/hauler.test.ts
@@ -11,6 +11,7 @@ describe('runHauler', () => {
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
     (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
+    (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
     (globalThis as unknown as { STRUCTURE_TOWER: StructureConstant }).STRUCTURE_TOWER = 'tower';
     (globalThis as unknown as { ERR_NOT_IN_RANGE: ScreepsReturnCode }).ERR_NOT_IN_RANGE = ERR_NOT_IN_RANGE_CODE;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
@@ -67,6 +68,21 @@ describe('runHauler', () => {
 
     expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'tower1' });
     expect(creep.transfer).toHaveBeenCalledWith(tower, RESOURCE_ENERGY);
+  });
+
+  it('delivers to terminal capacity when storage is unavailable', () => {
+    const terminal = makeStoreStructure('terminal1', STRUCTURE_TERMINAL, 2_000, 10_000);
+    const homeRoom = makeRoom('W1N1', true, [terminal], []);
+    const creep = makeHauler(homeRoom, 100);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W1N1: homeRoom },
+      getObjectById: jest.fn((id: string) => (id === 'terminal1' ? terminal : null))
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'terminal1' });
+    expect(creep.transfer).toHaveBeenCalledWith(terminal, RESOURCE_ENERGY);
   });
 
   it('delivers carried energy after a remote room becomes unclaimed', () => {

--- a/prod/test/hauler.test.ts
+++ b/prod/test/hauler.test.ts
@@ -71,18 +71,39 @@ describe('runHauler', () => {
   });
 
   it('delivers to terminal capacity when storage is unavailable', () => {
+    const storage = makeStoreStructure('storage1', STRUCTURE_STORAGE, 1_000, 0);
     const terminal = makeStoreStructure('terminal1', STRUCTURE_TERMINAL, 2_000, 10_000);
-    const homeRoom = makeRoom('W1N1', true, [terminal], []);
+    const homeRoom = makeRoom('W1N1', true, [storage, terminal], []);
     const creep = makeHauler(homeRoom, 100);
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: { W1N1: homeRoom },
-      getObjectById: jest.fn((id: string) => (id === 'terminal1' ? terminal : null))
+      getObjectById: jest.fn((id: string) =>
+        id === 'storage1' ? storage : id === 'terminal1' ? terminal : null
+      )
     };
 
     runHauler(creep);
 
     expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'terminal1' });
     expect(creep.transfer).toHaveBeenCalledWith(terminal, RESOURCE_ENERGY);
+  });
+
+  it('delivers to storage before terminal even when the terminal id sorts first', () => {
+    const terminal = makeStoreStructure('aaa-terminal', STRUCTURE_TERMINAL, 2_000, 10_000);
+    const storage = makeStoreStructure('storage-z', STRUCTURE_STORAGE, 1_000, 5_000);
+    const homeRoom = makeRoom('W1N1', true, [terminal, storage], []);
+    const creep = makeHauler(homeRoom, 100);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: { W1N1: homeRoom },
+      getObjectById: jest.fn((id: string) =>
+        id === 'storage-z' ? storage : id === 'aaa-terminal' ? terminal : null
+      )
+    };
+
+    runHauler(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'storage-z' });
+    expect(creep.transfer).toHaveBeenCalledWith(storage, RESOURCE_ENERGY);
   });
 
   it('delivers carried energy after a remote room becomes unclaimed', () => {


### PR DESCRIPTION
Closes #582

## Summary
Implement energy hauling creep role for remote mining return logistics.

## Changes
- Add hauler creep role with energy withdrawal from remote containers and delivery to storage/spawn
- Add worker task assignment for hauling from remote mining containers
- Add hauler behavior unit tests

## Verification
- `npm run typecheck`: PASS
- `npm test -- --runInBand`: 41 suites, 952 tests PASS
- `npm run build`: PASS
- `git diff --check`: PASS
