### PR TITLE
feat(territory): implement multi-room claim expansion with scout-ahead validation (#586)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1595,6 +1595,8 @@ var HIGH_RCL_WORKER_PATTERN = ["work", "work", "work", "carry", "move", "move"];
 var HIGH_RCL_WORKER_PATTERN_COST = 450;
 var EMERGENCY_DEFENDER_BODY = ["tough", "attack", "move"];
 var EMERGENCY_DEFENDER_BODY_COST = 140;
+var TERRITORY_SCOUT_BODY = ["move"];
+var TERRITORY_SCOUT_BODY_COST = 50;
 var MAX_CREEP_PARTS2 = 50;
 var MAX_REMOTE_HARVESTER_WORK_PARTS = 5;
 var MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS = 10;
@@ -3526,7 +3528,7 @@ var TERRITORY_CANDIDATE_PRIORITY_SCOUT = 5;
 var MAX_VISIBLE_TERRITORY_CANDIDATE_PRIORITY = TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR2 = ">";
 var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
-var TERRITORY_SCOUT_BODY_COST = 50;
+var TERRITORY_SCOUT_BODY_COST2 = 50;
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 = "occupationRecommendation";
 var REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 var recoveredTerritoryFollowUpRetryMetadata = /* @__PURE__ */ new WeakMap();
@@ -4421,7 +4423,7 @@ function getTerritoryIntentActionBodyCost(action, requiresControllerPressure = f
   if (isTerritoryControlAction2(action) && requiresControllerPressure) {
     return TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
   }
-  return action === "scout" ? TERRITORY_SCOUT_BODY_COST : TERRITORY_CONTROLLER_BODY_COST;
+  return action === "scout" ? TERRITORY_SCOUT_BODY_COST2 : TERRITORY_CONTROLLER_BODY_COST;
 }
 function shouldSpawnEmergencyReservationRenewalCandidate(candidate, activeCoverageCount) {
   return activeCoverageCount < TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET && candidate.intentAction === "reserve" && typeof candidate.renewalTicksToEnd === "number" && candidate.renewalTicksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
@@ -13155,8 +13157,6 @@ function isNonEmptyString9(value) {
 }
 
 // src/spawn/spawnPlanner.ts
-var TERRITORY_SCOUT_BODY = ["move"];
-var TERRITORY_SCOUT_BODY_COST2 = 50;
 var CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
 var CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
 var CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET = 6;
@@ -13708,7 +13708,7 @@ function canAffordBody(body, energyAvailable) {
 }
 function buildTerritorySpawnBody(energyAvailable, intent) {
   if (intent.action === "scout") {
-    return energyAvailable >= TERRITORY_SCOUT_BODY_COST2 ? [...TERRITORY_SCOUT_BODY] : [];
+    return energyAvailable >= TERRITORY_SCOUT_BODY_COST ? [...TERRITORY_SCOUT_BODY] : [];
   }
   if (requiresTerritoryControllerPressure(intent)) {
     return buildTerritoryControllerPressureBody(energyAvailable);
@@ -13724,6 +13724,463 @@ function isRecord10(value) {
 }
 function isNonEmptyString10(value) {
   return typeof value === "string" && value.length > 0;
+}
+
+// src/territory/scoutIntel.ts
+var TERRITORY_SCOUT_MEMORY_KEY_SEPARATOR = ">";
+var TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS = 1500;
+function recordVisibleRoomScoutIntel(colony, room, gameTime = getGameTime9(), scoutName, telemetryEvents = []) {
+  var _a, _b, _c, _d;
+  if (!isNonEmptyString11(colony) || !room || !isNonEmptyString11(room.name)) {
+    return null;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord3();
+  if (!territoryMemory) {
+    return null;
+  }
+  const key = getTerritoryScoutMemoryKey(colony, room.name);
+  const intel = buildTerritoryScoutIntel(colony, room, gameTime, scoutName);
+  const scoutIntel = getMutableScoutIntelRecords(territoryMemory);
+  scoutIntel[key] = intel;
+  const attempts = getMutableScoutAttemptRecords(territoryMemory);
+  const existingAttempt = normalizeTerritoryScoutAttempt(attempts[key]);
+  attempts[key] = {
+    colony,
+    roomName: room.name,
+    status: "observed",
+    requestedAt: (_a = existingAttempt == null ? void 0 : existingAttempt.requestedAt) != null ? _a : gameTime,
+    updatedAt: gameTime,
+    attemptCount: Math.max(1, (_b = existingAttempt == null ? void 0 : existingAttempt.attemptCount) != null ? _b : 1),
+    ...((_c = intel.controller) == null ? void 0 : _c.id) ? { controllerId: intel.controller.id } : {},
+    ...scoutName ? { scoutName } : {},
+    ...(existingAttempt == null ? void 0 : existingAttempt.lastValidation) ? { lastValidation: existingAttempt.lastValidation } : {}
+  };
+  recordTerritoryScoutTelemetry(telemetryEvents, {
+    colony,
+    targetRoom: room.name,
+    phase: "intel",
+    result: "recorded",
+    ...scoutName ? { scoutName } : {},
+    ...((_d = intel.controller) == null ? void 0 : _d.id) ? { controllerId: intel.controller.id } : {},
+    sourceCount: intel.sourceCount,
+    hostileCreepCount: intel.hostileCreepCount,
+    hostileStructureCount: intel.hostileStructureCount,
+    hostileSpawnCount: intel.hostileSpawnCount
+  });
+  return intel;
+}
+function ensureTerritoryScoutAttempt(colony, targetRoom, gameTime, telemetryEvents = [], controllerId) {
+  var _a;
+  if (!isNonEmptyString11(colony) || !isNonEmptyString11(targetRoom)) {
+    return null;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord3();
+  if (!territoryMemory) {
+    return null;
+  }
+  const key = getTerritoryScoutMemoryKey(colony, targetRoom);
+  const attempts = getMutableScoutAttemptRecords(territoryMemory);
+  const existingAttempt = normalizeTerritoryScoutAttempt(attempts[key]);
+  const shouldReuseAttempt = (existingAttempt == null ? void 0 : existingAttempt.status) === "requested" && gameTime >= existingAttempt.requestedAt && gameTime - existingAttempt.requestedAt <= TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS;
+  const attempt = shouldReuseAttempt ? {
+    ...existingAttempt,
+    updatedAt: gameTime,
+    ...(controllerId != null ? controllerId : existingAttempt.controllerId) ? { controllerId: controllerId != null ? controllerId : existingAttempt.controllerId } : {}
+  } : {
+    colony,
+    roomName: targetRoom,
+    status: "requested",
+    requestedAt: gameTime,
+    updatedAt: gameTime,
+    attemptCount: Math.max(1, ((_a = existingAttempt == null ? void 0 : existingAttempt.attemptCount) != null ? _a : 0) + 1),
+    ...controllerId ? { controllerId } : {},
+    ...(existingAttempt == null ? void 0 : existingAttempt.lastValidation) ? { lastValidation: existingAttempt.lastValidation } : {}
+  };
+  attempts[key] = attempt;
+  upsertTerritoryScoutIntent(territoryMemory, attempt);
+  recordTerritoryScoutTelemetry(telemetryEvents, {
+    colony,
+    targetRoom,
+    phase: "attempt",
+    result: "requested",
+    ...attempt.controllerId ? { controllerId: attempt.controllerId } : {}
+  });
+  return attempt;
+}
+function validateTerritoryScoutIntelForClaim({
+  colony,
+  targetRoom,
+  colonyOwnerUsername,
+  gameTime
+}) {
+  const intel = getTerritoryScoutIntel(colony, targetRoom);
+  if (!intel) {
+    const attempt = getTerritoryScoutAttempt(colony, targetRoom);
+    if ((attempt == null ? void 0 : attempt.status) === "requested" && gameTime >= attempt.requestedAt && gameTime - attempt.requestedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS) {
+      return { status: "fallback", reason: "scoutTimeout" };
+    }
+    return { status: "pending", reason: attempt ? "scoutPending" : "intelMissing" };
+  }
+  const controller = intel.controller;
+  if (!controller) {
+    return { status: "blocked", reason: "controllerMissing", intel };
+  }
+  if (controller.my === true || isNonEmptyString11(controller.ownerUsername) && controller.ownerUsername === colonyOwnerUsername) {
+    return { status: "blocked", reason: "controllerOwned", intel };
+  }
+  if (isNonEmptyString11(controller.ownerUsername)) {
+    return { status: "blocked", reason: "controllerOwned", intel };
+  }
+  if (isNonEmptyString11(controller.reservationUsername) && controller.reservationUsername !== colonyOwnerUsername) {
+    return { status: "blocked", reason: "controllerReserved", intel };
+  }
+  if (intel.hostileSpawnCount > 0) {
+    return { status: "blocked", reason: "hostileSpawn", intel };
+  }
+  if (intel.sourceCount <= 0) {
+    return { status: "blocked", reason: "sourcesMissing", intel };
+  }
+  return { status: "passed", intel };
+}
+function recordTerritoryScoutValidation(colony, targetRoom, result, gameTime, telemetryEvents = [], controllerId, score) {
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n;
+  if (!isNonEmptyString11(colony) || !isNonEmptyString11(targetRoom)) {
+    return;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord3();
+  if (!territoryMemory) {
+    return;
+  }
+  const key = getTerritoryScoutMemoryKey(colony, targetRoom);
+  const attempts = getMutableScoutAttemptRecords(territoryMemory);
+  const existingAttempt = normalizeTerritoryScoutAttempt(attempts[key]);
+  const status = result.status === "fallback" ? "timedOut" : result.status === "pending" ? (_a = existingAttempt == null ? void 0 : existingAttempt.status) != null ? _a : "requested" : (_b = existingAttempt == null ? void 0 : existingAttempt.status) != null ? _b : "observed";
+  attempts[key] = {
+    colony,
+    roomName: targetRoom,
+    status,
+    requestedAt: (_c = existingAttempt == null ? void 0 : existingAttempt.requestedAt) != null ? _c : gameTime,
+    updatedAt: gameTime,
+    attemptCount: Math.max(1, (_d = existingAttempt == null ? void 0 : existingAttempt.attemptCount) != null ? _d : 1),
+    ...((_g = controllerId != null ? controllerId : existingAttempt == null ? void 0 : existingAttempt.controllerId) != null ? _g : (_f = (_e = result.intel) == null ? void 0 : _e.controller) == null ? void 0 : _f.id) ? { controllerId: (_j = controllerId != null ? controllerId : existingAttempt == null ? void 0 : existingAttempt.controllerId) != null ? _j : (_i = (_h = result.intel) == null ? void 0 : _h.controller) == null ? void 0 : _i.id } : {},
+    ...(existingAttempt == null ? void 0 : existingAttempt.scoutName) ? { scoutName: existingAttempt.scoutName } : {},
+    lastValidation: {
+      status: result.status,
+      updatedAt: gameTime,
+      ...result.reason ? { reason: result.reason } : {}
+    }
+  };
+  recordTerritoryScoutTelemetry(telemetryEvents, {
+    colony,
+    targetRoom,
+    phase: "validation",
+    result: getTelemetryValidationResult(result.status),
+    ...result.reason ? { reason: result.reason } : {},
+    ...(controllerId != null ? controllerId : (_l = (_k = result.intel) == null ? void 0 : _k.controller) == null ? void 0 : _l.id) ? { controllerId: controllerId != null ? controllerId : (_n = (_m = result.intel) == null ? void 0 : _m.controller) == null ? void 0 : _n.id } : {},
+    ...result.intel ? { sourceCount: result.intel.sourceCount } : {},
+    ...result.intel ? { hostileCreepCount: result.intel.hostileCreepCount } : {},
+    ...result.intel ? { hostileStructureCount: result.intel.hostileStructureCount } : {},
+    ...result.intel ? { hostileSpawnCount: result.intel.hostileSpawnCount } : {},
+    ...score !== void 0 ? { score } : {}
+  });
+}
+function getTerritoryScoutSummary(colony) {
+  var _a, _b;
+  if (!isNonEmptyString11(colony)) {
+    return null;
+  }
+  const territoryMemory = getTerritoryMemoryRecord4();
+  if (!territoryMemory) {
+    return null;
+  }
+  const attempts = Object.values((_a = territoryMemory.scoutAttempts) != null ? _a : {}).flatMap((attempt) => {
+    const normalized = normalizeTerritoryScoutAttempt(attempt);
+    return (normalized == null ? void 0 : normalized.colony) === colony ? [normalized] : [];
+  }).sort(compareTerritoryScoutAttempts);
+  const intel = Object.values((_b = territoryMemory.scoutIntel) != null ? _b : {}).flatMap((record) => {
+    const normalized = normalizeTerritoryScoutIntel(record);
+    return (normalized == null ? void 0 : normalized.colony) === colony ? [normalized] : [];
+  }).sort(compareTerritoryScoutIntel);
+  return attempts.length > 0 || intel.length > 0 ? { attempts, intel } : null;
+}
+function buildTerritoryScoutIntel(colony, room, gameTime, scoutName) {
+  const controller = room.controller;
+  const sources = findRoomObjects7(room, "FIND_SOURCES");
+  const hostileCreeps = findRoomObjects7(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects7(room, "FIND_HOSTILE_STRUCTURES");
+  const mineral = findRoomObjects7(room, "FIND_MINERALS")[0];
+  return {
+    colony,
+    roomName: room.name,
+    updatedAt: gameTime,
+    ...controller ? { controller: summarizeScoutController(controller) } : {},
+    sourceIds: sources.map((source) => String(source.id)).sort(),
+    sourceCount: sources.length,
+    ...mineral ? { mineral: summarizeScoutMineral(mineral) } : {},
+    hostileCreepCount: hostileCreeps.length,
+    hostileStructureCount: hostileStructures.length,
+    hostileSpawnCount: hostileStructures.filter(isHostileSpawnStructure).length,
+    ...scoutName ? { scoutName } : {}
+  };
+}
+function summarizeScoutController(controller) {
+  const ownerUsername = getControllerOwnerUsername5(controller);
+  const reservationUsername = getControllerReservationUsername3(controller);
+  const reservationTicksToEnd = getControllerReservationTicksToEnd2(controller);
+  return {
+    ...typeof controller.id === "string" ? { id: controller.id } : {},
+    ...typeof controller.my === "boolean" ? { my: controller.my } : {},
+    ...ownerUsername ? { ownerUsername } : {},
+    ...reservationUsername ? { reservationUsername } : {},
+    ...typeof reservationTicksToEnd === "number" ? { reservationTicksToEnd } : {}
+  };
+}
+function summarizeScoutMineral(mineral) {
+  const rawMineral = mineral;
+  return {
+    id: String(mineral.id),
+    ...typeof rawMineral.mineralType === "string" ? { mineralType: rawMineral.mineralType } : {},
+    ...typeof rawMineral.density === "number" ? { density: rawMineral.density } : {}
+  };
+}
+function upsertTerritoryScoutIntent(territoryMemory, attempt) {
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIndex = intents.findIndex(
+    (intent) => intent.colony === attempt.colony && intent.targetRoom === attempt.roomName && intent.action === "scout"
+  );
+  const nextIntent = {
+    colony: attempt.colony,
+    targetRoom: attempt.roomName,
+    action: "scout",
+    status: existingIndex >= 0 && intents[existingIndex].status === "active" ? "active" : "planned",
+    updatedAt: attempt.updatedAt,
+    ...attempt.controllerId ? { controllerId: attempt.controllerId } : {}
+  };
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+  intents.push(nextIntent);
+}
+function recordTerritoryScoutTelemetry(telemetryEvents, event) {
+  telemetryEvents.push({
+    type: "territoryScout",
+    roomName: event.colony,
+    colony: event.colony,
+    targetRoom: event.targetRoom,
+    phase: event.phase,
+    result: event.result,
+    ...event.reason ? { reason: event.reason } : {},
+    ...event.controllerId ? { controllerId: event.controllerId } : {},
+    ...event.scoutName ? { scoutName: event.scoutName } : {},
+    ...event.sourceCount !== void 0 ? { sourceCount: event.sourceCount } : {},
+    ...event.hostileCreepCount !== void 0 ? { hostileCreepCount: event.hostileCreepCount } : {},
+    ...event.hostileStructureCount !== void 0 ? { hostileStructureCount: event.hostileStructureCount } : {},
+    ...event.hostileSpawnCount !== void 0 ? { hostileSpawnCount: event.hostileSpawnCount } : {},
+    ...event.score !== void 0 ? { score: event.score } : {}
+  });
+}
+function getTelemetryValidationResult(status) {
+  if (status === "passed") {
+    return "passed";
+  }
+  if (status === "blocked") {
+    return "blocked";
+  }
+  return status === "fallback" ? "fallback" : "pending";
+}
+function getTerritoryScoutIntel(colony, targetRoom) {
+  var _a, _b;
+  const rawIntel = (_b = (_a = getTerritoryMemoryRecord4()) == null ? void 0 : _a.scoutIntel) == null ? void 0 : _b[getTerritoryScoutMemoryKey(colony, targetRoom)];
+  return normalizeTerritoryScoutIntel(rawIntel);
+}
+function getTerritoryScoutAttempt(colony, targetRoom) {
+  var _a, _b;
+  const rawAttempt = (_b = (_a = getTerritoryMemoryRecord4()) == null ? void 0 : _a.scoutAttempts) == null ? void 0 : _b[getTerritoryScoutMemoryKey(colony, targetRoom)];
+  return normalizeTerritoryScoutAttempt(rawAttempt);
+}
+function getMutableScoutAttemptRecords(territoryMemory) {
+  if (!isRecord11(territoryMemory.scoutAttempts) || Array.isArray(territoryMemory.scoutAttempts)) {
+    territoryMemory.scoutAttempts = {};
+  }
+  return territoryMemory.scoutAttempts;
+}
+function getMutableScoutIntelRecords(territoryMemory) {
+  if (!isRecord11(territoryMemory.scoutIntel) || Array.isArray(territoryMemory.scoutIntel)) {
+    territoryMemory.scoutIntel = {};
+  }
+  return territoryMemory.scoutIntel;
+}
+function normalizeTerritoryScoutAttempt(rawAttempt) {
+  if (!isRecord11(rawAttempt)) {
+    return null;
+  }
+  if (!isNonEmptyString11(rawAttempt.colony) || !isNonEmptyString11(rawAttempt.roomName) || !isTerritoryScoutAttemptStatus(rawAttempt.status) || !isFiniteNumber6(rawAttempt.requestedAt) || !isFiniteNumber6(rawAttempt.updatedAt)) {
+    return null;
+  }
+  const attemptCount = isFiniteNumber6(rawAttempt.attemptCount) ? Math.max(1, Math.floor(rawAttempt.attemptCount)) : 1;
+  const lastValidation = normalizeTerritoryScoutValidation(rawAttempt.lastValidation);
+  return {
+    colony: rawAttempt.colony,
+    roomName: rawAttempt.roomName,
+    status: rawAttempt.status,
+    requestedAt: rawAttempt.requestedAt,
+    updatedAt: rawAttempt.updatedAt,
+    attemptCount,
+    ...typeof rawAttempt.controllerId === "string" ? { controllerId: rawAttempt.controllerId } : {},
+    ...isNonEmptyString11(rawAttempt.scoutName) ? { scoutName: rawAttempt.scoutName } : {},
+    ...lastValidation ? { lastValidation } : {}
+  };
+}
+function normalizeTerritoryScoutIntel(rawIntel) {
+  if (!isRecord11(rawIntel)) {
+    return null;
+  }
+  if (!isNonEmptyString11(rawIntel.colony) || !isNonEmptyString11(rawIntel.roomName) || !isFiniteNumber6(rawIntel.updatedAt)) {
+    return null;
+  }
+  const sourceIds = Array.isArray(rawIntel.sourceIds) ? rawIntel.sourceIds.flatMap((sourceId) => isNonEmptyString11(sourceId) ? [sourceId] : []) : [];
+  const sourceCount = isFiniteNumber6(rawIntel.sourceCount) ? Math.max(0, Math.floor(rawIntel.sourceCount)) : sourceIds.length;
+  const controller = normalizeTerritoryScoutControllerIntel(rawIntel.controller);
+  const mineral = normalizeTerritoryScoutMineralIntel(rawIntel.mineral);
+  return {
+    colony: rawIntel.colony,
+    roomName: rawIntel.roomName,
+    updatedAt: rawIntel.updatedAt,
+    ...controller ? { controller } : {},
+    sourceIds,
+    sourceCount,
+    ...mineral ? { mineral } : {},
+    hostileCreepCount: getBoundedCount(rawIntel.hostileCreepCount),
+    hostileStructureCount: getBoundedCount(rawIntel.hostileStructureCount),
+    hostileSpawnCount: getBoundedCount(rawIntel.hostileSpawnCount),
+    ...isNonEmptyString11(rawIntel.scoutName) ? { scoutName: rawIntel.scoutName } : {}
+  };
+}
+function normalizeTerritoryScoutControllerIntel(rawController) {
+  if (!isRecord11(rawController)) {
+    return null;
+  }
+  return {
+    ...typeof rawController.id === "string" ? { id: rawController.id } : {},
+    ...typeof rawController.my === "boolean" ? { my: rawController.my } : {},
+    ...isNonEmptyString11(rawController.ownerUsername) ? { ownerUsername: rawController.ownerUsername } : {},
+    ...isNonEmptyString11(rawController.reservationUsername) ? { reservationUsername: rawController.reservationUsername } : {},
+    ...isFiniteNumber6(rawController.reservationTicksToEnd) ? { reservationTicksToEnd: rawController.reservationTicksToEnd } : {}
+  };
+}
+function normalizeTerritoryScoutMineralIntel(rawMineral) {
+  if (!isRecord11(rawMineral) || !isNonEmptyString11(rawMineral.id)) {
+    return null;
+  }
+  return {
+    id: rawMineral.id,
+    ...isNonEmptyString11(rawMineral.mineralType) ? { mineralType: rawMineral.mineralType } : {},
+    ...isFiniteNumber6(rawMineral.density) ? { density: rawMineral.density } : {}
+  };
+}
+function normalizeTerritoryScoutValidation(rawValidation) {
+  if (!isRecord11(rawValidation)) {
+    return null;
+  }
+  if (!isTerritoryScoutValidationStatus(rawValidation.status) || !isFiniteNumber6(rawValidation.updatedAt)) {
+    return null;
+  }
+  return {
+    status: rawValidation.status,
+    updatedAt: rawValidation.updatedAt,
+    ...isTerritoryScoutValidationReason(rawValidation.reason) ? { reason: rawValidation.reason } : {}
+  };
+}
+function getBoundedCount(value) {
+  return isFiniteNumber6(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+function compareTerritoryScoutAttempts(left, right) {
+  return right.updatedAt - left.updatedAt || left.roomName.localeCompare(right.roomName);
+}
+function compareTerritoryScoutIntel(left, right) {
+  return right.updatedAt - left.updatedAt || left.roomName.localeCompare(right.roomName);
+}
+function findRoomObjects7(room, constantName) {
+  const findConstant = getGlobalNumber4(constantName);
+  const find = room.find;
+  if (typeof findConstant !== "number" || typeof find !== "function") {
+    return [];
+  }
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function isHostileSpawnStructure(structure) {
+  const structureType = structure.structureType;
+  return structureType === getStructureSpawnConstant();
+}
+function getStructureSpawnConstant() {
+  const structureSpawn = globalThis.STRUCTURE_SPAWN;
+  return structureSpawn != null ? structureSpawn : "spawn";
+}
+function getControllerOwnerUsername5(controller) {
+  var _a;
+  const username = (_a = controller.owner) == null ? void 0 : _a.username;
+  return isNonEmptyString11(username) ? username : void 0;
+}
+function getControllerReservationUsername3(controller) {
+  var _a;
+  const username = (_a = controller.reservation) == null ? void 0 : _a.username;
+  return isNonEmptyString11(username) ? username : void 0;
+}
+function getControllerReservationTicksToEnd2(controller) {
+  var _a;
+  const ticksToEnd = (_a = controller.reservation) == null ? void 0 : _a.ticksToEnd;
+  return typeof ticksToEnd === "number" ? ticksToEnd : void 0;
+}
+function getTerritoryScoutMemoryKey(colony, targetRoom) {
+  return `${colony}${TERRITORY_SCOUT_MEMORY_KEY_SEPARATOR}${targetRoom}`;
+}
+function getGlobalNumber4(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function getGameTime9() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" ? gameTime : 0;
+}
+function getTerritoryMemoryRecord4() {
+  var _a;
+  return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
+}
+function getWritableTerritoryMemoryRecord3() {
+  const memory = globalThis.Memory;
+  if (!memory) {
+    return null;
+  }
+  if (!isRecord11(memory.territory)) {
+    memory.territory = {};
+  }
+  return memory.territory;
+}
+function isTerritoryScoutAttemptStatus(status) {
+  return status === "requested" || status === "observed" || status === "timedOut";
+}
+function isTerritoryScoutValidationStatus(status) {
+  return status === "pending" || status === "passed" || status === "blocked" || status === "fallback";
+}
+function isTerritoryScoutValidationReason(reason) {
+  return reason === "intelMissing" || reason === "scoutPending" || reason === "scoutTimeout" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "hostileSpawn" || reason === "sourcesMissing";
+}
+function isFiniteNumber6(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+function isNonEmptyString11(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function isRecord11(value) {
+  return typeof value === "object" && value !== null;
 }
 
 // src/territory/expansionScoring.ts
@@ -13762,7 +14219,7 @@ function scoreExpansionCandidates(input) {
   const next = (_a = candidates.find((candidate) => candidate.evidenceStatus !== "unavailable")) != null ? _a : null;
   return attachExpansionCandidateReportColony({ candidates, next }, input.colonyName);
 }
-function refreshNextExpansionTargetSelection(colony, report, gameTime) {
+function refreshNextExpansionTargetSelection(colony, report, gameTime, telemetryEvents = []) {
   const colonyName = colony.room.name;
   persistExpansionCandidateScores(colonyName, report, gameTime);
   const candidate = selectPersistableExpansionCandidate(report);
@@ -13772,6 +14229,18 @@ function refreshNextExpansionTargetSelection(colony, report, gameTime) {
       status: "skipped",
       colony: colonyName,
       reason: getSelectionSkipReason(report)
+    };
+  }
+  const scoutValidation = validateVisibleNextExpansionScoutIntel(colony, candidate, gameTime, telemetryEvents);
+  if ((scoutValidation == null ? void 0 : scoutValidation.status) === "blocked") {
+    pruneNextExpansionTargets(colonyName);
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "unavailable",
+      targetRoom: candidate.roomName,
+      ...candidate.controllerId ? { controllerId: candidate.controllerId } : {},
+      score: candidate.score
     };
   }
   persistNextExpansionTarget(colonyName, candidate, gameTime);
@@ -13786,14 +14255,39 @@ function refreshNextExpansionTargetSelection(colony, report, gameTime) {
 function clearNextExpansionTargetIntent(colony) {
   pruneNextExpansionTargets(colony);
 }
+function validateVisibleNextExpansionScoutIntel(colony, candidate, gameTime, telemetryEvents) {
+  var _a, _b, _c;
+  const room = getVisibleRoom5(candidate.roomName);
+  if (!room) {
+    return null;
+  }
+  const colonyName = colony.room.name;
+  recordVisibleRoomScoutIntel(colonyName, room, gameTime, void 0, telemetryEvents);
+  const validation = validateTerritoryScoutIntelForClaim({
+    colony: colonyName,
+    targetRoom: candidate.roomName,
+    colonyOwnerUsername: getControllerOwnerUsername6(colony.room.controller),
+    gameTime
+  });
+  recordTerritoryScoutValidation(
+    colonyName,
+    candidate.roomName,
+    validation,
+    gameTime,
+    telemetryEvents,
+    (_c = candidate.controllerId) != null ? _c : (_b = (_a = validation.intel) == null ? void 0 : _a.controller) == null ? void 0 : _b.id,
+    candidate.score
+  );
+  return validation;
+}
 function buildRuntimeExpansionScoringInput(colony) {
   var _a, _b;
   return {
     colonyName: colony.room.name,
-    ...getControllerOwnerUsername5(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername5(colony.room.controller) } : {},
+    ...getControllerOwnerUsername6(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername6(colony.room.controller) } : {},
     energyCapacityAvailable: colony.energyCapacityAvailable,
     ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
-    ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername5(colony.room.controller)),
+    ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername6(colony.room.controller)),
     ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
     activePostClaimBootstrapCount: countActivePostClaimBootstraps(),
     candidates: buildRuntimeExpansionCandidates(colony)
@@ -13810,7 +14304,7 @@ function buildRuntimeExpansionCandidates(colony) {
   var _a;
   const rooms = (_a = getGameRooms2()) != null ? _a : {};
   const colonyName = colony.room.name;
-  const ownerUsername = getControllerOwnerUsername5(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername6(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames3(colonyName, ownerUsername);
   const adjacentRoomNames = getAdjacentRoomNamesByOwnedRoom(ownedRoomNames);
   const candidateOrders = /* @__PURE__ */ new Map();
@@ -13829,7 +14323,7 @@ function buildRuntimeExpansionCandidates(colony) {
     }
   }
   for (const room of Object.values(rooms)) {
-    if (!room || !isNonEmptyString11(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
+    if (!room || !isNonEmptyString12(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
       continue;
     }
     if (candidateOrders.has(room.name)) {
@@ -13875,13 +14369,13 @@ function buildUnseenExpansionCandidateEvidence(roomName) {
 }
 function buildVisibleExpansionCandidateEvidence(room) {
   const controller = room.controller;
-  const sources = findRoomObjects7(room, getFindConstant5("FIND_SOURCES"));
+  const sources = findRoomObjects8(room, getFindConstant5("FIND_SOURCES"));
   const controllerSourceRange = calculateAverageControllerSourceRange(controller, sources);
   const roomTerrain = getRoomTerrain4(room);
   const terrain = summarizeRoomTerrainFromTerrain(roomTerrain);
   const sourceAccessPoints = calculateAverageSourceAccessPoints(roomTerrain, sources);
-  const hostileCreepCount = findRoomObjects7(room, getFindConstant5("FIND_HOSTILE_CREEPS")).length;
-  const hostileStructureCount = findRoomObjects7(
+  const hostileCreepCount = findRoomObjects8(room, getFindConstant5("FIND_HOSTILE_CREEPS")).length;
+  const hostileStructureCount = findRoomObjects8(
     room,
     getFindConstant5("FIND_HOSTILE_STRUCTURES")
   ).length;
@@ -14018,7 +14512,7 @@ function hasForeignControllerPresence(input, controller) {
   if (!controller) {
     return false;
   }
-  return isNonEmptyString11(controller.ownerUsername) && controller.ownerUsername !== input.colonyOwnerUsername || isNonEmptyString11(controller.reservationUsername) && controller.reservationUsername !== input.colonyOwnerUsername;
+  return isNonEmptyString12(controller.ownerUsername) && controller.ownerUsername !== input.colonyOwnerUsername || isNonEmptyString12(controller.reservationUsername) && controller.reservationUsername !== input.colonyOwnerUsername;
 }
 function getDistanceScore(candidate) {
   const nearestOwnedDistance = candidate.nearestOwnedRoomDistance;
@@ -14137,12 +14631,12 @@ function hasRoomLimitPrecondition(candidate) {
   );
 }
 function persistExpansionCandidateScores(colony, report, gameTime) {
-  const territoryMemory = getWritableTerritoryMemoryRecord3();
+  const territoryMemory = getWritableTerritoryMemoryRecord4();
   if (!territoryMemory) {
     return;
   }
   const existingCandidates = Array.isArray(territoryMemory.expansionCandidates) ? territoryMemory.expansionCandidates.filter(
-    (candidate) => isRecord11(candidate) && candidate.colony !== colony
+    (candidate) => isRecord12(candidate) && candidate.colony !== colony
   ) : [];
   const nextCandidates = report.candidates.slice(0, MAX_PERSISTED_EXPANSION_CANDIDATES).map((candidate) => toPersistedExpansionCandidateMemory(colony, candidate, gameTime));
   if (existingCandidates.length === 0 && nextCandidates.length === 0) {
@@ -14185,7 +14679,7 @@ function getPersistedExpansionCandidateRecommendedAction(candidate) {
   return candidate.evidenceStatus === "insufficient-evidence" && candidate.adjacentToOwnedRoom ? "scout" : void 0;
 }
 function persistNextExpansionTarget(colony, candidate, gameTime) {
-  const territoryMemory = getWritableTerritoryMemoryRecord3();
+  const territoryMemory = getWritableTerritoryMemoryRecord4();
   if (!territoryMemory) {
     return;
   }
@@ -14228,7 +14722,7 @@ function upsertNextExpansionTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord11(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
+  if (isRecord12(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
     existingTarget.createdBy = NEXT_EXPANSION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -14246,7 +14740,7 @@ function upsertTerritoryIntent3(intents, nextIntent) {
   }
   intents.push(nextIntent);
 }
-function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTerritoryMemoryRecord4()) {
+function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTerritoryMemoryRecord5()) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return;
   }
@@ -14258,7 +14752,7 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
     if (activeTarget && isSameTarget(target, activeTarget)) {
       return true;
     }
-    if (isRecord11(target) && isNonEmptyString11(target.roomName) && target.action === "claim") {
+    if (isRecord12(target) && isNonEmptyString12(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey(target.roomName, "claim"));
     }
     return false;
@@ -14271,10 +14765,10 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
   );
 }
 function isNextExpansionTarget(target, colony) {
-  return isRecord11(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
+  return isRecord12(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
 }
 function isSameTarget(left, right) {
-  return isRecord11(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord12(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey(roomName, action) {
   return `${roomName}:${action}`;
@@ -14312,7 +14806,7 @@ function getVisibleOwnedRoomNames3(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString11(room.name) && (!ownerUsername || getControllerOwnerUsername5(room.controller) === ownerUsername)) {
+    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString12(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -14394,12 +14888,12 @@ function getAdjacentRoomNames3(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord11(exits)) {
+  if (!isRecord12(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER3.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString11(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString12(exitRoom) ? [exitRoom] : [];
   });
 }
 function getKnownRouteLength2(fromRoom, targetRoom) {
@@ -14433,11 +14927,11 @@ function getKnownRouteLength2(fromRoom, targetRoom) {
   return route.length;
 }
 function getTerritoryRouteDistanceCache3() {
-  const territoryMemory = getWritableTerritoryMemoryRecord3();
+  const territoryMemory = getWritableTerritoryMemoryRecord4();
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord11(territoryMemory.routeDistances)) {
+  if (!isRecord12(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
@@ -14450,9 +14944,9 @@ function getNoPathResultCode5() {
   return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE5;
 }
 function summarizeExpansionController(controller) {
-  const ownerUsername = getControllerOwnerUsername5(controller);
-  const reservationUsername = getControllerReservationUsername3(controller);
-  const reservationTicksToEnd = getControllerReservationTicksToEnd2(controller);
+  const ownerUsername = getControllerOwnerUsername6(controller);
+  const reservationUsername = getControllerReservationUsername4(controller);
+  const reservationTicksToEnd = getControllerReservationTicksToEnd3(controller);
   return {
     ...controller.my === true ? { my: true } : {},
     ...ownerUsername ? { ownerUsername } : {},
@@ -14559,7 +15053,7 @@ function getTerrainMask(name, fallback) {
   const value = globalThis[name];
   return typeof value === "number" ? value : fallback;
 }
-function findRoomObjects7(room, findConstant) {
+function findRoomObjects8(room, findConstant) {
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return [];
   }
@@ -14574,17 +15068,17 @@ function getFindConstant5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getControllerOwnerUsername5(controller) {
+function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString11(username) ? username : void 0;
+  return isNonEmptyString12(username) ? username : void 0;
 }
-function getControllerReservationUsername3(controller) {
+function getControllerReservationUsername4(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString11(username) ? username : void 0;
+  return isNonEmptyString12(username) ? username : void 0;
 }
-function getControllerReservationTicksToEnd2(controller) {
+function getControllerReservationTicksToEnd3(controller) {
   var _a;
   const ticksToEnd = (_a = controller.reservation) == null ? void 0 : _a.ticksToEnd;
   return typeof ticksToEnd === "number" ? ticksToEnd : void 0;
@@ -14592,22 +15086,26 @@ function getControllerReservationTicksToEnd2(controller) {
 function countActivePostClaimBootstraps() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord11(records)) {
+  if (!isRecord12(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord11(record) && record.status !== "ready"
+    (record) => isRecord12(record) && record.status !== "ready"
   ).length;
 }
 function getGameRooms2() {
   var _a;
   return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
 }
-function getTerritoryMemoryRecord4() {
+function getVisibleRoom5(roomName) {
+  var _a;
+  return (_a = getGameRooms2()) == null ? void 0 : _a[roomName];
+}
+function getTerritoryMemoryRecord5() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
-function getWritableTerritoryMemoryRecord3() {
+function getWritableTerritoryMemoryRecord4() {
   const memory = globalThis.Memory;
   if (!memory) {
     return null;
@@ -14626,10 +15124,10 @@ function toPercent(value) {
 function formatSourceAccessPoints(value) {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
-function isRecord11(value) {
+function isRecord12(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString11(value) {
+function isNonEmptyString12(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -14642,14 +15140,14 @@ var ROOM_EDGE_MAX5 = 47;
 var DEFAULT_TERRAIN_WALL_MASK5 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
-  if (!isNonEmptyString12(input.colony) || !isNonEmptyString12(input.roomName)) {
+  if (!isNonEmptyString13(input.colony) || !isNonEmptyString13(input.roomName)) {
     return;
   }
   const bootstraps = getWritablePostClaimBootstrapRecords();
   if (!bootstraps) {
     return;
   }
-  const gameTime = getGameTime9();
+  const gameTime = getGameTime10();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
   bootstraps[input.roomName] = {
@@ -14764,7 +15262,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   return { active: true, spawnConstructionPending: true };
 }
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
-  if (!isNonEmptyString12(roomName)) {
+  if (!isNonEmptyString13(roomName)) {
     return;
   }
   const record = getPostClaimBootstrapRecord(roomName);
@@ -14773,7 +15271,7 @@ function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, res
   }
   updatePostClaimBootstrapRecord(roomName, {
     status: "spawningWorkers",
-    updatedAt: getGameTime9()
+    updatedAt: getGameTime10()
   });
   telemetryEvents.push({
     type: "postClaimBootstrap",
@@ -14932,7 +15430,7 @@ function isTerrainWall3(terrain, position) {
 }
 function findExistingSpawnConstructionSite(room) {
   var _a;
-  const findConstant = getGlobalNumber4("FIND_MY_CONSTRUCTION_SITES");
+  const findConstant = getGlobalNumber5("FIND_MY_CONSTRUCTION_SITES");
   if (typeof room.find !== "function" || findConstant === null) {
     return null;
   }
@@ -14942,21 +15440,21 @@ function findExistingSpawnConstructionSite(room) {
   return (_a = sites[0]) != null ? _a : null;
 }
 function findSources2(room) {
-  const findConstant = getGlobalNumber4("FIND_SOURCES");
+  const findConstant = getGlobalNumber5("FIND_SOURCES");
   if (typeof room.find !== "function" || findConstant === null) {
     return [];
   }
   return room.find(findConstant);
 }
 function getRoomObjectPosition4(object) {
-  if (!isRecord12(object)) {
+  if (!isRecord13(object)) {
     return null;
   }
-  if (isFiniteNumber6(object.x) && isFiniteNumber6(object.y)) {
+  if (isFiniteNumber7(object.x) && isFiniteNumber7(object.y)) {
     return { x: object.x, y: object.y };
   }
   const pos = object.pos;
-  if (isRecord12(pos) && isFiniteNumber6(pos.x) && isFiniteNumber6(pos.y)) {
+  if (isRecord13(pos) && isFiniteNumber7(pos.x) && isFiniteNumber7(pos.y)) {
     return { x: pos.x, y: pos.y };
   }
   return null;
@@ -15003,13 +15501,13 @@ function getWritablePostClaimBootstrapRecords() {
   return memory.territory.postClaimBootstraps;
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
-  return isRecord12(value) && value.roomName === expectedRoomName && isNonEmptyString12(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber6(value.claimedAt) && isFiniteNumber6(value.updatedAt);
+  return isRecord13(value) && value.roomName === expectedRoomName && isNonEmptyString13(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber7(value.claimedAt) && isFiniteNumber7(value.updatedAt);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
 }
 function getPostClaimBootstrapWorkerTarget(record) {
-  return isFiniteNumber6(record.workerTarget) && record.workerTarget > 0 ? Math.floor(record.workerTarget) : POST_CLAIM_BOOTSTRAP_WORKER_TARGET;
+  return isFiniteNumber7(record.workerTarget) && record.workerTarget > 0 ? Math.floor(record.workerTarget) : POST_CLAIM_BOOTSTRAP_WORKER_TARGET;
 }
 function clampPosition(position) {
   return {
@@ -15050,7 +15548,7 @@ function getStructureConstant(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function getGlobalNumber4(name) {
+function getGlobalNumber5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : null;
 }
@@ -15058,18 +15556,18 @@ function getGlobalString(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getGameTime9() {
+function getGameTime10() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord12(value) {
+function isRecord13(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString12(value) {
+function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isFiniteNumber6(value) {
+function isFiniteNumber7(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
 
@@ -15097,7 +15595,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return void 0;
   }
-  const tick = getGameTime10();
+  const tick = getGameTime11();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -15194,7 +15692,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime10());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime11());
   }
   return {
     roomName: colony.room.name,
@@ -15203,11 +15701,11 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime10()),
+    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime11()),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime10()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime10()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime10()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime11()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime11()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime11()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -15217,6 +15715,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     ...territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {},
     ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
     ...buildTerritoryExecutionHintSummary(colony.room.name),
+    ...buildTerritoryScoutSummary(colony.room.name),
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
 }
@@ -15226,7 +15725,7 @@ function buildPostClaimBootstrapSummary(roomName) {
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime10());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime11());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -15241,6 +15740,18 @@ function buildTerritoryIntentSummary(colonyName, roleCounts) {
 function buildTerritoryExecutionHintSummary(colonyName) {
   const territoryExecutionHints = getActiveTerritoryFollowUpExecutionHints(colonyName);
   return territoryExecutionHints.length > 0 ? { territoryExecutionHints } : {};
+}
+function buildTerritoryScoutSummary(colonyName) {
+  const summary = getTerritoryScoutSummary(colonyName);
+  if (!summary) {
+    return {};
+  }
+  return {
+    territoryScout: {
+      ...summary.attempts.length > 0 ? { attempts: summary.attempts } : {},
+      ...summary.intel.length > 0 ? { intel: summary.intel } : {}
+    }
+  };
 }
 function summarizeSpawn(spawn) {
   if (!spawn.spawning) {
@@ -15361,7 +15872,7 @@ function isRecentWorkerTaskBehaviorSample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskBehaviorSample(value) {
-  return isRecord13(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord13(value.state) && isRecord13(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+  return isRecord14(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord14(value.state) && isRecord14(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
 }
 function isRecentWorkerTaskPolicyShadow(value, tick) {
   if (!isWorkerTaskPolicyShadow(value)) {
@@ -15370,15 +15881,15 @@ function isRecentWorkerTaskPolicyShadow(value, tick) {
   return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskPolicyShadow(value) {
-  return isRecord13(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
+  return isRecord14(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function shouldBuildStructureSnapshot(tick) {
   return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
 }
 function summarizeStructures(colony, colonyWorkers) {
   var _a, _b;
-  const roomStructures = (_a = findRoomObjects8(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const constructionSites = (_b = findRoomObjects8(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
+  const roomStructures = (_a = findRoomObjects9(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const constructionSites = (_b = findRoomObjects9(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
   const roadCount = countStructuresByType2(roomStructures, "STRUCTURE_ROAD", "road");
   const pendingRoadSiteCount = countConstructionSitesByType(constructionSites, "STRUCTURE_ROAD", "road");
   return {
@@ -15398,7 +15909,7 @@ function countConstructionSitesByType(constructionSites, globalName, fallback) {
   return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
 }
 function countOwnedRamparts(structures) {
-  return structures.filter((structure) => isRecord13(structure) && isObservedOwnedRampart(structure)).length;
+  return structures.filter((structure) => isRecord14(structure) && isObservedOwnedRampart(structure)).length;
 }
 function summarizeContainers(structures) {
   return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
@@ -15435,7 +15946,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   return [...repairCounts.entries()].sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId)).map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
 }
 function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
-  const structureRecord = isRecord13(structure) ? structure : {};
+  const structureRecord = isRecord14(structure) ? structure : {};
   const structureType = typeof structureRecord.structureType === "string" ? structureRecord.structureType : void 0;
   const hits = getFiniteNumber(structureRecord.hits);
   const hitsMax = getFiniteNumber(structureRecord.hitsMax);
@@ -15448,7 +15959,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord13(structure) && matchesStructureType10(structure.structureType, globalName, fallback);
+  return isRecord14(structure) && matchesStructureType10(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -15608,7 +16119,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord13(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord14(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio3(numerator, denominator) {
   if (denominator <= 0) {
@@ -15623,7 +16134,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord13(value)) {
+  if (!isRecord14(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -15664,7 +16175,7 @@ function isRecentSpawnCriticalRefillSample(sample, tick) {
   return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
 }
 function isSpawnCriticalRefillSample(value) {
-  return isRecord13(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
+  return isRecord14(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;
@@ -15691,10 +16202,10 @@ function buildControllerSummary(room) {
 }
 function summarizeResources(colony, colonyWorkers, events) {
   var _a, _b, _c, _d;
-  const roomStructures = (_a = findRoomObjects8(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const constructionSites = (_b = findRoomObjects8(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
-  const droppedResources = (_c = findRoomObjects8(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
-  const sources = (_d = findRoomObjects8(colony.room, "FIND_SOURCES")) != null ? _d : [];
+  const roomStructures = (_a = findRoomObjects9(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const constructionSites = (_b = findRoomObjects9(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
+  const droppedResources = (_c = findRoomObjects9(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
+  const sources = (_d = findRoomObjects9(colony.room, "FIND_SOURCES")) != null ? _d : [];
   return {
     storedEnergy: sumEnergyInStores(roomStructures),
     workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
@@ -15747,7 +16258,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord13(constructionSite)) {
+  if (!isRecord14(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -15761,7 +16272,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord13(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord14(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -15792,8 +16303,8 @@ function buildControllerProgressRemaining(room) {
 }
 function summarizeCombat(room, events) {
   var _a, _b;
-  const hostileCreeps = (_a = findRoomObjects8(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
-  const hostileStructures = (_b = findRoomObjects8(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
+  const hostileCreeps = (_a = findRoomObjects9(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
+  const hostileStructures = (_b = findRoomObjects9(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
   return {
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -15959,13 +16470,13 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   if (!eventLog) {
     return {};
   }
-  const harvestEvent = getGlobalNumber5("EVENT_HARVEST");
-  const transferEvent = getGlobalNumber5("EVENT_TRANSFER");
-  const buildEvent = getGlobalNumber5("EVENT_BUILD");
-  const repairEvent = getGlobalNumber5("EVENT_REPAIR");
-  const upgradeControllerEvent = getGlobalNumber5("EVENT_UPGRADE_CONTROLLER");
-  const attackEvent = getGlobalNumber5("EVENT_ATTACK");
-  const objectDestroyedEvent = getGlobalNumber5("EVENT_OBJECT_DESTROYED");
+  const harvestEvent = getGlobalNumber6("EVENT_HARVEST");
+  const transferEvent = getGlobalNumber6("EVENT_TRANSFER");
+  const buildEvent = getGlobalNumber6("EVENT_BUILD");
+  const repairEvent = getGlobalNumber6("EVENT_REPAIR");
+  const upgradeControllerEvent = getGlobalNumber6("EVENT_UPGRADE_CONTROLLER");
+  const attackEvent = getGlobalNumber6("EVENT_ATTACK");
+  const objectDestroyedEvent = getGlobalNumber6("EVENT_OBJECT_DESTROYED");
   const resourceEvents = {
     harvestedEnergy: 0,
     transferredEnergy: 0,
@@ -15983,10 +16494,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord13(entry) || typeof entry.event !== "number") {
+    if (!isRecord14(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord13(entry.data) ? entry.data : {};
+    const data = isRecord14(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -16038,7 +16549,7 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
 }
 function getSpawnExtensionEnergyStructureIds(room) {
   var _a, _b;
-  const structures = (_b = (_a = findRoomObjects8(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects8(room, "FIND_STRUCTURES")) != null ? _b : [];
+  const structures = (_b = (_a = findRoomObjects9(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects9(room, "FIND_STRUCTURES")) != null ? _b : [];
   const ids = /* @__PURE__ */ new Set();
   for (const structure of structures) {
     if (!isSpawnExtensionEnergyStructure2(structure)) {
@@ -16052,7 +16563,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord13(structure) && (matchesStructureType10(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType10(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord14(structure) && (matchesStructureType10(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType10(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -16061,10 +16572,10 @@ function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
 function getObjectId3(value) {
-  return isRecord13(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+  return isRecord14(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
-function findRoomObjects8(room, constantName) {
-  const findConstant = getGlobalNumber5(constantName);
+function findRoomObjects9(room, constantName) {
+  const findConstant = getGlobalNumber6(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return void 0;
@@ -16092,7 +16603,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord13(object) || !isRecord13(object.store)) {
+  if (!isRecord14(object) || !isRecord14(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -16104,7 +16615,7 @@ function getEnergyInStore(object) {
   return typeof storedEnergy === "number" ? storedEnergy : 0;
 }
 function getEnergyCapacityInStore(object) {
-  if (!isRecord13(object) || !isRecord13(object.store)) {
+  if (!isRecord14(object) || !isRecord14(object.store)) {
     return 0;
   }
   const getCapacity = object.store.getCapacity;
@@ -16125,7 +16636,7 @@ function getEnergyCapacityInStore(object) {
 function sumDroppedEnergy2(droppedResources) {
   const energyResource = getEnergyResource6();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord13(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord14(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -16138,7 +16649,7 @@ function getNumericEventData(data, key) {
   const value = data[key];
   return typeof value === "number" ? value : 0;
 }
-function getGlobalNumber5(name) {
+function getGlobalNumber6(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -16154,7 +16665,7 @@ function getEnergyResource6() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord13(value) {
+function isRecord14(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -16172,7 +16683,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime10() {
+function getGameTime11() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -16690,7 +17201,7 @@ var ERR_GCL_NOT_ENOUGH_CODE = -15;
 var autonomousExpansionClaimTickContext = null;
 function refreshAutonomousExpansionClaimIntent(colony, report, gameTime, telemetryEvents = []) {
   const context = getAutonomousExpansionClaimTickContext(gameTime);
-  const evaluation = evaluateAutonomousExpansionClaim(colony, report, gameTime, context);
+  const evaluation = evaluateAutonomousExpansionClaim(colony, report, gameTime, context, telemetryEvents);
   if (evaluation.status === "planned" && evaluation.targetRoom) {
     persistAutonomousExpansionClaimIntent(colony.room.name, evaluation, gameTime, context);
     recordAutonomousExpansionClaimTelemetry(telemetryEvents, evaluation, "intent");
@@ -16705,14 +17216,14 @@ function refreshAutonomousExpansionClaimIntent(colony, report, gameTime, telemet
   return evaluation;
 }
 function shouldDeferOccupationRecommendationForExpansionClaim(evaluation) {
-  return evaluation.status === "planned" || evaluation.reason === "controllerCooldown";
+  return evaluation.status === "planned" || evaluation.reason === "controllerCooldown" || evaluation.reason === "scoutPending";
 }
 function clearAutonomousExpansionClaimIntent(colony) {
   pruneAutonomousExpansionClaimTargets(colony);
   autonomousExpansionClaimTickContext = null;
 }
 function shouldPruneAutonomousExpansionClaimTargets(reason) {
-  return reason === "noAdjacentCandidate" || reason === "scoreBelowThreshold" || reason === "hostilePresence" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved";
+  return reason === "noAdjacentCandidate" || reason === "scoreBelowThreshold" || reason === "hostilePresence" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "sourcesMissing";
 }
 function getVisibleOwnedRoomCount() {
   var _a;
@@ -16740,7 +17251,7 @@ function isAutonomousExpansionClaimGclInsufficient() {
 function getAutonomousExpansionClaimTickContext(gameTime) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   const rawIntents = territoryMemory == null ? void 0 : territoryMemory.intents;
   if (autonomousExpansionClaimTickContext && autonomousExpansionClaimTickContext.gameTime === gameTime && autonomousExpansionClaimTickContext.gameMap === gameMap) {
     if (autonomousExpansionClaimTickContext.territoryMemory !== territoryMemory || autonomousExpansionClaimTickContext.rawIntents !== rawIntents) {
@@ -16789,8 +17300,8 @@ function recordExpansionClaimSkipTelemetry(creep, controller, reason, telemetryE
     reason
   });
 }
-function evaluateAutonomousExpansionClaim(colony, report, gameTime, context) {
-  var _a;
+function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, telemetryEvents) {
+  var _a, _b, _c;
   const colonyName = colony.room.name;
   const expansionReport = scoreExpansionCandidates(buildAutonomousExpansionScoringInput(colony, report, context));
   const adjacentCandidates = getRankedAdjacentExpansionCandidates(expansionReport);
@@ -16821,39 +17332,76 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context) {
   if (!hasSufficientAutonomousExpansionClaimRcl(colony)) {
     return { ...baseEvaluation, reason: "controllerLevelLow" };
   }
-  const room = getVisibleRoom5(candidate.roomName);
-  if (!room) {
-    return { ...baseEvaluation, reason: "roomNotVisible" };
+  const room = getVisibleRoom6(candidate.roomName);
+  const controller = room == null ? void 0 : room.controller;
+  const visibleControllerId = controller == null ? void 0 : controller.id;
+  const visibleControllerEvaluation = {
+    ...baseEvaluation,
+    ...typeof visibleControllerId === "string" ? { controllerId: visibleControllerId } : {}
+  };
+  if (room && isVisibleRoomHostile(room)) {
+    return { ...visibleControllerEvaluation, reason: "hostilePresence" };
   }
-  if (isVisibleRoomHostile(room)) {
-    return { ...baseEvaluation, reason: "hostilePresence" };
+  if (room && !controller) {
+    return { ...visibleControllerEvaluation, reason: "controllerMissing" };
   }
-  const controller = room.controller;
-  if (!controller) {
-    return { ...baseEvaluation, reason: "controllerMissing" };
+  if (controller && isControllerOwned2(controller)) {
+    return { ...visibleControllerEvaluation, reason: "controllerOwned" };
   }
-  const controllerId = controller.id;
+  if (controller && isControllerReserved(controller, getControllerOwnerUsername7(colony.room.controller))) {
+    return { ...visibleControllerEvaluation, reason: "controllerReserved" };
+  }
+  if (isAutonomousExpansionClaimGclInsufficient()) {
+    return { ...visibleControllerEvaluation, reason: "gclInsufficient" };
+  }
+  if (controller && isExpansionClaimControllerOnCooldown(controller)) {
+    return { ...visibleControllerEvaluation, reason: "controllerCooldown" };
+  }
+  if (isAutonomousClaimSuppressed(colonyName, candidate.roomName, gameTime, context.territoryIntents)) {
+    return { ...visibleControllerEvaluation, reason: "suppressed" };
+  }
+  if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
+    return { ...visibleControllerEvaluation, reason: "scoreBelowThreshold" };
+  }
+  if (room) {
+    recordVisibleRoomScoutIntel(colonyName, room, gameTime, void 0, telemetryEvents);
+  }
+  const scoutValidation = validateTerritoryScoutIntelForClaim({
+    colony: colonyName,
+    targetRoom: candidate.roomName,
+    colonyOwnerUsername: getControllerOwnerUsername7(colony.room.controller),
+    gameTime
+  });
+  const scoutControllerId = getScoutValidationControllerId(scoutValidation);
+  const controllerId = (_c = (_b = controller == null ? void 0 : controller.id) != null ? _b : scoutControllerId) != null ? _c : candidate.controllerId;
   const controllerEvaluation = {
     ...baseEvaluation,
     ...typeof controllerId === "string" ? { controllerId } : {}
   };
-  if (isControllerOwned2(controller)) {
-    return { ...controllerEvaluation, reason: "controllerOwned" };
+  recordTerritoryScoutValidation(
+    colonyName,
+    candidate.roomName,
+    scoutValidation,
+    gameTime,
+    telemetryEvents,
+    controllerEvaluation.controllerId,
+    candidate.score
+  );
+  if (scoutValidation.status === "pending") {
+    ensureTerritoryScoutAttempt(
+      colonyName,
+      candidate.roomName,
+      gameTime,
+      telemetryEvents,
+      controllerEvaluation.controllerId
+    );
+    return { ...controllerEvaluation, reason: "scoutPending" };
   }
-  if (isControllerReserved(controller, getControllerOwnerUsername6(colony.room.controller))) {
-    return { ...controllerEvaluation, reason: "controllerReserved" };
-  }
-  if (isAutonomousExpansionClaimGclInsufficient()) {
-    return { ...controllerEvaluation, reason: "gclInsufficient" };
-  }
-  if (isExpansionClaimControllerOnCooldown(controller)) {
-    return { ...controllerEvaluation, reason: "controllerCooldown" };
-  }
-  if (isAutonomousClaimSuppressed(colonyName, candidate.roomName, gameTime, context.territoryIntents)) {
-    return { ...controllerEvaluation, reason: "suppressed" };
-  }
-  if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
-    return { ...controllerEvaluation, reason: "scoreBelowThreshold" };
+  if (scoutValidation.status === "blocked") {
+    return {
+      ...controllerEvaluation,
+      reason: getScoutValidationClaimSkipReason(scoutValidation)
+    };
   }
   return {
     status: "planned",
@@ -16863,16 +17411,39 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context) {
     ...typeof controllerId === "string" ? { controllerId } : {}
   };
 }
+function getScoutValidationControllerId(validation) {
+  var _a, _b;
+  return (_b = (_a = validation.intel) == null ? void 0 : _a.controller) == null ? void 0 : _b.id;
+}
+function getScoutValidationClaimSkipReason(validation) {
+  switch (validation.reason) {
+    case "controllerMissing":
+      return "controllerMissing";
+    case "controllerOwned":
+      return "controllerOwned";
+    case "controllerReserved":
+      return "controllerReserved";
+    case "hostileSpawn":
+      return "hostilePresence";
+    case "sourcesMissing":
+      return "sourcesMissing";
+    case "intelMissing":
+    case "scoutPending":
+    case "scoutTimeout":
+    default:
+      return "scoutPending";
+  }
+}
 function buildAutonomousExpansionScoringInput(colony, report, context) {
   var _a, _b;
   const colonyName = colony.room.name;
-  const colonyOwnerUsername = getControllerOwnerUsername6(colony.room.controller);
+  const colonyOwnerUsername = getControllerOwnerUsername7(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames4(colonyName, colonyOwnerUsername);
   const adjacentRoomNamesByOwnedRoom = getAdjacentRoomNamesByOwnedRoom2(ownedRoomNames, context);
   const seenRooms = /* @__PURE__ */ new Set();
   const candidates = [];
   report.candidates.forEach((candidate, order) => {
-    if (!isNonEmptyString13(candidate.roomName) || seenRooms.has(candidate.roomName)) {
+    if (!isNonEmptyString14(candidate.roomName) || seenRooms.has(candidate.roomName)) {
       return;
     }
     seenRooms.add(candidate.roomName);
@@ -16892,7 +17463,7 @@ function buildAutonomousExpansionScoringInput(colony, report, context) {
   };
 }
 function toExpansionCandidateInput(candidate, order, adjacency) {
-  const room = getVisibleRoom5(candidate.roomName);
+  const room = getVisibleRoom6(candidate.roomName);
   const controller = room == null ? void 0 : room.controller;
   const controllerId = typeof (controller == null ? void 0 : controller.id) === "string" ? controller.id : candidate.controllerId;
   const hostileCreepCount = typeof candidate.hostileCreepCount === "number" ? candidate.hostileCreepCount : room ? findVisibleHostileCreeps2(room).length : void 0;
@@ -16914,12 +17485,12 @@ function toExpansionCandidateInput(candidate, order, adjacency) {
 }
 function summarizeExpansionController2(controller) {
   var _a, _b;
-  const ownerUsername = getControllerOwnerUsername6(controller);
+  const ownerUsername = getControllerOwnerUsername7(controller);
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
   return {
     ...typeof controller.my === "boolean" ? { my: controller.my } : {},
     ...ownerUsername ? { ownerUsername } : {},
-    ...isNonEmptyString13(reservationUsername) ? { reservationUsername } : {},
+    ...isNonEmptyString14(reservationUsername) ? { reservationUsername } : {},
     ...typeof ((_b = controller.reservation) == null ? void 0 : _b.ticksToEnd) === "number" ? { reservationTicksToEnd: controller.reservation.ticksToEnd } : {}
   };
 }
@@ -16940,7 +17511,7 @@ function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString13(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString14(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -16979,21 +17550,21 @@ function getAdjacentRoomNames4(roomName, gameMap = ((_a) => (_a = globalThis.Gam
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord14(exits)) {
+  if (!isRecord15(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER4.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString13(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString14(exitRoom) ? [exitRoom] : [];
   });
 }
 function countActivePostClaimBootstraps2() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord14(records)) {
+  if (!isRecord15(records)) {
     return 0;
   }
-  return Object.values(records).filter((record) => isRecord14(record) && record.status !== "ready").length;
+  return Object.values(records).filter((record) => isRecord15(record) && record.status !== "ready").length;
 }
 function hasSufficientAutonomousExpansionClaimRcl(colony) {
   var _a, _b;
@@ -17024,7 +17595,7 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime, con
   if (!evaluation.targetRoom) {
     return;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
@@ -17063,13 +17634,13 @@ function upsertTerritoryTarget2(territoryMemory, target) {
     territoryMemory.targets = [];
   }
   const existingTarget = territoryMemory.targets.find(
-    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord14(rawTarget) && rawTarget.createdBy === target.createdBy
+    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord15(rawTarget) && rawTarget.createdBy === target.createdBy
   );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord14(existingTarget)) {
+  if (isRecord15(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -17088,7 +17659,7 @@ function upsertTerritoryIntent4(intents, nextIntent) {
   }
   intents.push(nextIntent);
 }
-function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerritoryMemoryRecord5(), activeTarget, context) {
+function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerritoryMemoryRecord6(), activeTarget, context) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return;
   }
@@ -17100,7 +17671,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord14(target) && isNonEmptyString13(target.roomName) && target.action === "claim") {
+    if (isRecord15(target) && isNonEmptyString14(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -17119,7 +17690,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord14(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord15(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime, intents) {
@@ -17183,23 +17754,23 @@ function getControllerClaimCooldown(controller) {
   return typeof upgradeBlocked === "number" && upgradeBlocked > 0 ? upgradeBlocked : 0;
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord14(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord15(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isSameTarget2(left, right) {
-  return isRecord14(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord15(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
 }
-function getVisibleRoom5(roomName) {
+function getVisibleRoom6(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getTerritoryMemoryRecord5() {
+function getTerritoryMemoryRecord6() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
-function getWritableTerritoryMemoryRecord4() {
+function getWritableTerritoryMemoryRecord5() {
   const memory = globalThis.Memory;
   if (!memory) {
     return null;
@@ -17224,17 +17795,17 @@ function isControllerOwned2(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString13(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString14(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername6(controller) {
+function getControllerOwnerUsername7(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString13(username) ? username : void 0;
+  return isNonEmptyString14(username) ? username : void 0;
 }
-function isRecord14(value) {
+function isRecord15(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString13(value) {
+function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -17273,6 +17844,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   if (assignment.action === "scout") {
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime12(), creep.name, telemetryEvents);
     return;
   }
   const controller = selectTargetController(creep, assignment);
@@ -17340,7 +17912,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime11();
+  const gameTime = getGameTime12();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -17360,7 +17932,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime11());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime12());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -17440,7 +18012,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime11() {
+function getGameTime12() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -17635,17 +18207,17 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber7(refreshedAt) || !isRecord15(rawSelection) || !isNonEmptyString14(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber8(refreshedAt) || !isRecord16(rawSelection) || !isNonEmptyString15(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord15(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord16(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString14(rawSelection.targetRoom)) {
+    if (!isNonEmptyString15(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -17653,7 +18225,7 @@ function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
       colony: colonyName,
       targetRoom: rawSelection.targetRoom,
       ...typeof rawSelection.controllerId === "string" ? { controllerId: rawSelection.controllerId } : {},
-      ...isFiniteNumber7(rawSelection.score) ? { score: rawSelection.score } : {}
+      ...isFiniteNumber8(rawSelection.score) ? { score: rawSelection.score } : {}
     };
   }
   const reason = normalizeNextExpansionTargetSelectionReason(rawSelection.reason);
@@ -17682,13 +18254,13 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord15(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord16(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
   const controller = colony.room.controller;
-  const controllerLevel = isFiniteNumber7(controller == null ? void 0 : controller.level) ? controller.level : "unknown";
-  const downgradeState = isFiniteNumber7(controller == null ? void 0 : controller.ticksToDowngrade) && controller.ticksToDowngrade < NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS ? "guarded" : "stable";
+  const controllerLevel = isFiniteNumber8(controller == null ? void 0 : controller.level) ? controller.level : "unknown";
+  const downgradeState = isFiniteNumber8(controller == null ? void 0 : controller.ticksToDowngrade) && controller.ticksToDowngrade < NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS ? "guarded" : "stable";
   return [
     colony.room.name,
     colony.energyCapacityAvailable,
@@ -17712,20 +18284,20 @@ function countVisibleOwnedRooms2() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord15(records)) {
+  if (!isRecord16(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord15(record) && record.status !== "ready"
+    (record) => isRecord16(record) && record.status !== "ready"
   ).length;
 }
-function isRecord15(value) {
+function isRecord16(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString14(value) {
+function isNonEmptyString15(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isFiniteNumber7(value) {
+function isFiniteNumber8(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
 function createSpawnPlanningColony(colony, energyAvailable, usedSpawns) {
@@ -17830,7 +18402,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime12())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime13())
     );
   }
 };
@@ -17902,7 +18474,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime12() {
+function getGameTime13() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -18732,10 +19304,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord16(rawReplay)) {
+  if (!isRecord17(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString15(rawReplay.replayId) || !isNonEmptyString15(rawReplay.room) || !isFiniteNumber8(rawReplay.startTick) || !isFiniteNumber8(rawReplay.endTick) || !isFiniteNumber8(rawReplay.finalScore) || !isRecord16(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString16(rawReplay.replayId) || !isNonEmptyString16(rawReplay.room) || !isFiniteNumber9(rawReplay.startTick) || !isFiniteNumber9(rawReplay.endTick) || !isFiniteNumber9(rawReplay.finalScore) || !isRecord17(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -18760,13 +19332,13 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord16(value) {
+function isRecord17(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString15(value) {
+function isNonEmptyString16(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isFiniteNumber8(value) {
+function isFiniteNumber9(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
 

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -13813,13 +13813,13 @@ function validateTerritoryScoutIntelForClaim({
   colonyOwnerUsername,
   gameTime
 }) {
+  const attempt = getTerritoryScoutAttempt(colony, targetRoom);
   const intel = getTerritoryScoutIntel(colony, targetRoom);
   if (!intel) {
-    const attempt = getTerritoryScoutAttempt(colony, targetRoom);
-    if ((attempt == null ? void 0 : attempt.status) === "requested" && gameTime >= attempt.requestedAt && gameTime - attempt.requestedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS) {
-      return { status: "fallback", reason: "scoutTimeout" };
-    }
-    return { status: "pending", reason: attempt ? "scoutPending" : "intelMissing" };
+    return getUnavailableScoutIntelValidationResult(attempt, gameTime, "intelMissing");
+  }
+  if (!isScoutIntelUsableForClaim(intel, attempt, gameTime)) {
+    return getUnavailableScoutIntelValidationResult(attempt, gameTime, "scoutPending");
   }
   const controller = intel.controller;
   if (!controller) {
@@ -13999,6 +13999,24 @@ function getTerritoryScoutAttempt(colony, targetRoom) {
   var _a, _b;
   const rawAttempt = (_b = (_a = getTerritoryMemoryRecord4()) == null ? void 0 : _a.scoutAttempts) == null ? void 0 : _b[getTerritoryScoutMemoryKey(colony, targetRoom)];
   return normalizeTerritoryScoutAttempt(rawAttempt);
+}
+function getUnavailableScoutIntelValidationResult(attempt, gameTime, pendingReason) {
+  if (isScoutAttemptTimedOut(attempt, gameTime)) {
+    return { status: "fallback", reason: "scoutTimeout" };
+  }
+  return { status: "pending", reason: attempt ? "scoutPending" : pendingReason };
+}
+function isScoutIntelUsableForClaim(intel, attempt, gameTime) {
+  if (isScoutIntelExpired(intel, gameTime)) {
+    return false;
+  }
+  return (attempt == null ? void 0 : attempt.status) !== "requested" || intel.updatedAt >= attempt.requestedAt;
+}
+function isScoutIntelExpired(intel, gameTime) {
+  return gameTime >= intel.updatedAt && gameTime - intel.updatedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS;
+}
+function isScoutAttemptTimedOut(attempt, gameTime) {
+  return (attempt == null ? void 0 : attempt.status) === "requested" && gameTime >= attempt.requestedAt && gameTime - attempt.requestedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS;
 }
 function getMutableScoutAttemptRecords(territoryMemory) {
   if (!isRecord11(territoryMemory.scoutAttempts) || Array.isArray(territoryMemory.scoutAttempts)) {
@@ -17334,6 +17352,9 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   }
   const room = getVisibleRoom6(candidate.roomName);
   const controller = room == null ? void 0 : room.controller;
+  if (room) {
+    recordVisibleRoomScoutIntel(colonyName, room, gameTime, void 0, telemetryEvents);
+  }
   const visibleControllerId = controller == null ? void 0 : controller.id;
   const visibleControllerEvaluation = {
     ...baseEvaluation,
@@ -17362,9 +17383,6 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   }
   if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
     return { ...visibleControllerEvaluation, reason: "scoreBelowThreshold" };
-  }
-  if (room) {
-    recordVisibleRoomScoutIntel(colonyName, room, gameTime, void 0, telemetryEvents);
   }
   const scoutValidation = validateTerritoryScoutIntelForClaim({
     colony: colonyName,
@@ -17845,6 +17863,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   }
   if (assignment.action === "scout") {
     recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime12(), creep.name, telemetryEvents);
+    completeTerritoryAssignment(creep);
     return;
   }
   const controller = selectTargetController(creep, assignment);

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -12,6 +12,8 @@ const HIGH_RCL_WORKER_PATTERN: BodyPartConstant[] = ['work', 'work', 'work', 'ca
 const HIGH_RCL_WORKER_PATTERN_COST = 450;
 const EMERGENCY_DEFENDER_BODY: BodyPartConstant[] = ['tough', 'attack', 'move'];
 const EMERGENCY_DEFENDER_BODY_COST = 140;
+export const TERRITORY_SCOUT_BODY: BodyPartConstant[] = ['move'];
+export const TERRITORY_SCOUT_BODY_COST = 50;
 import {
   buildTerritoryClaimerBody,
   TERRITORY_CONTROLLER_PRESSURE_BODY,

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -22,7 +22,9 @@ import {
   buildTerritoryControllerBody,
   buildTerritoryControllerPressureBody,
   buildWorkerBody,
-  getBodyCost
+  getBodyCost,
+  TERRITORY_SCOUT_BODY,
+  TERRITORY_SCOUT_BODY_COST
 } from './bodyBuilder';
 import {
   buildTerritoryCreepMemory,
@@ -76,8 +78,6 @@ export interface SpawnPlanningOptions {
   allowTerritoryFollowUp?: boolean;
 }
 
-const TERRITORY_SCOUT_BODY: BodyPartConstant[] = ['move'];
-const TERRITORY_SCOUT_BODY_COST = 50;
 const CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
 const CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
 const CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET = 6;

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -28,6 +28,7 @@ import {
   type TerritoryIntentProgressSummary
 } from '../territory/territoryPlanner';
 import { getPostClaimBootstrapSummary, type PostClaimBootstrapSummary } from '../territory/postClaimBootstrap';
+import { getTerritoryScoutSummary } from '../territory/scoutIntel';
 import {
   summarizeAndResetCreepBehaviorTelemetry,
   type RuntimeBehaviorSummary as LegacyRuntimeBehaviorSummary
@@ -64,6 +65,7 @@ export type RuntimeTelemetryEvent =
   | RuntimeSpawnTelemetryEvent
   | RuntimeDefenseTelemetryEvent
   | RuntimeTerritoryClaimTelemetryEvent
+  | RuntimeTerritoryScoutTelemetryEvent
   | RuntimePostClaimBootstrapTelemetryEvent
   | RuntimeSpawnSitePlacedTelemetryEvent;
 
@@ -78,11 +80,22 @@ export type RuntimeTerritoryClaimTelemetryReason =
   | 'controllerCooldown'
   | 'gclInsufficient'
   | 'suppressed'
+  | 'scoutPending'
+  | 'sourcesMissing'
   | 'notInRange'
   | 'invalidTarget'
   | 'missingClaimPart'
   | 'gclUnavailable'
   | 'claimFailed';
+
+export type RuntimeTerritoryScoutTelemetryReason = TerritoryScoutValidationReason;
+export type RuntimeTerritoryScoutTelemetryResult =
+  | 'requested'
+  | 'recorded'
+  | 'pending'
+  | 'passed'
+  | 'blocked'
+  | 'fallback';
 
 export interface RuntimeSpawnTelemetryEvent {
   type: 'spawn';
@@ -109,6 +122,23 @@ export interface RuntimeTerritoryClaimTelemetryEvent {
   creepName?: string;
   result?: ScreepsReturnCode;
   reason?: RuntimeTerritoryClaimTelemetryReason;
+  score?: number;
+}
+
+export interface RuntimeTerritoryScoutTelemetryEvent {
+  type: 'territoryScout';
+  roomName: string;
+  colony: string;
+  targetRoom: string;
+  phase: 'attempt' | 'intel' | 'validation';
+  result: RuntimeTerritoryScoutTelemetryResult;
+  reason?: RuntimeTerritoryScoutTelemetryReason;
+  controllerId?: Id<StructureController>;
+  scoutName?: string;
+  sourceCount?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  hostileSpawnCount?: number;
   score?: number;
 }
 
@@ -168,7 +198,13 @@ interface RuntimeRoomSummary {
   omittedTerritoryIntentCount?: number;
   suspendedTerritoryIntentCounts?: Record<string, number>;
   territoryExecutionHints?: TerritoryExecutionHintMemory[];
+  territoryScout?: RuntimeTerritoryScoutSummary;
   postClaimBootstrap?: PostClaimBootstrapSummary;
+}
+
+interface RuntimeTerritoryScoutSummary {
+  attempts?: TerritoryScoutAttemptMemory[];
+  intel?: TerritoryScoutIntelMemory[];
 }
 
 interface RuntimeControllerSummary {
@@ -585,6 +621,7 @@ function summarizeRoom(
     ...(territoryExpansion.candidates.length > 0 ? { territoryExpansion } : {}),
     ...buildTerritoryIntentSummary(colony.room.name, roleCounts),
     ...buildTerritoryExecutionHintSummary(colony.room.name),
+    ...buildTerritoryScoutSummary(colony.room.name),
     ...buildPostClaimBootstrapSummary(colony.room.name)
   };
 }
@@ -626,6 +663,20 @@ function buildTerritoryExecutionHintSummary(
 ): { territoryExecutionHints?: TerritoryExecutionHintMemory[] } {
   const territoryExecutionHints = getActiveTerritoryFollowUpExecutionHints(colonyName);
   return territoryExecutionHints.length > 0 ? { territoryExecutionHints } : {};
+}
+
+function buildTerritoryScoutSummary(colonyName: string): { territoryScout?: RuntimeTerritoryScoutSummary } {
+  const summary = getTerritoryScoutSummary(colonyName);
+  if (!summary) {
+    return {};
+  }
+
+  return {
+    territoryScout: {
+      ...(summary.attempts.length > 0 ? { attempts: summary.attempts } : {}),
+      ...(summary.intel.length > 0 ? { intel: summary.intel } : {})
+    }
+  };
 }
 
 function summarizeSpawn(spawn: StructureSpawn): RuntimeSpawnStatus {

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -253,6 +253,10 @@ function evaluateAutonomousExpansionClaim(
 
   const room = getVisibleRoom(candidate.roomName);
   const controller = room?.controller;
+  if (room) {
+    recordVisibleRoomScoutIntel(colonyName, room, gameTime, undefined, telemetryEvents);
+  }
+
   const visibleControllerId = controller?.id;
   const visibleControllerEvaluation = {
     ...baseEvaluation,
@@ -291,10 +295,6 @@ function evaluateAutonomousExpansionClaim(
 
   if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
     return { ...visibleControllerEvaluation, reason: 'scoreBelowThreshold' };
-  }
-
-  if (room) {
-    recordVisibleRoomScoutIntel(colonyName, room, gameTime, undefined, telemetryEvents);
   }
 
   const scoutValidation = validateTerritoryScoutIntelForClaim({

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -12,6 +12,13 @@ import {
 import type { OccupationRecommendationReport, OccupationRecommendationScore } from './occupationRecommendation';
 import { TERRITORY_SUPPRESSION_RETRY_TICKS } from './territoryPlanner';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
+import {
+  ensureTerritoryScoutAttempt,
+  recordTerritoryScoutValidation,
+  recordVisibleRoomScoutIntel,
+  validateTerritoryScoutIntelForClaim,
+  type TerritoryScoutValidationResult
+} from './scoutIntel';
 
 export const AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR: TerritoryAutomationSource =
   'autonomousExpansionClaim';
@@ -57,7 +64,7 @@ export function refreshAutonomousExpansionClaimIntent(
   telemetryEvents: RuntimeTelemetryEvent[] = []
 ): AutonomousExpansionClaimEvaluation {
   const context = getAutonomousExpansionClaimTickContext(gameTime);
-  const evaluation = evaluateAutonomousExpansionClaim(colony, report, gameTime, context);
+  const evaluation = evaluateAutonomousExpansionClaim(colony, report, gameTime, context, telemetryEvents);
   if (evaluation.status === 'planned' && evaluation.targetRoom) {
     persistAutonomousExpansionClaimIntent(colony.room.name, evaluation, gameTime, context);
     recordAutonomousExpansionClaimTelemetry(telemetryEvents, evaluation, 'intent');
@@ -77,7 +84,11 @@ export function refreshAutonomousExpansionClaimIntent(
 export function shouldDeferOccupationRecommendationForExpansionClaim(
   evaluation: AutonomousExpansionClaimEvaluation
 ): boolean {
-  return evaluation.status === 'planned' || evaluation.reason === 'controllerCooldown';
+  return (
+    evaluation.status === 'planned' ||
+    evaluation.reason === 'controllerCooldown' ||
+    evaluation.reason === 'scoutPending'
+  );
 }
 
 export function clearAutonomousExpansionClaimIntent(colony: string): void {
@@ -94,7 +105,8 @@ function shouldPruneAutonomousExpansionClaimTargets(
     reason === 'hostilePresence' ||
     reason === 'controllerMissing' ||
     reason === 'controllerOwned' ||
-    reason === 'controllerReserved'
+    reason === 'controllerReserved' ||
+    reason === 'sourcesMissing'
   );
 }
 
@@ -199,7 +211,8 @@ function evaluateAutonomousExpansionClaim(
   colony: ColonySnapshot,
   report: OccupationRecommendationReport,
   gameTime: number,
-  context: AutonomousExpansionClaimTickContext
+  context: AutonomousExpansionClaimTickContext,
+  telemetryEvents: RuntimeTelemetryEvent[]
 ): AutonomousExpansionClaimEvaluation {
   const colonyName = colony.room.name;
   const expansionReport = scoreExpansionCandidates(buildAutonomousExpansionScoringInput(colony, report, context));
@@ -239,47 +252,89 @@ function evaluateAutonomousExpansionClaim(
   }
 
   const room = getVisibleRoom(candidate.roomName);
-  if (!room) {
-    return { ...baseEvaluation, reason: 'roomNotVisible' };
+  const controller = room?.controller;
+  const visibleControllerId = controller?.id;
+  const visibleControllerEvaluation = {
+    ...baseEvaluation,
+    ...(typeof visibleControllerId === 'string'
+      ? { controllerId: visibleControllerId as Id<StructureController> }
+      : {})
+  };
+
+  if (room && isVisibleRoomHostile(room)) {
+    return { ...visibleControllerEvaluation, reason: 'hostilePresence' };
   }
 
-  if (isVisibleRoomHostile(room)) {
-    return { ...baseEvaluation, reason: 'hostilePresence' };
+  if (room && !controller) {
+    return { ...visibleControllerEvaluation, reason: 'controllerMissing' };
   }
 
-  const controller = room.controller;
-  if (!controller) {
-    return { ...baseEvaluation, reason: 'controllerMissing' };
+  if (controller && isControllerOwned(controller)) {
+    return { ...visibleControllerEvaluation, reason: 'controllerOwned' };
   }
 
-  const controllerId = controller.id;
+  if (controller && isControllerReserved(controller, getControllerOwnerUsername(colony.room.controller))) {
+    return { ...visibleControllerEvaluation, reason: 'controllerReserved' };
+  }
+
+  if (isAutonomousExpansionClaimGclInsufficient()) {
+    return { ...visibleControllerEvaluation, reason: 'gclInsufficient' };
+  }
+
+  if (controller && isExpansionClaimControllerOnCooldown(controller)) {
+    return { ...visibleControllerEvaluation, reason: 'controllerCooldown' };
+  }
+
+  if (isAutonomousClaimSuppressed(colonyName, candidate.roomName, gameTime, context.territoryIntents)) {
+    return { ...visibleControllerEvaluation, reason: 'suppressed' };
+  }
+
+  if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
+    return { ...visibleControllerEvaluation, reason: 'scoreBelowThreshold' };
+  }
+
+  if (room) {
+    recordVisibleRoomScoutIntel(colonyName, room, gameTime, undefined, telemetryEvents);
+  }
+
+  const scoutValidation = validateTerritoryScoutIntelForClaim({
+    colony: colonyName,
+    targetRoom: candidate.roomName,
+    colonyOwnerUsername: getControllerOwnerUsername(colony.room.controller),
+    gameTime
+  });
+  const scoutControllerId = getScoutValidationControllerId(scoutValidation);
+  const controllerId = controller?.id ?? scoutControllerId ?? candidate.controllerId;
   const controllerEvaluation = {
     ...baseEvaluation,
     ...(typeof controllerId === 'string' ? { controllerId: controllerId as Id<StructureController> } : {})
   };
+  recordTerritoryScoutValidation(
+    colonyName,
+    candidate.roomName,
+    scoutValidation,
+    gameTime,
+    telemetryEvents,
+    controllerEvaluation.controllerId,
+    candidate.score
+  );
 
-  if (isControllerOwned(controller)) {
-    return { ...controllerEvaluation, reason: 'controllerOwned' };
+  if (scoutValidation.status === 'pending') {
+    ensureTerritoryScoutAttempt(
+      colonyName,
+      candidate.roomName,
+      gameTime,
+      telemetryEvents,
+      controllerEvaluation.controllerId
+    );
+    return { ...controllerEvaluation, reason: 'scoutPending' };
   }
 
-  if (isControllerReserved(controller, getControllerOwnerUsername(colony.room.controller))) {
-    return { ...controllerEvaluation, reason: 'controllerReserved' };
-  }
-
-  if (isAutonomousExpansionClaimGclInsufficient()) {
-    return { ...controllerEvaluation, reason: 'gclInsufficient' };
-  }
-
-  if (isExpansionClaimControllerOnCooldown(controller)) {
-    return { ...controllerEvaluation, reason: 'controllerCooldown' };
-  }
-
-  if (isAutonomousClaimSuppressed(colonyName, candidate.roomName, gameTime, context.territoryIntents)) {
-    return { ...controllerEvaluation, reason: 'suppressed' };
-  }
-
-  if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
-    return { ...controllerEvaluation, reason: 'scoreBelowThreshold' };
+  if (scoutValidation.status === 'blocked') {
+    return {
+      ...controllerEvaluation,
+      reason: getScoutValidationClaimSkipReason(scoutValidation)
+    };
   }
 
   return {
@@ -289,6 +344,34 @@ function evaluateAutonomousExpansionClaim(
     score: candidate.score,
     ...(typeof controllerId === 'string' ? { controllerId: controllerId as Id<StructureController> } : {})
   };
+}
+
+function getScoutValidationControllerId(
+  validation: TerritoryScoutValidationResult
+): Id<StructureController> | undefined {
+  return validation.intel?.controller?.id;
+}
+
+function getScoutValidationClaimSkipReason(
+  validation: TerritoryScoutValidationResult
+): RuntimeTerritoryClaimTelemetryReason {
+  switch (validation.reason) {
+    case 'controllerMissing':
+      return 'controllerMissing';
+    case 'controllerOwned':
+      return 'controllerOwned';
+    case 'controllerReserved':
+      return 'controllerReserved';
+    case 'hostileSpawn':
+      return 'hostilePresence';
+    case 'sourcesMissing':
+      return 'sourcesMissing';
+    case 'intelMissing':
+    case 'scoutPending':
+    case 'scoutTimeout':
+    default:
+      return 'scoutPending';
+  }
 }
 
 function buildAutonomousExpansionScoringInput(

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -1,5 +1,12 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
+import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
+import {
+  recordTerritoryScoutValidation,
+  recordVisibleRoomScoutIntel,
+  validateTerritoryScoutIntelForClaim,
+  type TerritoryScoutValidationResult
+} from './scoutIntel';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
 
 export const NEXT_EXPANSION_TARGET_CREATOR: TerritoryAutomationSource = 'nextExpansionScoring';
@@ -174,7 +181,8 @@ export function scoreExpansionCandidates(input: ExpansionScoringInput): Expansio
 export function refreshNextExpansionTargetSelection(
   colony: ColonySnapshot,
   report: ExpansionCandidateReport,
-  gameTime: number
+  gameTime: number,
+  telemetryEvents: RuntimeTelemetryEvent[] = []
 ): NextExpansionTargetSelection {
   const colonyName = colony.room.name;
   persistExpansionCandidateScores(colonyName, report, gameTime);
@@ -185,6 +193,19 @@ export function refreshNextExpansionTargetSelection(
       status: 'skipped',
       colony: colonyName,
       reason: getSelectionSkipReason(report)
+    };
+  }
+
+  const scoutValidation = validateVisibleNextExpansionScoutIntel(colony, candidate, gameTime, telemetryEvents);
+  if (scoutValidation?.status === 'blocked') {
+    pruneNextExpansionTargets(colonyName);
+    return {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'unavailable',
+      targetRoom: candidate.roomName,
+      ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
+      score: candidate.score
     };
   }
 
@@ -200,6 +221,37 @@ export function refreshNextExpansionTargetSelection(
 
 export function clearNextExpansionTargetIntent(colony: string): void {
   pruneNextExpansionTargets(colony);
+}
+
+function validateVisibleNextExpansionScoutIntel(
+  colony: ColonySnapshot,
+  candidate: ExpansionCandidateScore,
+  gameTime: number,
+  telemetryEvents: RuntimeTelemetryEvent[]
+): TerritoryScoutValidationResult | null {
+  const room = getVisibleRoom(candidate.roomName);
+  if (!room) {
+    return null;
+  }
+
+  const colonyName = colony.room.name;
+  recordVisibleRoomScoutIntel(colonyName, room, gameTime, undefined, telemetryEvents);
+  const validation = validateTerritoryScoutIntelForClaim({
+    colony: colonyName,
+    targetRoom: candidate.roomName,
+    colonyOwnerUsername: getControllerOwnerUsername(colony.room.controller),
+    gameTime
+  });
+  recordTerritoryScoutValidation(
+    colonyName,
+    candidate.roomName,
+    validation,
+    gameTime,
+    telemetryEvents,
+    candidate.controllerId ?? validation.intel?.controller?.id,
+    candidate.score
+  );
+  return validation;
 }
 
 function buildRuntimeExpansionScoringInput(colony: ColonySnapshot): ExpansionScoringInput {
@@ -1314,6 +1366,10 @@ function countActivePostClaimBootstraps(): number {
 
 function getGameRooms(): Game['rooms'] | undefined {
   return (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+}
+
+function getVisibleRoom(roomName: string): Room | undefined {
+  return getGameRooms()?.[roomName];
 }
 
 function getTerritoryMemoryRecord(): TerritoryMemory | undefined {

--- a/prod/src/territory/scoutIntel.ts
+++ b/prod/src/territory/scoutIntel.ts
@@ -136,18 +136,14 @@ export function validateTerritoryScoutIntelForClaim({
   colonyOwnerUsername?: string;
   gameTime: number;
 }): TerritoryScoutValidationResult {
+  const attempt = getTerritoryScoutAttempt(colony, targetRoom);
   const intel = getTerritoryScoutIntel(colony, targetRoom);
   if (!intel) {
-    const attempt = getTerritoryScoutAttempt(colony, targetRoom);
-    if (
-      attempt?.status === 'requested' &&
-      gameTime >= attempt.requestedAt &&
-      gameTime - attempt.requestedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS
-    ) {
-      return { status: 'fallback', reason: 'scoutTimeout' };
-    }
+    return getUnavailableScoutIntelValidationResult(attempt, gameTime, 'intelMissing');
+  }
 
-    return { status: 'pending', reason: attempt ? 'scoutPending' : 'intelMissing' };
+  if (!isScoutIntelUsableForClaim(intel, attempt, gameTime)) {
+    return getUnavailableScoutIntelValidationResult(attempt, gameTime, 'scoutPending');
   }
 
   const controller = intel.controller;
@@ -405,6 +401,42 @@ function getTerritoryScoutIntel(colony: string, targetRoom: string): TerritorySc
 function getTerritoryScoutAttempt(colony: string, targetRoom: string): TerritoryScoutAttemptMemory | null {
   const rawAttempt = getTerritoryMemoryRecord()?.scoutAttempts?.[getTerritoryScoutMemoryKey(colony, targetRoom)];
   return normalizeTerritoryScoutAttempt(rawAttempt);
+}
+
+function getUnavailableScoutIntelValidationResult(
+  attempt: TerritoryScoutAttemptMemory | null,
+  gameTime: number,
+  pendingReason: TerritoryScoutValidationReason
+): TerritoryScoutValidationResult {
+  if (isScoutAttemptTimedOut(attempt, gameTime)) {
+    return { status: 'fallback', reason: 'scoutTimeout' };
+  }
+
+  return { status: 'pending', reason: attempt ? 'scoutPending' : pendingReason };
+}
+
+function isScoutIntelUsableForClaim(
+  intel: TerritoryScoutIntelMemory,
+  attempt: TerritoryScoutAttemptMemory | null,
+  gameTime: number
+): boolean {
+  if (isScoutIntelExpired(intel, gameTime)) {
+    return false;
+  }
+
+  return attempt?.status !== 'requested' || intel.updatedAt >= attempt.requestedAt;
+}
+
+function isScoutIntelExpired(intel: TerritoryScoutIntelMemory, gameTime: number): boolean {
+  return gameTime >= intel.updatedAt && gameTime - intel.updatedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS;
+}
+
+function isScoutAttemptTimedOut(attempt: TerritoryScoutAttemptMemory | null, gameTime: number): boolean {
+  return (
+    attempt?.status === 'requested' &&
+    gameTime >= attempt.requestedAt &&
+    gameTime - attempt.requestedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS
+  );
 }
 
 function getMutableScoutAttemptRecords(

--- a/prod/src/territory/scoutIntel.ts
+++ b/prod/src/territory/scoutIntel.ts
@@ -1,0 +1,669 @@
+import type {
+  RuntimeTelemetryEvent,
+  RuntimeTerritoryScoutTelemetryReason,
+  RuntimeTerritoryScoutTelemetryResult
+} from '../telemetry/runtimeSummary';
+import { normalizeTerritoryIntents } from './territoryMemoryUtils';
+
+const TERRITORY_SCOUT_MEMORY_KEY_SEPARATOR = '>';
+export const TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS = 1_500;
+
+export interface TerritoryScoutValidationResult {
+  status: TerritoryScoutValidationStatus;
+  reason?: TerritoryScoutValidationReason;
+  intel?: TerritoryScoutIntelMemory;
+}
+
+export interface TerritoryScoutSummary {
+  attempts: TerritoryScoutAttemptMemory[];
+  intel: TerritoryScoutIntelMemory[];
+}
+
+export function recordVisibleRoomScoutIntel(
+  colony: string | undefined,
+  room: Room | undefined,
+  gameTime = getGameTime(),
+  scoutName?: string,
+  telemetryEvents: RuntimeTelemetryEvent[] = []
+): TerritoryScoutIntelMemory | null {
+  if (!isNonEmptyString(colony) || !room || !isNonEmptyString(room.name)) {
+    return null;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return null;
+  }
+
+  const key = getTerritoryScoutMemoryKey(colony, room.name);
+  const intel = buildTerritoryScoutIntel(colony, room, gameTime, scoutName);
+  const scoutIntel = getMutableScoutIntelRecords(territoryMemory);
+  scoutIntel[key] = intel;
+
+  const attempts = getMutableScoutAttemptRecords(territoryMemory);
+  const existingAttempt = normalizeTerritoryScoutAttempt(attempts[key]);
+  attempts[key] = {
+    colony,
+    roomName: room.name,
+    status: 'observed',
+    requestedAt: existingAttempt?.requestedAt ?? gameTime,
+    updatedAt: gameTime,
+    attemptCount: Math.max(1, existingAttempt?.attemptCount ?? 1),
+    ...(intel.controller?.id ? { controllerId: intel.controller.id } : {}),
+    ...(scoutName ? { scoutName } : {}),
+    ...(existingAttempt?.lastValidation ? { lastValidation: existingAttempt.lastValidation } : {})
+  };
+
+  recordTerritoryScoutTelemetry(telemetryEvents, {
+    colony,
+    targetRoom: room.name,
+    phase: 'intel',
+    result: 'recorded',
+    ...(scoutName ? { scoutName } : {}),
+    ...(intel.controller?.id ? { controllerId: intel.controller.id } : {}),
+    sourceCount: intel.sourceCount,
+    hostileCreepCount: intel.hostileCreepCount,
+    hostileStructureCount: intel.hostileStructureCount,
+    hostileSpawnCount: intel.hostileSpawnCount
+  });
+
+  return intel;
+}
+
+export function ensureTerritoryScoutAttempt(
+  colony: string,
+  targetRoom: string,
+  gameTime: number,
+  telemetryEvents: RuntimeTelemetryEvent[] = [],
+  controllerId?: Id<StructureController>
+): TerritoryScoutAttemptMemory | null {
+  if (!isNonEmptyString(colony) || !isNonEmptyString(targetRoom)) {
+    return null;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return null;
+  }
+
+  const key = getTerritoryScoutMemoryKey(colony, targetRoom);
+  const attempts = getMutableScoutAttemptRecords(territoryMemory);
+  const existingAttempt = normalizeTerritoryScoutAttempt(attempts[key]);
+  const shouldReuseAttempt =
+    existingAttempt?.status === 'requested' &&
+    gameTime >= existingAttempt.requestedAt &&
+    gameTime - existingAttempt.requestedAt <= TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS;
+  const attempt: TerritoryScoutAttemptMemory = shouldReuseAttempt
+    ? {
+        ...existingAttempt,
+        updatedAt: gameTime,
+        ...(controllerId ?? existingAttempt.controllerId
+          ? { controllerId: controllerId ?? existingAttempt.controllerId }
+          : {})
+      }
+    : {
+        colony,
+        roomName: targetRoom,
+        status: 'requested',
+        requestedAt: gameTime,
+        updatedAt: gameTime,
+        attemptCount: Math.max(1, (existingAttempt?.attemptCount ?? 0) + 1),
+        ...(controllerId ? { controllerId } : {}),
+        ...(existingAttempt?.lastValidation ? { lastValidation: existingAttempt.lastValidation } : {})
+      };
+  attempts[key] = attempt;
+  upsertTerritoryScoutIntent(territoryMemory, attempt);
+
+  recordTerritoryScoutTelemetry(telemetryEvents, {
+    colony,
+    targetRoom,
+    phase: 'attempt',
+    result: 'requested',
+    ...(attempt.controllerId ? { controllerId: attempt.controllerId } : {})
+  });
+
+  return attempt;
+}
+
+export function validateTerritoryScoutIntelForClaim({
+  colony,
+  targetRoom,
+  colonyOwnerUsername,
+  gameTime
+}: {
+  colony: string;
+  targetRoom: string;
+  colonyOwnerUsername?: string;
+  gameTime: number;
+}): TerritoryScoutValidationResult {
+  const intel = getTerritoryScoutIntel(colony, targetRoom);
+  if (!intel) {
+    const attempt = getTerritoryScoutAttempt(colony, targetRoom);
+    if (
+      attempt?.status === 'requested' &&
+      gameTime >= attempt.requestedAt &&
+      gameTime - attempt.requestedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS
+    ) {
+      return { status: 'fallback', reason: 'scoutTimeout' };
+    }
+
+    return { status: 'pending', reason: attempt ? 'scoutPending' : 'intelMissing' };
+  }
+
+  const controller = intel.controller;
+  if (!controller) {
+    return { status: 'blocked', reason: 'controllerMissing', intel };
+  }
+
+  if (
+    controller.my === true ||
+    (isNonEmptyString(controller.ownerUsername) && controller.ownerUsername === colonyOwnerUsername)
+  ) {
+    return { status: 'blocked', reason: 'controllerOwned', intel };
+  }
+
+  if (isNonEmptyString(controller.ownerUsername)) {
+    return { status: 'blocked', reason: 'controllerOwned', intel };
+  }
+
+  if (
+    isNonEmptyString(controller.reservationUsername) &&
+    controller.reservationUsername !== colonyOwnerUsername
+  ) {
+    return { status: 'blocked', reason: 'controllerReserved', intel };
+  }
+
+  if (intel.hostileSpawnCount > 0) {
+    return { status: 'blocked', reason: 'hostileSpawn', intel };
+  }
+
+  if (intel.sourceCount <= 0) {
+    return { status: 'blocked', reason: 'sourcesMissing', intel };
+  }
+
+  return { status: 'passed', intel };
+}
+
+export function recordTerritoryScoutValidation(
+  colony: string,
+  targetRoom: string,
+  result: TerritoryScoutValidationResult,
+  gameTime: number,
+  telemetryEvents: RuntimeTelemetryEvent[] = [],
+  controllerId?: Id<StructureController>,
+  score?: number
+): void {
+  if (!isNonEmptyString(colony) || !isNonEmptyString(targetRoom)) {
+    return;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const key = getTerritoryScoutMemoryKey(colony, targetRoom);
+  const attempts = getMutableScoutAttemptRecords(territoryMemory);
+  const existingAttempt = normalizeTerritoryScoutAttempt(attempts[key]);
+  const status =
+    result.status === 'fallback'
+      ? 'timedOut'
+      : result.status === 'pending'
+        ? existingAttempt?.status ?? 'requested'
+        : existingAttempt?.status ?? 'observed';
+  attempts[key] = {
+    colony,
+    roomName: targetRoom,
+    status,
+    requestedAt: existingAttempt?.requestedAt ?? gameTime,
+    updatedAt: gameTime,
+    attemptCount: Math.max(1, existingAttempt?.attemptCount ?? 1),
+    ...(controllerId ?? existingAttempt?.controllerId ?? result.intel?.controller?.id
+      ? { controllerId: controllerId ?? existingAttempt?.controllerId ?? result.intel?.controller?.id }
+      : {}),
+    ...(existingAttempt?.scoutName ? { scoutName: existingAttempt.scoutName } : {}),
+    lastValidation: {
+      status: result.status,
+      updatedAt: gameTime,
+      ...(result.reason ? { reason: result.reason } : {})
+    }
+  };
+
+  recordTerritoryScoutTelemetry(telemetryEvents, {
+    colony,
+    targetRoom,
+    phase: 'validation',
+    result: getTelemetryValidationResult(result.status),
+    ...(result.reason ? { reason: result.reason } : {}),
+    ...(controllerId ?? result.intel?.controller?.id ? { controllerId: controllerId ?? result.intel?.controller?.id } : {}),
+    ...(result.intel ? { sourceCount: result.intel.sourceCount } : {}),
+    ...(result.intel ? { hostileCreepCount: result.intel.hostileCreepCount } : {}),
+    ...(result.intel ? { hostileStructureCount: result.intel.hostileStructureCount } : {}),
+    ...(result.intel ? { hostileSpawnCount: result.intel.hostileSpawnCount } : {}),
+    ...(score !== undefined ? { score } : {})
+  });
+}
+
+export function getTerritoryScoutSummary(colony: string): TerritoryScoutSummary | null {
+  if (!isNonEmptyString(colony)) {
+    return null;
+  }
+
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return null;
+  }
+
+  const attempts = Object.values(territoryMemory.scoutAttempts ?? {})
+    .flatMap((attempt) => {
+      const normalized = normalizeTerritoryScoutAttempt(attempt);
+      return normalized?.colony === colony ? [normalized] : [];
+    })
+    .sort(compareTerritoryScoutAttempts);
+  const intel = Object.values(territoryMemory.scoutIntel ?? {})
+    .flatMap((record) => {
+      const normalized = normalizeTerritoryScoutIntel(record);
+      return normalized?.colony === colony ? [normalized] : [];
+    })
+    .sort(compareTerritoryScoutIntel);
+
+  return attempts.length > 0 || intel.length > 0 ? { attempts, intel } : null;
+}
+
+function buildTerritoryScoutIntel(
+  colony: string,
+  room: Room,
+  gameTime: number,
+  scoutName: string | undefined
+): TerritoryScoutIntelMemory {
+  const controller = room.controller;
+  const sources = findRoomObjects<Source>(room, 'FIND_SOURCES');
+  const hostileCreeps = findRoomObjects<Creep>(room, 'FIND_HOSTILE_CREEPS');
+  const hostileStructures = findRoomObjects<AnyStructure>(room, 'FIND_HOSTILE_STRUCTURES');
+  const mineral = findRoomObjects<Mineral>(room, 'FIND_MINERALS')[0];
+
+  return {
+    colony,
+    roomName: room.name,
+    updatedAt: gameTime,
+    ...(controller ? { controller: summarizeScoutController(controller) } : {}),
+    sourceIds: sources.map((source) => String(source.id)).sort(),
+    sourceCount: sources.length,
+    ...(mineral ? { mineral: summarizeScoutMineral(mineral) } : {}),
+    hostileCreepCount: hostileCreeps.length,
+    hostileStructureCount: hostileStructures.length,
+    hostileSpawnCount: hostileStructures.filter(isHostileSpawnStructure).length,
+    ...(scoutName ? { scoutName } : {})
+  };
+}
+
+function summarizeScoutController(controller: StructureController): TerritoryScoutControllerIntelMemory {
+  const ownerUsername = getControllerOwnerUsername(controller);
+  const reservationUsername = getControllerReservationUsername(controller);
+  const reservationTicksToEnd = getControllerReservationTicksToEnd(controller);
+  return {
+    ...(typeof controller.id === 'string' ? { id: controller.id as Id<StructureController> } : {}),
+    ...(typeof controller.my === 'boolean' ? { my: controller.my } : {}),
+    ...(ownerUsername ? { ownerUsername } : {}),
+    ...(reservationUsername ? { reservationUsername } : {}),
+    ...(typeof reservationTicksToEnd === 'number' ? { reservationTicksToEnd } : {})
+  };
+}
+
+function summarizeScoutMineral(mineral: Mineral): TerritoryScoutMineralIntelMemory {
+  const rawMineral = mineral as Mineral & { mineralType?: unknown; density?: unknown };
+  return {
+    id: String(mineral.id),
+    ...(typeof rawMineral.mineralType === 'string' ? { mineralType: rawMineral.mineralType } : {}),
+    ...(typeof rawMineral.density === 'number' ? { density: rawMineral.density } : {})
+  };
+}
+
+function upsertTerritoryScoutIntent(
+  territoryMemory: TerritoryMemory,
+  attempt: TerritoryScoutAttemptMemory
+): void {
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIndex = intents.findIndex(
+    (intent) =>
+      intent.colony === attempt.colony &&
+      intent.targetRoom === attempt.roomName &&
+      intent.action === 'scout'
+  );
+  const nextIntent: TerritoryIntentMemory = {
+    colony: attempt.colony,
+    targetRoom: attempt.roomName,
+    action: 'scout',
+    status: existingIndex >= 0 && intents[existingIndex].status === 'active' ? 'active' : 'planned',
+    updatedAt: attempt.updatedAt,
+    ...(attempt.controllerId ? { controllerId: attempt.controllerId } : {})
+  };
+
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+
+  intents.push(nextIntent);
+}
+
+function recordTerritoryScoutTelemetry(
+  telemetryEvents: RuntimeTelemetryEvent[],
+  event: {
+    colony: string;
+    targetRoom: string;
+    phase: 'attempt' | 'intel' | 'validation';
+    result: RuntimeTerritoryScoutTelemetryResult;
+    reason?: RuntimeTerritoryScoutTelemetryReason;
+    controllerId?: Id<StructureController>;
+    scoutName?: string;
+    sourceCount?: number;
+    hostileCreepCount?: number;
+    hostileStructureCount?: number;
+    hostileSpawnCount?: number;
+    score?: number;
+  }
+): void {
+  telemetryEvents.push({
+    type: 'territoryScout',
+    roomName: event.colony,
+    colony: event.colony,
+    targetRoom: event.targetRoom,
+    phase: event.phase,
+    result: event.result,
+    ...(event.reason ? { reason: event.reason } : {}),
+    ...(event.controllerId ? { controllerId: event.controllerId } : {}),
+    ...(event.scoutName ? { scoutName: event.scoutName } : {}),
+    ...(event.sourceCount !== undefined ? { sourceCount: event.sourceCount } : {}),
+    ...(event.hostileCreepCount !== undefined ? { hostileCreepCount: event.hostileCreepCount } : {}),
+    ...(event.hostileStructureCount !== undefined ? { hostileStructureCount: event.hostileStructureCount } : {}),
+    ...(event.hostileSpawnCount !== undefined ? { hostileSpawnCount: event.hostileSpawnCount } : {}),
+    ...(event.score !== undefined ? { score: event.score } : {})
+  });
+}
+
+function getTelemetryValidationResult(
+  status: TerritoryScoutValidationStatus
+): RuntimeTerritoryScoutTelemetryResult {
+  if (status === 'passed') {
+    return 'passed';
+  }
+
+  if (status === 'blocked') {
+    return 'blocked';
+  }
+
+  return status === 'fallback' ? 'fallback' : 'pending';
+}
+
+function getTerritoryScoutIntel(colony: string, targetRoom: string): TerritoryScoutIntelMemory | null {
+  const rawIntel = getTerritoryMemoryRecord()?.scoutIntel?.[getTerritoryScoutMemoryKey(colony, targetRoom)];
+  return normalizeTerritoryScoutIntel(rawIntel);
+}
+
+function getTerritoryScoutAttempt(colony: string, targetRoom: string): TerritoryScoutAttemptMemory | null {
+  const rawAttempt = getTerritoryMemoryRecord()?.scoutAttempts?.[getTerritoryScoutMemoryKey(colony, targetRoom)];
+  return normalizeTerritoryScoutAttempt(rawAttempt);
+}
+
+function getMutableScoutAttemptRecords(
+  territoryMemory: TerritoryMemory
+): Record<string, TerritoryScoutAttemptMemory> {
+  if (!isRecord(territoryMemory.scoutAttempts) || Array.isArray(territoryMemory.scoutAttempts)) {
+    territoryMemory.scoutAttempts = {};
+  }
+
+  return territoryMemory.scoutAttempts;
+}
+
+function getMutableScoutIntelRecords(
+  territoryMemory: TerritoryMemory
+): Record<string, TerritoryScoutIntelMemory> {
+  if (!isRecord(territoryMemory.scoutIntel) || Array.isArray(territoryMemory.scoutIntel)) {
+    territoryMemory.scoutIntel = {};
+  }
+
+  return territoryMemory.scoutIntel;
+}
+
+function normalizeTerritoryScoutAttempt(rawAttempt: unknown): TerritoryScoutAttemptMemory | null {
+  if (!isRecord(rawAttempt)) {
+    return null;
+  }
+
+  if (
+    !isNonEmptyString(rawAttempt.colony) ||
+    !isNonEmptyString(rawAttempt.roomName) ||
+    !isTerritoryScoutAttemptStatus(rawAttempt.status) ||
+    !isFiniteNumber(rawAttempt.requestedAt) ||
+    !isFiniteNumber(rawAttempt.updatedAt)
+  ) {
+    return null;
+  }
+
+  const attemptCount = isFiniteNumber(rawAttempt.attemptCount)
+    ? Math.max(1, Math.floor(rawAttempt.attemptCount))
+    : 1;
+  const lastValidation = normalizeTerritoryScoutValidation(rawAttempt.lastValidation);
+  return {
+    colony: rawAttempt.colony,
+    roomName: rawAttempt.roomName,
+    status: rawAttempt.status,
+    requestedAt: rawAttempt.requestedAt,
+    updatedAt: rawAttempt.updatedAt,
+    attemptCount,
+    ...(typeof rawAttempt.controllerId === 'string'
+      ? { controllerId: rawAttempt.controllerId as Id<StructureController> }
+      : {}),
+    ...(isNonEmptyString(rawAttempt.scoutName) ? { scoutName: rawAttempt.scoutName } : {}),
+    ...(lastValidation ? { lastValidation } : {})
+  };
+}
+
+function normalizeTerritoryScoutIntel(rawIntel: unknown): TerritoryScoutIntelMemory | null {
+  if (!isRecord(rawIntel)) {
+    return null;
+  }
+
+  if (
+    !isNonEmptyString(rawIntel.colony) ||
+    !isNonEmptyString(rawIntel.roomName) ||
+    !isFiniteNumber(rawIntel.updatedAt)
+  ) {
+    return null;
+  }
+
+  const sourceIds = Array.isArray(rawIntel.sourceIds)
+    ? rawIntel.sourceIds.flatMap((sourceId) => (isNonEmptyString(sourceId) ? [sourceId] : []))
+    : [];
+  const sourceCount = isFiniteNumber(rawIntel.sourceCount)
+    ? Math.max(0, Math.floor(rawIntel.sourceCount))
+    : sourceIds.length;
+  const controller = normalizeTerritoryScoutControllerIntel(rawIntel.controller);
+  const mineral = normalizeTerritoryScoutMineralIntel(rawIntel.mineral);
+  return {
+    colony: rawIntel.colony,
+    roomName: rawIntel.roomName,
+    updatedAt: rawIntel.updatedAt,
+    ...(controller ? { controller } : {}),
+    sourceIds,
+    sourceCount,
+    ...(mineral ? { mineral } : {}),
+    hostileCreepCount: getBoundedCount(rawIntel.hostileCreepCount),
+    hostileStructureCount: getBoundedCount(rawIntel.hostileStructureCount),
+    hostileSpawnCount: getBoundedCount(rawIntel.hostileSpawnCount),
+    ...(isNonEmptyString(rawIntel.scoutName) ? { scoutName: rawIntel.scoutName } : {})
+  };
+}
+
+function normalizeTerritoryScoutControllerIntel(rawController: unknown): TerritoryScoutControllerIntelMemory | null {
+  if (!isRecord(rawController)) {
+    return null;
+  }
+
+  return {
+    ...(typeof rawController.id === 'string'
+      ? { id: rawController.id as Id<StructureController> }
+      : {}),
+    ...(typeof rawController.my === 'boolean' ? { my: rawController.my } : {}),
+    ...(isNonEmptyString(rawController.ownerUsername) ? { ownerUsername: rawController.ownerUsername } : {}),
+    ...(isNonEmptyString(rawController.reservationUsername)
+      ? { reservationUsername: rawController.reservationUsername }
+      : {}),
+    ...(isFiniteNumber(rawController.reservationTicksToEnd)
+      ? { reservationTicksToEnd: rawController.reservationTicksToEnd }
+      : {})
+  };
+}
+
+function normalizeTerritoryScoutMineralIntel(rawMineral: unknown): TerritoryScoutMineralIntelMemory | null {
+  if (!isRecord(rawMineral) || !isNonEmptyString(rawMineral.id)) {
+    return null;
+  }
+
+  return {
+    id: rawMineral.id,
+    ...(isNonEmptyString(rawMineral.mineralType) ? { mineralType: rawMineral.mineralType } : {}),
+    ...(isFiniteNumber(rawMineral.density) ? { density: rawMineral.density } : {})
+  };
+}
+
+function normalizeTerritoryScoutValidation(rawValidation: unknown): TerritoryScoutValidationMemory | null {
+  if (!isRecord(rawValidation)) {
+    return null;
+  }
+
+  if (!isTerritoryScoutValidationStatus(rawValidation.status) || !isFiniteNumber(rawValidation.updatedAt)) {
+    return null;
+  }
+
+  return {
+    status: rawValidation.status,
+    updatedAt: rawValidation.updatedAt,
+    ...(isTerritoryScoutValidationReason(rawValidation.reason) ? { reason: rawValidation.reason } : {})
+  };
+}
+
+function getBoundedCount(value: unknown): number {
+  return isFiniteNumber(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function compareTerritoryScoutAttempts(
+  left: TerritoryScoutAttemptMemory,
+  right: TerritoryScoutAttemptMemory
+): number {
+  return right.updatedAt - left.updatedAt || left.roomName.localeCompare(right.roomName);
+}
+
+function compareTerritoryScoutIntel(
+  left: TerritoryScoutIntelMemory,
+  right: TerritoryScoutIntelMemory
+): number {
+  return right.updatedAt - left.updatedAt || left.roomName.localeCompare(right.roomName);
+}
+
+function findRoomObjects<T>(room: Room, constantName: string): T[] {
+  const findConstant = getGlobalNumber(constantName);
+  const find = (room as unknown as { find?: (type: number) => unknown }).find;
+  if (typeof findConstant !== 'number' || typeof find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? (result as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function isHostileSpawnStructure(structure: AnyStructure): boolean {
+  const structureType = (structure as AnyStructure & { structureType?: unknown }).structureType;
+  return structureType === getStructureSpawnConstant();
+}
+
+function getStructureSpawnConstant(): StructureConstant {
+  const structureSpawn = (globalThis as { STRUCTURE_SPAWN?: StructureConstant }).STRUCTURE_SPAWN;
+  return structureSpawn ?? ('spawn' as StructureConstant);
+}
+
+function getControllerOwnerUsername(controller: StructureController): string | undefined {
+  const username = (controller as StructureController & { owner?: { username?: string } }).owner?.username;
+  return isNonEmptyString(username) ? username : undefined;
+}
+
+function getControllerReservationUsername(controller: StructureController): string | undefined {
+  const username = (controller as StructureController & { reservation?: { username?: string } }).reservation?.username;
+  return isNonEmptyString(username) ? username : undefined;
+}
+
+function getControllerReservationTicksToEnd(controller: StructureController): number | undefined {
+  const ticksToEnd = (controller as StructureController & { reservation?: { ticksToEnd?: number } }).reservation
+    ?.ticksToEnd;
+  return typeof ticksToEnd === 'number' ? ticksToEnd : undefined;
+}
+
+function getTerritoryScoutMemoryKey(colony: string, targetRoom: string): string {
+  return `${colony}${TERRITORY_SCOUT_MEMORY_KEY_SEPARATOR}${targetRoom}`;
+}
+
+function getGlobalNumber(name: string): number | undefined {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof gameTime === 'number' ? gameTime : 0;
+}
+
+function getTerritoryMemoryRecord(): TerritoryMemory | undefined {
+  return (globalThis as { Memory?: Partial<Memory> }).Memory?.territory;
+}
+
+function getWritableTerritoryMemoryRecord(): TerritoryMemory | null {
+  const memory = (globalThis as { Memory?: Partial<Memory> }).Memory;
+  if (!memory) {
+    return null;
+  }
+
+  if (!isRecord(memory.territory)) {
+    memory.territory = {};
+  }
+
+  return memory.territory as TerritoryMemory;
+}
+
+function isTerritoryScoutAttemptStatus(status: unknown): status is TerritoryScoutAttemptStatus {
+  return status === 'requested' || status === 'observed' || status === 'timedOut';
+}
+
+function isTerritoryScoutValidationStatus(status: unknown): status is TerritoryScoutValidationStatus {
+  return status === 'pending' || status === 'passed' || status === 'blocked' || status === 'fallback';
+}
+
+function isTerritoryScoutValidationReason(reason: unknown): reason is TerritoryScoutValidationReason {
+  return (
+    reason === 'intelMissing' ||
+    reason === 'scoutPending' ||
+    reason === 'scoutTimeout' ||
+    reason === 'controllerMissing' ||
+    reason === 'controllerOwned' ||
+    reason === 'controllerReserved' ||
+    reason === 'hostileSpawn' ||
+    reason === 'sourcesMissing'
+  );
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -62,6 +62,7 @@ export function runTerritoryControllerCreep(
 
   if (assignment.action === 'scout') {
     recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime(), creep.name, telemetryEvents);
+    completeTerritoryAssignment(creep);
     return;
   }
 

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -15,6 +15,7 @@ import {
 } from './claimExecutor';
 import { recordPostClaimBootstrapClaimSuccess } from './postClaimBootstrap';
 import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
+import { recordVisibleRoomScoutIntel } from './scoutIntel';
 
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
@@ -60,6 +61,7 @@ export function runTerritoryControllerCreep(
   }
 
   if (assignment.action === 'scout') {
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime(), creep.name, telemetryEvents);
     return;
   }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -149,6 +149,17 @@ declare global {
     | 'autonomousExpansionClaim'
     | 'nextExpansionScoring';
   type TerritoryIntentSuspensionReason = 'hostile_presence';
+  type TerritoryScoutAttemptStatus = 'requested' | 'observed' | 'timedOut';
+  type TerritoryScoutValidationStatus = 'pending' | 'passed' | 'blocked' | 'fallback';
+  type TerritoryScoutValidationReason =
+    | 'intelMissing'
+    | 'scoutPending'
+    | 'scoutTimeout'
+    | 'controllerMissing'
+    | 'controllerOwned'
+    | 'controllerReserved'
+    | 'hostileSpawn'
+    | 'sourcesMissing';
   type TerritoryPostClaimBootstrapStatus =
     | 'detected'
     | 'spawnSitePending'
@@ -190,6 +201,8 @@ declare global {
     postClaimBootstraps?: Record<string, TerritoryPostClaimBootstrapMemory>;
     remoteMining?: Record<string, TerritoryRemoteMiningRoomMemory>;
     reservations?: Record<string, TerritoryReservationMemory>;
+    scoutAttempts?: Record<string, TerritoryScoutAttemptMemory>;
+    scoutIntel?: Record<string, TerritoryScoutIntelMemory>;
     routeDistancesUpdatedAt?: Record<string, number>;
     routeDistances?: Record<string, number | null>;
   }
@@ -230,6 +243,52 @@ declare global {
     ticksToEnd: number;
     updatedAt: number;
     controllerId?: Id<StructureController>;
+  }
+
+  interface TerritoryScoutControllerIntelMemory {
+    id?: Id<StructureController>;
+    my?: boolean;
+    ownerUsername?: string;
+    reservationUsername?: string;
+    reservationTicksToEnd?: number;
+  }
+
+  interface TerritoryScoutMineralIntelMemory {
+    id: string;
+    mineralType?: string;
+    density?: number;
+  }
+
+  interface TerritoryScoutValidationMemory {
+    status: TerritoryScoutValidationStatus;
+    updatedAt: number;
+    reason?: TerritoryScoutValidationReason;
+  }
+
+  interface TerritoryScoutAttemptMemory {
+    colony: string;
+    roomName: string;
+    status: TerritoryScoutAttemptStatus;
+    requestedAt: number;
+    updatedAt: number;
+    attemptCount: number;
+    controllerId?: Id<StructureController>;
+    scoutName?: string;
+    lastValidation?: TerritoryScoutValidationMemory;
+  }
+
+  interface TerritoryScoutIntelMemory {
+    colony: string;
+    roomName: string;
+    updatedAt: number;
+    controller?: TerritoryScoutControllerIntelMemory;
+    sourceIds: string[];
+    sourceCount: number;
+    mineral?: TerritoryScoutMineralIntelMemory;
+    hostileCreepCount: number;
+    hostileStructureCount: number;
+    hostileSpawnCount: number;
+    scoutName?: string;
   }
 
   interface TerritoryFollowUpMemory {

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -6,7 +6,9 @@ import {
   buildTerritoryControllerBody,
   buildTerritoryControllerPressureBody,
   buildWorkerBody,
-  getBodyCost
+  getBodyCost,
+  TERRITORY_SCOUT_BODY,
+  TERRITORY_SCOUT_BODY_COST
 } from '../src/spawn/bodyBuilder';
 import { TERRITORY_CONTROLLER_BODY, TERRITORY_CONTROLLER_BODY_COST } from '../src/spawn/creepBodies';
 
@@ -199,6 +201,11 @@ describe('creep body templates', () => {
   it('defines a claimer body template with claim and move', () => {
     expect(TERRITORY_CONTROLLER_BODY).toEqual(['claim', 'move']);
     expect(TERRITORY_CONTROLLER_BODY_COST).toBe(650);
+  });
+
+  it('defines a cheap scout body for single-room traversal', () => {
+    expect(TERRITORY_SCOUT_BODY).toEqual(['move']);
+    expect(TERRITORY_SCOUT_BODY_COST).toBe(50);
   });
 });
 

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -159,8 +159,31 @@ describe('autonomous expansion claim executor', () => {
       reason: 'scoreBelowThreshold'
     });
     expect(evaluation.score).toBeLessThanOrEqual(500);
-    expect(Memory.territory).toBeUndefined();
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.scoutIntel?.['W1N1>W2N1']).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      updatedAt: 101,
+      controller: { id: 'controller2', my: false },
+      sourceCount: 1,
+      hostileCreepCount: 0,
+      hostileStructureCount: 0,
+      hostileSpawnCount: 0
+    });
     expect(events).toEqual([
+      {
+        type: 'territoryScout',
+        roomName: 'W1N1',
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        phase: 'intel',
+        result: 'recorded',
+        controllerId: 'controller2',
+        sourceCount: 1,
+        hostileCreepCount: 0,
+        hostileStructureCount: 0,
+        hostileSpawnCount: 0
+      },
       {
         type: 'territoryClaim',
         roomName: 'W1N1',
@@ -499,6 +522,189 @@ describe('autonomous expansion claim executor', () => {
     ]);
   });
 
+  it('requests a fresh scout instead of claiming from expired positive scout intel', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            updatedAt: 100,
+            controller: { id: 'controller2' as Id<StructureController>, my: false },
+            sourceIds: ['source1', 'source2'],
+            sourceCount: 2,
+            hostileCreepCount: 0,
+            hostileStructureCount: 0,
+            hostileSpawnCount: 0
+          }
+        }
+      }
+    };
+
+    const evaluation = refreshAutonomousExpansionClaimIntent(
+      makeColony(),
+      makeReport([
+        makeCandidate({
+          roomName: 'W2N1',
+          controllerId: 'controller2' as Id<StructureController>,
+          sourceCount: 2
+        })
+      ]),
+      1_601
+    );
+
+    expect(evaluation).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2',
+      reason: 'scoutPending'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.scoutAttempts?.['W1N1>W2N1']).toEqual({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'requested',
+      requestedAt: 1_601,
+      updatedAt: 1_601,
+      attemptCount: 1,
+      controllerId: 'controller2',
+      lastValidation: {
+        status: 'pending',
+        reason: 'scoutPending',
+        updatedAt: 1_601
+      }
+    });
+  });
+
+  it('waits for the active scout request when existing intel predates it', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutAttempts: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'requested',
+            requestedAt: 140,
+            updatedAt: 140,
+            attemptCount: 1,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        },
+        scoutIntel: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            updatedAt: 130,
+            controller: { id: 'controller2' as Id<StructureController>, my: false },
+            sourceIds: ['source1', 'source2'],
+            sourceCount: 2,
+            hostileCreepCount: 0,
+            hostileStructureCount: 0,
+            hostileSpawnCount: 0
+          }
+        }
+      }
+    };
+
+    const evaluation = refreshAutonomousExpansionClaimIntent(
+      makeColony(),
+      makeReport([
+        makeCandidate({
+          roomName: 'W2N1',
+          controllerId: 'controller2' as Id<StructureController>,
+          sourceCount: 2
+        })
+      ]),
+      141
+    );
+
+    expect(evaluation).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2',
+      reason: 'scoutPending'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.scoutAttempts?.['W1N1>W2N1']).toEqual({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'requested',
+      requestedAt: 140,
+      updatedAt: 141,
+      attemptCount: 1,
+      controllerId: 'controller2',
+      lastValidation: {
+        status: 'pending',
+        reason: 'scoutPending',
+        updatedAt: 141
+      }
+    });
+  });
+
+  it('persists visible negative scout intel before returning a controller-owned skip', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            updatedAt: 130,
+            controller: { id: 'controller2' as Id<StructureController>, my: false },
+            sourceIds: ['source1', 'source2'],
+            sourceCount: 2,
+            hostileCreepCount: 0,
+            hostileStructureCount: 0,
+            hostileSpawnCount: 0
+          }
+        }
+      }
+    };
+    const visibleRoom = makeTargetRoom('W2N1', {
+      controllerId: 'controller2' as Id<StructureController>,
+      sourceCount: 1
+    });
+    const visibleController = visibleRoom.controller as StructureController & { owner?: { username: string } };
+    visibleController.owner = { username: 'enemy' };
+    (Game.rooms as Record<string, Room>).W2N1 = visibleRoom;
+
+    const evaluation = refreshAutonomousExpansionClaimIntent(
+      makeColony(),
+      makeReport([
+        makeCandidate({
+          roomName: 'W2N1',
+          controllerId: 'controller2' as Id<StructureController>,
+          sourceCount: 2
+        })
+      ]),
+      150
+    );
+
+    expect(evaluation).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2',
+      reason: 'controllerOwned'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.scoutIntel?.['W1N1>W2N1']).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      updatedAt: 150,
+      controller: {
+        id: 'controller2',
+        my: false,
+        ownerUsername: 'enemy'
+      },
+      sourceCount: 1,
+      hostileCreepCount: 0,
+      hostileStructureCount: 0,
+      hostileSpawnCount: 0
+    });
+  });
+
   it('blocks claim validation when scout intel sees a hostile controller', () => {
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
@@ -747,7 +953,14 @@ describe('autonomous expansion claim executor', () => {
       reason: 'controllerCooldown'
     });
     expect(shouldDeferOccupationRecommendationForExpansionClaim(evaluation)).toBe(true);
-    expect(Memory.territory).toBeUndefined();
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.scoutIntel?.['W1N1>W2N1']).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      updatedAt: 103,
+      controller: { id: 'controller2', my: false },
+      sourceCount: 1
+    });
   });
 
   it('marks and emits a gclInsufficient skip when GCL room cap is reached', () => {
@@ -787,7 +1000,14 @@ describe('autonomous expansion claim executor', () => {
       reason: 'gclInsufficient'
     });
     expect(shouldDeferOccupationRecommendationForExpansionClaim(evaluation)).toBe(false);
-    expect(Memory.territory).toBeUndefined();
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.scoutIntel?.['W1N1>W2N1']).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      updatedAt: 104,
+      controller: { id: 'controller2', my: false },
+      sourceCount: 1
+    });
   });
 });
 

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -17,6 +17,9 @@ describe('autonomous expansion claim executor', () => {
   beforeEach(() => {
     (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 1;
     (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 2;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 3;
+    (globalThis as unknown as { FIND_MINERALS: number }).FIND_MINERALS = 4;
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {},
@@ -33,6 +36,9 @@ describe('autonomous expansion claim executor', () => {
     delete (globalThis as { Memory?: Partial<Memory> }).Memory;
     delete (globalThis as { FIND_HOSTILE_CREEPS?: number }).FIND_HOSTILE_CREEPS;
     delete (globalThis as { FIND_HOSTILE_STRUCTURES?: number }).FIND_HOSTILE_STRUCTURES;
+    delete (globalThis as { FIND_SOURCES?: number }).FIND_SOURCES;
+    delete (globalThis as { FIND_MINERALS?: number }).FIND_MINERALS;
+    delete (globalThis as { STRUCTURE_SPAWN?: StructureConstant }).STRUCTURE_SPAWN;
   });
 
   it('records a claim intent for the best expansion-scored adjacent room above threshold', () => {
@@ -87,6 +93,33 @@ describe('autonomous expansion claim executor', () => {
       }
     ]);
     expect(events).toEqual([
+      {
+        type: 'territoryScout',
+        roomName: 'W1N1',
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        phase: 'intel',
+        result: 'recorded',
+        controllerId: 'controller12',
+        sourceCount: 1,
+        hostileCreepCount: 0,
+        hostileStructureCount: 0,
+        hostileSpawnCount: 0
+      },
+      {
+        type: 'territoryScout',
+        roomName: 'W1N1',
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        phase: 'validation',
+        result: 'passed',
+        controllerId: 'controller12',
+        sourceCount: 1,
+        hostileCreepCount: 0,
+        hostileStructureCount: 0,
+        hostileSpawnCount: 0,
+        score: evaluation.score
+      },
       {
         type: 'territoryClaim',
         roomName: 'W1N1',
@@ -161,7 +194,13 @@ describe('autonomous expansion claim executor', () => {
 
     const evaluation = refreshAutonomousExpansionClaimIntent(
       makeColony(),
-      makeReport([makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })]),
+      makeReport([
+        makeCandidate({
+          roomName: 'W2N1',
+          controllerId: 'controller2' as Id<StructureController>,
+          sourceCount: 2
+        })
+      ]),
       nextTick()
     );
 
@@ -338,6 +377,230 @@ describe('autonomous expansion claim executor', () => {
     });
     expect(Memory.territory).toBeUndefined();
     expect(events).toEqual([]);
+  });
+
+  it('creates a scout intent for an unvalidated adjacent claim candidate', () => {
+    const events: RuntimeTelemetryEvent[] = [];
+
+    const evaluation = refreshAutonomousExpansionClaimIntent(
+      makeColony(),
+      makeReport([
+        makeCandidate({
+          roomName: 'W2N1',
+          controllerId: 'controller2' as Id<StructureController>,
+          sourceCount: 2
+        })
+      ]),
+      120,
+      events
+    );
+
+    expect(evaluation).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      reason: 'scoutPending'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: 120,
+        controllerId: 'controller2'
+      }
+    ]);
+    expect(Memory.territory?.scoutAttempts?.['W1N1>W2N1']).toEqual({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'requested',
+      requestedAt: 120,
+      updatedAt: 120,
+      attemptCount: 1,
+      controllerId: 'controller2',
+      lastValidation: {
+        status: 'pending',
+        reason: 'intelMissing',
+        updatedAt: 120
+      }
+    });
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'territoryScout',
+        phase: 'validation',
+        result: 'pending',
+        reason: 'intelMissing',
+        targetRoom: 'W2N1',
+        score: evaluation.score
+      }),
+      expect.objectContaining({
+        type: 'territoryScout',
+        phase: 'attempt',
+        result: 'requested',
+        targetRoom: 'W2N1',
+        controllerId: 'controller2'
+      }),
+      expect.objectContaining({
+        type: 'territoryClaim',
+        phase: 'skip',
+        reason: 'scoutPending',
+        targetRoom: 'W2N1'
+      })
+    ]);
+  });
+
+  it('passes claim validation from positive scout intel even when the room is no longer visible', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            updatedAt: 130,
+            controller: { id: 'controller2' as Id<StructureController>, my: false },
+            sourceIds: ['source1', 'source2'],
+            sourceCount: 2,
+            hostileCreepCount: 0,
+            hostileStructureCount: 0,
+            hostileSpawnCount: 0
+          }
+        }
+      }
+    };
+
+    const evaluation = refreshAutonomousExpansionClaimIntent(
+      makeColony(),
+      makeReport([
+        makeCandidate({
+          roomName: 'W2N1',
+          controllerId: 'controller2' as Id<StructureController>,
+          sourceCount: 2
+        })
+      ]),
+      131
+    );
+
+    expect(evaluation).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'autonomousExpansionClaim',
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
+  it('blocks claim validation when scout intel sees a hostile controller', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            updatedAt: 140,
+            controller: {
+              id: 'controller2' as Id<StructureController>,
+              my: false,
+              ownerUsername: 'enemy'
+            },
+            sourceIds: ['source1'],
+            sourceCount: 1,
+            hostileCreepCount: 0,
+            hostileStructureCount: 0,
+            hostileSpawnCount: 0
+          }
+        }
+      }
+    };
+
+    const evaluation = refreshAutonomousExpansionClaimIntent(
+      makeColony(),
+      makeReport([
+        makeCandidate({
+          roomName: 'W2N1',
+          controllerId: 'controller2' as Id<StructureController>,
+          sourceCount: 2
+        })
+      ]),
+      141
+    );
+
+    expect(evaluation).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2',
+      reason: 'controllerOwned'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.scoutAttempts?.['W1N1>W2N1']?.lastValidation).toEqual({
+      status: 'blocked',
+      reason: 'controllerOwned',
+      updatedAt: 141
+    });
+  });
+
+  it('falls back to a best-effort claim after the scout validation timeout', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutAttempts: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'requested',
+            requestedAt: 100,
+            updatedAt: 100,
+            attemptCount: 1,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        }
+      }
+    };
+
+    const evaluation = refreshAutonomousExpansionClaimIntent(
+      makeColony(),
+      makeReport([
+        makeCandidate({
+          roomName: 'W2N1',
+          controllerId: 'controller2' as Id<StructureController>,
+          sourceCount: 2
+        })
+      ]),
+      1_701
+    );
+
+    expect(evaluation).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'autonomousExpansionClaim',
+        controllerId: 'controller2'
+      }
+    ]);
+    expect(Memory.territory?.scoutAttempts?.['W1N1>W2N1']).toMatchObject({
+      status: 'timedOut',
+      lastValidation: {
+        status: 'fallback',
+        reason: 'scoutTimeout',
+        updatedAt: 1_701
+      }
+    });
   });
 
   it('keeps an existing autonomous claim target when scoring reports it as configured', () => {
@@ -596,11 +859,13 @@ function makeTargetRoom(
   {
     controllerId,
     upgradeBlocked = 0,
+    sourceCount = 1,
     hostileCreeps = [],
     hostileStructures = []
   }: {
     controllerId: Id<StructureController>;
     upgradeBlocked?: number;
+    sourceCount?: number;
     hostileCreeps?: Creep[];
     hostileStructures?: AnyStructure[];
   }
@@ -619,6 +884,14 @@ function makeTargetRoom(
 
       if (type === FIND_HOSTILE_STRUCTURES) {
         return hostileStructures;
+      }
+
+      if (type === FIND_SOURCES) {
+        return Array.from({ length: sourceCount }, (_value, index) => ({ id: `${roomName}-source${index}` }));
+      }
+
+      if (type === FIND_MINERALS) {
+        return [{ id: `${roomName}-mineral`, mineralType: 'H' }];
       }
 
       return [];

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -1189,6 +1189,81 @@ describe('runtime telemetry summaries', () => {
     expect(room.territoryIntents).toBeUndefined();
   });
 
+  it('emits territory scout attempts and intel in room telemetry', () => {
+    const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutAttempts: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'observed',
+            requestedAt: RUNTIME_SUMMARY_INTERVAL - 3,
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 1,
+            attemptCount: 1,
+            scoutName: 'Scout1',
+            lastValidation: {
+              status: 'passed',
+              updatedAt: RUNTIME_SUMMARY_INTERVAL - 1
+            }
+          }
+        },
+        scoutIntel: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 1,
+            controller: { id: 'controller2' as Id<StructureController>, my: false },
+            sourceIds: ['source1', 'source2'],
+            sourceCount: 2,
+            mineral: { id: 'mineral1', mineralType: 'H' },
+            hostileCreepCount: 0,
+            hostileStructureCount: 0,
+            hostileSpawnCount: 0,
+            scoutName: 'Scout1'
+          }
+        }
+      }
+    };
+
+    emitRuntimeSummary([colony], [], [], { persistOccupationRecommendations: false });
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.territoryScout).toEqual({
+      attempts: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          status: 'observed',
+          requestedAt: RUNTIME_SUMMARY_INTERVAL - 3,
+          updatedAt: RUNTIME_SUMMARY_INTERVAL - 1,
+          attemptCount: 1,
+          scoutName: 'Scout1',
+          lastValidation: {
+            status: 'passed',
+            updatedAt: RUNTIME_SUMMARY_INTERVAL - 1
+          }
+        }
+      ],
+      intel: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          updatedAt: RUNTIME_SUMMARY_INTERVAL - 1,
+          controller: { id: 'controller2', my: false },
+          sourceIds: ['source1', 'source2'],
+          sourceCount: 2,
+          mineral: { id: 'mineral1', mineralType: 'H' },
+          hostileCreepCount: 0,
+          hostileStructureCount: 0,
+          hostileSpawnCount: 0,
+          scoutName: 'Scout1'
+        }
+      ]
+    });
+  });
+
   it('keeps emission gating deterministic', () => {
     expect(shouldEmitRuntimeSummary(1, [])).toBe(false);
     expect(shouldEmitRuntimeSummary(RUNTIME_SUMMARY_INTERVAL, [])).toBe(true);

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -108,7 +108,7 @@ describe('runTerritoryControllerCreep', () => {
     ]);
   });
 
-  it('keeps scout target attribution after entering the target room', () => {
+  it('records scout intel and clears target attribution after entering the target room', () => {
     const telemetryEvents: RuntimeTelemetryEvent[] = [];
     const creep = {
       name: 'Scout1',
@@ -136,7 +136,7 @@ describe('runTerritoryControllerCreep', () => {
 
     expect(creep.moveTo).not.toHaveBeenCalled();
     expect(creep.signController).not.toHaveBeenCalled();
-    expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'scout' });
+    expect(creep.memory.territory).toBeUndefined();
     expect(Memory.territory?.scoutIntel?.['W1N1>W1N2']).toEqual({
       colony: 'W1N1',
       roomName: 'W1N2',

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -9,8 +9,11 @@ import type { RuntimeTelemetryEvent } from '../src/telemetry/runtimeSummary';
 
 describe('runTerritoryControllerCreep', () => {
   beforeEach(() => {
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 5;
+    (globalThis as unknown as { FIND_MINERALS: number }).FIND_MINERALS = 8;
     (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 6;
     (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 7;
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { CLAIM: BodyPartConstant }).CLAIM = 'claim';
     (globalThis as unknown as { RoomPosition: typeof RoomPosition }).RoomPosition = jest.fn(
       (x: number, y: number, roomName: string) => ({ x, y, roomName }) as RoomPosition
@@ -20,6 +23,18 @@ describe('runTerritoryControllerCreep', () => {
       getObjectById: jest.fn().mockReturnValue(null)
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  afterEach(() => {
+    delete (globalThis as { FIND_SOURCES?: number }).FIND_SOURCES;
+    delete (globalThis as { FIND_MINERALS?: number }).FIND_MINERALS;
+    delete (globalThis as { FIND_HOSTILE_CREEPS?: number }).FIND_HOSTILE_CREEPS;
+    delete (globalThis as { FIND_HOSTILE_STRUCTURES?: number }).FIND_HOSTILE_STRUCTURES;
+    delete (globalThis as { STRUCTURE_SPAWN?: StructureConstant }).STRUCTURE_SPAWN;
+    delete (globalThis as { CLAIM?: BodyPartConstant }).CLAIM;
+    delete (globalThis as { RoomPosition?: typeof RoomPosition }).RoomPosition;
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
   });
 
   it('moves toward the target room before touching the controller', () => {
@@ -94,19 +109,63 @@ describe('runTerritoryControllerCreep', () => {
   });
 
   it('keeps scout target attribution after entering the target room', () => {
+    const telemetryEvents: RuntimeTelemetryEvent[] = [];
     const creep = {
+      name: 'Scout1',
       memory: { role: 'scout', colony: 'W1N1', territory: { targetRoom: 'W1N2', action: 'scout' } },
-      room: { name: 'W1N2' },
+      room: {
+        name: 'W1N2',
+        controller: { id: 'controller2' as Id<StructureController>, my: false },
+        find: jest.fn((findType: number) => {
+          if (findType === FIND_SOURCES) {
+            return [{ id: 'source1' }, { id: 'source2' }];
+          }
+
+          if (findType === FIND_MINERALS) {
+            return [{ id: 'mineral1', mineralType: 'H' }];
+          }
+
+          return [];
+        })
+      },
       moveTo: jest.fn(),
       signController: jest.fn()
     } as unknown as Creep;
 
-    runTerritoryControllerCreep(creep);
+    runTerritoryControllerCreep(creep, telemetryEvents);
 
     expect(creep.moveTo).not.toHaveBeenCalled();
     expect(creep.signController).not.toHaveBeenCalled();
     expect(creep.memory.territory).toEqual({ targetRoom: 'W1N2', action: 'scout' });
-    expect(Memory.territory).toBeUndefined();
+    expect(Memory.territory?.scoutIntel?.['W1N1>W1N2']).toEqual({
+      colony: 'W1N1',
+      roomName: 'W1N2',
+      updatedAt: 500,
+      controller: { id: 'controller2', my: false },
+      sourceIds: ['source1', 'source2'],
+      sourceCount: 2,
+      mineral: { id: 'mineral1', mineralType: 'H' },
+      hostileCreepCount: 0,
+      hostileStructureCount: 0,
+      hostileSpawnCount: 0,
+      scoutName: 'Scout1'
+    });
+    expect(telemetryEvents).toEqual([
+      {
+        type: 'territoryScout',
+        roomName: 'W1N1',
+        colony: 'W1N1',
+        targetRoom: 'W1N2',
+        phase: 'intel',
+        result: 'recorded',
+        controllerId: 'controller2',
+        scoutName: 'Scout1',
+        sourceCount: 2,
+        hostileCreepCount: 0,
+        hostileStructureCount: 0,
+        hostileSpawnCount: 0
+      }
+    ]);
   });
 
   it('reserves the target room controller and moves into range when needed', () => {


### PR DESCRIPTION
## Summary
Implements multi-room claim expansion with scout-ahead validation. Scouts validate target rooms before committing claims.

## Verification
- `cd prod && npm run typecheck`: PASS
- `cd prod && npm test -- --runInBand`: 41 suites, 963 tests PASS
- `cd prod && npm run build`: OK
- `git diff --check`: clean

## Changes
- `prod/src/territory/scoutIntel.ts`: New scout intel collection and validation module
- `prod/src/territory/claimExecutor.ts`: Scout-ahead validation integration in claim flow
- `prod/src/territory/expansionScoring.ts`: Scout-based scoring adjustments
- `prod/src/territory/territoryRunner.ts`: Scout task scheduling
- `prod/src/spawn/bodyBuilder.ts`: Scout body profile
- `prod/src/spawn/spawnPlanner.ts`: Scout spawn planning
- `prod/src/telemetry/runtimeSummary.ts`: Scout telemetry
- `prod/src/types.d.ts`: Type definitions
- `prod/test/`: Corresponding tests

Closes #586
