### PR TITLE
feat(telemetry): instrument energy telemetry fields in runtime summary (#583)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -15541,7 +15541,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
     const spawnSite = toSpawnSiteMemory(existingSpawnSite);
     updatePostClaimBootstrapRecord(roomName, {
       status: "spawnSitePending",
-      updatedAt: getGameTime11(),
+      updatedAt: getGameTime10(),
       workerTarget,
       spawnSite,
       lastResult: OK_CODE5
@@ -15565,7 +15565,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
   const nextStatus = sitePlan.result === OK_CODE5 ? "spawnSitePending" : "spawnSiteBlocked";
   updatePostClaimBootstrapRecord(roomName, {
     status: nextStatus,
-    updatedAt: getGameTime11(),
+    updatedAt: getGameTime10(),
     workerTarget,
     ...sitePlan.position ? { spawnSite: sitePlan.position } : {},
     lastResult: sitePlan.result
@@ -16518,19 +16518,32 @@ function buildControllerSummary(room) {
   return { controller: summary };
 }
 function summarizeResources(colony, colonyWorkers, events) {
-  var _a, _b, _c, _d;
+  var _a, _b, _c, _d, _e, _f;
   const roomStructures = (_a = findRoomObjects9(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const constructionSites = (_b = findRoomObjects9(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
-  const droppedResources = (_c = findRoomObjects9(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _c : [];
-  const sources = (_d = findRoomObjects9(colony.room, "FIND_SOURCES")) != null ? _d : [];
+  const ownedEnergyStructures = findOwnedEnergyStoreStructures(colony.room);
+  const roomCreeps = (_b = findRoomObjects9(colony.room, "FIND_MY_CREEPS")) != null ? _b : [];
+  const constructionSites = (_c = findRoomObjects9(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _c : [];
+  const droppedResources = (_d = findRoomObjects9(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _d : [];
+  const sources = (_e = findRoomObjects9(colony.room, "FIND_SOURCES")) != null ? _e : [];
   return {
-    storedEnergy: sumEnergyInStores(roomStructures),
-    workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
+    storedEnergy: sumEnergyInStores(ownedEnergyStructures),
+    workerCarriedEnergy: sumEnergyInStores(roomCreeps),
+    harvestedThisTick: (_f = events == null ? void 0 : events.harvestedEnergy) != null ? _f : 0,
     droppedEnergy: sumDroppedEnergy2(droppedResources),
     sourceCount: sources.length,
     productiveEnergy: summarizeProductiveEnergy(colony.room, colonyWorkers, constructionSites, roomStructures),
     ...events ? { events } : {}
   };
+}
+function findOwnedEnergyStoreStructures(room) {
+  var _a;
+  return ((_a = findRoomObjects9(room, "FIND_MY_STRUCTURES")) != null ? _a : []).filter(isOwnedEnergyStoreStructure);
+}
+function isOwnedEnergyStoreStructure(structure) {
+  if (!isRecord14(structure)) {
+    return false;
+  }
+  return matchesStructureType10(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType10(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType10(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType10(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType10(structure.structureType, "STRUCTURE_LINK", "link");
 }
 function summarizeProductiveEnergy(room, colonyWorkers, constructionSites, roomStructures) {
   const productiveAssignments = summarizeProductiveWorkerAssignments(colonyWorkers);
@@ -16910,7 +16923,7 @@ function getRoomEventLog(room) {
     return void 0;
   }
   try {
-    const eventLog = getEventLog.call(room);
+    const eventLog = getEventLog.call(room, getEnergyResource6());
     return Array.isArray(eventLog) ? eventLog : void 0;
   } catch {
     return void 0;
@@ -16923,13 +16936,16 @@ function getEnergyInStore(object) {
   if (!isRecord14(object) || !isRecord14(object.store)) {
     return 0;
   }
+  const storedEnergy = object.store[getEnergyResource6()];
+  if (typeof storedEnergy === "number") {
+    return storedEnergy;
+  }
   const getUsedCapacity = object.store.getUsedCapacity;
   if (typeof getUsedCapacity === "function") {
     const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource6());
     return typeof usedCapacity === "number" ? usedCapacity : 0;
   }
-  const storedEnergy = object.store[getEnergyResource6()];
-  return typeof storedEnergy === "number" ? storedEnergy : 0;
+  return 0;
 }
 function getEnergyCapacityInStore(object) {
   if (!isRecord14(object) || !isRecord14(object.store)) {

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -250,6 +250,7 @@ interface RuntimeResourceEventSummary {
 interface RuntimeResourceSummary {
   storedEnergy: number;
   workerCarriedEnergy: number;
+  harvestedThisTick: number;
   droppedEnergy: number;
   sourceCount: number;
   productiveEnergy: RuntimeProductiveEnergySummary;
@@ -1433,18 +1434,39 @@ function summarizeResources(
   events: RuntimeResourceEventSummary | undefined
 ): RuntimeResourceSummary {
   const roomStructures = findRoomObjects(colony.room, 'FIND_STRUCTURES') ?? colony.spawns;
+  const ownedEnergyStructures = findOwnedEnergyStoreStructures(colony.room);
+  const roomCreeps = findRoomObjects(colony.room, 'FIND_MY_CREEPS') ?? [];
   const constructionSites = findRoomObjects(colony.room, 'FIND_MY_CONSTRUCTION_SITES') ?? [];
   const droppedResources = findRoomObjects(colony.room, 'FIND_DROPPED_RESOURCES') ?? [];
   const sources = findRoomObjects(colony.room, 'FIND_SOURCES') ?? [];
 
   return {
-    storedEnergy: sumEnergyInStores(roomStructures),
-    workerCarriedEnergy: sumEnergyInStores(colonyWorkers),
+    storedEnergy: sumEnergyInStores(ownedEnergyStructures),
+    workerCarriedEnergy: sumEnergyInStores(roomCreeps),
+    harvestedThisTick: events?.harvestedEnergy ?? 0,
     droppedEnergy: sumDroppedEnergy(droppedResources),
     sourceCount: sources.length,
     productiveEnergy: summarizeProductiveEnergy(colony.room, colonyWorkers, constructionSites, roomStructures),
     ...(events ? { events } : {})
   };
+}
+
+function findOwnedEnergyStoreStructures(room: Room): unknown[] {
+  return (findRoomObjects(room, 'FIND_MY_STRUCTURES') ?? []).filter(isOwnedEnergyStoreStructure);
+}
+
+function isOwnedEnergyStoreStructure(structure: unknown): boolean {
+  if (!isRecord(structure)) {
+    return false;
+  }
+
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_EXTENSION', 'extension') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_STORAGE', 'storage') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container') ||
+    matchesStructureType(structure.structureType, 'STRUCTURE_LINK', 'link')
+  );
 }
 
 function summarizeProductiveEnergy(
@@ -1945,7 +1967,7 @@ function getRoomEventLog(room: Room): unknown[] | undefined {
   }
 
   try {
-    const eventLog = getEventLog.call(room);
+    const eventLog = getEventLog.call(room, getEnergyResource());
     return Array.isArray(eventLog) ? eventLog : undefined;
   } catch {
     return undefined;
@@ -1961,14 +1983,18 @@ function getEnergyInStore(object: unknown): number {
     return 0;
   }
 
+  const storedEnergy = object.store[getEnergyResource()];
+  if (typeof storedEnergy === 'number') {
+    return storedEnergy;
+  }
+
   const getUsedCapacity = object.store.getUsedCapacity;
   if (typeof getUsedCapacity === 'function') {
     const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource());
     return typeof usedCapacity === 'number' ? usedCapacity : 0;
   }
 
-  const storedEnergy = object.store[getEnergyResource()];
-  return typeof storedEnergy === 'number' ? storedEnergy : 0;
+  return 0;
 }
 
 function getEnergyCapacityInStore(object: unknown): number {
@@ -2026,7 +2052,9 @@ type StructureConstantGlobal =
   | 'STRUCTURE_RAMPART'
   | 'STRUCTURE_TOWER'
   | 'STRUCTURE_SPAWN'
-  | 'STRUCTURE_EXTENSION';
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_STORAGE'
+  | 'STRUCTURE_LINK';
 
 function matchesStructureType(value: unknown, globalName: StructureConstantGlobal, fallback: string): boolean {
   const expectedValue = (globalThis as Record<string, unknown>)[globalName] ?? fallback;

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -17,6 +17,7 @@ const TEST_GLOBALS = {
   FIND_HOSTILE_STRUCTURES: 105,
   FIND_MY_STRUCTURES: 106,
   FIND_MY_CONSTRUCTION_SITES: 107,
+  FIND_MY_CREEPS: 108,
   EVENT_HARVEST: 201,
   EVENT_TRANSFER: 202,
   EVENT_BUILD: 203,
@@ -25,12 +26,14 @@ const TEST_GLOBALS = {
   EVENT_ATTACK: 206,
   EVENT_OBJECT_DESTROYED: 207,
   RESOURCE_ENERGY: 'energy',
+  STRUCTURE_SPAWN: 'spawn',
   STRUCTURE_EXTENSION: 'extension',
   STRUCTURE_TOWER: 'tower',
   STRUCTURE_RAMPART: 'rampart',
   STRUCTURE_ROAD: 'road',
   STRUCTURE_CONTAINER: 'container',
-  STRUCTURE_STORAGE: 'storage'
+  STRUCTURE_STORAGE: 'storage',
+  STRUCTURE_LINK: 'link'
 } as const;
 
 const RUNTIME_GLOBAL_KEYS = Object.keys(TEST_GLOBALS);
@@ -49,18 +52,19 @@ describe('runtime telemetry summaries', () => {
   });
 
   it('emits cadence-limited runtime summaries with room, spawn, task, CPU, and KPI fields', () => {
-    const colony = makeColony({
-      time: RUNTIME_SUMMARY_INTERVAL,
-      spawn: {
-        name: 'Spawn1',
-        spawning: { name: 'worker-W1N1-20', remainingTime: 3 }
-      }
-    });
     const creeps = [
       makeWorker({ role: 'worker', colony: 'W1N1', task: { type: 'harvest', targetId: 'source1' as Id<Source> } }, 40),
       makeWorker({ role: 'worker', colony: 'W1N1' }, 20),
       makeWorker({ role: 'worker', colony: 'W2N2', task: { type: 'transfer', targetId: 'spawn2' as Id<AnyStoreStructure> } }, 80)
     ];
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      spawn: {
+        name: 'Spawn1',
+        spawning: { name: 'worker-W1N1-20', remainingTime: 3 }
+      },
+      creeps: creeps.filter((creep) => creep.memory.colony === 'W1N1')
+    });
 
     emitRuntimeSummary([colony], creeps);
 
@@ -108,6 +112,7 @@ describe('runtime telemetry summaries', () => {
           resources: {
             storedEnergy: 175,
             workerCarriedEnergy: 60,
+            harvestedThisTick: 10,
             droppedEnergy: 25,
             sourceCount: 2,
             productiveEnergy: {
@@ -604,6 +609,94 @@ describe('runtime telemetry summaries', () => {
     });
   });
 
+  it('reports storedEnergy from owned spawn, extension, and container stores', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false,
+      structures: [
+        { id: 'spawn1', structureType: TEST_GLOBALS.STRUCTURE_SPAWN, store: makeEnergyStore(40, 300) },
+        { id: 'extension1', structureType: TEST_GLOBALS.STRUCTURE_EXTENSION, store: makeEnergyStore(20, 50) },
+        { id: 'container1', structureType: TEST_GLOBALS.STRUCTURE_CONTAINER, store: makeEnergyStore(125, 2000) },
+        { id: 'tower1', structureType: TEST_GLOBALS.STRUCTURE_TOWER, store: makeEnergyStore(900, 1000) },
+        { id: 'unknown-store', store: makeEnergyStore(500, 500) }
+      ]
+    });
+
+    emitRuntimeSummary([colony], []);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect((room.resources as Record<string, unknown>).storedEnergy).toBe(185);
+  });
+
+  it('reports workerCarriedEnergy from owned creeps in the room', () => {
+    const roomCreeps = [
+      makeWorker({ role: 'worker', colony: 'W1N1' }, 15, 'WorkerA'),
+      makeWorker({ role: 'worker', colony: 'W1N1' }, 25, 'WorkerB'),
+      makeWorker({ role: 'claimer', colony: 'W1N1' }, 5, 'Claimer')
+    ];
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false,
+      creeps: roomCreeps
+    });
+
+    emitRuntimeSummary([colony], roomCreeps);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect((room.resources as Record<string, unknown>).workerCarriedEnergy).toBe(45);
+  });
+
+  it('reports harvestedThisTick from harvest event amounts', () => {
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false
+    });
+    const getEventLog = jest.fn(() => [
+      { event: TEST_GLOBALS.EVENT_HARVEST, data: { amount: 5, resourceType: TEST_GLOBALS.RESOURCE_ENERGY } },
+      { event: TEST_GLOBALS.EVENT_HARVEST, data: { amount: 7 } },
+      { event: TEST_GLOBALS.EVENT_HARVEST, data: { amount: 99, resourceType: 'power' } },
+      { event: TEST_GLOBALS.EVENT_TRANSFER, data: { amount: 11, resourceType: TEST_GLOBALS.RESOURCE_ENERGY } }
+    ]);
+    (colony.room as unknown as { getEventLog: jest.Mock }).getEventLog = getEventLog;
+
+    emitRuntimeSummary([colony], []);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    const resources = room.resources as Record<string, unknown>;
+    expect(resources.harvestedThisTick).toBe(12);
+    expect((resources.events as Record<string, unknown>).harvestedEnergy).toBe(12);
+    expect(getEventLog).toHaveBeenCalledWith(TEST_GLOBALS.RESOURCE_ENERGY);
+  });
+
+  it('reports zero energy fields when structures and creeps have no energy', () => {
+    const roomCreeps = [
+      makeWorker({ role: 'worker', colony: 'W1N1' }, 0, 'EmptyWorker'),
+      { name: 'NoStoreWorker', memory: { role: 'worker', colony: 'W1N1' } }
+    ];
+    const colony = makeColony({
+      time: RUNTIME_SUMMARY_INTERVAL,
+      includeEventLog: false,
+      structures: [
+        { id: 'spawn1', structureType: TEST_GLOBALS.STRUCTURE_SPAWN, store: makeEnergyStore(0, 300) },
+        { id: 'extension1', structureType: TEST_GLOBALS.STRUCTURE_EXTENSION }
+      ],
+      creeps: roomCreeps
+    });
+
+    emitRuntimeSummary([colony], roomCreeps as Creep[]);
+
+    const payload = parseLoggedSummary();
+    const [room] = payload.rooms as Array<Record<string, unknown>>;
+    expect(room.resources).toMatchObject({
+      storedEnergy: 0,
+      workerCarriedEnergy: 0,
+      harvestedThisTick: 0
+    });
+  });
+
   it('reports bounded room-level worker efficiency samples', () => {
     const colony = makeColony({ time: RUNTIME_SUMMARY_INTERVAL });
     const lowLoadReturnReasons: WorkerEfficiencyLowLoadReturnReason[] = [
@@ -920,8 +1013,9 @@ describe('runtime telemetry summaries', () => {
         ticksToDowngrade: 15000
       },
       resources: {
-        storedEnergy: 50,
-        workerCarriedEnergy: 7,
+        storedEnergy: 0,
+        workerCarriedEnergy: 0,
+        harvestedThisTick: 0,
         droppedEnergy: 0,
         sourceCount: 0
       },
@@ -1337,6 +1431,7 @@ function makeColony(options: {
   includeEventLog?: boolean;
   roomName?: string;
   structures?: unknown[];
+  creeps?: unknown[];
 }): ColonySnapshot {
   if (options.installGlobals !== false) {
     installRuntimeTelemetryGlobals();
@@ -1358,11 +1453,16 @@ function makeColony(options: {
   const spawn = {
     name: options.spawn?.name ?? (roomName === 'W1N1' ? 'Spawn1' : `Spawn-${roomName}`),
     room,
+    structureType: TEST_GLOBALS.STRUCTURE_SPAWN,
     spawning: options.spawn?.spawning ?? null,
     store: makeEnergyStore(50)
   } as unknown as StructureSpawn;
-  const structures = options.structures ?? [spawn, { store: makeEnergyStore(125) }];
+  const structures = options.structures ?? [
+    spawn,
+    { id: 'storage1', structureType: TEST_GLOBALS.STRUCTURE_STORAGE, store: makeEnergyStore(125) }
+  ];
   const constructionSites = options.constructionSites ?? [];
+  const roomCreeps = options.creeps ?? [];
 
   if (options.includeRoomFind !== false) {
     (room as unknown as { find?: jest.Mock }).find = jest.fn((findType: number): unknown[] => {
@@ -1373,6 +1473,8 @@ function makeColony(options: {
           return structures;
         case TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES:
           return constructionSites;
+        case TEST_GLOBALS.FIND_MY_CREEPS:
+          return roomCreeps;
         case TEST_GLOBALS.FIND_DROPPED_RESOURCES:
           return [
             { resourceType: TEST_GLOBALS.RESOURCE_ENERGY, amount: 25 },
@@ -1541,12 +1643,13 @@ function makeRemoteRoom(
 function makeEnergyStore(
   energy: number,
   capacity = energy
-): {
+): Record<string, unknown> & {
   getUsedCapacity: (resource?: ResourceConstant) => number;
   getCapacity: (resource?: ResourceConstant) => number;
   getFreeCapacity: (resource?: ResourceConstant) => number;
 } {
   return {
+    [TEST_GLOBALS.RESOURCE_ENERGY]: energy,
     getUsedCapacity: (resource?: ResourceConstant) => (resource === TEST_GLOBALS.RESOURCE_ENERGY ? energy : 0),
     getCapacity: (resource?: ResourceConstant) => (resource === TEST_GLOBALS.RESOURCE_ENERGY ? capacity : 0),
     getFreeCapacity: (resource?: ResourceConstant) =>

--- a/scripts/screeps_rl_dataset_export.py
+++ b/scripts/screeps_rl_dataset_export.py
@@ -842,6 +842,13 @@ def build_reward(payload: JsonObject, room: JsonObject) -> JsonObject:
     combat = room.get("combat") if isinstance(room.get("combat"), dict) else {}
     resource_events = resources.get("events") if isinstance(resources.get("events"), dict) else {}
     combat_events = combat.get("events") if isinstance(combat.get("events"), dict) else {}
+    harvested_this_tick_value = resources.get("harvestedThisTick")
+    harvested_this_tick = number_or_zero(harvested_this_tick_value)
+    harvested_energy = (
+        harvested_this_tick
+        if is_number(harvested_this_tick_value)
+        else number_or_zero(resource_events.get("harvestedEnergy"))
+    )
 
     return {
         "status": "components-only",
@@ -863,7 +870,8 @@ def build_reward(payload: JsonObject, room: JsonObject) -> JsonObject:
                 "storedEnergy": number_or_zero(resources.get("storedEnergy")),
                 "workerCarriedEnergy": number_or_zero(resources.get("workerCarriedEnergy")),
                 "droppedEnergy": number_or_zero(resources.get("droppedEnergy")),
-                "harvestedEnergy": number_or_zero(resource_events.get("harvestedEnergy")),
+                "harvestedThisTick": harvested_this_tick,
+                "harvestedEnergy": harvested_energy,
                 "transferredEnergy": number_or_zero(resource_events.get("transferredEnergy")),
             },
             "kills": {

--- a/scripts/screeps_runtime_kpi_reducer.py
+++ b/scripts/screeps_runtime_kpi_reducer.py
@@ -20,7 +20,7 @@ NOT_INSTRUMENTED = "not instrumented"
 NOT_OBSERVED = "not observed"
 
 CONTROLLER_FIELDS = ("level", "progress", "progressTotal", "ticksToDowngrade")
-RESOURCE_FIELDS = ("storedEnergy", "workerCarriedEnergy", "droppedEnergy", "sourceCount")
+RESOURCE_FIELDS = ("storedEnergy", "workerCarriedEnergy", "harvestedThisTick", "droppedEnergy", "sourceCount")
 RESOURCE_EVENT_FIELDS = ("harvestedEnergy", "transferredEnergy")
 COMBAT_FIELDS = ("hostileCreepCount", "hostileStructureCount")
 COMBAT_EVENT_FIELDS = ("attackCount", "attackDamage", "objectDestroyedCount", "creepDestroyedCount")

--- a/scripts/test_screeps_rl_dataset_export.py
+++ b/scripts/test_screeps_rl_dataset_export.py
@@ -49,6 +49,7 @@ class RlDatasetExportTest(unittest.TestCase):
                     "resources": {
                         "storedEnergy": 420,
                         "workerCarriedEnergy": 120,
+                        "harvestedThisTick": 80,
                         "droppedEnergy": 30,
                         "sourceCount": 2,
                         "events": {"harvestedEnergy": 80, "transferredEnergy": 65},
@@ -124,6 +125,8 @@ class RlDatasetExportTest(unittest.TestCase):
             [label["surface"] for label in row["actionLabels"]],
             ["construction-priority", "expansion-remote-candidate"],
         )
+        self.assertEqual(row["observation"]["resources"]["harvestedThisTick"], 80)
+        self.assertEqual(row["reward"]["components"]["resources"]["harvestedThisTick"], 80)
         self.assertEqual(row["reward"]["components"]["resources"]["harvestedEnergy"], 80)
         self.assertEqual(run_manifest["strategy"]["decisionSurfacesObserved"], [
             "construction-priority",
@@ -132,6 +135,7 @@ class RlDatasetExportTest(unittest.TestCase):
         self.assertFalse(run_manifest["strategy"]["liveEffect"])
         self.assertEqual(kpi_windows["input"]["runtimeSummaryCount"], 1)
         self.assertEqual(kpi_windows["resources"]["totals"]["latest"]["storedEnergy"], 420)
+        self.assertEqual(kpi_windows["resources"]["totals"]["latest"]["harvestedThisTick"], 80)
 
     def test_export_is_reproducible_for_same_inputs(self) -> None:
         payload = {

--- a/scripts/test_screeps_runtime_kpi_reducer.py
+++ b/scripts/test_screeps_runtime_kpi_reducer.py
@@ -29,6 +29,7 @@ class RuntimeKpiReducerTest(unittest.TestCase):
                     "resources": {
                         "storedEnergy": 175,
                         "workerCarriedEnergy": 60,
+                        "harvestedThisTick": 10,
                         "droppedEnergy": 25,
                         "sourceCount": 2,
                         "events": {"harvestedEnergy": 10, "transferredEnergy": 5},
@@ -56,6 +57,7 @@ class RuntimeKpiReducerTest(unittest.TestCase):
                     "resources": {
                         "storedEnergy": 210,
                         "workerCarriedEnergy": 20,
+                        "harvestedThisTick": 7,
                         "droppedEnergy": 5,
                         "sourceCount": 2,
                         "events": {"harvestedEnergy": 7, "transferredEnergy": 3},
@@ -101,12 +103,14 @@ class RuntimeKpiReducerTest(unittest.TestCase):
         self.assertEqual(report["resources"]["totals"]["latest"], {
             "storedEnergy": 210,
             "workerCarriedEnergy": 20,
+            "harvestedThisTick": 7,
             "droppedEnergy": 5,
             "sourceCount": 2,
         })
         self.assertEqual(report["resources"]["totals"]["delta"], {
             "storedEnergy": 35,
             "workerCarriedEnergy": -40,
+            "harvestedThisTick": -3,
             "droppedEnergy": -20,
             "sourceCount": 0,
         })
@@ -163,7 +167,13 @@ class RuntimeKpiReducerTest(unittest.TestCase):
             "rooms": [
                 {
                     "roomName": "W1N1",
-                    "resources": {"storedEnergy": 1, "workerCarriedEnergy": 0, "droppedEnergy": 0, "sourceCount": 1},
+                    "resources": {
+                        "storedEnergy": 1,
+                        "workerCarriedEnergy": 0,
+                        "harvestedThisTick": 0,
+                        "droppedEnergy": 0,
+                        "sourceCount": 1,
+                    },
                     "combat": {"hostileCreepCount": 0, "hostileStructureCount": 0},
                 },
                 {
@@ -171,6 +181,7 @@ class RuntimeKpiReducerTest(unittest.TestCase):
                     "resources": {
                         "storedEnergy": 2,
                         "workerCarriedEnergy": 0,
+                        "harvestedThisTick": 4,
                         "droppedEnergy": 0,
                         "sourceCount": 1,
                         "events": {"harvestedEnergy": 4, "transferredEnergy": 3},
@@ -189,7 +200,13 @@ class RuntimeKpiReducerTest(unittest.TestCase):
             "rooms": [
                 {
                     "roomName": "W1N1",
-                    "resources": {"storedEnergy": 5, "workerCarriedEnergy": 0, "droppedEnergy": 0, "sourceCount": 1},
+                    "resources": {
+                        "storedEnergy": 5,
+                        "workerCarriedEnergy": 0,
+                        "harvestedThisTick": 0,
+                        "droppedEnergy": 0,
+                        "sourceCount": 1,
+                    },
                     "combat": {"hostileCreepCount": 0, "hostileStructureCount": 0},
                 }
             ],
@@ -218,7 +235,13 @@ class RuntimeKpiReducerTest(unittest.TestCase):
             "rooms": [
                 {
                     "roomName": "W2N2",
-                    "resources": {"storedEnergy": 100, "workerCarriedEnergy": 7, "droppedEnergy": 3, "sourceCount": 2},
+                    "resources": {
+                        "storedEnergy": 100,
+                        "workerCarriedEnergy": 7,
+                        "harvestedThisTick": 6,
+                        "droppedEnergy": 3,
+                        "sourceCount": 2,
+                    },
                 },
             ],
         }
@@ -235,12 +258,14 @@ class RuntimeKpiReducerTest(unittest.TestCase):
         self.assertEqual(report["resources"]["totals"]["latest"], {
             "storedEnergy": 0,
             "workerCarriedEnergy": 0,
+            "harvestedThisTick": 0,
             "droppedEnergy": 0,
             "sourceCount": 0,
         })
         self.assertEqual(report["resources"]["totals"]["delta"], {
             "storedEnergy": -100,
             "workerCarriedEnergy": -7,
+            "harvestedThisTick": -6,
             "droppedEnergy": -3,
             "sourceCount": -2,
         })


### PR DESCRIPTION
Implements #583: adds storedEnergy, harvestedThisTick, workerCarriedEnergy fields to runtime summary console output.

### Changes
- Adds energy telemetry fields to runtimeSummary.ts
- Includes Jest test coverage
- Enables RL training data quality and resource-crisis alerts

Closes #583