### PR TITLE
feat(economy): prioritize road construction and repair for critical source-spawn-controller logistics paths (#617)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2218,22 +2218,70 @@ var ROOM_EDGE_MIN2 = 1;
 var ROOM_EDGE_MAX2 = 48;
 var ROOM_CENTER = 25;
 function buildCriticalRoadLogisticsContext(room, options = {}) {
+  var _a;
   const anchorPositions = findOwnedSpawnPositions(room);
-  const targetPositions = findLogisticsTargetPositions(room);
+  const { controllerPositions, sourcePositions, targetPositions } = findLogisticsTargetPositions(room);
   const colonyAnchorPositions = anchorPositions.length === 0 ? findColonyRoomLogisticsAnchorPositions(room, options.colonyRoomName, targetPositions) : [];
+  const logisticsAnchorPositions = anchorPositions.length > 0 ? anchorPositions : colonyAnchorPositions.length > 0 ? colonyAnchorPositions : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions);
+  const controllerSourceRoutePositions = logisticsAnchorPositions.length > 0 || ((_a = room.controller) == null ? void 0 : _a.my) === true ? controllerPositions : [];
   return {
-    anchorPositions: anchorPositions.length > 0 ? anchorPositions : colonyAnchorPositions.length > 0 ? colonyAnchorPositions : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
+    anchorPositions: logisticsAnchorPositions,
+    routes: buildCriticalRoadLogisticsRoutes(
+      logisticsAnchorPositions,
+      sourcePositions,
+      controllerSourceRoutePositions
+    ),
     targetPositions
   };
 }
 function isCriticalRoadLogisticsWork(target, context) {
-  if (!isRoadWorkTarget(target) || !target.pos || context.anchorPositions.length === 0 || context.targetPositions.length === 0) {
+  const routes = getCriticalRoadLogisticsRoutes(context);
+  if (!isRoadWorkTarget(target) || !target.pos || routes.length === 0) {
     return false;
   }
   const position = target.pos;
-  return context.anchorPositions.some(
-    (anchor) => context.targetPositions.some((destination) => isNearLogisticsRoute(position, anchor, destination))
+  return routes.some((route) => isNearLogisticsRoute(position, route.origin, route.destination));
+}
+function buildCriticalRoadLogisticsRoutes(anchorPositions, sourcePositions, controllerPositions) {
+  return uniqueCriticalRoadLogisticsRoutes([
+    ...sourcePositions.flatMap(
+      (source) => anchorPositions.map((anchor) => ({ origin: source, destination: anchor }))
+    ),
+    ...anchorPositions.flatMap(
+      (anchor) => controllerPositions.map((controller) => ({ origin: anchor, destination: controller }))
+    ),
+    ...controllerPositions.flatMap(
+      (controller) => sourcePositions.map((source) => ({ origin: controller, destination: source }))
+    )
+  ]);
+}
+function getCriticalRoadLogisticsRoutes(context) {
+  if (context.routes && context.routes.length > 0) {
+    return context.routes;
+  }
+  return context.anchorPositions.flatMap(
+    (anchor) => context.targetPositions.map((destination) => ({ origin: anchor, destination }))
   );
+}
+function uniqueCriticalRoadLogisticsRoutes(routes) {
+  const seen = /* @__PURE__ */ new Set();
+  return routes.filter((route) => {
+    const key = getRouteKey(route);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+function getRouteKey(route) {
+  const originKey = getRoomPositionKey(route.origin);
+  const destinationKey = getRoomPositionKey(route.destination);
+  return originKey <= destinationKey ? `${originKey}->${destinationKey}` : `${destinationKey}->${originKey}`;
+}
+function getRoomPositionKey(position) {
+  var _a;
+  return `${(_a = position.roomName) != null ? _a : ""}:${position.x}:${position.y}`;
 }
 function findOwnedSpawnPositions(room) {
   return findRoomObjects3(room, "FIND_MY_STRUCTURES").filter(
@@ -2243,8 +2291,8 @@ function findOwnedSpawnPositions(room) {
 function findLogisticsTargetPositions(room) {
   var _a;
   const sourcePositions = findRoomObjects3(room, "FIND_SOURCES").map((source) => source.pos).filter((position) => isSameRoomPosition(position, room.name));
-  const controllerPosition = isSameRoomPosition((_a = room.controller) == null ? void 0 : _a.pos, room.name) ? [room.controller.pos] : [];
-  return [...sourcePositions, ...controllerPosition];
+  const controllerPositions = isSameRoomPosition((_a = room.controller) == null ? void 0 : _a.pos, room.name) ? [room.controller.pos] : [];
+  return { controllerPositions, sourcePositions, targetPositions: [...sourcePositions, ...controllerPositions] };
 }
 function findColonyRoomLogisticsAnchorPositions(room, colonyRoomName, targetPositions) {
   if (targetPositions.length === 0 || !isNonEmptyString3(room.name) || !isNonEmptyString3(colonyRoomName) || colonyRoomName === room.name) {

--- a/prod/src/construction/criticalRoads.ts
+++ b/prod/src/construction/criticalRoads.ts
@@ -1,6 +1,12 @@
 export interface CriticalRoadLogisticsContext {
   anchorPositions: RoomPosition[];
+  routes?: CriticalRoadLogisticsRoute[];
   targetPositions: RoomPosition[];
+}
+
+export interface CriticalRoadLogisticsRoute {
+  destination: RoomPosition;
+  origin: RoomPosition;
 }
 
 export interface CriticalRoadLogisticsContextOptions {
@@ -24,19 +30,27 @@ export function buildCriticalRoadLogisticsContext(
   options: CriticalRoadLogisticsContextOptions = {}
 ): CriticalRoadLogisticsContext {
   const anchorPositions = findOwnedSpawnPositions(room);
-  const targetPositions = findLogisticsTargetPositions(room);
+  const { controllerPositions, sourcePositions, targetPositions } = findLogisticsTargetPositions(room);
   const colonyAnchorPositions =
     anchorPositions.length === 0
       ? findColonyRoomLogisticsAnchorPositions(room, options.colonyRoomName, targetPositions)
       : [];
+  const logisticsAnchorPositions =
+    anchorPositions.length > 0
+      ? anchorPositions
+      : colonyAnchorPositions.length > 0
+        ? colonyAnchorPositions
+        : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions);
+  const controllerSourceRoutePositions =
+    logisticsAnchorPositions.length > 0 || room.controller?.my === true ? controllerPositions : [];
 
   return {
-    anchorPositions:
-      anchorPositions.length > 0
-        ? anchorPositions
-        : colonyAnchorPositions.length > 0
-          ? colonyAnchorPositions
-          : findRemoteTerritoryLogisticsAnchorPositions(room, targetPositions),
+    anchorPositions: logisticsAnchorPositions,
+    routes: buildCriticalRoadLogisticsRoutes(
+      logisticsAnchorPositions,
+      sourcePositions,
+      controllerSourceRoutePositions
+    ),
     targetPositions
   };
 }
@@ -45,19 +59,64 @@ export function isCriticalRoadLogisticsWork(
   target: RoadWorkTarget,
   context: CriticalRoadLogisticsContext
 ): boolean {
-  if (
-    !isRoadWorkTarget(target) ||
-    !target.pos ||
-    context.anchorPositions.length === 0 ||
-    context.targetPositions.length === 0
-  ) {
+  const routes = getCriticalRoadLogisticsRoutes(context);
+  if (!isRoadWorkTarget(target) || !target.pos || routes.length === 0) {
     return false;
   }
 
   const position = target.pos;
-  return context.anchorPositions.some((anchor) =>
-    context.targetPositions.some((destination) => isNearLogisticsRoute(position, anchor, destination))
+  return routes.some((route) => isNearLogisticsRoute(position, route.origin, route.destination));
+}
+
+function buildCriticalRoadLogisticsRoutes(
+  anchorPositions: RoomPosition[],
+  sourcePositions: RoomPosition[],
+  controllerPositions: RoomPosition[]
+): CriticalRoadLogisticsRoute[] {
+  return uniqueCriticalRoadLogisticsRoutes([
+    ...sourcePositions.flatMap((source) =>
+      anchorPositions.map((anchor) => ({ origin: source, destination: anchor }))
+    ),
+    ...anchorPositions.flatMap((anchor) =>
+      controllerPositions.map((controller) => ({ origin: anchor, destination: controller }))
+    ),
+    ...controllerPositions.flatMap((controller) =>
+      sourcePositions.map((source) => ({ origin: controller, destination: source }))
+    )
+  ]);
+}
+
+function getCriticalRoadLogisticsRoutes(context: CriticalRoadLogisticsContext): CriticalRoadLogisticsRoute[] {
+  if (context.routes && context.routes.length > 0) {
+    return context.routes;
+  }
+
+  return context.anchorPositions.flatMap((anchor) =>
+    context.targetPositions.map((destination) => ({ origin: anchor, destination }))
   );
+}
+
+function uniqueCriticalRoadLogisticsRoutes(routes: CriticalRoadLogisticsRoute[]): CriticalRoadLogisticsRoute[] {
+  const seen = new Set<string>();
+  return routes.filter((route) => {
+    const key = getRouteKey(route);
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+function getRouteKey(route: CriticalRoadLogisticsRoute): string {
+  const originKey = getRoomPositionKey(route.origin);
+  const destinationKey = getRoomPositionKey(route.destination);
+  return originKey <= destinationKey ? `${originKey}->${destinationKey}` : `${destinationKey}->${originKey}`;
+}
+
+function getRoomPositionKey(position: RoomPosition): string {
+  return `${position.roomName ?? ''}:${position.x}:${position.y}`;
 }
 
 function findOwnedSpawnPositions(room: Room): RoomPosition[] {
@@ -69,13 +128,17 @@ function findOwnedSpawnPositions(room: Room): RoomPosition[] {
     .filter((position): position is RoomPosition => isSameRoomPosition(position, room.name));
 }
 
-function findLogisticsTargetPositions(room: Room): RoomPosition[] {
+function findLogisticsTargetPositions(room: Room): {
+  controllerPositions: RoomPosition[];
+  sourcePositions: RoomPosition[];
+  targetPositions: RoomPosition[];
+} {
   const sourcePositions = findRoomObjects<Source>(room, 'FIND_SOURCES')
     .map((source) => source.pos)
     .filter((position): position is RoomPosition => isSameRoomPosition(position, room.name));
-  const controllerPosition = isSameRoomPosition(room.controller?.pos, room.name) ? [room.controller.pos] : [];
+  const controllerPositions = isSameRoomPosition(room.controller?.pos, room.name) ? [room.controller.pos] : [];
 
-  return [...sourcePositions, ...controllerPosition];
+  return { controllerPositions, sourcePositions, targetPositions: [...sourcePositions, ...controllerPositions] };
 }
 
 function findColonyRoomLogisticsAnchorPositions(

--- a/prod/test/constructionPriority.test.ts
+++ b/prod/test/constructionPriority.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_REASONABLE_CONSTRUCTION_SITE_RANGE,
+  buildConstructionSiteImpactPriorityContext,
   buildRuntimeConstructionPriorityReport,
   planTowerConstruction,
   selectImpactWeightedConstructionSite,
@@ -267,6 +268,39 @@ describe('impact-weighted construction site selection', () => {
     expect(selectImpactWeightedConstructionSite(origin, [roadSite, containerSite], context)?.id).toBe(
       'source-container-site'
     );
+  });
+
+  it('prioritizes controller-source lane roads as critical logistics construction', () => {
+    installTestGlobals();
+    try {
+      const source = { id: 'source1', pos: makeRoomPosition(40, 10) } as Source;
+      const controller = { my: true, pos: makeRoomPosition(40, 40) } as StructureController;
+      const spawn = makeOwnedStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 10, 10);
+      const criticalRoadSite = makeConstructionSite('controller-source-road-site', 'road', 40, 25);
+      const sourceContainerSite = makeConstructionSite('source-container-site', 'container', 41, 10);
+      const room = {
+        name: 'W1N1',
+        controller,
+        find: jest.fn((findType: number) => {
+          if (findType === TEST_GLOBALS.FIND_MY_STRUCTURES) {
+            return [spawn];
+          }
+
+          return findType === TEST_GLOBALS.FIND_SOURCES ? [source] : [];
+        })
+      } as unknown as Room;
+      const origin = makeSelectionOrigin({
+        'controller-source-road-site': 8,
+        'source-container-site': 2
+      });
+      const context = buildConstructionSiteImpactPriorityContext(room);
+
+      expect(selectImpactWeightedConstructionSite(origin, [sourceContainerSite, criticalRoadSite], context)?.id).toBe(
+        'controller-source-road-site'
+      );
+    } finally {
+      clearTestGlobals();
+    }
   });
 
   it('keeps tower and protected rampart construction above road/container logistics', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -6361,6 +6361,67 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
   });
 
+  it('keeps emergency spawn refill before controller-source critical road construction', () => {
+    const roadSite = {
+      id: 'road-controller-source-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(40, 25)
+    } as ConstructionSite;
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 40, 10);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      pos: makeRoomPosition(40, 40),
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [roadSite],
+        controller,
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD - 1,
+        myStructures: [spawn as AnyOwnedStructure],
+        sources: [source]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+  });
+
+  it('keeps controller downgrade guard before controller-source critical road construction', () => {
+    const roadSite = {
+      id: 'road-controller-source-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(40, 25)
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 40, 10);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      pos: makeRoomPosition(40, 40),
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [roadSite],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it('keeps controller downgrade guard before tower refill', () => {
     const tower = makeEnergySink('tower1', 'tower' as StructureConstant, 500);
     const controller = {
@@ -6444,6 +6505,36 @@ describe('selectWorkerTask', () => {
     setGameCreeps({ Builder: makeLoadedWorker(room) });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-critical' });
+  });
+
+  it('repairs controller-source critical route roads before generic construction', () => {
+    const site = { id: 'generic-site1', structureType: 'tower' } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 40, 10);
+    const road = makeStructure('road-controller-source-critical', 'road' as StructureConstant, 1_000, 5_000, {
+      pos: makeRoomPosition(40, 25)
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      pos: makeRoomPosition(40, 40),
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source],
+        structures: [road]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'road-controller-source-critical' });
   });
 
   it('repairs colony-anchored remote critical roads before generic construction without a local spawn', () => {
@@ -7008,6 +7099,41 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-critical-site1' });
+  });
+
+  it('builds controller-source critical route road construction before source container construction', () => {
+    const roadSite = {
+      id: 'road-controller-source-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(40, 25)
+    } as ConstructionSite;
+    const containerSite = {
+      id: 'source-container-site1',
+      structureType: 'container',
+      pos: makeRoomPosition(41, 10)
+    } as ConstructionSite;
+    const fullSpawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 40, 10);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      pos: makeRoomPosition(40, 40),
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [containerSite, roadSite],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-controller-source-site1' });
   });
 
   it('repairs reserved-room critical route roads before container construction without a local spawn', () => {
@@ -8121,6 +8247,40 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-site1' });
+  });
+
+  it('keeps controller-source critical road construction before stored-surplus controller upgrading', () => {
+    const site = {
+      id: 'road-controller-source-site1',
+      structureType: 'road',
+      pos: makeRoomPosition(40, 25)
+    } as ConstructionSite;
+    const storage = makeStoredEnergyStructure('storage-surplus', 'storage' as StructureConstant, 1_000, {
+      my: true
+    });
+    const fullSpawn = makeEnergySink('spawn-full', 'spawn' as StructureConstant, 0, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const source = makeSource('source1', 40, 10);
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      pos: makeRoomPosition(40, 40),
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1
+    } as StructureController;
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller,
+        myStructures: [fullSpawn as AnyOwnedStructure],
+        sources: [source],
+        structures: [storage]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'road-controller-source-site1' });
   });
 
   it('keeps stored-surplus controller upgrading before off-route road construction', () => {


### PR DESCRIPTION
## Summary
- Prioritizes critical source/spawn/controller road construction and repair before lower-value work.
- Preserves emergency spawn/extension refill and controller downgrade safeguards.
- Adds/updates worker-task and construction-priority coverage, and regenerates the Screeps bundle.

## Linked issue
Closes #617

## Roadmap category
- Priority: P1
- Domain: Territory/Economy
- Kind: code
- Milestone: P1: Territory/Economy gameplay gate

## Verification
- `npm run typecheck`
- `npm test -- --runInBand` (46 suites / 1024 tests PASS)
- `npm run build`

## Safety
- Codex-authored production-code commit; no direct edits on `main`.
- Keeps official MMO behavior gated by existing deployment/review workflow; no direct deploy performed by this PR.
