### PR TITLE
docs(ops): harden cron registry and runtime alert contract (#620)

### DIFF
--- a/docs/ops/cron-and-route-registry.md
+++ b/docs/ops/cron-and-route-registry.md
@@ -1,7 +1,7 @@
 # Screeps Cron and Route Registry
 
-Last updated: 2026-05-01
-Tracking issue: https://github.com/lanyusea/screeps/issues/427
+Last updated: 2026-05-05
+Tracking issue: https://github.com/lanyusea/screeps/issues/620
 
 This registry keeps the minimum cron/channel contract in one place. Cron prompts may embed short self-contained summaries, but their target/cadence/route expectations must match this file.
 
@@ -33,10 +33,10 @@ When using raw IDs and named channels together, this registry is the comparison 
 
 | Job | ID | Schedule | Delivery | Purpose |
 | --- | --- | --- | --- | --- |
-| Screeps autonomous continuation worker | `f66ed36d7be0` | `8,28,48 * * * *` | `discord:#task-queue` | Dispatcher/reconciler for safe work lanes. |
-| Screeps P0 agent operations monitor | `75cedbb77150` | `13,43 * * * *` | `discord:1497820688843800776` | P0 autonomous-system health monitor. |
-| Screeps runtime room summary images | `befcbb7b2d60` | `23 * * * *` | `discord:1497588267057680385` | Runtime summary report/images for `E26S49`. |
-| Screeps runtime room alert image check | `1c093252ab70` | `1,16,31,46 * * * *` | `discord:1497588512436785284` | Runtime alert/tactical response for `E26S49`. |
+| Screeps autonomous continuation worker | `f66ed36d7be0` | `13,22,50 * * * *` | `discord:#task-queue` | Dispatcher/reconciler for safe work lanes. Stable workdir: `/root/screeps`. |
+| Screeps P0 agent operations monitor | `75cedbb77150` | `7,37 * * * *` | `discord:1497820688843800776` | P0 autonomous-system health monitor. |
+| Screeps runtime room summary images | `befcbb7b2d60` | `58 * * * *` | `discord:1497588267057680385` | Runtime summary report/images for `E26S49`. |
+| Screeps runtime room alert text check | `1df5ef0c3835` | `1,16,31,46 * * * *` | `discord:1497588512436785284` | Runtime alert/tactical response and autonomous recovery for `E26S49`; no-alert runs return exactly `[SILENT]`. |
 | Screeps dev-log fanout reporter | `d3bf35c278d5` | `25,55 * * * *` | `discord:#dev-log` | Dev log fanout from live repo/cron state. |
 | Screeps research-notes fanout reporter | `3c0d20aa2e45` | `10,40 * * * *` | `discord:#research-notes` | Research/RL progress fanout. |
 | Screeps roadmap fanout reporter | `92ca290f7996` | `34 * * * *` | `discord:#roadmap` | Roadmap/Pages image fanout. |
@@ -54,3 +54,5 @@ When using raw IDs and named channels together, this registry is the comparison 
 - When scanning cron output, ignore prompt/system/skill sections unless explicitly auditing historical prompt drift.
 - Cron runs must not recursively schedule new cron jobs.
 - Cron prompt updates require a pre-change snapshot and post-change `cronjob list` verification.
+- Long-lived recurring Screeps jobs should be configured as `forever` or with a very high repeat horizon. A finite `999` cap on critical recurring jobs is abnormal because it can silently stop automation after enough successful runs.
+- Repo/worktree-manipulating cron jobs must keep a stable current directory. Use `/root/screeps` as the default controller cwd, prefer `git -C <path>` or subshells over persistent `cd`, and return to `/root/screeps` before deleting any linked worktree. The 2026-05-05 continuation-worker incident was caused by a deleted `/root/screeps-worktrees/rl-dataset-gate-409` cwd blocking later terminal/file calls in the same cron run.

--- a/docs/ops/rules-registry.md
+++ b/docs/ops/rules-registry.md
@@ -1,7 +1,7 @@
 # Screeps Minimal Rules Registry
 
-Last updated: 2026-05-01
-Tracking issue: https://github.com/lanyusea/screeps/issues/427
+Last updated: 2026-05-05
+Tracking issue: https://github.com/lanyusea/screeps/issues/620
 
 This registry is the canonical compact rules standard for the two-person Screeps project. It intentionally avoids multi-level governance. The goal is to keep autonomous agents from doing the wrong thing while keeping the system small enough to maintain.
 
@@ -114,7 +114,7 @@ When the official target room (E26S49 on shardX) enters a dead-end state — def
 
 This authorization is automatic — no owner approval required. The agent MUST act immediately when the dead-end condition is detected, not wait for owner authorization. After recovery, post a concise summary to #decisions and update the P0 incident issue.
 
-The dead-end condition is checked by the runtime alert cron job (`1c093252ab70`). When detected with `room_dead` category and `owned_spawns=0 AND owned_creeps=0`, the alert handler must trigger the recovery sequence above, not just report.
+The dead-end condition is checked by the runtime alert cron job (`1df5ef0c3835`, `Screeps runtime room alert text check`). When detected with `room_dead` category and `owned_spawns=0 AND owned_creeps=0`, the alert handler must trigger the recovery sequence above, not just report.
 
 Owner @ notification is still required for: rollback decisions when multiple healthy commits exist, manual respawn when automated recovery fails, and non-recovery strategic decisions.
 


### PR DESCRIPTION
## Summary
- Syncs the cron/route registry to the current live Screeps cron schedule and runtime-alert job ID.
- Updates the minimal rules registry to point dead-end recovery at the live alert job `1df5ef0c3835`.
- Documents repeat-horizon and stable-cwd safeguards after the 2026-05-05 deleted-worktree cwd incident.

## Linked issue
Fixes #620

## Roadmap category
- Priority: P1
- Domain: Agent OS
- Kind: ops
- Milestone: P0: Agent OS / Discord visibility gate

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/audit-rules-consistency.py`
- `python3 scripts/audit-rules-consistency.py` → PASS with one pre-existing warning about legacy `Private smoke` alias wording.

## Safety
- Documentation/registry-only change; no production bot code or secrets changed.
- Live cron updates were applied separately through the scheduler API and verified with `cronjob list`.
