### PR TITLE
feat(economy): improve worker energy acquisition to leverage roads and adjacent claimed rooms (#623)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10593,7 +10593,7 @@ function selectSpawnRecoveryHarvestCandidate(creep, energySink) {
     sources,
     getSpawnRecoveryHarvestEnergyTarget(creep, energySink)
   );
-  const assignmentLoads = getWorkerHarvestLoads(creep, viableSources);
+  const assignmentLoads = getWorkerHarvestLoads(viableSources);
   const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
   const candidates = assignableSources.map(
     (source) => createSpawnRecoveryHarvestCandidate(
@@ -11690,7 +11690,7 @@ function selectBestHarvestSource(creep, sources) {
     return null;
   }
   const viableSources = selectViableHarvestSources(sources, getHarvestEnergyTarget(creep));
-  const assignmentLoads = getWorkerHarvestLoads(creep, viableSources);
+  const assignmentLoads = getWorkerHarvestLoads(viableSources);
   const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
   if (assignableSources.length === 0) {
     return null;
@@ -11855,6 +11855,9 @@ function estimateRoadAwareTravelCostBetweenRoomObjects(origin, target, targetRan
     if (pathCost !== null) {
       return pathCost;
     }
+    if (isPathFinderAvailable2()) {
+      return null;
+    }
   }
   const range = getRangeBetweenRoomObjects2(origin, target);
   if (range !== null) {
@@ -11908,12 +11911,14 @@ function createRoadAwareRoomCallback(allowedRoomNames) {
     }
     const matrix = new PathFinder.CostMatrix();
     for (const structure of room.find(FIND_STRUCTURES)) {
-      if (!isRoadStructure2(structure)) {
+      const position = getRoomObjectPosition3(structure);
+      if (!position) {
         continue;
       }
-      const position = getRoomObjectPosition3(structure);
-      if (position) {
+      if (isRoadStructure2(structure)) {
         matrix.set(position.x, position.y, ROAD_TRAVEL_COST);
+      } else if (isBlockingRoadAwareStructure(structure)) {
+        matrix.set(position.x, position.y, 255);
       }
     }
     matricesByRoomName.set(roomName, matrix);
@@ -11922,6 +11927,15 @@ function createRoadAwareRoomCallback(allowedRoomNames) {
 }
 function isRoadStructure2(structure) {
   return matchesStructureType8(structure.structureType, "STRUCTURE_ROAD", "road");
+}
+function isBlockingRoadAwareStructure(structure) {
+  return !isRoadStructure2(structure) && !isContainerStructure2(structure) && !isWalkableRampartStructure(structure);
+}
+function isContainerStructure2(structure) {
+  return matchesStructureType8(structure.structureType, "STRUCTURE_CONTAINER", "container");
+}
+function isWalkableRampartStructure(structure) {
+  return matchesStructureType8(structure.structureType, "STRUCTURE_RAMPART", "rampart") && (structure.my === true || structure.isPublic === true);
 }
 function selectViableHarvestSources(sources, harvestEnergyTarget) {
   const sourcesWithEnergy = sources.filter(hasHarvestableEnergy);
@@ -11947,40 +11961,27 @@ function getHarvestSourceAvailableEnergy(source) {
 function getHarvestEnergyTarget(creep) {
   return Math.max(1, getFreeEnergyCapacity3(creep));
 }
-function getWorkerHarvestLoads(creep, sources) {
-  var _a, _b, _c, _d, _e;
+function getWorkerHarvestLoads(sources) {
+  var _a, _b, _c;
   const assignmentLoads = /* @__PURE__ */ new Map();
   for (const source of sources) {
     assignmentLoads.set(source.id, createEmptyHarvestSourceAssignmentLoad());
   }
-  const roomName = (_a = creep.room) == null ? void 0 : _a.name;
-  if (!roomName) {
-    return assignmentLoads;
-  }
   const sourceIds = new Set(sources.map((source) => source.id));
-  const sourceRoomNamesById = new Map(
-    sources.map((source) => {
-      var _a2;
-      return [String(source.id), (_a2 = getPositionRoomName(source)) != null ? _a2 : roomName];
-    })
-  );
   for (const assignedCreep of getGameCreeps()) {
-    const task = (_b = assignedCreep.memory) == null ? void 0 : _b.task;
+    const task = (_a = assignedCreep.memory) == null ? void 0 : _a.task;
     const targetId = typeof (task == null ? void 0 : task.targetId) === "string" ? task.targetId : void 0;
-    if (((_c = assignedCreep.memory) == null ? void 0 : _c.role) !== "worker" || (task == null ? void 0 : task.type) !== "harvest" || !targetId || !sourceIds.has(targetId) || !isRelevantHarvestAssignmentRoom((_d = assignedCreep.room) == null ? void 0 : _d.name, roomName, sourceRoomNamesById.get(targetId))) {
+    if (((_b = assignedCreep.memory) == null ? void 0 : _b.role) !== "worker" || (task == null ? void 0 : task.type) !== "harvest" || !targetId || !sourceIds.has(targetId)) {
       continue;
     }
     const sourceId = targetId;
-    const currentLoad = (_e = assignmentLoads.get(sourceId)) != null ? _e : createEmptyHarvestSourceAssignmentLoad();
+    const currentLoad = (_c = assignmentLoads.get(sourceId)) != null ? _c : createEmptyHarvestSourceAssignmentLoad();
     assignmentLoads.set(sourceId, {
       assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts(assignedCreep),
       assignmentCount: currentLoad.assignmentCount + 1
     });
   }
   return assignmentLoads;
-}
-function isRelevantHarvestAssignmentRoom(assignedRoomName, workerRoomName, sourceRoomName) {
-  return assignedRoomName === workerRoomName || sourceRoomName !== void 0 && assignedRoomName === sourceRoomName;
 }
 function getGameCreeps() {
   var _a;
@@ -12813,7 +12814,7 @@ function matchesCapacityConstructionStructureType(actual, globalName, fallback) 
 function shouldReplaceTarget(creep, task, target) {
   var _a;
   if (task.type === "harvest" && isDepletedHarvestSource(target)) {
-    return !findSourceContainer(creep.room, target);
+    return !findVisibleHarvestSourceContainer(creep, target);
   }
   if (task.type === "transfer" && "store" in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
     return true;
@@ -12840,7 +12841,7 @@ function executeTask(creep, task, target) {
       return toTaskExecutionResult(creep.withdraw(target, RESOURCE_ENERGY), "work");
     case "transfer":
       return toTaskExecutionResult(creep.transfer(target, RESOURCE_ENERGY), "work", {
-        containerTransfer: isContainerStructure2(target)
+        containerTransfer: isContainerStructure3(target)
       });
     case "build":
       if (!checkEnergyBufferForSpending(creep.room, getCarriedEnergy(creep))) {
@@ -12918,7 +12919,7 @@ function recordTaskBehavior(creep, task, execution) {
     recordCreepBehaviorContainerTransfer(creep);
   }
 }
-function isContainerStructure2(target) {
+function isContainerStructure3(target) {
   const structureType = target == null ? void 0 : target.structureType;
   return typeof structureType === "string" && matchesContainerStructureType(structureType);
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10585,7 +10585,7 @@ function selectSpawnRecoveryEnergyAcquisitionTask(creep, energySink, harvestEta 
   return candidates.sort(compareSpawnRecoveryEnergyAcquisitionCandidates)[0].task;
 }
 function selectSpawnRecoveryHarvestCandidate(creep, energySink) {
-  const sources = findVisibleHarvestSources(creep);
+  const sources = findVisibleHarvestSourcesInRooms([creep.room]);
   if (sources.length === 0) {
     return null;
   }
@@ -11691,7 +11691,10 @@ function selectBestHarvestSource(creep, sources) {
   }
   const viableSources = selectViableHarvestSources(sources, getHarvestEnergyTarget(creep));
   const assignmentLoads = getWorkerHarvestLoads(viableSources);
-  const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
+  const assignableSources = selectReachableHarvestSources(
+    creep,
+    selectAssignableHarvestSources(creep, viableSources, assignmentLoads)
+  );
   if (assignableSources.length === 0) {
     return null;
   }
@@ -11710,6 +11713,12 @@ function selectAssignableHarvestSources(creep, sources, assignmentLoads) {
   return sources.filter(
     (source) => isAssignableHarvestSource(creep, source, getHarvestSourceAssignmentLoad(assignmentLoads, source))
   );
+}
+function selectReachableHarvestSources(creep, sources) {
+  if (!isPathFinderAvailable2()) {
+    return sources;
+  }
+  return sources.filter((source) => getHarvestSourceTravelCost(creep, source) !== null);
 }
 function isAssignableHarvestSource(creep, source, assignmentLoad) {
   if (!findVisibleSourceContainer(creep, source)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8966,6 +8966,12 @@ var MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS = 2;
 var MAX_SURPLUS_CONTROLLER_PROGRESS_WORKERS = 3;
 var BASELINE_WORKER_THROUGHPUT_ENERGY_CAPACITY = 550;
 var BUILDER_STORAGE_ACQUISITION_SITE_RANGE = BUILDER_DROPPED_PICKUP_RANGE;
+var ROAD_TRAVEL_COST = 1;
+var PLAIN_TRAVEL_COST = 2;
+var SWAMP_TRAVEL_COST = 10;
+var HARVEST_SOURCE_RANGE = 1;
+var HARVEST_SOURCE_CONTAINER_RANGE = 0;
+var MAX_HARVEST_PATH_OPS = 2e3;
 var nearTermSpawnExtensionRefillReserveCache = null;
 function selectWorkerTask(creep) {
   clearWorkerEfficiencyTelemetry(creep);
@@ -10579,7 +10585,7 @@ function selectSpawnRecoveryEnergyAcquisitionTask(creep, energySink, harvestEta 
   return candidates.sort(compareSpawnRecoveryEnergyAcquisitionCandidates)[0].task;
 }
 function selectSpawnRecoveryHarvestCandidate(creep, energySink) {
-  const sources = creep.room.find(FIND_SOURCES);
+  const sources = findVisibleHarvestSources(creep);
   if (sources.length === 0) {
     return null;
   }
@@ -10587,7 +10593,7 @@ function selectSpawnRecoveryHarvestCandidate(creep, energySink) {
     sources,
     getSpawnRecoveryHarvestEnergyTarget(creep, energySink)
   );
-  const assignmentLoads = getSameRoomWorkerHarvestLoads(creep.room.name, viableSources);
+  const assignmentLoads = getWorkerHarvestLoads(creep, viableSources);
   const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
   const candidates = assignableSources.map(
     (source) => createSpawnRecoveryHarvestCandidate(
@@ -10790,8 +10796,8 @@ function estimateHarvestDeliveryEtaFromSource(creep, source, energySink) {
   if (sourceAvailabilityDelay === null) {
     return null;
   }
-  const creepToSourceRange = getRangeBetweenRoomObjects2(creep, source);
-  const sourceToSinkRange = getRangeBetweenRoomObjects2(source, energySink);
+  const creepToSourceRange = getHarvestSourceTravelCost(creep, source);
+  const sourceToSinkRange = getHarvestSourceDeliveryTravelCost(creep, source, energySink);
   if (creepToSourceRange === null || sourceToSinkRange === null) {
     return null;
   }
@@ -11574,17 +11580,21 @@ function findClosestByRange(creep, objects) {
   return typeof (position == null ? void 0 : position.findClosestByRange) === "function" ? position.findClosestByRange(objects) : null;
 }
 function selectSourceContainerHarvestTask(creep) {
-  if (getActiveWorkParts(creep) <= 0 || typeof FIND_SOURCES !== "number" || !hasVisiblePositionedContainer(creep.room)) {
+  if (getActiveWorkParts(creep) <= 0 || typeof FIND_SOURCES !== "number") {
+    return null;
+  }
+  const harvestRooms = findVisibleHarvestRooms(creep);
+  if (!harvestRooms.some(hasVisiblePositionedContainer)) {
     return null;
   }
   const source = selectBestHarvestSource(
     creep,
-    creep.room.find(FIND_SOURCES).filter((candidate) => hasNonEmptySourceContainer(creep.room, candidate))
+    findVisibleHarvestSourcesInRooms(harvestRooms).filter((candidate) => hasNonEmptyVisibleSourceContainer(creep, candidate))
   );
   return source ? { type: "harvest", targetId: source.id } : null;
 }
-function hasNonEmptySourceContainer(room, source) {
-  const sourceContainer = findSourceContainer(room, source);
+function hasNonEmptyVisibleSourceContainer(creep, source) {
+  const sourceContainer = findVisibleSourceContainer(creep, source);
   return sourceContainer !== null && getStoredEnergy4(sourceContainer) > 0;
 }
 function hasVisiblePositionedContainer(room) {
@@ -11596,8 +11606,80 @@ function hasVisiblePositionedContainer(room) {
     return position !== null && matchesStructureType8(structure.structureType, "STRUCTURE_CONTAINER", "container");
   });
 }
+function findVisibleHarvestSources(creep) {
+  return findVisibleHarvestSourcesInRooms(findVisibleHarvestRooms(creep));
+}
+function findVisibleHarvestSourcesInRooms(rooms) {
+  if (typeof FIND_SOURCES !== "number") {
+    return [];
+  }
+  const sourcesById = /* @__PURE__ */ new Map();
+  for (const room of rooms) {
+    if (typeof room.find !== "function") {
+      continue;
+    }
+    for (const source of room.find(FIND_SOURCES)) {
+      sourcesById.set(String(source.id), source);
+    }
+  }
+  return [...sourcesById.values()];
+}
+function findVisibleHarvestRooms(creep) {
+  const rooms = [];
+  if (creep.room) {
+    rooms.push(creep.room);
+  }
+  for (const room of findVisibleAdjacentClaimedRooms(creep.room)) {
+    if (rooms.some((candidate) => candidate.name === room.name)) {
+      continue;
+    }
+    rooms.push(room);
+  }
+  return rooms;
+}
+function findVisibleAdjacentClaimedRooms(room) {
+  const roomName = room == null ? void 0 : room.name;
+  if (!roomName) {
+    return [];
+  }
+  const game = globalThis.Game;
+  const visibleRooms = game == null ? void 0 : game.rooms;
+  const adjacentRoomNames = getAdjacentRoomNames3(roomName, game == null ? void 0 : game.map);
+  if (!visibleRooms || adjacentRoomNames.length === 0) {
+    return [];
+  }
+  return adjacentRoomNames.map((adjacentRoomName) => visibleRooms[adjacentRoomName]).filter((candidate) => {
+    var _a;
+    return ((_a = candidate == null ? void 0 : candidate.controller) == null ? void 0 : _a.my) === true;
+  }).sort((left, right) => left.name.localeCompare(right.name));
+}
+function getAdjacentRoomNames3(roomName, gameMap) {
+  if (typeof (gameMap == null ? void 0 : gameMap.describeExits) !== "function") {
+    return [];
+  }
+  const exits = gameMap.describeExits(roomName);
+  if (!exits || typeof exits !== "object") {
+    return [];
+  }
+  return Object.values(exits).filter((adjacentRoomName) => typeof adjacentRoomName === "string" && adjacentRoomName.length > 0).sort((left, right) => left.localeCompare(right));
+}
+function findVisibleSourceContainer(creep, source) {
+  const sourceRoom = findVisibleSourceRoom(creep, source);
+  return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
+}
+function findVisibleSourceRoom(creep, source) {
+  var _a, _b, _c, _d, _e, _f;
+  const sourceRoomName = (_b = getPositionRoomName(source)) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name;
+  if (!sourceRoomName) {
+    return null;
+  }
+  if (((_c = creep.room) == null ? void 0 : _c.name) === sourceRoomName) {
+    return creep.room;
+  }
+  return (_f = (_e = (_d = globalThis.Game) == null ? void 0 : _d.rooms) == null ? void 0 : _e[sourceRoomName]) != null ? _f : null;
+}
 function selectHarvestSource(creep) {
-  const sources = creep.room.find(FIND_SOURCES);
+  const sources = findVisibleHarvestSources(creep);
   if (sources.length === 0) {
     return null;
   }
@@ -11608,7 +11690,7 @@ function selectBestHarvestSource(creep, sources) {
     return null;
   }
   const viableSources = selectViableHarvestSources(sources, getHarvestEnergyTarget(creep));
-  const assignmentLoads = getSameRoomWorkerHarvestLoads(creep.room.name, viableSources);
+  const assignmentLoads = getWorkerHarvestLoads(creep, viableSources);
   const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
   if (assignableSources.length === 0) {
     return null;
@@ -11630,7 +11712,7 @@ function selectAssignableHarvestSources(creep, sources, assignmentLoads) {
   );
 }
 function isAssignableHarvestSource(creep, source, assignmentLoad) {
-  if (!findSourceContainer(creep.room, source)) {
+  if (!findVisibleSourceContainer(creep, source)) {
     return true;
   }
   if (isWorkerAssignedToHarvestSource(creep, source)) {
@@ -11750,9 +11832,96 @@ function getTerrainWallMask5() {
   return typeof terrainWallMask === "number" ? terrainWallMask : 1;
 }
 function isCloserHarvestSource(creep, candidate, selected) {
-  const candidateRange = getRangeBetweenRoomObjects2(creep, candidate);
-  const selectedRange = getRangeBetweenRoomObjects2(creep, selected);
+  const candidateRange = getHarvestSourceTravelCost(creep, candidate);
+  const selectedRange = getHarvestSourceTravelCost(creep, selected);
   return candidateRange !== null && selectedRange !== null && candidateRange < selectedRange;
+}
+function getHarvestSourceTravelCost(creep, source) {
+  var _a;
+  const target = (_a = findVisibleSourceContainer(creep, source)) != null ? _a : source;
+  const targetRange = target === source ? HARVEST_SOURCE_RANGE : HARVEST_SOURCE_CONTAINER_RANGE;
+  return estimateRoadAwareTravelCostBetweenRoomObjects(creep, target, targetRange);
+}
+function getHarvestSourceDeliveryTravelCost(creep, source, energySink) {
+  var _a;
+  const harvestOrigin = (_a = findVisibleSourceContainer(creep, source)) != null ? _a : source;
+  return estimateRoadAwareTravelCostBetweenRoomObjects(harvestOrigin, energySink, HARVEST_SOURCE_RANGE);
+}
+function estimateRoadAwareTravelCostBetweenRoomObjects(origin, target, targetRange) {
+  const originPosition = getRoomObjectPosition3(origin);
+  const targetPosition = getRoomObjectPosition3(target);
+  if (originPosition && targetPosition) {
+    const pathCost = findRoadAwarePathCost(originPosition, targetPosition, targetRange);
+    if (pathCost !== null) {
+      return pathCost;
+    }
+  }
+  const range = getRangeBetweenRoomObjects2(origin, target);
+  if (range !== null) {
+    return Math.max(0, range - Math.max(0, targetRange - 1));
+  }
+  if (originPosition && targetPosition && isSameRoomPosition5(originPosition, targetPosition)) {
+    return Math.max(
+      0,
+      Math.max(Math.abs(originPosition.x - targetPosition.x), Math.abs(originPosition.y - targetPosition.y)) - Math.max(0, targetRange - 1)
+    );
+  }
+  return null;
+}
+function findRoadAwarePathCost(origin, target, targetRange) {
+  if (!isPathFinderAvailable2()) {
+    return null;
+  }
+  const result = PathFinder.search(origin, { pos: target, range: Math.max(0, targetRange) }, {
+    maxOps: MAX_HARVEST_PATH_OPS,
+    maxRooms: origin.roomName === target.roomName ? 1 : 2,
+    plainCost: PLAIN_TRAVEL_COST,
+    roomCallback: createRoadAwareRoomCallback(/* @__PURE__ */ new Set([origin.roomName, target.roomName])),
+    swampCost: SWAMP_TRAVEL_COST
+  });
+  if (result.incomplete) {
+    return null;
+  }
+  if (typeof result.cost === "number" && Number.isFinite(result.cost)) {
+    return Math.max(0, result.cost);
+  }
+  return Array.isArray(result.path) ? result.path.length : null;
+}
+function isPathFinderAvailable2() {
+  return typeof PathFinder !== "undefined" && typeof PathFinder.search === "function" && typeof PathFinder.CostMatrix === "function";
+}
+function createRoadAwareRoomCallback(allowedRoomNames) {
+  const matricesByRoomName = /* @__PURE__ */ new Map();
+  return (roomName) => {
+    var _a, _b;
+    if (!allowedRoomNames.has(roomName)) {
+      return false;
+    }
+    const cachedMatrix = matricesByRoomName.get(roomName);
+    if (cachedMatrix !== void 0) {
+      return cachedMatrix;
+    }
+    const room = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+    if (!room || typeof FIND_STRUCTURES !== "number" || typeof room.find !== "function") {
+      matricesByRoomName.set(roomName, false);
+      return false;
+    }
+    const matrix = new PathFinder.CostMatrix();
+    for (const structure of room.find(FIND_STRUCTURES)) {
+      if (!isRoadStructure2(structure)) {
+        continue;
+      }
+      const position = getRoomObjectPosition3(structure);
+      if (position) {
+        matrix.set(position.x, position.y, ROAD_TRAVEL_COST);
+      }
+    }
+    matricesByRoomName.set(roomName, matrix);
+    return matrix;
+  };
+}
+function isRoadStructure2(structure) {
+  return matchesStructureType8(structure.structureType, "STRUCTURE_ROAD", "road");
 }
 function selectViableHarvestSources(sources, harvestEnergyTarget) {
   const sourcesWithEnergy = sources.filter(hasHarvestableEnergy);
@@ -11778,30 +11947,40 @@ function getHarvestSourceAvailableEnergy(source) {
 function getHarvestEnergyTarget(creep) {
   return Math.max(1, getFreeEnergyCapacity3(creep));
 }
-function getSameRoomWorkerHarvestLoads(roomName, sources) {
-  var _a, _b, _c, _d;
+function getWorkerHarvestLoads(creep, sources) {
+  var _a, _b, _c, _d, _e;
   const assignmentLoads = /* @__PURE__ */ new Map();
   for (const source of sources) {
     assignmentLoads.set(source.id, createEmptyHarvestSourceAssignmentLoad());
   }
+  const roomName = (_a = creep.room) == null ? void 0 : _a.name;
   if (!roomName) {
     return assignmentLoads;
   }
   const sourceIds = new Set(sources.map((source) => source.id));
+  const sourceRoomNamesById = new Map(
+    sources.map((source) => {
+      var _a2;
+      return [String(source.id), (_a2 = getPositionRoomName(source)) != null ? _a2 : roomName];
+    })
+  );
   for (const assignedCreep of getGameCreeps()) {
-    const task = (_a = assignedCreep.memory) == null ? void 0 : _a.task;
+    const task = (_b = assignedCreep.memory) == null ? void 0 : _b.task;
     const targetId = typeof (task == null ? void 0 : task.targetId) === "string" ? task.targetId : void 0;
-    if (((_b = assignedCreep.memory) == null ? void 0 : _b.role) !== "worker" || ((_c = assignedCreep.room) == null ? void 0 : _c.name) !== roomName || (task == null ? void 0 : task.type) !== "harvest" || !targetId || !sourceIds.has(targetId)) {
+    if (((_c = assignedCreep.memory) == null ? void 0 : _c.role) !== "worker" || (task == null ? void 0 : task.type) !== "harvest" || !targetId || !sourceIds.has(targetId) || !isRelevantHarvestAssignmentRoom((_d = assignedCreep.room) == null ? void 0 : _d.name, roomName, sourceRoomNamesById.get(targetId))) {
       continue;
     }
     const sourceId = targetId;
-    const currentLoad = (_d = assignmentLoads.get(sourceId)) != null ? _d : createEmptyHarvestSourceAssignmentLoad();
+    const currentLoad = (_e = assignmentLoads.get(sourceId)) != null ? _e : createEmptyHarvestSourceAssignmentLoad();
     assignmentLoads.set(sourceId, {
       assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts(assignedCreep),
       assignmentCount: currentLoad.assignmentCount + 1
     });
   }
   return assignmentLoads;
+}
+function isRelevantHarvestAssignmentRoom(assignedRoomName, workerRoomName, sourceRoomName) {
+  return assignedRoomName === workerRoomName || sourceRoomName !== void 0 && assignedRoomName === sourceRoomName;
 }
 function getGameCreeps() {
   var _a;
@@ -12686,7 +12865,7 @@ function executeTask(creep, task, target) {
   }
 }
 function executeHarvestTask(creep, source) {
-  const sourceContainer = findSourceContainer(creep.room, source);
+  const sourceContainer = findVisibleHarvestSourceContainer(creep, source);
   if (!sourceContainer) {
     return toTaskExecutionResult(creep.harvest(source), "work");
   }
@@ -12753,7 +12932,7 @@ function isDedicatedSourceContainerHarvestTask(creep, task) {
 }
 function findHarvestTaskSourceContainer(creep, task) {
   const source = findHarvestTaskSource(creep, task);
-  return source === null ? null : findSourceContainer(creep.room, source);
+  return source === null ? null : findVisibleHarvestSourceContainer(creep, source);
 }
 function findHarvestTaskSource(creep, task) {
   var _a;
@@ -12765,6 +12944,26 @@ function findHarvestTaskSource(creep, task) {
   }
   const target = getTaskTarget(task);
   return target && String(target.id) === String(task.targetId) ? target : null;
+}
+function findVisibleHarvestSourceContainer(creep, source) {
+  const sourceRoom = findVisibleSourceRoom2(creep, source);
+  return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
+}
+function findVisibleSourceRoom2(creep, source) {
+  var _a, _b, _c, _d, _e, _f;
+  const sourceRoomName = (_b = getSourceRoomName(source)) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name;
+  if (!sourceRoomName) {
+    return null;
+  }
+  if (((_c = creep.room) == null ? void 0 : _c.name) === sourceRoomName) {
+    return creep.room;
+  }
+  return (_f = (_e = (_d = globalThis.Game) == null ? void 0 : _d.rooms) == null ? void 0 : _e[sourceRoomName]) != null ? _f : null;
+}
+function getSourceRoomName(source) {
+  var _a;
+  const roomName = (_a = source.pos) == null ? void 0 : _a.roomName;
+  return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
 }
 function isInRangeToRoomObject(creep, target, range) {
   const position = creep.pos;
@@ -15566,7 +15765,7 @@ function countVisibleOwnedRooms(colonyName, ownerUsername) {
 function getAdjacentRoomNamesByOwnedRoom(ownedRoomNames) {
   const adjacentRoomNames = /* @__PURE__ */ new Map();
   for (const roomName of ownedRoomNames) {
-    adjacentRoomNames.set(roomName, new Set(getAdjacentRoomNames3(roomName)));
+    adjacentRoomNames.set(roomName, new Set(getAdjacentRoomNames4(roomName)));
   }
   return adjacentRoomNames;
 }
@@ -15629,7 +15828,7 @@ function isNearbyExpansionCandidate(routeDistance, nearestOwnedDistance, adjacen
   }
   return adjacentToOwnedRoom || typeof routeDistance === "number" && routeDistance <= MAX_NEARBY_EXPANSION_ROUTE_DISTANCE || typeof nearestOwnedDistance.distance === "number" && nearestOwnedDistance.distance <= MAX_NEARBY_EXPANSION_ROUTE_DISTANCE;
 }
-function getAdjacentRoomNames3(roomName) {
+function getAdjacentRoomNames4(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
@@ -18385,7 +18584,7 @@ function getCachedAdjacentRoomNames(roomName, context) {
   if (cachedAdjacentRoomNames) {
     return cachedAdjacentRoomNames;
   }
-  const adjacentRoomNames = new Set(getAdjacentRoomNames4(roomName, context.gameMap));
+  const adjacentRoomNames = new Set(getAdjacentRoomNames5(roomName, context.gameMap));
   context.adjacentRoomNamesByOwnedRoom.set(roomName, adjacentRoomNames);
   return adjacentRoomNames;
 }
@@ -18401,7 +18600,7 @@ function getOwnedAdjacency(roomName, adjacentRoomNamesByOwnedRoom) {
   }
   return { adjacentToOwnedRoom: false };
 }
-function getAdjacentRoomNames4(roomName, gameMap = ((_a) => (_a = globalThis.Game) == null ? void 0 : _a.map)()) {
+function getAdjacentRoomNames5(roomName, gameMap = ((_a) => (_a = globalThis.Game) == null ? void 0 : _a.map)()) {
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
@@ -18740,7 +18939,7 @@ function scoreClaimTarget(roomName, homeRoom) {
 }
 function selectBestClaimTarget(homeRoom) {
   var _a, _b;
-  const adjacentRooms = getAdjacentRoomNames5(homeRoom.name);
+  const adjacentRooms = getAdjacentRoomNames6(homeRoom.name);
   const candidates = adjacentRooms.map((roomName) => scoreClaimTarget(roomName, homeRoom)).filter((candidate) => candidate.sources > 0 && candidate.score > 0 && !hasUnclaimableController(candidate));
   candidates.sort(compareClaimScores);
   return (_b = (_a = candidates[0]) == null ? void 0 : _a.roomName) != null ? _b : null;
@@ -18869,7 +19068,7 @@ function getRoomDistance(homeRoomName, roomName) {
   }
   return NO_ROUTE_DISTANCE;
 }
-function getAdjacentRoomNames5(roomName) {
+function getAdjacentRoomNames6(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
@@ -18953,7 +19152,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
   }
   const renewalThresholdTicks = getAdjacentRoomReservationRenewalThreshold(claimPartCount);
   const ownerUsername = getControllerOwnerUsername8(colony.room.controller);
-  const candidates = getAdjacentRoomNames6(colonyName).flatMap(
+  const candidates = getAdjacentRoomNames7(colonyName).flatMap(
     (roomName, order) => buildReservationCandidate(colony.room, roomName, order, ownerUsername, renewalThresholdTicks)
   );
   const actionableCandidate = selectBestReservationCandidate(
@@ -19241,7 +19440,7 @@ function isAdjacentRoomReservationTarget(target, colony) {
 function isSameTarget3(left, right) {
   return isRecord17(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
-function getAdjacentRoomNames6(roomName) {
+function getAdjacentRoomNames7(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
@@ -19400,7 +19599,7 @@ function clearColonyExpansionClaimIntent(colony) {
 }
 function selectColonyExpansionCandidate(colony) {
   const ownerUsername = getControllerOwnerUsername9(colony.room.controller);
-  const candidates = getAdjacentRoomNames7(colony.room.name).flatMap((roomName, order) => {
+  const candidates = getAdjacentRoomNames8(colony.room.name).flatMap((roomName, order) => {
     const claimScore = scoreClaimTarget(roomName, colony.room);
     if (claimScore.sources <= 0 || hasHostileClaimScore(claimScore)) {
       return [];
@@ -19573,7 +19772,7 @@ function upsertTerritoryIntent5(intents, nextIntent) {
 function isSameTarget4(left, right) {
   return isRecord18(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
-function getAdjacentRoomNames7(roomName) {
+function getAdjacentRoomNames8(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -989,7 +989,7 @@ function shouldReplaceTarget(
   target: Source | Resource<ResourceConstant> | AnyStoreStructure | ConstructionSite | StructureController | Structure
 ): boolean {
   if (task.type === 'harvest' && isDepletedHarvestSource(target)) {
-    return !findSourceContainer(creep.room, target);
+    return !findVisibleHarvestSourceContainer(creep, target);
   }
 
   if (task.type === 'transfer' && 'store' in target && target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1061,7 +1061,7 @@ function executeTask(
 }
 
 function executeHarvestTask(creep: Creep, source: Source): TaskExecutionResult {
-  const sourceContainer = findSourceContainer(creep.room, source);
+  const sourceContainer = findVisibleHarvestSourceContainer(creep, source);
   if (!sourceContainer) {
     return toTaskExecutionResult(creep.harvest(source), 'work');
   }
@@ -1162,7 +1162,7 @@ function findHarvestTaskSourceContainer(
   task: Extract<CreepTaskMemory, { type: 'harvest' }>
 ): StructureContainer | null {
   const source = findHarvestTaskSource(creep, task);
-  return source === null ? null : findSourceContainer(creep.room, source);
+  return source === null ? null : findVisibleHarvestSourceContainer(creep, source);
 }
 
 function findHarvestTaskSource(
@@ -1180,6 +1180,29 @@ function findHarvestTaskSource(
 
   const target = getTaskTarget(task) as Source | null;
   return target && String((target as { id?: unknown }).id) === String(task.targetId) ? target : null;
+}
+
+function findVisibleHarvestSourceContainer(creep: Creep, source: Source): StructureContainer | null {
+  const sourceRoom = findVisibleSourceRoom(creep, source);
+  return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
+}
+
+function findVisibleSourceRoom(creep: Creep, source: Source): Room | null {
+  const sourceRoomName = getSourceRoomName(source) ?? creep.room?.name;
+  if (!sourceRoomName) {
+    return null;
+  }
+
+  if (creep.room?.name === sourceRoomName) {
+    return creep.room;
+  }
+
+  return (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[sourceRoomName] ?? null;
+}
+
+function getSourceRoomName(source: Source): string | null {
+  const roomName = (source as Source & { pos?: { roomName?: unknown } }).pos?.roomName;
+  return typeof roomName === 'string' && roomName.length > 0 ? roomName : null;
 }
 
 function isInRangeToRoomObject(creep: Creep, target: RoomObject, range: number): boolean {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2656,7 +2656,7 @@ function selectSpawnRecoveryHarvestCandidate(
   creep: Creep,
   energySink: FillableEnergySink
 ): SpawnRecoveryHarvestCandidate | null {
-  const sources = findVisibleHarvestSources(creep);
+  const sources = findVisibleHarvestSourcesInRooms([creep.room]);
   if (sources.length === 0) {
     return null;
   }
@@ -4323,7 +4323,10 @@ function selectBestHarvestSource(creep: Creep, sources: Source[]): Source | null
 
   const viableSources = selectViableHarvestSources(sources, getHarvestEnergyTarget(creep));
   const assignmentLoads = getWorkerHarvestLoads(viableSources);
-  const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
+  const assignableSources = selectReachableHarvestSources(
+    creep,
+    selectAssignableHarvestSources(creep, viableSources, assignmentLoads)
+  );
   if (assignableSources.length === 0) {
     return null;
   }
@@ -4350,6 +4353,14 @@ function selectAssignableHarvestSources(
   return sources.filter((source) =>
     isAssignableHarvestSource(creep, source, getHarvestSourceAssignmentLoad(assignmentLoads, source))
   );
+}
+
+function selectReachableHarvestSources(creep: Creep, sources: Source[]): Source[] {
+  if (!isPathFinderAvailable()) {
+    return sources;
+  }
+
+  return sources.filter((source) => getHarvestSourceTravelCost(creep, source) !== null);
 }
 
 function isAssignableHarvestSource(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -2665,7 +2665,7 @@ function selectSpawnRecoveryHarvestCandidate(
     sources,
     getSpawnRecoveryHarvestEnergyTarget(creep, energySink)
   );
-  const assignmentLoads = getWorkerHarvestLoads(creep, viableSources);
+  const assignmentLoads = getWorkerHarvestLoads(viableSources);
   const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
   const candidates = assignableSources
     .map((source) =>
@@ -4322,7 +4322,7 @@ function selectBestHarvestSource(creep: Creep, sources: Source[]): Source | null
   }
 
   const viableSources = selectViableHarvestSources(sources, getHarvestEnergyTarget(creep));
-  const assignmentLoads = getWorkerHarvestLoads(creep, viableSources);
+  const assignmentLoads = getWorkerHarvestLoads(viableSources);
   const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
   if (assignableSources.length === 0) {
     return null;
@@ -4549,6 +4549,10 @@ function estimateRoadAwareTravelCostBetweenRoomObjects(
     if (pathCost !== null) {
       return pathCost;
     }
+
+    if (isPathFinderAvailable()) {
+      return null;
+    }
   }
 
   const range = getRangeBetweenRoomObjects(origin, target);
@@ -4619,13 +4623,15 @@ function createRoadAwareRoomCallback(allowedRoomNames: Set<string>): (roomName: 
 
     const matrix = new PathFinder.CostMatrix();
     for (const structure of room.find(FIND_STRUCTURES) as Structure[]) {
-      if (!isRoadStructure(structure)) {
+      const position = getRoomObjectPosition(structure);
+      if (!position) {
         continue;
       }
 
-      const position = getRoomObjectPosition(structure);
-      if (position) {
+      if (isRoadStructure(structure)) {
         matrix.set(position.x, position.y, ROAD_TRAVEL_COST);
+      } else if (isBlockingRoadAwareStructure(structure)) {
+        matrix.set(position.x, position.y, 0xff);
       }
     }
 
@@ -4636,6 +4642,21 @@ function createRoadAwareRoomCallback(allowedRoomNames: Set<string>): (roomName: 
 
 function isRoadStructure(structure: Structure): structure is StructureRoad {
   return matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road');
+}
+
+function isBlockingRoadAwareStructure(structure: Structure): boolean {
+  return !isRoadStructure(structure) && !isContainerStructure(structure) && !isWalkableRampartStructure(structure);
+}
+
+function isContainerStructure(structure: Structure): structure is StructureContainer {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container');
+}
+
+function isWalkableRampartStructure(structure: Structure): boolean {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') &&
+    ((structure as Partial<StructureRampart>).my === true || (structure as Partial<StructureRampart>).isPublic === true)
+  );
 }
 
 function selectViableHarvestSources(sources: Source[], harvestEnergyTarget: number): Source[] {
@@ -4668,24 +4689,13 @@ function getHarvestEnergyTarget(creep: Creep): number {
   return Math.max(1, getFreeEnergyCapacity(creep));
 }
 
-function getWorkerHarvestLoads(
-  creep: Creep,
-  sources: Source[]
-): Map<Id<Source>, HarvestSourceAssignmentLoad> {
+function getWorkerHarvestLoads(sources: Source[]): Map<Id<Source>, HarvestSourceAssignmentLoad> {
   const assignmentLoads = new Map<Id<Source>, HarvestSourceAssignmentLoad>();
   for (const source of sources) {
     assignmentLoads.set(source.id, createEmptyHarvestSourceAssignmentLoad());
   }
 
-  const roomName = creep.room?.name;
-  if (!roomName) {
-    return assignmentLoads;
-  }
-
   const sourceIds = new Set(sources.map((source) => source.id as string));
-  const sourceRoomNamesById = new Map<string, string | undefined>(
-    sources.map((source) => [String(source.id), getPositionRoomName(source) ?? roomName])
-  );
   for (const assignedCreep of getGameCreeps()) {
     const task = assignedCreep.memory?.task as Partial<CreepTaskMemory> | undefined;
     const targetId = typeof task?.targetId === 'string' ? task.targetId : undefined;
@@ -4694,8 +4704,7 @@ function getWorkerHarvestLoads(
       assignedCreep.memory?.role !== 'worker' ||
       task?.type !== 'harvest' ||
       !targetId ||
-      !sourceIds.has(targetId) ||
-      !isRelevantHarvestAssignmentRoom(assignedCreep.room?.name, roomName, sourceRoomNamesById.get(targetId))
+      !sourceIds.has(targetId)
     ) {
       continue;
     }
@@ -4709,14 +4718,6 @@ function getWorkerHarvestLoads(
   }
 
   return assignmentLoads;
-}
-
-function isRelevantHarvestAssignmentRoom(
-  assignedRoomName: string | undefined,
-  workerRoomName: string,
-  sourceRoomName: string | undefined
-): boolean {
-  return assignedRoomName === workerRoomName || (sourceRoomName !== undefined && assignedRoomName === sourceRoomName);
 }
 
 function getGameCreeps(): Creep[] {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -76,6 +76,12 @@ const MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS = 2;
 const MAX_SURPLUS_CONTROLLER_PROGRESS_WORKERS = 3;
 const BASELINE_WORKER_THROUGHPUT_ENERGY_CAPACITY = 550;
 const BUILDER_STORAGE_ACQUISITION_SITE_RANGE = BUILDER_DROPPED_PICKUP_RANGE;
+const ROAD_TRAVEL_COST = 1;
+const PLAIN_TRAVEL_COST = 2;
+const SWAMP_TRAVEL_COST = 10;
+const HARVEST_SOURCE_RANGE = 1;
+const HARVEST_SOURCE_CONTAINER_RANGE = 0;
+const MAX_HARVEST_PATH_OPS = 2_000;
 
 type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
 type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
@@ -2650,7 +2656,7 @@ function selectSpawnRecoveryHarvestCandidate(
   creep: Creep,
   energySink: FillableEnergySink
 ): SpawnRecoveryHarvestCandidate | null {
-  const sources = creep.room.find(FIND_SOURCES);
+  const sources = findVisibleHarvestSources(creep);
   if (sources.length === 0) {
     return null;
   }
@@ -2659,7 +2665,7 @@ function selectSpawnRecoveryHarvestCandidate(
     sources,
     getSpawnRecoveryHarvestEnergyTarget(creep, energySink)
   );
-  const assignmentLoads = getSameRoomWorkerHarvestLoads(creep.room.name, viableSources);
+  const assignmentLoads = getWorkerHarvestLoads(creep, viableSources);
   const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
   const candidates = assignableSources
     .map((source) =>
@@ -2986,8 +2992,8 @@ function estimateHarvestDeliveryEtaFromSource(
     return null;
   }
 
-  const creepToSourceRange = getRangeBetweenRoomObjects(creep, source);
-  const sourceToSinkRange = getRangeBetweenRoomObjects(source, energySink);
+  const creepToSourceRange = getHarvestSourceTravelCost(creep, source);
+  const sourceToSinkRange = getHarvestSourceDeliveryTravelCost(creep, source, energySink);
   if (creepToSourceRange === null || sourceToSinkRange === null) {
     return null;
   }
@@ -4173,21 +4179,25 @@ function findClosestByRange<T extends RoomObject>(creep: Creep, objects: T[]): T
 function selectSourceContainerHarvestTask(creep: Creep): Extract<CreepTaskMemory, { type: 'harvest' }> | null {
   if (
     getActiveWorkParts(creep) <= 0 ||
-    typeof FIND_SOURCES !== 'number' ||
-    !hasVisiblePositionedContainer(creep.room)
+    typeof FIND_SOURCES !== 'number'
   ) {
+    return null;
+  }
+
+  const harvestRooms = findVisibleHarvestRooms(creep);
+  if (!harvestRooms.some(hasVisiblePositionedContainer)) {
     return null;
   }
 
   const source = selectBestHarvestSource(
     creep,
-    creep.room.find(FIND_SOURCES).filter((candidate) => hasNonEmptySourceContainer(creep.room, candidate))
+    findVisibleHarvestSourcesInRooms(harvestRooms).filter((candidate) => hasNonEmptyVisibleSourceContainer(creep, candidate))
   );
   return source ? { type: 'harvest', targetId: source.id } : null;
 }
 
-function hasNonEmptySourceContainer(room: Room, source: Source): boolean {
-  const sourceContainer = findSourceContainer(room, source);
+function hasNonEmptyVisibleSourceContainer(creep: Creep, source: Source): boolean {
+  const sourceContainer = findVisibleSourceContainer(creep, source);
   return sourceContainer !== null && getStoredEnergy(sourceContainer) > 0;
 }
 
@@ -4205,8 +4215,100 @@ function hasVisiblePositionedContainer(room: Room): boolean {
   });
 }
 
+function findVisibleHarvestSources(creep: Creep): Source[] {
+  return findVisibleHarvestSourcesInRooms(findVisibleHarvestRooms(creep));
+}
+
+function findVisibleHarvestSourcesInRooms(rooms: Room[]): Source[] {
+  if (typeof FIND_SOURCES !== 'number') {
+    return [];
+  }
+
+  const sourcesById = new Map<string, Source>();
+  for (const room of rooms) {
+    if (typeof room.find !== 'function') {
+      continue;
+    }
+
+    for (const source of room.find(FIND_SOURCES) as Source[]) {
+      sourcesById.set(String(source.id), source);
+    }
+  }
+
+  return [...sourcesById.values()];
+}
+
+function findVisibleHarvestRooms(creep: Creep): Room[] {
+  const rooms: Room[] = [];
+  if (creep.room) {
+    rooms.push(creep.room);
+  }
+
+  for (const room of findVisibleAdjacentClaimedRooms(creep.room)) {
+    if (rooms.some((candidate) => candidate.name === room.name)) {
+      continue;
+    }
+
+    rooms.push(room);
+  }
+
+  return rooms;
+}
+
+function findVisibleAdjacentClaimedRooms(room: Room | undefined): Room[] {
+  const roomName = room?.name;
+  if (!roomName) {
+    return [];
+  }
+
+  const game = (globalThis as unknown as { Game?: Partial<Pick<Game, 'map' | 'rooms'>> }).Game;
+  const visibleRooms = game?.rooms;
+  const adjacentRoomNames = getAdjacentRoomNames(roomName, game?.map);
+  if (!visibleRooms || adjacentRoomNames.length === 0) {
+    return [];
+  }
+
+  return adjacentRoomNames
+    .map((adjacentRoomName) => visibleRooms[adjacentRoomName])
+    .filter((candidate): candidate is Room => candidate?.controller?.my === true)
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function getAdjacentRoomNames(roomName: string, gameMap: Partial<GameMap> | undefined): string[] {
+  if (typeof gameMap?.describeExits !== 'function') {
+    return [];
+  }
+
+  const exits = gameMap.describeExits(roomName) as ExitsInformation | null;
+  if (!exits || typeof exits !== 'object') {
+    return [];
+  }
+
+  return Object.values(exits)
+    .filter((adjacentRoomName): adjacentRoomName is string => typeof adjacentRoomName === 'string' && adjacentRoomName.length > 0)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function findVisibleSourceContainer(creep: Creep, source: Source): StructureContainer | null {
+  const sourceRoom = findVisibleSourceRoom(creep, source);
+  return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
+}
+
+function findVisibleSourceRoom(creep: Creep, source: Source): Room | null {
+  const sourceRoomName = getPositionRoomName(source) ?? creep.room?.name;
+  if (!sourceRoomName) {
+    return null;
+  }
+
+  if (creep.room?.name === sourceRoomName) {
+    return creep.room;
+  }
+
+  return (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[sourceRoomName] ?? null;
+}
+
 function selectHarvestSource(creep: Creep): Source | null {
-  const sources = creep.room.find(FIND_SOURCES);
+  const sources = findVisibleHarvestSources(creep);
   if (sources.length === 0) {
     return null;
   }
@@ -4220,7 +4322,7 @@ function selectBestHarvestSource(creep: Creep, sources: Source[]): Source | null
   }
 
   const viableSources = selectViableHarvestSources(sources, getHarvestEnergyTarget(creep));
-  const assignmentLoads = getSameRoomWorkerHarvestLoads(creep.room.name, viableSources);
+  const assignmentLoads = getWorkerHarvestLoads(creep, viableSources);
   const assignableSources = selectAssignableHarvestSources(creep, viableSources, assignmentLoads);
   if (assignableSources.length === 0) {
     return null;
@@ -4255,7 +4357,7 @@ function isAssignableHarvestSource(
   source: Source,
   assignmentLoad: HarvestSourceAssignmentLoad
 ): boolean {
-  if (!findSourceContainer(creep.room, source)) {
+  if (!findVisibleSourceContainer(creep, source)) {
     return true;
   }
 
@@ -4415,9 +4517,125 @@ function getTerrainWallMask(): number {
 }
 
 function isCloserHarvestSource(creep: Creep, candidate: Source, selected: Source): boolean {
-  const candidateRange = getRangeBetweenRoomObjects(creep, candidate);
-  const selectedRange = getRangeBetweenRoomObjects(creep, selected);
+  const candidateRange = getHarvestSourceTravelCost(creep, candidate);
+  const selectedRange = getHarvestSourceTravelCost(creep, selected);
   return candidateRange !== null && selectedRange !== null && candidateRange < selectedRange;
+}
+
+function getHarvestSourceTravelCost(creep: Creep, source: Source): number | null {
+  const target = findVisibleSourceContainer(creep, source) ?? source;
+  const targetRange = target === source ? HARVEST_SOURCE_RANGE : HARVEST_SOURCE_CONTAINER_RANGE;
+  return estimateRoadAwareTravelCostBetweenRoomObjects(creep, target, targetRange);
+}
+
+function getHarvestSourceDeliveryTravelCost(
+  creep: Creep,
+  source: Source,
+  energySink: FillableEnergySink
+): number | null {
+  const harvestOrigin = findVisibleSourceContainer(creep, source) ?? source;
+  return estimateRoadAwareTravelCostBetweenRoomObjects(harvestOrigin, energySink, HARVEST_SOURCE_RANGE);
+}
+
+function estimateRoadAwareTravelCostBetweenRoomObjects(
+  origin: RoomObject,
+  target: RoomObject,
+  targetRange: number
+): number | null {
+  const originPosition = getRoomObjectPosition(origin);
+  const targetPosition = getRoomObjectPosition(target);
+  if (originPosition && targetPosition) {
+    const pathCost = findRoadAwarePathCost(originPosition, targetPosition, targetRange);
+    if (pathCost !== null) {
+      return pathCost;
+    }
+  }
+
+  const range = getRangeBetweenRoomObjects(origin, target);
+  if (range !== null) {
+    return Math.max(0, range - Math.max(0, targetRange - 1));
+  }
+
+  if (originPosition && targetPosition && isSameRoomPosition(originPosition, targetPosition)) {
+    return Math.max(
+      0,
+      Math.max(Math.abs(originPosition.x - targetPosition.x), Math.abs(originPosition.y - targetPosition.y)) -
+        Math.max(0, targetRange - 1)
+    );
+  }
+
+  return null;
+}
+
+function findRoadAwarePathCost(
+  origin: RoomPosition,
+  target: RoomPosition,
+  targetRange: number
+): number | null {
+  if (!isPathFinderAvailable()) {
+    return null;
+  }
+
+  const result = PathFinder.search(origin, { pos: target, range: Math.max(0, targetRange) }, {
+    maxOps: MAX_HARVEST_PATH_OPS,
+    maxRooms: origin.roomName === target.roomName ? 1 : 2,
+    plainCost: PLAIN_TRAVEL_COST,
+    roomCallback: createRoadAwareRoomCallback(new Set([origin.roomName, target.roomName])),
+    swampCost: SWAMP_TRAVEL_COST
+  });
+
+  if (result.incomplete) {
+    return null;
+  }
+
+  if (typeof result.cost === 'number' && Number.isFinite(result.cost)) {
+    return Math.max(0, result.cost);
+  }
+
+  return Array.isArray(result.path) ? result.path.length : null;
+}
+
+function isPathFinderAvailable(): boolean {
+  return typeof PathFinder !== 'undefined' && typeof PathFinder.search === 'function' && typeof PathFinder.CostMatrix === 'function';
+}
+
+function createRoadAwareRoomCallback(allowedRoomNames: Set<string>): (roomName: string) => boolean | CostMatrix {
+  const matricesByRoomName = new Map<string, CostMatrix | false>();
+  return (roomName: string): boolean | CostMatrix => {
+    if (!allowedRoomNames.has(roomName)) {
+      return false;
+    }
+
+    const cachedMatrix = matricesByRoomName.get(roomName);
+    if (cachedMatrix !== undefined) {
+      return cachedMatrix;
+    }
+
+    const room = (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName];
+    if (!room || typeof FIND_STRUCTURES !== 'number' || typeof room.find !== 'function') {
+      matricesByRoomName.set(roomName, false);
+      return false;
+    }
+
+    const matrix = new PathFinder.CostMatrix();
+    for (const structure of room.find(FIND_STRUCTURES) as Structure[]) {
+      if (!isRoadStructure(structure)) {
+        continue;
+      }
+
+      const position = getRoomObjectPosition(structure);
+      if (position) {
+        matrix.set(position.x, position.y, ROAD_TRAVEL_COST);
+      }
+    }
+
+    matricesByRoomName.set(roomName, matrix);
+    return matrix;
+  };
+}
+
+function isRoadStructure(structure: Structure): structure is StructureRoad {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road');
 }
 
 function selectViableHarvestSources(sources: Source[], harvestEnergyTarget: number): Source[] {
@@ -4450,8 +4668,8 @@ function getHarvestEnergyTarget(creep: Creep): number {
   return Math.max(1, getFreeEnergyCapacity(creep));
 }
 
-function getSameRoomWorkerHarvestLoads(
-  roomName: string | undefined,
+function getWorkerHarvestLoads(
+  creep: Creep,
   sources: Source[]
 ): Map<Id<Source>, HarvestSourceAssignmentLoad> {
   const assignmentLoads = new Map<Id<Source>, HarvestSourceAssignmentLoad>();
@@ -4459,21 +4677,25 @@ function getSameRoomWorkerHarvestLoads(
     assignmentLoads.set(source.id, createEmptyHarvestSourceAssignmentLoad());
   }
 
+  const roomName = creep.room?.name;
   if (!roomName) {
     return assignmentLoads;
   }
 
   const sourceIds = new Set(sources.map((source) => source.id as string));
+  const sourceRoomNamesById = new Map<string, string | undefined>(
+    sources.map((source) => [String(source.id), getPositionRoomName(source) ?? roomName])
+  );
   for (const assignedCreep of getGameCreeps()) {
     const task = assignedCreep.memory?.task as Partial<CreepTaskMemory> | undefined;
     const targetId = typeof task?.targetId === 'string' ? task.targetId : undefined;
 
     if (
       assignedCreep.memory?.role !== 'worker' ||
-      assignedCreep.room?.name !== roomName ||
       task?.type !== 'harvest' ||
       !targetId ||
-      !sourceIds.has(targetId)
+      !sourceIds.has(targetId) ||
+      !isRelevantHarvestAssignmentRoom(assignedCreep.room?.name, roomName, sourceRoomNamesById.get(targetId))
     ) {
       continue;
     }
@@ -4487,6 +4709,14 @@ function getSameRoomWorkerHarvestLoads(
   }
 
   return assignmentLoads;
+}
+
+function isRelevantHarvestAssignmentRoom(
+  assignedRoomName: string | undefined,
+  workerRoomName: string,
+  sourceRoomName: string | undefined
+): boolean {
+  return assignedRoomName === workerRoomName || (sourceRoomName !== undefined && assignedRoomName === sourceRoomName);
 }
 
 function getGameCreeps(): Creep[] {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -41,6 +41,7 @@ describe('runWorker', () => {
     (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
     (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
     (globalThis as unknown as { CLAIM: BodyPartConstant }).CLAIM = 'claim';
+    delete (globalThis as unknown as { PathFinder?: Partial<PathFinder> }).PathFinder;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {} };
   });
@@ -173,6 +174,45 @@ describe('runWorker', () => {
     expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source1' });
     expect(creep.harvest).toHaveBeenCalledWith(source);
     expect(creep.moveTo).toHaveBeenCalledWith(source);
+  });
+
+  it('assigns and executes an adjacent claimed-room harvest when it is the closer source', () => {
+    const homeSource = { id: 'source-home', energy: 300, pos: { x: 40, y: 40, roomName: 'W1N1' } } as Source;
+    const adjacentSource = { id: 'source-adjacent', energy: 300, pos: { x: 2, y: 25, roomName: 'W2N1' } } as Source;
+    const homeRoom = {
+      name: 'W1N1',
+      find: jest.fn((type: number) => (type === FIND_SOURCES ? [homeSource] : []))
+    } as unknown as Room;
+    const adjacentRoom = {
+      name: 'W2N1',
+      controller: { id: 'controller2', my: true } as StructureController,
+      find: jest.fn((type: number) => (type === FIND_SOURCES ? [adjacentSource] : []))
+    } as unknown as Room;
+    const creep = {
+      memory: {},
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'source-adjacent' ? 2 : 15))
+      },
+      room: homeRoom,
+      harvest: jest.fn().mockReturnValue(ERR_NOT_IN_RANGE),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      getObjectById: jest.fn((id: string) => (id === 'source-adjacent' ? adjacentSource : homeSource)),
+      map: { describeExits: jest.fn().mockReturnValue({ '3': 'W2N1' }) } as unknown as GameMap,
+      rooms: { W1N1: homeRoom, W2N1: adjacentRoom }
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'source-adjacent' });
+    expect(creep.harvest).toHaveBeenCalledWith(adjacentSource);
+    expect(creep.moveTo).toHaveBeenCalledWith(adjacentSource);
   });
 
   it('splits empty workers across sources as harvest assignments change', () => {

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -511,6 +511,53 @@ describe('runWorker', () => {
     expect(creep.moveTo).not.toHaveBeenCalled();
   });
 
+  it('keeps a depleted remote harvest target when its visible source container can receive energy', () => {
+    const remoteSource = {
+      id: 'remote-source',
+      energy: 0,
+      pos: { x: 20, y: 20, roomName: 'W2N1' } as RoomPosition
+    } as Source;
+    const localSource = { id: 'local-source', energy: 300 } as Source;
+    const remoteContainer = {
+      id: 'remote-container',
+      structureType: 'container',
+      pos: { x: 20, y: 21, roomName: 'W2N1' } as RoomPosition,
+      store: { getFreeCapacity: jest.fn().mockReturnValue(100) }
+    } as unknown as StructureContainer;
+    const homeRoom = {
+      name: 'W1N1',
+      find: jest.fn((type: number) => (type === FIND_SOURCES ? [localSource] : []))
+    } as unknown as Room;
+    const remoteRoom = {
+      name: 'W2N1',
+      find: jest.fn((type: number) => (type === FIND_STRUCTURES ? [remoteContainer] : []))
+    } as unknown as Room;
+    const creep = {
+      memory: { role: 'worker', task: { type: 'harvest', targetId: 'remote-source' as Id<Source> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: { getRangeTo: jest.fn().mockReturnValue(10) },
+      room: homeRoom,
+      harvest: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: { Worker: creep },
+      rooms: { W1N1: homeRoom, W2N1: remoteRoom },
+      getObjectById: jest.fn((id: string) =>
+        id === 'remote-source' ? remoteSource : id === 'local-source' ? localSource : null
+      )
+    };
+
+    runWorker(creep);
+
+    expect(creep.memory.task).toEqual({ type: 'harvest', targetId: 'remote-source' });
+    expect(creep.moveTo).toHaveBeenCalledWith(remoteContainer);
+    expect(creep.harvest).not.toHaveBeenCalled();
+  });
+
   it('picks up dropped energy and moves when not in range', () => {
     const droppedEnergy = { id: 'drop1', resourceType: 'energy', amount: 25 } as Resource<ResourceConstant>;
     const creep = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2294,7 +2294,7 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
-  it('selects the least-assigned harvest source for same-room workers', () => {
+  it('selects the least-assigned harvest source while counting in-transit workers', () => {
     const source1 = { id: 'source1' } as Source;
     const source2 = { id: 'source2' } as Source;
     const room = {
@@ -2307,9 +2307,13 @@ describe('selectWorkerTask', () => {
           memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
           room
         } as unknown as Creep,
-        OtherRoom: {
+        InTransit1: {
           memory: { role: 'worker', task: { type: 'harvest', targetId: 'source2' as Id<Source> } },
           room: { name: 'W2N2' } as Room
+        } as unknown as Creep,
+        InTransit2: {
+          memory: { role: 'worker', task: { type: 'harvest', targetId: 'source2' as Id<Source> } },
+          room: { name: 'W3N3' } as Room
         } as unknown as Creep,
         Miner: {
           memory: { role: 'miner', task: { type: 'harvest', targetId: 'source2' as Id<Source> } },
@@ -2326,7 +2330,7 @@ describe('selectWorkerTask', () => {
       room
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
   it('uses source access capacity before closeness when harvest assignments tie', () => {
@@ -2567,14 +2571,40 @@ describe('selectWorkerTask', () => {
     const road = makeStructure('road1', 'road' as StructureConstant, 5_000, 5_000, {
       pos: makeRoomPosition(20, 10)
     });
-    const room = makeWorkerTaskRoom({ sources: [nearPlainSource, farRoadSource], structures: [road] });
-    const pathFinderSearch = jest.fn((_origin: RoomPosition, goal: { pos: RoomPosition }) => ({
+    const spawn = makeStructure('spawn1', 'spawn' as StructureConstant, 5_000, 5_000, {
+      pos: makeRoomPosition(21, 10)
+    });
+    const hostileRampart = makeStructure('rampart-hostile', 'rampart' as StructureConstant, 5_000, 5_000, {
+      my: false,
+      pos: makeRoomPosition(22, 10)
+    });
+    const tower = makeStructure('tower1', 'tower' as StructureConstant, 3_000, 3_000, {
+      pos: makeRoomPosition(23, 10)
+    });
+    const container = makeStructure('container1', 'container' as StructureConstant, 250_000, 250_000, {
+      pos: makeRoomPosition(24, 10)
+    });
+    const ownedRampart = makeStructure('rampart-owned', 'rampart' as StructureConstant, 5_000, 5_000, {
+      my: true,
+      pos: makeRoomPosition(25, 10)
+    });
+    const room = makeWorkerTaskRoom({
+      sources: [nearPlainSource, farRoadSource],
+      structures: [road, spawn, hostileRampart, tower, container, ownedRampart]
+    });
+    const matrixSets: Array<[number, number, number]> = [];
+    const pathFinderSearch = jest.fn((_origin: RoomPosition, goal: { pos: RoomPosition }, options?: PathFinderOpts) => {
+      options?.roomCallback?.('W1N1');
+      return {
       cost: goal.pos.x === 30 ? 4 : 20,
       incomplete: false,
       path: []
-    }));
+      };
+    });
     class TestCostMatrix {
-      set(_x: number, _y: number, _cost: number): void {}
+      set(x: number, y: number, cost: number): void {
+        matrixSets.push([x, y, cost]);
+      }
     }
     (globalThis as unknown as { PathFinder: Partial<PathFinder> }).PathFinder = {
       CostMatrix: TestCostMatrix as unknown as CostMatrix,
@@ -2592,6 +2622,47 @@ describe('selectWorkerTask', () => {
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-far-road' });
     expect(pathFinderSearch).toHaveBeenCalled();
+    expect(matrixSets).toEqual(expect.arrayContaining([[20, 10, 1], [21, 10, 255], [22, 10, 255], [23, 10, 255]]));
+    expect(matrixSets).not.toContainEqual([24, 10, 255]);
+    expect(matrixSets).not.toContainEqual([25, 10, 255]);
+  });
+
+  it('does not use range fallback for unreachable road-aware harvest paths', () => {
+    const blockedSource = makeSource('source-blocked', 11, 10);
+    const reachableSource = makeSource('source-reachable', 30, 10);
+    const spawn = makeEnergySinkWithEnergy('spawn1', 'spawn' as StructureConstant, 0, 300, {
+      pos: makeRoomPosition(10, 10)
+    });
+    const room = makeWorkerTaskRoom({
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [blockedSource, reachableSource]
+    });
+    const pathFinderSearch = jest.fn((_origin: RoomPosition, goal: { pos: RoomPosition }) => ({
+      cost: goal.pos.x === 30 ? 20 : 5,
+      incomplete: goal.pos.x === 11,
+      path: []
+    }));
+    class TestCostMatrix {
+      set(_x: number, _y: number, _cost: number): void {}
+    }
+    (globalThis as unknown as { PathFinder: Partial<PathFinder> }).PathFinder = {
+      CostMatrix: TestCostMatrix as unknown as CostMatrix,
+      search: pathFinderSearch as unknown as PathFinder['search']
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      rooms: { W1N1: room }
+    };
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: makeRoomPosition(10, 10),
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-reachable' });
   });
 
   it('ignores adjacent sources in rooms that are not claimed', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2665,6 +2665,40 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-reachable' });
   });
 
+  it('excludes unreachable road-aware harvest sources from ordinary selection', () => {
+    const blockedSource = makeSource('source-blocked', 11, 10);
+    const reachableSource = makeSource('source-reachable', 30, 10);
+    const room = makeWorkerTaskRoom({
+      sources: [blockedSource, reachableSource]
+    });
+    const pathFinderSearch = jest.fn((_origin: RoomPosition, goal: { pos: RoomPosition }) => ({
+      cost: goal.pos.x === 30 ? 20 : 5,
+      incomplete: goal.pos.x === 11,
+      path: []
+    }));
+    class TestCostMatrix {
+      set(_x: number, _y: number, _cost: number): void {}
+    }
+    (globalThis as unknown as { PathFinder: Partial<PathFinder> }).PathFinder = {
+      CostMatrix: TestCostMatrix as unknown as CostMatrix,
+      search: pathFinderSearch as unknown as PathFinder['search']
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      rooms: { W1N1: room }
+    };
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: makeRoomPosition(10, 10),
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-reachable' });
+  });
+
   it('ignores adjacent sources in rooms that are not claimed', () => {
     const homeSource = makeSource('source-home', 40, 40, 'W1N1');
     const neutralSource = makeSource('source-neutral', 2, 25, 'W2N1');
@@ -8955,6 +8989,44 @@ describe('selectWorkerTask', () => {
     setGameCreeps({ RecoveryWorker: creep });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('keeps spawn recovery direct harvest room-local when an adjacent claimed source is faster', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300, {
+      pos: makeRoomPosition(10, 10, 'W1N1')
+    });
+    const homeSource = withRangeTo(makeSource('source-home', 40, 40, 'W1N1'), { spawn1: 20 }) as unknown as Source;
+    const adjacentSource = withRangeTo(makeSource('source-adjacent', 2, 25, 'W2N1'), {
+      spawn1: 1
+    }) as unknown as Source;
+    const homeRoom = makeWorkerTaskRoom({
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [homeSource]
+    });
+    const adjacentRoom = makeWorkerTaskRoom({
+      controller: { id: 'controller2', my: true, level: 2 } as StructureController,
+      name: 'W2N1',
+      sources: [adjacentSource]
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      map: { describeExits: jest.fn().mockReturnValue({ '3': 'W2N1' }) } as unknown as GameMap,
+      rooms: { W1N1: homeRoom, W2N1: adjacentRoom }
+    };
+    const creep = {
+      name: 'RecoveryWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'source-adjacent' ? 1 : 20))
+      },
+      room: homeRoom
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-home' });
   });
 
   it('uses a load-ready source over a closer low-energy source for spawn recovery harvest', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -195,6 +195,7 @@ function makeWorkerTaskRoom({
   hostileStructures = [],
   myCreeps = [],
   myStructures = [],
+  name = 'W1N1',
   sources = [],
   structures = []
 }: {
@@ -206,11 +207,12 @@ function makeWorkerTaskRoom({
   hostileStructures?: AnyStructure[];
   myCreeps?: Creep[];
   myStructures?: AnyOwnedStructure[];
+  name?: string;
   sources?: Source[];
   structures?: AnyStructure[];
 } = {}): Room {
   return {
-    name: 'W1N1',
+    name,
     controller,
     ...(energyAvailable === undefined ? {} : { energyAvailable }),
     ...(energyCapacityAvailable === undefined ? {} : { energyCapacityAvailable }),
@@ -341,6 +343,7 @@ describe('selectWorkerTask', () => {
     (globalThis as unknown as { WORK: BodyPartConstant }).WORK = 'work';
     delete (globalThis as unknown as { FIND_MY_CREEPS?: number }).FIND_MY_CREEPS;
     delete (globalThis as unknown as { BUILD_POWER?: number }).BUILD_POWER;
+    delete (globalThis as unknown as { PathFinder?: Partial<PathFinder> }).PathFinder;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     (globalThis as unknown as { Game?: Partial<Game> }).Game = { creeps: {} };
   });
@@ -2532,6 +2535,87 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('selects an adjacent claimed-room source when it is closer than home sources', () => {
+    const homeSource = makeSource('source-home', 40, 40, 'W1N1');
+    const adjacentSource = makeSource('source-adjacent', 2, 25, 'W2N1');
+    const homeRoom = makeWorkerTaskRoom({ sources: [homeSource] });
+    const adjacentRoom = makeWorkerTaskRoom({
+      controller: { id: 'controller2', my: true, level: 2 } as StructureController,
+      name: 'W2N1',
+      sources: [adjacentSource]
+    });
+    const getRangeTo = jest.fn((target: Source) => (target.id === 'source-adjacent' ? 2 : 15));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      map: { describeExits: jest.fn().mockReturnValue({ '3': 'W2N1' }) } as unknown as GameMap,
+      rooms: { W1N1: homeRoom, W2N1: adjacentRoom }
+    };
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      pos: { getRangeTo },
+      room: homeRoom
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-adjacent' });
+  });
+
+  it('keeps harvest source selection road-cost-aware when range favors a slower source', () => {
+    const nearPlainSource = makeSource('source-near-plain', 12, 10);
+    const farRoadSource = makeSource('source-far-road', 30, 10);
+    const road = makeStructure('road1', 'road' as StructureConstant, 5_000, 5_000, {
+      pos: makeRoomPosition(20, 10)
+    });
+    const room = makeWorkerTaskRoom({ sources: [nearPlainSource, farRoadSource], structures: [road] });
+    const pathFinderSearch = jest.fn((_origin: RoomPosition, goal: { pos: RoomPosition }) => ({
+      cost: goal.pos.x === 30 ? 4 : 20,
+      incomplete: false,
+      path: []
+    }));
+    class TestCostMatrix {
+      set(_x: number, _y: number, _cost: number): void {}
+    }
+    (globalThis as unknown as { PathFinder: Partial<PathFinder> }).PathFinder = {
+      CostMatrix: TestCostMatrix as unknown as CostMatrix,
+      search: pathFinderSearch as unknown as PathFinder['search']
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      rooms: { W1N1: room }
+    };
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      pos: makeRoomPosition(10, 10),
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-far-road' });
+    expect(pathFinderSearch).toHaveBeenCalled();
+  });
+
+  it('ignores adjacent sources in rooms that are not claimed', () => {
+    const homeSource = makeSource('source-home', 40, 40, 'W1N1');
+    const neutralSource = makeSource('source-neutral', 2, 25, 'W2N1');
+    const homeRoom = makeWorkerTaskRoom({ sources: [homeSource] });
+    const neutralRoom = makeWorkerTaskRoom({
+      controller: { id: 'controller2', my: false, level: 0 } as StructureController,
+      name: 'W2N1',
+      sources: [neutralSource]
+    });
+    const getRangeTo = jest.fn((target: Source) => (target.id === 'source-neutral' ? 2 : 15));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {},
+      map: { describeExits: jest.fn().mockReturnValue({ '3': 'W2N1' }) } as unknown as GameMap,
+      rooms: { W1N1: homeRoom, W2N1: neutralRoom }
+    };
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(0) },
+      pos: { getRangeTo },
+      room: homeRoom
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-home' });
   });
 
   it('stands by deterministically when all sources are empty', () => {


### PR DESCRIPTION
## Summary
Improves worker energy acquisition to leverage the road network and adjacent claimed rooms for faster, more efficient energy gathering.

## Changes
- `prod/src/creeps/workerRunner.ts` — worker task selection with road-aware scoring
- `prod/src/tasks/workerTasks.ts` — energy acquisition targets including adjacent rooms
- `prod/test/workerRunner.test.ts` — worker runner integration tests
- `prod/test/workerTasks.test.ts` — adjacent-room source selection tests
- `prod/dist/main.js` — build artifact

## Verification
- Typecheck: PASS
- Jest: 1030/1030 tests PASS
- Build: PASS