### PR TITLE
feat(territory): improve claim execution reliability for recommended adjacent rooms (#626)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -18108,6 +18108,7 @@ function matchesStructureType13(actual, globalName, fallback) {
 
 // src/territory/claimExecutor.ts
 var AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR = "autonomousExpansionClaim";
+var EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS = 1500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE = 500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_RCL = 2;
 var EXIT_DIRECTION_ORDER4 = ["1", "3", "5", "7"];
@@ -18116,6 +18117,11 @@ var ERR_NOT_IN_RANGE_CODE6 = -9;
 var ERR_INVALID_TARGET_CODE3 = -7;
 var ERR_NO_BODYPART_CODE = -12;
 var ERR_GCL_NOT_ENOUGH_CODE = -15;
+var RECOMMENDED_EXPANSION_CLAIM_SOURCES = /* @__PURE__ */ new Set([
+  NEXT_EXPANSION_TARGET_CREATOR,
+  AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR,
+  "colonyExpansion"
+]);
 var autonomousExpansionClaimTickContext = null;
 function refreshAutonomousExpansionClaimIntent(colony, report, gameTime, telemetryEvents = []) {
   const context = getAutonomousExpansionClaimTickContext(gameTime);
@@ -18139,6 +18145,127 @@ function shouldDeferOccupationRecommendationForExpansionClaim(evaluation) {
 function clearAutonomousExpansionClaimIntent(colony) {
   pruneAutonomousExpansionClaimTargets(colony);
   autonomousExpansionClaimTickContext = null;
+}
+function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
+  var _a, _b, _c, _d;
+  const assignment = creep.memory.territory;
+  if (!isClaimExecutionAssignment(assignment) || !isRecommendedExpansionClaim(creep.memory.colony, assignment)) {
+    return false;
+  }
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
+    moveTowardClaimTarget(creep, assignment);
+    return true;
+  }
+  const gameTime = getGameTime12();
+  const execution = assignment;
+  if (typeof execution.claimStartedAt !== "number" || execution.claimStartedAt > gameTime) {
+    execution.claimStartedAt = gameTime;
+    execution.claimAttemptCount = 0;
+  }
+  const controller = selectClaimTargetController(creep, assignment);
+  if (!controller) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, ERR_INVALID_TARGET_CODE3, "controllerMissing", {
+      suppressIntent: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+  if (controller.my === true) {
+    recordRecommendedClaimSuccess(creep, assignment, controller, telemetryEvents);
+    completeClaimAssignment(creep);
+    return true;
+  }
+  if (hasClaimExecutionTimedOut(execution, gameTime)) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, ERR_INVALID_TARGET_CODE3, "claimFailed", {
+      controllerId: controller.id,
+      suppressIntent: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+  if (isForeignOwnedController(controller)) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, ERR_INVALID_TARGET_CODE3, "controllerOwned", {
+      controllerId: controller.id,
+      suppressIntent: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+  if (isExpansionClaimControllerOnCooldown(controller)) {
+    recordExpansionClaimSkipTelemetry(creep, controller, "controllerCooldown", telemetryEvents);
+    moveTowardController(creep, controller);
+    return true;
+  }
+  if (tryPressureForeignClaimBlocker(creep, assignment, controller, telemetryEvents)) {
+    return true;
+  }
+  if (getKnownActiveClaimPartCount(creep) === 0) {
+    recordRecommendedClaimRetry(creep, assignment, ERR_NO_BODYPART_CODE, "missingClaimPart", {
+      controllerId: controller.id,
+      releaseAssignment: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+  const result = executeExpansionClaim(creep, controller, telemetryEvents);
+  execution.lastClaimAttemptAt = gameTime;
+  execution.claimAttemptCount = ((_b = execution.claimAttemptCount) != null ? _b : 0) + 1;
+  if (result === OK_CODE6 && isClaimVerified(assignment.targetRoom, controller)) {
+    recordRecommendedClaimSuccess(creep, assignment, controller, telemetryEvents);
+    completeClaimAssignment(creep);
+    return true;
+  }
+  if (result === ERR_NOT_IN_RANGE_CODE6) {
+    moveTowardController(creep, controller);
+    return true;
+  }
+  if (hasClaimExecutionTimedOut(execution, gameTime)) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, result, "claimFailed", {
+      controllerId: controller.id,
+      suppressIntent: true
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+  if (result === ERR_INVALID_TARGET_CODE3 && isForeignReservedController3(controller, creep.memory.colony)) {
+    const activeClaimParts = getKnownActiveClaimPartCount(creep);
+    const needsPressureCreep = activeClaimParts !== null && activeClaimParts < TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS;
+    recordRecommendedClaimRetry(creep, assignment, result, "controllerReserved", {
+      controllerId: controller.id,
+      releaseAssignment: needsPressureCreep,
+      requiresControllerPressure: true
+    });
+    if (needsPressureCreep) {
+      completeClaimAssignment(creep);
+    }
+    return true;
+  }
+  if (result === ERR_INVALID_TARGET_CODE3 || result === ERR_NO_BODYPART_CODE) {
+    recordRecommendedClaimRetry(creep, assignment, result, (_c = getClaimResultReason(result)) != null ? _c : "claimFailed", {
+      controllerId: controller.id,
+      releaseAssignment: result === ERR_NO_BODYPART_CODE
+    });
+    if (result === ERR_NO_BODYPART_CODE) {
+      completeClaimAssignment(creep);
+    }
+    return true;
+  }
+  if (result === ERR_GCL_NOT_ENOUGH_CODE) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, result, "gclUnavailable", {
+      controllerId: controller.id,
+      suppressIntent: true
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+  recordRecommendedClaimRetry(creep, assignment, result, (_d = getClaimResultReason(result)) != null ? _d : "claimFailed", {
+    controllerId: controller.id
+  });
+  return true;
 }
 function shouldPruneAutonomousExpansionClaimTargets(reason) {
   return reason === "noAdjacentCandidate" || reason === "scoreBelowThreshold" || reason === "hostilePresence" || reason === "controllerMissing" || reason === "controllerOwned" || reason === "controllerReserved" || reason === "sourcesMissing";
@@ -18671,6 +18798,311 @@ function getControllerClaimCooldown(controller) {
   const upgradeBlocked = controller.upgradeBlocked;
   return typeof upgradeBlocked === "number" && upgradeBlocked > 0 ? upgradeBlocked : 0;
 }
+function isClaimExecutionAssignment(assignment) {
+  return typeof (assignment == null ? void 0 : assignment.targetRoom) === "string" && assignment.targetRoom.length > 0 && assignment.action === "claim";
+}
+function isRecommendedExpansionClaim(colony, assignment) {
+  if (!isNonEmptyString14(colony)) {
+    return false;
+  }
+  const territoryMemory = getTerritoryMemoryRecord6();
+  if (!territoryMemory) {
+    return false;
+  }
+  if (normalizeTerritoryIntents(territoryMemory.intents).some(
+    (intent) => intent.colony === colony && intent.targetRoom === assignment.targetRoom && intent.action === "claim" && intent.createdBy !== void 0 && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(intent.createdBy)
+  )) {
+    return true;
+  }
+  return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some(
+    (target) => isRecord15(target) && target.colony === colony && target.roomName === assignment.targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy)
+  ) : false;
+}
+function selectClaimTargetController(creep, assignment) {
+  var _a, _b, _c, _d;
+  if (assignment.controllerId) {
+    const game = globalThis.Game;
+    if (typeof (game == null ? void 0 : game.getObjectById) === "function") {
+      const controller = game.getObjectById.call(game, assignment.controllerId);
+      if (controller) {
+        return controller;
+      }
+    }
+  }
+  return (_d = (_c = (_a = creep.room) == null ? void 0 : _a.controller) != null ? _c : (_b = getVisibleRoom6(assignment.targetRoom)) == null ? void 0 : _b.controller) != null ? _d : null;
+}
+function moveTowardClaimTarget(creep, assignment) {
+  const visibleController = selectVisibleClaimTargetController(assignment);
+  if (visibleController) {
+    moveTowardController(creep, visibleController);
+    return;
+  }
+  if (typeof creep.moveTo !== "function") {
+    return;
+  }
+  const RoomPositionCtor = globalThis.RoomPosition;
+  if (typeof RoomPositionCtor === "function") {
+    creep.moveTo(new RoomPositionCtor(25, 25, assignment.targetRoom));
+  }
+}
+function selectVisibleClaimTargetController(assignment) {
+  var _a, _b, _c;
+  const game = globalThis.Game;
+  if (assignment.controllerId && typeof (game == null ? void 0 : game.getObjectById) === "function") {
+    const controller = game.getObjectById.call(game, assignment.controllerId);
+    if (controller) {
+      return controller;
+    }
+  }
+  return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
+}
+function moveTowardController(creep, controller) {
+  if (typeof creep.moveTo === "function") {
+    creep.moveTo(controller);
+  }
+}
+function hasClaimExecutionTimedOut(assignment, gameTime) {
+  return typeof assignment.claimStartedAt === "number" && gameTime >= assignment.claimStartedAt && gameTime - assignment.claimStartedAt >= EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS;
+}
+function tryPressureForeignClaimBlocker(creep, assignment, controller, telemetryEvents) {
+  if (!isForeignReservedController3(controller, creep.memory.colony)) {
+    return false;
+  }
+  const activeClaimParts = getKnownActiveClaimPartCount(creep);
+  if (activeClaimParts !== null && activeClaimParts < TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS) {
+    recordRecommendedClaimRetry(creep, assignment, ERR_INVALID_TARGET_CODE3, "controllerReserved", {
+      controllerId: controller.id,
+      releaseAssignment: true,
+      requiresControllerPressure: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+  if (typeof creep.attackController !== "function") {
+    return false;
+  }
+  const result = creep.attackController(controller);
+  if (result === ERR_NOT_IN_RANGE_CODE6) {
+    moveTowardController(creep, controller);
+    return true;
+  }
+  if (result === ERR_NO_BODYPART_CODE) {
+    recordRecommendedClaimRetry(creep, assignment, result, "missingClaimPart", {
+      controllerId: controller.id,
+      releaseAssignment: true,
+      requiresControllerPressure: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+  return result !== ERR_INVALID_TARGET_CODE3;
+}
+function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryEvents) {
+  const colony = getClaimColony(creep, controller);
+  const targetRoom = assignment.targetRoom;
+  recordPostClaimBootstrapClaimSuccess(
+    {
+      colony,
+      roomName: targetRoom,
+      controllerId: controller.id
+    },
+    telemetryEvents
+  );
+  completeRecommendedClaimIntent(colony, targetRoom, controller.id);
+  recordColonyExpansionClaimVerification({
+    colony,
+    targetRoom,
+    status: "claimed",
+    controllerId: controller.id,
+    creepName: creep.name,
+    updatedAt: getGameTime12()
+  });
+}
+function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason, options) {
+  var _a, _b, _c, _d, _e;
+  const colony = getClaimColony(creep);
+  recordTerritoryClaimTelemetry((_a = options.telemetryEvents) != null ? _a : [], {
+    colony,
+    targetRoom: assignment.targetRoom,
+    ...((_b = options.controllerId) != null ? _b : assignment.controllerId) ? { controllerId: (_c = options.controllerId) != null ? _c : assignment.controllerId } : {},
+    creepName: creep.name,
+    phase: "claim",
+    result,
+    reason
+  });
+  if (options.suppressIntent) {
+    suppressRecommendedClaimIntent(colony, assignment, getGameTime12(), options.controllerId, reason);
+  }
+  recordColonyExpansionClaimVerification({
+    colony,
+    targetRoom: assignment.targetRoom,
+    status: "failed",
+    ...((_d = options.controllerId) != null ? _d : assignment.controllerId) ? { controllerId: (_e = options.controllerId) != null ? _e : assignment.controllerId } : {},
+    creepName: creep.name,
+    result,
+    reason,
+    updatedAt: getGameTime12()
+  });
+}
+function recordRecommendedClaimRetry(creep, assignment, result, reason, options = {}) {
+  var _a, _b, _c;
+  const colony = getClaimColony(creep);
+  recordTerritoryClaimTelemetry((_a = options.telemetryEvents) != null ? _a : [], {
+    colony,
+    targetRoom: assignment.targetRoom,
+    ...((_b = options.controllerId) != null ? _b : assignment.controllerId) ? { controllerId: (_c = options.controllerId) != null ? _c : assignment.controllerId } : {},
+    creepName: creep.name,
+    phase: "claim",
+    result,
+    reason
+  });
+  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime12(), options);
+}
+function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, options) {
+  var _a, _b;
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  if (!territoryMemory) {
+    return;
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  for (let i = 0; i < intents.length; i += 1) {
+    const intent = intents[i];
+    if (!isMatchingRecommendedClaimIntent(intent, colony, assignment.targetRoom, void 0, allowUnscopedIntent)) {
+      continue;
+    }
+    intents[i] = {
+      ...intent,
+      status: options.releaseAssignment ? "planned" : "active",
+      updatedAt: gameTime,
+      lastAttemptAt: gameTime,
+      ...((_a = options.controllerId) != null ? _a : assignment.controllerId) ? { controllerId: (_b = options.controllerId) != null ? _b : assignment.controllerId } : {},
+      ...options.requiresControllerPressure || intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
+    };
+  }
+}
+function suppressRecommendedClaimIntent(colony, assignment, gameTime, controllerId, reason) {
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  if (!territoryMemory) {
+    return;
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  for (let i = 0; i < intents.length; i += 1) {
+    const intent = intents[i];
+    if (!isMatchingRecommendedClaimIntent(intent, colony, assignment.targetRoom, void 0, allowUnscopedIntent)) {
+      continue;
+    }
+    intents[i] = {
+      ...intent,
+      status: "suppressed",
+      updatedAt: gameTime,
+      lastAttemptAt: gameTime,
+      ...(controllerId != null ? controllerId : assignment.controllerId) ? { controllerId: controllerId != null ? controllerId : assignment.controllerId } : {},
+      ...reason === "controllerReserved" || intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
+    };
+  }
+}
+function completeRecommendedClaimIntent(colony, targetRoom, controllerId) {
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  if (!territoryMemory) {
+    return;
+  }
+  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, targetRoom);
+  territoryMemory.intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
+    (intent) => !isMatchingRecommendedClaimIntent(intent, colony, targetRoom, controllerId, allowUnscopedIntent)
+  );
+  if (Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = territoryMemory.targets.filter(
+      (target) => !isMatchingRecommendedClaimTarget(target, colony, targetRoom)
+    );
+  }
+}
+function isMatchingRecommendedClaimIntent(intent, colony, targetRoom, controllerId, allowUnscopedIntent = false) {
+  return intent.colony === colony && intent.targetRoom === targetRoom && intent.action === "claim" && (intent.createdBy !== void 0 && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(intent.createdBy) || allowUnscopedIntent && intent.createdBy === void 0) && (!controllerId || !intent.controllerId || intent.controllerId === controllerId);
+}
+function hasRecommendedClaimTarget(territoryMemory, colony, targetRoom) {
+  return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom)) : false;
+}
+function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
+  return isRecord15(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
+}
+function recordColonyExpansionClaimVerification(input) {
+  var _a;
+  const colonyRoom = getVisibleRoom6(input.colony);
+  const selection = (_a = colonyRoom == null ? void 0 : colonyRoom.memory) == null ? void 0 : _a.cachedExpansionSelection;
+  if (!isRecord15(selection) || selection.targetRoom !== input.targetRoom) {
+    return;
+  }
+  selection.claimExecution = {
+    status: input.status,
+    targetRoom: input.targetRoom,
+    updatedAt: input.updatedAt,
+    ...input.controllerId ? { controllerId: input.controllerId } : {},
+    ...input.creepName ? { creepName: input.creepName } : {},
+    ...input.result !== void 0 ? { result: input.result } : {},
+    ...input.reason ? { reason: input.reason } : {}
+  };
+}
+function isClaimVerified(targetRoom, controller) {
+  var _a, _b;
+  return ((_b = (_a = getVisibleClaimedRoom(targetRoom, controller)) == null ? void 0 : _a.controller) == null ? void 0 : _b.my) === true;
+}
+function getVisibleClaimedRoom(targetRoom, controller) {
+  var _a, _b;
+  const controllerRoom = controller.room;
+  if (((_a = controllerRoom == null ? void 0 : controllerRoom.controller) == null ? void 0 : _a.my) === true) {
+    return controllerRoom;
+  }
+  const gameRoom = getVisibleRoom6(targetRoom);
+  return ((_b = gameRoom == null ? void 0 : gameRoom.controller) == null ? void 0 : _b.my) === true ? gameRoom : null;
+}
+function completeClaimAssignment(creep) {
+  delete creep.memory.territory;
+}
+function getClaimColony(creep, controller) {
+  var _a, _b, _c, _d, _e;
+  return (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller == null ? void 0 : controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown";
+}
+function isForeignOwnedController(controller) {
+  return controller.my !== true && isNonEmptyString14(getControllerOwnerUsername7(controller));
+}
+function isForeignReservedController3(controller, colony) {
+  var _a, _b;
+  const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
+  if (!isNonEmptyString14(reservationUsername)) {
+    return false;
+  }
+  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom6(colony != null ? colony : "")) == null ? void 0 : _b.controller);
+}
+function getKnownActiveClaimPartCount(creep) {
+  var _a;
+  const claimPart = getBodyPartConstant5("CLAIM", "claim");
+  const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
+  if (typeof activeClaimParts === "number") {
+    return activeClaimParts;
+  }
+  return Array.isArray(creep.body) ? creep.body.filter((part) => isActiveBodyPart5(part, claimPart)).length : null;
+}
+function isActiveBodyPart5(part, bodyPartType) {
+  if (typeof part !== "object" || part === null) {
+    return false;
+  }
+  const bodyPart = part;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
+}
+function getBodyPartConstant5(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function isTerritoryAutomationSource3(source) {
+  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
+}
 function isAutonomousExpansionClaimTarget(target, colony) {
   return isRecord15(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
@@ -18683,6 +19115,11 @@ function getTargetKey2(roomName, action) {
 function getVisibleRoom6(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+}
+function getGameTime12() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" ? gameTime : 0;
 }
 function getTerritoryMemoryRecord6() {
   var _a;
@@ -18990,7 +19427,7 @@ var MIN_ADJACENT_ROOM_RESERVATION_SCORE = 500;
 var ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS_PER_CLAIM_PART = 600;
 var MAX_ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS = 1e3;
 var EXIT_DIRECTION_ORDER6 = ["1", "3", "5", "7"];
-function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime12(), options = {}) {
+function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime13(), options = {}) {
   const evaluation = selectAdjacentRoomReservationPlan(colony, options);
   if (evaluation.status === "planned" && evaluation.targetRoom) {
     persistAdjacentRoomReservationIntent(colony.room.name, evaluation, gameTime);
@@ -19378,7 +19815,7 @@ function getWritableTerritoryMemoryRecord6() {
   }
   return root.Memory.territory;
 }
-function getGameTime12() {
+function getGameTime13() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -19394,7 +19831,7 @@ function isRecord17(value) {
 var COLONY_EXPANSION_CLAIM_TARGET_CREATOR = "colonyExpansion";
 var MIN_COLONY_EXPANSION_CLAIM_SCORE = MIN_ADJACENT_ROOM_RESERVATION_SCORE;
 var EXIT_DIRECTION_ORDER7 = ["1", "3", "5", "7"];
-function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime13()) {
+function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime14()) {
   const colonyName = colony.room.name;
   if (assessment.territoryReady !== true) {
     const reservation2 = refreshAdjacentRoomReservationIntent(colony, gameTime, {
@@ -19677,7 +20114,7 @@ function getWritableTerritoryMemoryRecord7() {
   }
   return memory.territory;
 }
-function getGameTime13() {
+function getGameTime14() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -19727,7 +20164,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   if (assignment.action === "scout") {
-    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime14(), creep.name, telemetryEvents);
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime15(), creep.name, telemetryEvents);
     completeTerritoryAssignment(creep);
     return;
   }
@@ -19809,7 +20246,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime14();
+  const gameTime = getGameTime15();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -19829,7 +20266,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime14());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime15());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -19837,7 +20274,7 @@ function completeTerritoryAssignment(creep) {
 }
 function recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents) {
   var _a, _b;
-  const room = getVisibleClaimedRoom(assignment.targetRoom, controller);
+  const room = getVisibleClaimedRoom2(assignment.targetRoom, controller);
   if (!((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my)) {
     return;
   }
@@ -19850,7 +20287,7 @@ function recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetr
     telemetryEvents
   );
 }
-function getVisibleClaimedRoom(targetRoom, controller) {
+function getVisibleClaimedRoom2(targetRoom, controller) {
   var _a, _b, _c, _d;
   const controllerRoom = controller.room;
   if (((_a = controllerRoom == null ? void 0 : controllerRoom.controller) == null ? void 0 : _a.my) === true) {
@@ -19909,14 +20346,14 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime14() {
+function getGameTime15() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
 function isCreepKnownToHaveNoActiveClaimParts(creep) {
   var _a;
-  const claimPart = getBodyPartConstant5("CLAIM", "claim");
+  const claimPart = getBodyPartConstant6("CLAIM", "claim");
   const activeClaimParts = (_a = creep.getActiveBodyparts) == null ? void 0 : _a.call(creep, claimPart);
   if (typeof activeClaimParts === "number") {
     return activeClaimParts <= 0;
@@ -19924,16 +20361,16 @@ function isCreepKnownToHaveNoActiveClaimParts(creep) {
   if (!Array.isArray(creep.body)) {
     return false;
   }
-  return !creep.body.some((part) => isActiveBodyPart5(part, claimPart));
+  return !creep.body.some((part) => isActiveBodyPart6(part, claimPart));
 }
-function isActiveBodyPart5(part, bodyPartType) {
+function isActiveBodyPart6(part, bodyPartType) {
   if (typeof part !== "object" || part === null) {
     return false;
   }
   const bodyPart = part;
   return bodyPart.type === bodyPartType && typeof bodyPart.hits === "number" && bodyPart.hits > 0;
 }
-function getBodyPartConstant5(globalName, fallback) {
+function getBodyPartConstant6(globalName, fallback) {
   var _a;
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
@@ -19947,6 +20384,9 @@ function isTerritoryAssignment(assignment) {
 
 // src/creeps/claimerRunner.ts
 function runClaimer(creep, telemetryEvents = []) {
+  if (runRecommendedExpansionClaimExecutor(creep, telemetryEvents)) {
+    return;
+  }
   runTerritoryControllerCreep(creep, telemetryEvents);
 }
 
@@ -20331,7 +20771,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime15())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime16())
     );
   }
 };
@@ -20403,7 +20843,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime15() {
+function getGameTime16() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -18149,10 +18149,29 @@ function clearAutonomousExpansionClaimIntent(colony) {
 function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   var _a, _b, _c, _d;
   const assignment = creep.memory.territory;
-  if (!isClaimExecutionAssignment(assignment) || !isRecommendedExpansionClaim(creep.memory.colony, assignment)) {
+  if (!isClaimExecutionAssignment(assignment)) {
     return false;
   }
   const gameTime = getGameTime12();
+  const recommendedClaim = getRecommendedExpansionClaimExecutionGate(creep.memory.colony, assignment);
+  if (!recommendedClaim) {
+    return false;
+  }
+  if (!isRecommendedClaimIntentRunnable(recommendedClaim.intent, gameTime)) {
+    completeClaimAssignment(creep);
+    return true;
+  }
+  const visibleController = selectCurrentOrVisibleClaimTargetController(creep, assignment);
+  if ((visibleController == null ? void 0 : visibleController.my) === true) {
+    recordRecommendedClaimSuccess(creep, assignment, visibleController, telemetryEvents);
+    completeClaimAssignment(creep);
+    return true;
+  }
+  if (!isVisibleTerritoryAssignmentSafe(assignment, creep.memory.colony, creep)) {
+    suppressTerritoryIntent(creep.memory.colony, assignment, gameTime);
+    completeClaimAssignment(creep);
+    return true;
+  }
   const execution = assignment;
   if (typeof execution.claimStartedAt !== "number" || execution.claimStartedAt > gameTime) {
     execution.claimStartedAt = gameTime;
@@ -18803,28 +18822,60 @@ function getClaimResultReason(result) {
   }
 }
 function getControllerClaimCooldown(controller) {
-  const claimCooldown = controller.claimCooldown;
-  return typeof claimCooldown === "number" && claimCooldown > 0 ? claimCooldown : 0;
+  const upgradeBlocked = controller.upgradeBlocked;
+  return typeof upgradeBlocked === "number" && upgradeBlocked > 0 ? upgradeBlocked : 0;
 }
 function isClaimExecutionAssignment(assignment) {
   return typeof (assignment == null ? void 0 : assignment.targetRoom) === "string" && assignment.targetRoom.length > 0 && assignment.action === "claim";
 }
-function isRecommendedExpansionClaim(colony, assignment) {
+function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
+  var _a;
   if (!isNonEmptyString14(colony)) {
-    return false;
+    return null;
   }
   const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
+    return null;
+  }
+  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  const intent = (_a = normalizeTerritoryIntents(territoryMemory.intents).find(
+    (candidate) => isMatchingRecommendedClaimIntent(
+      candidate,
+      colony,
+      assignment.targetRoom,
+      assignment.controllerId,
+      allowUnscopedIntent
+    )
+  )) != null ? _a : null;
+  if (intent) {
+    return { intent };
+  }
+  return allowUnscopedIntent ? { intent: null } : null;
+}
+function isRecommendedClaimIntentRunnable(intent, gameTime) {
+  if (!intent || intent.status !== "planned" && intent.status !== "active") {
     return false;
   }
-  if (normalizeTerritoryIntents(territoryMemory.intents).some(
-    (intent) => intent.colony === colony && intent.targetRoom === assignment.targetRoom && intent.action === "claim" && intent.createdBy !== void 0 && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(intent.createdBy)
-  )) {
-    return true;
+  return !isTerritoryIntentSuspensionActive2(intent, gameTime);
+}
+function isTerritoryIntentSuspensionActive2(intent, gameTime) {
+  if (!intent.suspended) {
+    return false;
   }
-  return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some(
-    (target) => isRecord15(target) && target.colony === colony && target.roomName === assignment.targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy)
-  ) : false;
+  if (intent.suspended.reason === "hostile_presence") {
+    const hostileCount = getVisibleHostileCreepCount2(intent.targetRoom);
+    if (hostileCount !== null) {
+      return hostileCount > 0 && isHostileTerritoryIntentSuspensionCoolingDown2(intent.suspended, gameTime);
+    }
+  }
+  return isHostileTerritoryIntentSuspensionCoolingDown2(intent.suspended, gameTime);
+}
+function getVisibleHostileCreepCount2(targetRoom) {
+  const room = getVisibleRoom6(targetRoom);
+  return room ? findVisibleHostileCreeps2(room).length : null;
+}
+function isHostileTerritoryIntentSuspensionCoolingDown2(suspension, gameTime) {
+  return gameTime - suspension.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
 }
 function selectClaimTargetController(creep, assignment) {
   var _a, _b, _c, _d;
@@ -18863,6 +18914,13 @@ function selectVisibleClaimTargetController(assignment) {
     }
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
+}
+function selectCurrentOrVisibleClaimTargetController(creep, assignment) {
+  var _a;
+  if (((_a = creep.room) == null ? void 0 : _a.name) === assignment.targetRoom && creep.room.controller) {
+    return creep.room.controller;
+  }
+  return selectVisibleClaimTargetController(assignment);
 }
 function moveTowardController(creep, controller) {
   if (typeof creep.moveTo === "function") {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -18152,15 +18152,23 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   if (!isClaimExecutionAssignment(assignment) || !isRecommendedExpansionClaim(creep.memory.colony, assignment)) {
     return false;
   }
-  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
-    moveTowardClaimTarget(creep, assignment);
-    return true;
-  }
   const gameTime = getGameTime12();
   const execution = assignment;
   if (typeof execution.claimStartedAt !== "number" || execution.claimStartedAt > gameTime) {
     execution.claimStartedAt = gameTime;
     execution.claimAttemptCount = 0;
+  }
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
+    if (hasClaimExecutionTimedOut(execution, gameTime)) {
+      recordRecommendedClaimTerminalFailure(creep, assignment, ERR_INVALID_TARGET_CODE3, "claimFailed", {
+        suppressIntent: true,
+        telemetryEvents
+      });
+      completeClaimAssignment(creep);
+      return true;
+    }
+    moveTowardClaimTarget(creep, assignment);
+    return true;
   }
   const controller = selectClaimTargetController(creep, assignment);
   if (!controller) {
@@ -18795,8 +18803,8 @@ function getClaimResultReason(result) {
   }
 }
 function getControllerClaimCooldown(controller) {
-  const upgradeBlocked = controller.upgradeBlocked;
-  return typeof upgradeBlocked === "number" && upgradeBlocked > 0 ? upgradeBlocked : 0;
+  const claimCooldown = controller.claimCooldown;
+  return typeof claimCooldown === "number" && claimCooldown > 0 ? claimCooldown : 0;
 }
 function isClaimExecutionAssignment(assignment) {
   return typeof (assignment == null ? void 0 : assignment.targetRoom) === "string" && assignment.targetRoom.length > 0 && assignment.action === "claim";

--- a/prod/src/creeps/claimerRunner.ts
+++ b/prod/src/creeps/claimerRunner.ts
@@ -1,7 +1,11 @@
 import { runTerritoryControllerCreep } from '../territory/territoryRunner';
+import { runRecommendedExpansionClaimExecutor } from '../territory/claimExecutor';
 import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 
 export function runClaimer(creep: Creep, telemetryEvents: RuntimeTelemetryEvent[] = []): void {
+  if (runRecommendedExpansionClaimExecutor(creep, telemetryEvents)) {
+    return;
+  }
+
   runTerritoryControllerCreep(creep, telemetryEvents);
 }
-

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -14,7 +14,12 @@ import {
   type ExpansionScoringInput
 } from './expansionScoring';
 import type { OccupationRecommendationReport, OccupationRecommendationScore } from './occupationRecommendation';
-import { TERRITORY_SUPPRESSION_RETRY_TICKS } from './territoryPlanner';
+import {
+  isVisibleTerritoryAssignmentSafe,
+  suppressTerritoryIntent,
+  TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS,
+  TERRITORY_SUPPRESSION_RETRY_TICKS
+} from './territoryPlanner';
 import { normalizeTerritoryIntents } from './territoryMemoryUtils';
 import {
   ensureTerritoryScoutAttempt,
@@ -118,11 +123,34 @@ export function runRecommendedExpansionClaimExecutor(
   telemetryEvents: RuntimeTelemetryEvent[] = []
 ): boolean {
   const assignment = creep.memory.territory;
-  if (!isClaimExecutionAssignment(assignment) || !isRecommendedExpansionClaim(creep.memory.colony, assignment)) {
+  if (!isClaimExecutionAssignment(assignment)) {
     return false;
   }
 
   const gameTime = getGameTime();
+  const recommendedClaim = getRecommendedExpansionClaimExecutionGate(creep.memory.colony, assignment);
+  if (!recommendedClaim) {
+    return false;
+  }
+
+  if (!isRecommendedClaimIntentRunnable(recommendedClaim.intent, gameTime)) {
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  const visibleController = selectCurrentOrVisibleClaimTargetController(creep, assignment);
+  if (visibleController?.my === true) {
+    recordRecommendedClaimSuccess(creep, assignment, visibleController, telemetryEvents);
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  if (!isVisibleTerritoryAssignmentSafe(assignment, creep.memory.colony, creep)) {
+    suppressTerritoryIntent(creep.memory.colony, assignment, gameTime);
+    completeClaimAssignment(creep);
+    return true;
+  }
+
   const execution = assignment as ClaimExecutionAssignment;
   if (typeof execution.claimStartedAt !== 'number' || execution.claimStartedAt > gameTime) {
     execution.claimStartedAt = gameTime;
@@ -1038,8 +1066,8 @@ function getClaimResultReason(result: ScreepsReturnCode): RuntimeTerritoryClaimT
 }
 
 function getControllerClaimCooldown(controller: StructureController): number {
-  const claimCooldown = (controller as StructureController & { claimCooldown?: number }).claimCooldown;
-  return typeof claimCooldown === 'number' && claimCooldown > 0 ? claimCooldown : 0;
+  const upgradeBlocked = (controller as StructureController & { upgradeBlocked?: number }).upgradeBlocked;
+  return typeof upgradeBlocked === 'number' && upgradeBlocked > 0 ? upgradeBlocked : 0;
 }
 
 function isClaimExecutionAssignment(assignment: CreepTerritoryMemory | undefined): assignment is CreepTerritoryMemory {
@@ -1050,40 +1078,70 @@ function isClaimExecutionAssignment(assignment: CreepTerritoryMemory | undefined
   );
 }
 
-function isRecommendedExpansionClaim(colony: string | undefined, assignment: CreepTerritoryMemory): boolean {
+function getRecommendedExpansionClaimExecutionGate(
+  colony: string | undefined,
+  assignment: CreepTerritoryMemory
+): { intent: TerritoryIntentMemory | null } | null {
   if (!isNonEmptyString(colony)) {
-    return false;
+    return null;
   }
 
   const territoryMemory = getTerritoryMemoryRecord();
   if (!territoryMemory) {
+    return null;
+  }
+
+  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  const intent =
+    normalizeTerritoryIntents(territoryMemory.intents).find((candidate) =>
+      isMatchingRecommendedClaimIntent(
+        candidate,
+        colony,
+        assignment.targetRoom,
+        assignment.controllerId,
+        allowUnscopedIntent
+      )
+    ) ?? null;
+  if (intent) {
+    return { intent };
+  }
+
+  return allowUnscopedIntent ? { intent: null } : null;
+}
+
+function isRecommendedClaimIntentRunnable(intent: TerritoryIntentMemory | null, gameTime: number): boolean {
+  if (!intent || (intent.status !== 'planned' && intent.status !== 'active')) {
     return false;
   }
 
-  if (
-    normalizeTerritoryIntents(territoryMemory.intents).some(
-      (intent) =>
-        intent.colony === colony &&
-        intent.targetRoom === assignment.targetRoom &&
-        intent.action === 'claim' &&
-        intent.createdBy !== undefined &&
-        RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(intent.createdBy)
-    )
-  ) {
-    return true;
+  return !isTerritoryIntentSuspensionActive(intent, gameTime);
+}
+
+function isTerritoryIntentSuspensionActive(intent: TerritoryIntentMemory, gameTime: number): boolean {
+  if (!intent.suspended) {
+    return false;
   }
 
-  return Array.isArray(territoryMemory.targets)
-    ? territoryMemory.targets.some(
-        (target) =>
-          isRecord(target) &&
-          target.colony === colony &&
-          target.roomName === assignment.targetRoom &&
-          target.action === 'claim' &&
-          isTerritoryAutomationSource(target.createdBy) &&
-          RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy)
-      )
-    : false;
+  if (intent.suspended.reason === 'hostile_presence') {
+    const hostileCount = getVisibleHostileCreepCount(intent.targetRoom);
+    if (hostileCount !== null) {
+      return hostileCount > 0 && isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime);
+    }
+  }
+
+  return isHostileTerritoryIntentSuspensionCoolingDown(intent.suspended, gameTime);
+}
+
+function getVisibleHostileCreepCount(targetRoom: string): number | null {
+  const room = getVisibleRoom(targetRoom);
+  return room ? findVisibleHostileCreeps(room).length : null;
+}
+
+function isHostileTerritoryIntentSuspensionCoolingDown(
+  suspension: TerritoryIntentSuspensionMemory,
+  gameTime: number
+): boolean {
+  return gameTime - suspension.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
 }
 
 function selectClaimTargetController(
@@ -1130,6 +1188,17 @@ function selectVisibleClaimTargetController(assignment: CreepTerritoryMemory): S
   }
 
   return game?.rooms?.[assignment.targetRoom]?.controller ?? null;
+}
+
+function selectCurrentOrVisibleClaimTargetController(
+  creep: Creep,
+  assignment: CreepTerritoryMemory
+): StructureController | null {
+  if (creep.room?.name === assignment.targetRoom && creep.room.controller) {
+    return creep.room.controller;
+  }
+
+  return selectVisibleClaimTargetController(assignment);
 }
 
 function moveTowardController(creep: Creep, controller: StructureController): void {

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -1,7 +1,11 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
-import { TERRITORY_CONTROLLER_BODY_COST } from '../spawn/bodyBuilder';
+import {
+  TERRITORY_CONTROLLER_BODY_COST,
+  TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS
+} from '../spawn/bodyBuilder';
 import type { RuntimeTelemetryEvent, RuntimeTerritoryClaimTelemetryReason } from '../telemetry/runtimeSummary';
 import {
+  NEXT_EXPANSION_TARGET_CREATOR,
   scoreExpansionCandidates,
   type ExpansionCandidateInput,
   type ExpansionCandidateReport,
@@ -19,9 +23,11 @@ import {
   validateTerritoryScoutIntelForClaim,
   type TerritoryScoutValidationResult
 } from './scoutIntel';
+import { recordPostClaimBootstrapClaimSuccess } from './postClaimBootstrap';
 
 export const AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR: TerritoryAutomationSource =
   'autonomousExpansionClaim';
+export const EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS = 1_500;
 
 const MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE = 500;
 const MIN_AUTONOMOUS_EXPANSION_CLAIM_RCL = 2;
@@ -31,6 +37,11 @@ const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;
 const ERR_NO_BODYPART_CODE = -12 as ScreepsReturnCode;
 const ERR_GCL_NOT_ENOUGH_CODE = -15 as ScreepsReturnCode;
+const RECOMMENDED_EXPANSION_CLAIM_SOURCES = new Set<TerritoryAutomationSource>([
+  NEXT_EXPANSION_TARGET_CREATOR,
+  AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR,
+  'colonyExpansion'
+]);
 let autonomousExpansionClaimTickContext: AutonomousExpansionClaimTickContext | null = null;
 
 export type AutonomousExpansionClaimStatus = 'planned' | 'skipped';
@@ -47,6 +58,12 @@ interface AutonomousExpansionClaimTickContext {
   territoryIntents: TerritoryIntentMemory[];
   adjacentRoomNamesByOwnedRoom: Map<string, Set<string>>;
 }
+interface ClaimExecutionAssignment extends CreepTerritoryMemory {
+  claimStartedAt?: number;
+  lastClaimAttemptAt?: number;
+  claimAttemptCount?: number;
+}
+type RoomPositionConstructor = new (x: number, y: number, roomName: string) => RoomPosition;
 
 export interface AutonomousExpansionClaimEvaluation {
   status: AutonomousExpansionClaimStatus;
@@ -94,6 +111,148 @@ export function shouldDeferOccupationRecommendationForExpansionClaim(
 export function clearAutonomousExpansionClaimIntent(colony: string): void {
   pruneAutonomousExpansionClaimTargets(colony);
   autonomousExpansionClaimTickContext = null;
+}
+
+export function runRecommendedExpansionClaimExecutor(
+  creep: Creep,
+  telemetryEvents: RuntimeTelemetryEvent[] = []
+): boolean {
+  const assignment = creep.memory.territory;
+  if (!isClaimExecutionAssignment(assignment) || !isRecommendedExpansionClaim(creep.memory.colony, assignment)) {
+    return false;
+  }
+
+  if (creep.room?.name !== assignment.targetRoom) {
+    moveTowardClaimTarget(creep, assignment);
+    return true;
+  }
+
+  const gameTime = getGameTime();
+  const execution = assignment as ClaimExecutionAssignment;
+  if (typeof execution.claimStartedAt !== 'number' || execution.claimStartedAt > gameTime) {
+    execution.claimStartedAt = gameTime;
+    execution.claimAttemptCount = 0;
+  }
+
+  const controller = selectClaimTargetController(creep, assignment);
+  if (!controller) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, ERR_INVALID_TARGET_CODE, 'controllerMissing', {
+      suppressIntent: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  if (controller.my === true) {
+    recordRecommendedClaimSuccess(creep, assignment, controller, telemetryEvents);
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  if (hasClaimExecutionTimedOut(execution, gameTime)) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, ERR_INVALID_TARGET_CODE, 'claimFailed', {
+      controllerId: controller.id,
+      suppressIntent: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  if (isForeignOwnedController(controller)) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, ERR_INVALID_TARGET_CODE, 'controllerOwned', {
+      controllerId: controller.id,
+      suppressIntent: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  if (isExpansionClaimControllerOnCooldown(controller)) {
+    recordExpansionClaimSkipTelemetry(creep, controller, 'controllerCooldown', telemetryEvents);
+    moveTowardController(creep, controller);
+    return true;
+  }
+
+  if (tryPressureForeignClaimBlocker(creep, assignment, controller, telemetryEvents)) {
+    return true;
+  }
+
+  if (getKnownActiveClaimPartCount(creep) === 0) {
+    recordRecommendedClaimRetry(creep, assignment, ERR_NO_BODYPART_CODE, 'missingClaimPart', {
+      controllerId: controller.id,
+      releaseAssignment: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  const result = executeExpansionClaim(creep, controller, telemetryEvents);
+  execution.lastClaimAttemptAt = gameTime;
+  execution.claimAttemptCount = (execution.claimAttemptCount ?? 0) + 1;
+
+  if (result === OK_CODE && isClaimVerified(assignment.targetRoom, controller)) {
+    recordRecommendedClaimSuccess(creep, assignment, controller, telemetryEvents);
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  if (result === ERR_NOT_IN_RANGE_CODE) {
+    moveTowardController(creep, controller);
+    return true;
+  }
+
+  if (hasClaimExecutionTimedOut(execution, gameTime)) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, result, 'claimFailed', {
+      controllerId: controller.id,
+      suppressIntent: true
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  if (result === ERR_INVALID_TARGET_CODE && isForeignReservedController(controller, creep.memory.colony)) {
+    const activeClaimParts = getKnownActiveClaimPartCount(creep);
+    const needsPressureCreep =
+      activeClaimParts !== null && activeClaimParts < TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS;
+    recordRecommendedClaimRetry(creep, assignment, result, 'controllerReserved', {
+      controllerId: controller.id,
+      releaseAssignment: needsPressureCreep,
+      requiresControllerPressure: true
+    });
+    if (needsPressureCreep) {
+      completeClaimAssignment(creep);
+    }
+    return true;
+  }
+
+  if (result === ERR_INVALID_TARGET_CODE || result === ERR_NO_BODYPART_CODE) {
+    recordRecommendedClaimRetry(creep, assignment, result, getClaimResultReason(result) ?? 'claimFailed', {
+      controllerId: controller.id,
+      releaseAssignment: result === ERR_NO_BODYPART_CODE
+    });
+    if (result === ERR_NO_BODYPART_CODE) {
+      completeClaimAssignment(creep);
+    }
+    return true;
+  }
+
+  if (result === ERR_GCL_NOT_ENOUGH_CODE) {
+    recordRecommendedClaimTerminalFailure(creep, assignment, result, 'gclUnavailable', {
+      controllerId: controller.id,
+      suppressIntent: true
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  recordRecommendedClaimRetry(creep, assignment, result, getClaimResultReason(result) ?? 'claimFailed', {
+    controllerId: controller.id
+  });
+  return true;
 }
 
 function shouldPruneAutonomousExpansionClaimTargets(
@@ -874,6 +1033,479 @@ function getControllerClaimCooldown(controller: StructureController): number {
   return typeof upgradeBlocked === 'number' && upgradeBlocked > 0 ? upgradeBlocked : 0;
 }
 
+function isClaimExecutionAssignment(assignment: CreepTerritoryMemory | undefined): assignment is CreepTerritoryMemory {
+  return (
+    typeof assignment?.targetRoom === 'string' &&
+    assignment.targetRoom.length > 0 &&
+    assignment.action === 'claim'
+  );
+}
+
+function isRecommendedExpansionClaim(colony: string | undefined, assignment: CreepTerritoryMemory): boolean {
+  if (!isNonEmptyString(colony)) {
+    return false;
+  }
+
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return false;
+  }
+
+  if (
+    normalizeTerritoryIntents(territoryMemory.intents).some(
+      (intent) =>
+        intent.colony === colony &&
+        intent.targetRoom === assignment.targetRoom &&
+        intent.action === 'claim' &&
+        intent.createdBy !== undefined &&
+        RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(intent.createdBy)
+    )
+  ) {
+    return true;
+  }
+
+  return Array.isArray(territoryMemory.targets)
+    ? territoryMemory.targets.some(
+        (target) =>
+          isRecord(target) &&
+          target.colony === colony &&
+          target.roomName === assignment.targetRoom &&
+          target.action === 'claim' &&
+          isTerritoryAutomationSource(target.createdBy) &&
+          RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy)
+      )
+    : false;
+}
+
+function selectClaimTargetController(
+  creep: Creep,
+  assignment: CreepTerritoryMemory
+): StructureController | null {
+  if (assignment.controllerId) {
+    const game = (globalThis as { Game?: Partial<Game> }).Game;
+    if (typeof game?.getObjectById === 'function') {
+      const controller = game.getObjectById.call(game, assignment.controllerId) as StructureController | null;
+      if (controller) {
+        return controller;
+      }
+    }
+  }
+
+  return creep.room?.controller ?? getVisibleRoom(assignment.targetRoom)?.controller ?? null;
+}
+
+function moveTowardClaimTarget(creep: Creep, assignment: CreepTerritoryMemory): void {
+  const visibleController = selectVisibleClaimTargetController(assignment);
+  if (visibleController) {
+    moveTowardController(creep, visibleController);
+    return;
+  }
+
+  if (typeof creep.moveTo !== 'function') {
+    return;
+  }
+
+  const RoomPositionCtor = (globalThis as { RoomPosition?: RoomPositionConstructor }).RoomPosition;
+  if (typeof RoomPositionCtor === 'function') {
+    creep.moveTo(new RoomPositionCtor(25, 25, assignment.targetRoom));
+  }
+}
+
+function selectVisibleClaimTargetController(assignment: CreepTerritoryMemory): StructureController | null {
+  const game = (globalThis as { Game?: Partial<Game> }).Game;
+  if (assignment.controllerId && typeof game?.getObjectById === 'function') {
+    const controller = game.getObjectById.call(game, assignment.controllerId) as StructureController | null;
+    if (controller) {
+      return controller;
+    }
+  }
+
+  return game?.rooms?.[assignment.targetRoom]?.controller ?? null;
+}
+
+function moveTowardController(creep: Creep, controller: StructureController): void {
+  if (typeof creep.moveTo === 'function') {
+    creep.moveTo(controller);
+  }
+}
+
+function hasClaimExecutionTimedOut(assignment: ClaimExecutionAssignment, gameTime: number): boolean {
+  return (
+    typeof assignment.claimStartedAt === 'number' &&
+    gameTime >= assignment.claimStartedAt &&
+    gameTime - assignment.claimStartedAt >= EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS
+  );
+}
+
+function tryPressureForeignClaimBlocker(
+  creep: Creep,
+  assignment: CreepTerritoryMemory,
+  controller: StructureController,
+  telemetryEvents: RuntimeTelemetryEvent[]
+): boolean {
+  if (!isForeignReservedController(controller, creep.memory.colony)) {
+    return false;
+  }
+
+  const activeClaimParts = getKnownActiveClaimPartCount(creep);
+  if (activeClaimParts !== null && activeClaimParts < TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS) {
+    recordRecommendedClaimRetry(creep, assignment, ERR_INVALID_TARGET_CODE, 'controllerReserved', {
+      controllerId: controller.id,
+      releaseAssignment: true,
+      requiresControllerPressure: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  if (typeof creep.attackController !== 'function') {
+    return false;
+  }
+
+  const result = creep.attackController(controller);
+  if (result === ERR_NOT_IN_RANGE_CODE) {
+    moveTowardController(creep, controller);
+    return true;
+  }
+
+  if (result === ERR_NO_BODYPART_CODE) {
+    recordRecommendedClaimRetry(creep, assignment, result, 'missingClaimPart', {
+      controllerId: controller.id,
+      releaseAssignment: true,
+      requiresControllerPressure: true,
+      telemetryEvents
+    });
+    completeClaimAssignment(creep);
+    return true;
+  }
+
+  return result !== ERR_INVALID_TARGET_CODE;
+}
+
+function recordRecommendedClaimSuccess(
+  creep: Creep,
+  assignment: CreepTerritoryMemory,
+  controller: StructureController,
+  telemetryEvents: RuntimeTelemetryEvent[]
+): void {
+  const colony = getClaimColony(creep, controller);
+  const targetRoom = assignment.targetRoom;
+  recordPostClaimBootstrapClaimSuccess(
+    {
+      colony,
+      roomName: targetRoom,
+      controllerId: controller.id
+    },
+    telemetryEvents
+  );
+  completeRecommendedClaimIntent(colony, targetRoom, controller.id);
+  recordColonyExpansionClaimVerification({
+    colony,
+    targetRoom,
+    status: 'claimed',
+    controllerId: controller.id,
+    creepName: creep.name,
+    updatedAt: getGameTime()
+  });
+}
+
+function recordRecommendedClaimTerminalFailure(
+  creep: Creep,
+  assignment: CreepTerritoryMemory,
+  result: ScreepsReturnCode,
+  reason: RuntimeTerritoryClaimTelemetryReason,
+  options: {
+    controllerId?: Id<StructureController>;
+    suppressIntent: boolean;
+    telemetryEvents?: RuntimeTelemetryEvent[];
+  }
+): void {
+  const colony = getClaimColony(creep);
+  recordTerritoryClaimTelemetry(options.telemetryEvents ?? [], {
+    colony,
+    targetRoom: assignment.targetRoom,
+    ...(options.controllerId ?? assignment.controllerId
+      ? { controllerId: (options.controllerId ?? assignment.controllerId) as Id<StructureController> }
+      : {}),
+    creepName: creep.name,
+    phase: 'claim',
+    result,
+    reason
+  });
+  if (options.suppressIntent) {
+    suppressRecommendedClaimIntent(colony, assignment, getGameTime(), options.controllerId, reason);
+  }
+  recordColonyExpansionClaimVerification({
+    colony,
+    targetRoom: assignment.targetRoom,
+    status: 'failed',
+    ...(options.controllerId ?? assignment.controllerId
+      ? { controllerId: (options.controllerId ?? assignment.controllerId) as Id<StructureController> }
+      : {}),
+    creepName: creep.name,
+    result,
+    reason,
+    updatedAt: getGameTime()
+  });
+}
+
+function recordRecommendedClaimRetry(
+  creep: Creep,
+  assignment: CreepTerritoryMemory,
+  result: ScreepsReturnCode,
+  reason: RuntimeTerritoryClaimTelemetryReason,
+  options: {
+    controllerId?: Id<StructureController>;
+    releaseAssignment?: boolean;
+    requiresControllerPressure?: boolean;
+    telemetryEvents?: RuntimeTelemetryEvent[];
+  } = {}
+): void {
+  const colony = getClaimColony(creep);
+  recordTerritoryClaimTelemetry(options.telemetryEvents ?? [], {
+    colony,
+    targetRoom: assignment.targetRoom,
+    ...(options.controllerId ?? assignment.controllerId
+      ? { controllerId: (options.controllerId ?? assignment.controllerId) as Id<StructureController> }
+      : {}),
+    creepName: creep.name,
+    phase: 'claim',
+    result,
+    reason
+  });
+  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime(), options);
+}
+
+function updateRecommendedClaimIntentForRetry(
+  colony: string,
+  assignment: CreepTerritoryMemory,
+  gameTime: number,
+  options: {
+    controllerId?: Id<StructureController>;
+    releaseAssignment?: boolean;
+    requiresControllerPressure?: boolean;
+  }
+): void {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  for (let i = 0; i < intents.length; i += 1) {
+    const intent = intents[i];
+    if (!isMatchingRecommendedClaimIntent(intent, colony, assignment.targetRoom, undefined, allowUnscopedIntent)) {
+      continue;
+    }
+
+    intents[i] = {
+      ...intent,
+      status: options.releaseAssignment ? 'planned' : 'active',
+      updatedAt: gameTime,
+      lastAttemptAt: gameTime,
+      ...(options.controllerId ?? assignment.controllerId
+        ? { controllerId: (options.controllerId ?? assignment.controllerId) as Id<StructureController> }
+        : {}),
+      ...(options.requiresControllerPressure || intent.requiresControllerPressure
+        ? { requiresControllerPressure: true }
+        : {})
+    };
+  }
+}
+
+function suppressRecommendedClaimIntent(
+  colony: string,
+  assignment: CreepTerritoryMemory,
+  gameTime: number,
+  controllerId: Id<StructureController> | undefined,
+  reason: RuntimeTerritoryClaimTelemetryReason
+): void {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  for (let i = 0; i < intents.length; i += 1) {
+    const intent = intents[i];
+    if (!isMatchingRecommendedClaimIntent(intent, colony, assignment.targetRoom, undefined, allowUnscopedIntent)) {
+      continue;
+    }
+
+    intents[i] = {
+      ...intent,
+      status: 'suppressed',
+      updatedAt: gameTime,
+      lastAttemptAt: gameTime,
+      ...(controllerId ?? assignment.controllerId
+        ? { controllerId: (controllerId ?? assignment.controllerId) as Id<StructureController> }
+        : {}),
+      ...(reason === 'controllerReserved' || intent.requiresControllerPressure
+        ? { requiresControllerPressure: true }
+        : {})
+    };
+  }
+}
+
+function completeRecommendedClaimIntent(
+  colony: string,
+  targetRoom: string,
+  controllerId: Id<StructureController>
+): void {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return;
+  }
+
+  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, targetRoom);
+  territoryMemory.intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
+    (intent) => !isMatchingRecommendedClaimIntent(intent, colony, targetRoom, controllerId, allowUnscopedIntent)
+  );
+
+  if (Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = territoryMemory.targets.filter(
+      (target) => !isMatchingRecommendedClaimTarget(target, colony, targetRoom)
+    );
+  }
+}
+
+function isMatchingRecommendedClaimIntent(
+  intent: TerritoryIntentMemory,
+  colony: string,
+  targetRoom: string,
+  controllerId?: Id<StructureController>,
+  allowUnscopedIntent = false
+): boolean {
+  return (
+    intent.colony === colony &&
+    intent.targetRoom === targetRoom &&
+    intent.action === 'claim' &&
+    ((intent.createdBy !== undefined && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(intent.createdBy)) ||
+      (allowUnscopedIntent && intent.createdBy === undefined)) &&
+    (!controllerId || !intent.controllerId || intent.controllerId === controllerId)
+  );
+}
+
+function hasRecommendedClaimTarget(territoryMemory: TerritoryMemory, colony: string, targetRoom: string): boolean {
+  return Array.isArray(territoryMemory.targets)
+    ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom))
+    : false;
+}
+
+function isMatchingRecommendedClaimTarget(target: unknown, colony: string, targetRoom: string): boolean {
+  return (
+    isRecord(target) &&
+    target.colony === colony &&
+    target.roomName === targetRoom &&
+    target.action === 'claim' &&
+    isTerritoryAutomationSource(target.createdBy) &&
+    RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy)
+  );
+}
+
+function recordColonyExpansionClaimVerification(input: {
+  colony: string;
+  targetRoom: string;
+  status: 'claimed' | 'failed';
+  updatedAt: number;
+  controllerId?: Id<StructureController>;
+  creepName?: string;
+  result?: ScreepsReturnCode;
+  reason?: RuntimeTerritoryClaimTelemetryReason;
+}): void {
+  const colonyRoom = getVisibleRoom(input.colony) as (Room & { memory?: RoomMemory }) | undefined;
+  const selection = colonyRoom?.memory?.cachedExpansionSelection;
+  if (!isRecord(selection) || selection.targetRoom !== input.targetRoom) {
+    return;
+  }
+
+  (selection as Record<string, unknown>).claimExecution = {
+    status: input.status,
+    targetRoom: input.targetRoom,
+    updatedAt: input.updatedAt,
+    ...(input.controllerId ? { controllerId: input.controllerId } : {}),
+    ...(input.creepName ? { creepName: input.creepName } : {}),
+    ...(input.result !== undefined ? { result: input.result } : {}),
+    ...(input.reason ? { reason: input.reason } : {})
+  };
+}
+
+function isClaimVerified(targetRoom: string, controller: StructureController): boolean {
+  return getVisibleClaimedRoom(targetRoom, controller)?.controller?.my === true;
+}
+
+function getVisibleClaimedRoom(targetRoom: string, controller: StructureController): Room | null {
+  const controllerRoom = controller.room;
+  if (controllerRoom?.controller?.my === true) {
+    return controllerRoom;
+  }
+
+  const gameRoom = getVisibleRoom(targetRoom);
+  return gameRoom?.controller?.my === true ? gameRoom : null;
+}
+
+function completeClaimAssignment(creep: Creep): void {
+  delete creep.memory.territory;
+}
+
+function getClaimColony(creep: Creep, controller?: StructureController): string {
+  return creep.memory.colony ?? creep.room?.name ?? controller?.room?.name ?? 'unknown';
+}
+
+function isForeignOwnedController(controller: StructureController): boolean {
+  return controller.my !== true && isNonEmptyString(getControllerOwnerUsername(controller));
+}
+
+function isForeignReservedController(controller: StructureController, colony: string | undefined): boolean {
+  const reservationUsername = controller.reservation?.username;
+  if (!isNonEmptyString(reservationUsername)) {
+    return false;
+  }
+
+  return reservationUsername !== getControllerOwnerUsername(getVisibleRoom(colony ?? '')?.controller);
+}
+
+function getKnownActiveClaimPartCount(creep: Creep): number | null {
+  const claimPart = getBodyPartConstant('CLAIM', 'claim');
+  const activeClaimParts = creep.getActiveBodyparts?.(claimPart);
+  if (typeof activeClaimParts === 'number') {
+    return activeClaimParts;
+  }
+
+  return Array.isArray(creep.body)
+    ? creep.body.filter((part) => isActiveBodyPart(part, claimPart)).length
+    : null;
+}
+
+function isActiveBodyPart(part: unknown, bodyPartType: BodyPartConstant): boolean {
+  if (typeof part !== 'object' || part === null) {
+    return false;
+  }
+
+  const bodyPart = part as Partial<BodyPartDefinition>;
+  return bodyPart.type === bodyPartType && typeof bodyPart.hits === 'number' && bodyPart.hits > 0;
+}
+
+function getBodyPartConstant(globalName: 'CLAIM', fallback: BodyPartConstant): BodyPartConstant {
+  const constants = globalThis as unknown as Partial<Record<'CLAIM', BodyPartConstant>>;
+  return constants[globalName] ?? fallback;
+}
+
+function isTerritoryAutomationSource(source: unknown): source is TerritoryAutomationSource {
+  return (
+    source === 'occupationRecommendation' ||
+    source === 'autonomousExpansionClaim' ||
+    source === 'colonyExpansion' ||
+    source === 'nextExpansionScoring' ||
+    source === 'adjacentRoomReservation'
+  );
+}
+
 function isAutonomousExpansionClaimTarget(target: unknown, colony: string): boolean {
   return (
     isRecord(target) &&
@@ -898,6 +1530,11 @@ function getTargetKey(roomName: string, action: TerritoryIntentAction): string {
 
 function getVisibleRoom(roomName: string): Room | undefined {
   return (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[roomName];
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof gameTime === 'number' ? gameTime : 0;
 }
 
 function getTerritoryMemoryRecord(): TerritoryMemory | undefined {

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -122,16 +122,25 @@ export function runRecommendedExpansionClaimExecutor(
     return false;
   }
 
-  if (creep.room?.name !== assignment.targetRoom) {
-    moveTowardClaimTarget(creep, assignment);
-    return true;
-  }
-
   const gameTime = getGameTime();
   const execution = assignment as ClaimExecutionAssignment;
   if (typeof execution.claimStartedAt !== 'number' || execution.claimStartedAt > gameTime) {
     execution.claimStartedAt = gameTime;
     execution.claimAttemptCount = 0;
+  }
+
+  if (creep.room?.name !== assignment.targetRoom) {
+    if (hasClaimExecutionTimedOut(execution, gameTime)) {
+      recordRecommendedClaimTerminalFailure(creep, assignment, ERR_INVALID_TARGET_CODE, 'claimFailed', {
+        suppressIntent: true,
+        telemetryEvents
+      });
+      completeClaimAssignment(creep);
+      return true;
+    }
+
+    moveTowardClaimTarget(creep, assignment);
+    return true;
   }
 
   const controller = selectClaimTargetController(creep, assignment);
@@ -1029,8 +1038,8 @@ function getClaimResultReason(result: ScreepsReturnCode): RuntimeTerritoryClaimT
 }
 
 function getControllerClaimCooldown(controller: StructureController): number {
-  const upgradeBlocked = (controller as StructureController & { upgradeBlocked?: number }).upgradeBlocked;
-  return typeof upgradeBlocked === 'number' && upgradeBlocked > 0 ? upgradeBlocked : 0;
+  const claimCooldown = (controller as StructureController & { claimCooldown?: number }).claimCooldown;
+  return typeof claimCooldown === 'number' && claimCooldown > 0 ? claimCooldown : 0;
 }
 
 function isClaimExecutionAssignment(assignment: CreepTerritoryMemory | undefined): assignment is CreepTerritoryMemory {

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -3,6 +3,7 @@ import type { RuntimeTelemetryEvent } from '../src/telemetry/runtimeSummary';
 import {
   clearAutonomousExpansionClaimIntent,
   refreshAutonomousExpansionClaimIntent,
+  runRecommendedExpansionClaimExecutor,
   shouldDeferOccupationRecommendationForExpansionClaim
 } from '../src/territory/claimExecutor';
 import type {
@@ -20,6 +21,13 @@ describe('autonomous expansion claim executor', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 3;
     (globalThis as unknown as { FIND_MINERALS: number }).FIND_MINERALS = 4;
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { RoomPosition: RoomPositionConstructor }).RoomPosition = class {
+      constructor(
+        public readonly x: number,
+        public readonly y: number,
+        public readonly roomName: string
+      ) {}
+    } as RoomPositionConstructor;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       rooms: {},
@@ -39,6 +47,7 @@ describe('autonomous expansion claim executor', () => {
     delete (globalThis as { FIND_SOURCES?: number }).FIND_SOURCES;
     delete (globalThis as { FIND_MINERALS?: number }).FIND_MINERALS;
     delete (globalThis as { STRUCTURE_SPAWN?: StructureConstant }).STRUCTURE_SPAWN;
+    delete (globalThis as { RoomPosition?: RoomPositionConstructor }).RoomPosition;
   });
 
   it('records a claim intent for the best expansion-scored adjacent room above threshold', () => {
@@ -937,7 +946,7 @@ describe('autonomous expansion claim executor', () => {
   it('defers the reserve fallback while the target controller is on cooldown', () => {
     (Game.rooms as Record<string, Room>).W2N1 = makeTargetRoom('W2N1', {
       controllerId: 'controller2' as Id<StructureController>,
-      claimCooldown: 25
+      upgradeBlocked: 25
     });
 
     const evaluation = refreshAutonomousExpansionClaimIntent(
@@ -963,7 +972,7 @@ describe('autonomous expansion claim executor', () => {
     });
   });
 
-  it('plans a claim when the target controller only has upgradeBlocked', () => {
+  it('defers the claim while the target controller only has upgradeBlocked cooldown', () => {
     (Game.rooms as Record<string, Room>).W2N1 = makeTargetRoom('W2N1', {
       controllerId: 'controller2' as Id<StructureController>,
       upgradeBlocked: 25
@@ -976,32 +985,13 @@ describe('autonomous expansion claim executor', () => {
     );
 
     expect(evaluation).toMatchObject({
-      status: 'planned',
+      status: 'skipped',
       colony: 'W1N1',
       targetRoom: 'W2N1',
-      controllerId: 'controller2'
+      reason: 'controllerCooldown'
     });
     expect(shouldDeferOccupationRecommendationForExpansionClaim(evaluation)).toBe(true);
-    expect(Memory.territory?.targets).toEqual([
-      {
-        colony: 'W1N1',
-        roomName: 'W2N1',
-        action: 'claim',
-        createdBy: 'autonomousExpansionClaim',
-        controllerId: 'controller2'
-      }
-    ]);
-    expect(Memory.territory?.intents).toEqual([
-      {
-        colony: 'W1N1',
-        targetRoom: 'W2N1',
-        action: 'claim',
-        status: 'planned',
-        updatedAt: 103,
-        createdBy: 'autonomousExpansionClaim',
-        controllerId: 'controller2'
-      }
-    ]);
+    expect(Memory.territory?.targets).toBeUndefined();
   });
 
   it('marks and emits a gclInsufficient skip when GCL room cap is reached', () => {
@@ -1050,7 +1040,106 @@ describe('autonomous expansion claim executor', () => {
       sourceCount: 1
     });
   });
+
+  it('does not move a recommended claimer toward a visible hostile target room', () => {
+    const controllerId = 'controller2' as Id<StructureController>;
+    (Game as { time: number }).time = 2_001;
+    (Game.rooms as Record<string, Room>).W2N1 = makeTargetRoom('W2N1', {
+      controllerId,
+      hostileCreeps: [{ id: 'enemy1' } as Creep]
+    });
+    seedRecommendedClaimMemory({ controllerId, updatedAt: 2_000 });
+    const creep = makeRecommendedClaimCreep({ controllerId });
+
+    expect(runRecommendedExpansionClaimExecutor(creep)).toBe(true);
+
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 2_001,
+        createdBy: 'autonomousExpansionClaim',
+        controllerId
+      }
+    ]);
+  });
+
+  it('does not act on a recommended claimer while the claim intent is suspended', () => {
+    const controllerId = 'controller2' as Id<StructureController>;
+    (Game as { time: number }).time = 2_051;
+    seedRecommendedClaimMemory({
+      controllerId,
+      updatedAt: 2_000,
+      suspended: {
+        reason: 'hostile_presence',
+        hostileCount: 1,
+        updatedAt: 2_050
+      }
+    });
+    const creep = makeRecommendedClaimCreep({ controllerId });
+
+    expect(runRecommendedExpansionClaimExecutor(creep)).toBe(true);
+
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents?.[0]).toMatchObject({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      status: 'active',
+      updatedAt: 2_000,
+      createdBy: 'autonomousExpansionClaim',
+      controllerId,
+      suspended: {
+        reason: 'hostile_presence',
+        hostileCount: 1,
+        updatedAt: 2_050
+      }
+    });
+  });
+
+  it('respects fresh suppression for recommended claim intents', () => {
+    const controllerId = 'controller2' as Id<StructureController>;
+    (Game as { time: number }).time = 2_101;
+    (Game.rooms as Record<string, Room>).W2N1 = makeTargetRoom('W2N1', { controllerId });
+    seedRecommendedClaimMemory({
+      controllerId,
+      status: 'suppressed',
+      updatedAt: 2_100
+    });
+    const creep = makeRecommendedClaimCreep({ controllerId });
+
+    expect(runRecommendedExpansionClaimExecutor(creep)).toBe(true);
+
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 2_100,
+        createdBy: 'autonomousExpansionClaim',
+        controllerId
+      }
+    ]);
+  });
 });
+
+type RoomPositionConstructor = new (x: number, y: number, roomName: string) => RoomPosition;
+type MockClaimCreep = Creep & {
+  moveTo: jest.Mock;
+  claimController: jest.Mock;
+  memory: CreepMemory & { territory?: CreepTerritoryMemory };
+};
 
 function makeColony({
   roomName = 'W1N1',
@@ -1119,14 +1208,12 @@ function makeTargetRoom(
   roomName: string,
   {
     controllerId,
-    claimCooldown = 0,
     upgradeBlocked = 0,
     sourceCount = 1,
     hostileCreeps = [],
     hostileStructures = []
   }: {
     controllerId: Id<StructureController>;
-    claimCooldown?: number;
     upgradeBlocked?: number;
     sourceCount?: number;
     hostileCreeps?: Creep[];
@@ -1138,9 +1225,8 @@ function makeTargetRoom(
     controller: {
       id: controllerId,
       my: false,
-      ...(claimCooldown > 0 ? { claimCooldown } : {}),
       ...(upgradeBlocked > 0 ? { upgradeBlocked } : {})
-    } as StructureController & { claimCooldown?: number },
+    } as StructureController & { upgradeBlocked?: number },
     find: jest.fn((type: number) => {
       if (type === FIND_HOSTILE_CREEPS) {
         return hostileCreeps;
@@ -1161,6 +1247,59 @@ function makeTargetRoom(
       return [];
     })
   } as unknown as Room;
+}
+
+function seedRecommendedClaimMemory(intent: Partial<TerritoryIntentMemory> = {}): void {
+  const controllerId = intent.controllerId ?? ('controller2' as Id<StructureController>);
+  (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+    territory: {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'claim',
+          createdBy: 'autonomousExpansionClaim',
+          controllerId
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'claim',
+          status: 'active',
+          updatedAt: 2_000,
+          createdBy: 'autonomousExpansionClaim',
+          controllerId,
+          ...intent
+        }
+      ]
+    }
+  };
+}
+
+function makeRecommendedClaimCreep({
+  controllerId = 'controller2' as Id<StructureController>,
+  room = { name: 'W1N1' } as Room
+}: {
+  controllerId?: Id<StructureController>;
+  room?: Room;
+} = {}): MockClaimCreep {
+  return {
+    name: 'Claimer1',
+    memory: {
+      role: 'claimer',
+      colony: 'W1N1',
+      territory: {
+        targetRoom: 'W2N1',
+        action: 'claim',
+        controllerId
+      }
+    },
+    room,
+    moveTo: jest.fn(),
+    claimController: jest.fn()
+  } as unknown as MockClaimCreep;
 }
 
 function makeMap(exitsByRoom: Record<string, Partial<Record<'1' | '3' | '5' | '7', string>>>): GameMap {

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -937,7 +937,7 @@ describe('autonomous expansion claim executor', () => {
   it('defers the reserve fallback while the target controller is on cooldown', () => {
     (Game.rooms as Record<string, Room>).W2N1 = makeTargetRoom('W2N1', {
       controllerId: 'controller2' as Id<StructureController>,
-      upgradeBlocked: 25
+      claimCooldown: 25
     });
 
     const evaluation = refreshAutonomousExpansionClaimIntent(
@@ -961,6 +961,47 @@ describe('autonomous expansion claim executor', () => {
       controller: { id: 'controller2', my: false },
       sourceCount: 1
     });
+  });
+
+  it('plans a claim when the target controller only has upgradeBlocked', () => {
+    (Game.rooms as Record<string, Room>).W2N1 = makeTargetRoom('W2N1', {
+      controllerId: 'controller2' as Id<StructureController>,
+      upgradeBlocked: 25
+    });
+
+    const evaluation = refreshAutonomousExpansionClaimIntent(
+      makeColony(),
+      makeReport([makeCandidate({ roomName: 'W2N1', controllerId: 'controller2' as Id<StructureController> })]),
+      103
+    );
+
+    expect(evaluation).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2'
+    });
+    expect(shouldDeferOccupationRecommendationForExpansionClaim(evaluation)).toBe(true);
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'autonomousExpansionClaim',
+        controllerId: 'controller2'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 103,
+        createdBy: 'autonomousExpansionClaim',
+        controllerId: 'controller2'
+      }
+    ]);
   });
 
   it('marks and emits a gclInsufficient skip when GCL room cap is reached', () => {
@@ -1078,12 +1119,14 @@ function makeTargetRoom(
   roomName: string,
   {
     controllerId,
+    claimCooldown = 0,
     upgradeBlocked = 0,
     sourceCount = 1,
     hostileCreeps = [],
     hostileStructures = []
   }: {
     controllerId: Id<StructureController>;
+    claimCooldown?: number;
     upgradeBlocked?: number;
     sourceCount?: number;
     hostileCreeps?: Creep[];
@@ -1095,8 +1138,9 @@ function makeTargetRoom(
     controller: {
       id: controllerId,
       my: false,
+      ...(claimCooldown > 0 ? { claimCooldown } : {}),
       ...(upgradeBlocked > 0 ? { upgradeBlocked } : {})
-    } as StructureController,
+    } as StructureController & { claimCooldown?: number },
     find: jest.fn((type: number) => {
       if (type === FIND_HOSTILE_CREEPS) {
         return hostileCreeps;

--- a/prod/test/claimerRunner.test.ts
+++ b/prod/test/claimerRunner.test.ts
@@ -1,5 +1,6 @@
 import { runClaimer } from '../src/creeps/claimerRunner';
 import { buildTerritoryControllerBody } from '../src/spawn/bodyBuilder';
+import { EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS } from '../src/territory/claimExecutor';
 
 describe('runClaimer', () => {
   beforeEach(() => {
@@ -31,6 +32,38 @@ describe('runClaimer', () => {
     expect(creep.claimController).not.toHaveBeenCalled();
   });
 
+  it('routes recommended expansion claimers toward the visible target controller', () => {
+    const colonyRoom = makeColonyRoom();
+    const controller = { id: 'controller1', my: false } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 519,
+      rooms: {
+        W1N1: colonyRoom,
+        W2N1: { name: 'W2N1', controller } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: makeRecommendedClaimMemory()
+    };
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W1N1' },
+      moveTo: jest.fn(),
+      claimController: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+    expect(creep.claimController).not.toHaveBeenCalled();
+  });
+
   it('claims the target controller when in the target room', () => {
     const controller = { id: 'controller1', my: false } as StructureController;
     const getObjectById = jest.fn().mockReturnValue(controller);
@@ -59,6 +92,226 @@ describe('runClaimer', () => {
     expect(getObjectById).toHaveBeenCalledWith('controller1');
     expect(creep.claimController).toHaveBeenCalledWith(controller);
     expect(creep.moveTo).toHaveBeenCalledWith(controller);
+  });
+
+  it('records successful recommended expansion claims and clears completed claim pressure', () => {
+    const colonyRoom = makeColonyRoom();
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const targetRoom = { name: 'W2N1', controller } as unknown as Room;
+    const getObjectById = jest.fn().mockReturnValue(controller);
+    const events: Parameters<typeof runClaimer>[1] = [];
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 520,
+      rooms: {
+        W1N1: colonyRoom,
+        W2N1: targetRoom
+      },
+      getObjectById
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: makeRecommendedClaimMemory()
+    };
+
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W2N1', controller },
+      claimController: jest.fn(() => {
+        (controller as StructureController & { my: boolean }).my = true;
+        return 0 as ScreepsReturnCode;
+      }),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep, events);
+
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.targets).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([]);
+    expect(Memory.territory?.postClaimBootstraps?.W2N1).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'detected',
+      claimedAt: 520,
+      updatedAt: 520,
+      controllerId: 'controller1'
+    });
+    expect((colonyRoom.memory.cachedExpansionSelection as unknown as Record<string, unknown>).claimExecution).toEqual({
+      status: 'claimed',
+      targetRoom: 'W2N1',
+      updatedAt: 520,
+      controllerId: 'controller1',
+      creepName: 'Claimer1'
+    });
+  });
+
+  it('keeps recommended expansion claims retryable after a missing CLAIM part failure', () => {
+    const colonyRoom = makeColonyRoom();
+    const controller = { id: 'controller1', my: false } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 521,
+      rooms: {
+        W1N1: colonyRoom,
+        W2N1: { name: 'W2N1', controller } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: makeRecommendedClaimMemory()
+    };
+
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W2N1', controller },
+      body: [{ type: 'claim', hits: 0 }],
+      getActiveBodyparts: jest.fn().mockReturnValue(0),
+      claimController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller1'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 521,
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller1',
+        lastAttemptAt: 521
+      }
+    ]);
+    expect(
+      (colonyRoom.memory.cachedExpansionSelection as unknown as Record<string, unknown>).claimExecution
+    ).toBeUndefined();
+  });
+
+  it('suppresses and reports a recommended expansion claim after execution timeout', () => {
+    const colonyRoom = makeColonyRoom();
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const startedAt = 100;
+    const timedOutAt = startedAt + EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: timedOutAt,
+      rooms: {
+        W1N1: colonyRoom,
+        W2N1: { name: 'W2N1', controller } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: makeRecommendedClaimMemory()
+    };
+
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: {
+          targetRoom: 'W2N1',
+          action: 'claim',
+          controllerId: 'controller1' as Id<StructureController>,
+          claimStartedAt: startedAt
+        } as CreepTerritoryMemory & { claimStartedAt: number }
+      },
+      room: { name: 'W2N1', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      claimController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: timedOutAt,
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller1',
+        lastAttemptAt: timedOutAt
+      }
+    ]);
+    expect((colonyRoom.memory.cachedExpansionSelection as unknown as Record<string, unknown>).claimExecution).toEqual({
+      status: 'failed',
+      targetRoom: 'W2N1',
+      updatedAt: timedOutAt,
+      controllerId: 'controller1',
+      creepName: 'Claimer1',
+      result: -7,
+      reason: 'claimFailed'
+    });
+  });
+
+  it('treats an already-owned recommended expansion controller as a verified claim', () => {
+    const colonyRoom = makeColonyRoom();
+    const controller = { id: 'controller1', my: true } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 522,
+      rooms: {
+        W1N1: colonyRoom,
+        W2N1: { name: 'W2N1', controller } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: makeRecommendedClaimMemory()
+    };
+
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W2N1', controller },
+      claimController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.targets).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([]);
+    expect(
+      (colonyRoom.memory.cachedExpansionSelection as unknown as Record<string, unknown>).claimExecution
+    ).toMatchObject({
+      status: 'claimed',
+      targetRoom: 'W2N1',
+      updatedAt: 522,
+      controllerId: 'controller1'
+    });
   });
 
   it('keeps a large generated claimer body mobile enough to travel to the target', () => {
@@ -157,3 +410,43 @@ describe('runClaimer', () => {
     ]);
   });
 });
+
+function makeColonyRoom(): Room & { memory: RoomMemory } {
+  return {
+    name: 'W1N1',
+    memory: {
+      cachedExpansionSelection: {
+        status: 'planned',
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        controllerId: 'controller1' as Id<StructureController>,
+        score: 1_000
+      }
+    }
+  } as unknown as Room & { memory: RoomMemory };
+}
+
+function makeRecommendedClaimMemory(): TerritoryMemory {
+  return {
+    targets: [
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller1' as Id<StructureController>
+      }
+    ],
+    intents: [
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'active',
+        updatedAt: 519,
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller1' as Id<StructureController>
+      }
+    ]
+  };
+}

--- a/prod/test/claimerRunner.test.ts
+++ b/prod/test/claimerRunner.test.ts
@@ -62,6 +62,10 @@ describe('runClaimer', () => {
 
     expect(creep.moveTo).toHaveBeenCalledWith(controller);
     expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toMatchObject({
+      claimStartedAt: 519,
+      claimAttemptCount: 0
+    });
   });
 
   it('claims the target controller when in the target room', () => {
@@ -246,6 +250,66 @@ describe('runClaimer', () => {
 
     runClaimer(creep);
 
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: timedOutAt,
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller1',
+        lastAttemptAt: timedOutAt
+      }
+    ]);
+    expect((colonyRoom.memory.cachedExpansionSelection as unknown as Record<string, unknown>).claimExecution).toEqual({
+      status: 'failed',
+      targetRoom: 'W2N1',
+      updatedAt: timedOutAt,
+      controllerId: 'controller1',
+      creepName: 'Claimer1',
+      result: -7,
+      reason: 'claimFailed'
+    });
+  });
+
+  it('suppresses and reports a recommended expansion claim that times out before room entry', () => {
+    const colonyRoom = makeColonyRoom();
+    const startedAt = 100;
+    const timedOutAt = startedAt + EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: timedOutAt,
+      rooms: {
+        W1N1: colonyRoom
+      },
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: makeRecommendedClaimMemory()
+    };
+
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: {
+          targetRoom: 'W2N1',
+          action: 'claim',
+          controllerId: 'controller1' as Id<StructureController>,
+          claimStartedAt: startedAt
+        } as CreepTerritoryMemory & { claimStartedAt: number }
+      },
+      room: { name: 'W1N1' },
+      claimController: jest.fn(),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.moveTo).not.toHaveBeenCalled();
     expect(creep.claimController).not.toHaveBeenCalled();
     expect(creep.memory.territory).toBeUndefined();
     expect(Memory.territory?.intents).toEqual([

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -485,8 +485,8 @@ describe('runTerritoryControllerCreep', () => {
     const controller = {
       id: 'controller1',
       my: false,
-      upgradeBlocked: 10
-    } as StructureController;
+      claimCooldown: 10
+    } as StructureController & { claimCooldown: number };
     const telemetryEvents: RuntimeTelemetryEvent[] = [];
     const creep = {
       name: 'Claimer1',

--- a/prod/test/territoryRunner.test.ts
+++ b/prod/test/territoryRunner.test.ts
@@ -485,8 +485,8 @@ describe('runTerritoryControllerCreep', () => {
     const controller = {
       id: 'controller1',
       my: false,
-      claimCooldown: 10
-    } as StructureController & { claimCooldown: number };
+      upgradeBlocked: 10
+    } as StructureController & { upgradeBlocked: number };
     const telemetryEvents: RuntimeTelemetryEvent[] = [];
     const creep = {
       name: 'Claimer1',


### PR DESCRIPTION
## Summary
Improves territory claim execution reliability for recommended adjacent rooms after colony expansion planning identifies them.

## Changes
- `prod/src/territory/claimExecutor.ts` — enhanced claim execution with retry, verification, and timeout handling
- `prod/src/creeps/claimerRunner.ts` — claimer runner integration with improved claim flow
- `prod/test/claimerRunner.test.ts` — tests for claim execution reliability

## Verification
- Typecheck: PASS
- Jest: 1034/1034 tests PASS
- Build: PASS

Closes #626
