### PR TITLE
feat(rl): prototype offline strategy recommendation engine with dataset extraction (#266)

### DIFF
--- a/docs/research/strategy-dataset-card.md
+++ b/docs/research/strategy-dataset-card.md
@@ -1,0 +1,73 @@
+# Strategy Recommendation Dataset Card
+
+## Purpose
+
+This first issue #266 slice defines an offline JSONL dataset for high-level Screeps strategy recommendation. It is intended for replay analysis, incumbent heuristic baselines, and future offline RL experiments. It is not approved to control live Screeps MMO behavior.
+
+## Source Windows
+
+- Extractor: `scripts/extract-strategy-dataset.py`
+- Default artifact scan roots: the existing runtime artifact scanner defaults from `scripts/screeps_rl_dataset_export.py`, including local `runtime-artifacts`, `/root/screeps/runtime-artifacts`, and cron output when present.
+- Source artifact types: `#runtime-summary` lines and JSON runtime summary documents discovered in local artifacts.
+- Windowing: per-room chronological windows, default size 3 runtime summaries. If fewer than 3 summaries exist for a room, the extractor may emit one partial window.
+- Raw artifact text is not copied into the dataset. Rows retain source path display names, line numbers, source SHA-256, tick, and selected numeric/label fields.
+
+## Strategy Versions
+
+- Registry source: `prod/src/strategy/strategyRegistry.ts`
+- Current incumbent families represented as labels:
+  - `construction-priority.incumbent.v1`
+  - `expansion-remote.incumbent.v1`
+  - `defense-repair.incumbent.v1`
+- Shadow candidates remain metadata only. Dataset rows label observed incumbent decisions and do not mark shadow candidates as live actions.
+
+## Observation Features
+
+Each JSONL row stores a room-state feature snapshot from the latest summary in the source window:
+
+- RCL: controller level.
+- Creeps: worker count, total count when available, task counts.
+- Energy: available energy, capacity, stored energy, carried energy, dropped energy.
+- Hostiles: hostile creep and hostile structure counts.
+- Territory: observed owned-room count, source count, remote candidate count, expansion candidate count, and next high-level territory target when present.
+
+## Action Labels
+
+Labels are high-level strategy surfaces only:
+
+- `strategyPreset`: joined incumbent strategy IDs selected from the registry for the observed decision surfaces.
+- `expansionTarget`: target room when the observed territory action is `claim` or `occupy`.
+- `remoteTarget`: target room when the observed territory action is `reserve` or `scout`.
+- `constructionPriority`: observed `constructionPriority.nextPrimary.buildItem`.
+- `defensePosture`: `passive`, `alert`, or `active` from hostile pressure.
+
+No row contains low-level creep intents, spawn commands, or direct construction placement actions as policy outputs.
+
+## Reward Construction
+
+Rows use a component reward label, not an approved scalar objective:
+
+- Territory: controller level delta across the window, owned-room observation, controller non-degradation, and downgrade guard.
+- Resources: stored energy delta and latest energy capacity.
+- Kills/defense: latest hostile pressure and matching defense posture.
+
+A row is emitted only when the heuristic success filter passes: at least one high-level label exists, the controller did not degrade, downgrade risk is not critical, worker survival is observed, and hostile pressure is either absent or paired with active defense posture.
+
+## Known Bias
+
+- Artifacts are local and opportunistic, so they overrepresent rooms and ticks where telemetry was enabled and saved.
+- Labels come from incumbent behavior, not expert human review or a trained optimum.
+- Early-game rooms may dominate because the current official target has historically focused on bootstrap and survival.
+- Hostile and combat labels depend on visibility; unseen adjacent-room risk is underrepresented.
+- Successful windows are filtered with conservative heuristics, which can exclude valid recovery states with incomplete telemetry.
+
+## Train/Eval Split
+
+- Method: deterministic SHA-256 threshold on `splitSeed:sampleId`.
+- Default eval ratio: `0.2`.
+- Default split seed: `screeps-strategy-recommendation-v1`.
+- Splits are stable for a fixed source set, window size, registry version, and sample ID construction.
+
+## Safety
+
+The dataset and recommender are shadow-mode only. Learned or heuristic recommendations must pass simulator evidence, historical MMO validation, KPI rollout gates, and rollback gates before any future live influence is considered.

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -20665,6 +20665,368 @@ function runClaimer(creep, telemetryEvents = []) {
   runTerritoryControllerCreep(creep, telemetryEvents);
 }
 
+// src/strategy/strategyRecommender.ts
+var DEFAULT_STRATEGY_RECOMMENDATION_CONFIDENCE_THRESHOLD = 0.7;
+var MAX_RECOMMENDATIONS = 5;
+var LOW_RCL_ENERGY_CAPACITY_TARGET = 550;
+var TERRITORY_READY_RCL = 3;
+var EXPANSION_READY_RCL = 4;
+var HIGH_RCL = 5;
+var CRITICAL_REPAIR_BACKLOG_HITS = 1e5;
+function rejectUncertain(recommendations, threshold = DEFAULT_STRATEGY_RECOMMENDATION_CONFIDENCE_THRESHOLD) {
+  const resolvedThreshold = clampConfidence(threshold);
+  return recommendations.filter(
+    (recommendation) => Number.isFinite(recommendation.confidence) && recommendation.confidence >= resolvedThreshold
+  );
+}
+function generateStrategyRecommendations(roomState) {
+  if (!hasRoomStateEvidence(roomState)) {
+    return [
+      makeRecommendation({
+        defensePosture: "passive",
+        confidence: 0.42,
+        reasoning: "room state is empty; keep strategy recommendation in observation-only mode"
+      })
+    ];
+  }
+  const state = normalizeRoomState(roomState);
+  const recommendations = [];
+  const hostilePressure = state.hostileCreepCount + state.hostileStructureCount;
+  if (hostilePressure > 0) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: "defense-repair-and-ramparts",
+        defensePosture: "active",
+        confidence: state.hostileCreepCount > 0 ? 0.94 : 0.86,
+        reasoning: `hostile pressure visible in ${state.roomName}; keep strategy shadowed on active defense posture`
+      })
+    );
+  } else if (state.controllerLevel >= TERRITORY_READY_RCL && state.towerCount === 0) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: "tower-bootstrap",
+        defensePosture: "alert",
+        confidence: 0.74,
+        reasoning: `${state.roomName} has RCL ${state.controllerLevel} but no tower coverage`
+      })
+    );
+  } else if (state.repairBacklogHits >= CRITICAL_REPAIR_BACKLOG_HITS) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: "critical-repair-stabilization",
+        defensePosture: "alert",
+        confidence: 0.72,
+        reasoning: `${state.roomName} has a large repair backlog before territory growth should escalate`
+      })
+    );
+  }
+  if (state.controllerLevel <= 1 || state.workerCount <= 1) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: "bootstrap-spawn-extension-sources",
+        defensePosture: hostilePressure > 0 ? "active" : "passive",
+        confidence: state.workerCount === 0 ? 0.84 : 0.8,
+        reasoning: `${state.roomName} needs bootstrap worker and source throughput before higher-level strategy changes`
+      })
+    );
+  } else if (state.controllerLevel <= 3 || state.energyCapacity < LOW_RCL_ENERGY_CAPACITY_TARGET) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: "extension-container-road-bootstrap",
+        defensePosture: hostilePressure > 0 ? "active" : "passive",
+        confidence: state.energyCapacity < LOW_RCL_ENERGY_CAPACITY_TARGET ? 0.82 : 0.76,
+        reasoning: `${state.roomName} should favor energy capacity, containers, and roads at RCL ${state.controllerLevel}`
+      })
+    );
+  } else if (state.controllerLevel >= HIGH_RCL) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: "storage-road-territory-logistics",
+        defensePosture: hostilePressure > 0 ? "active" : "passive",
+        confidence: state.energyCapacity >= 1300 || state.storedEnergy > 5e3 ? 0.78 : 0.7,
+        reasoning: `${state.roomName} has high-RCL infrastructure; prioritize logistics that support territory growth`
+      })
+    );
+  }
+  const remoteTarget = selectBestTerritoryCandidate(state.territory.remoteTargets);
+  if (remoteTarget && state.controllerLevel >= TERRITORY_READY_RCL && state.workerCount >= 3 && hostilePressure === 0) {
+    recommendations.push(
+      makeRecommendation({
+        remoteTarget: remoteTarget.roomName,
+        defensePosture: "passive",
+        confidence: scoreTerritoryCandidate2(remoteTarget, 0.72),
+        reasoning: `${remoteTarget.roomName} is the strongest low-risk remote target for ${state.roomName}`
+      })
+    );
+  }
+  const expansionCandidate = selectBestTerritoryCandidate(state.territory.expansionCandidates);
+  if (expansionCandidate && state.controllerLevel >= EXPANSION_READY_RCL && state.workerCount >= 4 && hostilePressure === 0) {
+    recommendations.push(
+      makeRecommendation({
+        expansionCandidate: expansionCandidate.roomName,
+        defensePosture: "passive",
+        confidence: scoreTerritoryCandidate2(expansionCandidate, 0.76),
+        reasoning: `${expansionCandidate.roomName} is the strongest shadow-mode expansion candidate for ${state.roomName}`
+      })
+    );
+  }
+  if (recommendations.length === 0) {
+    recommendations.push(
+      makeRecommendation({
+        defensePosture: "passive",
+        confidence: 0.42,
+        reasoning: `${state.roomName} has insufficient strategy evidence for a high-confidence recommendation`
+      })
+    );
+  }
+  return recommendations.sort((left, right) => right.confidence - left.confidence || left.reasoning.localeCompare(right.reasoning)).slice(0, MAX_RECOMMENDATIONS);
+}
+function hasRoomStateEvidence(roomState) {
+  return typeof roomState.roomName === "string" || Number.isFinite(roomState.controllerLevel) || Number.isFinite(roomState.creepCount) || Number.isFinite(roomState.workerCount) || Number.isFinite(roomState.energyAvailable) || Number.isFinite(roomState.energyCapacity) || Number.isFinite(roomState.sourceCount) || Number.isFinite(roomState.hostileCreepCount) || Number.isFinite(roomState.hostileStructureCount);
+}
+function buildStrategyRecommendationRoomState(colony, creeps) {
+  var _a;
+  const room = colony.room;
+  const colonyCreeps = creeps.filter(
+    (creep) => {
+      var _a2;
+      return creep.memory.colony === room.name || ((_a2 = creep.room) == null ? void 0 : _a2.name) === room.name;
+    }
+  );
+  const hostileCreeps = findRoomObjects13(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects13(room, "FIND_HOSTILE_STRUCTURES");
+  const ownedStructures = findRoomObjects13(room, "FIND_MY_STRUCTURES");
+  const constructionSites = findRoomObjects13(room, "FIND_MY_CONSTRUCTION_SITES");
+  const sources = findRoomObjects13(room, "FIND_SOURCES");
+  return {
+    roomName: room.name,
+    controllerLevel: (_a = room.controller) == null ? void 0 : _a.level,
+    creepCount: colonyCreeps.length,
+    workerCount: colonyCreeps.filter((creep) => creep.memory.role === "worker").length,
+    energyAvailable: colony.energyAvailable,
+    energyCapacity: colony.energyCapacityAvailable,
+    storedEnergy: getStoredEnergy11(room),
+    sourceCount: sources.length,
+    hostileCreepCount: hostileCreeps.length,
+    hostileStructureCount: hostileStructures.length,
+    towerCount: countStructuresByType3(ownedStructures, "STRUCTURE_TOWER", "tower"),
+    rampartCount: countStructuresByType3(ownedStructures, "STRUCTURE_RAMPART", "rampart"),
+    pendingConstructionSiteCount: constructionSites.length,
+    repairBacklogHits: estimateRepairBacklogHits(ownedStructures),
+    territory: buildMemoryTerritoryState(room.name)
+  };
+}
+function normalizeRoomState(roomState) {
+  var _a, _b, _c;
+  const workerCount = finiteNumberOrZero(roomState.workerCount);
+  const creepCount = Math.max(finiteNumberOrZero(roomState.creepCount), workerCount);
+  return {
+    roomName: roomState.roomName && roomState.roomName.length > 0 ? roomState.roomName : "unknown-room",
+    controllerLevel: clampInteger(roomState.controllerLevel, 0, 8),
+    creepCount,
+    workerCount,
+    energyAvailable: finiteNumberOrZero(roomState.energyAvailable),
+    energyCapacity: finiteNumberOrZero(roomState.energyCapacity),
+    storedEnergy: finiteNumberOrZero(roomState.storedEnergy),
+    sourceCount: finiteNumberOrZero(roomState.sourceCount),
+    hostileCreepCount: finiteNumberOrZero(roomState.hostileCreepCount),
+    hostileStructureCount: finiteNumberOrZero(roomState.hostileStructureCount),
+    towerCount: finiteNumberOrZero(roomState.towerCount),
+    rampartCount: finiteNumberOrZero(roomState.rampartCount),
+    pendingConstructionSiteCount: finiteNumberOrZero(roomState.pendingConstructionSiteCount),
+    repairBacklogHits: finiteNumberOrZero(roomState.repairBacklogHits),
+    territory: {
+      ownedRoomCount: finiteNumberOrZero((_a = roomState.territory) == null ? void 0 : _a.ownedRoomCount),
+      remoteTargets: normalizeTerritoryCandidates((_b = roomState.territory) == null ? void 0 : _b.remoteTargets),
+      expansionCandidates: normalizeTerritoryCandidates((_c = roomState.territory) == null ? void 0 : _c.expansionCandidates)
+    }
+  };
+}
+function normalizeTerritoryCandidates(candidates) {
+  if (!Array.isArray(candidates)) {
+    return [];
+  }
+  return candidates.filter((candidate) => candidate.roomName.length > 0).map((candidate) => ({
+    roomName: candidate.roomName,
+    ...candidate.action ? { action: candidate.action } : {},
+    ...Number.isFinite(candidate.score) ? { score: candidate.score } : {},
+    ...Number.isFinite(candidate.routeDistance) ? { routeDistance: candidate.routeDistance } : {},
+    ...Number.isFinite(candidate.sourceCount) ? { sourceCount: candidate.sourceCount } : {},
+    ...Number.isFinite(candidate.hostileCreepCount) ? { hostileCreepCount: candidate.hostileCreepCount } : {},
+    ...Number.isFinite(candidate.hostileStructureCount) ? { hostileStructureCount: candidate.hostileStructureCount } : {},
+    ...candidate.evidenceStatus ? { evidenceStatus: candidate.evidenceStatus } : {}
+  }));
+}
+function selectBestTerritoryCandidate(candidates) {
+  var _a;
+  return (_a = [...candidates].sort(compareTerritoryCandidates2)[0]) != null ? _a : null;
+}
+function compareTerritoryCandidates2(left, right) {
+  var _a, _b;
+  return scoreTerritoryCandidate2(right, 0) - scoreTerritoryCandidate2(left, 0) || ((_a = left.routeDistance) != null ? _a : Number.POSITIVE_INFINITY) - ((_b = right.routeDistance) != null ? _b : Number.POSITIVE_INFINITY) || left.roomName.localeCompare(right.roomName);
+}
+function scoreTerritoryCandidate2(candidate, baseConfidence) {
+  var _a, _b;
+  const rawScore = Number.isFinite(candidate.score) ? Math.min(Math.max((_a = candidate.score) != null ? _a : 0, 0) / 1e3, 0.12) : 0;
+  const sourceBonus = Math.min(finiteNumberOrZero(candidate.sourceCount) * 0.03, 0.06);
+  const routeBonus = Number.isFinite(candidate.routeDistance) && ((_b = candidate.routeDistance) != null ? _b : Number.POSITIVE_INFINITY) <= 2 ? 0.04 : 0;
+  const evidenceBonus = candidate.evidenceStatus === "sufficient" ? 0.05 : 0;
+  const hostilePenalty = finiteNumberOrZero(candidate.hostileCreepCount) > 0 || finiteNumberOrZero(candidate.hostileStructureCount) > 0 ? 0.36 : 0;
+  return clampConfidence(baseConfidence + rawScore + sourceBonus + routeBonus + evidenceBonus - hostilePenalty);
+}
+function makeRecommendation(recommendation) {
+  return {
+    ...recommendation,
+    confidence: clampConfidence(recommendation.confidence)
+  };
+}
+function buildMemoryTerritoryState(roomName) {
+  var _a, _b, _c, _d;
+  const memory = globalThis.Memory;
+  const targets = (_a = memory == null ? void 0 : memory.territory) == null ? void 0 : _a.targets;
+  const remoteTargets = [];
+  const expansionCandidates = [];
+  if (Array.isArray(targets)) {
+    for (const target of targets) {
+      if (!isRecord19(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+        continue;
+      }
+      const action = normalizeTerritoryAction(target.action);
+      if (!action) {
+        continue;
+      }
+      const candidate = {
+        roomName: target.roomName,
+        action
+      };
+      if (action === "claim") {
+        expansionCandidates.push(candidate);
+      } else {
+        remoteTargets.push(candidate);
+      }
+    }
+  }
+  const roomMemory = (_d = (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[roomName]) == null ? void 0 : _d.memory;
+  const cachedExpansionSelection = roomMemory == null ? void 0 : roomMemory.cachedExpansionSelection;
+  if ((cachedExpansionSelection == null ? void 0 : cachedExpansionSelection.status) === "planned" && cachedExpansionSelection.colony === roomName && cachedExpansionSelection.targetRoom) {
+    expansionCandidates.push({
+      roomName: cachedExpansionSelection.targetRoom,
+      action: "claim",
+      ...Number.isFinite(cachedExpansionSelection.score) ? { score: cachedExpansionSelection.score } : {}
+    });
+  }
+  return {
+    ownedRoomCount: countVisibleOwnedRooms3(),
+    remoteTargets: deduplicateTerritoryCandidates(remoteTargets),
+    expansionCandidates: deduplicateTerritoryCandidates(expansionCandidates)
+  };
+}
+function deduplicateTerritoryCandidates(candidates) {
+  const byRoom = /* @__PURE__ */ new Map();
+  for (const candidate of candidates) {
+    const existing = byRoom.get(candidate.roomName);
+    if (!existing || scoreTerritoryCandidate2(candidate, 0) > scoreTerritoryCandidate2(existing, 0)) {
+      byRoom.set(candidate.roomName, candidate);
+    }
+  }
+  return [...byRoom.values()].sort(compareTerritoryCandidates2);
+}
+function normalizeTerritoryAction(action) {
+  if (action === "claim" || action === "reserve" || action === "scout") {
+    return action;
+  }
+  return void 0;
+}
+function countVisibleOwnedRooms3() {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return 0;
+  }
+  return Object.values(rooms).filter((room) => {
+    var _a2;
+    return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
+  }).length;
+}
+function countStructuresByType3(structures, globalName, fallback) {
+  return structures.filter(
+    (structure) => isRecord19(structure) && matchesStructureType14(structure.structureType, globalName, fallback)
+  ).length;
+}
+function estimateRepairBacklogHits(structures) {
+  return structures.reduce((total, structure) => {
+    if (!isRecord19(structure)) {
+      return total;
+    }
+    const hits = finiteNumberOrNull(structure.hits);
+    const hitsMax = finiteNumberOrNull(structure.hitsMax);
+    if (hits === null || hitsMax === null || hitsMax <= hits) {
+      return total;
+    }
+    return total + (hitsMax - hits);
+  }, 0);
+}
+function getStoredEnergy11(room) {
+  const storage = room.storage;
+  return getEnergyInStore2(storage);
+}
+function getEnergyInStore2(object) {
+  if (!isRecord19(object) || !isRecord19(object.store)) {
+    return 0;
+  }
+  const getUsedCapacity = object.store.getUsedCapacity;
+  const resourceEnergy = getResourceEnergy();
+  if (typeof getUsedCapacity === "function") {
+    const value = getUsedCapacity.call(object.store, resourceEnergy);
+    return finiteNumberOrZero(value);
+  }
+  return finiteNumberOrZero(object.store[resourceEnergy]);
+}
+function findRoomObjects13(room, constantName) {
+  const findConstant = getGlobalNumber9(constantName);
+  const find = room.find;
+  if (typeof findConstant !== "number" || typeof find !== "function") {
+    return [];
+  }
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function matchesStructureType14(value, globalName, fallback) {
+  const globalValue = globalThis[globalName];
+  return value === globalValue || value === fallback;
+}
+function getResourceEnergy() {
+  const value = globalThis.RESOURCE_ENERGY;
+  return value != null ? value : "energy";
+}
+function getGlobalNumber9(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function clampInteger(value, min, max) {
+  return Math.trunc(Math.min(Math.max(finiteNumberOrZero(value), min), max));
+}
+function clampConfidence(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(Math.max(Number(value.toFixed(3)), 0), 1);
+}
+function finiteNumberOrZero(value) {
+  var _a;
+  return (_a = finiteNumberOrNull(value)) != null ? _a : 0;
+}
+function finiteNumberOrNull(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+function isRecord19(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
 var OK_CODE8 = 0;
@@ -20732,6 +21094,7 @@ function runEconomy(preludeTelemetryEvents = []) {
     }
     transferEnergy(colony.room);
     manageStorage(colony.room);
+    recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
   }
   for (const creep of creeps) {
     if (creep.memory.role === "worker") {
@@ -20747,6 +21110,27 @@ function runEconomy(preludeTelemetryEvents = []) {
     }
   }
   return emitRuntimeSummary(colonies, creeps, telemetryEvents, { persistOccupationRecommendations: false });
+}
+function recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents) {
+  if (!shouldRecordStrategyRecommendationTelemetry(Game.time)) {
+    return;
+  }
+  const recommendations = rejectUncertain(
+    generateStrategyRecommendations(buildStrategyRecommendationRoomState(colony, creeps))
+  );
+  if (recommendations.length === 0) {
+    return;
+  }
+  telemetryEvents.push({
+    type: "strategyRecommendation",
+    roomName: colony.room.name,
+    tick: Game.time,
+    shadow: true,
+    recommendations
+  });
+}
+function shouldRecordStrategyRecommendationTelemetry(gameTime) {
+  return gameTime > 0 && gameTime % RUNTIME_SUMMARY_INTERVAL === 0;
 }
 function planCriticalConstructionSites(colony, spawnConstructionPending, bootstrapNonCriticalConstructionSuppressed = false) {
   if (spawnConstructionPending || bootstrapNonCriticalConstructionSuppressed) {
@@ -20851,13 +21235,13 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber8(refreshedAt) || !isRecord19(rawSelection) || !isNonEmptyString18(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber8(refreshedAt) || !isRecord20(rawSelection) || !isNonEmptyString18(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord19(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord20(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
@@ -20898,7 +21282,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord19(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord20(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -20909,12 +21293,12 @@ function getNextExpansionSelectionCacheStateKey(colony) {
     colony.room.name,
     colony.energyCapacityAvailable,
     controllerLevel,
-    countVisibleOwnedRooms3(),
+    countVisibleOwnedRooms4(),
     downgradeState,
     countActivePostClaimBootstraps3()
   ].join("|");
 }
-function countVisibleOwnedRooms3() {
+function countVisibleOwnedRooms4() {
   var _a;
   const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
   if (!rooms) {
@@ -20928,14 +21312,14 @@ function countVisibleOwnedRooms3() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord19(records)) {
+  if (!isRecord20(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord19(record) && record.status !== "ready"
+    (record) => isRecord20(record) && record.status !== "ready"
   ).length;
 }
-function isRecord19(value) {
+function isRecord20(value) {
   return typeof value === "object" && value !== null;
 }
 function isNonEmptyString18(value) {
@@ -21948,10 +22332,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord20(rawReplay)) {
+  if (!isRecord21(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString19(rawReplay.replayId) || !isNonEmptyString19(rawReplay.room) || !isFiniteNumber9(rawReplay.startTick) || !isFiniteNumber9(rawReplay.endTick) || !isFiniteNumber9(rawReplay.finalScore) || !isRecord20(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString19(rawReplay.replayId) || !isNonEmptyString19(rawReplay.room) || !isFiniteNumber9(rawReplay.startTick) || !isFiniteNumber9(rawReplay.endTick) || !isFiniteNumber9(rawReplay.finalScore) || !isRecord21(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -21976,7 +22360,7 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord20(value) {
+function isRecord21(value) {
   return typeof value === "object" && value !== null;
 }
 function isNonEmptyString19(value) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -21115,9 +21115,14 @@ function recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents) 
   if (!shouldRecordStrategyRecommendationTelemetry(Game.time)) {
     return;
   }
-  const recommendations = rejectUncertain(
-    generateStrategyRecommendations(buildStrategyRecommendationRoomState(colony, creeps))
-  );
+  let recommendations;
+  try {
+    recommendations = rejectUncertain(
+      generateStrategyRecommendations(buildStrategyRecommendationRoomState(colony, creeps))
+    );
+  } catch {
+    return;
+  }
   if (recommendations.length === 0) {
     return;
   }

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -184,9 +184,14 @@ function recordStrategyRecommendationTelemetry(
     return;
   }
 
-  const recommendations = rejectUncertain(
-    generateStrategyRecommendations(buildStrategyRecommendationRoomState(colony, creeps))
-  );
+  let recommendations: import('../strategy/strategyRecommender').StrategyRecommendation[];
+  try {
+    recommendations = rejectUncertain(
+      generateStrategyRecommendations(buildStrategyRecommendationRoomState(colony, creeps))
+    );
+  } catch {
+    return;
+  }
   if (recommendations.length === 0) {
     return;
   }

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -15,7 +15,12 @@ import { HAULER_ROLE, runHauler } from '../creeps/hauler';
 import { REMOTE_HARVESTER_ROLE, runRemoteHarvester } from '../creeps/remoteHarvester';
 import { getBodyCost, TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS } from '../spawn/bodyBuilder';
 import { planSpawn, type SpawnPlanningOptions, type SpawnRequest } from '../spawn/spawnPlanner';
-import { emitRuntimeSummary, type RuntimeSummary, type RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
+import {
+  RUNTIME_SUMMARY_INTERVAL,
+  emitRuntimeSummary,
+  type RuntimeSummary,
+  type RuntimeTelemetryEvent
+} from '../telemetry/runtimeSummary';
 import { recordSourceWorkloads } from './sourceWorkload';
 import { transferEnergy as transferLinkEnergy } from './linkManager';
 import { manageStorage } from './storageManager';
@@ -57,6 +62,11 @@ import {
   recordPostClaimBootstrapWorkerSpawn,
   refreshPostClaimBootstrap
 } from '../territory/postClaimBootstrap';
+import {
+  buildStrategyRecommendationRoomState,
+  generateStrategyRecommendations,
+  rejectUncertain
+} from '../strategy/strategyRecommender';
 
 const ERR_BUSY_CODE = -4 as ScreepsReturnCode;
 const OK_CODE = 0 as ScreepsReturnCode;
@@ -145,6 +155,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
 
     transferLinkEnergy(colony.room);
     manageStorage(colony.room);
+    recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
   }
 
   for (const creep of creeps) {
@@ -162,6 +173,35 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   }
 
   return emitRuntimeSummary(colonies, creeps, telemetryEvents, { persistOccupationRecommendations: false });
+}
+
+function recordStrategyRecommendationTelemetry(
+  colony: ColonySnapshot,
+  creeps: Creep[],
+  telemetryEvents: RuntimeTelemetryEvent[]
+): void {
+  if (!shouldRecordStrategyRecommendationTelemetry(Game.time)) {
+    return;
+  }
+
+  const recommendations = rejectUncertain(
+    generateStrategyRecommendations(buildStrategyRecommendationRoomState(colony, creeps))
+  );
+  if (recommendations.length === 0) {
+    return;
+  }
+
+  telemetryEvents.push({
+    type: 'strategyRecommendation',
+    roomName: colony.room.name,
+    tick: Game.time,
+    shadow: true,
+    recommendations
+  });
+}
+
+function shouldRecordStrategyRecommendationTelemetry(gameTime: number): boolean {
+  return gameTime > 0 && gameTime % RUNTIME_SUMMARY_INTERVAL === 0;
 }
 
 function planCriticalConstructionSites(

--- a/prod/src/strategy/strategyRecommender.ts
+++ b/prod/src/strategy/strategyRecommender.ts
@@ -1,0 +1,505 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+
+export type StrategyDefensePosture = 'passive' | 'alert' | 'active';
+
+export interface StrategyRecommendation {
+  constructionPreset?: string;
+  remoteTarget?: string;
+  expansionCandidate?: string;
+  defensePosture?: StrategyDefensePosture;
+  confidence: number;
+  reasoning: string;
+}
+
+export interface StrategyRecommendationRoomState {
+  roomName?: string;
+  controllerLevel?: number;
+  creepCount?: number;
+  workerCount?: number;
+  energyAvailable?: number;
+  energyCapacity?: number;
+  storedEnergy?: number;
+  sourceCount?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  towerCount?: number;
+  rampartCount?: number;
+  pendingConstructionSiteCount?: number;
+  repairBacklogHits?: number;
+  territory?: StrategyRecommendationTerritoryState;
+}
+
+export interface StrategyRecommendationTerritoryState {
+  ownedRoomCount?: number;
+  remoteTargets?: StrategyRecommendationTerritoryCandidate[];
+  expansionCandidates?: StrategyRecommendationTerritoryCandidate[];
+}
+
+export interface StrategyRecommendationTerritoryCandidate {
+  roomName: string;
+  action?: 'claim' | 'occupy' | 'reserve' | 'scout';
+  score?: number;
+  routeDistance?: number;
+  sourceCount?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  evidenceStatus?: string;
+}
+
+interface NormalizedStrategyRoomState {
+  roomName: string;
+  controllerLevel: number;
+  creepCount: number;
+  workerCount: number;
+  energyAvailable: number;
+  energyCapacity: number;
+  storedEnergy: number;
+  sourceCount: number;
+  hostileCreepCount: number;
+  hostileStructureCount: number;
+  towerCount: number;
+  rampartCount: number;
+  pendingConstructionSiteCount: number;
+  repairBacklogHits: number;
+  territory: {
+    ownedRoomCount: number;
+    remoteTargets: StrategyRecommendationTerritoryCandidate[];
+    expansionCandidates: StrategyRecommendationTerritoryCandidate[];
+  };
+}
+
+export const DEFAULT_STRATEGY_RECOMMENDATION_CONFIDENCE_THRESHOLD = 0.7;
+
+const MAX_RECOMMENDATIONS = 5;
+const LOW_RCL_ENERGY_CAPACITY_TARGET = 550;
+const TERRITORY_READY_RCL = 3;
+const EXPANSION_READY_RCL = 4;
+const HIGH_RCL = 5;
+const CRITICAL_REPAIR_BACKLOG_HITS = 100_000;
+
+export function rejectUncertain(
+  recommendations: StrategyRecommendation[],
+  threshold = DEFAULT_STRATEGY_RECOMMENDATION_CONFIDENCE_THRESHOLD
+): StrategyRecommendation[] {
+  const resolvedThreshold = clampConfidence(threshold);
+  return recommendations.filter(
+    (recommendation) =>
+      Number.isFinite(recommendation.confidence) && recommendation.confidence >= resolvedThreshold
+  );
+}
+
+export function generateStrategyRecommendations(
+  roomState: StrategyRecommendationRoomState
+): StrategyRecommendation[] {
+  if (!hasRoomStateEvidence(roomState)) {
+    return [
+      makeRecommendation({
+        defensePosture: 'passive',
+        confidence: 0.42,
+        reasoning: 'room state is empty; keep strategy recommendation in observation-only mode'
+      })
+    ];
+  }
+
+  const state = normalizeRoomState(roomState);
+  const recommendations: StrategyRecommendation[] = [];
+
+  const hostilePressure = state.hostileCreepCount + state.hostileStructureCount;
+  if (hostilePressure > 0) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: 'defense-repair-and-ramparts',
+        defensePosture: 'active',
+        confidence: state.hostileCreepCount > 0 ? 0.94 : 0.86,
+        reasoning: `hostile pressure visible in ${state.roomName}; keep strategy shadowed on active defense posture`
+      })
+    );
+  } else if (state.controllerLevel >= TERRITORY_READY_RCL && state.towerCount === 0) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: 'tower-bootstrap',
+        defensePosture: 'alert',
+        confidence: 0.74,
+        reasoning: `${state.roomName} has RCL ${state.controllerLevel} but no tower coverage`
+      })
+    );
+  } else if (state.repairBacklogHits >= CRITICAL_REPAIR_BACKLOG_HITS) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: 'critical-repair-stabilization',
+        defensePosture: 'alert',
+        confidence: 0.72,
+        reasoning: `${state.roomName} has a large repair backlog before territory growth should escalate`
+      })
+    );
+  }
+
+  if (state.controllerLevel <= 1 || state.workerCount <= 1) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: 'bootstrap-spawn-extension-sources',
+        defensePosture: hostilePressure > 0 ? 'active' : 'passive',
+        confidence: state.workerCount === 0 ? 0.84 : 0.8,
+        reasoning: `${state.roomName} needs bootstrap worker and source throughput before higher-level strategy changes`
+      })
+    );
+  } else if (state.controllerLevel <= 3 || state.energyCapacity < LOW_RCL_ENERGY_CAPACITY_TARGET) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: 'extension-container-road-bootstrap',
+        defensePosture: hostilePressure > 0 ? 'active' : 'passive',
+        confidence: state.energyCapacity < LOW_RCL_ENERGY_CAPACITY_TARGET ? 0.82 : 0.76,
+        reasoning: `${state.roomName} should favor energy capacity, containers, and roads at RCL ${state.controllerLevel}`
+      })
+    );
+  } else if (state.controllerLevel >= HIGH_RCL) {
+    recommendations.push(
+      makeRecommendation({
+        constructionPreset: 'storage-road-territory-logistics',
+        defensePosture: hostilePressure > 0 ? 'active' : 'passive',
+        confidence: state.energyCapacity >= 1300 || state.storedEnergy > 5000 ? 0.78 : 0.7,
+        reasoning: `${state.roomName} has high-RCL infrastructure; prioritize logistics that support territory growth`
+      })
+    );
+  }
+
+  const remoteTarget = selectBestTerritoryCandidate(state.territory.remoteTargets);
+  if (remoteTarget && state.controllerLevel >= TERRITORY_READY_RCL && state.workerCount >= 3 && hostilePressure === 0) {
+    recommendations.push(
+      makeRecommendation({
+        remoteTarget: remoteTarget.roomName,
+        defensePosture: 'passive',
+        confidence: scoreTerritoryCandidate(remoteTarget, 0.72),
+        reasoning: `${remoteTarget.roomName} is the strongest low-risk remote target for ${state.roomName}`
+      })
+    );
+  }
+
+  const expansionCandidate = selectBestTerritoryCandidate(state.territory.expansionCandidates);
+  if (expansionCandidate && state.controllerLevel >= EXPANSION_READY_RCL && state.workerCount >= 4 && hostilePressure === 0) {
+    recommendations.push(
+      makeRecommendation({
+        expansionCandidate: expansionCandidate.roomName,
+        defensePosture: 'passive',
+        confidence: scoreTerritoryCandidate(expansionCandidate, 0.76),
+        reasoning: `${expansionCandidate.roomName} is the strongest shadow-mode expansion candidate for ${state.roomName}`
+      })
+    );
+  }
+
+  if (recommendations.length === 0) {
+    recommendations.push(
+      makeRecommendation({
+        defensePosture: 'passive',
+        confidence: 0.42,
+        reasoning: `${state.roomName} has insufficient strategy evidence for a high-confidence recommendation`
+      })
+    );
+  }
+
+  return recommendations
+    .sort((left, right) => right.confidence - left.confidence || left.reasoning.localeCompare(right.reasoning))
+    .slice(0, MAX_RECOMMENDATIONS);
+}
+
+function hasRoomStateEvidence(roomState: StrategyRecommendationRoomState): boolean {
+  return (
+    typeof roomState.roomName === 'string' ||
+    Number.isFinite(roomState.controllerLevel) ||
+    Number.isFinite(roomState.creepCount) ||
+    Number.isFinite(roomState.workerCount) ||
+    Number.isFinite(roomState.energyAvailable) ||
+    Number.isFinite(roomState.energyCapacity) ||
+    Number.isFinite(roomState.sourceCount) ||
+    Number.isFinite(roomState.hostileCreepCount) ||
+    Number.isFinite(roomState.hostileStructureCount)
+  );
+}
+
+export function buildStrategyRecommendationRoomState(
+  colony: ColonySnapshot,
+  creeps: Creep[]
+): StrategyRecommendationRoomState {
+  const room = colony.room;
+  const colonyCreeps = creeps.filter(
+    (creep) => creep.memory.colony === room.name || creep.room?.name === room.name
+  );
+  const hostileCreeps = findRoomObjects<Creep>(room, 'FIND_HOSTILE_CREEPS');
+  const hostileStructures = findRoomObjects<Structure>(room, 'FIND_HOSTILE_STRUCTURES');
+  const ownedStructures = findRoomObjects<Structure>(room, 'FIND_MY_STRUCTURES');
+  const constructionSites = findRoomObjects<ConstructionSite>(room, 'FIND_MY_CONSTRUCTION_SITES');
+  const sources = findRoomObjects<Source>(room, 'FIND_SOURCES');
+
+  return {
+    roomName: room.name,
+    controllerLevel: room.controller?.level,
+    creepCount: colonyCreeps.length,
+    workerCount: colonyCreeps.filter((creep) => creep.memory.role === 'worker').length,
+    energyAvailable: colony.energyAvailable,
+    energyCapacity: colony.energyCapacityAvailable,
+    storedEnergy: getStoredEnergy(room),
+    sourceCount: sources.length,
+    hostileCreepCount: hostileCreeps.length,
+    hostileStructureCount: hostileStructures.length,
+    towerCount: countStructuresByType(ownedStructures, 'STRUCTURE_TOWER', 'tower'),
+    rampartCount: countStructuresByType(ownedStructures, 'STRUCTURE_RAMPART', 'rampart'),
+    pendingConstructionSiteCount: constructionSites.length,
+    repairBacklogHits: estimateRepairBacklogHits(ownedStructures),
+    territory: buildMemoryTerritoryState(room.name)
+  };
+}
+
+function normalizeRoomState(roomState: StrategyRecommendationRoomState): NormalizedStrategyRoomState {
+  const workerCount = finiteNumberOrZero(roomState.workerCount);
+  const creepCount = Math.max(finiteNumberOrZero(roomState.creepCount), workerCount);
+  return {
+    roomName: roomState.roomName && roomState.roomName.length > 0 ? roomState.roomName : 'unknown-room',
+    controllerLevel: clampInteger(roomState.controllerLevel, 0, 8),
+    creepCount,
+    workerCount,
+    energyAvailable: finiteNumberOrZero(roomState.energyAvailable),
+    energyCapacity: finiteNumberOrZero(roomState.energyCapacity),
+    storedEnergy: finiteNumberOrZero(roomState.storedEnergy),
+    sourceCount: finiteNumberOrZero(roomState.sourceCount),
+    hostileCreepCount: finiteNumberOrZero(roomState.hostileCreepCount),
+    hostileStructureCount: finiteNumberOrZero(roomState.hostileStructureCount),
+    towerCount: finiteNumberOrZero(roomState.towerCount),
+    rampartCount: finiteNumberOrZero(roomState.rampartCount),
+    pendingConstructionSiteCount: finiteNumberOrZero(roomState.pendingConstructionSiteCount),
+    repairBacklogHits: finiteNumberOrZero(roomState.repairBacklogHits),
+    territory: {
+      ownedRoomCount: finiteNumberOrZero(roomState.territory?.ownedRoomCount),
+      remoteTargets: normalizeTerritoryCandidates(roomState.territory?.remoteTargets),
+      expansionCandidates: normalizeTerritoryCandidates(roomState.territory?.expansionCandidates)
+    }
+  };
+}
+
+function normalizeTerritoryCandidates(
+  candidates: StrategyRecommendationTerritoryCandidate[] | undefined
+): StrategyRecommendationTerritoryCandidate[] {
+  if (!Array.isArray(candidates)) {
+    return [];
+  }
+
+  return candidates
+    .filter((candidate) => candidate.roomName.length > 0)
+    .map((candidate) => ({
+      roomName: candidate.roomName,
+      ...(candidate.action ? { action: candidate.action } : {}),
+      ...(Number.isFinite(candidate.score) ? { score: candidate.score } : {}),
+      ...(Number.isFinite(candidate.routeDistance) ? { routeDistance: candidate.routeDistance } : {}),
+      ...(Number.isFinite(candidate.sourceCount) ? { sourceCount: candidate.sourceCount } : {}),
+      ...(Number.isFinite(candidate.hostileCreepCount) ? { hostileCreepCount: candidate.hostileCreepCount } : {}),
+      ...(Number.isFinite(candidate.hostileStructureCount)
+        ? { hostileStructureCount: candidate.hostileStructureCount }
+        : {}),
+      ...(candidate.evidenceStatus ? { evidenceStatus: candidate.evidenceStatus } : {})
+    }));
+}
+
+function selectBestTerritoryCandidate(
+  candidates: StrategyRecommendationTerritoryCandidate[]
+): StrategyRecommendationTerritoryCandidate | null {
+  return [...candidates].sort(compareTerritoryCandidates)[0] ?? null;
+}
+
+function compareTerritoryCandidates(
+  left: StrategyRecommendationTerritoryCandidate,
+  right: StrategyRecommendationTerritoryCandidate
+): number {
+  return (
+    scoreTerritoryCandidate(right, 0) - scoreTerritoryCandidate(left, 0) ||
+    (left.routeDistance ?? Number.POSITIVE_INFINITY) - (right.routeDistance ?? Number.POSITIVE_INFINITY) ||
+    left.roomName.localeCompare(right.roomName)
+  );
+}
+
+function scoreTerritoryCandidate(candidate: StrategyRecommendationTerritoryCandidate, baseConfidence: number): number {
+  const rawScore = Number.isFinite(candidate.score) ? Math.min(Math.max(candidate.score ?? 0, 0) / 1000, 0.12) : 0;
+  const sourceBonus = Math.min(finiteNumberOrZero(candidate.sourceCount) * 0.03, 0.06);
+  const routeBonus =
+    Number.isFinite(candidate.routeDistance) && (candidate.routeDistance ?? Number.POSITIVE_INFINITY) <= 2 ? 0.04 : 0;
+  const evidenceBonus = candidate.evidenceStatus === 'sufficient' ? 0.05 : 0;
+  const hostilePenalty =
+    finiteNumberOrZero(candidate.hostileCreepCount) > 0 || finiteNumberOrZero(candidate.hostileStructureCount) > 0
+      ? 0.36
+      : 0;
+  return clampConfidence(baseConfidence + rawScore + sourceBonus + routeBonus + evidenceBonus - hostilePenalty);
+}
+
+function makeRecommendation(recommendation: StrategyRecommendation): StrategyRecommendation {
+  return {
+    ...recommendation,
+    confidence: clampConfidence(recommendation.confidence)
+  };
+}
+
+function buildMemoryTerritoryState(roomName: string): StrategyRecommendationTerritoryState {
+  const memory = (globalThis as { Memory?: Partial<Memory> }).Memory;
+  const targets = memory?.territory?.targets;
+  const remoteTargets: StrategyRecommendationTerritoryCandidate[] = [];
+  const expansionCandidates: StrategyRecommendationTerritoryCandidate[] = [];
+
+  if (Array.isArray(targets)) {
+    for (const target of targets) {
+      if (!isRecord(target) || target.colony !== roomName || typeof target.roomName !== 'string') {
+        continue;
+      }
+      const action = normalizeTerritoryAction(target.action);
+      if (!action) {
+        continue;
+      }
+      const candidate = {
+        roomName: target.roomName,
+        action
+      };
+      if (action === 'claim') {
+        expansionCandidates.push(candidate);
+      } else {
+        remoteTargets.push(candidate);
+      }
+    }
+  }
+
+  const roomMemory = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[roomName]?.memory;
+  const cachedExpansionSelection = roomMemory?.cachedExpansionSelection;
+  if (
+    cachedExpansionSelection?.status === 'planned' &&
+    cachedExpansionSelection.colony === roomName &&
+    cachedExpansionSelection.targetRoom
+  ) {
+    expansionCandidates.push({
+      roomName: cachedExpansionSelection.targetRoom,
+      action: 'claim',
+      ...(Number.isFinite(cachedExpansionSelection.score) ? { score: cachedExpansionSelection.score } : {})
+    });
+  }
+
+  return {
+    ownedRoomCount: countVisibleOwnedRooms(),
+    remoteTargets: deduplicateTerritoryCandidates(remoteTargets),
+    expansionCandidates: deduplicateTerritoryCandidates(expansionCandidates)
+  };
+}
+
+function deduplicateTerritoryCandidates(
+  candidates: StrategyRecommendationTerritoryCandidate[]
+): StrategyRecommendationTerritoryCandidate[] {
+  const byRoom = new Map<string, StrategyRecommendationTerritoryCandidate>();
+  for (const candidate of candidates) {
+    const existing = byRoom.get(candidate.roomName);
+    if (!existing || scoreTerritoryCandidate(candidate, 0) > scoreTerritoryCandidate(existing, 0)) {
+      byRoom.set(candidate.roomName, candidate);
+    }
+  }
+  return [...byRoom.values()].sort(compareTerritoryCandidates);
+}
+
+function normalizeTerritoryAction(action: unknown): StrategyRecommendationTerritoryCandidate['action'] | undefined {
+  if (action === 'claim' || action === 'reserve' || action === 'scout') {
+    return action;
+  }
+  return undefined;
+}
+
+function countVisibleOwnedRooms(): number {
+  const rooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
+  if (!rooms) {
+    return 0;
+  }
+  return Object.values(rooms).filter((room) => room?.controller?.my === true).length;
+}
+
+function countStructuresByType(structures: unknown[], globalName: string, fallback: string): number {
+  return structures.filter(
+    (structure) => isRecord(structure) && matchesStructureType(structure.structureType, globalName, fallback)
+  ).length;
+}
+
+function estimateRepairBacklogHits(structures: unknown[]): number {
+  return structures.reduce<number>((total, structure) => {
+    if (!isRecord(structure)) {
+      return total;
+    }
+    const hits = finiteNumberOrNull(structure.hits);
+    const hitsMax = finiteNumberOrNull(structure.hitsMax);
+    if (hits === null || hitsMax === null || hitsMax <= hits) {
+      return total;
+    }
+    return total + (hitsMax - hits);
+  }, 0);
+}
+
+function getStoredEnergy(room: Room): number {
+  const storage = (room as { storage?: unknown }).storage;
+  return getEnergyInStore(storage);
+}
+
+function getEnergyInStore(object: unknown): number {
+  if (!isRecord(object) || !isRecord(object.store)) {
+    return 0;
+  }
+
+  const getUsedCapacity = object.store.getUsedCapacity;
+  const resourceEnergy = getResourceEnergy();
+  if (typeof getUsedCapacity === 'function') {
+    const value = getUsedCapacity.call(object.store, resourceEnergy);
+    return finiteNumberOrZero(value);
+  }
+
+  return finiteNumberOrZero(object.store[resourceEnergy]);
+}
+
+function findRoomObjects<T>(room: Room, constantName: string): T[] {
+  const findConstant = getGlobalNumber(constantName);
+  const find = (room as unknown as { find?: unknown }).find;
+  if (typeof findConstant !== 'number' || typeof find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = find.call(room, findConstant);
+    return Array.isArray(result) ? (result as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function matchesStructureType(value: unknown, globalName: string, fallback: string): boolean {
+  const globalValue = (globalThis as Record<string, unknown>)[globalName];
+  return value === globalValue || value === fallback;
+}
+
+function getResourceEnergy(): ResourceConstant {
+  const value = (globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY;
+  return value ?? ('energy' as ResourceConstant);
+}
+
+function getGlobalNumber(name: string): number | undefined {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function clampInteger(value: unknown, min: number, max: number): number {
+  return Math.trunc(Math.min(Math.max(finiteNumberOrZero(value), min), max));
+}
+
+function clampConfidence(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(Math.max(Number(value.toFixed(3)), 0), 1);
+}
+
+function finiteNumberOrZero(value: unknown): number {
+  return finiteNumberOrNull(value) ?? 0;
+}
+
+function finiteNumberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -68,7 +68,8 @@ export type RuntimeTelemetryEvent =
   | RuntimeTerritoryClaimTelemetryEvent
   | RuntimeTerritoryScoutTelemetryEvent
   | RuntimePostClaimBootstrapTelemetryEvent
-  | RuntimeSpawnSitePlacedTelemetryEvent;
+  | RuntimeSpawnSitePlacedTelemetryEvent
+  | RuntimeStrategyRecommendationTelemetryEvent;
 
 export type RuntimeTerritoryClaimTelemetryReason =
   | 'noAdjacentCandidate'
@@ -166,6 +167,23 @@ export interface RuntimeSpawnSitePlacedTelemetryEvent {
   result: ScreepsReturnCode;
   spawnSite: TerritoryPostClaimBootstrapSpawnSiteMemory;
   existing?: boolean;
+}
+
+export interface RuntimeStrategyRecommendationTelemetryEvent {
+  type: 'strategyRecommendation';
+  roomName: string;
+  tick?: number;
+  shadow: true;
+  recommendations: RuntimeStrategyRecommendationTelemetryPayload[];
+}
+
+export interface RuntimeStrategyRecommendationTelemetryPayload {
+  constructionPreset?: string;
+  remoteTarget?: string;
+  expansionCandidate?: string;
+  defensePosture?: 'passive' | 'alert' | 'active';
+  confidence: number;
+  reasoning: string;
 }
 
 interface RuntimeSpawnStatus {

--- a/prod/test/strategyRecommender.test.ts
+++ b/prod/test/strategyRecommender.test.ts
@@ -1,0 +1,208 @@
+import {
+  generateStrategyRecommendations,
+  rejectUncertain,
+  type StrategyRecommendation,
+  type StrategyRecommendationRoomState
+} from '../src/strategy/strategyRecommender';
+
+describe('strategy recommender', () => {
+  it('filters recommendations below the default confidence threshold', () => {
+    const recommendations = rejectUncertain([
+      makeRecommendation({ confidence: 0.69, reasoning: 'below threshold' }),
+      makeRecommendation({ confidence: 0.7, reasoning: 'at threshold' }),
+      makeRecommendation({ confidence: 0.91, reasoning: 'above threshold' })
+    ]);
+
+    expect(recommendations.map((recommendation) => recommendation.reasoning)).toEqual([
+      'at threshold',
+      'above threshold'
+    ]);
+  });
+
+  it('uses a custom confidence threshold when supplied', () => {
+    const recommendations = rejectUncertain(
+      [
+        makeRecommendation({ confidence: 0.79, reasoning: 'below custom threshold' }),
+        makeRecommendation({ confidence: 0.8, reasoning: 'at custom threshold' })
+      ],
+      0.8
+    );
+
+    expect(recommendations).toHaveLength(1);
+    expect(recommendations[0].reasoning).toBe('at custom threshold');
+  });
+
+  it('returns well-typed recommendation payloads', () => {
+    const recommendations = generateStrategyRecommendations(makeStableHighRclRoom());
+
+    expect(recommendations.length).toBeGreaterThan(0);
+    for (const recommendation of recommendations) {
+      expect(typeof recommendation.confidence).toBe('number');
+      expect(recommendation.confidence).toBeGreaterThanOrEqual(0);
+      expect(recommendation.confidence).toBeLessThanOrEqual(1);
+      expect(typeof recommendation.reasoning).toBe('string');
+      expect(recommendation.reasoning.length).toBeGreaterThan(0);
+      if (recommendation.defensePosture !== undefined) {
+        expect(['passive', 'alert', 'active']).toContain(recommendation.defensePosture);
+      }
+    }
+  });
+
+  it('keeps empty room state low confidence so shadow mode rejects it', () => {
+    const recommendations = generateStrategyRecommendations({});
+
+    expect(recommendations).toEqual([
+      expect.objectContaining({
+        defensePosture: 'passive',
+        confidence: 0.42
+      })
+    ]);
+    expect(rejectUncertain(recommendations)).toHaveLength(0);
+  });
+
+  it('marks hostile rooms as active defense posture', () => {
+    const recommendations = generateStrategyRecommendations({
+      ...makeStableLowRclRoom(),
+      hostileCreepCount: 2,
+      hostileStructureCount: 1
+    });
+
+    expect(recommendations[0]).toMatchObject({
+      constructionPreset: 'defense-repair-and-ramparts',
+      defensePosture: 'active',
+      confidence: 0.94
+    });
+  });
+
+  it('recommends bootstrap construction for low-RCL rooms', () => {
+    const recommendations = generateStrategyRecommendations(makeStableLowRclRoom());
+
+    expect(recommendations).toContainEqual(
+      expect.objectContaining({
+        constructionPreset: 'extension-container-road-bootstrap',
+        defensePosture: 'passive'
+      })
+    );
+  });
+
+  it('recommends tower bootstrap when RCL supports towers but none are present', () => {
+    const recommendations = generateStrategyRecommendations({
+      ...makeStableLowRclRoom(),
+      controllerLevel: 3,
+      energyCapacity: 800,
+      towerCount: 0
+    });
+
+    expect(recommendations).toContainEqual(
+      expect.objectContaining({
+        constructionPreset: 'tower-bootstrap',
+        defensePosture: 'alert'
+      })
+    );
+  });
+
+  it('recommends safe remote targets for territory-ready rooms', () => {
+    const recommendations = generateStrategyRecommendations({
+      ...makeStableLowRclRoom(),
+      controllerLevel: 3,
+      workerCount: 4,
+      territory: {
+        remoteTargets: [
+          { roomName: 'W1N2', action: 'reserve', score: 700, routeDistance: 2, sourceCount: 2, evidenceStatus: 'sufficient' }
+        ]
+      }
+    });
+
+    expect(recommendations).toContainEqual(
+      expect.objectContaining({
+        remoteTarget: 'W1N2',
+        defensePosture: 'passive'
+      })
+    );
+  });
+
+  it('recommends expansion candidates for high-confidence high-RCL rooms', () => {
+    const recommendations = generateStrategyRecommendations(makeStableHighRclRoom());
+
+    expect(recommendations).toContainEqual(
+      expect.objectContaining({
+        expansionCandidate: 'W2N1',
+        defensePosture: 'passive'
+      })
+    );
+  });
+
+  it('penalizes hostile territory candidates below the default rejection threshold', () => {
+    const recommendations = generateStrategyRecommendations({
+      ...makeStableHighRclRoom(),
+      territory: {
+        expansionCandidates: [
+          {
+            roomName: 'W3N1',
+            action: 'claim',
+            score: 900,
+            routeDistance: 1,
+            sourceCount: 2,
+            hostileCreepCount: 3,
+            evidenceStatus: 'sufficient'
+          }
+        ]
+      }
+    });
+
+    const expansionRecommendation = recommendations.find(
+      (recommendation) => recommendation.expansionCandidate === 'W3N1'
+    );
+    expect(expansionRecommendation?.confidence).toBeLessThan(0.7);
+    expect(rejectUncertain(recommendations).some((recommendation) => recommendation.expansionCandidate === 'W3N1')).toBe(
+      false
+    );
+  });
+});
+
+function makeRecommendation(overrides: Partial<StrategyRecommendation> = {}): StrategyRecommendation {
+  return {
+    confidence: 0.9,
+    reasoning: 'test recommendation',
+    ...overrides
+  };
+}
+
+function makeStableLowRclRoom(): StrategyRecommendationRoomState {
+  return {
+    roomName: 'W1N1',
+    controllerLevel: 2,
+    creepCount: 4,
+    workerCount: 3,
+    energyAvailable: 300,
+    energyCapacity: 500,
+    sourceCount: 2,
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    towerCount: 0,
+    rampartCount: 0
+  };
+}
+
+function makeStableHighRclRoom(): StrategyRecommendationRoomState {
+  return {
+    roomName: 'W1N1',
+    controllerLevel: 5,
+    creepCount: 8,
+    workerCount: 6,
+    energyAvailable: 1300,
+    energyCapacity: 1300,
+    storedEnergy: 6000,
+    sourceCount: 2,
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    towerCount: 2,
+    rampartCount: 4,
+    territory: {
+      ownedRoomCount: 1,
+      expansionCandidates: [
+        { roomName: 'W2N1', action: 'claim', score: 880, routeDistance: 1, sourceCount: 2, evidenceStatus: 'sufficient' }
+      ]
+    }
+  };
+}

--- a/scripts/extract-strategy-dataset.py
+++ b/scripts/extract-strategy-dataset.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""Extract offline high-level strategy recommendation windows from Screeps artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence, TextIO
+
+import screeps_rl_dataset_export as dataset_export
+import screeps_runtime_kpi_reducer as kpi_reducer
+
+
+SCHEMA_VERSION = 1
+DATASET_TYPE = "screeps-strategy-recommendation-window"
+DEFAULT_OUT_PATH = Path("runtime-artifacts/strategy-datasets/strategy_windows.jsonl")
+DEFAULT_REGISTRY_PATH = Path("prod/src/strategy/strategyRegistry.ts")
+DEFAULT_WINDOW_SIZE = 3
+DEFAULT_SAMPLE_LIMIT = 500
+DEFAULT_EVAL_RATIO = 0.2
+DEFAULT_SPLIT_SEED = "screeps-strategy-recommendation-v1"
+ENTRY_RE = re.compile(
+    r"id:\s*'(?P<id>[^']+)'.*?"
+    r"version:\s*'(?P<version>[^']+)'.*?"
+    r"family:\s*'(?P<family>[^']+)'.*?"
+    r"rolloutStatus:\s*'(?P<rollout_status>[^']+)'",
+    re.DOTALL,
+)
+
+JsonObject = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class StrategyRegistryEntry:
+    strategy_id: str
+    version: str
+    family: str
+    rollout_status: str
+
+
+@dataclass(frozen=True)
+class RoomFrame:
+    record: dataset_export.ArtifactRecord
+    record_index: int
+    room: JsonObject
+    tick: int | float | None
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def eval_ratio(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a number") from error
+    if parsed < 0 or parsed >= 1:
+        raise argparse.ArgumentTypeError("must be at least 0 and less than 1")
+    return parsed
+
+
+def extract_strategy_dataset(
+    paths: Sequence[str],
+    out_path: Path = DEFAULT_OUT_PATH,
+    *,
+    registry_path: Path = DEFAULT_REGISTRY_PATH,
+    window_size: int = DEFAULT_WINDOW_SIZE,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    eval_ratio_value: float = DEFAULT_EVAL_RATIO,
+    split_seed: str = DEFAULT_SPLIT_SEED,
+    max_file_bytes: int = dataset_export.DEFAULT_MAX_FILE_BYTES,
+    bot_commit: str | None = None,
+    repo_root: Path | None = None,
+) -> JsonObject:
+    repo = (repo_root or Path.cwd()).resolve()
+    resolved_out_path = resolve_path_against_repo(out_path, repo)
+    resolved_registry_path = resolve_path_against_repo(registry_path, repo)
+    registry = read_strategy_registry(resolved_registry_path)
+    bot_commit = bot_commit or dataset_export.git_commit(repo)
+    scan = dataset_export.collect_artifact_records(
+        paths,
+        max_file_bytes=max_file_bytes,
+        excluded_roots=[resolved_out_path.parent],
+    )
+    rows = build_labeled_windows(
+        scan.records,
+        registry,
+        bot_commit=bot_commit,
+        window_size=window_size,
+        sample_limit=sample_limit,
+        eval_ratio_value=eval_ratio_value,
+        split_seed=split_seed,
+    )
+    runtime_lines = [
+        kpi_reducer.RUNTIME_SUMMARY_PREFIX
+        + json.dumps(record.payload, sort_keys=True, separators=(",", ":"))
+        + "\n"
+        for record in scan.records
+    ]
+    kpi_history = kpi_reducer.reduce_runtime_kpis(runtime_lines)
+
+    write_jsonl_atomic(resolved_out_path, rows)
+    manifest_path = resolved_out_path.with_suffix(".manifest.json")
+    manifest = {
+        "ok": True,
+        "type": "screeps-strategy-recommendation-dataset-manifest",
+        "schemaVersion": SCHEMA_VERSION,
+        "datasetPath": dataset_export.display_path(resolved_out_path),
+        "manifestPath": dataset_export.display_path(manifest_path),
+        "rowCount": len(rows),
+        "sourceArtifactCount": len(scan.source_files),
+        "runtimeSummaryArtifactCount": len(scan.records),
+        "skippedFileCount": len(scan.skipped_files),
+        "registryPath": dataset_export.display_path(resolved_registry_path),
+        "strategyVersions": [strategy_entry_to_json(entry) for entry in registry],
+        "windowSize": window_size,
+        "split": {
+            "method": "sha256-threshold",
+            "seed": split_seed,
+            "evalRatio": eval_ratio_value,
+            "counts": count_splits(rows),
+        },
+        "kpiHistory": kpi_history,
+        "safety": safety_notes(),
+    }
+    write_json_atomic(manifest_path, manifest)
+    return manifest
+
+
+def build_labeled_windows(
+    records: Sequence[dataset_export.ArtifactRecord],
+    registry: Sequence[StrategyRegistryEntry],
+    *,
+    bot_commit: str,
+    window_size: int,
+    sample_limit: int,
+    eval_ratio_value: float,
+    split_seed: str,
+) -> list[JsonObject]:
+    frames_by_room = collect_room_frames(records)
+    rows: list[JsonObject] = []
+    for room_name in sorted(frames_by_room):
+        frames = frames_by_room[room_name]
+        for window in iter_room_windows(frames, window_size):
+            latest_frame = window[-1]
+            labels = build_labels(latest_frame.room, registry)
+            reward = build_window_reward(window, labels)
+            if not reward["successful"]:
+                continue
+            sample_id = build_sample_id(window)
+            rows.append(
+                {
+                    "type": DATASET_TYPE,
+                    "schemaVersion": SCHEMA_VERSION,
+                    "sampleId": sample_id,
+                    "botCommit": bot_commit,
+                    "sourceWindow": [build_source_window_entry(frame) for frame in window],
+                    "features": build_features(latest_frame.record.payload, latest_frame.room),
+                    "labels": labels,
+                    "reward": reward,
+                    "strategyVersions": [strategy_entry_to_json(entry) for entry in registry],
+                    "split": assign_split(sample_id, split_seed, eval_ratio_value),
+                    "safety": safety_notes(),
+                }
+            )
+            if len(rows) >= sample_limit:
+                return rows
+    return rows
+
+
+def collect_room_frames(records: Sequence[dataset_export.ArtifactRecord]) -> dict[str, list[RoomFrame]]:
+    frames_by_room: dict[str, list[RoomFrame]] = {}
+    for record_index, record in enumerate(records):
+        rooms = record.payload.get("rooms")
+        if not isinstance(rooms, list):
+            continue
+        for room in rooms:
+            if not isinstance(room, dict):
+                continue
+            room_name = room.get("roomName")
+            if not isinstance(room_name, str) or not room_name:
+                continue
+            frame = RoomFrame(
+                record=record,
+                record_index=record_index,
+                room=room,
+                tick=number_or_none(record.payload.get("tick")),
+            )
+            frames_by_room.setdefault(room_name, []).append(frame)
+
+    for frames in frames_by_room.values():
+        frames.sort(key=lambda frame: (frame.tick is None, frame.tick or 0, frame.record.source.display_path, frame.record_index))
+    return frames_by_room
+
+
+def iter_room_windows(frames: Sequence[RoomFrame], window_size: int) -> list[list[RoomFrame]]:
+    if not frames:
+        return []
+    if len(frames) <= window_size:
+        return [list(frames)]
+    return [list(frames[index : index + window_size]) for index in range(0, len(frames) - window_size + 1)]
+
+
+def build_features(payload: JsonObject, room: JsonObject) -> JsonObject:
+    territory = room.get("territoryRecommendation") if isinstance(room.get("territoryRecommendation"), dict) else {}
+    candidates = territory.get("candidates") if isinstance(territory.get("candidates"), list) else []
+    expansion_candidates = [
+        candidate
+        for candidate in candidates
+        if isinstance(candidate, dict) and candidate.get("action") in {"claim", "occupy"}
+    ]
+    remote_candidates = [
+        candidate
+        for candidate in candidates
+        if isinstance(candidate, dict) and candidate.get("action") in {"reserve", "scout"}
+    ]
+    resources = room.get("resources") if isinstance(room.get("resources"), dict) else {}
+    combat = room.get("combat") if isinstance(room.get("combat"), dict) else {}
+    controller = room.get("controller") if isinstance(room.get("controller"), dict) else {}
+
+    return {
+        "tick": number_or_none(payload.get("tick")),
+        "roomName": redact_string(room.get("roomName")),
+        "rcl": number_or_none(controller.get("level")),
+        "creeps": {
+            "total": number_or_none(room.get("creepCount")),
+            "workers": number_or_none(room.get("workerCount")),
+            "taskCounts": select_number_map(room.get("taskCounts")),
+        },
+        "energy": {
+            "available": number_or_none(room.get("energyAvailable")),
+            "capacity": number_or_none(room.get("energyCapacity")),
+            "stored": number_or_none(resources.get("storedEnergy")),
+            "workerCarried": number_or_none(resources.get("workerCarriedEnergy")),
+            "dropped": number_or_none(resources.get("droppedEnergy")),
+        },
+        "hostiles": {
+            "creeps": number_or_zero(combat.get("hostileCreepCount")),
+            "structures": number_or_zero(combat.get("hostileStructureCount")),
+        },
+        "territory": {
+            "ownedRoomCountObserved": count_owned_rooms(payload),
+            "sourceCount": number_or_none(resources.get("sourceCount")),
+            "remoteCandidateCount": len(remote_candidates),
+            "expansionCandidateCount": len(expansion_candidates),
+            "nextTarget": summarize_territory_candidate(territory.get("next")),
+        },
+    }
+
+
+def build_labels(room: JsonObject, registry: Sequence[StrategyRegistryEntry]) -> JsonObject:
+    construction_priority = None
+    construction = room.get("constructionPriority")
+    if isinstance(construction, dict) and isinstance(construction.get("nextPrimary"), dict):
+        construction_priority = redact_string(construction["nextPrimary"].get("buildItem"))
+
+    territory_next = None
+    territory = room.get("territoryRecommendation")
+    if isinstance(territory, dict):
+        territory_next = territory.get("next")
+
+    expansion_target = None
+    remote_target = None
+    if isinstance(territory_next, dict):
+        action = territory_next.get("action")
+        room_name = redact_string(territory_next.get("roomName"))
+        if action in {"claim", "occupy"}:
+            expansion_target = room_name
+        elif action in {"reserve", "scout"}:
+            remote_target = room_name
+
+    defense_posture = infer_defense_posture(room)
+    strategy_ids = select_strategy_ids(registry, construction_priority, expansion_target, remote_target, defense_posture)
+    return {
+        "strategyPreset": "+".join(strategy_ids) if strategy_ids else "incumbent-baseline",
+        "strategyIds": strategy_ids,
+        "expansionTarget": expansion_target,
+        "remoteTarget": remote_target,
+        "constructionPriority": construction_priority,
+        "defensePosture": defense_posture,
+        "liveEffect": False,
+    }
+
+
+def build_window_reward(window: Sequence[RoomFrame], labels: JsonObject) -> JsonObject:
+    first_features = build_features(window[0].record.payload, window[0].room)
+    latest_features = build_features(window[-1].record.payload, window[-1].room)
+    first_rcl = nested_number(first_features, ("rcl",))
+    latest_rcl = nested_number(latest_features, ("rcl",))
+    first_energy = nested_number(first_features, ("energy", "stored"))
+    latest_energy = nested_number(latest_features, ("energy", "stored"))
+    latest_hostiles = number_or_zero(nested_get(latest_features, ("hostiles", "creeps"))) + number_or_zero(
+        nested_get(latest_features, ("hostiles", "structures"))
+    )
+    latest_workers = number_or_zero(nested_get(latest_features, ("creeps", "workers")))
+    latest_controller = window[-1].room.get("controller") if isinstance(window[-1].room.get("controller"), dict) else {}
+    ticks_to_downgrade = number_or_none(latest_controller.get("ticksToDowngrade"))
+
+    has_action_label = any(
+        labels.get(field_name) is not None
+        for field_name in ("expansionTarget", "remoteTarget", "constructionPriority", "defensePosture")
+    )
+    controller_non_degraded = first_rcl is None or latest_rcl is None or latest_rcl >= first_rcl
+    no_critical_downgrade = ticks_to_downgrade is None or ticks_to_downgrade >= 1000
+    hostile_response_valid = latest_hostiles == 0 or labels.get("defensePosture") == "active"
+    worker_survival = latest_workers > 0 or labels.get("constructionPriority") == "build initial spawn"
+    successful = bool(has_action_label and controller_non_degraded and no_critical_downgrade and hostile_response_valid and worker_survival)
+
+    return {
+        "successful": successful,
+        "status": "heuristic-success-label" if successful else "filtered",
+        "scalarReward": None,
+        "lexicographicOrder": ["territory", "resources", "kills"],
+        "components": {
+            "territory": {
+                "rclDelta": numeric_delta(first_rcl, latest_rcl),
+                "ownedRoomCountObserved": nested_get(latest_features, ("territory", "ownedRoomCountObserved")),
+                "controllerNonDegraded": controller_non_degraded,
+                "ticksToDowngrade": ticks_to_downgrade,
+            },
+            "resources": {
+                "storedEnergyDelta": numeric_delta(first_energy, latest_energy),
+                "energyCapacity": nested_get(latest_features, ("energy", "capacity")),
+            },
+            "kills": {
+                "hostilePressure": latest_hostiles,
+                "defensePosture": labels.get("defensePosture"),
+            },
+        },
+        "notes": "Success is a conservative offline label from retained room/control state, worker survival, and hostile response posture.",
+    }
+
+
+def select_strategy_ids(
+    registry: Sequence[StrategyRegistryEntry],
+    construction_priority: str | None,
+    expansion_target: str | None,
+    remote_target: str | None,
+    defense_posture: str,
+) -> list[str]:
+    families: list[str] = []
+    if construction_priority:
+        families.append("construction-priority")
+    if expansion_target or remote_target:
+        families.append("expansion-remote-candidate")
+    if defense_posture in {"alert", "active"}:
+        families.append("defense-posture-repair-threshold")
+    if not families:
+        families.append("construction-priority")
+
+    selected: list[str] = []
+    for family in families:
+        incumbent = next(
+            (
+                entry
+                for entry in registry
+                if entry.family == family and entry.rollout_status == "incumbent"
+            ),
+            None,
+        )
+        selected.append(incumbent.strategy_id if incumbent else f"{family}.incumbent")
+    return selected
+
+
+def infer_defense_posture(room: JsonObject) -> str:
+    combat = room.get("combat") if isinstance(room.get("combat"), dict) else {}
+    hostile_creeps = number_or_zero(combat.get("hostileCreepCount"))
+    hostile_structures = number_or_zero(combat.get("hostileStructureCount"))
+    if hostile_creeps > 0:
+        return "active"
+    if hostile_structures > 0:
+        return "alert"
+    return "passive"
+
+
+def build_sample_id(window: Sequence[RoomFrame]) -> str:
+    seed = [
+        {
+            "sourceId": frame.record.source.source_id,
+            "lineNumber": frame.record.line_number,
+            "recordIndex": frame.record_index,
+            "roomName": frame.room.get("roomName"),
+            "tick": frame.tick,
+        }
+        for frame in window
+    ]
+    digest = hashlib.sha256(json.dumps(seed, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return f"strategy-window-{digest[:16]}"
+
+
+def build_source_window_entry(frame: RoomFrame) -> JsonObject:
+    return {
+        "sourceId": frame.record.source.source_id,
+        "artifactKind": frame.record.artifact_kind,
+        "path": frame.record.source.display_path,
+        "lineNumber": frame.record.line_number,
+        "tick": frame.tick,
+        "roomName": redact_string(frame.room.get("roomName")),
+        "sha256": frame.record.source.sha256,
+    }
+
+
+def read_strategy_registry(path: Path) -> list[StrategyRegistryEntry]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise FileNotFoundError(f"strategy registry not readable: {dataset_export.display_path(path)}") from error
+
+    entries = [
+        StrategyRegistryEntry(
+            strategy_id=match.group("id"),
+            version=match.group("version"),
+            family=match.group("family"),
+            rollout_status=match.group("rollout_status"),
+        )
+        for match in ENTRY_RE.finditer(text)
+    ]
+    if not entries:
+        raise ValueError(f"no strategy registry entries found in {dataset_export.display_path(path)}")
+    return entries
+
+
+def summarize_territory_candidate(candidate: Any) -> JsonObject | None:
+    if not isinstance(candidate, dict) or not isinstance(candidate.get("roomName"), str):
+        return None
+    return {
+        "roomName": redact_string(candidate.get("roomName")),
+        "action": redact_string(candidate.get("action")),
+        "score": number_or_none(candidate.get("score")),
+        "routeDistance": number_or_none(candidate.get("routeDistance")),
+        "sourceCount": number_or_none(candidate.get("sourceCount")),
+        "evidenceStatus": redact_string(candidate.get("evidenceStatus")),
+    }
+
+
+def count_owned_rooms(payload: JsonObject) -> int:
+    rooms = payload.get("rooms")
+    if not isinstance(rooms, list):
+        return 0
+    return len([room for room in rooms if isinstance(room, dict) and isinstance(room.get("roomName"), str)])
+
+
+def assign_split(sample_id: str, split_seed: str, eval_ratio_value: float) -> JsonObject:
+    digest = hashlib.sha256(f"{split_seed}:{sample_id}".encode("utf-8")).hexdigest()
+    bucket = int(digest[:12], 16) / float(0xFFFFFFFFFFFF)
+    split = "eval" if bucket < eval_ratio_value else "train"
+    return {
+        "name": split,
+        "method": "sha256-threshold",
+        "seed": split_seed,
+        "evalRatio": eval_ratio_value,
+        "bucket": round(bucket, 8),
+    }
+
+
+def count_splits(rows: Sequence[JsonObject]) -> JsonObject:
+    counts: dict[str, int] = {}
+    for row in rows:
+        split = row.get("split")
+        name = split.get("name") if isinstance(split, dict) else None
+        counts[str(name or "unknown")] = counts.get(str(name or "unknown"), 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def safety_notes() -> JsonObject:
+    return {
+        "liveEffect": False,
+        "mode": "offline extraction and shadow recommendation only",
+        "officialMmoControl": "forbidden until simulator evidence, historical validation, rollout gates, and rollback gates pass",
+        "rawCreepIntentControl": False,
+    }
+
+
+def resolve_path_against_repo(path: Path, repo_root: Path) -> Path:
+    expanded = path.expanduser()
+    return (expanded if expanded.is_absolute() else repo_root / expanded).resolve()
+
+
+def write_jsonl_atomic(path: Path, rows: Sequence[JsonObject]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(json.dumps(row, sort_keys=True, separators=(",", ":"), ensure_ascii=True))
+                handle.write("\n")
+        os.replace(temp_name, path)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+
+
+def write_json_atomic(path: Path, payload: JsonObject) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(temp_name, path)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+
+
+def strategy_entry_to_json(entry: StrategyRegistryEntry) -> JsonObject:
+    return {
+        "id": entry.strategy_id,
+        "version": entry.version,
+        "family": entry.family,
+        "rolloutStatus": entry.rollout_status,
+    }
+
+
+def select_number_map(value: Any) -> JsonObject:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): item for key, item in value.items() if is_number(item)}
+
+
+def nested_get(value: Any, keys: tuple[str, ...]) -> Any:
+    current = value
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def nested_number(value: Any, keys: tuple[str, ...]) -> int | float | None:
+    return number_or_none(nested_get(value, keys))
+
+
+def numeric_delta(first: int | float | None, latest: int | float | None) -> int | float | None:
+    if first is None or latest is None:
+        return None
+    return latest - first
+
+
+def is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def number_or_none(value: Any) -> int | float | None:
+    return value if is_number(value) else None
+
+
+def number_or_zero(value: Any) -> int | float:
+    return value if is_number(value) else 0
+
+
+def redact_string(value: Any) -> str | None:
+    return dataset_export.redact_text(value) if isinstance(value, str) else None
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Runtime artifact files or directories to scan.")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT_PATH, help="JSONL dataset output path.")
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY_PATH, help="Strategy registry path.")
+    parser.add_argument("--window-size", type=positive_int, default=DEFAULT_WINDOW_SIZE)
+    parser.add_argument("--sample-limit", type=positive_int, default=DEFAULT_SAMPLE_LIMIT)
+    parser.add_argument("--eval-ratio", type=eval_ratio, default=DEFAULT_EVAL_RATIO)
+    parser.add_argument("--split-seed", default=DEFAULT_SPLIT_SEED)
+    parser.add_argument("--max-file-bytes", type=positive_int, default=dataset_export.DEFAULT_MAX_FILE_BYTES)
+    parser.add_argument("--bot-commit", default=None)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None, stdout: TextIO = sys.stdout) -> int:
+    args = build_arg_parser().parse_args(argv)
+    manifest = extract_strategy_dataset(
+        args.paths,
+        args.out,
+        registry_path=args.registry,
+        window_size=args.window_size,
+        sample_limit=args.sample_limit,
+        eval_ratio_value=args.eval_ratio,
+        split_seed=args.split_seed,
+        max_file_bytes=args.max_file_bytes,
+        bot_commit=args.bot_commit,
+    )
+    stdout.write(json.dumps(manifest, sort_keys=True))
+    stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Prototype offline RL strategy recommendation engine with dataset extraction (#266).

## Changes
- **`prod/src/strategy/strategyRecommender.ts`** — Lightweight rule-based strategy recommendation engine with confidence scoring and uncertainty rejection
- **`prod/test/strategyRecommender.test.ts`** — 8+ test cases covering edge cases, confidence filtering, and room states
- **`prod/src/economy/economyLoop.ts`** — Integration: logs strategy recommendations as telemetry events (shadow mode, no auto-apply)
- **`prod/src/telemetry/runtimeSummary.ts`** — Telemetry event type for strategyRecommendation
- **`scripts/extract-strategy-dataset.py`** — Extracts labeled training windows from runtime artifacts
- **`docs/research/strategy-dataset-card.md`** — Dataset card documenting sources, labels, and bias

## Verification
- `npm run typecheck` — passed
- `npm test -- --runInBand` — 1057 tests passed (48 suites)
- `npm run build` — passed

## Notes
- Recommendations are shadow-mode only (logged as telemetry, not applied)
- Rule-based incumbent baseline; RL policy integration is future work
- Controller verified post-merge reconciliation from stale base onto current main

Closes #266
