### PR TITLE
feat(economy): implement multi-room energy logistics with cross-room hauler and storage balancing (#629)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1251,10 +1251,10 @@ function runTowersWithResult(room) {
     actedTowerIds: /* @__PURE__ */ new Set()
   };
   for (const tower of getUsableTowers(room)) {
-    if (runTowerHeal(tower, context, result)) {
+    if (hasHostileTarget(context) && runTowerAttack(tower, context, result)) {
       continue;
     }
-    if (hasHostileTarget(context) && runTowerAttack(tower, context, result)) {
+    if (runTowerHeal(tower, context, result)) {
       continue;
     }
     runTowerRepair(tower, context, result);
@@ -5122,9 +5122,9 @@ function getVisibleController(targetRoom, controllerId) {
   if (roomController) {
     return roomController;
   }
-  const getObjectById3 = game == null ? void 0 : game.getObjectById;
-  if (controllerId && typeof getObjectById3 === "function") {
-    return getObjectById3.call(game, controllerId);
+  const getObjectById4 = game == null ? void 0 : game.getObjectById;
+  if (controllerId && typeof getObjectById4 === "function") {
+    return getObjectById4.call(game, controllerId);
   }
   return null;
 }
@@ -7988,11 +7988,11 @@ function selectCreepRoomController(creep, controllerId) {
     return roomController;
   }
   const game = globalThis.Game;
-  const getObjectById3 = game == null ? void 0 : game.getObjectById;
-  if (typeof getObjectById3 !== "function") {
+  const getObjectById4 = game == null ? void 0 : game.getObjectById;
+  if (typeof getObjectById4 !== "function") {
     return null;
   }
-  return getObjectById3.call(game, controllerId);
+  return getObjectById4.call(game, controllerId);
 }
 function getTerritoryControllerTargetState(controller, action, colonyOwnerUsername) {
   if (action === "reserve") {
@@ -8229,9 +8229,9 @@ function getVisibleController2(targetRoom, controllerId) {
   if (roomController) {
     return roomController;
   }
-  const getObjectById3 = game == null ? void 0 : game.getObjectById;
-  if (controllerId && typeof getObjectById3 === "function") {
-    return getObjectById3.call(game, controllerId);
+  const getObjectById4 = game == null ? void 0 : game.getObjectById;
+  if (controllerId && typeof getObjectById4 === "function") {
+    return getObjectById4.call(game, controllerId);
   }
   return null;
 }
@@ -12922,8 +12922,8 @@ function isUrgentEnergySpendingTask(task) {
 }
 function getTaskTarget(task) {
   const game = globalThis.Game;
-  const getObjectById3 = game == null ? void 0 : game.getObjectById;
-  return typeof getObjectById3 === "function" ? getObjectById3(String(task.targetId)) : null;
+  const getObjectById4 = game == null ? void 0 : game.getObjectById;
+  return typeof getObjectById4 === "function" ? getObjectById4(String(task.targetId)) : null;
 }
 function isCapacityEnablingConstructionSite(target) {
   const structureType = target == null ? void 0 : target.structureType;
@@ -13487,8 +13487,8 @@ function getEnergyResource5() {
 }
 function getObjectById(id) {
   var _a;
-  const getObjectById3 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  return typeof getObjectById3 === "function" ? getObjectById3(String(id)) : null;
+  const getObjectById4 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById4 === "function" ? getObjectById4(String(id)) : null;
 }
 function getVisibleRoom2(roomName) {
   var _a, _b;
@@ -13722,8 +13722,8 @@ function getEnergyResource6() {
 }
 function getObjectById2(id) {
   var _a;
-  const getObjectById3 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  return typeof getObjectById3 === "function" ? getObjectById3(String(id)) : null;
+  const getObjectById4 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById4 === "function" ? getObjectById4(String(id)) : null;
 }
 function getRemoteOperationCreeps2(homeRoom, targetRoom) {
   const findMyCreeps3 = globalThis.FIND_MY_CREEPS;
@@ -14200,6 +14200,729 @@ function isNonEmptyString9(value) {
   return typeof value === "string" && value.length > 0;
 }
 
+// src/economy/storageBalancer.ts
+var STORAGE_BALANCE_EXPORT_RATIO = 0.8;
+var STORAGE_BALANCE_IMPORT_RATIO = 0.3;
+var STORAGE_BALANCE_REFRESH_INTERVAL = 25;
+function balanceStorage() {
+  const memory = getEconomyMemory();
+  const gameTime = getGameTime10();
+  const existing = memory.storageBalance;
+  if (existing && isStorageBalanceFresh(existing, gameTime)) {
+    return;
+  }
+  memory.storageBalance = buildStorageBalanceState(gameTime);
+}
+function getStorageBalanceState() {
+  const memory = getEconomyMemory();
+  const gameTime = getGameTime10();
+  const existing = memory.storageBalance;
+  if (existing && isStorageBalanceFresh(existing, gameTime)) {
+    return existing;
+  }
+  const state = buildStorageBalanceState(gameTime);
+  memory.storageBalance = state;
+  return state;
+}
+function getRoomStoredEnergyState(room) {
+  const stores = getRoomEnergyStores(room);
+  const energy = stores.reduce((total, structure) => total + getStoredEnergy9(structure), 0);
+  const capacity = stores.reduce((total, structure) => total + getEnergyCapacity2(structure), 0);
+  const ratio = capacity > 0 ? energy / capacity : 0;
+  const exportableEnergy = capacity > 0 && ratio > STORAGE_BALANCE_EXPORT_RATIO ? Math.floor(energy - capacity * STORAGE_BALANCE_EXPORT_RATIO) : 0;
+  const importDemand = capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO ? Math.ceil(capacity * STORAGE_BALANCE_IMPORT_RATIO - energy) : 0;
+  return {
+    roomName: room.name,
+    energy,
+    capacity,
+    ratio,
+    exportableEnergy: Math.max(0, exportableEnergy),
+    importDemand: Math.max(0, importDemand),
+    mode: selectStorageBalanceMode(capacity, ratio)
+  };
+}
+function buildStorageBalanceState(gameTime) {
+  const roomStates = getOwnedRooms().map(getRoomStoredEnergyState).filter((state) => state.capacity > 0);
+  return {
+    updatedAt: gameTime,
+    rooms: Object.fromEntries(
+      roomStates.map((state) => [
+        state.roomName,
+        {
+          roomName: state.roomName,
+          mode: state.mode,
+          energy: state.energy,
+          capacity: state.capacity,
+          ratio: state.ratio,
+          exportableEnergy: state.exportableEnergy,
+          importDemand: state.importDemand,
+          updatedAt: gameTime
+        }
+      ])
+    ),
+    transfers: buildStorageTransfers(roomStates, gameTime)
+  };
+}
+function buildStorageTransfers(roomStates, gameTime) {
+  var _a;
+  const exporters = roomStates.filter((state) => state.mode === "export" && state.exportableEnergy > 0).sort(compareExportRooms);
+  const importers = roomStates.filter((state) => state.mode === "import" && state.importDemand > 0).sort(compareImportRooms);
+  const remainingExport = new Map(exporters.map((state) => [state.roomName, state.exportableEnergy]));
+  const transfers = [];
+  for (const importer of importers) {
+    let remainingDemand = importer.importDemand;
+    for (const exporter of exporters) {
+      if (remainingDemand <= 0) {
+        break;
+      }
+      const exportableEnergy = (_a = remainingExport.get(exporter.roomName)) != null ? _a : 0;
+      const amount = Math.min(exportableEnergy, remainingDemand);
+      if (amount <= 0) {
+        continue;
+      }
+      transfers.push({
+        sourceRoom: exporter.roomName,
+        targetRoom: importer.roomName,
+        amount,
+        updatedAt: gameTime
+      });
+      remainingExport.set(exporter.roomName, exportableEnergy - amount);
+      remainingDemand -= amount;
+    }
+  }
+  return transfers;
+}
+function compareExportRooms(left, right) {
+  return right.exportableEnergy - left.exportableEnergy || right.ratio - left.ratio || left.roomName.localeCompare(right.roomName);
+}
+function compareImportRooms(left, right) {
+  return right.importDemand - left.importDemand || left.ratio - right.ratio || left.roomName.localeCompare(right.roomName);
+}
+function selectStorageBalanceMode(capacity, ratio) {
+  if (capacity <= 0) {
+    return "balanced";
+  }
+  if (ratio > STORAGE_BALANCE_EXPORT_RATIO) {
+    return "export";
+  }
+  if (ratio < STORAGE_BALANCE_IMPORT_RATIO) {
+    return "import";
+  }
+  return "balanced";
+}
+function getRoomEnergyStores(room) {
+  const stores = [
+    room.storage,
+    room.terminal
+  ];
+  return stores.filter(
+    (structure) => structure !== void 0
+  );
+}
+function getStoredEnergy9(target) {
+  var _a;
+  const store = target.store;
+  const resource = getEnergyResource7();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+  const directEnergy = store == null ? void 0 : store[resource];
+  return typeof directEnergy === "number" && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
+}
+function getEnergyCapacity2(target) {
+  var _a, _b, _c;
+  const store = target.store;
+  const resource = getEnergyResource7();
+  const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof capacity === "number" && Number.isFinite(capacity)) {
+    return Math.max(0, capacity);
+  }
+  const genericCapacity = (_b = store == null ? void 0 : store.getCapacity) == null ? void 0 : _b.call(store);
+  if (typeof genericCapacity === "number" && Number.isFinite(genericCapacity)) {
+    return Math.max(0, genericCapacity);
+  }
+  const freeCapacity = (_c = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _c.call(store, resource);
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? getStoredEnergy9(target) + Math.max(0, freeCapacity) : 0;
+}
+function isStorageBalanceFresh(state, gameTime) {
+  return typeof state.updatedAt === "number" && Number.isFinite(state.updatedAt) && gameTime >= state.updatedAt && gameTime - state.updatedAt < STORAGE_BALANCE_REFRESH_INTERVAL;
+}
+function getOwnedRooms() {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return [];
+  }
+  return Object.values(rooms).filter((room) => {
+    var _a2;
+    return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
+  });
+}
+function getEconomyMemory() {
+  const memory = getMemory();
+  if (!memory.economy) {
+    memory.economy = {};
+  }
+  return memory.economy;
+}
+function getMemory() {
+  const global = globalThis;
+  if (!global.Memory) {
+    global.Memory = {};
+  }
+  return global.Memory;
+}
+function getGameTime10() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
+}
+function getEnergyResource7() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+
+// src/economy/crossRoomHauler.ts
+var CROSS_ROOM_HAULER_ROLE = "crossRoomHauler";
+var CARRY_MOVE_PAIR_COST = 100;
+var CARRY_CAPACITY_PER_PART = 50;
+var MAX_CARRY_MOVE_PAIRS = 25;
+var MIN_CARRY_MOVE_PAIRS = 1;
+var CROSS_ROOM_HAULER_REPLACEMENT_TICKS = 100;
+var CROSS_ROOM_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
+var ERR_NO_PATH_CODE5 = -2;
+var ERR_NOT_IN_RANGE_CODE6 = -9;
+function planCrossRoomHauler() {
+  const transfer = selectCrossRoomEnergyTransfer();
+  if (!transfer) {
+    return null;
+  }
+  const sourceRoom = getVisibleRoom4(transfer.sourceRoom);
+  const targetRoom = getVisibleRoom4(transfer.targetRoom);
+  if (!sourceRoom || !targetRoom) {
+    return null;
+  }
+  const source = selectSourceEnergyStructure(sourceRoom);
+  if (!source) {
+    return null;
+  }
+  const spawn = selectSourceRoomSpawn(sourceRoom.name);
+  if (!spawn) {
+    return null;
+  }
+  const sourceState = getRoomStoredEnergyState(sourceRoom);
+  const transferableEnergy = Math.min(transfer.amount, sourceState.exportableEnergy);
+  const body = buildCrossRoomHaulerBody(sourceRoom.energyAvailable, transferableEnergy);
+  if (body.length === 0) {
+    return null;
+  }
+  const route = findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name);
+  if (!route) {
+    return null;
+  }
+  return {
+    spawn,
+    body,
+    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime11()}`,
+    memory: {
+      role: CROSS_ROOM_HAULER_ROLE,
+      colony: sourceRoom.name,
+      crossRoomHauler: {
+        homeRoom: sourceRoom.name,
+        targetRoom: targetRoom.name,
+        sourceId: source.id,
+        state: "collecting",
+        route: route.rooms
+      }
+    }
+  };
+}
+function buildCrossRoomHaulerBody(energyAvailable, transferableEnergy) {
+  const energyBudget = Math.max(0, Math.floor(energyAvailable));
+  const energyScaledPairs = Math.ceil(Math.max(0, transferableEnergy) / CARRY_CAPACITY_PER_PART);
+  const affordablePairs = Math.floor(energyBudget / CARRY_MOVE_PAIR_COST);
+  const pairCount = Math.min(
+    MAX_CARRY_MOVE_PAIRS,
+    affordablePairs,
+    Math.max(MIN_CARRY_MOVE_PAIRS, energyScaledPairs)
+  );
+  if (pairCount <= 0) {
+    return [];
+  }
+  return Array.from({ length: pairCount }).flatMap(() => ["carry", "move"]);
+}
+function runCrossRoomHauler(creep) {
+  const assignment = getMutableCrossRoomHaulerMemory(creep);
+  if (!assignment) {
+    return;
+  }
+  if (assignment.state === "returning" && !isSourceUnassigned(assignment)) {
+    returnHome(creep, assignment);
+    return;
+  }
+  if (getCarriedEnergy4(creep) > 0) {
+    assignment.state = "delivering";
+    deliverEnergy2(creep, assignment);
+    return;
+  }
+  if (isSourceUnassigned(assignment) && !recoverSourceAssignment(creep, assignment)) {
+    return;
+  }
+  if (assignment.state === "returning") {
+    returnHome(creep, assignment);
+    return;
+  }
+  if (!hasSourceSurplusEnergy(assignment)) {
+    assignment.state = "returning";
+    returnHome(creep, assignment);
+    return;
+  }
+  assignment.state = "collecting";
+  collectEnergy(creep, assignment);
+}
+function selectCrossRoomEnergyTransfer() {
+  var _a;
+  const balance = getStorageBalanceState();
+  return (_a = balance.transfers.filter((transfer) => transfer.amount > 0).filter((transfer) => !hasActiveCrossRoomHauler(transfer)).filter((transfer) => isLiveTransferCandidate(transfer)).sort(compareTransfers)[0]) != null ? _a : null;
+}
+function isLiveTransferCandidate(transfer) {
+  const sourceRoom = getVisibleRoom4(transfer.sourceRoom);
+  const targetRoom = getVisibleRoom4(transfer.targetRoom);
+  if (!sourceRoom || !targetRoom) {
+    return false;
+  }
+  if (!isSafeOwnedRoom(sourceRoom.name) || !isSafeOwnedRoom(targetRoom.name)) {
+    return false;
+  }
+  const sourceState = getRoomStoredEnergyState(sourceRoom);
+  const targetState = getRoomStoredEnergyState(targetRoom);
+  if (sourceState.mode !== "export" || targetState.mode !== "import") {
+    return false;
+  }
+  return findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name) !== null;
+}
+function compareTransfers(left, right) {
+  var _a, _b, _c, _d;
+  const leftRouteDistance = (_b = (_a = findOwnedLogisticsRoute(left.sourceRoom, left.targetRoom)) == null ? void 0 : _a.distance) != null ? _b : Number.POSITIVE_INFINITY;
+  const rightRouteDistance = (_d = (_c = findOwnedLogisticsRoute(right.sourceRoom, right.targetRoom)) == null ? void 0 : _c.distance) != null ? _d : Number.POSITIVE_INFINITY;
+  return right.amount - left.amount || leftRouteDistance - rightRouteDistance || left.sourceRoom.localeCompare(right.sourceRoom) || left.targetRoom.localeCompare(right.targetRoom);
+}
+function hasActiveCrossRoomHauler(transfer) {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  if (!creeps) {
+    return false;
+  }
+  return Object.values(creeps).some((creep) => {
+    var _a2, _b;
+    const memory = normalizeCrossRoomHaulerMemory((_a2 = creep.memory) == null ? void 0 : _a2.crossRoomHauler);
+    return ((_b = creep.memory) == null ? void 0 : _b.role) === CROSS_ROOM_HAULER_ROLE && (memory == null ? void 0 : memory.homeRoom) === transfer.sourceRoom && memory.targetRoom === transfer.targetRoom && (creep.ticksToLive === void 0 || creep.ticksToLive > CROSS_ROOM_HAULER_REPLACEMENT_TICKS);
+  });
+}
+function collectEnergy(creep, assignment) {
+  var _a, _b;
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
+    delete creep.memory.task;
+    moveTowardRoom3(creep, assignment, assignment.homeRoom);
+    return;
+  }
+  let source = getAssignedSource2(assignment);
+  if (!source || getStoredEnergy10(source) <= 0) {
+    source = selectReplacementSource(assignment, creep.room);
+  }
+  if (!source) {
+    delete creep.memory.task;
+    markSourceUnassigned(assignment);
+    return;
+  }
+  const sourceId = assignment.sourceId;
+  if (!sourceId) {
+    markSourceUnassigned(assignment);
+    return;
+  }
+  const task = {
+    type: "withdraw",
+    targetId: sourceId
+  };
+  creep.memory.task = task;
+  const result = (_b = creep.withdraw) == null ? void 0 : _b.call(creep, source, getEnergyResource8());
+  if (result === getErrNotInRangeCode3()) {
+    moveTo3(creep, source);
+  }
+}
+function deliverEnergy2(creep, assignment) {
+  var _a, _b;
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
+    delete creep.memory.task;
+    moveTowardRoom3(creep, assignment, assignment.targetRoom);
+    return;
+  }
+  const target = selectDeliveryTarget(creep.room);
+  if (!target) {
+    delete creep.memory.task;
+    assignment.state = "returning";
+    returnHome(creep, assignment);
+    return;
+  }
+  const task = {
+    type: "transfer",
+    targetId: target.id
+  };
+  creep.memory.task = task;
+  const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, target, getEnergyResource8());
+  if (result === getErrNotInRangeCode3()) {
+    moveTo3(creep, target);
+  }
+}
+function returnHome(creep, assignment) {
+  var _a, _b;
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
+    delete creep.memory.task;
+    moveTowardRoom3(creep, assignment, assignment.homeRoom);
+    return;
+  }
+  const carriedEnergy = getCarriedEnergy4(creep);
+  if (carriedEnergy > 0) {
+    const homeTarget = selectHomeReturnTarget(creep.room);
+    if (homeTarget) {
+      const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, homeTarget, getEnergyResource8());
+      if (result === getErrNotInRangeCode3()) {
+        moveTo3(creep, homeTarget);
+      }
+      return;
+    }
+  }
+  delete creep.memory.task;
+  if (hasSourceSurplusEnergy(assignment)) {
+    assignment.state = "collecting";
+    return;
+  }
+  assignment.state = isSourceUnassigned(assignment) ? "unassigned" : "returning";
+}
+function selectDeliveryTarget(room) {
+  var _a;
+  const targets = [
+    ...findOwnedStructures4(room).filter(isSpawnOrExtensionWithDemand),
+    ...findRoomStructures2(room).filter(isContainerWithDemand),
+    ...[room.storage, room.terminal].filter(isStorageOrTerminalWithDemand)
+  ].sort(compareDeliveryTargets);
+  return (_a = targets[0]) != null ? _a : null;
+}
+function selectHomeReturnTarget(room) {
+  var _a;
+  const targets = [room.storage, room.terminal].filter(
+    (structure) => structure !== void 0 && getFreeEnergyCapacity5(structure) > 0
+  );
+  return (_a = targets.sort((left, right) => getObjectId5(left).localeCompare(getObjectId5(right)))[0]) != null ? _a : null;
+}
+function isSpawnOrExtensionWithDemand(structure) {
+  return (matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType12(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity5(structure) > 0;
+}
+function isContainerWithDemand(structure) {
+  return matchesStructureType12(structure.structureType, "STRUCTURE_CONTAINER", "container") && getFreeEnergyCapacity5(structure) > 0;
+}
+function isStorageOrTerminalWithDemand(structure) {
+  return structure !== void 0 && getFreeEnergyCapacity5(structure) > 0;
+}
+function compareDeliveryTargets(left, right) {
+  return getDeliveryPriority(right) - getDeliveryPriority(left) || getObjectId5(left).localeCompare(getObjectId5(right));
+}
+function getDeliveryPriority(target) {
+  if (matchesStructureType12(target.structureType, "STRUCTURE_SPAWN", "spawn")) {
+    return 3;
+  }
+  if (matchesStructureType12(target.structureType, "STRUCTURE_EXTENSION", "extension")) {
+    return 2;
+  }
+  if (matchesStructureType12(target.structureType, "STRUCTURE_STORAGE", "storage")) {
+    return 0;
+  }
+  if (matchesStructureType12(target.structureType, "STRUCTURE_TERMINAL", "terminal")) {
+    return -1;
+  }
+  return 1;
+}
+function selectSourceEnergyStructure(room) {
+  var _a;
+  return (_a = [room.storage, room.terminal].filter(
+    (structure) => structure !== void 0 && getStoredEnergy10(structure) > 0
+  ).sort((left, right) => getStoredEnergy10(right) - getStoredEnergy10(left) || getObjectId5(left).localeCompare(getObjectId5(right)))[0]) != null ? _a : null;
+}
+function hasSourceSurplusEnergy(assignment) {
+  const room = getVisibleRoom4(assignment.homeRoom);
+  if (!room) {
+    return false;
+  }
+  let source = getAssignedSource2(assignment);
+  if (!source || getStoredEnergy10(source) <= 0) {
+    source = selectReplacementSource(assignment, room);
+  }
+  return getRoomStoredEnergyState(room).mode === "export" && source !== null && getStoredEnergy10(source) > 0;
+}
+function recoverSourceAssignment(creep, assignment) {
+  var _a;
+  const homeRoom = getVisibleRoom4(assignment.homeRoom);
+  const source = homeRoom ? selectReplacementSource(assignment, homeRoom) : null;
+  if (source) {
+    assignment.state = "collecting";
+    return true;
+  }
+  delete creep.memory.task;
+  markSourceUnassigned(assignment);
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
+    moveTowardRoom3(creep, assignment, assignment.homeRoom);
+  }
+  return false;
+}
+function selectReplacementSource(assignment, room) {
+  const source = selectSourceEnergyStructure(room);
+  if (!source) {
+    markSourceUnassigned(assignment);
+    return null;
+  }
+  assignment.sourceId = source.id;
+  return source;
+}
+function getAssignedSource2(assignment) {
+  return assignment.sourceId ? getObjectById3(assignment.sourceId) : null;
+}
+function markSourceUnassigned(assignment) {
+  assignment.sourceId = null;
+  assignment.state = "unassigned";
+}
+function isSourceUnassigned(assignment) {
+  return assignment.state === "unassigned" || !assignment.sourceId;
+}
+function selectSourceRoomSpawn(roomName) {
+  var _a, _b;
+  const spawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
+  if (!spawns) {
+    return null;
+  }
+  return (_b = Object.values(spawns).filter((spawn) => {
+    var _a2;
+    return ((_a2 = spawn.room) == null ? void 0 : _a2.name) === roomName && !spawn.spawning;
+  }).sort((left, right) => getSpawnEnergyScore(right) - getSpawnEnergyScore(left) || left.name.localeCompare(right.name))[0]) != null ? _b : null;
+}
+function getSpawnEnergyScore(spawn) {
+  const room = spawn.room;
+  return typeof (room == null ? void 0 : room.energyAvailable) === "number" && Number.isFinite(room.energyAvailable) ? room.energyAvailable : 0;
+}
+function findOwnedLogisticsRoute(fromRoom, targetRoom) {
+  var _a;
+  if (fromRoom === targetRoom) {
+    return { distance: 0, rooms: [] };
+  }
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
+    return null;
+  }
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName) => isSafeLogisticsTransitRoom(roomName) ? 1 : Infinity
+  });
+  if (route === getNoPathResultCode5() || !Array.isArray(route)) {
+    return null;
+  }
+  const rooms = route.map((step) => isRecord10(step) && typeof step.room === "string" ? step.room : null).filter((roomName) => typeof roomName === "string");
+  if (rooms.length !== route.length || !rooms.every(isSafeLogisticsTransitRoom)) {
+    return null;
+  }
+  return { distance: rooms.length, rooms };
+}
+function moveTowardRoom3(creep, assignment, destinationRoom) {
+  var _a, _b;
+  const route = getAssignmentRoute(assignment);
+  const nextRoom = route ? selectNextRouteRoom((_a = creep.room) == null ? void 0 : _a.name, assignment, destinationRoom, route) : destinationRoom;
+  const visibleController = (_b = getVisibleRoom4(nextRoom)) == null ? void 0 : _b.controller;
+  if (visibleController) {
+    moveTo3(creep, visibleController);
+    return;
+  }
+  const RoomPositionCtor = globalThis.RoomPosition;
+  if (typeof RoomPositionCtor === "function") {
+    moveTo3(creep, new RoomPositionCtor(25, 25, nextRoom));
+  }
+}
+function getAssignmentRoute(assignment) {
+  const route = findOwnedLogisticsRoute(assignment.homeRoom, assignment.targetRoom);
+  if (!route) {
+    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString10) : null;
+  }
+  assignment.route = route.rooms;
+  return route.rooms;
+}
+function selectNextRouteRoom(currentRoom, assignment, destinationRoom, route) {
+  var _a, _b, _c;
+  if (!currentRoom) {
+    return destinationRoom;
+  }
+  if (destinationRoom === assignment.targetRoom) {
+    if (currentRoom === assignment.homeRoom) {
+      return (_a = route[0]) != null ? _a : assignment.targetRoom;
+    }
+    const routeIndex2 = route.indexOf(currentRoom);
+    return routeIndex2 >= 0 ? (_b = route[routeIndex2 + 1]) != null ? _b : assignment.targetRoom : destinationRoom;
+  }
+  const routeIndex = route.indexOf(currentRoom);
+  if (routeIndex > 0) {
+    return (_c = route[routeIndex - 1]) != null ? _c : assignment.homeRoom;
+  }
+  return assignment.homeRoom;
+}
+function isSafeOwnedRoom(roomName) {
+  var _a;
+  const room = getVisibleRoom4(roomName);
+  return ((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && !hasHostilePresence(room);
+}
+function isSafeLogisticsTransitRoom(roomName) {
+  var _a;
+  const room = getVisibleRoom4(roomName);
+  if (!room) {
+    return true;
+  }
+  if (hasHostilePresence(room)) {
+    return false;
+  }
+  return ((_a = room.controller) == null ? void 0 : _a.owner) === void 0 || room.controller.my === true;
+}
+function hasHostilePresence(room) {
+  const hostileCreepFind = getGlobalNumber5("FIND_HOSTILE_CREEPS");
+  if (typeof hostileCreepFind === "number" && typeof room.find === "function") {
+    const hostiles = room.find(hostileCreepFind);
+    if (Array.isArray(hostiles) && hostiles.length > 0) {
+      return true;
+    }
+  }
+  const hostileStructureFind = getGlobalNumber5("FIND_HOSTILE_STRUCTURES");
+  if (typeof hostileStructureFind === "number" && typeof room.find === "function") {
+    const hostiles = room.find(hostileStructureFind);
+    if (Array.isArray(hostiles) && hostiles.length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+function findOwnedStructures4(room) {
+  var _a, _b;
+  const findMyStructures = getGlobalNumber5("FIND_MY_STRUCTURES");
+  if (typeof findMyStructures !== "number" || typeof room.find !== "function") {
+    return Object.values((_b = (_a = globalThis.Game) == null ? void 0 : _a.spawns) != null ? _b : {}).filter(
+      (spawn) => {
+        var _a2;
+        return ((_a2 = spawn.room) == null ? void 0 : _a2.name) === room.name;
+      }
+    );
+  }
+  const structures = room.find(findMyStructures);
+  return Array.isArray(structures) ? structures : [];
+}
+function findRoomStructures2(room) {
+  const findStructures = getGlobalNumber5("FIND_STRUCTURES");
+  if (typeof findStructures !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const structures = room.find(findStructures);
+  return Array.isArray(structures) ? structures : [];
+}
+function normalizeCrossRoomHaulerMemory(value) {
+  if (!isRecord10(value)) {
+    return null;
+  }
+  if (!isNonEmptyString10(value.homeRoom) || !isNonEmptyString10(value.targetRoom)) {
+    return null;
+  }
+  const sourceId = isNonEmptyString10(value.sourceId) ? value.sourceId : null;
+  const state = value.state === "collecting" || value.state === "delivering" || value.state === "returning" || value.state === "unassigned" ? value.state : void 0;
+  return {
+    homeRoom: value.homeRoom,
+    targetRoom: value.targetRoom,
+    sourceId,
+    ...state ? { state: sourceId ? state : "unassigned" } : sourceId ? {} : { state: "unassigned" },
+    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString10) } : {}
+  };
+}
+function getMutableCrossRoomHaulerMemory(creep) {
+  var _a;
+  const normalized = normalizeCrossRoomHaulerMemory((_a = creep.memory) == null ? void 0 : _a.crossRoomHauler);
+  if (!normalized) {
+    return null;
+  }
+  creep.memory.crossRoomHauler = normalized;
+  return creep.memory.crossRoomHauler;
+}
+function moveTo3(creep, target) {
+  var _a;
+  (_a = creep.moveTo) == null ? void 0 : _a.call(creep, target, CROSS_ROOM_MOVE_OPTS);
+}
+function getCarriedEnergy4(creep) {
+  return getStoredEnergy10(creep);
+}
+function getStoredEnergy10(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const resource = getEnergyResource8();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+  const directEnergy = store == null ? void 0 : store[resource];
+  return typeof directEnergy === "number" && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
+}
+function getFreeEnergyCapacity5(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource8());
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+function getObjectById3(id) {
+  var _a;
+  const getObjectById4 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById4 === "function" ? getObjectById4(String(id)) : null;
+}
+function getVisibleRoom4(roomName) {
+  var _a, _b;
+  return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+}
+function getGameTime11() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
+}
+function getEnergyResource8() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function getErrNotInRangeCode3() {
+  var _a;
+  return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE6;
+}
+function getNoPathResultCode5() {
+  var _a;
+  return (_a = globalThis.ERR_NO_PATH) != null ? _a : ERR_NO_PATH_CODE5;
+}
+function getObjectId5(object) {
+  if (!isRecord10(object)) {
+    return "";
+  }
+  return typeof object.id === "string" ? object.id : typeof object.name === "string" ? object.name : "";
+}
+function matchesStructureType12(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+function getGlobalNumber5(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function isRecord10(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString10(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
 // src/spawn/spawnPlanner.ts
 var CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
 var CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
@@ -14212,7 +14935,7 @@ var HARVEST_POWER_PER_WORK_PART = 2;
 var HARVESTER_FULL_EXTRACTION_WORK_PARTS = Math.ceil(
   SOURCE_ENERGY_PER_TICK / HARVEST_POWER_PER_WORK_PART
 );
-var CARRY_CAPACITY_PER_PART = 50;
+var CARRY_CAPACITY_PER_PART2 = 50;
 var MAX_CREEP_PARTS4 = 50;
 var LOCAL_SUPPORT_WORKER_FLOOR = 3;
 var POST_CLAIM_SUSTAIN_UPGRADER_TARGET = 1;
@@ -14257,6 +14980,37 @@ function planSpawn(colony, roleCounts, gameTime, options = {}) {
   }
   return null;
 }
+function orderColoniesForSpawnPlanning(colonies) {
+  return [...colonies].sort(compareColoniesForSpawnPlanning);
+}
+function getSpawnEnergyForecast(colony) {
+  const balance = getStorageBalanceMemory();
+  const transfers = Array.isArray(balance == null ? void 0 : balance.transfers) ? balance.transfers : [];
+  const incomingEnergy = transfers.filter((transfer) => transfer.targetRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger2(transfer.amount), 0);
+  const outgoingEnergy = transfers.filter((transfer) => transfer.sourceRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger2(transfer.amount), 0);
+  const energyAvailable = normalizeNonNegativeInteger2(colony.energyAvailable);
+  return {
+    roomName: colony.room.name,
+    energyAvailable,
+    incomingEnergy,
+    outgoingEnergy,
+    effectiveEnergyAvailable: Math.max(0, energyAvailable + incomingEnergy - outgoingEnergy)
+  };
+}
+function shouldSuppressWorkerSpawnForCrossRoomImport(colony) {
+  var _a, _b;
+  const balance = getStorageBalanceMemory();
+  if (!balance) {
+    return false;
+  }
+  const roomBalance = (_a = balance == null ? void 0 : balance.rooms) == null ? void 0 : _a[colony.room.name];
+  if ((roomBalance == null ? void 0 : roomBalance.mode) !== "import") {
+    return false;
+  }
+  return ((_b = balance == null ? void 0 : balance.transfers) != null ? _b : []).some(
+    (transfer) => transfer.targetRoom === colony.room.name && transfer.amount > 0 && isLiveTransferCandidate(transfer)
+  );
+}
 function planSpawnForPriorityTier(tier, context) {
   switch (tier) {
     case "emergencyBootstrap":
@@ -14291,7 +15045,7 @@ function planEmergencyBootstrapSpawn(context) {
   );
 }
 function planLocalSurvivalSpawn(context) {
-  if (context.workerCapacity >= context.workerTarget || !hasRecoveryWorkerSpawnEnergy(context.colony)) {
+  if (context.workerCapacity >= context.workerTarget || !hasRecoveryWorkerSpawnEnergy(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) {
     return null;
   }
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
@@ -14367,7 +15121,7 @@ function getDesiredDefenderCount(hostileCount) {
   return Math.max(1, Math.ceil(hostileCount / HOSTILES_PER_DEFENDER));
 }
 function getRoomHostileCreepCount(room) {
-  const findHostiles = getGlobalNumber5("FIND_HOSTILE_CREEPS");
+  const findHostiles = getGlobalNumber6("FIND_HOSTILE_CREEPS");
   if (findHostiles === void 0 || typeof room.find !== "function") {
     return 0;
   }
@@ -14411,7 +15165,7 @@ function selectPostClaimControllerSustainPlan(colony) {
   var _a;
   const records = getPostClaimControllerSustainRecords(colony.room.name);
   for (const record of records) {
-    const targetRoom = getVisibleRoom4(record.roomName);
+    const targetRoom = getVisibleRoom5(record.roomName);
     if (((_a = targetRoom == null ? void 0 : targetRoom.controller) == null ? void 0 : _a.my) !== true) {
       continue;
     }
@@ -14438,7 +15192,7 @@ function selectPostClaimControllerSustainPlan(colony) {
 function getPostClaimControllerSustainRecords(colonyName) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord10(records)) {
+  if (!isRecord11(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -14446,7 +15200,7 @@ function getPostClaimControllerSustainRecords(colonyName) {
   ).sort(comparePostClaimControllerSustainRecords);
 }
 function isPostClaimControllerSustainRecord(record, colonyName) {
-  return isRecord10(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString10(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord11(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString11(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function comparePostClaimControllerSustainRecords(left, right) {
   const leftHasSpawn = hasOperationalSpawnInRoom(left.roomName);
@@ -14458,7 +15212,7 @@ function comparePostClaimControllerSustainRecords(left, right) {
 }
 function getVisibleControllerLevel(roomName) {
   var _a, _b;
-  const level = (_b = (_a = getVisibleRoom4(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
+  const level = (_b = (_a = getVisibleRoom5(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
   return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL2 + 1;
 }
 function hasOperationalSpawnInRoom(roomName) {
@@ -14704,7 +15458,7 @@ function planMultiRoomControllerUpgradeSpawn(context) {
   return null;
 }
 function shouldSpawnControllerUpgradeSurplusWorker(context) {
-  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
+  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
     return false;
   }
   const surplusWorkerTarget = Math.min(
@@ -14880,7 +15634,7 @@ function buildHarvesterBody(workParts, carryParts) {
 function getHarvesterCarryTarget(workParts, sourceDistance) {
   const roundTripTicks = Math.max(1, normalizeNonNegativeInteger2(sourceDistance) * 2);
   const harvestedEnergyBetweenTrips = workParts * HARVEST_POWER_PER_WORK_PART * roundTripTicks;
-  return Math.max(1, Math.ceil(harvestedEnergyBetweenTrips / CARRY_CAPACITY_PER_PART));
+  return Math.max(1, Math.ceil(harvestedEnergyBetweenTrips / CARRY_CAPACITY_PER_PART2));
 }
 function getHarvesterBodyCost(workParts, carryParts) {
   return getBodyCost(buildHarvesterBody(workParts, carryParts));
@@ -14934,17 +15688,26 @@ function buildTerritorySpawnBody(energyAvailable, intent) {
   }
   return buildTerritoryControllerBody(energyAvailable);
 }
-function getVisibleRoom4(roomName) {
+function getVisibleRoom5(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function isRecord10(value) {
+function compareColoniesForSpawnPlanning(left, right) {
+  const leftForecast = getSpawnEnergyForecast(left);
+  const rightForecast = getSpawnEnergyForecast(right);
+  return rightForecast.effectiveEnergyAvailable - leftForecast.effectiveEnergyAvailable || right.energyAvailable - left.energyAvailable || left.room.name.localeCompare(right.room.name);
+}
+function getStorageBalanceMemory() {
+  var _a, _b;
+  return (_b = (_a = globalThis.Memory) == null ? void 0 : _a.economy) == null ? void 0 : _b.storageBalance;
+}
+function isRecord11(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString10(value) {
+function isNonEmptyString11(value) {
   return typeof value === "string" && value.length > 0;
 }
-function getGlobalNumber5(name) {
+function getGlobalNumber6(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -14952,9 +15715,9 @@ function getGlobalNumber5(name) {
 // src/territory/scoutIntel.ts
 var TERRITORY_SCOUT_MEMORY_KEY_SEPARATOR = ">";
 var TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS = 1500;
-function recordVisibleRoomScoutIntel(colony, room, gameTime = getGameTime10(), scoutName, telemetryEvents = []) {
+function recordVisibleRoomScoutIntel(colony, room, gameTime = getGameTime12(), scoutName, telemetryEvents = []) {
   var _a, _b, _c, _d;
-  if (!isNonEmptyString11(colony) || !room || !isNonEmptyString11(room.name)) {
+  if (!isNonEmptyString12(colony) || !room || !isNonEmptyString12(room.name)) {
     return null;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord3();
@@ -14994,7 +15757,7 @@ function recordVisibleRoomScoutIntel(colony, room, gameTime = getGameTime10(), s
 }
 function ensureTerritoryScoutAttempt(colony, targetRoom, gameTime, telemetryEvents = [], controllerId) {
   var _a;
-  if (!isNonEmptyString11(colony) || !isNonEmptyString11(targetRoom)) {
+  if (!isNonEmptyString12(colony) || !isNonEmptyString12(targetRoom)) {
     return null;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord3();
@@ -15048,13 +15811,13 @@ function validateTerritoryScoutIntelForClaim({
   if (!controller) {
     return { status: "blocked", reason: "controllerMissing", intel };
   }
-  if (controller.my === true || isNonEmptyString11(controller.ownerUsername) && controller.ownerUsername === colonyOwnerUsername) {
+  if (controller.my === true || isNonEmptyString12(controller.ownerUsername) && controller.ownerUsername === colonyOwnerUsername) {
     return { status: "blocked", reason: "controllerOwned", intel };
   }
-  if (isNonEmptyString11(controller.ownerUsername)) {
+  if (isNonEmptyString12(controller.ownerUsername)) {
     return { status: "blocked", reason: "controllerOwned", intel };
   }
-  if (isNonEmptyString11(controller.reservationUsername) && controller.reservationUsername !== colonyOwnerUsername) {
+  if (isNonEmptyString12(controller.reservationUsername) && controller.reservationUsername !== colonyOwnerUsername) {
     return { status: "blocked", reason: "controllerReserved", intel };
   }
   if (intel.hostileSpawnCount > 0) {
@@ -15067,7 +15830,7 @@ function validateTerritoryScoutIntelForClaim({
 }
 function recordTerritoryScoutValidation(colony, targetRoom, result, gameTime, telemetryEvents = [], controllerId, score) {
   var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n;
-  if (!isNonEmptyString11(colony) || !isNonEmptyString11(targetRoom)) {
+  if (!isNonEmptyString12(colony) || !isNonEmptyString12(targetRoom)) {
     return;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord3();
@@ -15109,7 +15872,7 @@ function recordTerritoryScoutValidation(colony, targetRoom, result, gameTime, te
 }
 function getTerritoryScoutSummary(colony) {
   var _a, _b;
-  if (!isNonEmptyString11(colony)) {
+  if (!isNonEmptyString12(colony)) {
     return null;
   }
   const territoryMemory = getTerritoryMemoryRecord4();
@@ -15242,22 +16005,22 @@ function isScoutAttemptTimedOut(attempt, gameTime) {
   return (attempt == null ? void 0 : attempt.status) === "requested" && gameTime >= attempt.requestedAt && gameTime - attempt.requestedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS;
 }
 function getMutableScoutAttemptRecords(territoryMemory) {
-  if (!isRecord11(territoryMemory.scoutAttempts) || Array.isArray(territoryMemory.scoutAttempts)) {
+  if (!isRecord12(territoryMemory.scoutAttempts) || Array.isArray(territoryMemory.scoutAttempts)) {
     territoryMemory.scoutAttempts = {};
   }
   return territoryMemory.scoutAttempts;
 }
 function getMutableScoutIntelRecords(territoryMemory) {
-  if (!isRecord11(territoryMemory.scoutIntel) || Array.isArray(territoryMemory.scoutIntel)) {
+  if (!isRecord12(territoryMemory.scoutIntel) || Array.isArray(territoryMemory.scoutIntel)) {
     territoryMemory.scoutIntel = {};
   }
   return territoryMemory.scoutIntel;
 }
 function normalizeTerritoryScoutAttempt(rawAttempt) {
-  if (!isRecord11(rawAttempt)) {
+  if (!isRecord12(rawAttempt)) {
     return null;
   }
-  if (!isNonEmptyString11(rawAttempt.colony) || !isNonEmptyString11(rawAttempt.roomName) || !isTerritoryScoutAttemptStatus(rawAttempt.status) || !isFiniteNumber6(rawAttempt.requestedAt) || !isFiniteNumber6(rawAttempt.updatedAt)) {
+  if (!isNonEmptyString12(rawAttempt.colony) || !isNonEmptyString12(rawAttempt.roomName) || !isTerritoryScoutAttemptStatus(rawAttempt.status) || !isFiniteNumber6(rawAttempt.requestedAt) || !isFiniteNumber6(rawAttempt.updatedAt)) {
     return null;
   }
   const attemptCount = isFiniteNumber6(rawAttempt.attemptCount) ? Math.max(1, Math.floor(rawAttempt.attemptCount)) : 1;
@@ -15270,18 +16033,18 @@ function normalizeTerritoryScoutAttempt(rawAttempt) {
     updatedAt: rawAttempt.updatedAt,
     attemptCount,
     ...typeof rawAttempt.controllerId === "string" ? { controllerId: rawAttempt.controllerId } : {},
-    ...isNonEmptyString11(rawAttempt.scoutName) ? { scoutName: rawAttempt.scoutName } : {},
+    ...isNonEmptyString12(rawAttempt.scoutName) ? { scoutName: rawAttempt.scoutName } : {},
     ...lastValidation ? { lastValidation } : {}
   };
 }
 function normalizeTerritoryScoutIntel(rawIntel) {
-  if (!isRecord11(rawIntel)) {
+  if (!isRecord12(rawIntel)) {
     return null;
   }
-  if (!isNonEmptyString11(rawIntel.colony) || !isNonEmptyString11(rawIntel.roomName) || !isFiniteNumber6(rawIntel.updatedAt)) {
+  if (!isNonEmptyString12(rawIntel.colony) || !isNonEmptyString12(rawIntel.roomName) || !isFiniteNumber6(rawIntel.updatedAt)) {
     return null;
   }
-  const sourceIds = Array.isArray(rawIntel.sourceIds) ? rawIntel.sourceIds.flatMap((sourceId) => isNonEmptyString11(sourceId) ? [sourceId] : []) : [];
+  const sourceIds = Array.isArray(rawIntel.sourceIds) ? rawIntel.sourceIds.flatMap((sourceId) => isNonEmptyString12(sourceId) ? [sourceId] : []) : [];
   const sourceCount = isFiniteNumber6(rawIntel.sourceCount) ? Math.max(0, Math.floor(rawIntel.sourceCount)) : sourceIds.length;
   const controller = normalizeTerritoryScoutControllerIntel(rawIntel.controller);
   const mineral = normalizeTerritoryScoutMineralIntel(rawIntel.mineral);
@@ -15296,33 +16059,33 @@ function normalizeTerritoryScoutIntel(rawIntel) {
     hostileCreepCount: getBoundedCount(rawIntel.hostileCreepCount),
     hostileStructureCount: getBoundedCount(rawIntel.hostileStructureCount),
     hostileSpawnCount: getBoundedCount(rawIntel.hostileSpawnCount),
-    ...isNonEmptyString11(rawIntel.scoutName) ? { scoutName: rawIntel.scoutName } : {}
+    ...isNonEmptyString12(rawIntel.scoutName) ? { scoutName: rawIntel.scoutName } : {}
   };
 }
 function normalizeTerritoryScoutControllerIntel(rawController) {
-  if (!isRecord11(rawController)) {
+  if (!isRecord12(rawController)) {
     return null;
   }
   return {
     ...typeof rawController.id === "string" ? { id: rawController.id } : {},
     ...typeof rawController.my === "boolean" ? { my: rawController.my } : {},
-    ...isNonEmptyString11(rawController.ownerUsername) ? { ownerUsername: rawController.ownerUsername } : {},
-    ...isNonEmptyString11(rawController.reservationUsername) ? { reservationUsername: rawController.reservationUsername } : {},
+    ...isNonEmptyString12(rawController.ownerUsername) ? { ownerUsername: rawController.ownerUsername } : {},
+    ...isNonEmptyString12(rawController.reservationUsername) ? { reservationUsername: rawController.reservationUsername } : {},
     ...isFiniteNumber6(rawController.reservationTicksToEnd) ? { reservationTicksToEnd: rawController.reservationTicksToEnd } : {}
   };
 }
 function normalizeTerritoryScoutMineralIntel(rawMineral) {
-  if (!isRecord11(rawMineral) || !isNonEmptyString11(rawMineral.id)) {
+  if (!isRecord12(rawMineral) || !isNonEmptyString12(rawMineral.id)) {
     return null;
   }
   return {
     id: rawMineral.id,
-    ...isNonEmptyString11(rawMineral.mineralType) ? { mineralType: rawMineral.mineralType } : {},
+    ...isNonEmptyString12(rawMineral.mineralType) ? { mineralType: rawMineral.mineralType } : {},
     ...isFiniteNumber6(rawMineral.density) ? { density: rawMineral.density } : {}
   };
 }
 function normalizeTerritoryScoutValidation(rawValidation) {
-  if (!isRecord11(rawValidation)) {
+  if (!isRecord12(rawValidation)) {
     return null;
   }
   if (!isTerritoryScoutValidationStatus(rawValidation.status) || !isFiniteNumber6(rawValidation.updatedAt)) {
@@ -15344,7 +16107,7 @@ function compareTerritoryScoutIntel(left, right) {
   return right.updatedAt - left.updatedAt || left.roomName.localeCompare(right.roomName);
 }
 function findRoomObjects10(room, constantName) {
-  const findConstant = getGlobalNumber6(constantName);
+  const findConstant = getGlobalNumber7(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return [];
@@ -15367,12 +16130,12 @@ function getStructureSpawnConstant() {
 function getControllerOwnerUsername5(controller) {
   var _a;
   const username = (_a = controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString11(username) ? username : void 0;
+  return isNonEmptyString12(username) ? username : void 0;
 }
 function getControllerReservationUsername3(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString11(username) ? username : void 0;
+  return isNonEmptyString12(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd2(controller) {
   var _a;
@@ -15382,11 +16145,11 @@ function getControllerReservationTicksToEnd2(controller) {
 function getTerritoryScoutMemoryKey(colony, targetRoom) {
   return `${colony}${TERRITORY_SCOUT_MEMORY_KEY_SEPARATOR}${targetRoom}`;
 }
-function getGlobalNumber6(name) {
+function getGlobalNumber7(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getGameTime10() {
+function getGameTime12() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -15400,7 +16163,7 @@ function getWritableTerritoryMemoryRecord3() {
   if (!memory) {
     return null;
   }
-  if (!isRecord11(memory.territory)) {
+  if (!isRecord12(memory.territory)) {
     memory.territory = {};
   }
   return memory.territory;
@@ -15417,10 +16180,10 @@ function isTerritoryScoutValidationReason(reason) {
 function isFiniteNumber6(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isNonEmptyString11(value) {
+function isNonEmptyString12(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord11(value) {
+function isRecord12(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -15428,7 +16191,7 @@ function isRecord11(value) {
 var NEXT_EXPANSION_TARGET_CREATOR = "nextExpansionScoring";
 var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR4 = ">";
-var ERR_NO_PATH_CODE5 = -2;
+var ERR_NO_PATH_CODE6 = -2;
 var MAX_NEARBY_EXPANSION_ROUTE_DISTANCE = 2;
 var TERRAIN_SCAN_MIN = 2;
 var TERRAIN_SCAN_MAX = 47;
@@ -15498,7 +16261,7 @@ function clearNextExpansionTargetIntent(colony) {
 }
 function validateVisibleNextExpansionScoutIntel(colony, candidate, gameTime, telemetryEvents) {
   var _a, _b, _c;
-  const room = getVisibleRoom5(candidate.roomName);
+  const room = getVisibleRoom6(candidate.roomName);
   if (!room) {
     return null;
   }
@@ -15564,7 +16327,7 @@ function buildRuntimeExpansionCandidates(colony) {
     }
   }
   for (const room of Object.values(rooms)) {
-    if (!room || !isNonEmptyString12(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
+    if (!room || !isNonEmptyString13(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
       continue;
     }
     if (candidateOrders.has(room.name)) {
@@ -15753,7 +16516,7 @@ function hasForeignControllerPresence(input, controller) {
   if (!controller) {
     return false;
   }
-  return isNonEmptyString12(controller.ownerUsername) && controller.ownerUsername !== input.colonyOwnerUsername || isNonEmptyString12(controller.reservationUsername) && controller.reservationUsername !== input.colonyOwnerUsername;
+  return isNonEmptyString13(controller.ownerUsername) && controller.ownerUsername !== input.colonyOwnerUsername || isNonEmptyString13(controller.reservationUsername) && controller.reservationUsername !== input.colonyOwnerUsername;
 }
 function getDistanceScore(candidate) {
   const nearestOwnedDistance = candidate.nearestOwnedRoomDistance;
@@ -15877,7 +16640,7 @@ function persistExpansionCandidateScores(colony, report, gameTime) {
     return;
   }
   const existingCandidates = Array.isArray(territoryMemory.expansionCandidates) ? territoryMemory.expansionCandidates.filter(
-    (candidate) => isRecord12(candidate) && candidate.colony !== colony
+    (candidate) => isRecord13(candidate) && candidate.colony !== colony
   ) : [];
   const nextCandidates = report.candidates.slice(0, MAX_PERSISTED_EXPANSION_CANDIDATES).map((candidate) => toPersistedExpansionCandidateMemory(colony, candidate, gameTime));
   if (existingCandidates.length === 0 && nextCandidates.length === 0) {
@@ -15963,7 +16726,7 @@ function upsertNextExpansionTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord12(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
+  if (isRecord13(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
     existingTarget.createdBy = NEXT_EXPANSION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -15993,7 +16756,7 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
     if (activeTarget && isSameTarget(target, activeTarget)) {
       return true;
     }
-    if (isRecord12(target) && isNonEmptyString12(target.roomName) && target.action === "claim") {
+    if (isRecord13(target) && isNonEmptyString13(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey(target.roomName, "claim"));
     }
     return false;
@@ -16006,10 +16769,10 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
   );
 }
 function isNextExpansionTarget(target, colony) {
-  return isRecord12(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
+  return isRecord13(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
 }
 function isSameTarget(left, right) {
-  return isRecord12(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord13(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey(roomName, action) {
   return `${roomName}:${action}`;
@@ -16047,7 +16810,7 @@ function getVisibleOwnedRoomNames3(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString12(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
+    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString13(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -16129,12 +16892,12 @@ function getAdjacentRoomNames4(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord12(exits)) {
+  if (!isRecord13(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER3.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString12(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString13(exitRoom) ? [exitRoom] : [];
   });
 }
 function getKnownRouteLength2(fromRoom, targetRoom) {
@@ -16153,7 +16916,7 @@ function getKnownRouteLength2(fromRoom, targetRoom) {
     return void 0;
   }
   const route = gameMap.findRoute(fromRoom, targetRoom);
-  if (route === getNoPathResultCode5()) {
+  if (route === getNoPathResultCode6()) {
     if (cache) {
       cache[cacheKey] = null;
     }
@@ -16172,7 +16935,7 @@ function getTerritoryRouteDistanceCache3() {
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord12(territoryMemory.routeDistances)) {
+  if (!isRecord13(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
@@ -16180,9 +16943,9 @@ function getTerritoryRouteDistanceCache3() {
 function getTerritoryRouteDistanceCacheKey3(fromRoom, targetRoom) {
   return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR4}${targetRoom}`;
 }
-function getNoPathResultCode5() {
+function getNoPathResultCode6() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE5;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE6;
 }
 function summarizeExpansionController(controller) {
   const ownerUsername = getControllerOwnerUsername6(controller);
@@ -16312,12 +17075,12 @@ function getFindConstant5(name) {
 function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString12(username) ? username : void 0;
+  return isNonEmptyString13(username) ? username : void 0;
 }
 function getControllerReservationUsername4(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString12(username) ? username : void 0;
+  return isNonEmptyString13(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd3(controller) {
   var _a;
@@ -16327,18 +17090,18 @@ function getControllerReservationTicksToEnd3(controller) {
 function countActivePostClaimBootstraps() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord12(records)) {
+  if (!isRecord13(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord12(record) && record.status !== "ready"
+    (record) => isRecord13(record) && record.status !== "ready"
   ).length;
 }
 function getGameRooms2() {
   var _a;
   return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
 }
-function getVisibleRoom5(roomName) {
+function getVisibleRoom6(roomName) {
   var _a;
   return (_a = getGameRooms2()) == null ? void 0 : _a[roomName];
 }
@@ -16365,10 +17128,10 @@ function toPercent(value) {
 function formatSourceAccessPoints(value) {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
-function isRecord12(value) {
+function isRecord13(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString12(value) {
+function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -16381,14 +17144,14 @@ var ROOM_EDGE_MAX6 = 47;
 var DEFAULT_TERRAIN_WALL_MASK6 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
-  if (!isNonEmptyString13(input.colony) || !isNonEmptyString13(input.roomName)) {
+  if (!isNonEmptyString14(input.colony) || !isNonEmptyString14(input.roomName)) {
     return;
   }
   const bootstraps = getWritablePostClaimBootstrapRecords();
   if (!bootstraps) {
     return;
   }
-  const gameTime = getGameTime11();
+  const gameTime = getGameTime13();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
   bootstraps[input.roomName] = {
@@ -16504,7 +17267,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   return { active: true, spawnConstructionPending: true };
 }
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
-  if (!isNonEmptyString13(roomName)) {
+  if (!isNonEmptyString14(roomName)) {
     return;
   }
   const record = getPostClaimBootstrapRecord(roomName);
@@ -16513,7 +17276,7 @@ function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, res
   }
   updatePostClaimBootstrapRecord(roomName, {
     status: "spawningWorkers",
-    updatedAt: getGameTime11()
+    updatedAt: getGameTime13()
   });
   telemetryEvents.push({
     type: "postClaimBootstrap",
@@ -16556,7 +17319,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
     const spawnSite = toSpawnSiteMemory(existingSpawnSite);
     updatePostClaimBootstrapRecord(roomName, {
       status: "spawnSitePending",
-      updatedAt: getGameTime11(),
+      updatedAt: getGameTime13(),
       workerTarget,
       spawnSite,
       lastResult: OK_CODE6
@@ -16580,7 +17343,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
   const nextStatus = sitePlan.result === OK_CODE6 ? "spawnSitePending" : "spawnSiteBlocked";
   updatePostClaimBootstrapRecord(roomName, {
     status: nextStatus,
-    updatedAt: getGameTime11(),
+    updatedAt: getGameTime13(),
     workerTarget,
     ...sitePlan.position ? { spawnSite: sitePlan.position } : {},
     lastResult: sitePlan.result
@@ -16762,31 +17525,31 @@ function isTerrainWall4(terrain, position) {
 }
 function findExistingSpawnConstructionSite(room) {
   var _a;
-  const findConstant = getGlobalNumber7("FIND_MY_CONSTRUCTION_SITES");
+  const findConstant = getGlobalNumber8("FIND_MY_CONSTRUCTION_SITES");
   if (typeof room.find !== "function" || findConstant === null) {
     return null;
   }
   const sites = room.find(findConstant, {
-    filter: (site) => matchesStructureType12(site.structureType, "STRUCTURE_SPAWN", "spawn")
+    filter: (site) => matchesStructureType13(site.structureType, "STRUCTURE_SPAWN", "spawn")
   });
   return (_a = sites[0]) != null ? _a : null;
 }
 function findSources3(room) {
-  const findConstant = getGlobalNumber7("FIND_SOURCES");
+  const findConstant = getGlobalNumber8("FIND_SOURCES");
   if (typeof room.find !== "function" || findConstant === null) {
     return [];
   }
   return room.find(findConstant);
 }
 function getRoomObjectPosition4(object) {
-  if (!isRecord13(object)) {
+  if (!isRecord14(object)) {
     return null;
   }
   if (isFiniteNumber7(object.x) && isFiniteNumber7(object.y)) {
     return { x: object.x, y: object.y };
   }
   const pos = object.pos;
-  if (isRecord13(pos) && isFiniteNumber7(pos.x) && isFiniteNumber7(pos.y)) {
+  if (isRecord14(pos) && isFiniteNumber7(pos.x) && isFiniteNumber7(pos.y)) {
     return { x: pos.x, y: pos.y };
   }
   return null;
@@ -16833,7 +17596,7 @@ function getWritablePostClaimBootstrapRecords() {
   return memory.territory.postClaimBootstraps;
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
-  return isRecord13(value) && value.roomName === expectedRoomName && isNonEmptyString13(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber7(value.claimedAt) && isFiniteNumber7(value.updatedAt);
+  return isRecord14(value) && value.roomName === expectedRoomName && isNonEmptyString14(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber7(value.claimedAt) && isFiniteNumber7(value.updatedAt);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
@@ -16872,7 +17635,7 @@ function getRoomTerrain6(roomName) {
 function getTerrainWallMask6() {
   return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK6;
 }
-function matchesStructureType12(actual, globalName, fallback) {
+function matchesStructureType13(actual, globalName, fallback) {
   return actual === getStructureConstant(globalName, fallback);
 }
 function getStructureConstant(globalName, fallback) {
@@ -16880,7 +17643,7 @@ function getStructureConstant(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function getGlobalNumber7(name) {
+function getGlobalNumber8(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : null;
 }
@@ -16888,15 +17651,15 @@ function getGlobalString(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getGameTime11() {
+function getGameTime13() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord13(value) {
+function isRecord14(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString13(value) {
+function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber7(value) {
@@ -16927,7 +17690,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return void 0;
   }
-  const tick = getGameTime12();
+  const tick = getGameTime14();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -17024,7 +17787,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime12());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime14());
   }
   return {
     roomName: colony.room.name,
@@ -17034,11 +17797,11 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime12()),
+    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime14()),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime12()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime12()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime12()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime14()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime14()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime14()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -17058,7 +17821,7 @@ function buildPostClaimBootstrapSummary(roomName) {
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime12());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime14());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -17205,7 +17968,7 @@ function isRecentWorkerTaskBehaviorSample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskBehaviorSample(value) {
-  return isRecord14(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord14(value.state) && isRecord14(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+  return isRecord15(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord15(value.state) && isRecord15(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
 }
 function isRecentWorkerTaskPolicyShadow(value, tick) {
   if (!isWorkerTaskPolicyShadow(value)) {
@@ -17214,7 +17977,7 @@ function isRecentWorkerTaskPolicyShadow(value, tick) {
   return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskPolicyShadow(value) {
-  return isRecord14(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
+  return isRecord15(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function shouldBuildStructureSnapshot(tick) {
   return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
@@ -17242,13 +18005,13 @@ function countConstructionSitesByType(constructionSites, globalName, fallback) {
   return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
 }
 function countOwnedRamparts(structures) {
-  return structures.filter((structure) => isRecord14(structure) && isObservedOwnedRampart(structure)).length;
+  return structures.filter((structure) => isRecord15(structure) && isObservedOwnedRampart(structure)).length;
 }
 function summarizeContainers(structures) {
   return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
 }
 function toRuntimeContainerSnapshot(structure) {
-  const id = getObjectId5(structure);
+  const id = getObjectId6(structure);
   if (!id) {
     return null;
   }
@@ -17271,7 +18034,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   }
   const structuresById = /* @__PURE__ */ new Map();
   for (const structure of roomStructures) {
-    const id = getObjectId5(structure);
+    const id = getObjectId6(structure);
     if (id) {
       structuresById.set(id, structure);
     }
@@ -17279,7 +18042,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   return [...repairCounts.entries()].sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId)).map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
 }
 function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
-  const structureRecord = isRecord14(structure) ? structure : {};
+  const structureRecord = isRecord15(structure) ? structure : {};
   const structureType = typeof structureRecord.structureType === "string" ? structureRecord.structureType : void 0;
   const hits = getFiniteNumber(structureRecord.hits);
   const hitsMax = getFiniteNumber(structureRecord.hitsMax);
@@ -17292,7 +18055,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord14(structure) && matchesStructureType13(structure.structureType, globalName, fallback);
+  return isRecord15(structure) && matchesStructureType14(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -17452,7 +18215,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord14(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord15(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio3(numerator, denominator) {
   if (denominator <= 0) {
@@ -17467,7 +18230,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord14(value)) {
+  if (!isRecord15(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -17508,7 +18271,7 @@ function isRecentSpawnCriticalRefillSample(sample, tick) {
   return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
 }
 function isSpawnCriticalRefillSample(value) {
-  return isRecord14(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
+  return isRecord15(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;
@@ -17556,10 +18319,10 @@ function findOwnedEnergyStoreStructures(room) {
   return ((_a = findRoomObjects12(room, "FIND_MY_STRUCTURES")) != null ? _a : []).filter(isOwnedEnergyStoreStructure);
 }
 function isOwnedEnergyStoreStructure(structure) {
-  if (!isRecord14(structure)) {
+  if (!isRecord15(structure)) {
     return false;
   }
-  return matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType13(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType13(structure.structureType, "STRUCTURE_LINK", "link");
+  return matchesStructureType14(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType14(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType14(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType14(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType14(structure.structureType, "STRUCTURE_LINK", "link");
 }
 function summarizeProductiveEnergy(room, colonyWorkers, constructionSites, roomStructures) {
   const productiveAssignments = summarizeProductiveWorkerAssignments(colonyWorkers);
@@ -17604,7 +18367,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord14(constructionSite)) {
+  if (!isRecord15(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -17618,7 +18381,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord14(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord15(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -17630,10 +18393,10 @@ function getRepairBacklogHits(structure) {
   return Math.max(0, Math.ceil(repairCeiling - hits));
 }
 function isObservableRepairBacklogStructure(structure) {
-  return matchesStructureType13(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
+  return matchesStructureType14(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType14(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
 }
 function isObservedOwnedRampart(structure) {
-  return matchesStructureType13(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
+  return matchesStructureType14(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
 }
 function buildControllerProgressRemaining(room) {
   const controller = room.controller;
@@ -17816,13 +18579,13 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   if (!eventLog) {
     return {};
   }
-  const harvestEvent = getGlobalNumber8("EVENT_HARVEST");
-  const transferEvent = getGlobalNumber8("EVENT_TRANSFER");
-  const buildEvent = getGlobalNumber8("EVENT_BUILD");
-  const repairEvent = getGlobalNumber8("EVENT_REPAIR");
-  const upgradeControllerEvent = getGlobalNumber8("EVENT_UPGRADE_CONTROLLER");
-  const attackEvent = getGlobalNumber8("EVENT_ATTACK");
-  const objectDestroyedEvent = getGlobalNumber8("EVENT_OBJECT_DESTROYED");
+  const harvestEvent = getGlobalNumber9("EVENT_HARVEST");
+  const transferEvent = getGlobalNumber9("EVENT_TRANSFER");
+  const buildEvent = getGlobalNumber9("EVENT_BUILD");
+  const repairEvent = getGlobalNumber9("EVENT_REPAIR");
+  const upgradeControllerEvent = getGlobalNumber9("EVENT_UPGRADE_CONTROLLER");
+  const attackEvent = getGlobalNumber9("EVENT_ATTACK");
+  const objectDestroyedEvent = getGlobalNumber9("EVENT_OBJECT_DESTROYED");
   const resourceEvents = {
     harvestedEnergy: 0,
     transferredEnergy: 0,
@@ -17840,10 +18603,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord14(entry) || typeof entry.event !== "number") {
+    if (!isRecord15(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord14(entry.data) ? entry.data : {};
+    const data = isRecord15(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -17901,7 +18664,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
     if (!isSpawnExtensionEnergyStructure2(structure)) {
       continue;
     }
-    const id = getObjectId5(structure);
+    const id = getObjectId6(structure);
     if (id) {
       ids.add(id);
     }
@@ -17909,7 +18672,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord14(structure) && (matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord15(structure) && (matchesStructureType14(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType14(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -17917,11 +18680,11 @@ function getEventTargetId(data) {
 function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
-function getObjectId5(value) {
-  return isRecord14(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+function getObjectId6(value) {
+  return isRecord15(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects12(room, constantName) {
-  const findConstant = getGlobalNumber8(constantName);
+  const findConstant = getGlobalNumber9(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return void 0;
@@ -17939,7 +18702,7 @@ function getRoomEventLog(room) {
     return void 0;
   }
   try {
-    const eventLog = getEventLog.call(room, getEnergyResource7());
+    const eventLog = getEventLog.call(room, getEnergyResource9());
     return Array.isArray(eventLog) ? eventLog : void 0;
   } catch {
     return void 0;
@@ -17949,32 +18712,32 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord14(object) || !isRecord14(object.store)) {
+  if (!isRecord15(object) || !isRecord15(object.store)) {
     return 0;
   }
-  const storedEnergy = object.store[getEnergyResource7()];
+  const storedEnergy = object.store[getEnergyResource9()];
   if (typeof storedEnergy === "number") {
     return storedEnergy;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
   if (typeof getUsedCapacity === "function") {
-    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource7());
+    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource9());
     return typeof usedCapacity === "number" ? usedCapacity : 0;
   }
   return 0;
 }
 function getEnergyCapacityInStore(object) {
-  if (!isRecord14(object) || !isRecord14(object.store)) {
+  if (!isRecord15(object) || !isRecord15(object.store)) {
     return 0;
   }
   const getCapacity = object.store.getCapacity;
   if (typeof getCapacity === "function") {
-    const capacity2 = getCapacity.call(object.store, getEnergyResource7());
+    const capacity2 = getCapacity.call(object.store, getEnergyResource9());
     return typeof capacity2 === "number" && Number.isFinite(capacity2) ? Math.max(0, capacity2) : 0;
   }
   const getFreeCapacity = object.store.getFreeCapacity;
   if (typeof getFreeCapacity === "function") {
-    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource7());
+    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource9());
     if (typeof freeCapacity === "number" && Number.isFinite(freeCapacity)) {
       return Math.max(0, getEnergyInStore(object) + freeCapacity);
     }
@@ -17983,26 +18746,26 @@ function getEnergyCapacityInStore(object) {
   return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
 }
 function sumDroppedEnergy2(droppedResources) {
-  const energyResource = getEnergyResource7();
+  const energyResource = getEnergyResource9();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord14(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord15(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
   }, 0);
 }
 function isEnergyEventData(data) {
-  return data.resourceType === void 0 || data.resourceType === getEnergyResource7();
+  return data.resourceType === void 0 || data.resourceType === getEnergyResource9();
 }
 function getNumericEventData(data, key) {
   const value = data[key];
   return typeof value === "number" ? value : 0;
 }
-function getGlobalNumber8(name) {
+function getGlobalNumber9(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function matchesStructureType13(value, globalName, fallback) {
+function matchesStructureType14(value, globalName, fallback) {
   var _a;
   const expectedValue = (_a = globalThis[globalName]) != null ? _a : fallback;
   return value === expectedValue;
@@ -18010,11 +18773,11 @@ function matchesStructureType13(value, globalName, fallback) {
 function getFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function getEnergyResource7() {
+function getEnergyResource9() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord14(value) {
+function isRecord15(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -18032,7 +18795,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime12() {
+function getGameTime14() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -18215,7 +18978,7 @@ function manageStorage(room) {
     return { assignedTasks: 0, linkTransfers: [] };
   }
   const linkTransfers = transferStorageLinkEnergy(room);
-  const storageEnergy = getStoredEnergy9(storage);
+  const storageEnergy = getStoredEnergy11(storage);
   if (storageEnergy <= 0) {
     return { assignedTasks: 0, linkTransfers };
   }
@@ -18230,14 +18993,14 @@ function manageStorage(room) {
 }
 function transferStorageLinkEnergy(room) {
   const { controllerLink, storageLink } = classifyLinks(room);
-  if (!controllerLink || !storageLink || getObjectId6(controllerLink) === getObjectId6(storageLink)) {
+  if (!controllerLink || !storageLink || getObjectId7(controllerLink) === getObjectId7(storageLink)) {
     return [];
   }
   if (getLinkCooldown2(storageLink) > 0) {
     return [];
   }
-  const storedEnergy = getStoredEnergy9(storageLink);
-  const destinationFreeCapacity = getFreeEnergyCapacity5(controllerLink);
+  const storedEnergy = getStoredEnergy11(storageLink);
+  const destinationFreeCapacity = getFreeEnergyCapacity6(controllerLink);
   const amount = Math.min(storedEnergy, destinationFreeCapacity);
   if (amount <= 0) {
     return [];
@@ -18245,9 +19008,9 @@ function transferStorageLinkEnergy(room) {
   return [
     {
       amount,
-      destinationId: getObjectId6(controllerLink),
+      destinationId: getObjectId7(controllerLink),
       result: transferLinkEnergy2(storageLink, controllerLink, amount),
-      sourceId: getObjectId6(storageLink)
+      sourceId: getObjectId7(storageLink)
     }
   ];
 }
@@ -18266,41 +19029,41 @@ function buildEnergyDemandState(room) {
   };
 }
 function findSpawnExtensionRefillTargets(room) {
-  const structures = findOwnedStructures4(room).filter(
-    (structure) => (matchesStructureType14(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType14(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity5(structure) > 0
+  const structures = findOwnedStructures5(room).filter(
+    (structure) => (matchesStructureType15(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType15(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity6(structure) > 0
   );
   if (!isRoomSpawnExtensionEnergyLow(room, structures)) {
     return [];
   }
   return structures.map((target) => ({
-    freeCapacity: getFreeEnergyCapacity5(target),
-    id: getObjectId6(target),
+    freeCapacity: getFreeEnergyCapacity6(target),
+    id: getObjectId7(target),
     priority: 3,
     target
   }));
 }
 function findTowerRefillTargets(room) {
-  return findOwnedStructures4(room).filter(
-    (structure) => matchesStructureType14(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy9(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity5(structure) > 0
+  return findOwnedStructures5(room).filter(
+    (structure) => matchesStructureType15(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy11(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity6(structure) > 0
   ).map((target) => ({
-    freeCapacity: getFreeEnergyCapacity5(target),
-    id: getObjectId6(target),
+    freeCapacity: getFreeEnergyCapacity6(target),
+    id: getObjectId7(target),
     priority: 2,
     target
   }));
 }
 function findStorageLinkRefillTargets(room) {
   const { controllerLink, storageLink } = classifyLinks(room);
-  if (!controllerLink || !storageLink || getObjectId6(controllerLink) === getObjectId6(storageLink)) {
+  if (!controllerLink || !storageLink || getObjectId7(controllerLink) === getObjectId7(storageLink)) {
     return [];
   }
-  if (getFreeEnergyCapacity5(controllerLink) <= 0 || getFreeEnergyCapacity5(storageLink) <= 0) {
+  if (getFreeEnergyCapacity6(controllerLink) <= 0 || getFreeEnergyCapacity6(storageLink) <= 0) {
     return [];
   }
   return [
     {
-      freeCapacity: getFreeEnergyCapacity5(storageLink),
-      id: getObjectId6(storageLink),
+      freeCapacity: getFreeEnergyCapacity6(storageLink),
+      id: getObjectId7(storageLink),
       priority: 1,
       target: storageLink
     }
@@ -18315,16 +19078,16 @@ function isRoomSpawnExtensionEnergyLow(room, structures) {
   if (typeof energyAvailable === "number" && Number.isFinite(energyAvailable) && typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable)) {
     return energyAvailable < energyCapacityAvailable;
   }
-  return structures.some((structure) => getFreeEnergyCapacity5(structure) > 0);
+  return structures.some((structure) => getFreeEnergyCapacity6(structure) > 0);
 }
 function findStorageManagementWorkers(room, storage, demandState) {
-  const storageId = getObjectId6(storage);
+  const storageId = getObjectId7(storage);
   const demandTargetIds = new Set(demandState.targets.map((target) => target.id));
   return findMyCreeps2(room).filter((creep) => isEligibleStorageManagementWorker(creep, room.name)).filter((creep) => isAssignableStorageManagementWorker(creep, storageId, demandTargetIds)).sort(compareWorkers);
 }
 function reserveExistingAssignments(workers, storage, demandState, storageEnergy) {
   let projectedStorageEnergy = storageEnergy;
-  const storageId = getObjectId6(storage);
+  const storageId = getObjectId7(storage);
   for (const worker of workers) {
     const task = worker.memory.task;
     if ((task == null ? void 0 : task.type) === "transfer") {
@@ -18333,12 +19096,12 @@ function reserveExistingAssignments(workers, storage, demandState, storageEnergy
       if (typeof remainingCapacity === "number") {
         demandState.remainingCapacityById.set(
           targetId,
-          Math.max(0, remainingCapacity - getCarriedEnergy4(worker))
+          Math.max(0, remainingCapacity - getCarriedEnergy5(worker))
         );
       }
     }
     if ((task == null ? void 0 : task.type) === "withdraw" && String(task.targetId) === storageId) {
-      projectedStorageEnergy -= getFreeEnergyCapacity5(worker);
+      projectedStorageEnergy -= getFreeEnergyCapacity6(worker);
     }
   }
   return Math.max(0, projectedStorageEnergy);
@@ -18346,7 +19109,7 @@ function reserveExistingAssignments(workers, storage, demandState, storageEnergy
 function assignLoadedWorkers(workers, demandState) {
   let assignedTasks = 0;
   for (const worker of workers) {
-    const carriedEnergy = getCarriedEnergy4(worker);
+    const carriedEnergy = getCarriedEnergy5(worker);
     if (carriedEnergy <= 0) {
       continue;
     }
@@ -18369,13 +19132,13 @@ function assignStorageWithdrawals(room, workers, storage, demandState, initialPr
   let assignedTasks = 0;
   let projectedStorageEnergy = initialProjectedStorageEnergy;
   for (const worker of workers) {
-    if (!hasRemainingDemand(demandState) || getCarriedEnergy4(worker) > 0) {
+    if (!hasRemainingDemand(demandState) || getCarriedEnergy5(worker) > 0) {
       continue;
     }
     if (((_a = worker.memory.task) == null ? void 0 : _a.type) === "withdraw" && String(worker.memory.task.targetId) === String(storage.id)) {
       continue;
     }
-    const freeCapacity = getFreeEnergyCapacity5(worker);
+    const freeCapacity = getFreeEnergyCapacity6(worker);
     const withdrawableStorageEnergy = getStorageEnergyAvailableForWithdrawal(room, storage, projectedStorageEnergy);
     const plannedWithdrawal = Math.min(freeCapacity, projectedStorageEnergy);
     if (plannedWithdrawal <= 0 || plannedWithdrawal > withdrawableStorageEnergy || !withdrawFromStorage(room, plannedWithdrawal, storage, projectedStorageEnergy)) {
@@ -18481,11 +19244,11 @@ function getRoomStorage2(room) {
   if (room.storage) {
     return room.storage;
   }
-  return (_a = findOwnedStructures4(room).filter(
-    (structure) => matchesStructureType14(structure.structureType, "STRUCTURE_STORAGE", "storage")
+  return (_a = findOwnedStructures5(room).filter(
+    (structure) => matchesStructureType15(structure.structureType, "STRUCTURE_STORAGE", "storage")
   )[0]) != null ? _a : null;
 }
-function findOwnedStructures4(room) {
+function findOwnedStructures5(room) {
   if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
     return [];
   }
@@ -18499,29 +19262,29 @@ function findMyCreeps2(room) {
   const result = room.find(FIND_MY_CREEPS);
   return Array.isArray(result) ? result : [];
 }
-function getStoredEnergy9(target) {
+function getStoredEnergy11(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const storedEnergy = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource8());
+  const storedEnergy = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource10());
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
-function getFreeEnergyCapacity5(target) {
+function getFreeEnergyCapacity6(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource8());
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource10());
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
 }
-function getCarriedEnergy4(creep) {
-  return getStoredEnergy9(creep);
+function getCarriedEnergy5(creep) {
+  return getStoredEnergy11(creep);
 }
 function getLinkCooldown2(link) {
   return typeof link.cooldown === "number" && Number.isFinite(link.cooldown) ? link.cooldown : 0;
 }
-function getEnergyResource8() {
+function getEnergyResource10() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
-function getObjectId6(object) {
+function getObjectId7(object) {
   if (typeof object !== "object" || object === null) {
     return "";
   }
@@ -18531,7 +19294,7 @@ function getObjectId6(object) {
   }
   return typeof candidate.name === "string" ? candidate.name : "";
 }
-function matchesStructureType14(actual, globalName, fallback) {
+function matchesStructureType15(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -18544,7 +19307,7 @@ var MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE = 500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_RCL = 2;
 var EXIT_DIRECTION_ORDER4 = ["1", "3", "5", "7"];
 var OK_CODE7 = 0;
-var ERR_NOT_IN_RANGE_CODE6 = -9;
+var ERR_NOT_IN_RANGE_CODE7 = -9;
 var ERR_INVALID_TARGET_CODE3 = -7;
 var ERR_NO_BODYPART_CODE = -12;
 var ERR_GCL_NOT_ENOUGH_CODE = -15;
@@ -18583,7 +19346,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   if (!isClaimExecutionAssignment(assignment)) {
     return false;
   }
-  const gameTime = getGameTime13();
+  const gameTime = getGameTime15();
   const recommendedClaim = getRecommendedExpansionClaimExecutionGate(creep.memory.colony, assignment);
   if (!recommendedClaim) {
     return false;
@@ -18677,7 +19440,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
     completeClaimAssignment(creep);
     return true;
   }
-  if (result === ERR_NOT_IN_RANGE_CODE6) {
+  if (result === ERR_NOT_IN_RANGE_CODE7) {
     moveTowardController(creep, controller);
     return true;
   }
@@ -18835,7 +19598,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   if (!hasSufficientAutonomousExpansionClaimRcl(colony)) {
     return { ...baseEvaluation, reason: "controllerLevelLow" };
   }
-  const room = getVisibleRoom6(candidate.roomName);
+  const room = getVisibleRoom7(candidate.roomName);
   const controller = room == null ? void 0 : room.controller;
   if (room) {
     recordVisibleRoomScoutIntel(colonyName, room, gameTime, void 0, telemetryEvents);
@@ -18946,7 +19709,7 @@ function buildAutonomousExpansionScoringInput(colony, report, context) {
   const seenRooms = /* @__PURE__ */ new Set();
   const candidates = [];
   report.candidates.forEach((candidate, order) => {
-    if (!isNonEmptyString14(candidate.roomName) || seenRooms.has(candidate.roomName)) {
+    if (!isNonEmptyString15(candidate.roomName) || seenRooms.has(candidate.roomName)) {
       return;
     }
     seenRooms.add(candidate.roomName);
@@ -18966,7 +19729,7 @@ function buildAutonomousExpansionScoringInput(colony, report, context) {
   };
 }
 function toExpansionCandidateInput(candidate, order, adjacency) {
-  const room = getVisibleRoom6(candidate.roomName);
+  const room = getVisibleRoom7(candidate.roomName);
   const controller = room == null ? void 0 : room.controller;
   const controllerId = typeof (controller == null ? void 0 : controller.id) === "string" ? controller.id : candidate.controllerId;
   const hostileCreepCount = typeof candidate.hostileCreepCount === "number" ? candidate.hostileCreepCount : room ? findVisibleHostileCreeps2(room).length : void 0;
@@ -18993,7 +19756,7 @@ function summarizeExpansionController2(controller) {
   return {
     ...typeof controller.my === "boolean" ? { my: controller.my } : {},
     ...ownerUsername ? { ownerUsername } : {},
-    ...isNonEmptyString14(reservationUsername) ? { reservationUsername } : {},
+    ...isNonEmptyString15(reservationUsername) ? { reservationUsername } : {},
     ...typeof ((_b = controller.reservation) == null ? void 0 : _b.ticksToEnd) === "number" ? { reservationTicksToEnd: controller.reservation.ticksToEnd } : {}
   };
 }
@@ -19014,7 +19777,7 @@ function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString14(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString15(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -19053,21 +19816,21 @@ function getAdjacentRoomNames5(roomName, gameMap = ((_a) => (_a = globalThis.Gam
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord15(exits)) {
+  if (!isRecord16(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER4.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString14(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString15(exitRoom) ? [exitRoom] : [];
   });
 }
 function countActivePostClaimBootstraps2() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord15(records)) {
+  if (!isRecord16(records)) {
     return 0;
   }
-  return Object.values(records).filter((record) => isRecord15(record) && record.status !== "ready").length;
+  return Object.values(records).filter((record) => isRecord16(record) && record.status !== "ready").length;
 }
 function hasSufficientAutonomousExpansionClaimRcl(colony) {
   var _a, _b;
@@ -19137,13 +19900,13 @@ function upsertTerritoryTarget2(territoryMemory, target) {
     territoryMemory.targets = [];
   }
   const existingTarget = territoryMemory.targets.find(
-    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord15(rawTarget) && rawTarget.createdBy === target.createdBy
+    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord16(rawTarget) && rawTarget.createdBy === target.createdBy
   );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord15(existingTarget)) {
+  if (isRecord16(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -19174,7 +19937,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord15(target) && isNonEmptyString14(target.roomName) && target.action === "claim") {
+    if (isRecord16(target) && isNonEmptyString15(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -19193,7 +19956,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord15(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord16(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime, intents) {
@@ -19240,7 +20003,7 @@ function getClaimResultReason(result) {
   switch (result) {
     case OK_CODE7:
       return null;
-    case ERR_NOT_IN_RANGE_CODE6:
+    case ERR_NOT_IN_RANGE_CODE7:
       return "notInRange";
     case ERR_INVALID_TARGET_CODE3:
       return "invalidTarget";
@@ -19261,7 +20024,7 @@ function isClaimExecutionAssignment(assignment) {
 }
 function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   var _a;
-  if (!isNonEmptyString14(colony)) {
+  if (!isNonEmptyString15(colony)) {
     return null;
   }
   const territoryMemory = getTerritoryMemoryRecord6();
@@ -19302,7 +20065,7 @@ function isTerritoryIntentSuspensionActive2(intent, gameTime) {
   return isHostileTerritoryIntentSuspensionCoolingDown2(intent.suspended, gameTime);
 }
 function getVisibleHostileCreepCount2(targetRoom) {
-  const room = getVisibleRoom6(targetRoom);
+  const room = getVisibleRoom7(targetRoom);
   return room ? findVisibleHostileCreeps2(room).length : null;
 }
 function isHostileTerritoryIntentSuspensionCoolingDown2(suspension, gameTime) {
@@ -19319,7 +20082,7 @@ function selectClaimTargetController(creep, assignment) {
       }
     }
   }
-  return (_d = (_c = (_a = creep.room) == null ? void 0 : _a.controller) != null ? _c : (_b = getVisibleRoom6(assignment.targetRoom)) == null ? void 0 : _b.controller) != null ? _d : null;
+  return (_d = (_c = (_a = creep.room) == null ? void 0 : _a.controller) != null ? _c : (_b = getVisibleRoom7(assignment.targetRoom)) == null ? void 0 : _b.controller) != null ? _d : null;
 }
 function moveTowardClaimTarget(creep, assignment) {
   const visibleController = selectVisibleClaimTargetController(assignment);
@@ -19380,7 +20143,7 @@ function tryPressureForeignClaimBlocker(creep, assignment, controller, telemetry
     return false;
   }
   const result = creep.attackController(controller);
-  if (result === ERR_NOT_IN_RANGE_CODE6) {
+  if (result === ERR_NOT_IN_RANGE_CODE7) {
     moveTowardController(creep, controller);
     return true;
   }
@@ -19414,7 +20177,7 @@ function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryE
     status: "claimed",
     controllerId: controller.id,
     creepName: creep.name,
-    updatedAt: getGameTime13()
+    updatedAt: getGameTime15()
   });
 }
 function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason, options) {
@@ -19430,7 +20193,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     reason
   });
   if (options.suppressIntent) {
-    suppressRecommendedClaimIntent(colony, assignment, getGameTime13(), options.controllerId, reason);
+    suppressRecommendedClaimIntent(colony, assignment, getGameTime15(), options.controllerId, reason);
   }
   recordColonyExpansionClaimVerification({
     colony,
@@ -19440,7 +20203,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     creepName: creep.name,
     result,
     reason,
-    updatedAt: getGameTime13()
+    updatedAt: getGameTime15()
   });
 }
 function recordRecommendedClaimRetry(creep, assignment, result, reason, options = {}) {
@@ -19455,7 +20218,7 @@ function recordRecommendedClaimRetry(creep, assignment, result, reason, options 
     result,
     reason
   });
-  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime13(), options);
+  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime15(), options);
 }
 function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, options) {
   var _a, _b;
@@ -19526,13 +20289,13 @@ function hasRecommendedClaimTarget(territoryMemory, colony, targetRoom) {
   return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom)) : false;
 }
 function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
-  return isRecord15(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
+  return isRecord16(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
 }
 function recordColonyExpansionClaimVerification(input) {
   var _a;
-  const colonyRoom = getVisibleRoom6(input.colony);
+  const colonyRoom = getVisibleRoom7(input.colony);
   const selection = (_a = colonyRoom == null ? void 0 : colonyRoom.memory) == null ? void 0 : _a.cachedExpansionSelection;
-  if (!isRecord15(selection) || selection.targetRoom !== input.targetRoom) {
+  if (!isRecord16(selection) || selection.targetRoom !== input.targetRoom) {
     return;
   }
   selection.claimExecution = {
@@ -19555,7 +20318,7 @@ function getVisibleClaimedRoom(targetRoom, controller) {
   if (((_a = controllerRoom == null ? void 0 : controllerRoom.controller) == null ? void 0 : _a.my) === true) {
     return controllerRoom;
   }
-  const gameRoom = getVisibleRoom6(targetRoom);
+  const gameRoom = getVisibleRoom7(targetRoom);
   return ((_b = gameRoom == null ? void 0 : gameRoom.controller) == null ? void 0 : _b.my) === true ? gameRoom : null;
 }
 function completeClaimAssignment(creep) {
@@ -19566,15 +20329,15 @@ function getClaimColony(creep, controller) {
   return (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller == null ? void 0 : controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown";
 }
 function isForeignOwnedController(controller) {
-  return controller.my !== true && isNonEmptyString14(getControllerOwnerUsername7(controller));
+  return controller.my !== true && isNonEmptyString15(getControllerOwnerUsername7(controller));
 }
 function isForeignReservedController3(controller, colony) {
   var _a, _b;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  if (!isNonEmptyString14(reservationUsername)) {
+  if (!isNonEmptyString15(reservationUsername)) {
     return false;
   }
-  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom6(colony != null ? colony : "")) == null ? void 0 : _b.controller);
+  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom7(colony != null ? colony : "")) == null ? void 0 : _b.controller);
 }
 function getKnownActiveClaimPartCount(creep) {
   var _a;
@@ -19601,19 +20364,19 @@ function isTerritoryAutomationSource3(source) {
   return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord15(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord16(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isSameTarget2(left, right) {
-  return isRecord15(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord16(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
 }
-function getVisibleRoom6(roomName) {
+function getVisibleRoom7(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameTime13() {
+function getGameTime15() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -19647,17 +20410,17 @@ function isControllerOwned2(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString14(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString15(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
 function getControllerOwnerUsername7(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString14(username) ? username : void 0;
+  return isNonEmptyString15(username) ? username : void 0;
 }
-function isRecord15(value) {
+function isRecord16(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString14(value) {
+function isNonEmptyString15(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -19677,7 +20440,7 @@ var DISTANCE_PENALTY = 55;
 var NO_ROUTE_DISTANCE = 99;
 function scoreClaimTarget(roomName, homeRoom) {
   const details = [];
-  const room = getVisibleRoom7(roomName);
+  const room = getVisibleRoom8(roomName);
   const scoutIntel = getScoutIntel(homeRoom.name, roomName);
   const sources = countSources(room, scoutIntel);
   const distance = getRoomDistance(homeRoom.name, roomName);
@@ -19749,7 +20512,7 @@ function hasUnclaimableController(score) {
     (detail) => detail === "controller already claimed" || detail === "controller already reserved" || detail === "controller missing"
   );
 }
-function getVisibleRoom7(roomName) {
+function getVisibleRoom8(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -19793,8 +20556,8 @@ function scoreTerrain(roomName, details) {
     details.push("terrain unknown");
     return 0;
   }
-  const wallMask = (_a = getGlobalNumber9("TERRAIN_MASK_WALL")) != null ? _a : DEFAULT_TERRAIN_WALL_MASK8;
-  const swampMask = (_b = getGlobalNumber9("TERRAIN_MASK_SWAMP")) != null ? _b : DEFAULT_TERRAIN_SWAMP_MASK2;
+  const wallMask = (_a = getGlobalNumber10("TERRAIN_MASK_WALL")) != null ? _a : DEFAULT_TERRAIN_WALL_MASK8;
+  const swampMask = (_b = getGlobalNumber10("TERRAIN_MASK_SWAMP")) != null ? _b : DEFAULT_TERRAIN_SWAMP_MASK2;
   let total = 0;
   let walls = 0;
   let swamps = 0;
@@ -19821,20 +20584,20 @@ function getControllerStatus2(room, scoutIntel) {
     if (!controller) {
       return "missing";
     }
-    if (controller.my === true || isNonEmptyString15((_a = controller.owner) == null ? void 0 : _a.username)) {
+    if (controller.my === true || isNonEmptyString16((_a = controller.owner) == null ? void 0 : _a.username)) {
       return "owned";
     }
-    if (isNonEmptyString15((_b = controller.reservation) == null ? void 0 : _b.username)) {
+    if (isNonEmptyString16((_b = controller.reservation) == null ? void 0 : _b.username)) {
       return "reserved";
     }
     return "neutral";
   }
   if (scoutIntel == null ? void 0 : scoutIntel.controller) {
     const controller = scoutIntel.controller;
-    if (controller.my === true || isNonEmptyString15(controller.ownerUsername)) {
+    if (controller.my === true || isNonEmptyString16(controller.ownerUsername)) {
       return "owned";
     }
-    if (isNonEmptyString15(controller.reservationUsername)) {
+    if (isNonEmptyString16(controller.reservationUsername)) {
       return "reserved";
     }
     return "neutral";
@@ -19872,12 +20635,12 @@ function getAdjacentRoomNames6(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord16(exits)) {
+  if (!isRecord17(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER5.flatMap((direction) => {
     const adjacentRoom = exits[direction];
-    return isNonEmptyString15(adjacentRoom) ? [adjacentRoom] : [];
+    return isNonEmptyString16(adjacentRoom) ? [adjacentRoom] : [];
   });
 }
 function getRoomTerrain8(roomName) {
@@ -19889,7 +20652,7 @@ function getRoomTerrain8(roomName) {
   return gameMap.getRoomTerrain(roomName);
 }
 function findRoomObjects13(room, constantName) {
-  const findConstant = getGlobalNumber9(constantName);
+  const findConstant = getGlobalNumber10(constantName);
   if (!room || typeof room.find !== "function" || typeof findConstant !== "number") {
     return [];
   }
@@ -19907,14 +20670,14 @@ function getRange2(origin, target) {
   }
   return null;
 }
-function getGlobalNumber9(name) {
+function getGlobalNumber10(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function isRecord16(value) {
+function isRecord17(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString15(value) {
+function isNonEmptyString16(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -19924,7 +20687,7 @@ var MIN_ADJACENT_ROOM_RESERVATION_SCORE = 500;
 var ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS_PER_CLAIM_PART = 600;
 var MAX_ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS = 1e3;
 var EXIT_DIRECTION_ORDER6 = ["1", "3", "5", "7"];
-function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime14(), options = {}) {
+function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime16(), options = {}) {
   const evaluation = selectAdjacentRoomReservationPlan(colony, options);
   if (evaluation.status === "planned" && evaluation.targetRoom) {
     persistAdjacentRoomReservationIntent(colony.room.name, evaluation, gameTime);
@@ -20002,7 +20765,7 @@ function buildReservationCandidate(homeRoom, roomName, order, ownerUsername, ren
   if (controllerState.kind !== "neutral" && controllerState.kind !== "ownReserved") {
     return [];
   }
-  if (hasHostilePresence(homeRoom.name, roomName)) {
+  if (hasHostilePresence2(homeRoom.name, roomName)) {
     return [];
   }
   const effectiveScore = controllerState.kind === "ownReserved" ? score.score + CLAIM_SCORE_RESERVED_PENALTY : score.score;
@@ -20067,7 +20830,7 @@ function getReservationClaimPartCount(energyCapacityAvailable) {
   return buildTerritoryReserverBody(energyCapacityAvailable).filter((part) => part === "claim").length;
 }
 function getReservationControllerState(colonyName, roomName, ownerUsername) {
-  const room = getVisibleRoom8(roomName);
+  const room = getVisibleRoom9(roomName);
   if (room) {
     const controller2 = room.controller;
     if (!controller2) {
@@ -20083,11 +20846,11 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString16(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString17(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString16(controller.reservationUsername)) {
-    if (isNonEmptyString16(ownerUsername) && controller.reservationUsername === ownerUsername) {
+  if (isNonEmptyString17(controller.reservationUsername)) {
+    if (isNonEmptyString17(ownerUsername) && controller.reservationUsername === ownerUsername) {
       return {
         kind: "ownReserved",
         ...controller.id ? { controllerId: controller.id } : {},
@@ -20101,12 +20864,12 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
 function getVisibleControllerReservationState(controller, ownerUsername) {
   var _a;
   const controllerId = controller.id;
-  if (controller.my === true || isNonEmptyString16((_a = controller.owner) == null ? void 0 : _a.username)) {
+  if (controller.my === true || isNonEmptyString17((_a = controller.owner) == null ? void 0 : _a.username)) {
     return { kind: "owned", controllerId };
   }
   const reservation = controller.reservation;
-  if (isNonEmptyString16(reservation == null ? void 0 : reservation.username)) {
-    if (isNonEmptyString16(ownerUsername) && reservation.username === ownerUsername) {
+  if (isNonEmptyString17(reservation == null ? void 0 : reservation.username)) {
+    if (isNonEmptyString17(ownerUsername) && reservation.username === ownerUsername) {
       return {
         kind: "ownReserved",
         controllerId,
@@ -20117,9 +20880,9 @@ function getVisibleControllerReservationState(controller, ownerUsername) {
   }
   return { kind: "neutral", controllerId };
 }
-function hasHostilePresence(colonyName, roomName) {
+function hasHostilePresence2(colonyName, roomName) {
   var _a, _b, _c;
-  const room = getVisibleRoom8(roomName);
+  const room = getVisibleRoom9(roomName);
   if (room) {
     return countVisibleHostiles(room) > 0;
   }
@@ -20196,7 +20959,7 @@ function upsertAdjacentRoomReservationTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord17(existingTarget)) {
+  if (isRecord18(existingTarget)) {
     existingTarget.createdBy = ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -20229,13 +20992,13 @@ function hasBlockingTerritoryPlan(colony) {
   );
 }
 function isBlockingTerritoryTarget(target, colony) {
-  return isRecord17(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
+  return isRecord18(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
 }
 function isAdjacentRoomReservationTarget(target, colony) {
-  return isRecord17(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
+  return isRecord18(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
 }
 function isSameTarget3(left, right) {
-  return isRecord17(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord18(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getAdjacentRoomNames7(roomName) {
   var _a;
@@ -20244,12 +21007,12 @@ function getAdjacentRoomNames7(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord17(exits)) {
+  if (!isRecord18(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER6.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString16(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString17(exitRoom) ? [exitRoom] : [];
   });
 }
 function countVisibleOwnedRooms2(colonyName, ownerUsername) {
@@ -20260,7 +21023,7 @@ function countVisibleOwnedRooms2(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString16(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString17(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
@@ -20278,7 +21041,7 @@ function getScoutIntel2(colonyName, roomName) {
   var _a, _b, _c;
   return (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel) == null ? void 0 : _c[`${colonyName}>${roomName}`];
 }
-function getVisibleRoom8(roomName) {
+function getVisibleRoom9(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -20296,7 +21059,7 @@ function getFindConstant6(name) {
 function getControllerOwnerUsername8(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString16(username) ? username : void 0;
+  return isNonEmptyString17(username) ? username : void 0;
 }
 function getTerritoryMemoryRecord7() {
   var _a;
@@ -20312,15 +21075,15 @@ function getWritableTerritoryMemoryRecord6() {
   }
   return root.Memory.territory;
 }
-function getGameTime14() {
+function getGameTime16() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString16(value) {
+function isNonEmptyString17(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord17(value) {
+function isRecord18(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -20328,7 +21091,7 @@ function isRecord17(value) {
 var COLONY_EXPANSION_CLAIM_TARGET_CREATOR = "colonyExpansion";
 var MIN_COLONY_EXPANSION_CLAIM_SCORE = MIN_ADJACENT_ROOM_RESERVATION_SCORE;
 var EXIT_DIRECTION_ORDER7 = ["1", "3", "5", "7"];
-function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime15()) {
+function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime17()) {
   const colonyName = colony.room.name;
   if (assessment.territoryReady !== true) {
     const reservation2 = refreshAdjacentRoomReservationIntent(colony, gameTime, {
@@ -20424,18 +21187,18 @@ function hasHostileClaimScore(score) {
 }
 function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) {
   var _a, _b;
-  const room = getVisibleRoom9(roomName);
+  const room = getVisibleRoom10(roomName);
   if (room) {
     const controller2 = room.controller;
     if (!controller2) {
       return { kind: "missing" };
     }
     const controllerId = controller2.id;
-    if (controller2.my === true || isNonEmptyString17((_a = controller2.owner) == null ? void 0 : _a.username)) {
+    if (controller2.my === true || isNonEmptyString18((_a = controller2.owner) == null ? void 0 : _a.username)) {
       return { kind: "owned", controllerId };
     }
     const reservationUsername = (_b = controller2.reservation) == null ? void 0 : _b.username;
-    if (isNonEmptyString17(reservationUsername)) {
+    if (isNonEmptyString18(reservationUsername)) {
       return reservationUsername === ownerUsername ? { kind: "ownReserved", controllerId } : { kind: "foreignReserved", controllerId };
     }
     return { kind: "neutral", controllerId };
@@ -20448,10 +21211,10 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString17(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString18(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString17(controller.reservationUsername)) {
+  if (isNonEmptyString18(controller.reservationUsername)) {
     return controller.reservationUsername === ownerUsername ? { kind: "ownReserved", ...controller.id ? { controllerId: controller.id } : {} } : { kind: "foreignReserved", ...controller.id ? { controllerId: controller.id } : {} };
   }
   return { kind: "neutral", ...controller.id ? { controllerId: controller.id } : {} };
@@ -20462,7 +21225,7 @@ function hasBlockingClaimIntent(colony, targetRoom) {
     return false;
   }
   if (Array.isArray(territoryMemory.targets) && territoryMemory.targets.some(
-    (target) => isRecord18(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
+    (target) => isRecord19(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
   )) {
     return true;
   }
@@ -20506,13 +21269,13 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
   const removedRooms = /* @__PURE__ */ new Set();
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter((target) => {
-      if (!isRecord18(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
+      if (!isRecord19(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
         return true;
       }
       if (activeTarget && isSameTarget4(target, activeTarget)) {
         return true;
       }
-      if (isNonEmptyString17(target.roomName)) {
+      if (isNonEmptyString18(target.roomName)) {
         removedRooms.add(target.roomName);
       }
       return false;
@@ -20529,7 +21292,7 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
 function pruneAdjacentReservationForTarget(colony, targetRoom, territoryMemory) {
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter(
-      (target) => !(isRecord18(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
+      (target) => !(isRecord19(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
     );
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
@@ -20546,7 +21309,7 @@ function upsertTerritoryTarget3(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord18(existingTarget)) {
+  if (isRecord19(existingTarget)) {
     existingTarget.createdBy = COLONY_EXPANSION_CLAIM_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -20567,7 +21330,7 @@ function upsertTerritoryIntent5(intents, nextIntent) {
   intents.push(nextIntent);
 }
 function isSameTarget4(left, right) {
-  return isRecord18(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord19(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getAdjacentRoomNames8(roomName) {
   var _a;
@@ -20576,15 +21339,15 @@ function getAdjacentRoomNames8(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord18(exits)) {
+  if (!isRecord19(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER7.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString17(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString18(exitRoom) ? [exitRoom] : [];
   });
 }
-function getVisibleRoom9(roomName) {
+function getVisibleRoom10(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -20595,7 +21358,7 @@ function getScoutIntel3(homeRoomName, roomName) {
 function getControllerOwnerUsername9(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString17(username) ? username : void 0;
+  return isNonEmptyString18(username) ? username : void 0;
 }
 function getTerritoryMemoryRecord8() {
   var _a;
@@ -20611,20 +21374,20 @@ function getWritableTerritoryMemoryRecord7() {
   }
   return memory.territory;
 }
-function getGameTime15() {
+function getGameTime17() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord18(value) {
+function isRecord19(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString17(value) {
+function isNonEmptyString18(value) {
   return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/territoryRunner.ts
-var ERR_NOT_IN_RANGE_CODE7 = -9;
+var ERR_NOT_IN_RANGE_CODE8 = -9;
 var ERR_INVALID_TARGET_CODE4 = -7;
 var ERR_NO_BODYPART_CODE2 = -12;
 var ERR_GCL_NOT_ENOUGH_CODE2 = -15;
@@ -20661,7 +21424,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   if (assignment.action === "scout") {
-    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime16(), creep.name, telemetryEvents);
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime18(), creep.name, telemetryEvents);
     completeTerritoryAssignment(creep);
     return;
   }
@@ -20688,7 +21451,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   }
   if (isTerritoryControlAction4(assignment.action) && typeof creep.attackController === "function" && canCreepPressureTerritoryController(creep, controller, creep.memory.colony)) {
     const pressureResult = executeControllerAction(creep, controller, "attackController");
-    if (pressureResult === ERR_NOT_IN_RANGE_CODE7 && typeof creep.moveTo === "function") {
+    if (pressureResult === ERR_NOT_IN_RANGE_CODE8 && typeof creep.moveTo === "function") {
       creep.moveTo(controller);
       return;
     }
@@ -20714,7 +21477,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   if (assignment.action === "claim" && result === OK_CODE8) {
     recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents);
   }
-  if (result === ERR_NOT_IN_RANGE_CODE7 && typeof creep.moveTo === "function") {
+  if (result === ERR_NOT_IN_RANGE_CODE8 && typeof creep.moveTo === "function") {
     creep.moveTo(controller);
     return;
   }
@@ -20743,7 +21506,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime16();
+  const gameTime = getGameTime18();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -20753,7 +21516,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   suppressTerritoryIntent(creep.memory.colony, assignment, gameTime);
   creep.memory.territory = (_a = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, gameTime)) != null ? _a : reserveAssignment;
   const reserveResult = executeControllerAction(creep, controller, "reserveController");
-  if (reserveResult === ERR_NOT_IN_RANGE_CODE7 && typeof creep.moveTo === "function") {
+  if (reserveResult === ERR_NOT_IN_RANGE_CODE8 && typeof creep.moveTo === "function") {
     creep.moveTo(controller);
     return true;
   }
@@ -20763,7 +21526,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime16());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime18());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -20797,9 +21560,9 @@ function selectTargetController(creep, assignment) {
   var _a, _b;
   if (assignment.controllerId) {
     const game = globalThis.Game;
-    const getObjectById3 = game == null ? void 0 : game.getObjectById;
-    if (typeof getObjectById3 === "function") {
-      const controller = getObjectById3.call(game, assignment.controllerId);
+    const getObjectById4 = game == null ? void 0 : game.getObjectById;
+    if (typeof getObjectById4 === "function") {
+      const controller = getObjectById4.call(game, assignment.controllerId);
       if (controller) {
         return controller;
       }
@@ -20843,7 +21606,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime16() {
+function getGameTime18() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -21027,7 +21790,7 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
     workerCount: colonyCreeps.filter((creep) => creep.memory.role === "worker").length,
     energyAvailable: colony.energyAvailable,
     energyCapacity: colony.energyCapacityAvailable,
-    storedEnergy: getStoredEnergy10(room),
+    storedEnergy: getStoredEnergy12(room),
     sourceCount: sources.length,
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -21110,7 +21873,7 @@ function buildMemoryTerritoryState(roomName) {
   const expansionCandidates = [];
   if (Array.isArray(targets)) {
     for (const target of targets) {
-      if (!isRecord19(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+      if (!isRecord20(target) || target.colony !== roomName || typeof target.roomName !== "string") {
         continue;
       }
       const action = normalizeTerritoryAction(target.action);
@@ -21172,12 +21935,12 @@ function countVisibleOwnedRooms3() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord19(structure) && matchesStructureType15(structure.structureType, globalName, fallback)
+    (structure) => isRecord20(structure) && matchesStructureType16(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
   return structures.reduce((total, structure) => {
-    if (!isRecord19(structure)) {
+    if (!isRecord20(structure)) {
       return total;
     }
     const hits = finiteNumberOrNull(structure.hits);
@@ -21188,12 +21951,12 @@ function estimateRepairBacklogHits(structures) {
     return total + (hitsMax - hits);
   }, 0);
 }
-function getStoredEnergy10(room) {
+function getStoredEnergy12(room) {
   const storage = room.storage;
   return getEnergyInStore2(storage);
 }
 function getEnergyInStore2(object) {
-  if (!isRecord19(object) || !isRecord19(object.store)) {
+  if (!isRecord20(object) || !isRecord20(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -21205,7 +21968,7 @@ function getEnergyInStore2(object) {
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
 function findRoomObjects14(room, constantName) {
-  const findConstant = getGlobalNumber10(constantName);
+  const findConstant = getGlobalNumber11(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return [];
@@ -21217,7 +21980,7 @@ function findRoomObjects14(room, constantName) {
     return [];
   }
 }
-function matchesStructureType15(value, globalName, fallback) {
+function matchesStructureType16(value, globalName, fallback) {
   const globalValue = globalThis[globalName];
   return value === globalValue || value === fallback;
 }
@@ -21225,7 +21988,7 @@ function getResourceEnergy() {
   const value = globalThis.RESOURCE_ENERGY;
   return value != null ? value : "energy";
 }
-function getGlobalNumber10(name) {
+function getGlobalNumber11(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -21245,7 +22008,7 @@ function finiteNumberOrZero(value) {
 function finiteNumberOrNull(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function isRecord19(value) {
+function isRecord20(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -21255,9 +22018,13 @@ var OK_CODE9 = 0;
 var NEXT_EXPANSION_SCORING_REFRESH_INTERVAL = 50;
 var NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS = 5e3;
 function runEconomy(preludeTelemetryEvents = []) {
+  var _a, _b;
   const creeps = Object.values(Game.creeps);
-  const colonies = getOwnedColonies();
+  balanceStorage();
+  const colonies = orderColoniesForSpawnPlanning(getOwnedColonies());
   const telemetryEvents = [...preludeTelemetryEvents];
+  const usedSpawnsByRoom = /* @__PURE__ */ new Map();
+  const reservedSpawnEnergyByRoom = /* @__PURE__ */ new Map();
   clearColonySurvivalAssessmentCache();
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
@@ -21276,9 +22043,9 @@ function runEconomy(preludeTelemetryEvents = []) {
       roleCounts,
       Game.time
     );
-    let availableEnergy = colony.energyAvailable;
+    let availableEnergy = Math.max(0, colony.energyAvailable - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0));
     let successfulSpawnCount = 0;
-    const usedSpawns = /* @__PURE__ */ new Set();
+    const usedSpawns = new Set((_b = usedSpawnsByRoom.get(colony.room.name)) != null ? _b : []);
     while (true) {
       const planningColony = createSpawnPlanningColony(colony, availableEnergy, usedSpawns);
       const spawnRequest = planSpawn(
@@ -21303,7 +22070,10 @@ function runEconomy(preludeTelemetryEvents = []) {
         break;
       }
       usedSpawns.add(outcome.spawn);
-      availableEnergy = Math.max(0, availableEnergy - getBodyCost(spawnRequest.body));
+      const bodyCost = getBodyCost(spawnRequest.body);
+      recordUsedSpawn(usedSpawnsByRoom, colony.room.name, outcome.spawn);
+      recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, colony.room.name, bodyCost);
+      availableEnergy = Math.max(0, availableEnergy - bodyCost);
       successfulSpawnCount += 1;
       recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
       if (spawnRequest.memory.role !== "worker") {
@@ -21318,6 +22088,7 @@ function runEconomy(preludeTelemetryEvents = []) {
     manageStorage(colony.room);
     recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
   }
+  attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
   for (const creep of creeps) {
     if (creep.memory.role === "worker") {
       runWorker(creep);
@@ -21325,6 +22096,8 @@ function runEconomy(preludeTelemetryEvents = []) {
       runRemoteHarvester(creep);
     } else if (creep.memory.role === HAULER_ROLE) {
       runHauler(creep);
+    } else if (creep.memory.role === CROSS_ROOM_HAULER_ROLE) {
+      runCrossRoomHauler(creep);
     } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE) {
       runClaimer(creep, telemetryEvents);
     } else if (creep.memory.role === TERRITORY_SCOUT_ROLE) {
@@ -21358,6 +22131,41 @@ function recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents) 
 }
 function shouldRecordStrategyRecommendationTelemetry(gameTime) {
   return gameTime > 0 && gameTime % RUNTIME_SUMMARY_INTERVAL === 0;
+}
+function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom) {
+  var _a, _b;
+  const spawnRequest = planCrossRoomHauler();
+  if (!spawnRequest) {
+    return;
+  }
+  const sourceRoomName = spawnRequest.spawn.room.name;
+  const sourceColony = colonies.find((colony) => colony.room.name === sourceRoomName);
+  const usedSpawns = (_a = usedSpawnsByRoom.get(sourceRoomName)) != null ? _a : /* @__PURE__ */ new Set();
+  const candidateSpawns = ((_b = sourceColony == null ? void 0 : sourceColony.spawns) != null ? _b : [spawnRequest.spawn]).filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn));
+  if (candidateSpawns.length === 0) {
+    return;
+  }
+  if (getBodyCost(spawnRequest.body) > getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom)) {
+    return;
+  }
+  const request = candidateSpawns.includes(spawnRequest.spawn) ? spawnRequest : { ...spawnRequest, spawn: candidateSpawns[0] };
+  const outcome = attemptSpawnRequest(
+    request,
+    sourceRoomName,
+    telemetryEvents,
+    candidateSpawns
+  );
+  if (!outcome || outcome.result !== OK_CODE9) {
+    return;
+  }
+  recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
+  recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, sourceRoomName, getBodyCost(spawnRequest.body));
+}
+function getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom) {
+  var _a, _b;
+  const sourceRoomName = spawnRequest.spawn.room.name;
+  const roomEnergy = (_a = sourceColony == null ? void 0 : sourceColony.energyAvailable) != null ? _a : spawnRequest.spawn.room.energyAvailable;
+  return Math.max(0, roomEnergy - ((_b = reservedSpawnEnergyByRoom.get(sourceRoomName)) != null ? _b : 0));
 }
 function planCriticalConstructionSites(colony, spawnConstructionPending, bootstrapNonCriticalConstructionSuppressed = false) {
   if (spawnConstructionPending || bootstrapNonCriticalConstructionSuppressed) {
@@ -21462,17 +22270,17 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber8(refreshedAt) || !isRecord20(rawSelection) || !isNonEmptyString18(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber8(refreshedAt) || !isRecord21(rawSelection) || !isNonEmptyString19(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord20(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord21(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString18(rawSelection.targetRoom)) {
+    if (!isNonEmptyString19(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -21509,7 +22317,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord20(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord21(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -21539,17 +22347,17 @@ function countVisibleOwnedRooms4() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord20(records)) {
+  if (!isRecord21(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord20(record) && record.status !== "ready"
+    (record) => isRecord21(record) && record.status !== "ready"
   ).length;
 }
-function isRecord20(value) {
+function isRecord21(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString18(value) {
+function isNonEmptyString19(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber8(value) {
@@ -21612,6 +22420,19 @@ function addPlannedWorker(roleCounts) {
   }
   return nextRoleCounts;
 }
+function recordUsedSpawn(usedSpawnsByRoom, roomName, spawn) {
+  var _a;
+  const usedSpawns = (_a = usedSpawnsByRoom.get(roomName)) != null ? _a : /* @__PURE__ */ new Set();
+  usedSpawns.add(spawn);
+  usedSpawnsByRoom.set(roomName, usedSpawns);
+}
+function recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, roomName, bodyCost) {
+  var _a;
+  reservedSpawnEnergyByRoom.set(
+    roomName,
+    ((_a = reservedSpawnEnergyByRoom.get(roomName)) != null ? _a : 0) + bodyCost
+  );
+}
 function getSpawnAttemptOrder(spawnRequest, spawns) {
   return [spawnRequest.spawn, ...spawns.filter((spawn) => spawn !== spawnRequest.spawn && !spawn.spawning)];
 }
@@ -21657,7 +22478,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime17())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime19())
     );
   }
 };
@@ -21729,7 +22550,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime17() {
+function getGameTime19() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -22559,10 +23380,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord21(rawReplay)) {
+  if (!isRecord22(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString19(rawReplay.replayId) || !isNonEmptyString19(rawReplay.room) || !isFiniteNumber9(rawReplay.startTick) || !isFiniteNumber9(rawReplay.endTick) || !isFiniteNumber9(rawReplay.finalScore) || !isRecord21(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString20(rawReplay.replayId) || !isNonEmptyString20(rawReplay.room) || !isFiniteNumber9(rawReplay.startTick) || !isFiniteNumber9(rawReplay.endTick) || !isFiniteNumber9(rawReplay.finalScore) || !isRecord22(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -22587,10 +23408,10 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord21(value) {
+function isRecord22(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString19(value) {
+function isNonEmptyString20(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber9(value) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4928,9 +4928,9 @@ function getVisibleController(targetRoom, controllerId) {
   if (roomController) {
     return roomController;
   }
-  const getObjectById3 = game == null ? void 0 : game.getObjectById;
-  if (controllerId && typeof getObjectById3 === "function") {
-    return getObjectById3.call(game, controllerId);
+  const getObjectById4 = game == null ? void 0 : game.getObjectById;
+  if (controllerId && typeof getObjectById4 === "function") {
+    return getObjectById4.call(game, controllerId);
   }
   return null;
 }
@@ -7794,11 +7794,11 @@ function selectCreepRoomController(creep, controllerId) {
     return roomController;
   }
   const game = globalThis.Game;
-  const getObjectById3 = game == null ? void 0 : game.getObjectById;
-  if (typeof getObjectById3 !== "function") {
+  const getObjectById4 = game == null ? void 0 : game.getObjectById;
+  if (typeof getObjectById4 !== "function") {
     return null;
   }
-  return getObjectById3.call(game, controllerId);
+  return getObjectById4.call(game, controllerId);
 }
 function getTerritoryControllerTargetState(controller, action, colonyOwnerUsername) {
   if (action === "reserve") {
@@ -8035,9 +8035,9 @@ function getVisibleController2(targetRoom, controllerId) {
   if (roomController) {
     return roomController;
   }
-  const getObjectById3 = game == null ? void 0 : game.getObjectById;
-  if (controllerId && typeof getObjectById3 === "function") {
-    return getObjectById3.call(game, controllerId);
+  const getObjectById4 = game == null ? void 0 : game.getObjectById;
+  if (controllerId && typeof getObjectById4 === "function") {
+    return getObjectById4.call(game, controllerId);
   }
   return null;
 }
@@ -12728,8 +12728,8 @@ function isUrgentEnergySpendingTask(task) {
 }
 function getTaskTarget(task) {
   const game = globalThis.Game;
-  const getObjectById3 = game == null ? void 0 : game.getObjectById;
-  return typeof getObjectById3 === "function" ? getObjectById3(String(task.targetId)) : null;
+  const getObjectById4 = game == null ? void 0 : game.getObjectById;
+  return typeof getObjectById4 === "function" ? getObjectById4(String(task.targetId)) : null;
 }
 function isCapacityEnablingConstructionSite(target) {
   const structureType = target == null ? void 0 : target.structureType;
@@ -13293,8 +13293,8 @@ function getEnergyResource5() {
 }
 function getObjectById(id) {
   var _a;
-  const getObjectById3 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  return typeof getObjectById3 === "function" ? getObjectById3(String(id)) : null;
+  const getObjectById4 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById4 === "function" ? getObjectById4(String(id)) : null;
 }
 function getVisibleRoom2(roomName) {
   var _a, _b;
@@ -13528,8 +13528,8 @@ function getEnergyResource6() {
 }
 function getObjectById2(id) {
   var _a;
-  const getObjectById3 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  return typeof getObjectById3 === "function" ? getObjectById3(String(id)) : null;
+  const getObjectById4 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById4 === "function" ? getObjectById4(String(id)) : null;
 }
 function getRemoteOperationCreeps2(homeRoom, targetRoom) {
   const findMyCreeps3 = globalThis.FIND_MY_CREEPS;
@@ -14060,6 +14060,37 @@ function planSpawn(colony, roleCounts, gameTime, options = {}) {
   }
   return null;
 }
+function orderColoniesForSpawnPlanning(colonies) {
+  return [...colonies].sort(compareColoniesForSpawnPlanning);
+}
+function getSpawnEnergyForecast(colony) {
+  const balance = getStorageBalanceMemory();
+  const transfers = Array.isArray(balance == null ? void 0 : balance.transfers) ? balance.transfers : [];
+  const incomingEnergy = transfers.filter((transfer) => transfer.targetRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger2(transfer.amount), 0);
+  const outgoingEnergy = transfers.filter((transfer) => transfer.sourceRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger2(transfer.amount), 0);
+  const energyAvailable = normalizeNonNegativeInteger2(colony.energyAvailable);
+  return {
+    roomName: colony.room.name,
+    energyAvailable,
+    incomingEnergy,
+    outgoingEnergy,
+    effectiveEnergyAvailable: Math.max(0, energyAvailable + incomingEnergy - outgoingEnergy)
+  };
+}
+function shouldSuppressWorkerSpawnForCrossRoomImport(colony) {
+  var _a, _b;
+  const balance = getStorageBalanceMemory();
+  if (!balance) {
+    return false;
+  }
+  const roomBalance = (_a = balance == null ? void 0 : balance.rooms) == null ? void 0 : _a[colony.room.name];
+  if ((roomBalance == null ? void 0 : roomBalance.mode) !== "import") {
+    return false;
+  }
+  return ((_b = balance == null ? void 0 : balance.transfers) != null ? _b : []).some(
+    (transfer) => transfer.targetRoom === colony.room.name && transfer.amount > 0 && isExportRoomWithSupply(balance, transfer.sourceRoom)
+  );
+}
 function planSpawnForPriorityTier(tier, context) {
   switch (tier) {
     case "emergencyBootstrap":
@@ -14094,7 +14125,7 @@ function planEmergencyBootstrapSpawn(context) {
   );
 }
 function planLocalSurvivalSpawn(context) {
-  if (context.workerCapacity >= context.workerTarget || !hasRecoveryWorkerSpawnEnergy(context.colony)) {
+  if (context.workerCapacity >= context.workerTarget || !hasRecoveryWorkerSpawnEnergy(context.colony) || shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) {
     return null;
   }
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
@@ -14462,7 +14493,7 @@ function planMultiRoomControllerUpgradeSpawn(context) {
   return null;
 }
 function shouldSpawnControllerUpgradeSurplusWorker(context) {
-  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
+  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || shouldSuppressWorkerSpawnForCrossRoomImport(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
     return false;
   }
   const surplusWorkerTarget = Math.min(
@@ -14695,6 +14726,20 @@ function buildTerritorySpawnBody(energyAvailable, intent) {
 function getVisibleRoom4(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+}
+function compareColoniesForSpawnPlanning(left, right) {
+  const leftForecast = getSpawnEnergyForecast(left);
+  const rightForecast = getSpawnEnergyForecast(right);
+  return rightForecast.effectiveEnergyAvailable - leftForecast.effectiveEnergyAvailable || right.energyAvailable - left.energyAvailable || left.room.name.localeCompare(right.room.name);
+}
+function isExportRoomWithSupply(balance, roomName) {
+  var _a;
+  const roomBalance = (_a = balance.rooms) == null ? void 0 : _a[roomName];
+  return (roomBalance == null ? void 0 : roomBalance.mode) === "export" && roomBalance.exportableEnergy > 0;
+}
+function getStorageBalanceMemory() {
+  var _a, _b;
+  return (_b = (_a = globalThis.Memory) == null ? void 0 : _a.economy) == null ? void 0 : _b.storageBalance;
 }
 function isRecord10(value) {
   return typeof value === "object" && value !== null;
@@ -18315,6 +18360,647 @@ function matchesStructureType13(actual, globalName, fallback) {
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 
+// src/economy/storageBalancer.ts
+var STORAGE_BALANCE_EXPORT_RATIO = 0.8;
+var STORAGE_BALANCE_IMPORT_RATIO = 0.3;
+var STORAGE_BALANCE_REFRESH_INTERVAL = 25;
+function balanceStorage() {
+  const memory = getEconomyMemory();
+  const gameTime = getGameTime12();
+  const existing = memory.storageBalance;
+  if (existing && isStorageBalanceFresh(existing, gameTime)) {
+    return;
+  }
+  memory.storageBalance = buildStorageBalanceState(gameTime);
+}
+function getStorageBalanceState() {
+  const memory = getEconomyMemory();
+  const gameTime = getGameTime12();
+  const existing = memory.storageBalance;
+  if (existing && isStorageBalanceFresh(existing, gameTime)) {
+    return existing;
+  }
+  const state = buildStorageBalanceState(gameTime);
+  memory.storageBalance = state;
+  return state;
+}
+function getRoomStoredEnergyState(room) {
+  const stores = getRoomEnergyStores(room);
+  const energy = stores.reduce((total, structure) => total + getStoredEnergy11(structure), 0);
+  const capacity = stores.reduce((total, structure) => total + getEnergyCapacity2(structure), 0);
+  const ratio = capacity > 0 ? energy / capacity : 0;
+  const exportableEnergy = capacity > 0 && ratio > STORAGE_BALANCE_EXPORT_RATIO ? Math.floor(energy - capacity * STORAGE_BALANCE_EXPORT_RATIO) : 0;
+  const importDemand = capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO ? Math.ceil(capacity * STORAGE_BALANCE_IMPORT_RATIO - energy) : 0;
+  return {
+    roomName: room.name,
+    energy,
+    capacity,
+    ratio,
+    exportableEnergy: Math.max(0, exportableEnergy),
+    importDemand: Math.max(0, importDemand),
+    mode: selectStorageBalanceMode(capacity, ratio)
+  };
+}
+function buildStorageBalanceState(gameTime) {
+  const roomStates = getOwnedRooms().map(getRoomStoredEnergyState).filter((state) => state.capacity > 0);
+  return {
+    updatedAt: gameTime,
+    rooms: Object.fromEntries(
+      roomStates.map((state) => [
+        state.roomName,
+        {
+          roomName: state.roomName,
+          mode: state.mode,
+          energy: state.energy,
+          capacity: state.capacity,
+          ratio: state.ratio,
+          exportableEnergy: state.exportableEnergy,
+          importDemand: state.importDemand,
+          updatedAt: gameTime
+        }
+      ])
+    ),
+    transfers: buildStorageTransfers(roomStates, gameTime)
+  };
+}
+function buildStorageTransfers(roomStates, gameTime) {
+  var _a;
+  const exporters = roomStates.filter((state) => state.mode === "export" && state.exportableEnergy > 0).sort(compareExportRooms);
+  const importers = roomStates.filter((state) => state.mode === "import" && state.importDemand > 0).sort(compareImportRooms);
+  const remainingExport = new Map(exporters.map((state) => [state.roomName, state.exportableEnergy]));
+  const transfers = [];
+  for (const importer of importers) {
+    let remainingDemand = importer.importDemand;
+    for (const exporter of exporters) {
+      if (remainingDemand <= 0) {
+        break;
+      }
+      const exportableEnergy = (_a = remainingExport.get(exporter.roomName)) != null ? _a : 0;
+      const amount = Math.min(exportableEnergy, remainingDemand);
+      if (amount <= 0) {
+        continue;
+      }
+      transfers.push({
+        sourceRoom: exporter.roomName,
+        targetRoom: importer.roomName,
+        amount,
+        updatedAt: gameTime
+      });
+      remainingExport.set(exporter.roomName, exportableEnergy - amount);
+      remainingDemand -= amount;
+    }
+  }
+  return transfers;
+}
+function compareExportRooms(left, right) {
+  return right.exportableEnergy - left.exportableEnergy || right.ratio - left.ratio || left.roomName.localeCompare(right.roomName);
+}
+function compareImportRooms(left, right) {
+  return right.importDemand - left.importDemand || left.ratio - right.ratio || left.roomName.localeCompare(right.roomName);
+}
+function selectStorageBalanceMode(capacity, ratio) {
+  if (capacity <= 0) {
+    return "balanced";
+  }
+  if (ratio > STORAGE_BALANCE_EXPORT_RATIO) {
+    return "export";
+  }
+  if (ratio < STORAGE_BALANCE_IMPORT_RATIO) {
+    return "import";
+  }
+  return "balanced";
+}
+function getRoomEnergyStores(room) {
+  const stores = [
+    room.storage,
+    room.terminal
+  ];
+  return stores.filter(
+    (structure) => structure !== void 0
+  );
+}
+function getStoredEnergy11(target) {
+  var _a;
+  const store = target.store;
+  const resource = getEnergyResource9();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+  const directEnergy = store == null ? void 0 : store[resource];
+  return typeof directEnergy === "number" && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
+}
+function getEnergyCapacity2(target) {
+  var _a, _b, _c;
+  const store = target.store;
+  const resource = getEnergyResource9();
+  const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof capacity === "number" && Number.isFinite(capacity)) {
+    return Math.max(0, capacity);
+  }
+  const genericCapacity = (_b = store == null ? void 0 : store.getCapacity) == null ? void 0 : _b.call(store);
+  if (typeof genericCapacity === "number" && Number.isFinite(genericCapacity)) {
+    return Math.max(0, genericCapacity);
+  }
+  const freeCapacity = (_c = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _c.call(store, resource);
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? getStoredEnergy11(target) + Math.max(0, freeCapacity) : 0;
+}
+function isStorageBalanceFresh(state, gameTime) {
+  return typeof state.updatedAt === "number" && Number.isFinite(state.updatedAt) && gameTime >= state.updatedAt && gameTime - state.updatedAt < STORAGE_BALANCE_REFRESH_INTERVAL;
+}
+function getOwnedRooms() {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return [];
+  }
+  return Object.values(rooms).filter((room) => {
+    var _a2;
+    return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
+  });
+}
+function getEconomyMemory() {
+  const memory = getMemory();
+  if (!memory.economy) {
+    memory.economy = {};
+  }
+  return memory.economy;
+}
+function getMemory() {
+  const global = globalThis;
+  if (!global.Memory) {
+    global.Memory = {};
+  }
+  return global.Memory;
+}
+function getGameTime12() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
+}
+function getEnergyResource9() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+
+// src/economy/crossRoomHauler.ts
+var CROSS_ROOM_HAULER_ROLE = "crossRoomHauler";
+var CARRY_MOVE_PAIR_COST = 100;
+var CARRY_CAPACITY_PER_PART2 = 50;
+var MAX_CARRY_MOVE_PAIRS = 25;
+var MIN_CARRY_MOVE_PAIRS = 1;
+var CROSS_ROOM_HAULER_REPLACEMENT_TICKS = 100;
+var CROSS_ROOM_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
+var ERR_NO_PATH_CODE6 = -2;
+var ERR_NOT_IN_RANGE_CODE6 = -9;
+function planCrossRoomHauler() {
+  const transfer = selectCrossRoomEnergyTransfer();
+  if (!transfer) {
+    return null;
+  }
+  const sourceRoom = getVisibleRoom6(transfer.sourceRoom);
+  const targetRoom = getVisibleRoom6(transfer.targetRoom);
+  if (!sourceRoom || !targetRoom) {
+    return null;
+  }
+  const source = selectSourceEnergyStructure(sourceRoom);
+  if (!source) {
+    return null;
+  }
+  const spawn = selectSourceRoomSpawn(sourceRoom.name);
+  if (!spawn) {
+    return null;
+  }
+  const sourceState = getRoomStoredEnergyState(sourceRoom);
+  const transferableEnergy = Math.min(transfer.amount, sourceState.exportableEnergy);
+  const body = buildCrossRoomHaulerBody(sourceRoom.energyAvailable, transferableEnergy);
+  if (body.length === 0) {
+    return null;
+  }
+  const route = findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name);
+  if (!route) {
+    return null;
+  }
+  return {
+    spawn,
+    body,
+    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime13()}`,
+    memory: {
+      role: CROSS_ROOM_HAULER_ROLE,
+      colony: sourceRoom.name,
+      crossRoomHauler: {
+        homeRoom: sourceRoom.name,
+        targetRoom: targetRoom.name,
+        sourceId: source.id,
+        state: "collecting",
+        route: route.rooms
+      }
+    }
+  };
+}
+function buildCrossRoomHaulerBody(energyAvailable, transferableEnergy) {
+  const energyBudget = Math.max(0, Math.floor(energyAvailable));
+  const energyScaledPairs = Math.ceil(Math.max(0, transferableEnergy) / CARRY_CAPACITY_PER_PART2);
+  const affordablePairs = Math.floor(energyBudget / CARRY_MOVE_PAIR_COST);
+  const pairCount = Math.min(
+    MAX_CARRY_MOVE_PAIRS,
+    affordablePairs,
+    Math.max(MIN_CARRY_MOVE_PAIRS, energyScaledPairs)
+  );
+  if (pairCount <= 0) {
+    return [];
+  }
+  return Array.from({ length: pairCount }).flatMap(() => ["carry", "move"]);
+}
+function runCrossRoomHauler(creep) {
+  const assignment = getMutableCrossRoomHaulerMemory(creep);
+  if (!assignment) {
+    return;
+  }
+  if (assignment.state === "returning") {
+    returnHome(creep, assignment);
+    return;
+  }
+  if (getCarriedEnergy5(creep) > 0) {
+    assignment.state = "delivering";
+    deliverEnergy2(creep, assignment);
+    return;
+  }
+  if (!hasSourceSurplusEnergy(assignment)) {
+    assignment.state = "returning";
+    returnHome(creep, assignment);
+    return;
+  }
+  assignment.state = "collecting";
+  collectEnergy(creep, assignment);
+}
+function selectCrossRoomEnergyTransfer() {
+  var _a;
+  const balance = getStorageBalanceState();
+  return (_a = balance.transfers.filter((transfer) => transfer.amount > 0).filter((transfer) => !hasActiveCrossRoomHauler(transfer)).filter((transfer) => isLiveTransferCandidate(transfer)).sort(compareTransfers)[0]) != null ? _a : null;
+}
+function isLiveTransferCandidate(transfer) {
+  const sourceRoom = getVisibleRoom6(transfer.sourceRoom);
+  const targetRoom = getVisibleRoom6(transfer.targetRoom);
+  if (!sourceRoom || !targetRoom) {
+    return false;
+  }
+  if (!isSafeOwnedRoom(sourceRoom.name) || !isSafeOwnedRoom(targetRoom.name)) {
+    return false;
+  }
+  const sourceState = getRoomStoredEnergyState(sourceRoom);
+  const targetState = getRoomStoredEnergyState(targetRoom);
+  if (sourceState.mode !== "export" || targetState.mode !== "import") {
+    return false;
+  }
+  return findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name) !== null;
+}
+function compareTransfers(left, right) {
+  var _a, _b, _c, _d;
+  const leftRouteDistance = (_b = (_a = findOwnedLogisticsRoute(left.sourceRoom, left.targetRoom)) == null ? void 0 : _a.distance) != null ? _b : Number.POSITIVE_INFINITY;
+  const rightRouteDistance = (_d = (_c = findOwnedLogisticsRoute(right.sourceRoom, right.targetRoom)) == null ? void 0 : _c.distance) != null ? _d : Number.POSITIVE_INFINITY;
+  return right.amount - left.amount || leftRouteDistance - rightRouteDistance || left.sourceRoom.localeCompare(right.sourceRoom) || left.targetRoom.localeCompare(right.targetRoom);
+}
+function hasActiveCrossRoomHauler(transfer) {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  if (!creeps) {
+    return false;
+  }
+  return Object.values(creeps).some((creep) => {
+    var _a2, _b;
+    const memory = normalizeCrossRoomHaulerMemory((_a2 = creep.memory) == null ? void 0 : _a2.crossRoomHauler);
+    return ((_b = creep.memory) == null ? void 0 : _b.role) === CROSS_ROOM_HAULER_ROLE && (memory == null ? void 0 : memory.homeRoom) === transfer.sourceRoom && memory.targetRoom === transfer.targetRoom && (creep.ticksToLive === void 0 || creep.ticksToLive > CROSS_ROOM_HAULER_REPLACEMENT_TICKS);
+  });
+}
+function collectEnergy(creep, assignment) {
+  var _a, _b;
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
+    delete creep.memory.task;
+    moveTowardRoom3(creep, assignment, assignment.homeRoom);
+    return;
+  }
+  const source = getObjectById3(assignment.sourceId);
+  if (!source || getStoredEnergy12(source) <= 0) {
+    delete creep.memory.task;
+    assignment.state = "returning";
+    returnHome(creep, assignment);
+    return;
+  }
+  const task = {
+    type: "withdraw",
+    targetId: assignment.sourceId
+  };
+  creep.memory.task = task;
+  const result = (_b = creep.withdraw) == null ? void 0 : _b.call(creep, source, getEnergyResource10());
+  if (result === getErrNotInRangeCode3()) {
+    moveTo3(creep, source);
+  }
+}
+function deliverEnergy2(creep, assignment) {
+  var _a, _b;
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
+    delete creep.memory.task;
+    moveTowardRoom3(creep, assignment, assignment.targetRoom);
+    return;
+  }
+  const target = selectDeliveryTarget(creep.room);
+  if (!target) {
+    delete creep.memory.task;
+    assignment.state = "returning";
+    returnHome(creep, assignment);
+    return;
+  }
+  const task = {
+    type: "transfer",
+    targetId: target.id
+  };
+  creep.memory.task = task;
+  const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, target, getEnergyResource10());
+  if (result === getErrNotInRangeCode3()) {
+    moveTo3(creep, target);
+  }
+}
+function returnHome(creep, assignment) {
+  var _a, _b;
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
+    delete creep.memory.task;
+    moveTowardRoom3(creep, assignment, assignment.homeRoom);
+    return;
+  }
+  const carriedEnergy = getCarriedEnergy5(creep);
+  if (carriedEnergy > 0) {
+    const homeTarget = selectHomeReturnTarget(creep.room);
+    if (homeTarget) {
+      const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, homeTarget, getEnergyResource10());
+      if (result === getErrNotInRangeCode3()) {
+        moveTo3(creep, homeTarget);
+      }
+      return;
+    }
+  }
+  delete creep.memory.task;
+  assignment.state = hasSourceSurplusEnergy(assignment) ? "collecting" : "returning";
+}
+function selectDeliveryTarget(room) {
+  var _a;
+  const targets = [
+    ...findOwnedStructures4(room).filter(isSpawnOrExtensionWithDemand),
+    ...findRoomStructures2(room).filter(isContainerWithDemand)
+  ].sort(compareDeliveryTargets);
+  return (_a = targets[0]) != null ? _a : null;
+}
+function selectHomeReturnTarget(room) {
+  var _a;
+  const targets = [room.storage, room.terminal].filter(
+    (structure) => structure !== void 0 && getFreeEnergyCapacity7(structure) > 0
+  );
+  return (_a = targets.sort((left, right) => getObjectId6(left).localeCompare(getObjectId6(right)))[0]) != null ? _a : null;
+}
+function isSpawnOrExtensionWithDemand(structure) {
+  return (matchesStructureType14(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType14(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity7(structure) > 0;
+}
+function isContainerWithDemand(structure) {
+  return matchesStructureType14(structure.structureType, "STRUCTURE_CONTAINER", "container") && getFreeEnergyCapacity7(structure) > 0;
+}
+function compareDeliveryTargets(left, right) {
+  return getDeliveryPriority(right) - getDeliveryPriority(left) || getObjectId6(left).localeCompare(getObjectId6(right));
+}
+function getDeliveryPriority(target) {
+  if (matchesStructureType14(target.structureType, "STRUCTURE_SPAWN", "spawn")) {
+    return 3;
+  }
+  if (matchesStructureType14(target.structureType, "STRUCTURE_EXTENSION", "extension")) {
+    return 2;
+  }
+  return 1;
+}
+function selectSourceEnergyStructure(room) {
+  var _a;
+  return (_a = [room.storage, room.terminal].filter(
+    (structure) => structure !== void 0 && getStoredEnergy12(structure) > 0
+  ).sort((left, right) => getStoredEnergy12(right) - getStoredEnergy12(left) || getObjectId6(left).localeCompare(getObjectId6(right)))[0]) != null ? _a : null;
+}
+function hasSourceSurplusEnergy(assignment) {
+  const room = getVisibleRoom6(assignment.homeRoom);
+  if (!room) {
+    return false;
+  }
+  return getRoomStoredEnergyState(room).mode === "export" && getObjectById3(assignment.sourceId) !== null;
+}
+function selectSourceRoomSpawn(roomName) {
+  var _a, _b;
+  const spawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
+  if (!spawns) {
+    return null;
+  }
+  return (_b = Object.values(spawns).filter((spawn) => {
+    var _a2;
+    return ((_a2 = spawn.room) == null ? void 0 : _a2.name) === roomName && !spawn.spawning;
+  }).sort((left, right) => getSpawnEnergyScore(right) - getSpawnEnergyScore(left) || left.name.localeCompare(right.name))[0]) != null ? _b : null;
+}
+function getSpawnEnergyScore(spawn) {
+  const room = spawn.room;
+  return typeof (room == null ? void 0 : room.energyAvailable) === "number" && Number.isFinite(room.energyAvailable) ? room.energyAvailable : 0;
+}
+function findOwnedLogisticsRoute(fromRoom, targetRoom) {
+  var _a;
+  if (fromRoom === targetRoom) {
+    return { distance: 0, rooms: [] };
+  }
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
+    return null;
+  }
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName) => isSafeOwnedRoom(roomName) ? 1 : Infinity
+  });
+  if (route === getNoPathResultCode6() || !Array.isArray(route)) {
+    return null;
+  }
+  const rooms = route.map((step) => isRecord15(step) && typeof step.room === "string" ? step.room : null).filter((roomName) => typeof roomName === "string");
+  if (rooms.length !== route.length || !rooms.every(isSafeOwnedRoom)) {
+    return null;
+  }
+  return { distance: rooms.length, rooms };
+}
+function moveTowardRoom3(creep, assignment, destinationRoom) {
+  var _a, _b;
+  const route = getAssignmentRoute(assignment);
+  const nextRoom = route ? selectNextRouteRoom((_a = creep.room) == null ? void 0 : _a.name, assignment, destinationRoom, route) : destinationRoom;
+  const visibleController = (_b = getVisibleRoom6(nextRoom)) == null ? void 0 : _b.controller;
+  if (visibleController) {
+    moveTo3(creep, visibleController);
+    return;
+  }
+  const RoomPositionCtor = globalThis.RoomPosition;
+  if (typeof RoomPositionCtor === "function") {
+    moveTo3(creep, new RoomPositionCtor(25, 25, nextRoom));
+  }
+}
+function getAssignmentRoute(assignment) {
+  const route = findOwnedLogisticsRoute(assignment.homeRoom, assignment.targetRoom);
+  if (!route) {
+    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString14) : null;
+  }
+  assignment.route = route.rooms;
+  return route.rooms;
+}
+function selectNextRouteRoom(currentRoom, assignment, destinationRoom, route) {
+  var _a, _b, _c;
+  if (!currentRoom) {
+    return destinationRoom;
+  }
+  if (destinationRoom === assignment.targetRoom) {
+    if (currentRoom === assignment.homeRoom) {
+      return (_a = route[0]) != null ? _a : assignment.targetRoom;
+    }
+    const routeIndex2 = route.indexOf(currentRoom);
+    return routeIndex2 >= 0 ? (_b = route[routeIndex2 + 1]) != null ? _b : assignment.targetRoom : destinationRoom;
+  }
+  const routeIndex = route.indexOf(currentRoom);
+  if (routeIndex > 0) {
+    return (_c = route[routeIndex - 1]) != null ? _c : assignment.homeRoom;
+  }
+  return assignment.homeRoom;
+}
+function isSafeOwnedRoom(roomName) {
+  var _a;
+  const room = getVisibleRoom6(roomName);
+  return ((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && !hasHostilePresence(room);
+}
+function hasHostilePresence(room) {
+  const hostileCreepFind = getGlobalNumber8("FIND_HOSTILE_CREEPS");
+  if (typeof hostileCreepFind === "number" && typeof room.find === "function") {
+    const hostiles = room.find(hostileCreepFind);
+    if (Array.isArray(hostiles) && hostiles.length > 0) {
+      return true;
+    }
+  }
+  const hostileStructureFind = getGlobalNumber8("FIND_HOSTILE_STRUCTURES");
+  if (typeof hostileStructureFind === "number" && typeof room.find === "function") {
+    const hostiles = room.find(hostileStructureFind);
+    if (Array.isArray(hostiles) && hostiles.length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+function findOwnedStructures4(room) {
+  var _a, _b;
+  const findMyStructures = getGlobalNumber8("FIND_MY_STRUCTURES");
+  if (typeof findMyStructures !== "number" || typeof room.find !== "function") {
+    return Object.values((_b = (_a = globalThis.Game) == null ? void 0 : _a.spawns) != null ? _b : {}).filter(
+      (spawn) => {
+        var _a2;
+        return ((_a2 = spawn.room) == null ? void 0 : _a2.name) === room.name;
+      }
+    );
+  }
+  const structures = room.find(findMyStructures);
+  return Array.isArray(structures) ? structures : [];
+}
+function findRoomStructures2(room) {
+  const findStructures = getGlobalNumber8("FIND_STRUCTURES");
+  if (typeof findStructures !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const structures = room.find(findStructures);
+  return Array.isArray(structures) ? structures : [];
+}
+function normalizeCrossRoomHaulerMemory(value) {
+  if (!isRecord15(value)) {
+    return null;
+  }
+  return isNonEmptyString14(value.homeRoom) && isNonEmptyString14(value.targetRoom) && isNonEmptyString14(value.sourceId) ? {
+    homeRoom: value.homeRoom,
+    targetRoom: value.targetRoom,
+    sourceId: value.sourceId,
+    ...value.state === "collecting" || value.state === "delivering" || value.state === "returning" ? { state: value.state } : {},
+    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString14) } : {}
+  } : null;
+}
+function getMutableCrossRoomHaulerMemory(creep) {
+  var _a;
+  const normalized = normalizeCrossRoomHaulerMemory((_a = creep.memory) == null ? void 0 : _a.crossRoomHauler);
+  if (!normalized) {
+    return null;
+  }
+  creep.memory.crossRoomHauler = normalized;
+  return creep.memory.crossRoomHauler;
+}
+function moveTo3(creep, target) {
+  var _a;
+  (_a = creep.moveTo) == null ? void 0 : _a.call(creep, target, CROSS_ROOM_MOVE_OPTS);
+}
+function getCarriedEnergy5(creep) {
+  return getStoredEnergy12(creep);
+}
+function getStoredEnergy12(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const resource = getEnergyResource10();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+  const directEnergy = store == null ? void 0 : store[resource];
+  return typeof directEnergy === "number" && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
+}
+function getFreeEnergyCapacity7(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource10());
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+function getObjectById3(id) {
+  var _a;
+  const getObjectById4 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById4 === "function" ? getObjectById4(String(id)) : null;
+}
+function getVisibleRoom6(roomName) {
+  var _a, _b;
+  return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+}
+function getGameTime13() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
+}
+function getEnergyResource10() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function getErrNotInRangeCode3() {
+  var _a;
+  return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE6;
+}
+function getNoPathResultCode6() {
+  var _a;
+  return (_a = globalThis.ERR_NO_PATH) != null ? _a : ERR_NO_PATH_CODE6;
+}
+function getObjectId6(object) {
+  if (!isRecord15(object)) {
+    return "";
+  }
+  return typeof object.id === "string" ? object.id : typeof object.name === "string" ? object.name : "";
+}
+function matchesStructureType14(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+function getGlobalNumber8(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function isRecord15(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString14(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
 // src/territory/claimExecutor.ts
 var AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR = "autonomousExpansionClaim";
 var EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS = 1500;
@@ -18322,7 +19008,7 @@ var MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE = 500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_RCL = 2;
 var EXIT_DIRECTION_ORDER4 = ["1", "3", "5", "7"];
 var OK_CODE6 = 0;
-var ERR_NOT_IN_RANGE_CODE6 = -9;
+var ERR_NOT_IN_RANGE_CODE7 = -9;
 var ERR_INVALID_TARGET_CODE3 = -7;
 var ERR_NO_BODYPART_CODE = -12;
 var ERR_GCL_NOT_ENOUGH_CODE = -15;
@@ -18361,7 +19047,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   if (!isClaimExecutionAssignment(assignment)) {
     return false;
   }
-  const gameTime = getGameTime12();
+  const gameTime = getGameTime14();
   const recommendedClaim = getRecommendedExpansionClaimExecutionGate(creep.memory.colony, assignment);
   if (!recommendedClaim) {
     return false;
@@ -18455,7 +19141,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
     completeClaimAssignment(creep);
     return true;
   }
-  if (result === ERR_NOT_IN_RANGE_CODE6) {
+  if (result === ERR_NOT_IN_RANGE_CODE7) {
     moveTowardController(creep, controller);
     return true;
   }
@@ -18613,7 +19299,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   if (!hasSufficientAutonomousExpansionClaimRcl(colony)) {
     return { ...baseEvaluation, reason: "controllerLevelLow" };
   }
-  const room = getVisibleRoom6(candidate.roomName);
+  const room = getVisibleRoom7(candidate.roomName);
   const controller = room == null ? void 0 : room.controller;
   if (room) {
     recordVisibleRoomScoutIntel(colonyName, room, gameTime, void 0, telemetryEvents);
@@ -18724,7 +19410,7 @@ function buildAutonomousExpansionScoringInput(colony, report, context) {
   const seenRooms = /* @__PURE__ */ new Set();
   const candidates = [];
   report.candidates.forEach((candidate, order) => {
-    if (!isNonEmptyString14(candidate.roomName) || seenRooms.has(candidate.roomName)) {
+    if (!isNonEmptyString15(candidate.roomName) || seenRooms.has(candidate.roomName)) {
       return;
     }
     seenRooms.add(candidate.roomName);
@@ -18744,7 +19430,7 @@ function buildAutonomousExpansionScoringInput(colony, report, context) {
   };
 }
 function toExpansionCandidateInput(candidate, order, adjacency) {
-  const room = getVisibleRoom6(candidate.roomName);
+  const room = getVisibleRoom7(candidate.roomName);
   const controller = room == null ? void 0 : room.controller;
   const controllerId = typeof (controller == null ? void 0 : controller.id) === "string" ? controller.id : candidate.controllerId;
   const hostileCreepCount = typeof candidate.hostileCreepCount === "number" ? candidate.hostileCreepCount : room ? findVisibleHostileCreeps2(room).length : void 0;
@@ -18771,7 +19457,7 @@ function summarizeExpansionController2(controller) {
   return {
     ...typeof controller.my === "boolean" ? { my: controller.my } : {},
     ...ownerUsername ? { ownerUsername } : {},
-    ...isNonEmptyString14(reservationUsername) ? { reservationUsername } : {},
+    ...isNonEmptyString15(reservationUsername) ? { reservationUsername } : {},
     ...typeof ((_b = controller.reservation) == null ? void 0 : _b.ticksToEnd) === "number" ? { reservationTicksToEnd: controller.reservation.ticksToEnd } : {}
   };
 }
@@ -18792,7 +19478,7 @@ function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString14(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString15(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -18831,21 +19517,21 @@ function getAdjacentRoomNames5(roomName, gameMap = ((_a) => (_a = globalThis.Gam
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord15(exits)) {
+  if (!isRecord16(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER4.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString14(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString15(exitRoom) ? [exitRoom] : [];
   });
 }
 function countActivePostClaimBootstraps2() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord15(records)) {
+  if (!isRecord16(records)) {
     return 0;
   }
-  return Object.values(records).filter((record) => isRecord15(record) && record.status !== "ready").length;
+  return Object.values(records).filter((record) => isRecord16(record) && record.status !== "ready").length;
 }
 function hasSufficientAutonomousExpansionClaimRcl(colony) {
   var _a, _b;
@@ -18915,13 +19601,13 @@ function upsertTerritoryTarget2(territoryMemory, target) {
     territoryMemory.targets = [];
   }
   const existingTarget = territoryMemory.targets.find(
-    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord15(rawTarget) && rawTarget.createdBy === target.createdBy
+    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord16(rawTarget) && rawTarget.createdBy === target.createdBy
   );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord15(existingTarget)) {
+  if (isRecord16(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -18952,7 +19638,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord15(target) && isNonEmptyString14(target.roomName) && target.action === "claim") {
+    if (isRecord16(target) && isNonEmptyString15(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -18971,7 +19657,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord15(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord16(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime, intents) {
@@ -19018,7 +19704,7 @@ function getClaimResultReason(result) {
   switch (result) {
     case OK_CODE6:
       return null;
-    case ERR_NOT_IN_RANGE_CODE6:
+    case ERR_NOT_IN_RANGE_CODE7:
       return "notInRange";
     case ERR_INVALID_TARGET_CODE3:
       return "invalidTarget";
@@ -19039,7 +19725,7 @@ function isClaimExecutionAssignment(assignment) {
 }
 function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   var _a;
-  if (!isNonEmptyString14(colony)) {
+  if (!isNonEmptyString15(colony)) {
     return null;
   }
   const territoryMemory = getTerritoryMemoryRecord6();
@@ -19080,7 +19766,7 @@ function isTerritoryIntentSuspensionActive2(intent, gameTime) {
   return isHostileTerritoryIntentSuspensionCoolingDown2(intent.suspended, gameTime);
 }
 function getVisibleHostileCreepCount2(targetRoom) {
-  const room = getVisibleRoom6(targetRoom);
+  const room = getVisibleRoom7(targetRoom);
   return room ? findVisibleHostileCreeps2(room).length : null;
 }
 function isHostileTerritoryIntentSuspensionCoolingDown2(suspension, gameTime) {
@@ -19097,7 +19783,7 @@ function selectClaimTargetController(creep, assignment) {
       }
     }
   }
-  return (_d = (_c = (_a = creep.room) == null ? void 0 : _a.controller) != null ? _c : (_b = getVisibleRoom6(assignment.targetRoom)) == null ? void 0 : _b.controller) != null ? _d : null;
+  return (_d = (_c = (_a = creep.room) == null ? void 0 : _a.controller) != null ? _c : (_b = getVisibleRoom7(assignment.targetRoom)) == null ? void 0 : _b.controller) != null ? _d : null;
 }
 function moveTowardClaimTarget(creep, assignment) {
   const visibleController = selectVisibleClaimTargetController(assignment);
@@ -19158,7 +19844,7 @@ function tryPressureForeignClaimBlocker(creep, assignment, controller, telemetry
     return false;
   }
   const result = creep.attackController(controller);
-  if (result === ERR_NOT_IN_RANGE_CODE6) {
+  if (result === ERR_NOT_IN_RANGE_CODE7) {
     moveTowardController(creep, controller);
     return true;
   }
@@ -19192,7 +19878,7 @@ function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryE
     status: "claimed",
     controllerId: controller.id,
     creepName: creep.name,
-    updatedAt: getGameTime12()
+    updatedAt: getGameTime14()
   });
 }
 function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason, options) {
@@ -19208,7 +19894,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     reason
   });
   if (options.suppressIntent) {
-    suppressRecommendedClaimIntent(colony, assignment, getGameTime12(), options.controllerId, reason);
+    suppressRecommendedClaimIntent(colony, assignment, getGameTime14(), options.controllerId, reason);
   }
   recordColonyExpansionClaimVerification({
     colony,
@@ -19218,7 +19904,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     creepName: creep.name,
     result,
     reason,
-    updatedAt: getGameTime12()
+    updatedAt: getGameTime14()
   });
 }
 function recordRecommendedClaimRetry(creep, assignment, result, reason, options = {}) {
@@ -19233,7 +19919,7 @@ function recordRecommendedClaimRetry(creep, assignment, result, reason, options 
     result,
     reason
   });
-  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime12(), options);
+  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime14(), options);
 }
 function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, options) {
   var _a, _b;
@@ -19304,13 +19990,13 @@ function hasRecommendedClaimTarget(territoryMemory, colony, targetRoom) {
   return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom)) : false;
 }
 function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
-  return isRecord15(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
+  return isRecord16(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
 }
 function recordColonyExpansionClaimVerification(input) {
   var _a;
-  const colonyRoom = getVisibleRoom6(input.colony);
+  const colonyRoom = getVisibleRoom7(input.colony);
   const selection = (_a = colonyRoom == null ? void 0 : colonyRoom.memory) == null ? void 0 : _a.cachedExpansionSelection;
-  if (!isRecord15(selection) || selection.targetRoom !== input.targetRoom) {
+  if (!isRecord16(selection) || selection.targetRoom !== input.targetRoom) {
     return;
   }
   selection.claimExecution = {
@@ -19333,7 +20019,7 @@ function getVisibleClaimedRoom(targetRoom, controller) {
   if (((_a = controllerRoom == null ? void 0 : controllerRoom.controller) == null ? void 0 : _a.my) === true) {
     return controllerRoom;
   }
-  const gameRoom = getVisibleRoom6(targetRoom);
+  const gameRoom = getVisibleRoom7(targetRoom);
   return ((_b = gameRoom == null ? void 0 : gameRoom.controller) == null ? void 0 : _b.my) === true ? gameRoom : null;
 }
 function completeClaimAssignment(creep) {
@@ -19344,15 +20030,15 @@ function getClaimColony(creep, controller) {
   return (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller == null ? void 0 : controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown";
 }
 function isForeignOwnedController(controller) {
-  return controller.my !== true && isNonEmptyString14(getControllerOwnerUsername7(controller));
+  return controller.my !== true && isNonEmptyString15(getControllerOwnerUsername7(controller));
 }
 function isForeignReservedController3(controller, colony) {
   var _a, _b;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  if (!isNonEmptyString14(reservationUsername)) {
+  if (!isNonEmptyString15(reservationUsername)) {
     return false;
   }
-  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom6(colony != null ? colony : "")) == null ? void 0 : _b.controller);
+  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom7(colony != null ? colony : "")) == null ? void 0 : _b.controller);
 }
 function getKnownActiveClaimPartCount(creep) {
   var _a;
@@ -19379,19 +20065,19 @@ function isTerritoryAutomationSource3(source) {
   return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord15(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord16(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isSameTarget2(left, right) {
-  return isRecord15(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord16(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
 }
-function getVisibleRoom6(roomName) {
+function getVisibleRoom7(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameTime12() {
+function getGameTime14() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -19425,17 +20111,17 @@ function isControllerOwned2(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString14(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString15(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
 function getControllerOwnerUsername7(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString14(username) ? username : void 0;
+  return isNonEmptyString15(username) ? username : void 0;
 }
-function isRecord15(value) {
+function isRecord16(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString14(value) {
+function isNonEmptyString15(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -19455,7 +20141,7 @@ var DISTANCE_PENALTY = 55;
 var NO_ROUTE_DISTANCE = 99;
 function scoreClaimTarget(roomName, homeRoom) {
   const details = [];
-  const room = getVisibleRoom7(roomName);
+  const room = getVisibleRoom8(roomName);
   const scoutIntel = getScoutIntel(homeRoom.name, roomName);
   const sources = countSources(room, scoutIntel);
   const distance = getRoomDistance(homeRoom.name, roomName);
@@ -19527,7 +20213,7 @@ function hasUnclaimableController(score) {
     (detail) => detail === "controller already claimed" || detail === "controller already reserved" || detail === "controller missing"
   );
 }
-function getVisibleRoom7(roomName) {
+function getVisibleRoom8(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -19571,8 +20257,8 @@ function scoreTerrain(roomName, details) {
     details.push("terrain unknown");
     return 0;
   }
-  const wallMask = (_a = getGlobalNumber8("TERRAIN_MASK_WALL")) != null ? _a : DEFAULT_TERRAIN_WALL_MASK8;
-  const swampMask = (_b = getGlobalNumber8("TERRAIN_MASK_SWAMP")) != null ? _b : DEFAULT_TERRAIN_SWAMP_MASK2;
+  const wallMask = (_a = getGlobalNumber9("TERRAIN_MASK_WALL")) != null ? _a : DEFAULT_TERRAIN_WALL_MASK8;
+  const swampMask = (_b = getGlobalNumber9("TERRAIN_MASK_SWAMP")) != null ? _b : DEFAULT_TERRAIN_SWAMP_MASK2;
   let total = 0;
   let walls = 0;
   let swamps = 0;
@@ -19599,20 +20285,20 @@ function getControllerStatus2(room, scoutIntel) {
     if (!controller) {
       return "missing";
     }
-    if (controller.my === true || isNonEmptyString15((_a = controller.owner) == null ? void 0 : _a.username)) {
+    if (controller.my === true || isNonEmptyString16((_a = controller.owner) == null ? void 0 : _a.username)) {
       return "owned";
     }
-    if (isNonEmptyString15((_b = controller.reservation) == null ? void 0 : _b.username)) {
+    if (isNonEmptyString16((_b = controller.reservation) == null ? void 0 : _b.username)) {
       return "reserved";
     }
     return "neutral";
   }
   if (scoutIntel == null ? void 0 : scoutIntel.controller) {
     const controller = scoutIntel.controller;
-    if (controller.my === true || isNonEmptyString15(controller.ownerUsername)) {
+    if (controller.my === true || isNonEmptyString16(controller.ownerUsername)) {
       return "owned";
     }
-    if (isNonEmptyString15(controller.reservationUsername)) {
+    if (isNonEmptyString16(controller.reservationUsername)) {
       return "reserved";
     }
     return "neutral";
@@ -19650,12 +20336,12 @@ function getAdjacentRoomNames6(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord16(exits)) {
+  if (!isRecord17(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER5.flatMap((direction) => {
     const adjacentRoom = exits[direction];
-    return isNonEmptyString15(adjacentRoom) ? [adjacentRoom] : [];
+    return isNonEmptyString16(adjacentRoom) ? [adjacentRoom] : [];
   });
 }
 function getRoomTerrain8(roomName) {
@@ -19667,7 +20353,7 @@ function getRoomTerrain8(roomName) {
   return gameMap.getRoomTerrain(roomName);
 }
 function findRoomObjects12(room, constantName) {
-  const findConstant = getGlobalNumber8(constantName);
+  const findConstant = getGlobalNumber9(constantName);
   if (!room || typeof room.find !== "function" || typeof findConstant !== "number") {
     return [];
   }
@@ -19685,14 +20371,14 @@ function getRange2(origin, target) {
   }
   return null;
 }
-function getGlobalNumber8(name) {
+function getGlobalNumber9(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function isRecord16(value) {
+function isRecord17(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString15(value) {
+function isNonEmptyString16(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -19702,7 +20388,7 @@ var MIN_ADJACENT_ROOM_RESERVATION_SCORE = 500;
 var ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS_PER_CLAIM_PART = 600;
 var MAX_ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS = 1e3;
 var EXIT_DIRECTION_ORDER6 = ["1", "3", "5", "7"];
-function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime13(), options = {}) {
+function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime15(), options = {}) {
   const evaluation = selectAdjacentRoomReservationPlan(colony, options);
   if (evaluation.status === "planned" && evaluation.targetRoom) {
     persistAdjacentRoomReservationIntent(colony.room.name, evaluation, gameTime);
@@ -19780,7 +20466,7 @@ function buildReservationCandidate(homeRoom, roomName, order, ownerUsername, ren
   if (controllerState.kind !== "neutral" && controllerState.kind !== "ownReserved") {
     return [];
   }
-  if (hasHostilePresence(homeRoom.name, roomName)) {
+  if (hasHostilePresence2(homeRoom.name, roomName)) {
     return [];
   }
   const effectiveScore = controllerState.kind === "ownReserved" ? score.score + CLAIM_SCORE_RESERVED_PENALTY : score.score;
@@ -19845,7 +20531,7 @@ function getReservationClaimPartCount(energyCapacityAvailable) {
   return buildTerritoryReserverBody(energyCapacityAvailable).filter((part) => part === "claim").length;
 }
 function getReservationControllerState(colonyName, roomName, ownerUsername) {
-  const room = getVisibleRoom8(roomName);
+  const room = getVisibleRoom9(roomName);
   if (room) {
     const controller2 = room.controller;
     if (!controller2) {
@@ -19861,11 +20547,11 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString16(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString17(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString16(controller.reservationUsername)) {
-    if (isNonEmptyString16(ownerUsername) && controller.reservationUsername === ownerUsername) {
+  if (isNonEmptyString17(controller.reservationUsername)) {
+    if (isNonEmptyString17(ownerUsername) && controller.reservationUsername === ownerUsername) {
       return {
         kind: "ownReserved",
         ...controller.id ? { controllerId: controller.id } : {},
@@ -19879,12 +20565,12 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
 function getVisibleControllerReservationState(controller, ownerUsername) {
   var _a;
   const controllerId = controller.id;
-  if (controller.my === true || isNonEmptyString16((_a = controller.owner) == null ? void 0 : _a.username)) {
+  if (controller.my === true || isNonEmptyString17((_a = controller.owner) == null ? void 0 : _a.username)) {
     return { kind: "owned", controllerId };
   }
   const reservation = controller.reservation;
-  if (isNonEmptyString16(reservation == null ? void 0 : reservation.username)) {
-    if (isNonEmptyString16(ownerUsername) && reservation.username === ownerUsername) {
+  if (isNonEmptyString17(reservation == null ? void 0 : reservation.username)) {
+    if (isNonEmptyString17(ownerUsername) && reservation.username === ownerUsername) {
       return {
         kind: "ownReserved",
         controllerId,
@@ -19895,9 +20581,9 @@ function getVisibleControllerReservationState(controller, ownerUsername) {
   }
   return { kind: "neutral", controllerId };
 }
-function hasHostilePresence(colonyName, roomName) {
+function hasHostilePresence2(colonyName, roomName) {
   var _a, _b, _c;
-  const room = getVisibleRoom8(roomName);
+  const room = getVisibleRoom9(roomName);
   if (room) {
     return countVisibleHostiles(room) > 0;
   }
@@ -19974,7 +20660,7 @@ function upsertAdjacentRoomReservationTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord17(existingTarget)) {
+  if (isRecord18(existingTarget)) {
     existingTarget.createdBy = ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -20007,13 +20693,13 @@ function hasBlockingTerritoryPlan(colony) {
   );
 }
 function isBlockingTerritoryTarget(target, colony) {
-  return isRecord17(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
+  return isRecord18(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
 }
 function isAdjacentRoomReservationTarget(target, colony) {
-  return isRecord17(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
+  return isRecord18(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
 }
 function isSameTarget3(left, right) {
-  return isRecord17(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord18(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getAdjacentRoomNames7(roomName) {
   var _a;
@@ -20022,12 +20708,12 @@ function getAdjacentRoomNames7(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord17(exits)) {
+  if (!isRecord18(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER6.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString16(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString17(exitRoom) ? [exitRoom] : [];
   });
 }
 function countVisibleOwnedRooms2(colonyName, ownerUsername) {
@@ -20038,7 +20724,7 @@ function countVisibleOwnedRooms2(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString16(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString17(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
@@ -20056,7 +20742,7 @@ function getScoutIntel2(colonyName, roomName) {
   var _a, _b, _c;
   return (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel) == null ? void 0 : _c[`${colonyName}>${roomName}`];
 }
-function getVisibleRoom8(roomName) {
+function getVisibleRoom9(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -20074,7 +20760,7 @@ function getFindConstant6(name) {
 function getControllerOwnerUsername8(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString16(username) ? username : void 0;
+  return isNonEmptyString17(username) ? username : void 0;
 }
 function getTerritoryMemoryRecord7() {
   var _a;
@@ -20090,15 +20776,15 @@ function getWritableTerritoryMemoryRecord6() {
   }
   return root.Memory.territory;
 }
-function getGameTime13() {
+function getGameTime15() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString16(value) {
+function isNonEmptyString17(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord17(value) {
+function isRecord18(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -20106,7 +20792,7 @@ function isRecord17(value) {
 var COLONY_EXPANSION_CLAIM_TARGET_CREATOR = "colonyExpansion";
 var MIN_COLONY_EXPANSION_CLAIM_SCORE = MIN_ADJACENT_ROOM_RESERVATION_SCORE;
 var EXIT_DIRECTION_ORDER7 = ["1", "3", "5", "7"];
-function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime14()) {
+function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime16()) {
   const colonyName = colony.room.name;
   if (assessment.territoryReady !== true) {
     const reservation2 = refreshAdjacentRoomReservationIntent(colony, gameTime, {
@@ -20202,18 +20888,18 @@ function hasHostileClaimScore(score) {
 }
 function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) {
   var _a, _b;
-  const room = getVisibleRoom9(roomName);
+  const room = getVisibleRoom10(roomName);
   if (room) {
     const controller2 = room.controller;
     if (!controller2) {
       return { kind: "missing" };
     }
     const controllerId = controller2.id;
-    if (controller2.my === true || isNonEmptyString17((_a = controller2.owner) == null ? void 0 : _a.username)) {
+    if (controller2.my === true || isNonEmptyString18((_a = controller2.owner) == null ? void 0 : _a.username)) {
       return { kind: "owned", controllerId };
     }
     const reservationUsername = (_b = controller2.reservation) == null ? void 0 : _b.username;
-    if (isNonEmptyString17(reservationUsername)) {
+    if (isNonEmptyString18(reservationUsername)) {
       return reservationUsername === ownerUsername ? { kind: "ownReserved", controllerId } : { kind: "foreignReserved", controllerId };
     }
     return { kind: "neutral", controllerId };
@@ -20226,10 +20912,10 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString17(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString18(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString17(controller.reservationUsername)) {
+  if (isNonEmptyString18(controller.reservationUsername)) {
     return controller.reservationUsername === ownerUsername ? { kind: "ownReserved", ...controller.id ? { controllerId: controller.id } : {} } : { kind: "foreignReserved", ...controller.id ? { controllerId: controller.id } : {} };
   }
   return { kind: "neutral", ...controller.id ? { controllerId: controller.id } : {} };
@@ -20240,7 +20926,7 @@ function hasBlockingClaimIntent(colony, targetRoom) {
     return false;
   }
   if (Array.isArray(territoryMemory.targets) && territoryMemory.targets.some(
-    (target) => isRecord18(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
+    (target) => isRecord19(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
   )) {
     return true;
   }
@@ -20284,13 +20970,13 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
   const removedRooms = /* @__PURE__ */ new Set();
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter((target) => {
-      if (!isRecord18(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
+      if (!isRecord19(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
         return true;
       }
       if (activeTarget && isSameTarget4(target, activeTarget)) {
         return true;
       }
-      if (isNonEmptyString17(target.roomName)) {
+      if (isNonEmptyString18(target.roomName)) {
         removedRooms.add(target.roomName);
       }
       return false;
@@ -20307,7 +20993,7 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
 function pruneAdjacentReservationForTarget(colony, targetRoom, territoryMemory) {
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter(
-      (target) => !(isRecord18(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
+      (target) => !(isRecord19(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
     );
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
@@ -20324,7 +21010,7 @@ function upsertTerritoryTarget3(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord18(existingTarget)) {
+  if (isRecord19(existingTarget)) {
     existingTarget.createdBy = COLONY_EXPANSION_CLAIM_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -20345,7 +21031,7 @@ function upsertTerritoryIntent5(intents, nextIntent) {
   intents.push(nextIntent);
 }
 function isSameTarget4(left, right) {
-  return isRecord18(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord19(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getAdjacentRoomNames8(roomName) {
   var _a;
@@ -20354,15 +21040,15 @@ function getAdjacentRoomNames8(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord18(exits)) {
+  if (!isRecord19(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER7.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString17(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString18(exitRoom) ? [exitRoom] : [];
   });
 }
-function getVisibleRoom9(roomName) {
+function getVisibleRoom10(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -20373,7 +21059,7 @@ function getScoutIntel3(homeRoomName, roomName) {
 function getControllerOwnerUsername9(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString17(username) ? username : void 0;
+  return isNonEmptyString18(username) ? username : void 0;
 }
 function getTerritoryMemoryRecord8() {
   var _a;
@@ -20389,20 +21075,20 @@ function getWritableTerritoryMemoryRecord7() {
   }
   return memory.territory;
 }
-function getGameTime14() {
+function getGameTime16() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord18(value) {
+function isRecord19(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString17(value) {
+function isNonEmptyString18(value) {
   return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/territoryRunner.ts
-var ERR_NOT_IN_RANGE_CODE7 = -9;
+var ERR_NOT_IN_RANGE_CODE8 = -9;
 var ERR_INVALID_TARGET_CODE4 = -7;
 var ERR_NO_BODYPART_CODE2 = -12;
 var ERR_GCL_NOT_ENOUGH_CODE2 = -15;
@@ -20439,7 +21125,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   if (assignment.action === "scout") {
-    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime15(), creep.name, telemetryEvents);
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime17(), creep.name, telemetryEvents);
     completeTerritoryAssignment(creep);
     return;
   }
@@ -20466,7 +21152,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   }
   if (isTerritoryControlAction4(assignment.action) && typeof creep.attackController === "function" && canCreepPressureTerritoryController(creep, controller, creep.memory.colony)) {
     const pressureResult = executeControllerAction(creep, controller, "attackController");
-    if (pressureResult === ERR_NOT_IN_RANGE_CODE7 && typeof creep.moveTo === "function") {
+    if (pressureResult === ERR_NOT_IN_RANGE_CODE8 && typeof creep.moveTo === "function") {
       creep.moveTo(controller);
       return;
     }
@@ -20492,7 +21178,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   if (assignment.action === "claim" && result === OK_CODE7) {
     recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents);
   }
-  if (result === ERR_NOT_IN_RANGE_CODE7 && typeof creep.moveTo === "function") {
+  if (result === ERR_NOT_IN_RANGE_CODE8 && typeof creep.moveTo === "function") {
     creep.moveTo(controller);
     return;
   }
@@ -20521,7 +21207,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime15();
+  const gameTime = getGameTime17();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -20531,7 +21217,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   suppressTerritoryIntent(creep.memory.colony, assignment, gameTime);
   creep.memory.territory = (_a = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, gameTime)) != null ? _a : reserveAssignment;
   const reserveResult = executeControllerAction(creep, controller, "reserveController");
-  if (reserveResult === ERR_NOT_IN_RANGE_CODE7 && typeof creep.moveTo === "function") {
+  if (reserveResult === ERR_NOT_IN_RANGE_CODE8 && typeof creep.moveTo === "function") {
     creep.moveTo(controller);
     return true;
   }
@@ -20541,7 +21227,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime15());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime17());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -20575,9 +21261,9 @@ function selectTargetController(creep, assignment) {
   var _a, _b;
   if (assignment.controllerId) {
     const game = globalThis.Game;
-    const getObjectById3 = game == null ? void 0 : game.getObjectById;
-    if (typeof getObjectById3 === "function") {
-      const controller = getObjectById3.call(game, assignment.controllerId);
+    const getObjectById4 = game == null ? void 0 : game.getObjectById;
+    if (typeof getObjectById4 === "function") {
+      const controller = getObjectById4.call(game, assignment.controllerId);
       if (controller) {
         return controller;
       }
@@ -20621,7 +21307,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime15() {
+function getGameTime17() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -20805,7 +21491,7 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
     workerCount: colonyCreeps.filter((creep) => creep.memory.role === "worker").length,
     energyAvailable: colony.energyAvailable,
     energyCapacity: colony.energyCapacityAvailable,
-    storedEnergy: getStoredEnergy11(room),
+    storedEnergy: getStoredEnergy13(room),
     sourceCount: sources.length,
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -20888,7 +21574,7 @@ function buildMemoryTerritoryState(roomName) {
   const expansionCandidates = [];
   if (Array.isArray(targets)) {
     for (const target of targets) {
-      if (!isRecord19(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+      if (!isRecord20(target) || target.colony !== roomName || typeof target.roomName !== "string") {
         continue;
       }
       const action = normalizeTerritoryAction(target.action);
@@ -20950,12 +21636,12 @@ function countVisibleOwnedRooms3() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord19(structure) && matchesStructureType14(structure.structureType, globalName, fallback)
+    (structure) => isRecord20(structure) && matchesStructureType15(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
   return structures.reduce((total, structure) => {
-    if (!isRecord19(structure)) {
+    if (!isRecord20(structure)) {
       return total;
     }
     const hits = finiteNumberOrNull(structure.hits);
@@ -20966,12 +21652,12 @@ function estimateRepairBacklogHits(structures) {
     return total + (hitsMax - hits);
   }, 0);
 }
-function getStoredEnergy11(room) {
+function getStoredEnergy13(room) {
   const storage = room.storage;
   return getEnergyInStore2(storage);
 }
 function getEnergyInStore2(object) {
-  if (!isRecord19(object) || !isRecord19(object.store)) {
+  if (!isRecord20(object) || !isRecord20(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -20983,7 +21669,7 @@ function getEnergyInStore2(object) {
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
 function findRoomObjects13(room, constantName) {
-  const findConstant = getGlobalNumber9(constantName);
+  const findConstant = getGlobalNumber10(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return [];
@@ -20995,7 +21681,7 @@ function findRoomObjects13(room, constantName) {
     return [];
   }
 }
-function matchesStructureType14(value, globalName, fallback) {
+function matchesStructureType15(value, globalName, fallback) {
   const globalValue = globalThis[globalName];
   return value === globalValue || value === fallback;
 }
@@ -21003,7 +21689,7 @@ function getResourceEnergy() {
   const value = globalThis.RESOURCE_ENERGY;
   return value != null ? value : "energy";
 }
-function getGlobalNumber9(name) {
+function getGlobalNumber10(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -21023,7 +21709,7 @@ function finiteNumberOrZero(value) {
 function finiteNumberOrNull(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function isRecord19(value) {
+function isRecord20(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -21033,10 +21719,15 @@ var OK_CODE8 = 0;
 var NEXT_EXPANSION_SCORING_REFRESH_INTERVAL = 50;
 var NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS = 5e3;
 function runEconomy(preludeTelemetryEvents = []) {
+  var _a, _b;
   const creeps = Object.values(Game.creeps);
-  const colonies = getOwnedColonies();
+  balanceStorage();
+  const colonies = orderColoniesForSpawnPlanning(getOwnedColonies());
   const telemetryEvents = [...preludeTelemetryEvents];
+  const usedSpawnsByRoom = /* @__PURE__ */ new Map();
+  const reservedSpawnEnergyByRoom = /* @__PURE__ */ new Map();
   clearColonySurvivalAssessmentCache();
+  attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = countCreepsByRole(creeps, colony.room.name);
@@ -21054,9 +21745,9 @@ function runEconomy(preludeTelemetryEvents = []) {
       roleCounts,
       Game.time
     );
-    let availableEnergy = colony.energyAvailable;
+    let availableEnergy = Math.max(0, colony.energyAvailable - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0));
     let successfulSpawnCount = 0;
-    const usedSpawns = /* @__PURE__ */ new Set();
+    const usedSpawns = new Set((_b = usedSpawnsByRoom.get(colony.room.name)) != null ? _b : []);
     while (true) {
       const planningColony = createSpawnPlanningColony(colony, availableEnergy, usedSpawns);
       const spawnRequest = planSpawn(
@@ -21103,6 +21794,8 @@ function runEconomy(preludeTelemetryEvents = []) {
       runRemoteHarvester(creep);
     } else if (creep.memory.role === HAULER_ROLE) {
       runHauler(creep);
+    } else if (creep.memory.role === CROSS_ROOM_HAULER_ROLE) {
+      runCrossRoomHauler(creep);
     } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE) {
       runClaimer(creep, telemetryEvents);
     } else if (creep.memory.role === TERRITORY_SCOUT_ROLE) {
@@ -21136,6 +21829,30 @@ function recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents) 
 }
 function shouldRecordStrategyRecommendationTelemetry(gameTime) {
   return gameTime > 0 && gameTime % RUNTIME_SUMMARY_INTERVAL === 0;
+}
+function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom) {
+  var _a, _b;
+  const spawnRequest = planCrossRoomHauler();
+  if (!spawnRequest) {
+    return;
+  }
+  const sourceRoomName = spawnRequest.spawn.room.name;
+  const sourceColony = colonies.find((colony) => colony.room.name === sourceRoomName);
+  const candidateSpawns = (_a = sourceColony == null ? void 0 : sourceColony.spawns) != null ? _a : [spawnRequest.spawn];
+  const outcome = attemptSpawnRequest(
+    spawnRequest,
+    sourceRoomName,
+    telemetryEvents,
+    candidateSpawns
+  );
+  if (!outcome || outcome.result !== OK_CODE8) {
+    return;
+  }
+  recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
+  reservedSpawnEnergyByRoom.set(
+    sourceRoomName,
+    ((_b = reservedSpawnEnergyByRoom.get(sourceRoomName)) != null ? _b : 0) + getBodyCost(spawnRequest.body)
+  );
 }
 function planCriticalConstructionSites(colony, spawnConstructionPending, bootstrapNonCriticalConstructionSuppressed = false) {
   if (spawnConstructionPending || bootstrapNonCriticalConstructionSuppressed) {
@@ -21240,17 +21957,17 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber8(refreshedAt) || !isRecord20(rawSelection) || !isNonEmptyString18(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber8(refreshedAt) || !isRecord21(rawSelection) || !isNonEmptyString19(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord20(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord21(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString18(rawSelection.targetRoom)) {
+    if (!isNonEmptyString19(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -21287,7 +22004,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord20(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord21(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -21317,17 +22034,17 @@ function countVisibleOwnedRooms4() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord20(records)) {
+  if (!isRecord21(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord20(record) && record.status !== "ready"
+    (record) => isRecord21(record) && record.status !== "ready"
   ).length;
 }
-function isRecord20(value) {
+function isRecord21(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString18(value) {
+function isNonEmptyString19(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber8(value) {
@@ -21390,6 +22107,12 @@ function addPlannedWorker(roleCounts) {
   }
   return nextRoleCounts;
 }
+function recordUsedSpawn(usedSpawnsByRoom, roomName, spawn) {
+  var _a;
+  const usedSpawns = (_a = usedSpawnsByRoom.get(roomName)) != null ? _a : /* @__PURE__ */ new Set();
+  usedSpawns.add(spawn);
+  usedSpawnsByRoom.set(roomName, usedSpawns);
+}
 function getSpawnAttemptOrder(spawnRequest, spawns) {
   return [spawnRequest.spawn, ...spawns.filter((spawn) => spawn !== spawnRequest.spawn && !spawn.spawning)];
 }
@@ -21435,7 +22158,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime16())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime18())
     );
   }
 };
@@ -21507,7 +22230,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime16() {
+function getGameTime18() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -22337,10 +23060,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord21(rawReplay)) {
+  if (!isRecord22(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString19(rawReplay.replayId) || !isNonEmptyString19(rawReplay.room) || !isFiniteNumber9(rawReplay.startTick) || !isFiniteNumber9(rawReplay.endTick) || !isFiniteNumber9(rawReplay.finalScore) || !isRecord21(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString20(rawReplay.replayId) || !isNonEmptyString20(rawReplay.room) || !isFiniteNumber9(rawReplay.startTick) || !isFiniteNumber9(rawReplay.endTick) || !isFiniteNumber9(rawReplay.finalScore) || !isRecord22(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -22365,10 +23088,10 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord21(value) {
+function isRecord22(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString19(value) {
+function isNonEmptyString20(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber9(value) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -14329,6 +14329,7 @@ function collectEnergy(creep, assignment) {
   const source = getObjectById3(assignment.sourceId);
   if (!source || getStoredEnergy10(source) <= 0) {
     delete creep.memory.task;
+    delete assignment.sourceId;
     assignment.state = "returning";
     returnHome(creep, assignment);
     return;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -14392,7 +14392,8 @@ function selectDeliveryTarget(room) {
   var _a;
   const targets = [
     ...findOwnedStructures3(room).filter(isSpawnOrExtensionWithDemand),
-    ...findRoomStructures2(room).filter(isContainerWithDemand)
+    ...findRoomStructures2(room).filter(isContainerWithDemand),
+    ...[room.storage, room.terminal].filter(isStorageOrTerminalWithDemand)
   ].sort(compareDeliveryTargets);
   return (_a = targets[0]) != null ? _a : null;
 }
@@ -14409,6 +14410,9 @@ function isSpawnOrExtensionWithDemand(structure) {
 function isContainerWithDemand(structure) {
   return matchesStructureType11(structure.structureType, "STRUCTURE_CONTAINER", "container") && getFreeEnergyCapacity5(structure) > 0;
 }
+function isStorageOrTerminalWithDemand(structure) {
+  return structure !== void 0 && getFreeEnergyCapacity5(structure) > 0;
+}
 function compareDeliveryTargets(left, right) {
   return getDeliveryPriority(right) - getDeliveryPriority(left) || getObjectId4(left).localeCompare(getObjectId4(right));
 }
@@ -14418,6 +14422,12 @@ function getDeliveryPriority(target) {
   }
   if (matchesStructureType11(target.structureType, "STRUCTURE_EXTENSION", "extension")) {
     return 2;
+  }
+  if (matchesStructureType11(target.structureType, "STRUCTURE_STORAGE", "storage")) {
+    return 0;
+  }
+  if (matchesStructureType11(target.structureType, "STRUCTURE_TERMINAL", "terminal")) {
+    return -1;
   }
   return 1;
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -14006,6 +14006,658 @@ function isNonEmptyString9(value) {
   return typeof value === "string" && value.length > 0;
 }
 
+// src/economy/storageBalancer.ts
+var STORAGE_BALANCE_EXPORT_RATIO = 0.8;
+var STORAGE_BALANCE_IMPORT_RATIO = 0.3;
+var STORAGE_BALANCE_REFRESH_INTERVAL = 25;
+function balanceStorage() {
+  const memory = getEconomyMemory();
+  const gameTime = getGameTime9();
+  const existing = memory.storageBalance;
+  if (existing && isStorageBalanceFresh(existing, gameTime)) {
+    return;
+  }
+  memory.storageBalance = buildStorageBalanceState(gameTime);
+}
+function getStorageBalanceState() {
+  const memory = getEconomyMemory();
+  const gameTime = getGameTime9();
+  const existing = memory.storageBalance;
+  if (existing && isStorageBalanceFresh(existing, gameTime)) {
+    return existing;
+  }
+  const state = buildStorageBalanceState(gameTime);
+  memory.storageBalance = state;
+  return state;
+}
+function getRoomStoredEnergyState(room) {
+  const stores = getRoomEnergyStores(room);
+  const energy = stores.reduce((total, structure) => total + getStoredEnergy9(structure), 0);
+  const capacity = stores.reduce((total, structure) => total + getEnergyCapacity2(structure), 0);
+  const ratio = capacity > 0 ? energy / capacity : 0;
+  const exportableEnergy = capacity > 0 && ratio > STORAGE_BALANCE_EXPORT_RATIO ? Math.floor(energy - capacity * STORAGE_BALANCE_EXPORT_RATIO) : 0;
+  const importDemand = capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO ? Math.ceil(capacity * STORAGE_BALANCE_IMPORT_RATIO - energy) : 0;
+  return {
+    roomName: room.name,
+    energy,
+    capacity,
+    ratio,
+    exportableEnergy: Math.max(0, exportableEnergy),
+    importDemand: Math.max(0, importDemand),
+    mode: selectStorageBalanceMode(capacity, ratio)
+  };
+}
+function buildStorageBalanceState(gameTime) {
+  const roomStates = getOwnedRooms().map(getRoomStoredEnergyState).filter((state) => state.capacity > 0);
+  return {
+    updatedAt: gameTime,
+    rooms: Object.fromEntries(
+      roomStates.map((state) => [
+        state.roomName,
+        {
+          roomName: state.roomName,
+          mode: state.mode,
+          energy: state.energy,
+          capacity: state.capacity,
+          ratio: state.ratio,
+          exportableEnergy: state.exportableEnergy,
+          importDemand: state.importDemand,
+          updatedAt: gameTime
+        }
+      ])
+    ),
+    transfers: buildStorageTransfers(roomStates, gameTime)
+  };
+}
+function buildStorageTransfers(roomStates, gameTime) {
+  var _a;
+  const exporters = roomStates.filter((state) => state.mode === "export" && state.exportableEnergy > 0).sort(compareExportRooms);
+  const importers = roomStates.filter((state) => state.mode === "import" && state.importDemand > 0).sort(compareImportRooms);
+  const remainingExport = new Map(exporters.map((state) => [state.roomName, state.exportableEnergy]));
+  const transfers = [];
+  for (const importer of importers) {
+    let remainingDemand = importer.importDemand;
+    for (const exporter of exporters) {
+      if (remainingDemand <= 0) {
+        break;
+      }
+      const exportableEnergy = (_a = remainingExport.get(exporter.roomName)) != null ? _a : 0;
+      const amount = Math.min(exportableEnergy, remainingDemand);
+      if (amount <= 0) {
+        continue;
+      }
+      transfers.push({
+        sourceRoom: exporter.roomName,
+        targetRoom: importer.roomName,
+        amount,
+        updatedAt: gameTime
+      });
+      remainingExport.set(exporter.roomName, exportableEnergy - amount);
+      remainingDemand -= amount;
+    }
+  }
+  return transfers;
+}
+function compareExportRooms(left, right) {
+  return right.exportableEnergy - left.exportableEnergy || right.ratio - left.ratio || left.roomName.localeCompare(right.roomName);
+}
+function compareImportRooms(left, right) {
+  return right.importDemand - left.importDemand || left.ratio - right.ratio || left.roomName.localeCompare(right.roomName);
+}
+function selectStorageBalanceMode(capacity, ratio) {
+  if (capacity <= 0) {
+    return "balanced";
+  }
+  if (ratio > STORAGE_BALANCE_EXPORT_RATIO) {
+    return "export";
+  }
+  if (ratio < STORAGE_BALANCE_IMPORT_RATIO) {
+    return "import";
+  }
+  return "balanced";
+}
+function getRoomEnergyStores(room) {
+  const stores = [
+    room.storage,
+    room.terminal
+  ];
+  return stores.filter(
+    (structure) => structure !== void 0
+  );
+}
+function getStoredEnergy9(target) {
+  var _a;
+  const store = target.store;
+  const resource = getEnergyResource7();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+  const directEnergy = store == null ? void 0 : store[resource];
+  return typeof directEnergy === "number" && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
+}
+function getEnergyCapacity2(target) {
+  var _a, _b, _c;
+  const store = target.store;
+  const resource = getEnergyResource7();
+  const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof capacity === "number" && Number.isFinite(capacity)) {
+    return Math.max(0, capacity);
+  }
+  const genericCapacity = (_b = store == null ? void 0 : store.getCapacity) == null ? void 0 : _b.call(store);
+  if (typeof genericCapacity === "number" && Number.isFinite(genericCapacity)) {
+    return Math.max(0, genericCapacity);
+  }
+  const freeCapacity = (_c = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _c.call(store, resource);
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? getStoredEnergy9(target) + Math.max(0, freeCapacity) : 0;
+}
+function isStorageBalanceFresh(state, gameTime) {
+  return typeof state.updatedAt === "number" && Number.isFinite(state.updatedAt) && gameTime >= state.updatedAt && gameTime - state.updatedAt < STORAGE_BALANCE_REFRESH_INTERVAL;
+}
+function getOwnedRooms() {
+  var _a;
+  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+  if (!rooms) {
+    return [];
+  }
+  return Object.values(rooms).filter((room) => {
+    var _a2;
+    return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
+  });
+}
+function getEconomyMemory() {
+  const memory = getMemory();
+  if (!memory.economy) {
+    memory.economy = {};
+  }
+  return memory.economy;
+}
+function getMemory() {
+  const global = globalThis;
+  if (!global.Memory) {
+    global.Memory = {};
+  }
+  return global.Memory;
+}
+function getGameTime9() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
+}
+function getEnergyResource7() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+
+// src/economy/crossRoomHauler.ts
+var CROSS_ROOM_HAULER_ROLE = "crossRoomHauler";
+var CARRY_MOVE_PAIR_COST = 100;
+var CARRY_CAPACITY_PER_PART = 50;
+var MAX_CARRY_MOVE_PAIRS = 25;
+var MIN_CARRY_MOVE_PAIRS = 1;
+var CROSS_ROOM_HAULER_REPLACEMENT_TICKS = 100;
+var CROSS_ROOM_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
+var ERR_NO_PATH_CODE5 = -2;
+var ERR_NOT_IN_RANGE_CODE6 = -9;
+function planCrossRoomHauler() {
+  const transfer = selectCrossRoomEnergyTransfer();
+  if (!transfer) {
+    return null;
+  }
+  const sourceRoom = getVisibleRoom4(transfer.sourceRoom);
+  const targetRoom = getVisibleRoom4(transfer.targetRoom);
+  if (!sourceRoom || !targetRoom) {
+    return null;
+  }
+  const source = selectSourceEnergyStructure(sourceRoom);
+  if (!source) {
+    return null;
+  }
+  const spawn = selectSourceRoomSpawn(sourceRoom.name);
+  if (!spawn) {
+    return null;
+  }
+  const sourceState = getRoomStoredEnergyState(sourceRoom);
+  const transferableEnergy = Math.min(transfer.amount, sourceState.exportableEnergy);
+  const body = buildCrossRoomHaulerBody(sourceRoom.energyAvailable, transferableEnergy);
+  if (body.length === 0) {
+    return null;
+  }
+  const route = findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name);
+  if (!route) {
+    return null;
+  }
+  return {
+    spawn,
+    body,
+    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime10()}`,
+    memory: {
+      role: CROSS_ROOM_HAULER_ROLE,
+      colony: sourceRoom.name,
+      crossRoomHauler: {
+        homeRoom: sourceRoom.name,
+        targetRoom: targetRoom.name,
+        sourceId: source.id,
+        state: "collecting",
+        route: route.rooms
+      }
+    }
+  };
+}
+function buildCrossRoomHaulerBody(energyAvailable, transferableEnergy) {
+  const energyBudget = Math.max(0, Math.floor(energyAvailable));
+  const energyScaledPairs = Math.ceil(Math.max(0, transferableEnergy) / CARRY_CAPACITY_PER_PART);
+  const affordablePairs = Math.floor(energyBudget / CARRY_MOVE_PAIR_COST);
+  const pairCount = Math.min(
+    MAX_CARRY_MOVE_PAIRS,
+    affordablePairs,
+    Math.max(MIN_CARRY_MOVE_PAIRS, energyScaledPairs)
+  );
+  if (pairCount <= 0) {
+    return [];
+  }
+  return Array.from({ length: pairCount }).flatMap(() => ["carry", "move"]);
+}
+function runCrossRoomHauler(creep) {
+  const assignment = getMutableCrossRoomHaulerMemory(creep);
+  if (!assignment) {
+    return;
+  }
+  if (assignment.state === "returning") {
+    returnHome(creep, assignment);
+    return;
+  }
+  if (getCarriedEnergy4(creep) > 0) {
+    assignment.state = "delivering";
+    deliverEnergy2(creep, assignment);
+    return;
+  }
+  if (!hasSourceSurplusEnergy(assignment)) {
+    assignment.state = "returning";
+    returnHome(creep, assignment);
+    return;
+  }
+  assignment.state = "collecting";
+  collectEnergy(creep, assignment);
+}
+function selectCrossRoomEnergyTransfer() {
+  var _a;
+  const balance = getStorageBalanceState();
+  return (_a = balance.transfers.filter((transfer) => transfer.amount > 0).filter((transfer) => !hasActiveCrossRoomHauler(transfer)).filter((transfer) => isLiveTransferCandidate(transfer)).sort(compareTransfers)[0]) != null ? _a : null;
+}
+function isLiveTransferCandidate(transfer) {
+  const sourceRoom = getVisibleRoom4(transfer.sourceRoom);
+  const targetRoom = getVisibleRoom4(transfer.targetRoom);
+  if (!sourceRoom || !targetRoom) {
+    return false;
+  }
+  if (!isSafeOwnedRoom(sourceRoom.name) || !isSafeOwnedRoom(targetRoom.name)) {
+    return false;
+  }
+  const sourceState = getRoomStoredEnergyState(sourceRoom);
+  const targetState = getRoomStoredEnergyState(targetRoom);
+  if (sourceState.mode !== "export" || targetState.mode !== "import") {
+    return false;
+  }
+  return findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name) !== null;
+}
+function compareTransfers(left, right) {
+  var _a, _b, _c, _d;
+  const leftRouteDistance = (_b = (_a = findOwnedLogisticsRoute(left.sourceRoom, left.targetRoom)) == null ? void 0 : _a.distance) != null ? _b : Number.POSITIVE_INFINITY;
+  const rightRouteDistance = (_d = (_c = findOwnedLogisticsRoute(right.sourceRoom, right.targetRoom)) == null ? void 0 : _c.distance) != null ? _d : Number.POSITIVE_INFINITY;
+  return right.amount - left.amount || leftRouteDistance - rightRouteDistance || left.sourceRoom.localeCompare(right.sourceRoom) || left.targetRoom.localeCompare(right.targetRoom);
+}
+function hasActiveCrossRoomHauler(transfer) {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  if (!creeps) {
+    return false;
+  }
+  return Object.values(creeps).some((creep) => {
+    var _a2, _b;
+    const memory = normalizeCrossRoomHaulerMemory((_a2 = creep.memory) == null ? void 0 : _a2.crossRoomHauler);
+    return ((_b = creep.memory) == null ? void 0 : _b.role) === CROSS_ROOM_HAULER_ROLE && (memory == null ? void 0 : memory.homeRoom) === transfer.sourceRoom && memory.targetRoom === transfer.targetRoom && (creep.ticksToLive === void 0 || creep.ticksToLive > CROSS_ROOM_HAULER_REPLACEMENT_TICKS);
+  });
+}
+function collectEnergy(creep, assignment) {
+  var _a, _b;
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
+    delete creep.memory.task;
+    moveTowardRoom3(creep, assignment, assignment.homeRoom);
+    return;
+  }
+  const source = getObjectById3(assignment.sourceId);
+  if (!source || getStoredEnergy10(source) <= 0) {
+    delete creep.memory.task;
+    assignment.state = "returning";
+    returnHome(creep, assignment);
+    return;
+  }
+  const task = {
+    type: "withdraw",
+    targetId: assignment.sourceId
+  };
+  creep.memory.task = task;
+  const result = (_b = creep.withdraw) == null ? void 0 : _b.call(creep, source, getEnergyResource8());
+  if (result === getErrNotInRangeCode3()) {
+    moveTo3(creep, source);
+  }
+}
+function deliverEnergy2(creep, assignment) {
+  var _a, _b;
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
+    delete creep.memory.task;
+    moveTowardRoom3(creep, assignment, assignment.targetRoom);
+    return;
+  }
+  const target = selectDeliveryTarget(creep.room);
+  if (!target) {
+    delete creep.memory.task;
+    assignment.state = "returning";
+    returnHome(creep, assignment);
+    return;
+  }
+  const task = {
+    type: "transfer",
+    targetId: target.id
+  };
+  creep.memory.task = task;
+  const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, target, getEnergyResource8());
+  if (result === getErrNotInRangeCode3()) {
+    moveTo3(creep, target);
+  }
+}
+function returnHome(creep, assignment) {
+  var _a, _b;
+  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
+    delete creep.memory.task;
+    moveTowardRoom3(creep, assignment, assignment.homeRoom);
+    return;
+  }
+  const carriedEnergy = getCarriedEnergy4(creep);
+  if (carriedEnergy > 0) {
+    const homeTarget = selectHomeReturnTarget(creep.room);
+    if (homeTarget) {
+      const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, homeTarget, getEnergyResource8());
+      if (result === getErrNotInRangeCode3()) {
+        moveTo3(creep, homeTarget);
+      }
+      return;
+    }
+  }
+  delete creep.memory.task;
+  assignment.state = hasSourceSurplusEnergy(assignment) ? "collecting" : "returning";
+}
+function selectDeliveryTarget(room) {
+  var _a;
+  const targets = [
+    ...findOwnedStructures3(room).filter(isSpawnOrExtensionWithDemand),
+    ...findRoomStructures2(room).filter(isContainerWithDemand)
+  ].sort(compareDeliveryTargets);
+  return (_a = targets[0]) != null ? _a : null;
+}
+function selectHomeReturnTarget(room) {
+  var _a;
+  const targets = [room.storage, room.terminal].filter(
+    (structure) => structure !== void 0 && getFreeEnergyCapacity5(structure) > 0
+  );
+  return (_a = targets.sort((left, right) => getObjectId4(left).localeCompare(getObjectId4(right)))[0]) != null ? _a : null;
+}
+function isSpawnOrExtensionWithDemand(structure) {
+  return (matchesStructureType11(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType11(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity5(structure) > 0;
+}
+function isContainerWithDemand(structure) {
+  return matchesStructureType11(structure.structureType, "STRUCTURE_CONTAINER", "container") && getFreeEnergyCapacity5(structure) > 0;
+}
+function compareDeliveryTargets(left, right) {
+  return getDeliveryPriority(right) - getDeliveryPriority(left) || getObjectId4(left).localeCompare(getObjectId4(right));
+}
+function getDeliveryPriority(target) {
+  if (matchesStructureType11(target.structureType, "STRUCTURE_SPAWN", "spawn")) {
+    return 3;
+  }
+  if (matchesStructureType11(target.structureType, "STRUCTURE_EXTENSION", "extension")) {
+    return 2;
+  }
+  return 1;
+}
+function selectSourceEnergyStructure(room) {
+  var _a;
+  return (_a = [room.storage, room.terminal].filter(
+    (structure) => structure !== void 0 && getStoredEnergy10(structure) > 0
+  ).sort((left, right) => getStoredEnergy10(right) - getStoredEnergy10(left) || getObjectId4(left).localeCompare(getObjectId4(right)))[0]) != null ? _a : null;
+}
+function hasSourceSurplusEnergy(assignment) {
+  const room = getVisibleRoom4(assignment.homeRoom);
+  if (!room) {
+    return false;
+  }
+  return getRoomStoredEnergyState(room).mode === "export" && getObjectById3(assignment.sourceId) !== null;
+}
+function selectSourceRoomSpawn(roomName) {
+  var _a, _b;
+  const spawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
+  if (!spawns) {
+    return null;
+  }
+  return (_b = Object.values(spawns).filter((spawn) => {
+    var _a2;
+    return ((_a2 = spawn.room) == null ? void 0 : _a2.name) === roomName && !spawn.spawning;
+  }).sort((left, right) => getSpawnEnergyScore(right) - getSpawnEnergyScore(left) || left.name.localeCompare(right.name))[0]) != null ? _b : null;
+}
+function getSpawnEnergyScore(spawn) {
+  const room = spawn.room;
+  return typeof (room == null ? void 0 : room.energyAvailable) === "number" && Number.isFinite(room.energyAvailable) ? room.energyAvailable : 0;
+}
+function findOwnedLogisticsRoute(fromRoom, targetRoom) {
+  var _a;
+  if (fromRoom === targetRoom) {
+    return { distance: 0, rooms: [] };
+  }
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
+    return null;
+  }
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName) => isSafeLogisticsTransitRoom(roomName) ? 1 : Infinity
+  });
+  if (route === getNoPathResultCode5() || !Array.isArray(route)) {
+    return null;
+  }
+  const rooms = route.map((step) => isRecord10(step) && typeof step.room === "string" ? step.room : null).filter((roomName) => typeof roomName === "string");
+  if (rooms.length !== route.length || !rooms.every(isSafeLogisticsTransitRoom)) {
+    return null;
+  }
+  return { distance: rooms.length, rooms };
+}
+function moveTowardRoom3(creep, assignment, destinationRoom) {
+  var _a, _b;
+  const route = getAssignmentRoute(assignment);
+  const nextRoom = route ? selectNextRouteRoom((_a = creep.room) == null ? void 0 : _a.name, assignment, destinationRoom, route) : destinationRoom;
+  const visibleController = (_b = getVisibleRoom4(nextRoom)) == null ? void 0 : _b.controller;
+  if (visibleController) {
+    moveTo3(creep, visibleController);
+    return;
+  }
+  const RoomPositionCtor = globalThis.RoomPosition;
+  if (typeof RoomPositionCtor === "function") {
+    moveTo3(creep, new RoomPositionCtor(25, 25, nextRoom));
+  }
+}
+function getAssignmentRoute(assignment) {
+  const route = findOwnedLogisticsRoute(assignment.homeRoom, assignment.targetRoom);
+  if (!route) {
+    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString10) : null;
+  }
+  assignment.route = route.rooms;
+  return route.rooms;
+}
+function selectNextRouteRoom(currentRoom, assignment, destinationRoom, route) {
+  var _a, _b, _c;
+  if (!currentRoom) {
+    return destinationRoom;
+  }
+  if (destinationRoom === assignment.targetRoom) {
+    if (currentRoom === assignment.homeRoom) {
+      return (_a = route[0]) != null ? _a : assignment.targetRoom;
+    }
+    const routeIndex2 = route.indexOf(currentRoom);
+    return routeIndex2 >= 0 ? (_b = route[routeIndex2 + 1]) != null ? _b : assignment.targetRoom : destinationRoom;
+  }
+  const routeIndex = route.indexOf(currentRoom);
+  if (routeIndex > 0) {
+    return (_c = route[routeIndex - 1]) != null ? _c : assignment.homeRoom;
+  }
+  return assignment.homeRoom;
+}
+function isSafeOwnedRoom(roomName) {
+  var _a;
+  const room = getVisibleRoom4(roomName);
+  return ((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && !hasHostilePresence(room);
+}
+function isSafeLogisticsTransitRoom(roomName) {
+  var _a;
+  const room = getVisibleRoom4(roomName);
+  if (!room) {
+    return true;
+  }
+  if (hasHostilePresence(room)) {
+    return false;
+  }
+  return ((_a = room.controller) == null ? void 0 : _a.owner) === void 0 || room.controller.my === true;
+}
+function hasHostilePresence(room) {
+  const hostileCreepFind = getGlobalNumber4("FIND_HOSTILE_CREEPS");
+  if (typeof hostileCreepFind === "number" && typeof room.find === "function") {
+    const hostiles = room.find(hostileCreepFind);
+    if (Array.isArray(hostiles) && hostiles.length > 0) {
+      return true;
+    }
+  }
+  const hostileStructureFind = getGlobalNumber4("FIND_HOSTILE_STRUCTURES");
+  if (typeof hostileStructureFind === "number" && typeof room.find === "function") {
+    const hostiles = room.find(hostileStructureFind);
+    if (Array.isArray(hostiles) && hostiles.length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+function findOwnedStructures3(room) {
+  var _a, _b;
+  const findMyStructures = getGlobalNumber4("FIND_MY_STRUCTURES");
+  if (typeof findMyStructures !== "number" || typeof room.find !== "function") {
+    return Object.values((_b = (_a = globalThis.Game) == null ? void 0 : _a.spawns) != null ? _b : {}).filter(
+      (spawn) => {
+        var _a2;
+        return ((_a2 = spawn.room) == null ? void 0 : _a2.name) === room.name;
+      }
+    );
+  }
+  const structures = room.find(findMyStructures);
+  return Array.isArray(structures) ? structures : [];
+}
+function findRoomStructures2(room) {
+  const findStructures = getGlobalNumber4("FIND_STRUCTURES");
+  if (typeof findStructures !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const structures = room.find(findStructures);
+  return Array.isArray(structures) ? structures : [];
+}
+function normalizeCrossRoomHaulerMemory(value) {
+  if (!isRecord10(value)) {
+    return null;
+  }
+  return isNonEmptyString10(value.homeRoom) && isNonEmptyString10(value.targetRoom) && isNonEmptyString10(value.sourceId) ? {
+    homeRoom: value.homeRoom,
+    targetRoom: value.targetRoom,
+    sourceId: value.sourceId,
+    ...value.state === "collecting" || value.state === "delivering" || value.state === "returning" ? { state: value.state } : {},
+    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString10) } : {}
+  } : null;
+}
+function getMutableCrossRoomHaulerMemory(creep) {
+  var _a;
+  const normalized = normalizeCrossRoomHaulerMemory((_a = creep.memory) == null ? void 0 : _a.crossRoomHauler);
+  if (!normalized) {
+    return null;
+  }
+  creep.memory.crossRoomHauler = normalized;
+  return creep.memory.crossRoomHauler;
+}
+function moveTo3(creep, target) {
+  var _a;
+  (_a = creep.moveTo) == null ? void 0 : _a.call(creep, target, CROSS_ROOM_MOVE_OPTS);
+}
+function getCarriedEnergy4(creep) {
+  return getStoredEnergy10(creep);
+}
+function getStoredEnergy10(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const resource = getEnergyResource8();
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
+  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+  const directEnergy = store == null ? void 0 : store[resource];
+  return typeof directEnergy === "number" && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
+}
+function getFreeEnergyCapacity5(target) {
+  var _a;
+  const store = target == null ? void 0 : target.store;
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource8());
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+function getObjectById3(id) {
+  var _a;
+  const getObjectById4 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById4 === "function" ? getObjectById4(String(id)) : null;
+}
+function getVisibleRoom4(roomName) {
+  var _a, _b;
+  return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+}
+function getGameTime10() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
+}
+function getEnergyResource8() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function getErrNotInRangeCode3() {
+  var _a;
+  return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE6;
+}
+function getNoPathResultCode5() {
+  var _a;
+  return (_a = globalThis.ERR_NO_PATH) != null ? _a : ERR_NO_PATH_CODE5;
+}
+function getObjectId4(object) {
+  if (!isRecord10(object)) {
+    return "";
+  }
+  return typeof object.id === "string" ? object.id : typeof object.name === "string" ? object.name : "";
+}
+function matchesStructureType11(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+function getGlobalNumber4(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function isRecord10(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString10(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
 // src/spawn/spawnPlanner.ts
 var CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
 var CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
@@ -14018,7 +14670,7 @@ var HARVEST_POWER_PER_WORK_PART = 2;
 var HARVESTER_FULL_EXTRACTION_WORK_PARTS = Math.ceil(
   SOURCE_ENERGY_PER_TICK / HARVEST_POWER_PER_WORK_PART
 );
-var CARRY_CAPACITY_PER_PART = 50;
+var CARRY_CAPACITY_PER_PART2 = 50;
 var MAX_CREEP_PARTS4 = 50;
 var LOCAL_SUPPORT_WORKER_FLOOR = 3;
 var POST_CLAIM_SUSTAIN_UPGRADER_TARGET = 1;
@@ -14088,7 +14740,7 @@ function shouldSuppressWorkerSpawnForCrossRoomImport(colony) {
     return false;
   }
   return ((_b = balance == null ? void 0 : balance.transfers) != null ? _b : []).some(
-    (transfer) => transfer.targetRoom === colony.room.name && transfer.amount > 0 && isExportRoomWithSupply(balance, transfer.sourceRoom)
+    (transfer) => transfer.targetRoom === colony.room.name && transfer.amount > 0 && isLiveTransferCandidate(transfer)
   );
 }
 function planSpawnForPriorityTier(tier, context) {
@@ -14125,7 +14777,7 @@ function planEmergencyBootstrapSpawn(context) {
   );
 }
 function planLocalSurvivalSpawn(context) {
-  if (context.workerCapacity >= context.workerTarget || !hasRecoveryWorkerSpawnEnergy(context.colony) || shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) {
+  if (context.workerCapacity >= context.workerTarget || !hasRecoveryWorkerSpawnEnergy(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) {
     return null;
   }
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
@@ -14191,7 +14843,7 @@ function selectPostClaimControllerSustainPlan(colony) {
   var _a;
   const records = getPostClaimControllerSustainRecords(colony.room.name);
   for (const record of records) {
-    const targetRoom = getVisibleRoom4(record.roomName);
+    const targetRoom = getVisibleRoom5(record.roomName);
     if (((_a = targetRoom == null ? void 0 : targetRoom.controller) == null ? void 0 : _a.my) !== true) {
       continue;
     }
@@ -14218,7 +14870,7 @@ function selectPostClaimControllerSustainPlan(colony) {
 function getPostClaimControllerSustainRecords(colonyName) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord10(records)) {
+  if (!isRecord11(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -14226,7 +14878,7 @@ function getPostClaimControllerSustainRecords(colonyName) {
   ).sort(comparePostClaimControllerSustainRecords);
 }
 function isPostClaimControllerSustainRecord(record, colonyName) {
-  return isRecord10(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString10(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord11(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString11(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function comparePostClaimControllerSustainRecords(left, right) {
   const leftHasSpawn = hasOperationalSpawnInRoom(left.roomName);
@@ -14238,7 +14890,7 @@ function comparePostClaimControllerSustainRecords(left, right) {
 }
 function getVisibleControllerLevel(roomName) {
   var _a, _b;
-  const level = (_b = (_a = getVisibleRoom4(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
+  const level = (_b = (_a = getVisibleRoom5(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
   return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL2 + 1;
 }
 function hasOperationalSpawnInRoom(roomName) {
@@ -14323,7 +14975,7 @@ function planDefenseSpawn(context) {
   };
 }
 function hasDefenseTowerRefillDemand(room) {
-  const findMyStructures = getGlobalNumber4("FIND_MY_STRUCTURES");
+  const findMyStructures = getGlobalNumber5("FIND_MY_STRUCTURES");
   if (findMyStructures === void 0 || typeof room.find !== "function") {
     return false;
   }
@@ -14336,11 +14988,11 @@ function isTowerStructure2(structure) {
   return structure.structureType === towerType || structure.structureType === "tower";
 }
 function isTowerBelowDefenseRefillFloor(tower) {
-  const usedEnergy = getStoredEnergy9(tower);
+  const usedEnergy = getStoredEnergy11(tower);
   if (usedEnergy !== null) {
     return usedEnergy < DEFENSE_TOWER_REFILL_ENERGY_FLOOR;
   }
-  return getFreeEnergyCapacity5(tower) > 0;
+  return getFreeEnergyCapacity6(tower) > 0;
 }
 function planRemoteEconomySpawn(context) {
   if (context.options.workersOnly || context.survival.mode !== "TERRITORY_READY" || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
@@ -14493,7 +15145,7 @@ function planMultiRoomControllerUpgradeSpawn(context) {
   return null;
 }
 function shouldSpawnControllerUpgradeSurplusWorker(context) {
-  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || shouldSuppressWorkerSpawnForCrossRoomImport(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
+  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony) || !hasControllerUpgradeSurplusEnergy(context.colony) || !isControllerUpgradeableForSurplus(context.colony.room.controller)) {
     return false;
   }
   const surplusWorkerTarget = Math.min(
@@ -14669,7 +15321,7 @@ function buildHarvesterBody(workParts, carryParts) {
 function getHarvesterCarryTarget(workParts, sourceDistance) {
   const roundTripTicks = Math.max(1, normalizeNonNegativeInteger2(sourceDistance) * 2);
   const harvestedEnergyBetweenTrips = workParts * HARVEST_POWER_PER_WORK_PART * roundTripTicks;
-  return Math.max(1, Math.ceil(harvestedEnergyBetweenTrips / CARRY_CAPACITY_PER_PART));
+  return Math.max(1, Math.ceil(harvestedEnergyBetweenTrips / CARRY_CAPACITY_PER_PART2));
 }
 function getHarvesterBodyCost(workParts, carryParts) {
   return getBodyCost(buildHarvesterBody(workParts, carryParts));
@@ -14723,7 +15375,7 @@ function buildTerritorySpawnBody(energyAvailable, intent) {
   }
   return buildTerritoryControllerBody(energyAvailable);
 }
-function getVisibleRoom4(roomName) {
+function getVisibleRoom5(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -14732,22 +15384,17 @@ function compareColoniesForSpawnPlanning(left, right) {
   const rightForecast = getSpawnEnergyForecast(right);
   return rightForecast.effectiveEnergyAvailable - leftForecast.effectiveEnergyAvailable || right.energyAvailable - left.energyAvailable || left.room.name.localeCompare(right.room.name);
 }
-function isExportRoomWithSupply(balance, roomName) {
-  var _a;
-  const roomBalance = (_a = balance.rooms) == null ? void 0 : _a[roomName];
-  return (roomBalance == null ? void 0 : roomBalance.mode) === "export" && roomBalance.exportableEnergy > 0;
-}
 function getStorageBalanceMemory() {
   var _a, _b;
   return (_b = (_a = globalThis.Memory) == null ? void 0 : _a.economy) == null ? void 0 : _b.storageBalance;
 }
-function isRecord10(value) {
+function isRecord11(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString10(value) {
+function isNonEmptyString11(value) {
   return typeof value === "string" && value.length > 0;
 }
-function getStoredEnergy9(structure) {
+function getStoredEnergy11(structure) {
   var _a, _b;
   const resourceEnergy = (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
   const getUsedCapacity = (_b = structure.store) == null ? void 0 : _b.getUsedCapacity;
@@ -14757,7 +15404,7 @@ function getStoredEnergy9(structure) {
   const usedCapacity = getUsedCapacity.call(structure.store, resourceEnergy);
   return typeof usedCapacity === "number" && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : null;
 }
-function getFreeEnergyCapacity5(structure) {
+function getFreeEnergyCapacity6(structure) {
   var _a, _b;
   const resourceEnergy = (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
   const getFreeCapacity = (_b = structure.store) == null ? void 0 : _b.getFreeCapacity;
@@ -14767,7 +15414,7 @@ function getFreeEnergyCapacity5(structure) {
   const freeCapacity = getFreeCapacity.call(structure.store, resourceEnergy);
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
 }
-function getGlobalNumber4(name) {
+function getGlobalNumber5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -14775,9 +15422,9 @@ function getGlobalNumber4(name) {
 // src/territory/scoutIntel.ts
 var TERRITORY_SCOUT_MEMORY_KEY_SEPARATOR = ">";
 var TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS = 1500;
-function recordVisibleRoomScoutIntel(colony, room, gameTime = getGameTime9(), scoutName, telemetryEvents = []) {
+function recordVisibleRoomScoutIntel(colony, room, gameTime = getGameTime11(), scoutName, telemetryEvents = []) {
   var _a, _b, _c, _d;
-  if (!isNonEmptyString11(colony) || !room || !isNonEmptyString11(room.name)) {
+  if (!isNonEmptyString12(colony) || !room || !isNonEmptyString12(room.name)) {
     return null;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord3();
@@ -14817,7 +15464,7 @@ function recordVisibleRoomScoutIntel(colony, room, gameTime = getGameTime9(), sc
 }
 function ensureTerritoryScoutAttempt(colony, targetRoom, gameTime, telemetryEvents = [], controllerId) {
   var _a;
-  if (!isNonEmptyString11(colony) || !isNonEmptyString11(targetRoom)) {
+  if (!isNonEmptyString12(colony) || !isNonEmptyString12(targetRoom)) {
     return null;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord3();
@@ -14871,13 +15518,13 @@ function validateTerritoryScoutIntelForClaim({
   if (!controller) {
     return { status: "blocked", reason: "controllerMissing", intel };
   }
-  if (controller.my === true || isNonEmptyString11(controller.ownerUsername) && controller.ownerUsername === colonyOwnerUsername) {
+  if (controller.my === true || isNonEmptyString12(controller.ownerUsername) && controller.ownerUsername === colonyOwnerUsername) {
     return { status: "blocked", reason: "controllerOwned", intel };
   }
-  if (isNonEmptyString11(controller.ownerUsername)) {
+  if (isNonEmptyString12(controller.ownerUsername)) {
     return { status: "blocked", reason: "controllerOwned", intel };
   }
-  if (isNonEmptyString11(controller.reservationUsername) && controller.reservationUsername !== colonyOwnerUsername) {
+  if (isNonEmptyString12(controller.reservationUsername) && controller.reservationUsername !== colonyOwnerUsername) {
     return { status: "blocked", reason: "controllerReserved", intel };
   }
   if (intel.hostileSpawnCount > 0) {
@@ -14890,7 +15537,7 @@ function validateTerritoryScoutIntelForClaim({
 }
 function recordTerritoryScoutValidation(colony, targetRoom, result, gameTime, telemetryEvents = [], controllerId, score) {
   var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n;
-  if (!isNonEmptyString11(colony) || !isNonEmptyString11(targetRoom)) {
+  if (!isNonEmptyString12(colony) || !isNonEmptyString12(targetRoom)) {
     return;
   }
   const territoryMemory = getWritableTerritoryMemoryRecord3();
@@ -14932,7 +15579,7 @@ function recordTerritoryScoutValidation(colony, targetRoom, result, gameTime, te
 }
 function getTerritoryScoutSummary(colony) {
   var _a, _b;
-  if (!isNonEmptyString11(colony)) {
+  if (!isNonEmptyString12(colony)) {
     return null;
   }
   const territoryMemory = getTerritoryMemoryRecord4();
@@ -15065,22 +15712,22 @@ function isScoutAttemptTimedOut(attempt, gameTime) {
   return (attempt == null ? void 0 : attempt.status) === "requested" && gameTime >= attempt.requestedAt && gameTime - attempt.requestedAt > TERRITORY_SCOUT_VALIDATION_TIMEOUT_TICKS;
 }
 function getMutableScoutAttemptRecords(territoryMemory) {
-  if (!isRecord11(territoryMemory.scoutAttempts) || Array.isArray(territoryMemory.scoutAttempts)) {
+  if (!isRecord12(territoryMemory.scoutAttempts) || Array.isArray(territoryMemory.scoutAttempts)) {
     territoryMemory.scoutAttempts = {};
   }
   return territoryMemory.scoutAttempts;
 }
 function getMutableScoutIntelRecords(territoryMemory) {
-  if (!isRecord11(territoryMemory.scoutIntel) || Array.isArray(territoryMemory.scoutIntel)) {
+  if (!isRecord12(territoryMemory.scoutIntel) || Array.isArray(territoryMemory.scoutIntel)) {
     territoryMemory.scoutIntel = {};
   }
   return territoryMemory.scoutIntel;
 }
 function normalizeTerritoryScoutAttempt(rawAttempt) {
-  if (!isRecord11(rawAttempt)) {
+  if (!isRecord12(rawAttempt)) {
     return null;
   }
-  if (!isNonEmptyString11(rawAttempt.colony) || !isNonEmptyString11(rawAttempt.roomName) || !isTerritoryScoutAttemptStatus(rawAttempt.status) || !isFiniteNumber6(rawAttempt.requestedAt) || !isFiniteNumber6(rawAttempt.updatedAt)) {
+  if (!isNonEmptyString12(rawAttempt.colony) || !isNonEmptyString12(rawAttempt.roomName) || !isTerritoryScoutAttemptStatus(rawAttempt.status) || !isFiniteNumber6(rawAttempt.requestedAt) || !isFiniteNumber6(rawAttempt.updatedAt)) {
     return null;
   }
   const attemptCount = isFiniteNumber6(rawAttempt.attemptCount) ? Math.max(1, Math.floor(rawAttempt.attemptCount)) : 1;
@@ -15093,18 +15740,18 @@ function normalizeTerritoryScoutAttempt(rawAttempt) {
     updatedAt: rawAttempt.updatedAt,
     attemptCount,
     ...typeof rawAttempt.controllerId === "string" ? { controllerId: rawAttempt.controllerId } : {},
-    ...isNonEmptyString11(rawAttempt.scoutName) ? { scoutName: rawAttempt.scoutName } : {},
+    ...isNonEmptyString12(rawAttempt.scoutName) ? { scoutName: rawAttempt.scoutName } : {},
     ...lastValidation ? { lastValidation } : {}
   };
 }
 function normalizeTerritoryScoutIntel(rawIntel) {
-  if (!isRecord11(rawIntel)) {
+  if (!isRecord12(rawIntel)) {
     return null;
   }
-  if (!isNonEmptyString11(rawIntel.colony) || !isNonEmptyString11(rawIntel.roomName) || !isFiniteNumber6(rawIntel.updatedAt)) {
+  if (!isNonEmptyString12(rawIntel.colony) || !isNonEmptyString12(rawIntel.roomName) || !isFiniteNumber6(rawIntel.updatedAt)) {
     return null;
   }
-  const sourceIds = Array.isArray(rawIntel.sourceIds) ? rawIntel.sourceIds.flatMap((sourceId) => isNonEmptyString11(sourceId) ? [sourceId] : []) : [];
+  const sourceIds = Array.isArray(rawIntel.sourceIds) ? rawIntel.sourceIds.flatMap((sourceId) => isNonEmptyString12(sourceId) ? [sourceId] : []) : [];
   const sourceCount = isFiniteNumber6(rawIntel.sourceCount) ? Math.max(0, Math.floor(rawIntel.sourceCount)) : sourceIds.length;
   const controller = normalizeTerritoryScoutControllerIntel(rawIntel.controller);
   const mineral = normalizeTerritoryScoutMineralIntel(rawIntel.mineral);
@@ -15119,33 +15766,33 @@ function normalizeTerritoryScoutIntel(rawIntel) {
     hostileCreepCount: getBoundedCount(rawIntel.hostileCreepCount),
     hostileStructureCount: getBoundedCount(rawIntel.hostileStructureCount),
     hostileSpawnCount: getBoundedCount(rawIntel.hostileSpawnCount),
-    ...isNonEmptyString11(rawIntel.scoutName) ? { scoutName: rawIntel.scoutName } : {}
+    ...isNonEmptyString12(rawIntel.scoutName) ? { scoutName: rawIntel.scoutName } : {}
   };
 }
 function normalizeTerritoryScoutControllerIntel(rawController) {
-  if (!isRecord11(rawController)) {
+  if (!isRecord12(rawController)) {
     return null;
   }
   return {
     ...typeof rawController.id === "string" ? { id: rawController.id } : {},
     ...typeof rawController.my === "boolean" ? { my: rawController.my } : {},
-    ...isNonEmptyString11(rawController.ownerUsername) ? { ownerUsername: rawController.ownerUsername } : {},
-    ...isNonEmptyString11(rawController.reservationUsername) ? { reservationUsername: rawController.reservationUsername } : {},
+    ...isNonEmptyString12(rawController.ownerUsername) ? { ownerUsername: rawController.ownerUsername } : {},
+    ...isNonEmptyString12(rawController.reservationUsername) ? { reservationUsername: rawController.reservationUsername } : {},
     ...isFiniteNumber6(rawController.reservationTicksToEnd) ? { reservationTicksToEnd: rawController.reservationTicksToEnd } : {}
   };
 }
 function normalizeTerritoryScoutMineralIntel(rawMineral) {
-  if (!isRecord11(rawMineral) || !isNonEmptyString11(rawMineral.id)) {
+  if (!isRecord12(rawMineral) || !isNonEmptyString12(rawMineral.id)) {
     return null;
   }
   return {
     id: rawMineral.id,
-    ...isNonEmptyString11(rawMineral.mineralType) ? { mineralType: rawMineral.mineralType } : {},
+    ...isNonEmptyString12(rawMineral.mineralType) ? { mineralType: rawMineral.mineralType } : {},
     ...isFiniteNumber6(rawMineral.density) ? { density: rawMineral.density } : {}
   };
 }
 function normalizeTerritoryScoutValidation(rawValidation) {
-  if (!isRecord11(rawValidation)) {
+  if (!isRecord12(rawValidation)) {
     return null;
   }
   if (!isTerritoryScoutValidationStatus(rawValidation.status) || !isFiniteNumber6(rawValidation.updatedAt)) {
@@ -15167,7 +15814,7 @@ function compareTerritoryScoutIntel(left, right) {
   return right.updatedAt - left.updatedAt || left.roomName.localeCompare(right.roomName);
 }
 function findRoomObjects9(room, constantName) {
-  const findConstant = getGlobalNumber5(constantName);
+  const findConstant = getGlobalNumber6(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return [];
@@ -15190,12 +15837,12 @@ function getStructureSpawnConstant() {
 function getControllerOwnerUsername5(controller) {
   var _a;
   const username = (_a = controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString11(username) ? username : void 0;
+  return isNonEmptyString12(username) ? username : void 0;
 }
 function getControllerReservationUsername3(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString11(username) ? username : void 0;
+  return isNonEmptyString12(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd2(controller) {
   var _a;
@@ -15205,11 +15852,11 @@ function getControllerReservationTicksToEnd2(controller) {
 function getTerritoryScoutMemoryKey(colony, targetRoom) {
   return `${colony}${TERRITORY_SCOUT_MEMORY_KEY_SEPARATOR}${targetRoom}`;
 }
-function getGlobalNumber5(name) {
+function getGlobalNumber6(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getGameTime9() {
+function getGameTime11() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -15223,7 +15870,7 @@ function getWritableTerritoryMemoryRecord3() {
   if (!memory) {
     return null;
   }
-  if (!isRecord11(memory.territory)) {
+  if (!isRecord12(memory.territory)) {
     memory.territory = {};
   }
   return memory.territory;
@@ -15240,10 +15887,10 @@ function isTerritoryScoutValidationReason(reason) {
 function isFiniteNumber6(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function isNonEmptyString11(value) {
+function isNonEmptyString12(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord11(value) {
+function isRecord12(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -15251,7 +15898,7 @@ function isRecord11(value) {
 var NEXT_EXPANSION_TARGET_CREATOR = "nextExpansionScoring";
 var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR4 = ">";
-var ERR_NO_PATH_CODE5 = -2;
+var ERR_NO_PATH_CODE6 = -2;
 var MAX_NEARBY_EXPANSION_ROUTE_DISTANCE = 2;
 var TERRAIN_SCAN_MIN = 2;
 var TERRAIN_SCAN_MAX = 47;
@@ -15321,7 +15968,7 @@ function clearNextExpansionTargetIntent(colony) {
 }
 function validateVisibleNextExpansionScoutIntel(colony, candidate, gameTime, telemetryEvents) {
   var _a, _b, _c;
-  const room = getVisibleRoom5(candidate.roomName);
+  const room = getVisibleRoom6(candidate.roomName);
   if (!room) {
     return null;
   }
@@ -15387,7 +16034,7 @@ function buildRuntimeExpansionCandidates(colony) {
     }
   }
   for (const room of Object.values(rooms)) {
-    if (!room || !isNonEmptyString12(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
+    if (!room || !isNonEmptyString13(room.name) || room.name === colonyName || ownedRoomNames.has(room.name)) {
       continue;
     }
     if (candidateOrders.has(room.name)) {
@@ -15576,7 +16223,7 @@ function hasForeignControllerPresence(input, controller) {
   if (!controller) {
     return false;
   }
-  return isNonEmptyString12(controller.ownerUsername) && controller.ownerUsername !== input.colonyOwnerUsername || isNonEmptyString12(controller.reservationUsername) && controller.reservationUsername !== input.colonyOwnerUsername;
+  return isNonEmptyString13(controller.ownerUsername) && controller.ownerUsername !== input.colonyOwnerUsername || isNonEmptyString13(controller.reservationUsername) && controller.reservationUsername !== input.colonyOwnerUsername;
 }
 function getDistanceScore(candidate) {
   const nearestOwnedDistance = candidate.nearestOwnedRoomDistance;
@@ -15700,7 +16347,7 @@ function persistExpansionCandidateScores(colony, report, gameTime) {
     return;
   }
   const existingCandidates = Array.isArray(territoryMemory.expansionCandidates) ? territoryMemory.expansionCandidates.filter(
-    (candidate) => isRecord12(candidate) && candidate.colony !== colony
+    (candidate) => isRecord13(candidate) && candidate.colony !== colony
   ) : [];
   const nextCandidates = report.candidates.slice(0, MAX_PERSISTED_EXPANSION_CANDIDATES).map((candidate) => toPersistedExpansionCandidateMemory(colony, candidate, gameTime));
   if (existingCandidates.length === 0 && nextCandidates.length === 0) {
@@ -15786,7 +16433,7 @@ function upsertNextExpansionTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord12(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
+  if (isRecord13(existingTarget) && existingTarget.createdBy === NEXT_EXPANSION_TARGET_CREATOR) {
     existingTarget.createdBy = NEXT_EXPANSION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -15816,7 +16463,7 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
     if (activeTarget && isSameTarget(target, activeTarget)) {
       return true;
     }
-    if (isRecord12(target) && isNonEmptyString12(target.roomName) && target.action === "claim") {
+    if (isRecord13(target) && isNonEmptyString13(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey(target.roomName, "claim"));
     }
     return false;
@@ -15829,10 +16476,10 @@ function pruneNextExpansionTargets(colony, activeTarget, territoryMemory = getTe
   );
 }
 function isNextExpansionTarget(target, colony) {
-  return isRecord12(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
+  return isRecord13(target) && target.colony === colony && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR;
 }
 function isSameTarget(left, right) {
-  return isRecord12(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord13(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey(roomName, action) {
   return `${roomName}:${action}`;
@@ -15870,7 +16517,7 @@ function getVisibleOwnedRoomNames3(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString12(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
+    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString13(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -15952,12 +16599,12 @@ function getAdjacentRoomNames4(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord12(exits)) {
+  if (!isRecord13(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER3.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString12(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString13(exitRoom) ? [exitRoom] : [];
   });
 }
 function getKnownRouteLength2(fromRoom, targetRoom) {
@@ -15976,7 +16623,7 @@ function getKnownRouteLength2(fromRoom, targetRoom) {
     return void 0;
   }
   const route = gameMap.findRoute(fromRoom, targetRoom);
-  if (route === getNoPathResultCode5()) {
+  if (route === getNoPathResultCode6()) {
     if (cache) {
       cache[cacheKey] = null;
     }
@@ -15995,7 +16642,7 @@ function getTerritoryRouteDistanceCache3() {
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord12(territoryMemory.routeDistances)) {
+  if (!isRecord13(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
@@ -16003,9 +16650,9 @@ function getTerritoryRouteDistanceCache3() {
 function getTerritoryRouteDistanceCacheKey3(fromRoom, targetRoom) {
   return `${fromRoom}${TERRITORY_ROUTE_DISTANCE_SEPARATOR4}${targetRoom}`;
 }
-function getNoPathResultCode5() {
+function getNoPathResultCode6() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE5;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE6;
 }
 function summarizeExpansionController(controller) {
   const ownerUsername = getControllerOwnerUsername6(controller);
@@ -16135,12 +16782,12 @@ function getFindConstant5(name) {
 function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString12(username) ? username : void 0;
+  return isNonEmptyString13(username) ? username : void 0;
 }
 function getControllerReservationUsername4(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString12(username) ? username : void 0;
+  return isNonEmptyString13(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd3(controller) {
   var _a;
@@ -16150,18 +16797,18 @@ function getControllerReservationTicksToEnd3(controller) {
 function countActivePostClaimBootstraps() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord12(records)) {
+  if (!isRecord13(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord12(record) && record.status !== "ready"
+    (record) => isRecord13(record) && record.status !== "ready"
   ).length;
 }
 function getGameRooms2() {
   var _a;
   return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
 }
-function getVisibleRoom5(roomName) {
+function getVisibleRoom6(roomName) {
   var _a;
   return (_a = getGameRooms2()) == null ? void 0 : _a[roomName];
 }
@@ -16188,10 +16835,10 @@ function toPercent(value) {
 function formatSourceAccessPoints(value) {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
-function isRecord12(value) {
+function isRecord13(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString12(value) {
+function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -16204,14 +16851,14 @@ var ROOM_EDGE_MAX6 = 47;
 var DEFAULT_TERRAIN_WALL_MASK6 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
-  if (!isNonEmptyString13(input.colony) || !isNonEmptyString13(input.roomName)) {
+  if (!isNonEmptyString14(input.colony) || !isNonEmptyString14(input.roomName)) {
     return;
   }
   const bootstraps = getWritablePostClaimBootstrapRecords();
   if (!bootstraps) {
     return;
   }
-  const gameTime = getGameTime10();
+  const gameTime = getGameTime12();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
   bootstraps[input.roomName] = {
@@ -16327,7 +16974,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   return { active: true, spawnConstructionPending: true };
 }
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
-  if (!isNonEmptyString13(roomName)) {
+  if (!isNonEmptyString14(roomName)) {
     return;
   }
   const record = getPostClaimBootstrapRecord(roomName);
@@ -16336,7 +16983,7 @@ function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, res
   }
   updatePostClaimBootstrapRecord(roomName, {
     status: "spawningWorkers",
-    updatedAt: getGameTime10()
+    updatedAt: getGameTime12()
   });
   telemetryEvents.push({
     type: "postClaimBootstrap",
@@ -16379,7 +17026,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
     const spawnSite = toSpawnSiteMemory(existingSpawnSite);
     updatePostClaimBootstrapRecord(roomName, {
       status: "spawnSitePending",
-      updatedAt: getGameTime10(),
+      updatedAt: getGameTime12(),
       workerTarget,
       spawnSite,
       lastResult: OK_CODE5
@@ -16403,7 +17050,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
   const nextStatus = sitePlan.result === OK_CODE5 ? "spawnSitePending" : "spawnSiteBlocked";
   updatePostClaimBootstrapRecord(roomName, {
     status: nextStatus,
-    updatedAt: getGameTime10(),
+    updatedAt: getGameTime12(),
     workerTarget,
     ...sitePlan.position ? { spawnSite: sitePlan.position } : {},
     lastResult: sitePlan.result
@@ -16585,31 +17232,31 @@ function isTerrainWall4(terrain, position) {
 }
 function findExistingSpawnConstructionSite(room) {
   var _a;
-  const findConstant = getGlobalNumber6("FIND_MY_CONSTRUCTION_SITES");
+  const findConstant = getGlobalNumber7("FIND_MY_CONSTRUCTION_SITES");
   if (typeof room.find !== "function" || findConstant === null) {
     return null;
   }
   const sites = room.find(findConstant, {
-    filter: (site) => matchesStructureType11(site.structureType, "STRUCTURE_SPAWN", "spawn")
+    filter: (site) => matchesStructureType12(site.structureType, "STRUCTURE_SPAWN", "spawn")
   });
   return (_a = sites[0]) != null ? _a : null;
 }
 function findSources3(room) {
-  const findConstant = getGlobalNumber6("FIND_SOURCES");
+  const findConstant = getGlobalNumber7("FIND_SOURCES");
   if (typeof room.find !== "function" || findConstant === null) {
     return [];
   }
   return room.find(findConstant);
 }
 function getRoomObjectPosition4(object) {
-  if (!isRecord13(object)) {
+  if (!isRecord14(object)) {
     return null;
   }
   if (isFiniteNumber7(object.x) && isFiniteNumber7(object.y)) {
     return { x: object.x, y: object.y };
   }
   const pos = object.pos;
-  if (isRecord13(pos) && isFiniteNumber7(pos.x) && isFiniteNumber7(pos.y)) {
+  if (isRecord14(pos) && isFiniteNumber7(pos.x) && isFiniteNumber7(pos.y)) {
     return { x: pos.x, y: pos.y };
   }
   return null;
@@ -16656,7 +17303,7 @@ function getWritablePostClaimBootstrapRecords() {
   return memory.territory.postClaimBootstraps;
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
-  return isRecord13(value) && value.roomName === expectedRoomName && isNonEmptyString13(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber7(value.claimedAt) && isFiniteNumber7(value.updatedAt);
+  return isRecord14(value) && value.roomName === expectedRoomName && isNonEmptyString14(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber7(value.claimedAt) && isFiniteNumber7(value.updatedAt);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
@@ -16695,7 +17342,7 @@ function getRoomTerrain6(roomName) {
 function getTerrainWallMask6() {
   return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK6;
 }
-function matchesStructureType11(actual, globalName, fallback) {
+function matchesStructureType12(actual, globalName, fallback) {
   return actual === getStructureConstant(globalName, fallback);
 }
 function getStructureConstant(globalName, fallback) {
@@ -16703,7 +17350,7 @@ function getStructureConstant(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function getGlobalNumber6(name) {
+function getGlobalNumber7(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : null;
 }
@@ -16711,15 +17358,15 @@ function getGlobalString(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getGameTime10() {
+function getGameTime12() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord13(value) {
+function isRecord14(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString13(value) {
+function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber7(value) {
@@ -16750,7 +17397,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return void 0;
   }
-  const tick = getGameTime11();
+  const tick = getGameTime13();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -16847,7 +17494,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime11());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime13());
   }
   return {
     roomName: colony.room.name,
@@ -16857,11 +17504,11 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime11()),
+    ...summarizeRuntimeBehavior(colonyWorkers, getGameTime13()),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime11()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime11()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime11()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime13()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime13()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime13()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -16881,7 +17528,7 @@ function buildPostClaimBootstrapSummary(roomName) {
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime11());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime13());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -17028,7 +17675,7 @@ function isRecentWorkerTaskBehaviorSample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskBehaviorSample(value) {
-  return isRecord14(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord14(value.state) && isRecord14(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+  return isRecord15(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord15(value.state) && isRecord15(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
 }
 function isRecentWorkerTaskPolicyShadow(value, tick) {
   if (!isWorkerTaskPolicyShadow(value)) {
@@ -17037,7 +17684,7 @@ function isRecentWorkerTaskPolicyShadow(value, tick) {
   return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskPolicyShadow(value) {
-  return isRecord14(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
+  return isRecord15(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function shouldBuildStructureSnapshot(tick) {
   return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
@@ -17065,13 +17712,13 @@ function countConstructionSitesByType(constructionSites, globalName, fallback) {
   return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
 }
 function countOwnedRamparts(structures) {
-  return structures.filter((structure) => isRecord14(structure) && isObservedOwnedRampart(structure)).length;
+  return structures.filter((structure) => isRecord15(structure) && isObservedOwnedRampart(structure)).length;
 }
 function summarizeContainers(structures) {
   return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
 }
 function toRuntimeContainerSnapshot(structure) {
-  const id = getObjectId4(structure);
+  const id = getObjectId5(structure);
   if (!id) {
     return null;
   }
@@ -17094,7 +17741,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   }
   const structuresById = /* @__PURE__ */ new Map();
   for (const structure of roomStructures) {
-    const id = getObjectId4(structure);
+    const id = getObjectId5(structure);
     if (id) {
       structuresById.set(id, structure);
     }
@@ -17102,7 +17749,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   return [...repairCounts.entries()].sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId)).map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
 }
 function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
-  const structureRecord = isRecord14(structure) ? structure : {};
+  const structureRecord = isRecord15(structure) ? structure : {};
   const structureType = typeof structureRecord.structureType === "string" ? structureRecord.structureType : void 0;
   const hits = getFiniteNumber(structureRecord.hits);
   const hitsMax = getFiniteNumber(structureRecord.hitsMax);
@@ -17115,7 +17762,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord14(structure) && matchesStructureType12(structure.structureType, globalName, fallback);
+  return isRecord15(structure) && matchesStructureType13(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -17275,7 +17922,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord14(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord15(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio3(numerator, denominator) {
   if (denominator <= 0) {
@@ -17290,7 +17937,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord14(value)) {
+  if (!isRecord15(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -17331,7 +17978,7 @@ function isRecentSpawnCriticalRefillSample(sample, tick) {
   return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
 }
 function isSpawnCriticalRefillSample(value) {
-  return isRecord14(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
+  return isRecord15(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;
@@ -17379,10 +18026,10 @@ function findOwnedEnergyStoreStructures(room) {
   return ((_a = findRoomObjects11(room, "FIND_MY_STRUCTURES")) != null ? _a : []).filter(isOwnedEnergyStoreStructure);
 }
 function isOwnedEnergyStoreStructure(structure) {
-  if (!isRecord14(structure)) {
+  if (!isRecord15(structure)) {
     return false;
   }
-  return matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType12(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType12(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType12(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType12(structure.structureType, "STRUCTURE_LINK", "link");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType13(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType13(structure.structureType, "STRUCTURE_LINK", "link");
 }
 function summarizeProductiveEnergy(room, colonyWorkers, constructionSites, roomStructures) {
   const productiveAssignments = summarizeProductiveWorkerAssignments(colonyWorkers);
@@ -17427,7 +18074,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord14(constructionSite)) {
+  if (!isRecord15(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -17441,7 +18088,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord14(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord15(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -17453,10 +18100,10 @@ function getRepairBacklogHits(structure) {
   return Math.max(0, Math.ceil(repairCeiling - hits));
 }
 function isObservableRepairBacklogStructure(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType12(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
+  return matchesStructureType13(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
 }
 function isObservedOwnedRampart(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
+  return matchesStructureType13(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
 }
 function buildControllerProgressRemaining(room) {
   const controller = room.controller;
@@ -17639,13 +18286,13 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   if (!eventLog) {
     return {};
   }
-  const harvestEvent = getGlobalNumber7("EVENT_HARVEST");
-  const transferEvent = getGlobalNumber7("EVENT_TRANSFER");
-  const buildEvent = getGlobalNumber7("EVENT_BUILD");
-  const repairEvent = getGlobalNumber7("EVENT_REPAIR");
-  const upgradeControllerEvent = getGlobalNumber7("EVENT_UPGRADE_CONTROLLER");
-  const attackEvent = getGlobalNumber7("EVENT_ATTACK");
-  const objectDestroyedEvent = getGlobalNumber7("EVENT_OBJECT_DESTROYED");
+  const harvestEvent = getGlobalNumber8("EVENT_HARVEST");
+  const transferEvent = getGlobalNumber8("EVENT_TRANSFER");
+  const buildEvent = getGlobalNumber8("EVENT_BUILD");
+  const repairEvent = getGlobalNumber8("EVENT_REPAIR");
+  const upgradeControllerEvent = getGlobalNumber8("EVENT_UPGRADE_CONTROLLER");
+  const attackEvent = getGlobalNumber8("EVENT_ATTACK");
+  const objectDestroyedEvent = getGlobalNumber8("EVENT_OBJECT_DESTROYED");
   const resourceEvents = {
     harvestedEnergy: 0,
     transferredEnergy: 0,
@@ -17663,10 +18310,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord14(entry) || typeof entry.event !== "number") {
+    if (!isRecord15(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord14(entry.data) ? entry.data : {};
+    const data = isRecord15(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -17724,7 +18371,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
     if (!isSpawnExtensionEnergyStructure2(structure)) {
       continue;
     }
-    const id = getObjectId4(structure);
+    const id = getObjectId5(structure);
     if (id) {
       ids.add(id);
     }
@@ -17732,7 +18379,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord14(structure) && (matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType12(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord15(structure) && (matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -17740,11 +18387,11 @@ function getEventTargetId(data) {
 function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
-function getObjectId4(value) {
-  return isRecord14(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+function getObjectId5(value) {
+  return isRecord15(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects11(room, constantName) {
-  const findConstant = getGlobalNumber7(constantName);
+  const findConstant = getGlobalNumber8(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return void 0;
@@ -17762,7 +18409,7 @@ function getRoomEventLog(room) {
     return void 0;
   }
   try {
-    const eventLog = getEventLog.call(room, getEnergyResource7());
+    const eventLog = getEventLog.call(room, getEnergyResource9());
     return Array.isArray(eventLog) ? eventLog : void 0;
   } catch {
     return void 0;
@@ -17772,32 +18419,32 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord14(object) || !isRecord14(object.store)) {
+  if (!isRecord15(object) || !isRecord15(object.store)) {
     return 0;
   }
-  const storedEnergy = object.store[getEnergyResource7()];
+  const storedEnergy = object.store[getEnergyResource9()];
   if (typeof storedEnergy === "number") {
     return storedEnergy;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
   if (typeof getUsedCapacity === "function") {
-    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource7());
+    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource9());
     return typeof usedCapacity === "number" ? usedCapacity : 0;
   }
   return 0;
 }
 function getEnergyCapacityInStore(object) {
-  if (!isRecord14(object) || !isRecord14(object.store)) {
+  if (!isRecord15(object) || !isRecord15(object.store)) {
     return 0;
   }
   const getCapacity = object.store.getCapacity;
   if (typeof getCapacity === "function") {
-    const capacity2 = getCapacity.call(object.store, getEnergyResource7());
+    const capacity2 = getCapacity.call(object.store, getEnergyResource9());
     return typeof capacity2 === "number" && Number.isFinite(capacity2) ? Math.max(0, capacity2) : 0;
   }
   const getFreeCapacity = object.store.getFreeCapacity;
   if (typeof getFreeCapacity === "function") {
-    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource7());
+    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource9());
     if (typeof freeCapacity === "number" && Number.isFinite(freeCapacity)) {
       return Math.max(0, getEnergyInStore(object) + freeCapacity);
     }
@@ -17806,26 +18453,26 @@ function getEnergyCapacityInStore(object) {
   return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
 }
 function sumDroppedEnergy2(droppedResources) {
-  const energyResource = getEnergyResource7();
+  const energyResource = getEnergyResource9();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord14(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord15(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
   }, 0);
 }
 function isEnergyEventData(data) {
-  return data.resourceType === void 0 || data.resourceType === getEnergyResource7();
+  return data.resourceType === void 0 || data.resourceType === getEnergyResource9();
 }
 function getNumericEventData(data, key) {
   const value = data[key];
   return typeof value === "number" ? value : 0;
 }
-function getGlobalNumber7(name) {
+function getGlobalNumber8(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function matchesStructureType12(value, globalName, fallback) {
+function matchesStructureType13(value, globalName, fallback) {
   var _a;
   const expectedValue = (_a = globalThis[globalName]) != null ? _a : fallback;
   return value === expectedValue;
@@ -17833,11 +18480,11 @@ function matchesStructureType12(value, globalName, fallback) {
 function getFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function getEnergyResource7() {
+function getEnergyResource9() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord14(value) {
+function isRecord15(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -17855,7 +18502,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime11() {
+function getGameTime13() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -18038,7 +18685,7 @@ function manageStorage(room) {
     return { assignedTasks: 0, linkTransfers: [] };
   }
   const linkTransfers = transferStorageLinkEnergy(room);
-  const storageEnergy = getStoredEnergy10(storage);
+  const storageEnergy = getStoredEnergy12(storage);
   if (storageEnergy <= 0) {
     return { assignedTasks: 0, linkTransfers };
   }
@@ -18053,14 +18700,14 @@ function manageStorage(room) {
 }
 function transferStorageLinkEnergy(room) {
   const { controllerLink, storageLink } = classifyLinks(room);
-  if (!controllerLink || !storageLink || getObjectId5(controllerLink) === getObjectId5(storageLink)) {
+  if (!controllerLink || !storageLink || getObjectId6(controllerLink) === getObjectId6(storageLink)) {
     return [];
   }
   if (getLinkCooldown2(storageLink) > 0) {
     return [];
   }
-  const storedEnergy = getStoredEnergy10(storageLink);
-  const destinationFreeCapacity = getFreeEnergyCapacity6(controllerLink);
+  const storedEnergy = getStoredEnergy12(storageLink);
+  const destinationFreeCapacity = getFreeEnergyCapacity7(controllerLink);
   const amount = Math.min(storedEnergy, destinationFreeCapacity);
   if (amount <= 0) {
     return [];
@@ -18068,9 +18715,9 @@ function transferStorageLinkEnergy(room) {
   return [
     {
       amount,
-      destinationId: getObjectId5(controllerLink),
+      destinationId: getObjectId6(controllerLink),
       result: transferLinkEnergy2(storageLink, controllerLink, amount),
-      sourceId: getObjectId5(storageLink)
+      sourceId: getObjectId6(storageLink)
     }
   ];
 }
@@ -18089,41 +18736,41 @@ function buildEnergyDemandState(room) {
   };
 }
 function findSpawnExtensionRefillTargets(room) {
-  const structures = findOwnedStructures3(room).filter(
-    (structure) => (matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity6(structure) > 0
+  const structures = findOwnedStructures4(room).filter(
+    (structure) => (matchesStructureType14(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType14(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity7(structure) > 0
   );
   if (!isRoomSpawnExtensionEnergyLow(room, structures)) {
     return [];
   }
   return structures.map((target) => ({
-    freeCapacity: getFreeEnergyCapacity6(target),
-    id: getObjectId5(target),
+    freeCapacity: getFreeEnergyCapacity7(target),
+    id: getObjectId6(target),
     priority: 3,
     target
   }));
 }
 function findTowerRefillTargets(room) {
-  return findOwnedStructures3(room).filter(
-    (structure) => matchesStructureType13(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy10(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity6(structure) > 0
+  return findOwnedStructures4(room).filter(
+    (structure) => matchesStructureType14(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy12(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity7(structure) > 0
   ).map((target) => ({
-    freeCapacity: getFreeEnergyCapacity6(target),
-    id: getObjectId5(target),
+    freeCapacity: getFreeEnergyCapacity7(target),
+    id: getObjectId6(target),
     priority: 2,
     target
   }));
 }
 function findStorageLinkRefillTargets(room) {
   const { controllerLink, storageLink } = classifyLinks(room);
-  if (!controllerLink || !storageLink || getObjectId5(controllerLink) === getObjectId5(storageLink)) {
+  if (!controllerLink || !storageLink || getObjectId6(controllerLink) === getObjectId6(storageLink)) {
     return [];
   }
-  if (getFreeEnergyCapacity6(controllerLink) <= 0 || getFreeEnergyCapacity6(storageLink) <= 0) {
+  if (getFreeEnergyCapacity7(controllerLink) <= 0 || getFreeEnergyCapacity7(storageLink) <= 0) {
     return [];
   }
   return [
     {
-      freeCapacity: getFreeEnergyCapacity6(storageLink),
-      id: getObjectId5(storageLink),
+      freeCapacity: getFreeEnergyCapacity7(storageLink),
+      id: getObjectId6(storageLink),
       priority: 1,
       target: storageLink
     }
@@ -18138,16 +18785,16 @@ function isRoomSpawnExtensionEnergyLow(room, structures) {
   if (typeof energyAvailable === "number" && Number.isFinite(energyAvailable) && typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable)) {
     return energyAvailable < energyCapacityAvailable;
   }
-  return structures.some((structure) => getFreeEnergyCapacity6(structure) > 0);
+  return structures.some((structure) => getFreeEnergyCapacity7(structure) > 0);
 }
 function findStorageManagementWorkers(room, storage, demandState) {
-  const storageId = getObjectId5(storage);
+  const storageId = getObjectId6(storage);
   const demandTargetIds = new Set(demandState.targets.map((target) => target.id));
   return findMyCreeps2(room).filter((creep) => isEligibleStorageManagementWorker(creep, room.name)).filter((creep) => isAssignableStorageManagementWorker(creep, storageId, demandTargetIds)).sort(compareWorkers);
 }
 function reserveExistingAssignments(workers, storage, demandState, storageEnergy) {
   let projectedStorageEnergy = storageEnergy;
-  const storageId = getObjectId5(storage);
+  const storageId = getObjectId6(storage);
   for (const worker of workers) {
     const task = worker.memory.task;
     if ((task == null ? void 0 : task.type) === "transfer") {
@@ -18156,12 +18803,12 @@ function reserveExistingAssignments(workers, storage, demandState, storageEnergy
       if (typeof remainingCapacity === "number") {
         demandState.remainingCapacityById.set(
           targetId,
-          Math.max(0, remainingCapacity - getCarriedEnergy4(worker))
+          Math.max(0, remainingCapacity - getCarriedEnergy5(worker))
         );
       }
     }
     if ((task == null ? void 0 : task.type) === "withdraw" && String(task.targetId) === storageId) {
-      projectedStorageEnergy -= getFreeEnergyCapacity6(worker);
+      projectedStorageEnergy -= getFreeEnergyCapacity7(worker);
     }
   }
   return Math.max(0, projectedStorageEnergy);
@@ -18169,7 +18816,7 @@ function reserveExistingAssignments(workers, storage, demandState, storageEnergy
 function assignLoadedWorkers(workers, demandState) {
   let assignedTasks = 0;
   for (const worker of workers) {
-    const carriedEnergy = getCarriedEnergy4(worker);
+    const carriedEnergy = getCarriedEnergy5(worker);
     if (carriedEnergy <= 0) {
       continue;
     }
@@ -18192,13 +18839,13 @@ function assignStorageWithdrawals(room, workers, storage, demandState, initialPr
   let assignedTasks = 0;
   let projectedStorageEnergy = initialProjectedStorageEnergy;
   for (const worker of workers) {
-    if (!hasRemainingDemand(demandState) || getCarriedEnergy4(worker) > 0) {
+    if (!hasRemainingDemand(demandState) || getCarriedEnergy5(worker) > 0) {
       continue;
     }
     if (((_a = worker.memory.task) == null ? void 0 : _a.type) === "withdraw" && String(worker.memory.task.targetId) === String(storage.id)) {
       continue;
     }
-    const freeCapacity = getFreeEnergyCapacity6(worker);
+    const freeCapacity = getFreeEnergyCapacity7(worker);
     const withdrawableStorageEnergy = getStorageEnergyAvailableForWithdrawal(room, storage, projectedStorageEnergy);
     const plannedWithdrawal = Math.min(freeCapacity, projectedStorageEnergy);
     if (plannedWithdrawal <= 0 || plannedWithdrawal > withdrawableStorageEnergy || !withdrawFromStorage(room, plannedWithdrawal, storage, projectedStorageEnergy)) {
@@ -18304,11 +18951,11 @@ function getRoomStorage2(room) {
   if (room.storage) {
     return room.storage;
   }
-  return (_a = findOwnedStructures3(room).filter(
-    (structure) => matchesStructureType13(structure.structureType, "STRUCTURE_STORAGE", "storage")
+  return (_a = findOwnedStructures4(room).filter(
+    (structure) => matchesStructureType14(structure.structureType, "STRUCTURE_STORAGE", "storage")
   )[0]) != null ? _a : null;
 }
-function findOwnedStructures3(room) {
+function findOwnedStructures4(room) {
   if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
     return [];
   }
@@ -18322,29 +18969,29 @@ function findMyCreeps2(room) {
   const result = room.find(FIND_MY_CREEPS);
   return Array.isArray(result) ? result : [];
 }
-function getStoredEnergy10(target) {
+function getStoredEnergy12(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const storedEnergy = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource8());
+  const storedEnergy = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource10());
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
-function getFreeEnergyCapacity6(target) {
+function getFreeEnergyCapacity7(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource8());
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource10());
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
 }
-function getCarriedEnergy4(creep) {
-  return getStoredEnergy10(creep);
+function getCarriedEnergy5(creep) {
+  return getStoredEnergy12(creep);
 }
 function getLinkCooldown2(link) {
   return typeof link.cooldown === "number" && Number.isFinite(link.cooldown) ? link.cooldown : 0;
 }
-function getEnergyResource8() {
+function getEnergyResource10() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
-function getObjectId5(object) {
+function getObjectId6(object) {
   if (typeof object !== "object" || object === null) {
     return "";
   }
@@ -18354,651 +19001,10 @@ function getObjectId5(object) {
   }
   return typeof candidate.name === "string" ? candidate.name : "";
 }
-function matchesStructureType13(actual, globalName, fallback) {
-  var _a;
-  const constants = globalThis;
-  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
-}
-
-// src/economy/storageBalancer.ts
-var STORAGE_BALANCE_EXPORT_RATIO = 0.8;
-var STORAGE_BALANCE_IMPORT_RATIO = 0.3;
-var STORAGE_BALANCE_REFRESH_INTERVAL = 25;
-function balanceStorage() {
-  const memory = getEconomyMemory();
-  const gameTime = getGameTime12();
-  const existing = memory.storageBalance;
-  if (existing && isStorageBalanceFresh(existing, gameTime)) {
-    return;
-  }
-  memory.storageBalance = buildStorageBalanceState(gameTime);
-}
-function getStorageBalanceState() {
-  const memory = getEconomyMemory();
-  const gameTime = getGameTime12();
-  const existing = memory.storageBalance;
-  if (existing && isStorageBalanceFresh(existing, gameTime)) {
-    return existing;
-  }
-  const state = buildStorageBalanceState(gameTime);
-  memory.storageBalance = state;
-  return state;
-}
-function getRoomStoredEnergyState(room) {
-  const stores = getRoomEnergyStores(room);
-  const energy = stores.reduce((total, structure) => total + getStoredEnergy11(structure), 0);
-  const capacity = stores.reduce((total, structure) => total + getEnergyCapacity2(structure), 0);
-  const ratio = capacity > 0 ? energy / capacity : 0;
-  const exportableEnergy = capacity > 0 && ratio > STORAGE_BALANCE_EXPORT_RATIO ? Math.floor(energy - capacity * STORAGE_BALANCE_EXPORT_RATIO) : 0;
-  const importDemand = capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO ? Math.ceil(capacity * STORAGE_BALANCE_IMPORT_RATIO - energy) : 0;
-  return {
-    roomName: room.name,
-    energy,
-    capacity,
-    ratio,
-    exportableEnergy: Math.max(0, exportableEnergy),
-    importDemand: Math.max(0, importDemand),
-    mode: selectStorageBalanceMode(capacity, ratio)
-  };
-}
-function buildStorageBalanceState(gameTime) {
-  const roomStates = getOwnedRooms().map(getRoomStoredEnergyState).filter((state) => state.capacity > 0);
-  return {
-    updatedAt: gameTime,
-    rooms: Object.fromEntries(
-      roomStates.map((state) => [
-        state.roomName,
-        {
-          roomName: state.roomName,
-          mode: state.mode,
-          energy: state.energy,
-          capacity: state.capacity,
-          ratio: state.ratio,
-          exportableEnergy: state.exportableEnergy,
-          importDemand: state.importDemand,
-          updatedAt: gameTime
-        }
-      ])
-    ),
-    transfers: buildStorageTransfers(roomStates, gameTime)
-  };
-}
-function buildStorageTransfers(roomStates, gameTime) {
-  var _a;
-  const exporters = roomStates.filter((state) => state.mode === "export" && state.exportableEnergy > 0).sort(compareExportRooms);
-  const importers = roomStates.filter((state) => state.mode === "import" && state.importDemand > 0).sort(compareImportRooms);
-  const remainingExport = new Map(exporters.map((state) => [state.roomName, state.exportableEnergy]));
-  const transfers = [];
-  for (const importer of importers) {
-    let remainingDemand = importer.importDemand;
-    for (const exporter of exporters) {
-      if (remainingDemand <= 0) {
-        break;
-      }
-      const exportableEnergy = (_a = remainingExport.get(exporter.roomName)) != null ? _a : 0;
-      const amount = Math.min(exportableEnergy, remainingDemand);
-      if (amount <= 0) {
-        continue;
-      }
-      transfers.push({
-        sourceRoom: exporter.roomName,
-        targetRoom: importer.roomName,
-        amount,
-        updatedAt: gameTime
-      });
-      remainingExport.set(exporter.roomName, exportableEnergy - amount);
-      remainingDemand -= amount;
-    }
-  }
-  return transfers;
-}
-function compareExportRooms(left, right) {
-  return right.exportableEnergy - left.exportableEnergy || right.ratio - left.ratio || left.roomName.localeCompare(right.roomName);
-}
-function compareImportRooms(left, right) {
-  return right.importDemand - left.importDemand || left.ratio - right.ratio || left.roomName.localeCompare(right.roomName);
-}
-function selectStorageBalanceMode(capacity, ratio) {
-  if (capacity <= 0) {
-    return "balanced";
-  }
-  if (ratio > STORAGE_BALANCE_EXPORT_RATIO) {
-    return "export";
-  }
-  if (ratio < STORAGE_BALANCE_IMPORT_RATIO) {
-    return "import";
-  }
-  return "balanced";
-}
-function getRoomEnergyStores(room) {
-  const stores = [
-    room.storage,
-    room.terminal
-  ];
-  return stores.filter(
-    (structure) => structure !== void 0
-  );
-}
-function getStoredEnergy11(target) {
-  var _a;
-  const store = target.store;
-  const resource = getEnergyResource9();
-  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
-  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
-    return Math.max(0, usedCapacity);
-  }
-  const directEnergy = store == null ? void 0 : store[resource];
-  return typeof directEnergy === "number" && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
-}
-function getEnergyCapacity2(target) {
-  var _a, _b, _c;
-  const store = target.store;
-  const resource = getEnergyResource9();
-  const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, resource);
-  if (typeof capacity === "number" && Number.isFinite(capacity)) {
-    return Math.max(0, capacity);
-  }
-  const genericCapacity = (_b = store == null ? void 0 : store.getCapacity) == null ? void 0 : _b.call(store);
-  if (typeof genericCapacity === "number" && Number.isFinite(genericCapacity)) {
-    return Math.max(0, genericCapacity);
-  }
-  const freeCapacity = (_c = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _c.call(store, resource);
-  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? getStoredEnergy11(target) + Math.max(0, freeCapacity) : 0;
-}
-function isStorageBalanceFresh(state, gameTime) {
-  return typeof state.updatedAt === "number" && Number.isFinite(state.updatedAt) && gameTime >= state.updatedAt && gameTime - state.updatedAt < STORAGE_BALANCE_REFRESH_INTERVAL;
-}
-function getOwnedRooms() {
-  var _a;
-  const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
-  if (!rooms) {
-    return [];
-  }
-  return Object.values(rooms).filter((room) => {
-    var _a2;
-    return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
-  });
-}
-function getEconomyMemory() {
-  const memory = getMemory();
-  if (!memory.economy) {
-    memory.economy = {};
-  }
-  return memory.economy;
-}
-function getMemory() {
-  const global = globalThis;
-  if (!global.Memory) {
-    global.Memory = {};
-  }
-  return global.Memory;
-}
-function getGameTime12() {
-  var _a;
-  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
-  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
-}
-function getEnergyResource9() {
-  var _a;
-  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
-}
-
-// src/economy/crossRoomHauler.ts
-var CROSS_ROOM_HAULER_ROLE = "crossRoomHauler";
-var CARRY_MOVE_PAIR_COST = 100;
-var CARRY_CAPACITY_PER_PART2 = 50;
-var MAX_CARRY_MOVE_PAIRS = 25;
-var MIN_CARRY_MOVE_PAIRS = 1;
-var CROSS_ROOM_HAULER_REPLACEMENT_TICKS = 100;
-var CROSS_ROOM_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
-var ERR_NO_PATH_CODE6 = -2;
-var ERR_NOT_IN_RANGE_CODE6 = -9;
-function planCrossRoomHauler() {
-  const transfer = selectCrossRoomEnergyTransfer();
-  if (!transfer) {
-    return null;
-  }
-  const sourceRoom = getVisibleRoom6(transfer.sourceRoom);
-  const targetRoom = getVisibleRoom6(transfer.targetRoom);
-  if (!sourceRoom || !targetRoom) {
-    return null;
-  }
-  const source = selectSourceEnergyStructure(sourceRoom);
-  if (!source) {
-    return null;
-  }
-  const spawn = selectSourceRoomSpawn(sourceRoom.name);
-  if (!spawn) {
-    return null;
-  }
-  const sourceState = getRoomStoredEnergyState(sourceRoom);
-  const transferableEnergy = Math.min(transfer.amount, sourceState.exportableEnergy);
-  const body = buildCrossRoomHaulerBody(sourceRoom.energyAvailable, transferableEnergy);
-  if (body.length === 0) {
-    return null;
-  }
-  const route = findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name);
-  if (!route) {
-    return null;
-  }
-  return {
-    spawn,
-    body,
-    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime13()}`,
-    memory: {
-      role: CROSS_ROOM_HAULER_ROLE,
-      colony: sourceRoom.name,
-      crossRoomHauler: {
-        homeRoom: sourceRoom.name,
-        targetRoom: targetRoom.name,
-        sourceId: source.id,
-        state: "collecting",
-        route: route.rooms
-      }
-    }
-  };
-}
-function buildCrossRoomHaulerBody(energyAvailable, transferableEnergy) {
-  const energyBudget = Math.max(0, Math.floor(energyAvailable));
-  const energyScaledPairs = Math.ceil(Math.max(0, transferableEnergy) / CARRY_CAPACITY_PER_PART2);
-  const affordablePairs = Math.floor(energyBudget / CARRY_MOVE_PAIR_COST);
-  const pairCount = Math.min(
-    MAX_CARRY_MOVE_PAIRS,
-    affordablePairs,
-    Math.max(MIN_CARRY_MOVE_PAIRS, energyScaledPairs)
-  );
-  if (pairCount <= 0) {
-    return [];
-  }
-  return Array.from({ length: pairCount }).flatMap(() => ["carry", "move"]);
-}
-function runCrossRoomHauler(creep) {
-  const assignment = getMutableCrossRoomHaulerMemory(creep);
-  if (!assignment) {
-    return;
-  }
-  if (assignment.state === "returning") {
-    returnHome(creep, assignment);
-    return;
-  }
-  if (getCarriedEnergy5(creep) > 0) {
-    assignment.state = "delivering";
-    deliverEnergy2(creep, assignment);
-    return;
-  }
-  if (!hasSourceSurplusEnergy(assignment)) {
-    assignment.state = "returning";
-    returnHome(creep, assignment);
-    return;
-  }
-  assignment.state = "collecting";
-  collectEnergy(creep, assignment);
-}
-function selectCrossRoomEnergyTransfer() {
-  var _a;
-  const balance = getStorageBalanceState();
-  return (_a = balance.transfers.filter((transfer) => transfer.amount > 0).filter((transfer) => !hasActiveCrossRoomHauler(transfer)).filter((transfer) => isLiveTransferCandidate(transfer)).sort(compareTransfers)[0]) != null ? _a : null;
-}
-function isLiveTransferCandidate(transfer) {
-  const sourceRoom = getVisibleRoom6(transfer.sourceRoom);
-  const targetRoom = getVisibleRoom6(transfer.targetRoom);
-  if (!sourceRoom || !targetRoom) {
-    return false;
-  }
-  if (!isSafeOwnedRoom(sourceRoom.name) || !isSafeOwnedRoom(targetRoom.name)) {
-    return false;
-  }
-  const sourceState = getRoomStoredEnergyState(sourceRoom);
-  const targetState = getRoomStoredEnergyState(targetRoom);
-  if (sourceState.mode !== "export" || targetState.mode !== "import") {
-    return false;
-  }
-  return findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name) !== null;
-}
-function compareTransfers(left, right) {
-  var _a, _b, _c, _d;
-  const leftRouteDistance = (_b = (_a = findOwnedLogisticsRoute(left.sourceRoom, left.targetRoom)) == null ? void 0 : _a.distance) != null ? _b : Number.POSITIVE_INFINITY;
-  const rightRouteDistance = (_d = (_c = findOwnedLogisticsRoute(right.sourceRoom, right.targetRoom)) == null ? void 0 : _c.distance) != null ? _d : Number.POSITIVE_INFINITY;
-  return right.amount - left.amount || leftRouteDistance - rightRouteDistance || left.sourceRoom.localeCompare(right.sourceRoom) || left.targetRoom.localeCompare(right.targetRoom);
-}
-function hasActiveCrossRoomHauler(transfer) {
-  var _a;
-  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  if (!creeps) {
-    return false;
-  }
-  return Object.values(creeps).some((creep) => {
-    var _a2, _b;
-    const memory = normalizeCrossRoomHaulerMemory((_a2 = creep.memory) == null ? void 0 : _a2.crossRoomHauler);
-    return ((_b = creep.memory) == null ? void 0 : _b.role) === CROSS_ROOM_HAULER_ROLE && (memory == null ? void 0 : memory.homeRoom) === transfer.sourceRoom && memory.targetRoom === transfer.targetRoom && (creep.ticksToLive === void 0 || creep.ticksToLive > CROSS_ROOM_HAULER_REPLACEMENT_TICKS);
-  });
-}
-function collectEnergy(creep, assignment) {
-  var _a, _b;
-  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
-    delete creep.memory.task;
-    moveTowardRoom3(creep, assignment, assignment.homeRoom);
-    return;
-  }
-  const source = getObjectById3(assignment.sourceId);
-  if (!source || getStoredEnergy12(source) <= 0) {
-    delete creep.memory.task;
-    assignment.state = "returning";
-    returnHome(creep, assignment);
-    return;
-  }
-  const task = {
-    type: "withdraw",
-    targetId: assignment.sourceId
-  };
-  creep.memory.task = task;
-  const result = (_b = creep.withdraw) == null ? void 0 : _b.call(creep, source, getEnergyResource10());
-  if (result === getErrNotInRangeCode3()) {
-    moveTo3(creep, source);
-  }
-}
-function deliverEnergy2(creep, assignment) {
-  var _a, _b;
-  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
-    delete creep.memory.task;
-    moveTowardRoom3(creep, assignment, assignment.targetRoom);
-    return;
-  }
-  const target = selectDeliveryTarget(creep.room);
-  if (!target) {
-    delete creep.memory.task;
-    assignment.state = "returning";
-    returnHome(creep, assignment);
-    return;
-  }
-  const task = {
-    type: "transfer",
-    targetId: target.id
-  };
-  creep.memory.task = task;
-  const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, target, getEnergyResource10());
-  if (result === getErrNotInRangeCode3()) {
-    moveTo3(creep, target);
-  }
-}
-function returnHome(creep, assignment) {
-  var _a, _b;
-  if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
-    delete creep.memory.task;
-    moveTowardRoom3(creep, assignment, assignment.homeRoom);
-    return;
-  }
-  const carriedEnergy = getCarriedEnergy5(creep);
-  if (carriedEnergy > 0) {
-    const homeTarget = selectHomeReturnTarget(creep.room);
-    if (homeTarget) {
-      const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, homeTarget, getEnergyResource10());
-      if (result === getErrNotInRangeCode3()) {
-        moveTo3(creep, homeTarget);
-      }
-      return;
-    }
-  }
-  delete creep.memory.task;
-  assignment.state = hasSourceSurplusEnergy(assignment) ? "collecting" : "returning";
-}
-function selectDeliveryTarget(room) {
-  var _a;
-  const targets = [
-    ...findOwnedStructures4(room).filter(isSpawnOrExtensionWithDemand),
-    ...findRoomStructures2(room).filter(isContainerWithDemand)
-  ].sort(compareDeliveryTargets);
-  return (_a = targets[0]) != null ? _a : null;
-}
-function selectHomeReturnTarget(room) {
-  var _a;
-  const targets = [room.storage, room.terminal].filter(
-    (structure) => structure !== void 0 && getFreeEnergyCapacity7(structure) > 0
-  );
-  return (_a = targets.sort((left, right) => getObjectId6(left).localeCompare(getObjectId6(right)))[0]) != null ? _a : null;
-}
-function isSpawnOrExtensionWithDemand(structure) {
-  return (matchesStructureType14(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType14(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity7(structure) > 0;
-}
-function isContainerWithDemand(structure) {
-  return matchesStructureType14(structure.structureType, "STRUCTURE_CONTAINER", "container") && getFreeEnergyCapacity7(structure) > 0;
-}
-function compareDeliveryTargets(left, right) {
-  return getDeliveryPriority(right) - getDeliveryPriority(left) || getObjectId6(left).localeCompare(getObjectId6(right));
-}
-function getDeliveryPriority(target) {
-  if (matchesStructureType14(target.structureType, "STRUCTURE_SPAWN", "spawn")) {
-    return 3;
-  }
-  if (matchesStructureType14(target.structureType, "STRUCTURE_EXTENSION", "extension")) {
-    return 2;
-  }
-  return 1;
-}
-function selectSourceEnergyStructure(room) {
-  var _a;
-  return (_a = [room.storage, room.terminal].filter(
-    (structure) => structure !== void 0 && getStoredEnergy12(structure) > 0
-  ).sort((left, right) => getStoredEnergy12(right) - getStoredEnergy12(left) || getObjectId6(left).localeCompare(getObjectId6(right)))[0]) != null ? _a : null;
-}
-function hasSourceSurplusEnergy(assignment) {
-  const room = getVisibleRoom6(assignment.homeRoom);
-  if (!room) {
-    return false;
-  }
-  return getRoomStoredEnergyState(room).mode === "export" && getObjectById3(assignment.sourceId) !== null;
-}
-function selectSourceRoomSpawn(roomName) {
-  var _a, _b;
-  const spawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
-  if (!spawns) {
-    return null;
-  }
-  return (_b = Object.values(spawns).filter((spawn) => {
-    var _a2;
-    return ((_a2 = spawn.room) == null ? void 0 : _a2.name) === roomName && !spawn.spawning;
-  }).sort((left, right) => getSpawnEnergyScore(right) - getSpawnEnergyScore(left) || left.name.localeCompare(right.name))[0]) != null ? _b : null;
-}
-function getSpawnEnergyScore(spawn) {
-  const room = spawn.room;
-  return typeof (room == null ? void 0 : room.energyAvailable) === "number" && Number.isFinite(room.energyAvailable) ? room.energyAvailable : 0;
-}
-function findOwnedLogisticsRoute(fromRoom, targetRoom) {
-  var _a;
-  if (fromRoom === targetRoom) {
-    return { distance: 0, rooms: [] };
-  }
-  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
-  if (typeof (gameMap == null ? void 0 : gameMap.findRoute) !== "function") {
-    return null;
-  }
-  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
-    routeCallback: (roomName) => isSafeOwnedRoom(roomName) ? 1 : Infinity
-  });
-  if (route === getNoPathResultCode6() || !Array.isArray(route)) {
-    return null;
-  }
-  const rooms = route.map((step) => isRecord15(step) && typeof step.room === "string" ? step.room : null).filter((roomName) => typeof roomName === "string");
-  if (rooms.length !== route.length || !rooms.every(isSafeOwnedRoom)) {
-    return null;
-  }
-  return { distance: rooms.length, rooms };
-}
-function moveTowardRoom3(creep, assignment, destinationRoom) {
-  var _a, _b;
-  const route = getAssignmentRoute(assignment);
-  const nextRoom = route ? selectNextRouteRoom((_a = creep.room) == null ? void 0 : _a.name, assignment, destinationRoom, route) : destinationRoom;
-  const visibleController = (_b = getVisibleRoom6(nextRoom)) == null ? void 0 : _b.controller;
-  if (visibleController) {
-    moveTo3(creep, visibleController);
-    return;
-  }
-  const RoomPositionCtor = globalThis.RoomPosition;
-  if (typeof RoomPositionCtor === "function") {
-    moveTo3(creep, new RoomPositionCtor(25, 25, nextRoom));
-  }
-}
-function getAssignmentRoute(assignment) {
-  const route = findOwnedLogisticsRoute(assignment.homeRoom, assignment.targetRoom);
-  if (!route) {
-    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString14) : null;
-  }
-  assignment.route = route.rooms;
-  return route.rooms;
-}
-function selectNextRouteRoom(currentRoom, assignment, destinationRoom, route) {
-  var _a, _b, _c;
-  if (!currentRoom) {
-    return destinationRoom;
-  }
-  if (destinationRoom === assignment.targetRoom) {
-    if (currentRoom === assignment.homeRoom) {
-      return (_a = route[0]) != null ? _a : assignment.targetRoom;
-    }
-    const routeIndex2 = route.indexOf(currentRoom);
-    return routeIndex2 >= 0 ? (_b = route[routeIndex2 + 1]) != null ? _b : assignment.targetRoom : destinationRoom;
-  }
-  const routeIndex = route.indexOf(currentRoom);
-  if (routeIndex > 0) {
-    return (_c = route[routeIndex - 1]) != null ? _c : assignment.homeRoom;
-  }
-  return assignment.homeRoom;
-}
-function isSafeOwnedRoom(roomName) {
-  var _a;
-  const room = getVisibleRoom6(roomName);
-  return ((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && !hasHostilePresence(room);
-}
-function hasHostilePresence(room) {
-  const hostileCreepFind = getGlobalNumber8("FIND_HOSTILE_CREEPS");
-  if (typeof hostileCreepFind === "number" && typeof room.find === "function") {
-    const hostiles = room.find(hostileCreepFind);
-    if (Array.isArray(hostiles) && hostiles.length > 0) {
-      return true;
-    }
-  }
-  const hostileStructureFind = getGlobalNumber8("FIND_HOSTILE_STRUCTURES");
-  if (typeof hostileStructureFind === "number" && typeof room.find === "function") {
-    const hostiles = room.find(hostileStructureFind);
-    if (Array.isArray(hostiles) && hostiles.length > 0) {
-      return true;
-    }
-  }
-  return false;
-}
-function findOwnedStructures4(room) {
-  var _a, _b;
-  const findMyStructures = getGlobalNumber8("FIND_MY_STRUCTURES");
-  if (typeof findMyStructures !== "number" || typeof room.find !== "function") {
-    return Object.values((_b = (_a = globalThis.Game) == null ? void 0 : _a.spawns) != null ? _b : {}).filter(
-      (spawn) => {
-        var _a2;
-        return ((_a2 = spawn.room) == null ? void 0 : _a2.name) === room.name;
-      }
-    );
-  }
-  const structures = room.find(findMyStructures);
-  return Array.isArray(structures) ? structures : [];
-}
-function findRoomStructures2(room) {
-  const findStructures = getGlobalNumber8("FIND_STRUCTURES");
-  if (typeof findStructures !== "number" || typeof room.find !== "function") {
-    return [];
-  }
-  const structures = room.find(findStructures);
-  return Array.isArray(structures) ? structures : [];
-}
-function normalizeCrossRoomHaulerMemory(value) {
-  if (!isRecord15(value)) {
-    return null;
-  }
-  return isNonEmptyString14(value.homeRoom) && isNonEmptyString14(value.targetRoom) && isNonEmptyString14(value.sourceId) ? {
-    homeRoom: value.homeRoom,
-    targetRoom: value.targetRoom,
-    sourceId: value.sourceId,
-    ...value.state === "collecting" || value.state === "delivering" || value.state === "returning" ? { state: value.state } : {},
-    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString14) } : {}
-  } : null;
-}
-function getMutableCrossRoomHaulerMemory(creep) {
-  var _a;
-  const normalized = normalizeCrossRoomHaulerMemory((_a = creep.memory) == null ? void 0 : _a.crossRoomHauler);
-  if (!normalized) {
-    return null;
-  }
-  creep.memory.crossRoomHauler = normalized;
-  return creep.memory.crossRoomHauler;
-}
-function moveTo3(creep, target) {
-  var _a;
-  (_a = creep.moveTo) == null ? void 0 : _a.call(creep, target, CROSS_ROOM_MOVE_OPTS);
-}
-function getCarriedEnergy5(creep) {
-  return getStoredEnergy12(creep);
-}
-function getStoredEnergy12(target) {
-  var _a;
-  const store = target == null ? void 0 : target.store;
-  const resource = getEnergyResource10();
-  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, resource);
-  if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
-    return Math.max(0, usedCapacity);
-  }
-  const directEnergy = store == null ? void 0 : store[resource];
-  return typeof directEnergy === "number" && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
-}
-function getFreeEnergyCapacity7(target) {
-  var _a;
-  const store = target == null ? void 0 : target.store;
-  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource10());
-  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
-}
-function getObjectById3(id) {
-  var _a;
-  const getObjectById4 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  return typeof getObjectById4 === "function" ? getObjectById4(String(id)) : null;
-}
-function getVisibleRoom6(roomName) {
-  var _a, _b;
-  return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
-}
-function getGameTime13() {
-  var _a;
-  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
-  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
-}
-function getEnergyResource10() {
-  var _a;
-  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
-}
-function getErrNotInRangeCode3() {
-  var _a;
-  return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE6;
-}
-function getNoPathResultCode6() {
-  var _a;
-  return (_a = globalThis.ERR_NO_PATH) != null ? _a : ERR_NO_PATH_CODE6;
-}
-function getObjectId6(object) {
-  if (!isRecord15(object)) {
-    return "";
-  }
-  return typeof object.id === "string" ? object.id : typeof object.name === "string" ? object.name : "";
-}
 function matchesStructureType14(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
-}
-function getGlobalNumber8(name) {
-  const value = globalThis[name];
-  return typeof value === "number" ? value : void 0;
-}
-function isRecord15(value) {
-  return typeof value === "object" && value !== null;
-}
-function isNonEmptyString14(value) {
-  return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/claimExecutor.ts

--- a/prod/src/economy/crossRoomHauler.ts
+++ b/prod/src/economy/crossRoomHauler.ts
@@ -137,7 +137,7 @@ function selectCrossRoomEnergyTransfer(): EconomyStorageTransferMemory | null {
   );
 }
 
-function isLiveTransferCandidate(transfer: EconomyStorageTransferMemory): boolean {
+export function isLiveTransferCandidate(transfer: EconomyStorageTransferMemory): boolean {
   const sourceRoom = getVisibleRoom(transfer.sourceRoom);
   const targetRoom = getVisibleRoom(transfer.targetRoom);
   if (!sourceRoom || !targetRoom) {
@@ -368,7 +368,7 @@ function findOwnedLogisticsRoute(fromRoom: string, targetRoom: string): Logistic
   }
 
   const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
-    routeCallback: (roomName: string) => (isSafeOwnedRoom(roomName) ? 1 : Infinity)
+    routeCallback: (roomName: string) => (isSafeLogisticsTransitRoom(roomName) ? 1 : Infinity)
   });
   if (route === getNoPathResultCode() || !Array.isArray(route)) {
     return null;
@@ -377,7 +377,7 @@ function findOwnedLogisticsRoute(fromRoom: string, targetRoom: string): Logistic
   const rooms = route
     .map((step) => (isRecord(step) && typeof step.room === 'string' ? step.room : null))
     .filter((roomName): roomName is string => typeof roomName === 'string');
-  if (rooms.length !== route.length || !rooms.every(isSafeOwnedRoom)) {
+  if (rooms.length !== route.length || !rooms.every(isSafeLogisticsTransitRoom)) {
     return null;
   }
 
@@ -444,6 +444,19 @@ function selectNextRouteRoom(
 function isSafeOwnedRoom(roomName: string): boolean {
   const room = getVisibleRoom(roomName);
   return room?.controller?.my === true && !hasHostilePresence(room);
+}
+
+function isSafeLogisticsTransitRoom(roomName: string): boolean {
+  const room = getVisibleRoom(roomName);
+  if (!room) {
+    return true;
+  }
+
+  if (hasHostilePresence(room)) {
+    return false;
+  }
+
+  return room.controller?.owner === undefined || room.controller.my === true;
 }
 
 function hasHostilePresence(room: Room): boolean {

--- a/prod/src/economy/crossRoomHauler.ts
+++ b/prod/src/economy/crossRoomHauler.ts
@@ -112,7 +112,7 @@ export function runCrossRoomHauler(creep: Creep): void {
     return;
   }
 
-  if (assignment.state === 'returning') {
+  if (assignment.state === 'returning' && !isSourceUnassigned(assignment)) {
     returnHome(creep, assignment);
     return;
   }
@@ -120,6 +120,15 @@ export function runCrossRoomHauler(creep: Creep): void {
   if (getCarriedEnergy(creep) > 0) {
     assignment.state = 'delivering';
     deliverEnergy(creep, assignment);
+    return;
+  }
+
+  if (isSourceUnassigned(assignment) && !recoverSourceAssignment(creep, assignment)) {
+    return;
+  }
+
+  if (assignment.state === 'returning') {
+    returnHome(creep, assignment);
     return;
   }
 
@@ -202,18 +211,26 @@ function collectEnergy(creep: Creep, assignment: CreepCrossRoomHaulerMemory): vo
     return;
   }
 
-  const source = getObjectById<EnergySourceStructure>(assignment.sourceId);
+  let source = getAssignedSource(assignment);
   if (!source || getStoredEnergy(source) <= 0) {
+    source = selectReplacementSource(assignment, creep.room);
+  }
+
+  if (!source) {
     delete creep.memory.task;
-    delete (assignment as Partial<CreepCrossRoomHaulerMemory>).sourceId;
-    assignment.state = 'returning';
-    returnHome(creep, assignment);
+    markSourceUnassigned(assignment);
+    return;
+  }
+
+  const sourceId = assignment.sourceId;
+  if (!sourceId) {
+    markSourceUnassigned(assignment);
     return;
   }
 
   const task: Extract<CreepTaskMemory, { type: 'withdraw' }> = {
     type: 'withdraw',
-    targetId: assignment.sourceId
+    targetId: sourceId
   };
   creep.memory.task = task;
   const result = creep.withdraw?.(source, getEnergyResource());
@@ -268,7 +285,12 @@ function returnHome(creep: Creep, assignment: CreepCrossRoomHaulerMemory): void 
   }
 
   delete creep.memory.task;
-  assignment.state = hasSourceSurplusEnergy(assignment) ? 'collecting' : 'returning';
+  if (hasSourceSurplusEnergy(assignment)) {
+    assignment.state = 'collecting';
+    return;
+  }
+
+  assignment.state = isSourceUnassigned(assignment) ? 'unassigned' : 'returning';
 }
 
 function selectDeliveryTarget(room: Room): DeliveryTarget | null {
@@ -348,7 +370,55 @@ function hasSourceSurplusEnergy(assignment: CreepCrossRoomHaulerMemory): boolean
     return false;
   }
 
-  return getRoomStoredEnergyState(room).mode === 'export' && getObjectById<EnergySourceStructure>(assignment.sourceId) !== null;
+  let source = getAssignedSource(assignment);
+  if (!source || getStoredEnergy(source) <= 0) {
+    source = selectReplacementSource(assignment, room);
+  }
+
+  return getRoomStoredEnergyState(room).mode === 'export' && source !== null && getStoredEnergy(source) > 0;
+}
+
+function recoverSourceAssignment(creep: Creep, assignment: CreepCrossRoomHaulerMemory): boolean {
+  const homeRoom = getVisibleRoom(assignment.homeRoom);
+  const source = homeRoom ? selectReplacementSource(assignment, homeRoom) : null;
+  if (source) {
+    assignment.state = 'collecting';
+    return true;
+  }
+
+  delete creep.memory.task;
+  markSourceUnassigned(assignment);
+  if (creep.room?.name !== assignment.homeRoom) {
+    moveTowardRoom(creep, assignment, assignment.homeRoom);
+  }
+  return false;
+}
+
+function selectReplacementSource(
+  assignment: CreepCrossRoomHaulerMemory,
+  room: Room
+): EnergySourceStructure | null {
+  const source = selectSourceEnergyStructure(room);
+  if (!source) {
+    markSourceUnassigned(assignment);
+    return null;
+  }
+
+  assignment.sourceId = source.id as Id<AnyStoreStructure>;
+  return source;
+}
+
+function getAssignedSource(assignment: CreepCrossRoomHaulerMemory): EnergySourceStructure | null {
+  return assignment.sourceId ? getObjectById<EnergySourceStructure>(assignment.sourceId) : null;
+}
+
+function markSourceUnassigned(assignment: CreepCrossRoomHaulerMemory): void {
+  assignment.sourceId = null;
+  assignment.state = 'unassigned';
+}
+
+function isSourceUnassigned(assignment: CreepCrossRoomHaulerMemory): boolean {
+  return assignment.state === 'unassigned' || !assignment.sourceId;
 }
 
 function selectSourceRoomSpawn(roomName: string): StructureSpawn | null {
@@ -527,19 +597,32 @@ function normalizeCrossRoomHaulerMemory(value: unknown): CreepCrossRoomHaulerMem
     return null;
   }
 
-  return isNonEmptyString(value.homeRoom) &&
-    isNonEmptyString(value.targetRoom) &&
-    isNonEmptyString(value.sourceId)
-    ? {
-        homeRoom: value.homeRoom,
-        targetRoom: value.targetRoom,
-        sourceId: value.sourceId as Id<AnyStoreStructure>,
-        ...(value.state === 'collecting' || value.state === 'delivering' || value.state === 'returning'
-          ? { state: value.state }
-          : {}),
-        ...(Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString) } : {})
-      }
+  if (!isNonEmptyString(value.homeRoom) || !isNonEmptyString(value.targetRoom)) {
+    return null;
+  }
+
+  const sourceId = isNonEmptyString(value.sourceId)
+    ? (value.sourceId as Id<AnyStoreStructure>)
     : null;
+  const state =
+    value.state === 'collecting' ||
+    value.state === 'delivering' ||
+    value.state === 'returning' ||
+    value.state === 'unassigned'
+      ? value.state
+      : undefined;
+
+  return {
+    homeRoom: value.homeRoom,
+    targetRoom: value.targetRoom,
+    sourceId,
+    ...(state
+      ? { state: sourceId ? state : 'unassigned' }
+      : sourceId
+        ? {}
+        : { state: 'unassigned' }),
+    ...(Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString) } : {})
+  };
 }
 
 function getMutableCrossRoomHaulerMemory(creep: Creep): CreepCrossRoomHaulerMemory | null {

--- a/prod/src/economy/crossRoomHauler.ts
+++ b/prod/src/economy/crossRoomHauler.ts
@@ -16,12 +16,19 @@ const CROSS_ROOM_MOVE_OPTS: MoveToOpts = { reusePath: 20, ignoreRoads: false };
 const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 
-type DeliveryTarget = StructureSpawn | StructureExtension | StructureContainer;
+type DeliveryTarget =
+  | StructureSpawn
+  | StructureExtension
+  | StructureContainer
+  | StructureStorage
+  | StructureTerminal;
 type EnergySourceStructure = StructureStorage | StructureTerminal;
 type LogisticsStructureGlobal =
   | 'STRUCTURE_CONTAINER'
   | 'STRUCTURE_EXTENSION'
-  | 'STRUCTURE_SPAWN';
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_STORAGE'
+  | 'STRUCTURE_TERMINAL';
 
 interface LogisticsRoute {
   distance: number;
@@ -266,7 +273,8 @@ function returnHome(creep: Creep, assignment: CreepCrossRoomHaulerMemory): void 
 function selectDeliveryTarget(room: Room): DeliveryTarget | null {
   const targets = [
     ...findOwnedStructures(room).filter(isSpawnOrExtensionWithDemand),
-    ...findRoomStructures(room).filter(isContainerWithDemand)
+    ...findRoomStructures(room).filter(isContainerWithDemand),
+    ...[room.storage, room.terminal].filter(isStorageOrTerminalWithDemand)
   ].sort(compareDeliveryTargets);
 
   return targets[0] ?? null;
@@ -296,6 +304,10 @@ function isContainerWithDemand(structure: Structure): structure is StructureCont
   );
 }
 
+function isStorageOrTerminalWithDemand(structure: StructureStorage | StructureTerminal | undefined): structure is EnergySourceStructure {
+  return structure !== undefined && getFreeEnergyCapacity(structure) > 0;
+}
+
 function compareDeliveryTargets(left: DeliveryTarget, right: DeliveryTarget): number {
   return getDeliveryPriority(right) - getDeliveryPriority(left) || getObjectId(left).localeCompare(getObjectId(right));
 }
@@ -307,6 +319,14 @@ function getDeliveryPriority(target: DeliveryTarget): number {
 
   if (matchesStructureType(target.structureType, 'STRUCTURE_EXTENSION', 'extension')) {
     return 2;
+  }
+
+  if (matchesStructureType(target.structureType, 'STRUCTURE_STORAGE', 'storage')) {
+    return 0;
+  }
+
+  if (matchesStructureType(target.structureType, 'STRUCTURE_TERMINAL', 'terminal')) {
+    return -1;
   }
 
   return 1;

--- a/prod/src/economy/crossRoomHauler.ts
+++ b/prod/src/economy/crossRoomHauler.ts
@@ -1,0 +1,609 @@
+import type { SpawnRequest } from '../spawn/spawnPlanner';
+import {
+  getRoomStoredEnergyState,
+  getStorageBalanceState
+} from './storageBalancer';
+
+export const CROSS_ROOM_HAULER_ROLE = 'crossRoomHauler';
+export type SpawnPlan = SpawnRequest;
+
+const CARRY_MOVE_PAIR_COST = 100;
+const CARRY_CAPACITY_PER_PART = 50;
+const MAX_CARRY_MOVE_PAIRS = 25;
+const MIN_CARRY_MOVE_PAIRS = 1;
+const CROSS_ROOM_HAULER_REPLACEMENT_TICKS = 100;
+const CROSS_ROOM_MOVE_OPTS: MoveToOpts = { reusePath: 20, ignoreRoads: false };
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+
+type DeliveryTarget = StructureSpawn | StructureExtension | StructureContainer;
+type EnergySourceStructure = StructureStorage | StructureTerminal;
+type LogisticsStructureGlobal =
+  | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_SPAWN';
+
+interface LogisticsRoute {
+  distance: number;
+  rooms: string[];
+}
+
+export function planCrossRoomHauler(): SpawnPlan | null {
+  const transfer = selectCrossRoomEnergyTransfer();
+  if (!transfer) {
+    return null;
+  }
+
+  const sourceRoom = getVisibleRoom(transfer.sourceRoom);
+  const targetRoom = getVisibleRoom(transfer.targetRoom);
+  if (!sourceRoom || !targetRoom) {
+    return null;
+  }
+
+  const source = selectSourceEnergyStructure(sourceRoom);
+  if (!source) {
+    return null;
+  }
+
+  const spawn = selectSourceRoomSpawn(sourceRoom.name);
+  if (!spawn) {
+    return null;
+  }
+
+  const sourceState = getRoomStoredEnergyState(sourceRoom);
+  const transferableEnergy = Math.min(transfer.amount, sourceState.exportableEnergy);
+  const body = buildCrossRoomHaulerBody(sourceRoom.energyAvailable, transferableEnergy);
+  if (body.length === 0) {
+    return null;
+  }
+
+  const route = findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name);
+  if (!route) {
+    return null;
+  }
+
+  return {
+    spawn,
+    body,
+    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime()}`,
+    memory: {
+      role: CROSS_ROOM_HAULER_ROLE,
+      colony: sourceRoom.name,
+      crossRoomHauler: {
+        homeRoom: sourceRoom.name,
+        targetRoom: targetRoom.name,
+        sourceId: source.id as Id<AnyStoreStructure>,
+        state: 'collecting',
+        route: route.rooms
+      }
+    }
+  };
+}
+
+export function buildCrossRoomHaulerBody(
+  energyAvailable: number,
+  transferableEnergy: number
+): BodyPartConstant[] {
+  const energyBudget = Math.max(0, Math.floor(energyAvailable));
+  const energyScaledPairs = Math.ceil(Math.max(0, transferableEnergy) / CARRY_CAPACITY_PER_PART);
+  const affordablePairs = Math.floor(energyBudget / CARRY_MOVE_PAIR_COST);
+  const pairCount = Math.min(
+    MAX_CARRY_MOVE_PAIRS,
+    affordablePairs,
+    Math.max(MIN_CARRY_MOVE_PAIRS, energyScaledPairs)
+  );
+  if (pairCount <= 0) {
+    return [];
+  }
+
+  return Array.from({ length: pairCount }).flatMap(() => ['carry', 'move'] as BodyPartConstant[]);
+}
+
+export function runCrossRoomHauler(creep: Creep): void {
+  const assignment = getMutableCrossRoomHaulerMemory(creep);
+  if (!assignment) {
+    return;
+  }
+
+  if (assignment.state === 'returning') {
+    returnHome(creep, assignment);
+    return;
+  }
+
+  if (getCarriedEnergy(creep) > 0) {
+    assignment.state = 'delivering';
+    deliverEnergy(creep, assignment);
+    return;
+  }
+
+  if (!hasSourceSurplusEnergy(assignment)) {
+    assignment.state = 'returning';
+    returnHome(creep, assignment);
+    return;
+  }
+
+  assignment.state = 'collecting';
+  collectEnergy(creep, assignment);
+}
+
+function selectCrossRoomEnergyTransfer(): EconomyStorageTransferMemory | null {
+  const balance = getStorageBalanceState();
+  return (
+    balance.transfers
+      .filter((transfer) => transfer.amount > 0)
+      .filter((transfer) => !hasActiveCrossRoomHauler(transfer))
+      .filter((transfer) => isLiveTransferCandidate(transfer))
+      .sort(compareTransfers)[0] ?? null
+  );
+}
+
+function isLiveTransferCandidate(transfer: EconomyStorageTransferMemory): boolean {
+  const sourceRoom = getVisibleRoom(transfer.sourceRoom);
+  const targetRoom = getVisibleRoom(transfer.targetRoom);
+  if (!sourceRoom || !targetRoom) {
+    return false;
+  }
+
+  if (!isSafeOwnedRoom(sourceRoom.name) || !isSafeOwnedRoom(targetRoom.name)) {
+    return false;
+  }
+
+  const sourceState = getRoomStoredEnergyState(sourceRoom);
+  const targetState = getRoomStoredEnergyState(targetRoom);
+  if (sourceState.mode !== 'export' || targetState.mode !== 'import') {
+    return false;
+  }
+
+  return findOwnedLogisticsRoute(sourceRoom.name, targetRoom.name) !== null;
+}
+
+function compareTransfers(
+  left: EconomyStorageTransferMemory,
+  right: EconomyStorageTransferMemory
+): number {
+  const leftRouteDistance = findOwnedLogisticsRoute(left.sourceRoom, left.targetRoom)?.distance ?? Number.POSITIVE_INFINITY;
+  const rightRouteDistance = findOwnedLogisticsRoute(right.sourceRoom, right.targetRoom)?.distance ?? Number.POSITIVE_INFINITY;
+  return (
+    right.amount - left.amount ||
+    leftRouteDistance - rightRouteDistance ||
+    left.sourceRoom.localeCompare(right.sourceRoom) ||
+    left.targetRoom.localeCompare(right.targetRoom)
+  );
+}
+
+function hasActiveCrossRoomHauler(transfer: EconomyStorageTransferMemory): boolean {
+  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  if (!creeps) {
+    return false;
+  }
+
+  return Object.values(creeps).some((creep) => {
+    const memory = normalizeCrossRoomHaulerMemory(creep.memory?.crossRoomHauler);
+    return (
+      creep.memory?.role === CROSS_ROOM_HAULER_ROLE &&
+      memory?.homeRoom === transfer.sourceRoom &&
+      memory.targetRoom === transfer.targetRoom &&
+      (creep.ticksToLive === undefined || creep.ticksToLive > CROSS_ROOM_HAULER_REPLACEMENT_TICKS)
+    );
+  });
+}
+
+function collectEnergy(creep: Creep, assignment: CreepCrossRoomHaulerMemory): void {
+  if (creep.room?.name !== assignment.homeRoom) {
+    delete creep.memory.task;
+    moveTowardRoom(creep, assignment, assignment.homeRoom);
+    return;
+  }
+
+  const source = getObjectById<EnergySourceStructure>(assignment.sourceId);
+  if (!source || getStoredEnergy(source) <= 0) {
+    delete creep.memory.task;
+    assignment.state = 'returning';
+    returnHome(creep, assignment);
+    return;
+  }
+
+  const task: Extract<CreepTaskMemory, { type: 'withdraw' }> = {
+    type: 'withdraw',
+    targetId: assignment.sourceId
+  };
+  creep.memory.task = task;
+  const result = creep.withdraw?.(source, getEnergyResource());
+  if (result === getErrNotInRangeCode()) {
+    moveTo(creep, source);
+  }
+}
+
+function deliverEnergy(creep: Creep, assignment: CreepCrossRoomHaulerMemory): void {
+  if (creep.room?.name !== assignment.targetRoom) {
+    delete creep.memory.task;
+    moveTowardRoom(creep, assignment, assignment.targetRoom);
+    return;
+  }
+
+  const target = selectDeliveryTarget(creep.room);
+  if (!target) {
+    delete creep.memory.task;
+    assignment.state = 'returning';
+    returnHome(creep, assignment);
+    return;
+  }
+
+  const task: Extract<CreepTaskMemory, { type: 'transfer' }> = {
+    type: 'transfer',
+    targetId: target.id as Id<AnyStoreStructure>
+  };
+  creep.memory.task = task;
+  const result = creep.transfer?.(target, getEnergyResource());
+  if (result === getErrNotInRangeCode()) {
+    moveTo(creep, target);
+  }
+}
+
+function returnHome(creep: Creep, assignment: CreepCrossRoomHaulerMemory): void {
+  if (creep.room?.name !== assignment.homeRoom) {
+    delete creep.memory.task;
+    moveTowardRoom(creep, assignment, assignment.homeRoom);
+    return;
+  }
+
+  const carriedEnergy = getCarriedEnergy(creep);
+  if (carriedEnergy > 0) {
+    const homeTarget = selectHomeReturnTarget(creep.room);
+    if (homeTarget) {
+      const result = creep.transfer?.(homeTarget, getEnergyResource());
+      if (result === getErrNotInRangeCode()) {
+        moveTo(creep, homeTarget);
+      }
+      return;
+    }
+  }
+
+  delete creep.memory.task;
+  assignment.state = hasSourceSurplusEnergy(assignment) ? 'collecting' : 'returning';
+}
+
+function selectDeliveryTarget(room: Room): DeliveryTarget | null {
+  const targets = [
+    ...findOwnedStructures(room).filter(isSpawnOrExtensionWithDemand),
+    ...findRoomStructures(room).filter(isContainerWithDemand)
+  ].sort(compareDeliveryTargets);
+
+  return targets[0] ?? null;
+}
+
+function selectHomeReturnTarget(room: Room): EnergySourceStructure | null {
+  const targets = [room.storage, room.terminal].filter(
+    (structure): structure is EnergySourceStructure =>
+      structure !== undefined && getFreeEnergyCapacity(structure) > 0
+  );
+
+  return targets.sort((left, right) => getObjectId(left).localeCompare(getObjectId(right)))[0] ?? null;
+}
+
+function isSpawnOrExtensionWithDemand(structure: AnyOwnedStructure): structure is StructureSpawn | StructureExtension {
+  return (
+    (matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+      matchesStructureType(structure.structureType, 'STRUCTURE_EXTENSION', 'extension')) &&
+    getFreeEnergyCapacity(structure) > 0
+  );
+}
+
+function isContainerWithDemand(structure: Structure): structure is StructureContainer {
+  return (
+    matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container') &&
+    getFreeEnergyCapacity(structure) > 0
+  );
+}
+
+function compareDeliveryTargets(left: DeliveryTarget, right: DeliveryTarget): number {
+  return getDeliveryPriority(right) - getDeliveryPriority(left) || getObjectId(left).localeCompare(getObjectId(right));
+}
+
+function getDeliveryPriority(target: DeliveryTarget): number {
+  if (matchesStructureType(target.structureType, 'STRUCTURE_SPAWN', 'spawn')) {
+    return 3;
+  }
+
+  if (matchesStructureType(target.structureType, 'STRUCTURE_EXTENSION', 'extension')) {
+    return 2;
+  }
+
+  return 1;
+}
+
+function selectSourceEnergyStructure(room: Room): EnergySourceStructure | null {
+  return [room.storage, room.terminal]
+    .filter(
+      (structure): structure is EnergySourceStructure =>
+        structure !== undefined && getStoredEnergy(structure) > 0
+    )
+    .sort((left, right) => getStoredEnergy(right) - getStoredEnergy(left) || getObjectId(left).localeCompare(getObjectId(right)))[0] ?? null;
+}
+
+function hasSourceSurplusEnergy(assignment: CreepCrossRoomHaulerMemory): boolean {
+  const room = getVisibleRoom(assignment.homeRoom);
+  if (!room) {
+    return false;
+  }
+
+  return getRoomStoredEnergyState(room).mode === 'export' && getObjectById<EnergySourceStructure>(assignment.sourceId) !== null;
+}
+
+function selectSourceRoomSpawn(roomName: string): StructureSpawn | null {
+  const spawns = (globalThis as { Game?: Partial<Pick<Game, 'spawns'>> }).Game?.spawns;
+  if (!spawns) {
+    return null;
+  }
+
+  return Object.values(spawns)
+    .filter((spawn) => spawn.room?.name === roomName && !spawn.spawning)
+    .sort((left, right) => getSpawnEnergyScore(right) - getSpawnEnergyScore(left) || left.name.localeCompare(right.name))[0] ?? null;
+}
+
+function getSpawnEnergyScore(spawn: StructureSpawn): number {
+  const room = spawn.room;
+  return typeof room?.energyAvailable === 'number' && Number.isFinite(room.energyAvailable)
+    ? room.energyAvailable
+    : 0;
+}
+
+function findOwnedLogisticsRoute(fromRoom: string, targetRoom: string): LogisticsRoute | null {
+  if (fromRoom === targetRoom) {
+    return { distance: 0, rooms: [] };
+  }
+
+  const gameMap = (globalThis as { Game?: Partial<Pick<Game, 'map'>> }).Game?.map as
+    | (Partial<GameMap> & {
+        findRoute?: (
+          fromRoom: string,
+          toRoom: string,
+          opts?: { routeCallback?: (roomName: string, fromRoomName: string) => number }
+        ) => unknown;
+      })
+    | undefined;
+
+  if (typeof gameMap?.findRoute !== 'function') {
+    return null;
+  }
+
+  const route = gameMap.findRoute.call(gameMap, fromRoom, targetRoom, {
+    routeCallback: (roomName: string) => (isSafeOwnedRoom(roomName) ? 1 : Infinity)
+  });
+  if (route === getNoPathResultCode() || !Array.isArray(route)) {
+    return null;
+  }
+
+  const rooms = route
+    .map((step) => (isRecord(step) && typeof step.room === 'string' ? step.room : null))
+    .filter((roomName): roomName is string => typeof roomName === 'string');
+  if (rooms.length !== route.length || !rooms.every(isSafeOwnedRoom)) {
+    return null;
+  }
+
+  return { distance: rooms.length, rooms };
+}
+
+function moveTowardRoom(
+  creep: Creep,
+  assignment: CreepCrossRoomHaulerMemory,
+  destinationRoom: string
+): void {
+  const route = getAssignmentRoute(assignment);
+  const nextRoom = route ? selectNextRouteRoom(creep.room?.name, assignment, destinationRoom, route) : destinationRoom;
+  const visibleController = getVisibleRoom(nextRoom)?.controller;
+  if (visibleController) {
+    moveTo(creep, visibleController);
+    return;
+  }
+
+  const RoomPositionCtor = (globalThis as { RoomPosition?: new (x: number, y: number, roomName: string) => RoomPosition })
+    .RoomPosition;
+  if (typeof RoomPositionCtor === 'function') {
+    moveTo(creep, new RoomPositionCtor(25, 25, nextRoom));
+  }
+}
+
+function getAssignmentRoute(assignment: CreepCrossRoomHaulerMemory): string[] | null {
+  const route = findOwnedLogisticsRoute(assignment.homeRoom, assignment.targetRoom);
+  if (!route) {
+    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString) : null;
+  }
+
+  assignment.route = route.rooms;
+  return route.rooms;
+}
+
+function selectNextRouteRoom(
+  currentRoom: string | undefined,
+  assignment: CreepCrossRoomHaulerMemory,
+  destinationRoom: string,
+  route: string[]
+): string {
+  if (!currentRoom) {
+    return destinationRoom;
+  }
+
+  if (destinationRoom === assignment.targetRoom) {
+    if (currentRoom === assignment.homeRoom) {
+      return route[0] ?? assignment.targetRoom;
+    }
+
+    const routeIndex = route.indexOf(currentRoom);
+    return routeIndex >= 0 ? route[routeIndex + 1] ?? assignment.targetRoom : destinationRoom;
+  }
+
+  const routeIndex = route.indexOf(currentRoom);
+  if (routeIndex > 0) {
+    return route[routeIndex - 1] ?? assignment.homeRoom;
+  }
+
+  return assignment.homeRoom;
+}
+
+function isSafeOwnedRoom(roomName: string): boolean {
+  const room = getVisibleRoom(roomName);
+  return room?.controller?.my === true && !hasHostilePresence(room);
+}
+
+function hasHostilePresence(room: Room): boolean {
+  const hostileCreepFind = getGlobalNumber('FIND_HOSTILE_CREEPS');
+  if (typeof hostileCreepFind === 'number' && typeof room.find === 'function') {
+    const hostiles = room.find(hostileCreepFind as FindConstant);
+    if (Array.isArray(hostiles) && hostiles.length > 0) {
+      return true;
+    }
+  }
+
+  const hostileStructureFind = getGlobalNumber('FIND_HOSTILE_STRUCTURES');
+  if (typeof hostileStructureFind === 'number' && typeof room.find === 'function') {
+    const hostiles = room.find(hostileStructureFind as FindConstant);
+    if (Array.isArray(hostiles) && hostiles.length > 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function findOwnedStructures(room: Room): AnyOwnedStructure[] {
+  const findMyStructures = getGlobalNumber('FIND_MY_STRUCTURES');
+  if (typeof findMyStructures !== 'number' || typeof room.find !== 'function') {
+    return Object.values((globalThis as { Game?: Partial<Pick<Game, 'spawns'>> }).Game?.spawns ?? {}).filter(
+      (spawn) => spawn.room?.name === room.name
+    ) as AnyOwnedStructure[];
+  }
+
+  const structures = room.find(findMyStructures as FindConstant);
+  return Array.isArray(structures) ? (structures as AnyOwnedStructure[]) : [];
+}
+
+function findRoomStructures(room: Room): Structure[] {
+  const findStructures = getGlobalNumber('FIND_STRUCTURES');
+  if (typeof findStructures !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  const structures = room.find(findStructures as FindConstant);
+  return Array.isArray(structures) ? (structures as Structure[]) : [];
+}
+
+function normalizeCrossRoomHaulerMemory(value: unknown): CreepCrossRoomHaulerMemory | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return isNonEmptyString(value.homeRoom) &&
+    isNonEmptyString(value.targetRoom) &&
+    isNonEmptyString(value.sourceId)
+    ? {
+        homeRoom: value.homeRoom,
+        targetRoom: value.targetRoom,
+        sourceId: value.sourceId as Id<AnyStoreStructure>,
+        ...(value.state === 'collecting' || value.state === 'delivering' || value.state === 'returning'
+          ? { state: value.state }
+          : {}),
+        ...(Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString) } : {})
+      }
+    : null;
+}
+
+function getMutableCrossRoomHaulerMemory(creep: Creep): CreepCrossRoomHaulerMemory | null {
+  const normalized = normalizeCrossRoomHaulerMemory(creep.memory?.crossRoomHauler);
+  if (!normalized) {
+    return null;
+  }
+
+  creep.memory.crossRoomHauler = normalized;
+  return creep.memory.crossRoomHauler;
+}
+
+function moveTo(creep: Creep, target: RoomObject | RoomPosition): void {
+  creep.moveTo?.(target, CROSS_ROOM_MOVE_OPTS);
+}
+
+function getCarriedEnergy(creep: Creep): number {
+  return getStoredEnergy(creep);
+}
+
+function getStoredEnergy(target: unknown): number {
+  const store = (target as { store?: { getUsedCapacity?: (resource?: ResourceConstant) => number | null; [resource: string]: unknown } } | null)
+    ?.store;
+  const resource = getEnergyResource();
+  const usedCapacity = store?.getUsedCapacity?.(resource);
+  if (typeof usedCapacity === 'number' && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+
+  const directEnergy = store?.[resource];
+  return typeof directEnergy === 'number' && Number.isFinite(directEnergy) ? Math.max(0, directEnergy) : 0;
+}
+
+function getFreeEnergyCapacity(target: unknown): number {
+  const store = (target as { store?: { getFreeCapacity?: (resource?: ResourceConstant) => number | null } } | null)
+    ?.store;
+  const freeCapacity = store?.getFreeCapacity?.(getEnergyResource());
+  return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+
+function getObjectById<T>(id: string): T | null {
+  const getObjectById = (globalThis as { Game?: Partial<Pick<Game, 'getObjectById'>> }).Game?.getObjectById as
+    | ((id: string) => T | null)
+    | undefined;
+  return typeof getObjectById === 'function' ? getObjectById(String(id)) : null;
+}
+
+function getVisibleRoom(roomName: string): Room | undefined {
+  return (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName];
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Pick<Game, 'time'>> }).Game?.time;
+  return typeof gameTime === 'number' && Number.isFinite(gameTime) ? gameTime : 0;
+}
+
+function getEnergyResource(): ResourceConstant {
+  return ((globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
+}
+
+function getErrNotInRangeCode(): ScreepsReturnCode {
+  return (globalThis as { ERR_NOT_IN_RANGE?: ScreepsReturnCode }).ERR_NOT_IN_RANGE ?? ERR_NOT_IN_RANGE_CODE;
+}
+
+function getNoPathResultCode(): ScreepsReturnCode {
+  return (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH ?? ERR_NO_PATH_CODE;
+}
+
+function getObjectId(object: unknown): string {
+  if (!isRecord(object)) {
+    return '';
+  }
+
+  return typeof object.id === 'string'
+    ? object.id
+    : typeof object.name === 'string'
+      ? object.name
+      : '';
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: LogisticsStructureGlobal,
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<Record<LogisticsStructureGlobal, string>>;
+  return actual === (constants[globalName] ?? fallback);
+}
+
+function getGlobalNumber(name: string): number | undefined {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/prod/src/economy/crossRoomHauler.ts
+++ b/prod/src/economy/crossRoomHauler.ts
@@ -205,6 +205,7 @@ function collectEnergy(creep: Creep, assignment: CreepCrossRoomHaulerMemory): vo
   const source = getObjectById<EnergySourceStructure>(assignment.sourceId);
   if (!source || getStoredEnergy(source) <= 0) {
     delete creep.memory.task;
+    delete (assignment as Partial<CreepCrossRoomHaulerMemory>).sourceId;
     assignment.state = 'returning';
     returnHome(creep, assignment);
     return;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -14,7 +14,12 @@ import { runWorker } from '../creeps/workerRunner';
 import { HAULER_ROLE, runHauler } from '../creeps/hauler';
 import { REMOTE_HARVESTER_ROLE, runRemoteHarvester } from '../creeps/remoteHarvester';
 import { getBodyCost, TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS } from '../spawn/bodyBuilder';
-import { planSpawn, type SpawnPlanningOptions, type SpawnRequest } from '../spawn/spawnPlanner';
+import {
+  orderColoniesForSpawnPlanning,
+  planSpawn,
+  type SpawnPlanningOptions,
+  type SpawnRequest
+} from '../spawn/spawnPlanner';
 import {
   RUNTIME_SUMMARY_INTERVAL,
   emitRuntimeSummary,
@@ -24,6 +29,12 @@ import {
 import { recordSourceWorkloads } from './sourceWorkload';
 import { transferEnergy as transferLinkEnergy } from './linkManager';
 import { manageStorage } from './storageManager';
+import { balanceStorage } from './storageBalancer';
+import {
+  CROSS_ROOM_HAULER_ROLE,
+  planCrossRoomHauler,
+  runCrossRoomHauler
+} from './crossRoomHauler';
 import {
   buildRuntimeOccupationRecommendationReport,
   clearOccupationRecommendationClaimIntent,
@@ -86,9 +97,13 @@ interface SpawnAttemptOutcome {
 
 export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = []): RuntimeSummary | undefined {
   const creeps = Object.values(Game.creeps);
-  const colonies = getOwnedColonies();
+  balanceStorage();
+  const colonies = orderColoniesForSpawnPlanning(getOwnedColonies());
   const telemetryEvents: RuntimeTelemetryEvent[] = [...preludeTelemetryEvents];
+  const usedSpawnsByRoom = new Map<string, Set<StructureSpawn>>();
+  const reservedSpawnEnergyByRoom = new Map<string, number>();
   clearColonySurvivalAssessmentCache();
+  attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
 
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
@@ -107,9 +122,9 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       roleCounts,
       Game.time
     );
-    let availableEnergy = colony.energyAvailable;
+    let availableEnergy = Math.max(0, colony.energyAvailable - (reservedSpawnEnergyByRoom.get(colony.room.name) ?? 0));
     let successfulSpawnCount = 0;
-    const usedSpawns = new Set<StructureSpawn>();
+    const usedSpawns = new Set<StructureSpawn>(usedSpawnsByRoom.get(colony.room.name) ?? []);
 
     while (true) {
       const planningColony = createSpawnPlanningColony(colony, availableEnergy, usedSpawns);
@@ -165,6 +180,8 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       runRemoteHarvester(creep);
     } else if (creep.memory.role === HAULER_ROLE) {
       runHauler(creep);
+    } else if (creep.memory.role === CROSS_ROOM_HAULER_ROLE) {
+      runCrossRoomHauler(creep);
     } else if (creep.memory.role === TERRITORY_CLAIMER_ROLE) {
       runClaimer(creep, telemetryEvents);
     } else if (creep.memory.role === TERRITORY_SCOUT_ROLE) {
@@ -207,6 +224,37 @@ function recordStrategyRecommendationTelemetry(
 
 function shouldRecordStrategyRecommendationTelemetry(gameTime: number): boolean {
   return gameTime > 0 && gameTime % RUNTIME_SUMMARY_INTERVAL === 0;
+}
+
+function attemptCrossRoomHaulerSpawn(
+  colonies: ColonySnapshot[],
+  telemetryEvents: RuntimeTelemetryEvent[],
+  usedSpawnsByRoom: Map<string, Set<StructureSpawn>>,
+  reservedSpawnEnergyByRoom: Map<string, number>
+): void {
+  const spawnRequest = planCrossRoomHauler();
+  if (!spawnRequest) {
+    return;
+  }
+
+  const sourceRoomName = spawnRequest.spawn.room.name;
+  const sourceColony = colonies.find((colony) => colony.room.name === sourceRoomName);
+  const candidateSpawns = sourceColony?.spawns ?? [spawnRequest.spawn];
+  const outcome = attemptSpawnRequest(
+    spawnRequest,
+    sourceRoomName,
+    telemetryEvents,
+    candidateSpawns
+  );
+  if (!outcome || outcome.result !== OK_CODE) {
+    return;
+  }
+
+  recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
+  reservedSpawnEnergyByRoom.set(
+    sourceRoomName,
+    (reservedSpawnEnergyByRoom.get(sourceRoomName) ?? 0) + getBodyCost(spawnRequest.body)
+  );
 }
 
 function planCriticalConstructionSites(
@@ -586,6 +634,16 @@ function addPlannedWorker(roleCounts: RoleCounts): RoleCounts {
   }
 
   return nextRoleCounts;
+}
+
+function recordUsedSpawn(
+  usedSpawnsByRoom: Map<string, Set<StructureSpawn>>,
+  roomName: string,
+  spawn: StructureSpawn
+): void {
+  const usedSpawns = usedSpawnsByRoom.get(roomName) ?? new Set<StructureSpawn>();
+  usedSpawns.add(spawn);
+  usedSpawnsByRoom.set(roomName, usedSpawns);
 }
 
 function getSpawnAttemptOrder(spawnRequest: SpawnRequest, spawns: StructureSpawn[]): StructureSpawn[] {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -103,7 +103,6 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   const usedSpawnsByRoom = new Map<string, Set<StructureSpawn>>();
   const reservedSpawnEnergyByRoom = new Map<string, number>();
   clearColonySurvivalAssessmentCache();
-  attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
 
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
@@ -153,7 +152,10 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       }
 
       usedSpawns.add(outcome.spawn);
-      availableEnergy = Math.max(0, availableEnergy - getBodyCost(spawnRequest.body));
+      const bodyCost = getBodyCost(spawnRequest.body);
+      recordUsedSpawn(usedSpawnsByRoom, colony.room.name, outcome.spawn);
+      recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, colony.room.name, bodyCost);
+      availableEnergy = Math.max(0, availableEnergy - bodyCost);
       successfulSpawnCount += 1;
       recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
 
@@ -172,6 +174,8 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
     manageStorage(colony.room);
     recordStrategyRecommendationTelemetry(colony, creeps, telemetryEvents);
   }
+
+  attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom, reservedSpawnEnergyByRoom);
 
   for (const creep of creeps) {
     if (creep.memory.role === 'worker') {
@@ -239,9 +243,25 @@ function attemptCrossRoomHaulerSpawn(
 
   const sourceRoomName = spawnRequest.spawn.room.name;
   const sourceColony = colonies.find((colony) => colony.room.name === sourceRoomName);
-  const candidateSpawns = sourceColony?.spawns ?? [spawnRequest.spawn];
+  const usedSpawns = usedSpawnsByRoom.get(sourceRoomName) ?? new Set<StructureSpawn>();
+  const candidateSpawns = (sourceColony?.spawns ?? [spawnRequest.spawn])
+    .filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn));
+  if (candidateSpawns.length === 0) {
+    return;
+  }
+
+  if (
+    getBodyCost(spawnRequest.body) >
+    getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom)
+  ) {
+    return;
+  }
+
+  const request = candidateSpawns.includes(spawnRequest.spawn)
+    ? spawnRequest
+    : { ...spawnRequest, spawn: candidateSpawns[0] };
   const outcome = attemptSpawnRequest(
-    spawnRequest,
+    request,
     sourceRoomName,
     telemetryEvents,
     candidateSpawns
@@ -251,10 +271,17 @@ function attemptCrossRoomHaulerSpawn(
   }
 
   recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
-  reservedSpawnEnergyByRoom.set(
-    sourceRoomName,
-    (reservedSpawnEnergyByRoom.get(sourceRoomName) ?? 0) + getBodyCost(spawnRequest.body)
-  );
+  recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, sourceRoomName, getBodyCost(spawnRequest.body));
+}
+
+function getAvailableSpawnEnergyAfterReservations(
+  sourceColony: ColonySnapshot | undefined,
+  spawnRequest: SpawnRequest,
+  reservedSpawnEnergyByRoom: Map<string, number>
+): number {
+  const sourceRoomName = spawnRequest.spawn.room.name;
+  const roomEnergy = sourceColony?.energyAvailable ?? spawnRequest.spawn.room.energyAvailable;
+  return Math.max(0, roomEnergy - (reservedSpawnEnergyByRoom.get(sourceRoomName) ?? 0));
 }
 
 function planCriticalConstructionSites(
@@ -644,6 +671,17 @@ function recordUsedSpawn(
   const usedSpawns = usedSpawnsByRoom.get(roomName) ?? new Set<StructureSpawn>();
   usedSpawns.add(spawn);
   usedSpawnsByRoom.set(roomName, usedSpawns);
+}
+
+function recordReservedSpawnEnergy(
+  reservedSpawnEnergyByRoom: Map<string, number>,
+  roomName: string,
+  bodyCost: number
+): void {
+  reservedSpawnEnergyByRoom.set(
+    roomName,
+    (reservedSpawnEnergyByRoom.get(roomName) ?? 0) + bodyCost
+  );
 }
 
 function getSpawnAttemptOrder(spawnRequest: SpawnRequest, spawns: StructureSpawn[]): StructureSpawn[] {

--- a/prod/src/economy/storageBalancer.ts
+++ b/prod/src/economy/storageBalancer.ts
@@ -1,0 +1,264 @@
+export const STORAGE_BALANCE_EXPORT_RATIO = 0.8;
+export const STORAGE_BALANCE_IMPORT_RATIO = 0.3;
+export const STORAGE_BALANCE_REFRESH_INTERVAL = 25;
+
+export interface RoomStoredEnergyState {
+  roomName: string;
+  energy: number;
+  capacity: number;
+  ratio: number;
+  exportableEnergy: number;
+  importDemand: number;
+  mode: EconomyStorageBalanceMode;
+}
+
+interface RoomEnergyStore {
+  store?: {
+    getUsedCapacity?: (resource?: ResourceConstant) => number | null;
+    getCapacity?: (resource?: ResourceConstant) => number | null;
+    getFreeCapacity?: (resource?: ResourceConstant) => number | null;
+    [resource: string]: unknown;
+  };
+}
+
+export function balanceStorage(): void {
+  const memory = getEconomyMemory();
+  const gameTime = getGameTime();
+  const existing = memory.storageBalance;
+  if (existing && isStorageBalanceFresh(existing, gameTime)) {
+    return;
+  }
+
+  memory.storageBalance = buildStorageBalanceState(gameTime);
+}
+
+export function getStorageBalanceState(): EconomyStorageBalanceMemory {
+  const memory = getEconomyMemory();
+  const gameTime = getGameTime();
+  const existing = memory.storageBalance;
+  if (existing && isStorageBalanceFresh(existing, gameTime)) {
+    return existing;
+  }
+
+  const state = buildStorageBalanceState(gameTime);
+  memory.storageBalance = state;
+  return state;
+}
+
+export function getRoomStoredEnergyState(room: Room): RoomStoredEnergyState {
+  const stores = getRoomEnergyStores(room);
+  const energy = stores.reduce((total, structure) => total + getStoredEnergy(structure), 0);
+  const capacity = stores.reduce((total, structure) => total + getEnergyCapacity(structure), 0);
+  const ratio = capacity > 0 ? energy / capacity : 0;
+  const exportableEnergy =
+    capacity > 0 && ratio > STORAGE_BALANCE_EXPORT_RATIO
+      ? Math.floor(energy - capacity * STORAGE_BALANCE_EXPORT_RATIO)
+      : 0;
+  const importDemand =
+    capacity > 0 && ratio < STORAGE_BALANCE_IMPORT_RATIO
+      ? Math.ceil(capacity * STORAGE_BALANCE_IMPORT_RATIO - energy)
+      : 0;
+
+  return {
+    roomName: room.name,
+    energy,
+    capacity,
+    ratio,
+    exportableEnergy: Math.max(0, exportableEnergy),
+    importDemand: Math.max(0, importDemand),
+    mode: selectStorageBalanceMode(capacity, ratio)
+  };
+}
+
+function buildStorageBalanceState(gameTime: number): EconomyStorageBalanceMemory {
+  const roomStates = getOwnedRooms()
+    .map(getRoomStoredEnergyState)
+    .filter((state) => state.capacity > 0);
+
+  return {
+    updatedAt: gameTime,
+    rooms: Object.fromEntries(
+      roomStates.map((state) => [
+        state.roomName,
+        {
+          roomName: state.roomName,
+          mode: state.mode,
+          energy: state.energy,
+          capacity: state.capacity,
+          ratio: state.ratio,
+          exportableEnergy: state.exportableEnergy,
+          importDemand: state.importDemand,
+          updatedAt: gameTime
+        }
+      ])
+    ),
+    transfers: buildStorageTransfers(roomStates, gameTime)
+  };
+}
+
+function buildStorageTransfers(
+  roomStates: RoomStoredEnergyState[],
+  gameTime: number
+): EconomyStorageTransferMemory[] {
+  const exporters = roomStates
+    .filter((state) => state.mode === 'export' && state.exportableEnergy > 0)
+    .sort(compareExportRooms);
+  const importers = roomStates
+    .filter((state) => state.mode === 'import' && state.importDemand > 0)
+    .sort(compareImportRooms);
+
+  const remainingExport = new Map(exporters.map((state) => [state.roomName, state.exportableEnergy]));
+  const transfers: EconomyStorageTransferMemory[] = [];
+
+  for (const importer of importers) {
+    let remainingDemand = importer.importDemand;
+    for (const exporter of exporters) {
+      if (remainingDemand <= 0) {
+        break;
+      }
+
+      const exportableEnergy = remainingExport.get(exporter.roomName) ?? 0;
+      const amount = Math.min(exportableEnergy, remainingDemand);
+      if (amount <= 0) {
+        continue;
+      }
+
+      transfers.push({
+        sourceRoom: exporter.roomName,
+        targetRoom: importer.roomName,
+        amount,
+        updatedAt: gameTime
+      });
+      remainingExport.set(exporter.roomName, exportableEnergy - amount);
+      remainingDemand -= amount;
+    }
+  }
+
+  return transfers;
+}
+
+function compareExportRooms(left: RoomStoredEnergyState, right: RoomStoredEnergyState): number {
+  return (
+    right.exportableEnergy - left.exportableEnergy ||
+    right.ratio - left.ratio ||
+    left.roomName.localeCompare(right.roomName)
+  );
+}
+
+function compareImportRooms(left: RoomStoredEnergyState, right: RoomStoredEnergyState): number {
+  return (
+    right.importDemand - left.importDemand ||
+    left.ratio - right.ratio ||
+    left.roomName.localeCompare(right.roomName)
+  );
+}
+
+function selectStorageBalanceMode(
+  capacity: number,
+  ratio: number
+): EconomyStorageBalanceMode {
+  if (capacity <= 0) {
+    return 'balanced';
+  }
+
+  if (ratio > STORAGE_BALANCE_EXPORT_RATIO) {
+    return 'export';
+  }
+
+  if (ratio < STORAGE_BALANCE_IMPORT_RATIO) {
+    return 'import';
+  }
+
+  return 'balanced';
+}
+
+function getRoomEnergyStores(room: Room): RoomEnergyStore[] {
+  const stores = [
+    room.storage as unknown as RoomEnergyStore | undefined,
+    room.terminal as unknown as RoomEnergyStore | undefined
+  ];
+  return stores.filter(
+    (structure): structure is RoomEnergyStore => structure !== undefined
+  );
+}
+
+function getStoredEnergy(target: RoomEnergyStore): number {
+  const store = target.store;
+  const resource = getEnergyResource();
+  const usedCapacity = store?.getUsedCapacity?.(resource);
+  if (typeof usedCapacity === 'number' && Number.isFinite(usedCapacity)) {
+    return Math.max(0, usedCapacity);
+  }
+
+  const directEnergy = store?.[resource];
+  return typeof directEnergy === 'number' && Number.isFinite(directEnergy)
+    ? Math.max(0, directEnergy)
+    : 0;
+}
+
+function getEnergyCapacity(target: RoomEnergyStore): number {
+  const store = target.store;
+  const resource = getEnergyResource();
+  const capacity = store?.getCapacity?.(resource);
+  if (typeof capacity === 'number' && Number.isFinite(capacity)) {
+    return Math.max(0, capacity);
+  }
+
+  const genericCapacity = store?.getCapacity?.();
+  if (typeof genericCapacity === 'number' && Number.isFinite(genericCapacity)) {
+    return Math.max(0, genericCapacity);
+  }
+
+  const freeCapacity = store?.getFreeCapacity?.(resource);
+  return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity)
+    ? getStoredEnergy(target) + Math.max(0, freeCapacity)
+    : 0;
+}
+
+function isStorageBalanceFresh(
+  state: EconomyStorageBalanceMemory,
+  gameTime: number
+): boolean {
+  return (
+    typeof state.updatedAt === 'number' &&
+    Number.isFinite(state.updatedAt) &&
+    gameTime >= state.updatedAt &&
+    gameTime - state.updatedAt < STORAGE_BALANCE_REFRESH_INTERVAL
+  );
+}
+
+function getOwnedRooms(): Room[] {
+  const rooms = (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms;
+  if (!rooms) {
+    return [];
+  }
+
+  return Object.values(rooms).filter((room): room is Room => room?.controller?.my === true);
+}
+
+function getEconomyMemory(): EconomyMemory {
+  const memory = getMemory();
+  if (!memory.economy) {
+    memory.economy = {};
+  }
+
+  return memory.economy;
+}
+
+function getMemory(): Partial<Memory> {
+  const global = globalThis as unknown as { Memory?: Partial<Memory> };
+  if (!global.Memory) {
+    global.Memory = {};
+  }
+
+  return global.Memory;
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Pick<Game, 'time'>> }).Game?.time;
+  return typeof gameTime === 'number' && Number.isFinite(gameTime) ? gameTime : 0;
+}
+
+function getEnergyResource(): ResourceConstant {
+  return ((globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
+}

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -84,6 +84,14 @@ export interface SpawnPlanningOptions {
   allowTerritoryFollowUp?: boolean;
 }
 
+export interface SpawnEnergyForecast {
+  roomName: string;
+  energyAvailable: number;
+  incomingEnergy: number;
+  outgoingEnergy: number;
+  effectiveEnergyAvailable: number;
+}
+
 const CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
 const CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
 const CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET = 6;
@@ -148,6 +156,49 @@ export function planSpawn(
   return null;
 }
 
+export function orderColoniesForSpawnPlanning(colonies: ColonySnapshot[]): ColonySnapshot[] {
+  return [...colonies].sort(compareColoniesForSpawnPlanning);
+}
+
+export function getSpawnEnergyForecast(colony: ColonySnapshot): SpawnEnergyForecast {
+  const balance = getStorageBalanceMemory();
+  const transfers = Array.isArray(balance?.transfers) ? balance.transfers : [];
+  const incomingEnergy = transfers
+    .filter((transfer) => transfer.targetRoom === colony.room.name)
+    .reduce((total, transfer) => total + normalizeNonNegativeInteger(transfer.amount), 0);
+  const outgoingEnergy = transfers
+    .filter((transfer) => transfer.sourceRoom === colony.room.name)
+    .reduce((total, transfer) => total + normalizeNonNegativeInteger(transfer.amount), 0);
+  const energyAvailable = normalizeNonNegativeInteger(colony.energyAvailable);
+
+  return {
+    roomName: colony.room.name,
+    energyAvailable,
+    incomingEnergy,
+    outgoingEnergy,
+    effectiveEnergyAvailable: Math.max(0, energyAvailable + incomingEnergy - outgoingEnergy)
+  };
+}
+
+export function shouldSuppressWorkerSpawnForCrossRoomImport(colony: ColonySnapshot): boolean {
+  const balance = getStorageBalanceMemory();
+  if (!balance) {
+    return false;
+  }
+
+  const roomBalance = balance?.rooms?.[colony.room.name];
+  if (roomBalance?.mode !== 'import') {
+    return false;
+  }
+
+  return (balance?.transfers ?? []).some(
+    (transfer) =>
+      transfer.targetRoom === colony.room.name &&
+      transfer.amount > 0 &&
+      isExportRoomWithSupply(balance, transfer.sourceRoom)
+  );
+}
+
 function planSpawnForPriorityTier(
   tier: SpawnPriorityTier,
   context: SpawnPlanningContext
@@ -194,7 +245,8 @@ function planEmergencyBootstrapSpawn(context: SpawnPlanningContext): SpawnReques
 function planLocalSurvivalSpawn(context: SpawnPlanningContext): SpawnRequest | null {
   if (
     context.workerCapacity >= context.workerTarget ||
-    !hasRecoveryWorkerSpawnEnergy(context.colony)
+    !hasRecoveryWorkerSpawnEnergy(context.colony) ||
+    shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)
   ) {
     return null;
   }
@@ -712,6 +764,7 @@ function shouldSpawnControllerUpgradeSurplusWorker(context: SpawnPlanningContext
     context.territoryIntentPending ||
     context.survival.mode !== 'TERRITORY_READY' ||
     hasControllerUpgradeBlockingTerritoryWork(context.colony) ||
+    shouldSuppressWorkerSpawnForCrossRoomImport(context.colony) ||
     !hasControllerUpgradeSurplusEnergy(context.colony) ||
     !isControllerUpgradeableForSurplus(context.colony.room.controller)
   ) {
@@ -1069,6 +1122,28 @@ function buildTerritorySpawnBody(energyAvailable: number, intent: TerritoryInten
 
 function getVisibleRoom(roomName: string): Room | undefined {
   return (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName];
+}
+
+function compareColoniesForSpawnPlanning(left: ColonySnapshot, right: ColonySnapshot): number {
+  const leftForecast = getSpawnEnergyForecast(left);
+  const rightForecast = getSpawnEnergyForecast(right);
+  return (
+    rightForecast.effectiveEnergyAvailable - leftForecast.effectiveEnergyAvailable ||
+    right.energyAvailable - left.energyAvailable ||
+    left.room.name.localeCompare(right.room.name)
+  );
+}
+
+function isExportRoomWithSupply(
+  balance: EconomyStorageBalanceMemory,
+  roomName: string
+): boolean {
+  const roomBalance = balance.rooms?.[roomName];
+  return roomBalance?.mode === 'export' && roomBalance.exportableEnergy > 0;
+}
+
+function getStorageBalanceMemory(): EconomyStorageBalanceMemory | undefined {
+  return (globalThis as unknown as { Memory?: Partial<Memory> }).Memory?.economy?.storageBalance;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -47,6 +47,7 @@ import {
   buildMultiRoomUpgraderMemory,
   selectMultiRoomUpgradePlans
 } from '../territory/multiRoomUpgrader';
+import { isLiveTransferCandidate } from '../economy/crossRoomHauler';
 
 type SpawnPriorityTier =
   | 'emergencyBootstrap'
@@ -195,7 +196,7 @@ export function shouldSuppressWorkerSpawnForCrossRoomImport(colony: ColonySnapsh
     (transfer) =>
       transfer.targetRoom === colony.room.name &&
       transfer.amount > 0 &&
-      isExportRoomWithSupply(balance, transfer.sourceRoom)
+      isLiveTransferCandidate(transfer)
   );
 }
 
@@ -246,7 +247,7 @@ function planLocalSurvivalSpawn(context: SpawnPlanningContext): SpawnRequest | n
   if (
     context.workerCapacity >= context.workerTarget ||
     !hasRecoveryWorkerSpawnEnergy(context.colony) ||
-    shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)
+    (context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony))
   ) {
     return null;
   }
@@ -764,7 +765,7 @@ function shouldSpawnControllerUpgradeSurplusWorker(context: SpawnPlanningContext
     context.territoryIntentPending ||
     context.survival.mode !== 'TERRITORY_READY' ||
     hasControllerUpgradeBlockingTerritoryWork(context.colony) ||
-    shouldSuppressWorkerSpawnForCrossRoomImport(context.colony) ||
+    (context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) ||
     !hasControllerUpgradeSurplusEnergy(context.colony) ||
     !isControllerUpgradeableForSurplus(context.colony.room.controller)
   ) {
@@ -1132,14 +1133,6 @@ function compareColoniesForSpawnPlanning(left: ColonySnapshot, right: ColonySnap
     right.energyAvailable - left.energyAvailable ||
     left.room.name.localeCompare(right.room.name)
   );
-}
-
-function isExportRoomWithSupply(
-  balance: EconomyStorageBalanceMemory,
-  roomName: string
-): boolean {
-  const roomBalance = balance.rooms?.[roomName];
-  return roomBalance?.mode === 'export' && roomBalance.exportableEnergy > 0;
 }
 
 function getStorageBalanceMemory(): EconomyStorageBalanceMemory | undefined {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -49,6 +49,7 @@ declare global {
     workerBehavior?: WorkerTaskBehaviorSampleMemory;
     workerTaskPolicyShadow?: WorkerTaskPolicyShadowMemory;
     behaviorTelemetry?: CreepBehaviorTelemetryMemory;
+    crossRoomHauler?: CreepCrossRoomHaulerMemory;
   }
 
   type DefenseActionType =
@@ -119,6 +120,41 @@ declare global {
 
   interface EconomyMemory {
     sourceWorkloads?: Record<string, EconomyRoomSourceWorkloadMemory>;
+    storageBalance?: EconomyStorageBalanceMemory;
+  }
+
+  type EconomyStorageBalanceMode = 'export' | 'import' | 'balanced';
+
+  interface EconomyStorageBalanceMemory {
+    updatedAt: number;
+    rooms: Record<string, EconomyStorageBalanceRoomMemory>;
+    transfers: EconomyStorageTransferMemory[];
+  }
+
+  interface EconomyStorageBalanceRoomMemory {
+    roomName: string;
+    mode: EconomyStorageBalanceMode;
+    energy: number;
+    capacity: number;
+    ratio: number;
+    exportableEnergy: number;
+    importDemand: number;
+    updatedAt: number;
+  }
+
+  interface EconomyStorageTransferMemory {
+    sourceRoom: string;
+    targetRoom: string;
+    amount: number;
+    updatedAt: number;
+  }
+
+  interface CreepCrossRoomHaulerMemory {
+    homeRoom: string;
+    targetRoom: string;
+    sourceId: Id<AnyStoreStructure>;
+    state?: 'collecting' | 'delivering' | 'returning';
+    route?: string[];
   }
 
   interface EconomyRoomSourceWorkloadMemory {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -152,8 +152,8 @@ declare global {
   interface CreepCrossRoomHaulerMemory {
     homeRoom: string;
     targetRoom: string;
-    sourceId: Id<AnyStoreStructure>;
-    state?: 'collecting' | 'delivering' | 'returning';
+    sourceId?: Id<AnyStoreStructure> | null;
+    state?: 'collecting' | 'delivering' | 'returning' | 'unassigned';
     route?: string[];
   }
 

--- a/prod/test/crossRoomLogistics.test.ts
+++ b/prod/test/crossRoomLogistics.test.ts
@@ -95,6 +95,29 @@ describe('cross-room energy logistics', () => {
     expect(buildCrossRoomHaulerBody(800, 150)).toEqual(plan?.body);
   });
 
+  it('plans cross-room hauling through neutral transit rooms', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950, energyAvailable: 800 });
+    const transitRoom = makeNeutralRoom('W2N1');
+    const targetRoom = makeOwnedRoom({ roomName: 'W3N1', storageEnergy: 100 });
+    const sourceSpawn = makeSpawn('Spawn1', sourceRoom);
+    installGame([sourceRoom, transitRoom, targetRoom], [sourceSpawn], {}, (fromRoom, toRoom, options) => {
+      const route = [
+        { exit: 1, room: 'W2N1' },
+        { exit: 1, room: toRoom }
+      ];
+      if (route.some((step) => options?.routeCallback?.(step.room, fromRoom) === Infinity)) {
+        return ERR_NO_PATH_CODE;
+      }
+
+      return route;
+    });
+    balanceStorage();
+
+    const plan = planCrossRoomHauler();
+
+    expect(plan?.memory.crossRoomHauler?.route).toEqual(['W2N1', 'W3N1']);
+  });
+
   it('does nothing when all owned rooms are balanced', () => {
     const roomA = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 500 });
     const roomB = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 400 });
@@ -151,6 +174,43 @@ describe('cross-room energy logistics', () => {
     const targetColony = makeColony(targetRoom, [targetSpawn]);
 
     expect(planSpawn(targetColony, { worker: 3, workerCapacity: 2 }, 101)).toBeNull();
+  });
+
+  it('keeps worker recovery active in importing rooms with zero worker capacity', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100, energyAvailable: 300 });
+    const targetSpawn = makeSpawn('Spawn2', targetRoom);
+    installGame([sourceRoom, targetRoom], [makeSpawn('Spawn1', sourceRoom), targetSpawn]);
+    balanceStorage();
+    const targetColony = makeColony(targetRoom, [targetSpawn]);
+
+    expect(planSpawn(targetColony, { worker: 3, workerCapacity: 0 }, 102)).toEqual({
+      spawn: targetSpawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W2N1-102',
+      memory: { role: 'worker', colony: 'W2N1' }
+    });
+  });
+
+  it('does not suppress local workers for impossible cross-room transfer lanes', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100, energyAvailable: 300 });
+    const targetSpawn = makeSpawn('Spawn2', targetRoom);
+    installGame(
+      [sourceRoom, targetRoom],
+      [makeSpawn('Spawn1', sourceRoom), targetSpawn],
+      {},
+      () => ERR_NO_PATH_CODE
+    );
+    balanceStorage();
+    const targetColony = makeColony(targetRoom, [targetSpawn]);
+
+    expect(planSpawn(targetColony, { worker: 3, workerCapacity: 2 }, 103)).toEqual({
+      spawn: targetSpawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W2N1-103',
+      memory: { role: 'worker', colony: 'W2N1' }
+    });
   });
 
   it('orders spawn planning by effective energy after planned transfers', () => {
@@ -317,6 +377,21 @@ describe('cross-room energy logistics', () => {
 
         return [];
       })
+    } as unknown as Room;
+
+    return room;
+  }
+
+  function makeNeutralRoom(roomName: string): Room {
+    const controller = { id: `${roomName}-controller`, my: false } as StructureController;
+    registerObject(controller);
+    const room = {
+      name: roomName,
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller,
+      memory: {},
+      find: jest.fn(() => [])
     } as unknown as Room;
 
     return room;

--- a/prod/test/crossRoomLogistics.test.ts
+++ b/prod/test/crossRoomLogistics.test.ts
@@ -358,14 +358,12 @@ describe('cross-room energy logistics', () => {
     expect(moveTo).toHaveBeenCalledWith(sourceRoom.controller, { reusePath: 20, ignoreRoads: false });
   });
 
-  it('clears a dry assigned source before returning home', () => {
+  it('reassigns to a non-empty source when the assigned source is dry', () => {
     const sourceRoom = makeOwnedRoom({
       roomName: 'W1N1',
-      storageEnergy: 950,
-      storageCapacity: 0,
-      terminalEnergy: 0,
-      terminalCapacity: 1_000
+      storageEnergy: 950
     });
+    (sourceRoom as { terminal?: StructureTerminal }).terminal = makeTerminal('W1N1-terminal', 0, 0);
     const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100 });
     installGame([sourceRoom, targetRoom], []);
     const creep = makeCrossRoomHauler({
@@ -376,9 +374,48 @@ describe('cross-room energy logistics', () => {
 
     runCrossRoomHauler(creep);
 
-    expect(creep.memory.crossRoomHauler?.state).toBe('returning');
-    expect(creep.memory.crossRoomHauler?.sourceId).toBeUndefined();
+    expect(creep.memory.crossRoomHauler?.state).toBe('collecting');
+    expect(creep.memory.crossRoomHauler?.sourceId).toBe('W1N1-storage');
+    expect(creep.withdraw).toHaveBeenCalledWith(sourceRoom.storage, RESOURCE_ENERGY);
+    expect(creep.memory.task).toEqual({ type: 'withdraw', targetId: 'W1N1-storage' });
+  });
+
+  it('keeps a dry hauler memory valid while waiting for a source to recover', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 0 });
+    (sourceRoom as { terminal?: StructureTerminal }).terminal = makeTerminal('W1N1-terminal', 0, 0);
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100 });
+    installGame([sourceRoom, targetRoom], []);
+    const creep = makeCrossRoomHauler({
+      room: sourceRoom,
+      carriedEnergy: () => 0
+    });
+    creep.memory.crossRoomHauler!.sourceId = 'W1N1-terminal' as Id<AnyStoreStructure>;
+
+    runCrossRoomHauler(creep);
+
+    expect(creep.memory.crossRoomHauler).toMatchObject({
+      state: 'unassigned',
+      sourceId: null
+    });
     expect(creep.withdraw).not.toHaveBeenCalled();
+  });
+
+  it('recovers an unassigned hauler source before collecting again', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100 });
+    installGame([sourceRoom, targetRoom], []);
+    const creep = makeCrossRoomHauler({
+      room: sourceRoom,
+      carriedEnergy: () => 0
+    });
+    delete (creep.memory.crossRoomHauler as Partial<CreepCrossRoomHaulerMemory>).sourceId;
+    creep.memory.crossRoomHauler!.state = 'returning';
+
+    runCrossRoomHauler(creep);
+
+    expect(creep.memory.crossRoomHauler?.state).toBe('collecting');
+    expect(creep.memory.crossRoomHauler?.sourceId).toBe('W1N1-storage');
+    expect(creep.withdraw).toHaveBeenCalledWith(sourceRoom.storage, RESOURCE_ENERGY);
   });
 
   function makeOwnedRoom({

--- a/prod/test/crossRoomLogistics.test.ts
+++ b/prod/test/crossRoomLogistics.test.ts
@@ -29,6 +29,8 @@ describe('cross-room energy logistics', () => {
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
     (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
     (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { STRUCTURE_STORAGE: StructureConstant }).STRUCTURE_STORAGE = 'storage';
+    (globalThis as unknown as { STRUCTURE_TERMINAL: StructureConstant }).STRUCTURE_TERMINAL = 'terminal';
     (globalThis as unknown as { ERR_NOT_IN_RANGE: ScreepsReturnCode }).ERR_NOT_IN_RANGE = ERR_NOT_IN_RANGE_CODE;
     (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = ERR_NO_PATH_CODE;
     (globalThis as unknown as { RoomPosition: new (x: number, y: number, roomName: string) => RoomPosition })
@@ -300,6 +302,43 @@ describe('cross-room energy logistics', () => {
 
     expect(creep.transfer).toHaveBeenCalledWith(container, RESOURCE_ENERGY);
     expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'W2N1-container' });
+  });
+
+  it('delivers to deficit-room storage when transient sinks are unavailable', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100 });
+    installGame([sourceRoom, targetRoom], []);
+    const creep = makeCrossRoomHauler({
+      room: targetRoom,
+      carriedEnergy: () => 100,
+      transfer: jest.fn(() => OK_CODE)
+    });
+
+    runCrossRoomHauler(creep);
+
+    expect(creep.transfer).toHaveBeenCalledWith(targetRoom.storage, RESOURCE_ENERGY);
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'W2N1-storage' });
+  });
+
+  it('delivers to deficit-room terminal when storage is full', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    const targetRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      storageEnergy: 1_000,
+      terminalEnergy: 100,
+      terminalCapacity: 1_000
+    });
+    installGame([sourceRoom, targetRoom], []);
+    const creep = makeCrossRoomHauler({
+      room: targetRoom,
+      carriedEnergy: () => 100,
+      transfer: jest.fn(() => OK_CODE)
+    });
+
+    runCrossRoomHauler(creep);
+
+    expect(creep.transfer).toHaveBeenCalledWith(targetRoom.terminal, RESOURCE_ENERGY);
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'W2N1-terminal' });
   });
 
   it('returns home when empty and the source room no longer has surplus', () => {

--- a/prod/test/crossRoomLogistics.test.ts
+++ b/prod/test/crossRoomLogistics.test.ts
@@ -358,6 +358,29 @@ describe('cross-room energy logistics', () => {
     expect(moveTo).toHaveBeenCalledWith(sourceRoom.controller, { reusePath: 20, ignoreRoads: false });
   });
 
+  it('clears a dry assigned source before returning home', () => {
+    const sourceRoom = makeOwnedRoom({
+      roomName: 'W1N1',
+      storageEnergy: 950,
+      storageCapacity: 0,
+      terminalEnergy: 0,
+      terminalCapacity: 1_000
+    });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100 });
+    installGame([sourceRoom, targetRoom], []);
+    const creep = makeCrossRoomHauler({
+      room: sourceRoom,
+      carriedEnergy: () => 0
+    });
+    creep.memory.crossRoomHauler!.sourceId = 'W1N1-terminal' as Id<AnyStoreStructure>;
+
+    runCrossRoomHauler(creep);
+
+    expect(creep.memory.crossRoomHauler?.state).toBe('returning');
+    expect(creep.memory.crossRoomHauler?.sourceId).toBeUndefined();
+    expect(creep.withdraw).not.toHaveBeenCalled();
+  });
+
   function makeOwnedRoom({
     roomName,
     storageEnergy,

--- a/prod/test/crossRoomLogistics.test.ts
+++ b/prod/test/crossRoomLogistics.test.ts
@@ -1,0 +1,455 @@
+import { ColonySnapshot } from '../src/colony/colonyRegistry';
+import {
+  CROSS_ROOM_HAULER_ROLE,
+  buildCrossRoomHaulerBody,
+  planCrossRoomHauler,
+  runCrossRoomHauler
+} from '../src/economy/crossRoomHauler';
+import { balanceStorage } from '../src/economy/storageBalancer';
+import {
+  getSpawnEnergyForecast,
+  orderColoniesForSpawnPlanning,
+  planSpawn
+} from '../src/spawn/spawnPlanner';
+
+describe('cross-room energy logistics', () => {
+  const OK_CODE = 0 as ScreepsReturnCode;
+  const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+  const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+  const objectRegistry = new Map<string, unknown>();
+
+  beforeEach(() => {
+    objectRegistry.clear();
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 1;
+    (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 2;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 3;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 4;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 5;
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { ERR_NOT_IN_RANGE: ScreepsReturnCode }).ERR_NOT_IN_RANGE = ERR_NOT_IN_RANGE_CODE;
+    (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = ERR_NO_PATH_CODE;
+    (globalThis as unknown as { RoomPosition: new (x: number, y: number, roomName: string) => RoomPosition })
+      .RoomPosition = class {
+      public constructor(
+        public readonly x: number,
+        public readonly y: number,
+        public readonly roomName: string
+      ) {}
+    } as unknown as new (x: number, y: number, roomName: string) => RoomPosition;
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  });
+
+  it('flags export and import rooms from storage thresholds', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 900 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 200 });
+    const balancedRoom = makeOwnedRoom({ roomName: 'W3N1', storageEnergy: 500 });
+    installGame([sourceRoom, targetRoom, balancedRoom], []);
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.rooms.W1N1).toMatchObject({
+      mode: 'export',
+      energy: 900,
+      capacity: 1_000,
+      exportableEnergy: 100
+    });
+    expect(Memory.economy?.storageBalance?.rooms.W2N1).toMatchObject({
+      mode: 'import',
+      importDemand: 100
+    });
+    expect(Memory.economy?.storageBalance?.rooms.W3N1).toMatchObject({ mode: 'balanced' });
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([
+      { sourceRoom: 'W1N1', targetRoom: 'W2N1', amount: 100, updatedAt: 100 }
+    ]);
+  });
+
+  it('plans a proportional CARRY/MOVE hauler from a surplus room to a deficit room', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950, energyAvailable: 800 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100 });
+    const sourceSpawn = makeSpawn('Spawn1', sourceRoom);
+    installGame([sourceRoom, targetRoom], [sourceSpawn]);
+    balanceStorage();
+
+    const plan = planCrossRoomHauler();
+
+    expect(plan).toMatchObject({
+      spawn: sourceSpawn,
+      body: ['carry', 'move', 'carry', 'move', 'carry', 'move'],
+      name: 'crossRoomHauler-W1N1-W2N1-100',
+      memory: {
+        role: CROSS_ROOM_HAULER_ROLE,
+        colony: 'W1N1',
+        crossRoomHauler: {
+          homeRoom: 'W1N1',
+          targetRoom: 'W2N1',
+          sourceId: 'W1N1-storage',
+          state: 'collecting',
+          route: ['W2N1']
+        }
+      }
+    });
+    expect(buildCrossRoomHaulerBody(800, 150)).toEqual(plan?.body);
+  });
+
+  it('does nothing when all owned rooms are balanced', () => {
+    const roomA = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 500 });
+    const roomB = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 400 });
+    installGame([roomA, roomB], [makeSpawn('Spawn1', roomA), makeSpawn('Spawn2', roomB)]);
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([]);
+    expect(planCrossRoomHauler()).toBeNull();
+  });
+
+  it('degrades to no-op when only one room is owned', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    installGame([sourceRoom], [makeSpawn('Spawn1', sourceRoom)]);
+
+    balanceStorage();
+
+    expect(Memory.economy?.storageBalance?.rooms.W1N1?.mode).toBe('export');
+    expect(Memory.economy?.storageBalance?.transfers).toEqual([]);
+    expect(planCrossRoomHauler()).toBeNull();
+  });
+
+  it('rejects cross-room hauling through hostile owned rooms', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    const hostileTransitRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      storageEnergy: 500,
+      hostileCreeps: [{} as Creep]
+    });
+    const targetRoom = makeOwnedRoom({ roomName: 'W3N1', storageEnergy: 100 });
+    const sourceSpawn = makeSpawn('Spawn1', sourceRoom);
+    installGame([sourceRoom, hostileTransitRoom, targetRoom], [sourceSpawn], {}, (fromRoom, toRoom, options) => {
+      const route = [
+        { exit: 1, room: 'W2N1' },
+        { exit: 1, room: toRoom }
+      ];
+      if (route.some((step) => options?.routeCallback?.(step.room, fromRoom) === Infinity)) {
+        return ERR_NO_PATH_CODE;
+      }
+
+      return route;
+    });
+    balanceStorage();
+
+    expect(planCrossRoomHauler()).toBeNull();
+  });
+
+  it('suppresses routine worker spawning in an importing deficit room', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100, energyAvailable: 300 });
+    const targetSpawn = makeSpawn('Spawn2', targetRoom);
+    installGame([sourceRoom, targetRoom], [makeSpawn('Spawn1', sourceRoom), targetSpawn]);
+    balanceStorage();
+    const targetColony = makeColony(targetRoom, [targetSpawn]);
+
+    expect(planSpawn(targetColony, { worker: 3, workerCapacity: 2 }, 101)).toBeNull();
+  });
+
+  it('orders spawn planning by effective energy after planned transfers', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950, energyAvailable: 900 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100, energyAvailable: 300 });
+    const balancedRoom = makeOwnedRoom({ roomName: 'W3N1', storageEnergy: 500, energyAvailable: 500 });
+    installGame([sourceRoom, targetRoom, balancedRoom], []);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      economy: {
+        storageBalance: {
+          updatedAt: 100,
+          rooms: {},
+          transfers: [{ sourceRoom: 'W1N1', targetRoom: 'W2N1', amount: 600, updatedAt: 100 }]
+        }
+      }
+    };
+    const colonies = [
+      makeColony(sourceRoom),
+      makeColony(targetRoom),
+      makeColony(balancedRoom)
+    ];
+
+    expect(getSpawnEnergyForecast(colonies[0])).toMatchObject({
+      roomName: 'W1N1',
+      effectiveEnergyAvailable: 300
+    });
+    expect(orderColoniesForSpawnPlanning(colonies).map((colony) => colony.room.name)).toEqual([
+      'W2N1',
+      'W3N1',
+      'W1N1'
+    ]);
+  });
+
+  it('withdraws from the source room and delivers to spawn energy demand', () => {
+    let carriedEnergy = 0;
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    const targetOwnedStructures: AnyOwnedStructure[] = [];
+    const targetRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      storageEnergy: 100,
+      myStructures: targetOwnedStructures
+    });
+    const targetSpawn = makeSpawn('Spawn2', targetRoom, 300);
+    targetOwnedStructures.push(targetSpawn as unknown as AnyOwnedStructure);
+    installGame([sourceRoom, targetRoom], [targetSpawn]);
+    const creep = makeCrossRoomHauler({
+      room: sourceRoom,
+      carriedEnergy: () => carriedEnergy,
+      withdraw: jest.fn(() => {
+        carriedEnergy = 100;
+        return OK_CODE;
+      }),
+      transfer: jest.fn(() => {
+        carriedEnergy = 0;
+        return OK_CODE;
+      })
+    });
+
+    runCrossRoomHauler(creep);
+
+    expect(creep.withdraw).toHaveBeenCalledWith(sourceRoom.storage, RESOURCE_ENERGY);
+    expect(creep.memory.task).toEqual({ type: 'withdraw', targetId: 'W1N1-storage' });
+
+    creep.room = targetRoom;
+    runCrossRoomHauler(creep);
+
+    expect(creep.transfer).toHaveBeenCalledWith(targetSpawn, RESOURCE_ENERGY);
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'Spawn2' });
+  });
+
+  it('falls back to deficit-room containers when spawn and extensions are full', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 950 });
+    const container = makeContainer('W2N1-container', 0, 2_000);
+    const targetRoom = makeOwnedRoom({
+      roomName: 'W2N1',
+      storageEnergy: 100,
+      structures: [container]
+    });
+    installGame([sourceRoom, targetRoom], []);
+    const creep = makeCrossRoomHauler({
+      room: targetRoom,
+      carriedEnergy: () => 100,
+      transfer: jest.fn(() => OK_CODE)
+    });
+
+    runCrossRoomHauler(creep);
+
+    expect(creep.transfer).toHaveBeenCalledWith(container, RESOURCE_ENERGY);
+    expect(creep.memory.task).toEqual({ type: 'transfer', targetId: 'W2N1-container' });
+  });
+
+  it('returns home when empty and the source room no longer has surplus', () => {
+    const sourceRoom = makeOwnedRoom({ roomName: 'W1N1', storageEnergy: 700 });
+    const targetRoom = makeOwnedRoom({ roomName: 'W2N1', storageEnergy: 100 });
+    installGame([sourceRoom, targetRoom], []);
+    const moveTo = jest.fn();
+    const creep = makeCrossRoomHauler({
+      room: targetRoom,
+      carriedEnergy: () => 0,
+      moveTo
+    });
+
+    runCrossRoomHauler(creep);
+
+    expect(creep.memory.crossRoomHauler?.state).toBe('returning');
+    expect(moveTo).toHaveBeenCalledWith(sourceRoom.controller, { reusePath: 20, ignoreRoads: false });
+  });
+
+  function makeOwnedRoom({
+    roomName,
+    storageEnergy,
+    storageCapacity = 1_000,
+    terminalEnergy = 0,
+    terminalCapacity = 0,
+    energyAvailable = 800,
+    energyCapacityAvailable = 800,
+    myStructures = [],
+    structures = [],
+    hostileCreeps = [],
+    hostileStructures = []
+  }: {
+    roomName: string;
+    storageEnergy: number;
+    storageCapacity?: number;
+    terminalEnergy?: number;
+    terminalCapacity?: number;
+    energyAvailable?: number;
+    energyCapacityAvailable?: number;
+    myStructures?: AnyOwnedStructure[];
+    structures?: Structure[];
+    hostileCreeps?: Creep[];
+    hostileStructures?: Structure[];
+  }): Room {
+    const controller = { id: `${roomName}-controller`, my: true, level: 4 } as StructureController;
+    registerObject(controller);
+    const room = {
+      name: roomName,
+      energyAvailable,
+      energyCapacityAvailable,
+      controller,
+      memory: {},
+      storage: makeStorage(`${roomName}-storage`, storageEnergy, storageCapacity),
+      ...(terminalCapacity > 0 ? { terminal: makeTerminal(`${roomName}-terminal`, terminalEnergy, terminalCapacity) } : {}),
+      find: jest.fn((type: number) => {
+        if (type === FIND_MY_STRUCTURES) {
+          return myStructures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return structures;
+        }
+
+        if (type === FIND_HOSTILE_CREEPS) {
+          return hostileCreeps;
+        }
+
+        if (type === FIND_HOSTILE_STRUCTURES) {
+          return hostileStructures;
+        }
+
+        if (type === FIND_SOURCES) {
+          return [{ id: `${roomName}-source` } as Source];
+        }
+
+        return [];
+      })
+    } as unknown as Room;
+
+    return room;
+  }
+
+  function makeColony(room: Room, spawns: StructureSpawn[] = []): ColonySnapshot {
+    return {
+      room,
+      spawns,
+      energyAvailable: room.energyAvailable,
+      energyCapacityAvailable: room.energyCapacityAvailable
+    };
+  }
+
+  function makeSpawn(name: string, room: Room, freeCapacity = 0): StructureSpawn {
+    const spawn = {
+      id: name,
+      name,
+      room,
+      structureType: 'spawn',
+      spawning: null,
+      store: makeStore(300 - freeCapacity, 300)
+    } as unknown as StructureSpawn;
+    registerObject(spawn);
+    return spawn;
+  }
+
+  function makeContainer(id: string, energy: number, capacity: number): StructureContainer {
+    const container = {
+      id,
+      structureType: 'container',
+      store: makeStore(energy, capacity)
+    } as unknown as StructureContainer;
+    registerObject(container);
+    return container;
+  }
+
+  function makeStorage(id: string, energy: number, capacity: number): StructureStorage {
+    const storage = {
+      id,
+      structureType: 'storage',
+      store: makeStore(energy, capacity)
+    } as unknown as StructureStorage;
+    registerObject(storage);
+    return storage;
+  }
+
+  function makeTerminal(id: string, energy: number, capacity: number): StructureTerminal {
+    const terminal = {
+      id,
+      structureType: 'terminal',
+      store: makeStore(energy, capacity)
+    } as unknown as StructureTerminal;
+    registerObject(terminal);
+    return terminal;
+  }
+
+  function makeStore(energy: number, capacity: number): StoreDefinition {
+    return {
+      getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0)),
+      getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? capacity : 0)),
+      getFreeCapacity: jest.fn((resource?: ResourceConstant) =>
+        resource === RESOURCE_ENERGY ? Math.max(0, capacity - energy) : 0
+      )
+    } as unknown as StoreDefinition;
+  }
+
+  function makeCrossRoomHauler({
+    room,
+    carriedEnergy,
+    withdraw = jest.fn(() => OK_CODE),
+    transfer = jest.fn(() => OK_CODE),
+    moveTo = jest.fn()
+  }: {
+    room: Room;
+    carriedEnergy: () => number;
+    withdraw?: jest.Mock;
+    transfer?: jest.Mock;
+    moveTo?: jest.Mock;
+  }): Creep {
+    return {
+      room,
+      memory: {
+        role: CROSS_ROOM_HAULER_ROLE,
+        colony: 'W1N1',
+        crossRoomHauler: {
+          homeRoom: 'W1N1',
+          targetRoom: 'W2N1',
+          sourceId: 'W1N1-storage' as Id<AnyStoreStructure>,
+          state: 'collecting',
+          route: ['W2N1']
+        }
+      },
+      store: {
+        getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? carriedEnergy() : 0)),
+        getFreeCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? 200 - carriedEnergy() : 0))
+      },
+      withdraw,
+      transfer,
+      moveTo
+    } as unknown as Creep;
+  }
+
+  function installGame(
+    rooms: Room[],
+    spawns: StructureSpawn[],
+    creeps: Record<string, Creep> = {},
+    findRoute: (
+      fromRoom: string,
+      toRoom: string,
+      options?: { routeCallback?: (roomName: string, fromRoomName: string) => number }
+    ) => unknown = (_fromRoom, toRoom, options) => {
+      if (options?.routeCallback?.(toRoom, _fromRoom) === Infinity) {
+        return ERR_NO_PATH_CODE;
+      }
+
+      return [{ exit: 1, room: toRoom }];
+    }
+  ): void {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 100,
+      rooms: Object.fromEntries(rooms.map((room) => [room.name, room])),
+      spawns: Object.fromEntries(spawns.map((spawn) => [spawn.name, spawn])),
+      creeps,
+      getObjectById: jest.fn((id: string) => objectRegistry.get(id) ?? null) as Game['getObjectById'],
+      map: { findRoute } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  }
+
+  function registerObject(object: { id?: string }): void {
+    if (typeof object.id === 'string') {
+      objectRegistry.set(object.id, object);
+    }
+  }
+});

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -140,6 +140,114 @@ describe('runEconomy', () => {
     );
   });
 
+  it('keeps a single source-room spawn on local recovery before cross-room hauling', () => {
+    (globalThis as unknown as { FIND_SOURCES: number; RESOURCE_ENERGY: ResourceConstant }).FIND_SOURCES = 1;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const sourceRoom = makeStorageEconomyRoom({
+      roomName: 'W1N1',
+      storageEnergy: 950,
+      energyAvailable: 300,
+      energyCapacityAvailable: 300
+    });
+    const targetRoom = makeStorageEconomyRoom({
+      roomName: 'W2N1',
+      storageEnergy: 100,
+      energyAvailable: 300,
+      energyCapacityAvailable: 300
+    });
+    const spawn = {
+      name: 'Spawn1',
+      room: sourceRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 129,
+      rooms: { W1N1: sourceRoom, W2N1: targetRoom },
+      spawns: { Spawn1: spawn },
+      creeps: {},
+      map: {
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }])
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledTimes(1);
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-129', {
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+  });
+
+  it('uses spare source-room spawn capacity for cross-room hauling after local recovery', () => {
+    (globalThis as unknown as { FIND_SOURCES: number; RESOURCE_ENERGY: ResourceConstant }).FIND_SOURCES = 1;
+    (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const sourceRoom = makeStorageEconomyRoom({
+      roomName: 'W1N1',
+      storageEnergy: 950,
+      energyAvailable: 600,
+      energyCapacityAvailable: 300
+    });
+    const targetRoom = makeStorageEconomyRoom({
+      roomName: 'W2N1',
+      storageEnergy: 100,
+      energyAvailable: 300,
+      energyCapacityAvailable: 300
+    });
+    const spawn1 = {
+      name: 'Spawn1',
+      room: sourceRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const spawn2 = {
+      name: 'Spawn2',
+      room: sourceRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const workers = {
+      Worker1: makeEconomyWorker(sourceRoom),
+      Worker2: makeEconomyWorker(sourceRoom)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 130,
+      rooms: { W1N1: sourceRoom, W2N1: targetRoom },
+      spawns: { Spawn1: spawn1, Spawn2: spawn2 },
+      creeps: workers,
+      map: {
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 1, room: toRoom }])
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(spawn1.spawnCreep).toHaveBeenCalledTimes(1);
+    expect(spawn2.spawnCreep).toHaveBeenCalledTimes(1);
+    expect(spawn1.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-130', {
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+    expect(spawn2.spawnCreep).toHaveBeenCalledWith(
+      ['carry', 'move', 'carry', 'move', 'carry', 'move'],
+      'crossRoomHauler-W1N1-W2N1-130',
+      {
+        memory: {
+          role: 'crossRoomHauler',
+          colony: 'W1N1',
+          crossRoomHauler: {
+            homeRoom: 'W1N1',
+            targetRoom: 'W2N1',
+            sourceId: 'W1N1-storage',
+            state: 'collecting',
+            route: ['W2N1']
+          }
+        }
+      }
+    );
+  });
+
   it('keeps spawning a productive worker while baseline workers still leave refill pressure', () => {
     (globalThis as unknown as {
       FIND_MY_STRUCTURES: number;
@@ -2148,6 +2256,49 @@ function makeOwnedEconomyRoom(roomName: string): Room {
     } as StructureController,
     find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
   } as unknown as Room;
+}
+
+function makeStorageEconomyRoom({
+  roomName,
+  storageEnergy,
+  storageCapacity = 1_000,
+  energyAvailable,
+  energyCapacityAvailable
+}: {
+  roomName: string;
+  storageEnergy: number;
+  storageCapacity?: number;
+  energyAvailable: number;
+  energyCapacityAvailable: number;
+}): Room {
+  return {
+    name: roomName,
+    energyAvailable,
+    energyCapacityAvailable,
+    controller: {
+      my: true,
+      owner: { username: 'me' },
+      level: 3,
+      ticksToDowngrade: 10_000
+    } as StructureController,
+    memory: {},
+    storage: {
+      id: `${roomName}-storage`,
+      structureType: 'storage',
+      store: makeEnergyStore(storageEnergy, storageCapacity)
+    } as StructureStorage,
+    find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
+  } as unknown as Room;
+}
+
+function makeEnergyStore(energy: number, capacity: number): StoreDefinition {
+  return {
+    getUsedCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? energy : 0)),
+    getCapacity: jest.fn((resource?: ResourceConstant) => (resource === RESOURCE_ENERGY ? capacity : 0)),
+    getFreeCapacity: jest.fn((resource?: ResourceConstant) =>
+      resource === RESOURCE_ENERGY ? Math.max(0, capacity - energy) : 0
+    )
+  } as unknown as StoreDefinition;
 }
 
 function makeVisibleForeignReservedRoom(


### PR DESCRIPTION
Implements multi-room energy logistics with cross-room hauler role and storage balancing.

**Changes:**
- New `crossRoomHauler` creep role for moving energy between colonies
- New `storageBalancer` for intelligent surplus distribution
- Updated `economyLoop` to coordinate multi-room spawn and energy flow
- Updated `spawnPlanner` with colony ordering for spawn planning
- Updated type definitions

**Verification:**
- `npm run typecheck` — passes
- `npm test -- --runInBand` — 49 suites, 1067 tests pass
- `npm run build` — succeeds

Refs #629