### PR TITLE
feat(territory): implement multi-room controller upgrade coordination with claimer efficiency (#633)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5216,6 +5216,7 @@ var TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 var TERRITORY_SCOUT_BODY_COST2 = 50;
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 = "occupationRecommendation";
 var REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
+var MAX_CONTROLLER_LEVEL = 8;
 var recoveredTerritoryFollowUpRetryMetadata = /* @__PURE__ */ new WeakMap();
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options = {}) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
@@ -5458,9 +5459,12 @@ function selectVisibleTerritoryControllerTask(creep) {
     return canCreepActOnVisibleReserveController(creep, controller, intent.colony) ? { type: "reserve", targetId: controller.id } : null;
   }
   if (controller.my === true) {
-    return getStoredEnergy(creep) > 0 ? { type: "upgrade", targetId: controller.id } : null;
+    return getStoredEnergy(creep) > 0 && canLevelUpVisibleController(controller) ? { type: "upgrade", targetId: controller.id } : null;
   }
   return canUseControllerClaimPart(creep) ? { type: "claim", targetId: controller.id } : null;
+}
+function canLevelUpVisibleController(controller) {
+  return typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL;
 }
 function canCreepReserveTerritoryController(creep, controller, colony) {
   const activeClaimParts = getActiveControllerClaimPartCount(creep);
@@ -9149,7 +9153,7 @@ var FINISHABLE_CONSTRUCTION_SITE_PRIORITY_MULTIPLIER = 2;
 var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 var DEFAULT_SOURCE_ENERGY_CAPACITY = 3e3;
 var DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
-var MAX_CONTROLLER_LEVEL = 8;
+var MAX_CONTROLLER_LEVEL2 = 8;
 var UPGRADER_BOOST_CONTROLLER_PROGRESS_RATIO = 0.9;
 var UPGRADER_BOOST_LOW_ENERGY_RATIO = 0.5;
 var SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
@@ -9459,7 +9463,7 @@ function selectColonyRecallEnergySink(room) {
 function selectControllerSustainUpgradeTask(creep, controller) {
   var _a, _b;
   const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-  if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || sustain.targetRoom !== ((_b = creep.room) == null ? void 0 : _b.name) || (controller == null ? void 0 : controller.my) !== true || !canUpgradeController(controller)) {
+  if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || sustain.targetRoom !== ((_b = creep.room) == null ? void 0 : _b.name) || (controller == null ? void 0 : controller.my) !== true || !canLevelUpController(controller)) {
     return null;
   }
   return { type: "upgrade", targetId: controller.id };
@@ -11485,7 +11489,7 @@ function canUpgradeController(controller) {
   return (controller == null ? void 0 : controller.my) === true;
 }
 function canLevelUpController(controller) {
-  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL;
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL2;
 }
 function selectSource2ControllerLaneHarvestTask(creep) {
   const controller = creep.room.controller;
@@ -13774,12 +13778,11 @@ var MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP = 1;
 var SPAWN_CONSTRUCTION_UPGRADER_CAP_BONUS = 1;
 var REMOTE_UPGRADER_PATTERN = ["work", "carry", "move"];
 var REMOTE_UPGRADER_TRAVEL_PATTERN = ["work", "carry", "move", "move"];
-var RESERVED_CONTROLLER_BASE_BODY = ["claim", "move"];
 var REMOTE_UPGRADER_PATTERN_COST = 200;
 var MOVE_PART_COST = 50;
 var MAX_CREEP_PARTS3 = 50;
 var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
-var DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
+var MAX_CONTROLLER_LEVEL3 = 8;
 var ERR_NO_PATH_CODE4 = -2;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR3 = ">";
 var ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
@@ -13806,15 +13809,13 @@ function selectMultiRoomUpgradePlans(colony, options = {}) {
   return candidates.sort(compareMultiRoomUpgradeCandidates).map(({ order: _order, ...plan }) => plan);
 }
 function buildMultiRoomUpgraderBody(energyAvailable, plan) {
-  const baseBody = plan.controllerState === "reserved" ? RESERVED_CONTROLLER_BASE_BODY : [];
-  const remainingEnergy = energyAvailable - getBodyCost2(baseBody);
-  if (remainingEnergy < REMOTE_UPGRADER_PATTERN_COST) {
+  if (energyAvailable < REMOTE_UPGRADER_PATTERN_COST) {
     return [];
   }
   const pattern = getRemoteUpgraderPattern(plan.routeDistance);
   const patternCost = getBodyCost2(pattern);
-  const maxPatternCountByEnergy = Math.floor(remainingEnergy / patternCost);
-  const maxPatternCountBySize = Math.floor((MAX_CREEP_PARTS3 - baseBody.length) / pattern.length);
+  const maxPatternCountByEnergy = Math.floor(energyAvailable / patternCost);
+  const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS3 / pattern.length);
   const patternCount = Math.min(
     maxPatternCountByEnergy,
     maxPatternCountBySize,
@@ -13824,7 +13825,6 @@ function buildMultiRoomUpgraderBody(energyAvailable, plan) {
     return [];
   }
   const body = [
-    ...baseBody,
     ...Array.from({ length: patternCount }).flatMap(() => pattern)
   ];
   const unusedEnergy = energyAvailable - getBodyCost2(body);
@@ -13839,7 +13839,7 @@ function buildMultiRoomUpgraderMemory(plan) {
     colony: plan.homeRoom,
     territory: {
       targetRoom: plan.targetRoom,
-      action: plan.controllerState === "reserved" ? "reserve" : "claim",
+      action: "claim",
       controllerId: plan.controllerId
     },
     controllerSustain: {
@@ -13856,14 +13856,12 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
     return [];
   }
   const homeRoom = colony.room.name;
-  const ownerUsername = getControllerOwnerUsername3(colony.room.controller);
-  const activeUpgraderCounts = getActiveMultiRoomUpgraderCountsByTarget(homeRoom);
+  const activeUpgraderCounts = getActiveMultiRoomUpgraderCountsByTarget();
   const candidates = [];
   let order = 0;
   for (const room of Object.values(rooms)) {
     const candidate = getVisibleMultiRoomUpgradeCandidate(
       homeRoom,
-      ownerUsername,
       room,
       config,
       activeUpgraderCounts,
@@ -13876,7 +13874,7 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
   }
   return candidates;
 }
-function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, config, activeUpgraderCounts, order) {
+function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgraderCounts, order) {
   var _a;
   if (!isNonEmptyString9(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
     return null;
@@ -13885,7 +13883,7 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, conf
   if (!controller || !isNonEmptyString9(controller.id)) {
     return null;
   }
-  const controllerState = getEligibleControllerState(controller, ownerUsername);
+  const controllerState = getEligibleControllerState(controller);
   if (!controllerState) {
     return null;
   }
@@ -13907,20 +13905,14 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, ownerUsername, room, conf
     controllerId: controller.id,
     controllerLevel: getControllerLevel(controller),
     controllerState,
+    ...getControllerTicksToDowngradePlanField(controller),
     ...typeof routeDistance === "number" ? { routeDistance } : {},
     activeUpgraderCount,
     order
   };
 }
-function getEligibleControllerState(controller, ownerUsername) {
-  if (controller.my === true) {
-    return controller.level < 8 ? "owned" : null;
-  }
-  const reservationUsername = getControllerReservationUsername2(controller);
-  if (ownerUsername && reservationUsername === ownerUsername) {
-    return "reserved";
-  }
-  return null;
+function getEligibleControllerState(controller) {
+  return controller.my === true && getControllerLevel(controller) < MAX_CONTROLLER_LEVEL3 ? "owned" : null;
 }
 function hasPrimaryRoomStorageSurplus(colony, storageEnergyThresholdRatio) {
   const storage = colony.room.storage;
@@ -14011,17 +14003,16 @@ function getBodyPartCost2(part) {
   }
 }
 function compareMultiRoomUpgradeCandidates(left, right) {
-  return left.controllerLevel - right.controllerLevel || compareOptionalNumbers3(left.routeDistance, right.routeDistance) || left.targetRoom.localeCompare(right.targetRoom) || left.order - right.order;
+  return compareOptionalNumbers3(left.controllerTicksToDowngrade, right.controllerTicksToDowngrade) || left.controllerLevel - right.controllerLevel || compareOptionalNumbers3(left.routeDistance, right.routeDistance) || left.targetRoom.localeCompare(right.targetRoom) || left.order - right.order;
 }
 function compareOptionalNumbers3(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 var activeMultiRoomUpgraderCountCache = null;
-function getActiveMultiRoomUpgraderCountsByTarget(homeRoom) {
-  var _a, _b;
+function getActiveMultiRoomUpgraderCountsByTarget() {
   const cache = getActiveMultiRoomUpgraderCountCache();
-  const activeByTarget = (_a = cache.countsByHomeRoom[homeRoom]) != null ? _a : {};
-  const plannedByTarget = (_b = cache.plannedByHomeRoom[homeRoom]) != null ? _b : {};
+  const activeByTarget = combineNestedCountMaps(cache.countsByHomeRoom);
+  const plannedByTarget = combineNestedCountMaps(cache.plannedByHomeRoom);
   return combineCountMaps(activeByTarget, plannedByTarget);
 }
 function countActiveMultiRoomUpgradersByHomeRoom(creeps) {
@@ -14046,6 +14037,16 @@ function combineCountMaps(baseCounts, overlayCounts) {
   }
   return combined;
 }
+function combineNestedCountMaps(countsByHomeRoom) {
+  var _a;
+  const combined = {};
+  for (const countsByTarget of Object.values(countsByHomeRoom)) {
+    for (const [targetRoom, count] of Object.entries(countsByTarget)) {
+      combined[targetRoom] = ((_a = combined[targetRoom]) != null ? _a : 0) + count;
+    }
+  }
+  return combined;
+}
 function getActiveMultiRoomUpgraderCountCache() {
   var _a;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
@@ -14064,17 +14065,10 @@ function isActiveMultiRoomUpgrader(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
 function getControllerLevel(controller) {
-  return typeof controller.level === "number" ? controller.level : DEFAULT_RESERVED_CONTROLLER_LEVEL;
+  return typeof controller.level === "number" && Number.isFinite(controller.level) ? controller.level : MAX_CONTROLLER_LEVEL3;
 }
-function getControllerOwnerUsername3(controller) {
-  var _a;
-  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : null;
-}
-function getControllerReservationUsername2(controller) {
-  var _a;
-  const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : null;
+function getControllerTicksToDowngradePlanField(controller) {
+  return typeof controller.ticksToDowngrade === "number" && Number.isFinite(controller.ticksToDowngrade) ? { controllerTicksToDowngrade: Math.max(0, Math.floor(controller.ticksToDowngrade)) } : {};
 }
 function getStoredEnergy8(storage) {
   const storedEnergy = storage.store.getUsedCapacity(RESOURCE_ENERGY);
@@ -14927,7 +14921,7 @@ function isNonEmptyString10(value) {
 var CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
 var CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
 var CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET = 6;
-var MAX_CONTROLLER_LEVEL2 = 8;
+var MAX_CONTROLLER_LEVEL4 = 8;
 var SOURCE_ENERGY_CAPACITY = 3e3;
 var SOURCE_REGEN_TICKS = 300;
 var SOURCE_ENERGY_PER_TICK = SOURCE_ENERGY_CAPACITY / SOURCE_REGEN_TICKS;
@@ -15213,7 +15207,7 @@ function comparePostClaimControllerSustainRecords(left, right) {
 function getVisibleControllerLevel(roomName) {
   var _a, _b;
   const level = (_b = (_a = getVisibleRoom5(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
-  return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL2 + 1;
+  return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL4 + 1;
 }
 function hasOperationalSpawnInRoom(roomName) {
   var _a;
@@ -15471,7 +15465,7 @@ function hasControllerUpgradeSurplusEnergy(colony) {
   return colony.energyCapacityAvailable >= CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY && colony.energyAvailable >= colony.energyCapacityAvailable;
 }
 function isControllerUpgradeableForSurplus(controller) {
-  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && controller.level < MAX_CONTROLLER_LEVEL2;
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && controller.level < MAX_CONTROLLER_LEVEL4;
 }
 function hasControllerUpgradeBlockingTerritoryWork(colony) {
   return hasActiveTerritoryIntentBacklog(colony.room.name) || hasVisibleForeignReservedTerritoryTarget(colony);
@@ -15498,7 +15492,7 @@ function hasVisibleForeignReservedTerritoryTarget(colony) {
   if (!Array.isArray(targets)) {
     return false;
   }
-  const colonyOwnerUsername = getControllerOwnerUsername4(colony.room.controller);
+  const colonyOwnerUsername = getControllerOwnerUsername3(colony.room.controller);
   return targets.some((target) => {
     if (typeof target !== "object" || target === null) {
       return false;
@@ -15522,7 +15516,7 @@ function isForeignReservedController2(controller, colonyOwnerUsername) {
   const reservationUsername = (_a = controller == null ? void 0 : controller.reservation) == null ? void 0 : _a.username;
   return (controller == null ? void 0 : controller.my) !== true && typeof reservationUsername === "string" && reservationUsername.length > 0 && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername4(controller) {
+function getControllerOwnerUsername3(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return typeof username === "string" && username.length > 0 ? username : void 0;
@@ -15910,8 +15904,8 @@ function buildTerritoryScoutIntel(colony, room, gameTime, scoutName) {
   };
 }
 function summarizeScoutController(controller) {
-  const ownerUsername = getControllerOwnerUsername5(controller);
-  const reservationUsername = getControllerReservationUsername3(controller);
+  const ownerUsername = getControllerOwnerUsername4(controller);
+  const reservationUsername = getControllerReservationUsername2(controller);
   const reservationTicksToEnd = getControllerReservationTicksToEnd2(controller);
   return {
     ...typeof controller.id === "string" ? { id: controller.id } : {},
@@ -16127,12 +16121,12 @@ function getStructureSpawnConstant() {
   const structureSpawn = globalThis.STRUCTURE_SPAWN;
   return structureSpawn != null ? structureSpawn : "spawn";
 }
-function getControllerOwnerUsername5(controller) {
+function getControllerOwnerUsername4(controller) {
   var _a;
   const username = (_a = controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString12(username) ? username : void 0;
 }
-function getControllerReservationUsername3(controller) {
+function getControllerReservationUsername2(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
   return isNonEmptyString12(username) ? username : void 0;
@@ -16270,7 +16264,7 @@ function validateVisibleNextExpansionScoutIntel(colony, candidate, gameTime, tel
   const validation = validateTerritoryScoutIntelForClaim({
     colony: colonyName,
     targetRoom: candidate.roomName,
-    colonyOwnerUsername: getControllerOwnerUsername6(colony.room.controller),
+    colonyOwnerUsername: getControllerOwnerUsername5(colony.room.controller),
     gameTime
   });
   recordTerritoryScoutValidation(
@@ -16288,10 +16282,10 @@ function buildRuntimeExpansionScoringInput(colony) {
   var _a, _b;
   return {
     colonyName: colony.room.name,
-    ...getControllerOwnerUsername6(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername6(colony.room.controller) } : {},
+    ...getControllerOwnerUsername5(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername5(colony.room.controller) } : {},
     energyCapacityAvailable: colony.energyCapacityAvailable,
     ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
-    ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername6(colony.room.controller)),
+    ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername5(colony.room.controller)),
     ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
     activePostClaimBootstrapCount: countActivePostClaimBootstraps(),
     candidates: buildRuntimeExpansionCandidates(colony)
@@ -16308,7 +16302,7 @@ function buildRuntimeExpansionCandidates(colony) {
   var _a;
   const rooms = (_a = getGameRooms2()) != null ? _a : {};
   const colonyName = colony.room.name;
-  const ownerUsername = getControllerOwnerUsername6(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername5(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames3(colonyName, ownerUsername);
   const adjacentRoomNames = getAdjacentRoomNamesByOwnedRoom(ownedRoomNames);
   const candidateOrders = /* @__PURE__ */ new Map();
@@ -16810,7 +16804,7 @@ function getVisibleOwnedRoomNames3(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString13(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
+    if (((_a = room == null ? void 0 : room.controller) == null ? void 0 : _a.my) === true && isNonEmptyString13(room.name) && (!ownerUsername || getControllerOwnerUsername5(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -16948,8 +16942,8 @@ function getNoPathResultCode6() {
   return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE6;
 }
 function summarizeExpansionController(controller) {
-  const ownerUsername = getControllerOwnerUsername6(controller);
-  const reservationUsername = getControllerReservationUsername4(controller);
+  const ownerUsername = getControllerOwnerUsername5(controller);
+  const reservationUsername = getControllerReservationUsername3(controller);
   const reservationTicksToEnd = getControllerReservationTicksToEnd3(controller);
   return {
     ...controller.my === true ? { my: true } : {},
@@ -17072,12 +17066,12 @@ function getFindConstant5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getControllerOwnerUsername6(controller) {
+function getControllerOwnerUsername5(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString13(username) ? username : void 0;
 }
-function getControllerReservationUsername4(controller) {
+function getControllerReservationUsername3(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
   return isNonEmptyString13(username) ? username : void 0;
@@ -19617,7 +19611,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   if (controller && isControllerOwned2(controller)) {
     return { ...visibleControllerEvaluation, reason: "controllerOwned" };
   }
-  if (controller && isControllerReserved(controller, getControllerOwnerUsername7(colony.room.controller))) {
+  if (controller && isControllerReserved(controller, getControllerOwnerUsername6(colony.room.controller))) {
     return { ...visibleControllerEvaluation, reason: "controllerReserved" };
   }
   if (isAutonomousExpansionClaimGclInsufficient()) {
@@ -19635,7 +19629,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   const scoutValidation = validateTerritoryScoutIntelForClaim({
     colony: colonyName,
     targetRoom: candidate.roomName,
-    colonyOwnerUsername: getControllerOwnerUsername7(colony.room.controller),
+    colonyOwnerUsername: getControllerOwnerUsername6(colony.room.controller),
     gameTime
   });
   const scoutControllerId = getScoutValidationControllerId(scoutValidation);
@@ -19703,7 +19697,7 @@ function getScoutValidationClaimSkipReason(validation) {
 function buildAutonomousExpansionScoringInput(colony, report, context) {
   var _a, _b;
   const colonyName = colony.room.name;
-  const colonyOwnerUsername = getControllerOwnerUsername7(colony.room.controller);
+  const colonyOwnerUsername = getControllerOwnerUsername6(colony.room.controller);
   const ownedRoomNames = getVisibleOwnedRoomNames4(colonyName, colonyOwnerUsername);
   const adjacentRoomNamesByOwnedRoom = getAdjacentRoomNamesByOwnedRoom2(ownedRoomNames, context);
   const seenRooms = /* @__PURE__ */ new Set();
@@ -19751,7 +19745,7 @@ function toExpansionCandidateInput(candidate, order, adjacency) {
 }
 function summarizeExpansionController2(controller) {
   var _a, _b;
-  const ownerUsername = getControllerOwnerUsername7(controller);
+  const ownerUsername = getControllerOwnerUsername6(controller);
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
   return {
     ...typeof controller.my === "boolean" ? { my: controller.my } : {},
@@ -19777,7 +19771,7 @@ function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString15(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString15(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -20329,7 +20323,7 @@ function getClaimColony(creep, controller) {
   return (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller == null ? void 0 : controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown";
 }
 function isForeignOwnedController(controller) {
-  return controller.my !== true && isNonEmptyString15(getControllerOwnerUsername7(controller));
+  return controller.my !== true && isNonEmptyString15(getControllerOwnerUsername6(controller));
 }
 function isForeignReservedController3(controller, colony) {
   var _a, _b;
@@ -20337,7 +20331,7 @@ function isForeignReservedController3(controller, colony) {
   if (!isNonEmptyString15(reservationUsername)) {
     return false;
   }
-  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom7(colony != null ? colony : "")) == null ? void 0 : _b.controller);
+  return reservationUsername !== getControllerOwnerUsername6((_b = getVisibleRoom7(colony != null ? colony : "")) == null ? void 0 : _b.controller);
 }
 function getKnownActiveClaimPartCount(creep) {
   var _a;
@@ -20412,7 +20406,7 @@ function isControllerReserved(controller, colonyOwnerUsername) {
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
   return isNonEmptyString15(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername7(controller) {
+function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString15(username) ? username : void 0;
@@ -20711,7 +20705,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
     return { status: "skipped", colony: colonyName, reason: "energyCapacityLow", claimBlocker };
   }
   const renewalThresholdTicks = getAdjacentRoomReservationRenewalThreshold(claimPartCount);
-  const ownerUsername = getControllerOwnerUsername8(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername7(colony.room.controller);
   const candidates = getAdjacentRoomNames7(colonyName).flatMap(
     (roomName, order) => buildReservationCandidate(colony.room, roomName, order, ownerUsername, renewalThresholdTicks)
   );
@@ -20815,7 +20809,7 @@ function getAdjacentRoomClaimBlocker(colony) {
   if (typeof controllerLevel !== "number" || controllerLevel < 2) {
     return "controllerLevelLow";
   }
-  const ownerUsername = getControllerOwnerUsername8(controller);
+  const ownerUsername = getControllerOwnerUsername7(controller);
   const ownedRoomCount = countVisibleOwnedRooms2(colony.room.name, ownerUsername);
   const gclLevel = getGclLevel();
   if (typeof gclLevel === "number" && ownedRoomCount >= gclLevel) {
@@ -21023,7 +21017,7 @@ function countVisibleOwnedRooms2(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString17(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString17(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
@@ -21056,7 +21050,7 @@ function getFindConstant6(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getControllerOwnerUsername8(controller) {
+function getControllerOwnerUsername7(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString17(username) ? username : void 0;
@@ -21158,7 +21152,7 @@ function clearColonyExpansionClaimIntent(colony) {
   pruneColonyExpansionClaimTargets(colony, territoryMemory);
 }
 function selectColonyExpansionCandidate(colony) {
-  const ownerUsername = getControllerOwnerUsername9(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername8(colony.room.controller);
   const candidates = getAdjacentRoomNames8(colony.room.name).flatMap((roomName, order) => {
     const claimScore = scoreClaimTarget(roomName, colony.room);
     if (claimScore.sources <= 0 || hasHostileClaimScore(claimScore)) {
@@ -21355,7 +21349,7 @@ function getScoutIntel3(homeRoomName, roomName) {
   var _a, _b, _c;
   return (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel) == null ? void 0 : _c[`${homeRoomName}>${roomName}`];
 }
-function getControllerOwnerUsername9(controller) {
+function getControllerOwnerUsername8(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString18(username) ? username : void 0;

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -545,7 +545,7 @@ function selectControllerSustainUpgradeTask(
     sustain?.role !== 'upgrader' ||
     sustain.targetRoom !== creep.room?.name ||
     controller?.my !== true ||
-    !canUpgradeController(controller)
+    !canLevelUpController(controller)
   ) {
     return null;
   }

--- a/prod/src/territory/multiRoomUpgrader.ts
+++ b/prod/src/territory/multiRoomUpgrader.ts
@@ -8,17 +8,16 @@ export const MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP = 1;
 const SPAWN_CONSTRUCTION_UPGRADER_CAP_BONUS = 1;
 const REMOTE_UPGRADER_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move'];
 const REMOTE_UPGRADER_TRAVEL_PATTERN: BodyPartConstant[] = ['work', 'carry', 'move', 'move'];
-const RESERVED_CONTROLLER_BASE_BODY: BodyPartConstant[] = ['claim', 'move'];
 const REMOTE_UPGRADER_PATTERN_COST = 200;
 const MOVE_PART_COST = 50;
 const MAX_CREEP_PARTS = 50;
 const MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
-const DEFAULT_RESERVED_CONTROLLER_LEVEL = 0;
+const MAX_CONTROLLER_LEVEL = 8;
 const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const TERRITORY_ROUTE_DISTANCE_SEPARATOR = '>';
 const ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
 
-export type MultiRoomUpgradeControllerState = 'owned' | 'reserved';
+export type MultiRoomUpgradeControllerState = 'owned';
 
 export interface MultiRoomUpgraderOptions {
   storageEnergyThresholdRatio?: number;
@@ -31,6 +30,7 @@ export interface MultiRoomUpgradePlan {
   controllerId: Id<StructureController>;
   controllerLevel: number;
   controllerState: MultiRoomUpgradeControllerState;
+  controllerTicksToDowngrade?: number;
   routeDistance?: number;
   activeUpgraderCount: number;
 }
@@ -90,18 +90,16 @@ export function selectMultiRoomUpgradePlans(
 
 export function buildMultiRoomUpgraderBody(
   energyAvailable: number,
-  plan: Pick<MultiRoomUpgradePlan, 'controllerState' | 'routeDistance'>
+  plan: Pick<MultiRoomUpgradePlan, 'routeDistance'>
 ): BodyPartConstant[] {
-  const baseBody = plan.controllerState === 'reserved' ? RESERVED_CONTROLLER_BASE_BODY : [];
-  const remainingEnergy = energyAvailable - getBodyCost(baseBody);
-  if (remainingEnergy < REMOTE_UPGRADER_PATTERN_COST) {
+  if (energyAvailable < REMOTE_UPGRADER_PATTERN_COST) {
     return [];
   }
 
   const pattern = getRemoteUpgraderPattern(plan.routeDistance);
   const patternCost = getBodyCost(pattern);
-  const maxPatternCountByEnergy = Math.floor(remainingEnergy / patternCost);
-  const maxPatternCountBySize = Math.floor((MAX_CREEP_PARTS - baseBody.length) / pattern.length);
+  const maxPatternCountByEnergy = Math.floor(energyAvailable / patternCost);
+  const maxPatternCountBySize = Math.floor(MAX_CREEP_PARTS / pattern.length);
   const patternCount = Math.min(
     maxPatternCountByEnergy,
     maxPatternCountBySize,
@@ -112,7 +110,6 @@ export function buildMultiRoomUpgraderBody(
   }
 
   const body = [
-    ...baseBody,
     ...Array.from({ length: patternCount }).flatMap(() => pattern)
   ];
   const unusedEnergy = energyAvailable - getBodyCost(body);
@@ -129,7 +126,7 @@ export function buildMultiRoomUpgraderMemory(plan: MultiRoomUpgradePlan): CreepM
     colony: plan.homeRoom,
     territory: {
       targetRoom: plan.targetRoom,
-      action: plan.controllerState === 'reserved' ? 'reserve' : 'claim',
+      action: 'claim',
       controllerId: plan.controllerId
     },
     controllerSustain: {
@@ -150,15 +147,13 @@ function getVisibleMultiRoomUpgradeCandidates(
   }
 
   const homeRoom = colony.room.name;
-  const ownerUsername = getControllerOwnerUsername(colony.room.controller);
-  const activeUpgraderCounts = getActiveMultiRoomUpgraderCountsByTarget(homeRoom);
+  const activeUpgraderCounts = getActiveMultiRoomUpgraderCountsByTarget();
   const candidates: MultiRoomUpgradeCandidate[] = [];
   let order = 0;
 
   for (const room of Object.values(rooms)) {
     const candidate = getVisibleMultiRoomUpgradeCandidate(
       homeRoom,
-      ownerUsername,
       room,
       config,
       activeUpgraderCounts,
@@ -175,7 +170,6 @@ function getVisibleMultiRoomUpgradeCandidates(
 
 function getVisibleMultiRoomUpgradeCandidate(
   homeRoom: string,
-  ownerUsername: string | null,
   room: Room,
   config: MultiRoomUpgraderConfig,
   activeUpgraderCounts: Record<string, number>,
@@ -190,7 +184,7 @@ function getVisibleMultiRoomUpgradeCandidate(
     return null;
   }
 
-  const controllerState = getEligibleControllerState(controller, ownerUsername);
+  const controllerState = getEligibleControllerState(controller);
   if (!controllerState) {
     return null;
   }
@@ -216,6 +210,7 @@ function getVisibleMultiRoomUpgradeCandidate(
     controllerId: controller.id,
     controllerLevel: getControllerLevel(controller),
     controllerState,
+    ...getControllerTicksToDowngradePlanField(controller),
     ...(typeof routeDistance === 'number' ? { routeDistance } : {}),
     activeUpgraderCount,
     order
@@ -223,19 +218,9 @@ function getVisibleMultiRoomUpgradeCandidate(
 }
 
 function getEligibleControllerState(
-  controller: StructureController,
-  ownerUsername: string | null
+  controller: StructureController
 ): MultiRoomUpgradeControllerState | null {
-  if (controller.my === true) {
-    return controller.level < 8 ? 'owned' : null;
-  }
-
-  const reservationUsername = getControllerReservationUsername(controller);
-  if (ownerUsername && reservationUsername === ownerUsername) {
-    return 'reserved';
-  }
-
-  return null;
+  return controller.my === true && getControllerLevel(controller) < MAX_CONTROLLER_LEVEL ? 'owned' : null;
 }
 
 function hasPrimaryRoomStorageSurplus(colony: ColonySnapshot, storageEnergyThresholdRatio: number): boolean {
@@ -365,6 +350,7 @@ function compareMultiRoomUpgradeCandidates(
   right: MultiRoomUpgradeCandidate
 ): number {
   return (
+    compareOptionalNumbers(left.controllerTicksToDowngrade, right.controllerTicksToDowngrade) ||
     left.controllerLevel - right.controllerLevel ||
     compareOptionalNumbers(left.routeDistance, right.routeDistance) ||
     left.targetRoom.localeCompare(right.targetRoom) ||
@@ -389,10 +375,10 @@ interface RouteDistanceCacheState {
   updatedAt: Record<string, number>;
 }
 
-function getActiveMultiRoomUpgraderCountsByTarget(homeRoom: string): Record<string, number> {
+function getActiveMultiRoomUpgraderCountsByTarget(): Record<string, number> {
   const cache = getActiveMultiRoomUpgraderCountCache();
-  const activeByTarget = cache.countsByHomeRoom[homeRoom] ?? {};
-  const plannedByTarget = cache.plannedByHomeRoom[homeRoom] ?? {};
+  const activeByTarget = combineNestedCountMaps(cache.countsByHomeRoom);
+  const plannedByTarget = combineNestedCountMaps(cache.plannedByHomeRoom);
   return combineCountMaps(activeByTarget, plannedByTarget);
 }
 
@@ -431,6 +417,17 @@ function combineCountMaps(
   return combined;
 }
 
+function combineNestedCountMaps(countsByHomeRoom: Record<string, Record<string, number>>): Record<string, number> {
+  const combined: Record<string, number> = {};
+  for (const countsByTarget of Object.values(countsByHomeRoom)) {
+    for (const [targetRoom, count] of Object.entries(countsByTarget)) {
+      combined[targetRoom] = (combined[targetRoom] ?? 0) + count;
+    }
+  }
+
+  return combined;
+}
+
 function getActiveMultiRoomUpgraderCountCache(): ActiveMultiRoomUpgraderCountCache {
   const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
   const gameTime = getGameTime();
@@ -454,18 +451,17 @@ function isActiveMultiRoomUpgrader(creep: Creep): boolean {
 }
 
 function getControllerLevel(controller: StructureController): number {
-  return typeof controller.level === 'number' ? controller.level : DEFAULT_RESERVED_CONTROLLER_LEVEL;
+  return typeof controller.level === 'number' && Number.isFinite(controller.level)
+    ? controller.level
+    : MAX_CONTROLLER_LEVEL;
 }
 
-function getControllerOwnerUsername(controller: StructureController | undefined): string | null {
-  const username = (controller as (StructureController & { owner?: { username?: string } }) | undefined)?.owner
-    ?.username;
-  return isNonEmptyString(username) ? username : null;
-}
-
-function getControllerReservationUsername(controller: StructureController): string | null {
-  const username = (controller as StructureController & { reservation?: { username?: string } }).reservation?.username;
-  return isNonEmptyString(username) ? username : null;
+function getControllerTicksToDowngradePlanField(
+  controller: StructureController
+): Pick<MultiRoomUpgradePlan, 'controllerTicksToDowngrade'> {
+  return typeof controller.ticksToDowngrade === 'number' && Number.isFinite(controller.ticksToDowngrade)
+    ? { controllerTicksToDowngrade: Math.max(0, Math.floor(controller.ticksToDowngrade)) }
+    : {};
 }
 
 function getStoredEnergy(storage: StructureStorage): number {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -73,6 +73,7 @@ const TERRITORY_EMERGENCY_RESERVATION_COVERAGE_TARGET = 2;
 const TERRITORY_SCOUT_BODY_COST = 50;
 const OCCUPATION_RECOMMENDATION_TARGET_CREATOR: TerritoryTargetMemory['createdBy'] = 'occupationRecommendation';
 const REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
+const MAX_CONTROLLER_LEVEL = 8;
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -519,10 +520,20 @@ export function selectVisibleTerritoryControllerTask(creep: Creep): CreepTaskMem
   }
 
   if (controller.my === true) {
-    return getStoredEnergy(creep) > 0 ? { type: 'upgrade', targetId: controller.id } : null;
+    return getStoredEnergy(creep) > 0 && canLevelUpVisibleController(controller)
+      ? { type: 'upgrade', targetId: controller.id }
+      : null;
   }
 
   return canUseControllerClaimPart(creep) ? { type: 'claim', targetId: controller.id } : null;
+}
+
+function canLevelUpVisibleController(controller: StructureController): boolean {
+  return (
+    typeof controller.level === 'number' &&
+    Number.isFinite(controller.level) &&
+    controller.level < MAX_CONTROLLER_LEVEL
+  );
 }
 
 export function canCreepReserveTerritoryController(

--- a/prod/test/multiRoomUpgrader.test.ts
+++ b/prod/test/multiRoomUpgrader.test.ts
@@ -94,11 +94,16 @@ describe('multi-room upgrader planner', () => {
     } as unknown as StructureStorage;
   }
 
-  function makeOwnedController(roomName: string, level: number): StructureController {
+  function makeOwnedController(
+    roomName: string,
+    level: number,
+    ticksToDowngrade?: number
+  ): StructureController {
     return {
       id: `${roomName}-controller`,
       my: true,
       level,
+      ...(typeof ticksToDowngrade === 'number' ? { ticksToDowngrade } : {}),
       owner: { username: 'player' }
     } as StructureController;
   }
@@ -112,13 +117,13 @@ describe('multi-room upgrader planner', () => {
     } as StructureController;
   }
 
-  function makeRemoteUpgrader(targetRoom: string, ticksToLive = 1_000): Creep {
+  function makeRemoteUpgrader(targetRoom: string, ticksToLive = 1_000, homeRoom = 'W1N1'): Creep {
     return {
       ticksToLive,
       memory: {
         role: 'worker',
         colony: targetRoom,
-        controllerSustain: { homeRoom: 'W1N1', targetRoom, role: 'upgrader' }
+        controllerSustain: { homeRoom, targetRoom, role: 'upgrader' }
       }
     } as Creep;
   }
@@ -203,18 +208,21 @@ describe('multi-room upgrader planner', () => {
     });
   });
 
-  it('ranks lower controller levels before proximity', () => {
+  it('prioritizes controllers closest to downgrade before level or proximity', () => {
     const colony = makeColony();
     installGame({
       colony,
       rooms: [
-        makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 3) }),
-        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })
+        makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 1, 20_000) }),
+        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 4, 2_000) })
       ],
       routeLengths: { W2N1: 1, W3N1: 3 }
     });
 
-    expect(selectMultiRoomUpgradePlan(colony)?.targetRoom).toBe('W3N1');
+    expect(selectMultiRoomUpgradePlan(colony)).toMatchObject({
+      targetRoom: 'W3N1',
+      controllerTicksToDowngrade: 2_000
+    });
   });
 
   it('returns all eligible plans in ranked order', () => {
@@ -222,8 +230,8 @@ describe('multi-room upgrader planner', () => {
     installGame({
       colony,
       rooms: [
-        makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 3) }),
-        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2) })
+        makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 3, 5_000) }),
+        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2, 2_000) })
       ],
       routeLengths: { W2N1: 1, W3N1: 3 }
     });
@@ -355,6 +363,21 @@ describe('multi-room upgrader planner', () => {
     expect(planWithCap3?.targetRoom).toBe('W2N1');
   });
 
+  it('counts active upgraders from every home room toward the target cap', () => {
+    const colony = makeColony();
+    installGame({
+      colony,
+      rooms: [
+        makeRoom({ roomName: 'W2N1', controller: makeOwnedController('W2N1', 1, 1_000) }),
+        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 2, 2_000) })
+      ],
+      creeps: { Existing: makeRemoteUpgrader('W2N1', 1_000, 'W9N9') },
+      routeLengths: { W2N1: 1, W3N1: 1 }
+    });
+
+    expect(selectMultiRoomUpgradePlan(colony)?.targetRoom).toBe('W3N1');
+  });
+
   it('temporarily allows an extra upgrader for claimed rooms with active spawn construction', () => {
     const colony = makeColony();
     installGame({
@@ -394,33 +417,39 @@ describe('multi-room upgrader planner', () => {
     expect(selectMultiRoomUpgradePlan(colony)).toBeNull();
   });
 
-  it('selects own reserved rooms and builds a reserve-capable sustain body', () => {
+  it('skips maxed and unowned controllers instead of building claimer sustain bodies', () => {
     const colony = makeColony({ storageEnergy: 900, storageCapacity: 1_000 });
     installGame({
       colony,
-      rooms: [makeRoom({ roomName: 'W2N1', controller: makeReservedController('W2N1') })],
-      routeLengths: { W2N1: 1 }
+      rooms: [
+        makeRoom({ roomName: 'W2N1', controller: makeReservedController('W2N1') }),
+        makeRoom({ roomName: 'W3N1', controller: makeOwnedController('W3N1', 8, 1_000) }),
+        makeRoom({ roomName: 'W4N1', controller: makeOwnedController('W4N1', 7, 3_000) })
+      ],
+      routeLengths: { W2N1: 1, W3N1: 1, W4N1: 1 }
     });
 
     const plan = selectMultiRoomUpgradePlan(colony);
 
     expect(plan).toEqual({
       homeRoom: 'W1N1',
-      targetRoom: 'W2N1',
-      controllerId: 'W2N1-controller',
-      controllerLevel: 0,
-      controllerState: 'reserved',
+      targetRoom: 'W4N1',
+      controllerId: 'W4N1-controller',
+      controllerLevel: 7,
+      controllerState: 'owned',
+      controllerTicksToDowngrade: 3_000,
       routeDistance: 1,
       activeUpgraderCount: 0
     });
-    expect(buildMultiRoomUpgraderMemory(plan!)).toEqual({
-      role: 'worker',
-      colony: 'W1N1',
-      territory: { targetRoom: 'W2N1', action: 'reserve', controllerId: 'W2N1-controller' },
-      controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' }
-    });
     expect(buildMultiRoomUpgraderBody(1_000, plan!)).toEqual([
-      'claim',
+      'work',
+      'carry',
+      'move',
+      'work',
+      'carry',
+      'move',
+      'work',
+      'carry',
       'move',
       'work',
       'carry',

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -539,7 +539,51 @@ describe('planSpawn', () => {
     });
   });
 
-  it('tries the next ranked multi-room upgrade plan when the first body is unaffordable', () => {
+  it('dispatches multi-room upgraders to the lowest downgrade timer before lower-level controllers', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController(),
+      storageEnergy: 850,
+      storageCapacity: 1_000
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTerritoryRoom('W2N1', {
+          id: 'safeController',
+          my: true,
+          level: 1,
+          ticksToDowngrade: 20_000
+        } as StructureController),
+        W3N1: makeTerritoryRoom('W3N1', {
+          id: 'urgentController',
+          my: true,
+          level: 4,
+          ticksToDowngrade: 1_500
+        } as StructureController)
+      },
+      spawns: { Spawn1: spawn },
+      creeps: {},
+      map: {
+        findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 3, room: toRoom }])
+      } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(planSpawn(colony, { worker: 3 }, 130)).toMatchObject({
+      spawn,
+      name: 'worker-W1N1-W3N1-multiroom-upgrader-130',
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W3N1', action: 'claim', controllerId: 'urgentController' },
+        controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W3N1', role: 'upgrader' }
+      }
+    });
+  });
+
+  it('skips unowned multi-room upgrade candidates before selecting an owned room', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,
       energyCapacityAvailable: 650,
@@ -570,10 +614,10 @@ describe('planSpawn', () => {
     };
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
 
-    expect(planSpawn(colony, { worker: 3 }, 130)).toEqual({
+    expect(planSpawn(colony, { worker: 3 }, 131)).toEqual({
       spawn,
       body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
-      name: 'worker-W1N1-W3N1-multiroom-upgrader-130',
+      name: 'worker-W1N1-W3N1-multiroom-upgrader-131',
       memory: {
         role: 'worker',
         colony: 'W1N1',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -5814,6 +5814,30 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller2' });
   });
 
+  it('does not spend dedicated controller sustain energy on a maxed controller', () => {
+    const controller = { id: 'controller2', my: true, level: 8 } as StructureController;
+    const site = { id: 'spawn-site1', structureType: 'spawn' } as ConstructionSite;
+    const creep = {
+      memory: {
+        role: 'worker',
+        colony: 'W2N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller2' },
+        controllerSustain: { homeRoom: 'W1N1', targetRoom: 'W2N1', role: 'upgrader' }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(50),
+        getFreeCapacity: jest.fn().mockReturnValue(0)
+      },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        controller
+      })
+    } as unknown as Creep;
+    (creep.room as Room & { name: string }).name = 'W2N1';
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'build', targetId: 'spawn-site1' });
+  });
+
   it('does not prioritize a freshly suppressed urgent reservation renewal', () => {
     const controller = {
       id: 'controller2',


### PR DESCRIPTION
## Summary
Multi-room controller upgrade coordination: upgrades controllers across claimed rooms, prioritizing rooms closest to downgrade, and integrates claimer efficiency improvements.

## Implementation
- `prod/src/territory/multiRoomUpgrader.ts`: core multi-room upgrade allocation
- `prod/src/territory/territoryPlanner.ts`: integration with territory planning
- `prod/src/tasks/workerTasks.ts`: worker task integration
- Tests cover upgrade allocation, downgrade priority, and integration

## Verification
- `npm run typecheck`: PASS
- `npm test -- --runInBand`: 50/50 suites, 1094 tests PASS
- `npm run build`: PASS, `prod/dist/main.js` regenerated (948.5kb)

Closes #633
