### PR TITLE
feat(territory): bootstrap infrastructure in newly claimed rooms (#639)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -21948,12 +21948,15 @@ function isNonEmptyString18(value) {
 }
 
 // src/territory/claimedRoomBootstrapper.ts
-var ROOM_EDGE_MIN7 = 1;
-var ROOM_EDGE_MAX7 = 48;
+var ROOM_EDGE_MIN8 = 1;
+var ROOM_EDGE_MAX8 = 48;
 var SPAWN_EDGE_MIN = 2;
 var SPAWN_EDGE_MAX = 47;
-var DEFAULT_TERRAIN_WALL_MASK10 = 1;
+var MAX_SPAWN_SITE_SCAN_RADIUS = 8;
+var DEFAULT_TERRAIN_WALL_MASK11 = 1;
 var OK_CODE8 = 0;
+var ERR_FULL_CODE3 = -8;
+var ERR_RCL_NOT_ENOUGH_CODE = -14;
 function refreshClaimedRoomBootstrapperOwnership() {
   var _a;
   const game = globalThis.Game;
@@ -22056,7 +22059,7 @@ function placeSpawnConstructionSite(room) {
   const positions = findSpawnConstructionPositions(room);
   for (const position of positions) {
     const result = room.createConstructionSite(position.x, position.y, getStructureConstant2("STRUCTURE_SPAWN", "spawn"));
-    if (result === OK_CODE8) {
+    if (result === OK_CODE8 || isFatalConstructionSiteResult(result)) {
       return result;
     }
   }
@@ -22123,7 +22126,7 @@ function buildSpawnPlacementLookups2(room, anchor, maximumScanRadius) {
   return {
     blockingPositions,
     mineralPositions,
-    terrain: getRoomTerrain10(room)
+    terrain: getRoomTerrain11(room)
   };
 }
 function lookForArea2(room, lookConstantName, anchor, maximumScanRadius) {
@@ -22152,7 +22155,7 @@ function lookForArea2(room, lookConstantName, anchor, maximumScanRadius) {
   }
 }
 function canPlaceSpawn(lookups, position) {
-  return position.x >= SPAWN_EDGE_MIN && position.x <= SPAWN_EDGE_MAX && position.y >= SPAWN_EDGE_MIN && position.y <= SPAWN_EDGE_MAX && !lookups.blockingPositions.has(getPositionKey4(position)) && !lookups.mineralPositions.has(getPositionKey4(position)) && !isTerrainWall5(lookups.terrain, position);
+  return position.x >= SPAWN_EDGE_MIN && position.x <= SPAWN_EDGE_MAX && position.y >= SPAWN_EDGE_MIN && position.y <= SPAWN_EDGE_MAX && !lookups.blockingPositions.has(getPositionKey4(position)) && !lookups.mineralPositions.has(getPositionKey4(position)) && !isTerrainWall6(lookups.terrain, position);
 }
 function planMissingSourceContainerConstructionSites(colony) {
   var _a, _b;
@@ -22161,17 +22164,17 @@ function planMissingSourceContainerConstructionSites(colony) {
     return [];
   }
   const sources = getSortedSources3(room);
-  if (sources.length === 0 || sources.every((source) => hasSourceContainerCoverage(room, source))) {
+  if (sources.length === 0 || sources.every((source) => hasSourceContainerCoverage2(room, source))) {
     return [];
   }
   const lookups = createSourceContainerLookups(room);
   if (!lookups) {
     return [];
   }
-  const anchor = selectSourceContainerAnchor(colony);
+  const anchor = selectSourceContainerAnchor2(colony);
   const results = [];
   for (const source of sources) {
-    if (hasSourceContainerCoverage(room, source)) {
+    if (hasSourceContainerCoverage2(room, source)) {
       continue;
     }
     const position = selectSourceContainerPosition2(source, lookups, anchor);
@@ -22187,21 +22190,21 @@ function planMissingSourceContainerConstructionSites(colony) {
   }
   return results;
 }
-function hasSourceContainerCoverage(room, source) {
+function hasSourceContainerCoverage2(room, source) {
   return findSourceContainer(room, source) !== null || findSourceContainerConstructionSite(room, source) !== null;
 }
 function createSourceContainerLookups(room) {
   if (typeof FIND_STRUCTURES !== "number" || typeof FIND_CONSTRUCTION_SITES !== "number") {
     return null;
   }
-  const terrain = getRoomTerrain10(room);
+  const terrain = getRoomTerrain11(room);
   if (!terrain) {
     return null;
   }
   const blockedPositions = /* @__PURE__ */ new Set();
   for (const object of [
-    ...findRoomObjects14(room, "FIND_STRUCTURES"),
-    ...findRoomObjects14(room, "FIND_CONSTRUCTION_SITES")
+    ...findRoomObjects15(room, "FIND_STRUCTURES"),
+    ...findRoomObjects15(room, "FIND_CONSTRUCTION_SITES")
   ]) {
     const position = getAnyObjectPosition(object);
     if (position && isSameRoomPosition4(position, room.name)) {
@@ -22210,7 +22213,7 @@ function createSourceContainerLookups(room) {
   }
   return { terrain, blockedPositions };
 }
-function selectSourceContainerAnchor(colony) {
+function selectSourceContainerAnchor2(colony) {
   const [primarySpawn] = colony.spawns.filter((spawn) => getRoomObjectPosition2(spawn) !== null).sort((left, right) => left.name.localeCompare(right.name));
   return getRoomObjectPosition2(primarySpawn != null ? primarySpawn : colony.room.controller);
 }
@@ -22233,15 +22236,15 @@ function selectSourceContainerPosition2(source, lookups, anchor) {
       });
     }
   }
-  return (_a = positions.filter((position) => canPlaceSourceContainer2(lookups, position)).sort((left, right) => compareSourceContainerPositions2(left, right, anchor))[0]) != null ? _a : null;
+  return (_a = positions.filter((position) => canPlaceSourceContainer3(lookups, position)).sort((left, right) => compareSourceContainerPositions3(left, right, anchor))[0]) != null ? _a : null;
 }
-function canPlaceSourceContainer2(lookups, position) {
-  if (position.x < ROOM_EDGE_MIN7 || position.x > ROOM_EDGE_MAX7 || position.y < ROOM_EDGE_MIN7 || position.y > ROOM_EDGE_MAX7 || isTerrainWall5(lookups.terrain, position)) {
+function canPlaceSourceContainer3(lookups, position) {
+  if (position.x < ROOM_EDGE_MIN8 || position.x > ROOM_EDGE_MAX8 || position.y < ROOM_EDGE_MIN8 || position.y > ROOM_EDGE_MAX8 || isTerrainWall6(lookups.terrain, position)) {
     return false;
   }
   return !lookups.blockedPositions.has(getPositionKey4(position));
 }
-function compareSourceContainerPositions2(left, right, anchor) {
+function compareSourceContainerPositions3(left, right, anchor) {
   if (anchor) {
     const leftRange = getRangeBetweenPositions3(left, anchor);
     const rightRange = getRangeBetweenPositions3(right, anchor);
@@ -22260,7 +22263,7 @@ function isClaimedRoomBootstrapComplete(colony) {
   if (countExistingAndPendingStructures(room, "STRUCTURE_EXTENSION", "extension") < getExtensionLimitForRcl((_a = room.controller) == null ? void 0 : _a.level)) {
     return false;
   }
-  if (getSortedSources3(room).some((source) => !hasSourceContainerCoverage(room, source))) {
+  if (getSortedSources3(room).some((source) => !hasSourceContainerCoverage2(room, source))) {
     return false;
   }
   if (((_c = (_b = room.controller) == null ? void 0 : _b.level) != null ? _c : 0) >= 3 && countExistingAndPendingStructures(room, "STRUCTURE_TOWER", "tower") <= 0) {
@@ -22284,23 +22287,23 @@ function countExistingAndPendingStructures(room, globalName, fallback) {
   return countExistingStructures(room, globalName, fallback) + countPendingConstructionSites(room, globalName, fallback);
 }
 function countExistingStructures(room, globalName, fallback) {
-  return findRoomObjects14(room, "FIND_MY_STRUCTURES").filter(
+  return findRoomObjects15(room, "FIND_MY_STRUCTURES").filter(
     (object) => matchesStructureType16(object.structureType, globalName, fallback)
   ).length;
 }
 function countPendingConstructionSites(room, globalName, fallback) {
-  return findRoomObjects14(room, "FIND_MY_CONSTRUCTION_SITES").filter(
+  return findRoomObjects15(room, "FIND_MY_CONSTRUCTION_SITES").filter(
     (object) => matchesStructureType16(object.structureType, globalName, fallback)
   ).length;
 }
 function getSortedSources3(room) {
-  return findRoomObjects14(room, "FIND_SOURCES").filter((source) => {
+  return findRoomObjects15(room, "FIND_SOURCES").filter((source) => {
     const position = getAnyObjectPosition(source);
     return position !== null && isSameRoomPosition4(position, room.name);
   }).sort((left, right) => String(left.id).localeCompare(String(right.id)));
 }
-function findRoomObjects14(room, globalName) {
-  const findConstant = getGlobalNumber11(globalName);
+function findRoomObjects15(room, globalName) {
+  const findConstant = getGlobalNumber12(globalName);
   if (findConstant === null || typeof room.find !== "function") {
     return [];
   }
@@ -22338,20 +22341,23 @@ function getAnyObjectPosition(object) {
   }
   return null;
 }
-function getRoomTerrain10(room) {
+function getRoomTerrain11(room) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   return typeof (gameMap == null ? void 0 : gameMap.getRoomTerrain) === "function" ? gameMap.getRoomTerrain(room.name) : null;
 }
-function isTerrainWall5(terrain, position) {
-  return terrain !== null && (terrain.get(position.x, position.y) & getTerrainWallMask8()) !== 0;
+function isTerrainWall6(terrain, position) {
+  return terrain !== null && (terrain.get(position.x, position.y) & getTerrainWallMask9()) !== 0;
 }
 function getMaximumSpawnSiteScanRadius2(anchor) {
-  return Math.max(
-    anchor.x - SPAWN_EDGE_MIN,
-    SPAWN_EDGE_MAX - anchor.x,
-    anchor.y - SPAWN_EDGE_MIN,
-    SPAWN_EDGE_MAX - anchor.y
+  return Math.min(
+    MAX_SPAWN_SITE_SCAN_RADIUS,
+    Math.max(
+      anchor.x - SPAWN_EDGE_MIN,
+      SPAWN_EDGE_MAX - anchor.x,
+      anchor.y - SPAWN_EDGE_MIN,
+      SPAWN_EDGE_MAX - anchor.y
+    )
   );
 }
 function clampSpawnPosition(position) {
@@ -22395,7 +22401,7 @@ function getStructureConstant2(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function getGlobalNumber11(name) {
+function getGlobalNumber12(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : null;
 }
@@ -22403,9 +22409,16 @@ function getGlobalString2(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getTerrainWallMask8() {
+function getGlobalReturnCode(name, fallback) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : fallback;
+}
+function isFatalConstructionSiteResult(result) {
+  return result === getGlobalReturnCode("ERR_FULL", ERR_FULL_CODE3) || result === getGlobalReturnCode("ERR_RCL_NOT_ENOUGH", ERR_RCL_NOT_ENOUGH_CODE);
+}
+function getTerrainWallMask9() {
   const terrainWallMask = globalThis.TERRAIN_MASK_WALL;
-  return typeof terrainWallMask === "number" ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK10;
+  return typeof terrainWallMask === "number" ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK11;
 }
 function getGameTime19() {
   var _a;
@@ -22811,11 +22824,11 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
       return creep.memory.colony === room.name || ((_a2 = creep.room) == null ? void 0 : _a2.name) === room.name;
     }
   );
-  const hostileCreeps = findRoomObjects15(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects15(room, "FIND_HOSTILE_STRUCTURES");
-  const ownedStructures = findRoomObjects15(room, "FIND_MY_STRUCTURES");
-  const constructionSites = findRoomObjects15(room, "FIND_MY_CONSTRUCTION_SITES");
-  const sources = findRoomObjects15(room, "FIND_SOURCES");
+  const hostileCreeps = findRoomObjects16(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects16(room, "FIND_HOSTILE_STRUCTURES");
+  const ownedStructures = findRoomObjects16(room, "FIND_MY_STRUCTURES");
+  const constructionSites = findRoomObjects16(room, "FIND_MY_CONSTRUCTION_SITES");
+  const sources = findRoomObjects16(room, "FIND_SOURCES");
   return {
     roomName: room.name,
     controllerLevel: (_a = room.controller) == null ? void 0 : _a.level,
@@ -23000,8 +23013,8 @@ function getEnergyInStore2(object) {
   }
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
-function findRoomObjects15(room, constantName) {
-  const findConstant = getGlobalNumber12(constantName);
+function findRoomObjects16(room, constantName) {
+  const findConstant = getGlobalNumber13(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return [];
@@ -23021,7 +23034,7 @@ function getResourceEnergy() {
   const value = globalThis.RESOURCE_ENERGY;
   return value != null ? value : "energy";
 }
-function getGlobalNumber12(name) {
+function getGlobalNumber13(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -21669,12 +21669,484 @@ function isNonEmptyString18(value) {
   return typeof value === "string" && value.length > 0;
 }
 
+// src/territory/claimedRoomBootstrapper.ts
+var ROOM_EDGE_MIN7 = 1;
+var ROOM_EDGE_MAX7 = 48;
+var SPAWN_EDGE_MIN = 2;
+var SPAWN_EDGE_MAX = 47;
+var DEFAULT_TERRAIN_WALL_MASK10 = 1;
+var OK_CODE8 = 0;
+function refreshClaimedRoomBootstrapperOwnership() {
+  var _a;
+  const game = globalThis.Game;
+  const rooms = game == null ? void 0 : game.rooms;
+  const memory = getWritableBootstrapperMemory();
+  if (!rooms || !memory) {
+    return { detectedRoomNames: [] };
+  }
+  const detectedRoomNames = [];
+  for (const room of Object.values(rooms)) {
+    if (!(room == null ? void 0 : room.name) || !room.controller) {
+      continue;
+    }
+    const owned = room.controller.my === true;
+    const previous = memory.rooms[room.name];
+    const activePostClaimRecord = getActivePostClaimBootstrapRecord(room.name);
+    const newlyClaimed = owned && (previous == null ? void 0 : previous.owned) === false;
+    if (newlyClaimed) {
+      detectedRoomNames.push(room.name);
+    }
+    const claimedAt = newlyClaimed ? getGameTime19() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
+    memory.rooms[room.name] = {
+      roomName: room.name,
+      owned,
+      updatedAt: getGameTime19(),
+      ...claimedAt !== void 0 ? { claimedAt } : {},
+      ...newlyClaimed ? {} : (previous == null ? void 0 : previous.completedAt) !== void 0 ? { completedAt: previous.completedAt } : {}
+    };
+  }
+  return { detectedRoomNames };
+}
+function runClaimedRoomBootstrapperForColony(colony) {
+  var _a, _b;
+  const room = colony.room;
+  if (((_a = room.controller) == null ? void 0 : _a.my) !== true || !isClaimedRoomBootstrapActive(room.name)) {
+    return null;
+  }
+  const spawnStatus = getSpawnBootstrapStatus(colony);
+  if (!spawnStatus.hasSpawn) {
+    if (!spawnStatus.hasSpawnSite) {
+      const result = placeSpawnConstructionSite(room);
+      return result === null ? { roomName: room.name, phase: "spawn" } : { roomName: room.name, phase: "spawn", result };
+    }
+    return { roomName: room.name, phase: "spawn" };
+  }
+  if (countExistingAndPendingStructures(room, "STRUCTURE_EXTENSION", "extension") < getExtensionLimitForRcl(room.controller.level)) {
+    const result = planExtensionConstruction(colony);
+    if (result !== null) {
+      return { roomName: room.name, phase: "extension", result };
+    }
+  }
+  const sourceContainerResults = planMissingSourceContainerConstructionSites(colony);
+  if (sourceContainerResults.length > 0) {
+    return { roomName: room.name, phase: "sourceContainer", results: sourceContainerResults };
+  }
+  const roadResults = planEarlyRoadConstruction(colony, {
+    maxSitesPerTick: 1,
+    maxPendingRoadSites: 100,
+    maxTargetsPerTick: 3
+  });
+  if (roadResults.length > 0) {
+    return { roomName: room.name, phase: "road", results: roadResults };
+  }
+  if (((_b = room.controller.level) != null ? _b : 0) >= 3 && countExistingAndPendingStructures(room, "STRUCTURE_TOWER", "tower") <= 0) {
+    const result = planTowerConstruction(colony);
+    if (result !== null) {
+      return { roomName: room.name, phase: "tower", result };
+    }
+  }
+  if (isClaimedRoomBootstrapComplete(colony)) {
+    markClaimedRoomBootstrapComplete(room.name);
+    return { roomName: room.name, phase: "complete" };
+  }
+  return { roomName: room.name, phase: "complete" };
+}
+function isClaimedRoomBootstrapActive(roomName) {
+  const record = getBootstrapperRoomRecord(roomName);
+  if ((record == null ? void 0 : record.owned) !== true) {
+    return false;
+  }
+  if (record.claimedAt === void 0 && !getActivePostClaimBootstrapRecord(roomName)) {
+    return false;
+  }
+  return record.completedAt === void 0;
+}
+function getSpawnBootstrapStatus(colony) {
+  const room = colony.room;
+  return {
+    hasSpawn: colony.spawns.some((spawn) => {
+      var _a;
+      return ((_a = spawn.room) == null ? void 0 : _a.name) === room.name;
+    }) || countExistingStructures(room, "STRUCTURE_SPAWN", "spawn") > 0,
+    hasSpawnSite: countPendingConstructionSites(room, "STRUCTURE_SPAWN", "spawn") > 0
+  };
+}
+function placeSpawnConstructionSite(room) {
+  if (typeof room.createConstructionSite !== "function") {
+    return null;
+  }
+  const positions = findSpawnConstructionPositions(room);
+  for (const position of positions) {
+    const result = room.createConstructionSite(position.x, position.y, getStructureConstant2("STRUCTURE_SPAWN", "spawn"));
+    if (result === OK_CODE8) {
+      return result;
+    }
+  }
+  return null;
+}
+function findSpawnConstructionPositions(room) {
+  const anchor = selectInitialSpawnAnchor2(room);
+  if (!anchor) {
+    return [];
+  }
+  const maximumScanRadius = getMaximumSpawnSiteScanRadius2(anchor);
+  const lookups = buildSpawnPlacementLookups2(room, anchor, maximumScanRadius);
+  const positions = [];
+  for (let radius = 0; radius <= maximumScanRadius; radius += 1) {
+    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
+      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
+          continue;
+        }
+        const position = { x, y, roomName: room.name };
+        if (canPlaceSpawn(lookups, position)) {
+          positions.push(position);
+        }
+      }
+    }
+  }
+  return positions;
+}
+function selectInitialSpawnAnchor2(room) {
+  const controllerPosition = getRoomObjectPosition2(room.controller);
+  if (!controllerPosition) {
+    return null;
+  }
+  const nearestSourcePosition = getSortedSources3(room).map((source) => getRoomObjectPosition2(source)).filter((position) => position !== null).sort((left, right) => getRangeBetweenPositions3(controllerPosition, left) - getRangeBetweenPositions3(controllerPosition, right))[0];
+  if (!nearestSourcePosition) {
+    return clampSpawnPosition({ x: controllerPosition.x, y: controllerPosition.y, roomName: room.name });
+  }
+  return clampSpawnPosition({
+    x: Math.round((controllerPosition.x + nearestSourcePosition.x) / 2),
+    y: Math.round((controllerPosition.y + nearestSourcePosition.y) / 2),
+    roomName: room.name
+  });
+}
+function buildSpawnPlacementLookups2(room, anchor, maximumScanRadius) {
+  const blockingPositions = /* @__PURE__ */ new Set();
+  for (const object of [
+    room.controller,
+    ...getSortedSources3(room),
+    ...lookForArea2(room, "LOOK_STRUCTURES", anchor, maximumScanRadius),
+    ...lookForArea2(room, "LOOK_CONSTRUCTION_SITES", anchor, maximumScanRadius)
+  ]) {
+    const position = getAnyObjectPosition(object);
+    if (position) {
+      blockingPositions.add(getPositionKey4(position));
+    }
+  }
+  const mineralPositions = /* @__PURE__ */ new Set();
+  for (const object of lookForArea2(room, "LOOK_MINERALS", anchor, maximumScanRadius)) {
+    const position = getAnyObjectPosition(object);
+    if (position) {
+      mineralPositions.add(getPositionKey4(position));
+    }
+  }
+  return {
+    blockingPositions,
+    mineralPositions,
+    terrain: getRoomTerrain10(room)
+  };
+}
+function lookForArea2(room, lookConstantName, anchor, maximumScanRadius) {
+  const lookConstant = getGlobalString2(lookConstantName);
+  if (!lookConstant || typeof room.lookForAtArea !== "function") {
+    return [];
+  }
+  const bounds = {
+    top: Math.max(SPAWN_EDGE_MIN, anchor.y - maximumScanRadius),
+    left: Math.max(SPAWN_EDGE_MIN, anchor.x - maximumScanRadius),
+    bottom: Math.min(SPAWN_EDGE_MAX, anchor.y + maximumScanRadius),
+    right: Math.min(SPAWN_EDGE_MAX, anchor.x + maximumScanRadius)
+  };
+  try {
+    const result = room.lookForAtArea(
+      lookConstant,
+      bounds.top,
+      bounds.left,
+      bounds.bottom,
+      bounds.right,
+      true
+    );
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function canPlaceSpawn(lookups, position) {
+  return position.x >= SPAWN_EDGE_MIN && position.x <= SPAWN_EDGE_MAX && position.y >= SPAWN_EDGE_MIN && position.y <= SPAWN_EDGE_MAX && !lookups.blockingPositions.has(getPositionKey4(position)) && !lookups.mineralPositions.has(getPositionKey4(position)) && !isTerrainWall5(lookups.terrain, position);
+}
+function planMissingSourceContainerConstructionSites(colony) {
+  var _a, _b;
+  const room = colony.room;
+  if (typeof room.createConstructionSite !== "function" || ((_b = (_a = room.controller) == null ? void 0 : _a.level) != null ? _b : 0) < 2 || typeof FIND_SOURCES !== "number") {
+    return [];
+  }
+  const sources = getSortedSources3(room);
+  if (sources.length === 0 || sources.every((source) => hasSourceContainerCoverage(room, source))) {
+    return [];
+  }
+  const lookups = createSourceContainerLookups(room);
+  if (!lookups) {
+    return [];
+  }
+  const anchor = selectSourceContainerAnchor(colony);
+  const results = [];
+  for (const source of sources) {
+    if (hasSourceContainerCoverage(room, source)) {
+      continue;
+    }
+    const position = selectSourceContainerPosition2(source, lookups, anchor);
+    if (!position) {
+      continue;
+    }
+    const result = room.createConstructionSite(position.x, position.y, getStructureConstant2("STRUCTURE_CONTAINER", "container"));
+    results.push(result);
+    if (result !== OK_CODE8) {
+      break;
+    }
+    lookups.blockedPositions.add(getPositionKey4(position));
+  }
+  return results;
+}
+function hasSourceContainerCoverage(room, source) {
+  return findSourceContainer(room, source) !== null || findSourceContainerConstructionSite(room, source) !== null;
+}
+function createSourceContainerLookups(room) {
+  if (typeof FIND_STRUCTURES !== "number" || typeof FIND_CONSTRUCTION_SITES !== "number") {
+    return null;
+  }
+  const terrain = getRoomTerrain10(room);
+  if (!terrain) {
+    return null;
+  }
+  const blockedPositions = /* @__PURE__ */ new Set();
+  for (const object of [
+    ...findRoomObjects14(room, "FIND_STRUCTURES"),
+    ...findRoomObjects14(room, "FIND_CONSTRUCTION_SITES")
+  ]) {
+    const position = getAnyObjectPosition(object);
+    if (position && isSameRoomPosition4(position, room.name)) {
+      blockedPositions.add(getPositionKey4(position));
+    }
+  }
+  return { terrain, blockedPositions };
+}
+function selectSourceContainerAnchor(colony) {
+  const [primarySpawn] = colony.spawns.filter((spawn) => getRoomObjectPosition2(spawn) !== null).sort((left, right) => left.name.localeCompare(right.name));
+  return getRoomObjectPosition2(primarySpawn != null ? primarySpawn : colony.room.controller);
+}
+function selectSourceContainerPosition2(source, lookups, anchor) {
+  var _a;
+  const sourcePosition = getRoomObjectPosition2(source);
+  if (!sourcePosition || typeof sourcePosition.roomName !== "string") {
+    return null;
+  }
+  const positions = [];
+  for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -1; dx <= 1; dx += 1) {
+      if (dx === 0 && dy === 0) {
+        continue;
+      }
+      positions.push({
+        x: sourcePosition.x + dx,
+        y: sourcePosition.y + dy,
+        roomName: sourcePosition.roomName
+      });
+    }
+  }
+  return (_a = positions.filter((position) => canPlaceSourceContainer2(lookups, position)).sort((left, right) => compareSourceContainerPositions2(left, right, anchor))[0]) != null ? _a : null;
+}
+function canPlaceSourceContainer2(lookups, position) {
+  if (position.x < ROOM_EDGE_MIN7 || position.x > ROOM_EDGE_MAX7 || position.y < ROOM_EDGE_MIN7 || position.y > ROOM_EDGE_MAX7 || isTerrainWall5(lookups.terrain, position)) {
+    return false;
+  }
+  return !lookups.blockedPositions.has(getPositionKey4(position));
+}
+function compareSourceContainerPositions2(left, right, anchor) {
+  if (anchor) {
+    const leftRange = getRangeBetweenPositions3(left, anchor);
+    const rightRange = getRangeBetweenPositions3(right, anchor);
+    if (leftRange !== rightRange) {
+      return leftRange - rightRange;
+    }
+  }
+  return left.y - right.y || left.x - right.x;
+}
+function isClaimedRoomBootstrapComplete(colony) {
+  var _a, _b, _c;
+  const room = colony.room;
+  if (!getSpawnBootstrapStatus(colony).hasSpawn) {
+    return false;
+  }
+  if (countExistingAndPendingStructures(room, "STRUCTURE_EXTENSION", "extension") < getExtensionLimitForRcl((_a = room.controller) == null ? void 0 : _a.level)) {
+    return false;
+  }
+  if (getSortedSources3(room).some((source) => !hasSourceContainerCoverage(room, source))) {
+    return false;
+  }
+  if (((_c = (_b = room.controller) == null ? void 0 : _b.level) != null ? _c : 0) >= 3 && countExistingAndPendingStructures(room, "STRUCTURE_TOWER", "tower") <= 0) {
+    return false;
+  }
+  return true;
+}
+function markClaimedRoomBootstrapComplete(roomName) {
+  const memory = getWritableBootstrapperMemory();
+  const record = memory == null ? void 0 : memory.rooms[roomName];
+  if (!memory || !record || record.completedAt !== void 0) {
+    return;
+  }
+  memory.rooms[roomName] = {
+    ...record,
+    completedAt: getGameTime19(),
+    updatedAt: getGameTime19()
+  };
+}
+function countExistingAndPendingStructures(room, globalName, fallback) {
+  return countExistingStructures(room, globalName, fallback) + countPendingConstructionSites(room, globalName, fallback);
+}
+function countExistingStructures(room, globalName, fallback) {
+  return findRoomObjects14(room, "FIND_MY_STRUCTURES").filter(
+    (object) => matchesStructureType16(object.structureType, globalName, fallback)
+  ).length;
+}
+function countPendingConstructionSites(room, globalName, fallback) {
+  return findRoomObjects14(room, "FIND_MY_CONSTRUCTION_SITES").filter(
+    (object) => matchesStructureType16(object.structureType, globalName, fallback)
+  ).length;
+}
+function getSortedSources3(room) {
+  return findRoomObjects14(room, "FIND_SOURCES").filter((source) => {
+    const position = getAnyObjectPosition(source);
+    return position !== null && isSameRoomPosition4(position, room.name);
+  }).sort((left, right) => String(left.id).localeCompare(String(right.id)));
+}
+function findRoomObjects14(room, globalName) {
+  const findConstant = getGlobalNumber11(globalName);
+  if (findConstant === null || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function getAnyObjectPosition(object) {
+  if (!isRecord20(object)) {
+    return null;
+  }
+  if (isFiniteNumber8(object.x) && isFiniteNumber8(object.y)) {
+    return {
+      x: object.x,
+      y: object.y,
+      ...typeof object.roomName === "string" ? { roomName: object.roomName } : {}
+    };
+  }
+  const position = object.pos;
+  if (isRecord20(position) && isFiniteNumber8(position.x) && isFiniteNumber8(position.y)) {
+    return {
+      x: position.x,
+      y: position.y,
+      ...typeof position.roomName === "string" ? { roomName: position.roomName } : {}
+    };
+  }
+  for (const value of Object.values(object)) {
+    const nestedPosition = getAnyObjectPosition(value);
+    if (nestedPosition) {
+      return nestedPosition;
+    }
+  }
+  return null;
+}
+function getRoomTerrain10(room) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  return typeof (gameMap == null ? void 0 : gameMap.getRoomTerrain) === "function" ? gameMap.getRoomTerrain(room.name) : null;
+}
+function isTerrainWall5(terrain, position) {
+  return terrain !== null && (terrain.get(position.x, position.y) & getTerrainWallMask8()) !== 0;
+}
+function getMaximumSpawnSiteScanRadius2(anchor) {
+  return Math.max(
+    anchor.x - SPAWN_EDGE_MIN,
+    SPAWN_EDGE_MAX - anchor.x,
+    anchor.y - SPAWN_EDGE_MIN,
+    SPAWN_EDGE_MAX - anchor.y
+  );
+}
+function clampSpawnPosition(position) {
+  return {
+    x: Math.max(SPAWN_EDGE_MIN, Math.min(SPAWN_EDGE_MAX, position.x)),
+    y: Math.max(SPAWN_EDGE_MIN, Math.min(SPAWN_EDGE_MAX, position.y)),
+    roomName: position.roomName
+  };
+}
+function getBootstrapperRoomRecord(roomName) {
+  var _a, _b, _c, _d;
+  const record = (_d = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.claimedRoomBootstrapper) == null ? void 0 : _c.rooms) == null ? void 0 : _d[roomName];
+  return isBootstrapperRoomRecord(record, roomName) ? record : null;
+}
+function getWritableBootstrapperMemory() {
+  const memory = globalThis.Memory;
+  if (!memory) {
+    return null;
+  }
+  if (!memory.territory) {
+    memory.territory = {};
+  }
+  if (!memory.territory.claimedRoomBootstrapper) {
+    memory.territory.claimedRoomBootstrapper = { rooms: {} };
+  }
+  return memory.territory.claimedRoomBootstrapper;
+}
+function getActivePostClaimBootstrapRecord(roomName) {
+  var _a, _b, _c;
+  const record = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps) == null ? void 0 : _c[roomName];
+  return isRecord20(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
+}
+function isBootstrapperRoomRecord(value, expectedRoomName) {
+  return isRecord20(value) && value.roomName === expectedRoomName && typeof value.owned === "boolean" && isFiniteNumber8(value.updatedAt);
+}
+function matchesStructureType16(actual, globalName, fallback) {
+  return actual === getStructureConstant2(globalName, fallback);
+}
+function getStructureConstant2(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function getGlobalNumber11(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : null;
+}
+function getGlobalString2(name) {
+  const value = globalThis[name];
+  return typeof value === "string" ? value : null;
+}
+function getTerrainWallMask8() {
+  const terrainWallMask = globalThis.TERRAIN_MASK_WALL;
+  return typeof terrainWallMask === "number" ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK10;
+}
+function getGameTime19() {
+  var _a;
+  const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
+}
+function isRecord20(value) {
+  return typeof value === "object" && value !== null;
+}
+function isFiniteNumber8(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
 // src/territory/territoryRunner.ts
 var ERR_NOT_IN_RANGE_CODE8 = -9;
 var ERR_INVALID_TARGET_CODE4 = -7;
 var ERR_NO_BODYPART_CODE2 = -12;
 var ERR_GCL_NOT_ENOUGH_CODE2 = -15;
-var OK_CODE8 = 0;
+var OK_CODE9 = 0;
 var CLAIM_FATAL_RESULT_CODES = /* @__PURE__ */ new Set([
   ERR_INVALID_TARGET_CODE4,
   ERR_NO_BODYPART_CODE2,
@@ -21707,7 +22179,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   if (assignment.action === "scout") {
-    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime19(), creep.name, telemetryEvents);
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime20(), creep.name, telemetryEvents);
     completeTerritoryAssignment(creep);
     return;
   }
@@ -21757,7 +22229,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   const result = assignment.action === "claim" ? executeExpansionClaim(creep, controller, telemetryEvents) : executeControllerAction(creep, controller, "reserveController");
-  if (assignment.action === "claim" && result === OK_CODE8) {
+  if (assignment.action === "claim" && result === OK_CODE9) {
     recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents);
   }
   if (result === ERR_NOT_IN_RANGE_CODE8 && typeof creep.moveTo === "function") {
@@ -21789,7 +22261,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime19();
+  const gameTime = getGameTime20();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -21809,7 +22281,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime19());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime20());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -21856,7 +22328,7 @@ function selectTargetController(creep, assignment) {
 function executeControllerAction(creep, controller, action) {
   const controllerAction = creep[action];
   if (typeof controllerAction !== "function") {
-    return OK_CODE8;
+    return OK_CODE9;
   }
   return controllerAction.call(creep, controller);
 }
@@ -21889,7 +22361,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime19() {
+function getGameTime20() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -22061,11 +22533,11 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
       return creep.memory.colony === room.name || ((_a2 = creep.room) == null ? void 0 : _a2.name) === room.name;
     }
   );
-  const hostileCreeps = findRoomObjects14(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects14(room, "FIND_HOSTILE_STRUCTURES");
-  const ownedStructures = findRoomObjects14(room, "FIND_MY_STRUCTURES");
-  const constructionSites = findRoomObjects14(room, "FIND_MY_CONSTRUCTION_SITES");
-  const sources = findRoomObjects14(room, "FIND_SOURCES");
+  const hostileCreeps = findRoomObjects15(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects15(room, "FIND_HOSTILE_STRUCTURES");
+  const ownedStructures = findRoomObjects15(room, "FIND_MY_STRUCTURES");
+  const constructionSites = findRoomObjects15(room, "FIND_MY_CONSTRUCTION_SITES");
+  const sources = findRoomObjects15(room, "FIND_SOURCES");
   return {
     roomName: room.name,
     controllerLevel: (_a = room.controller) == null ? void 0 : _a.level,
@@ -22156,7 +22628,7 @@ function buildMemoryTerritoryState(roomName) {
   const expansionCandidates = [];
   if (Array.isArray(targets)) {
     for (const target of targets) {
-      if (!isRecord20(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+      if (!isRecord21(target) || target.colony !== roomName || typeof target.roomName !== "string") {
         continue;
       }
       const action = normalizeTerritoryAction(target.action);
@@ -22218,12 +22690,12 @@ function countVisibleOwnedRooms3() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord20(structure) && matchesStructureType16(structure.structureType, globalName, fallback)
+    (structure) => isRecord21(structure) && matchesStructureType17(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
   return structures.reduce((total, structure) => {
-    if (!isRecord20(structure)) {
+    if (!isRecord21(structure)) {
       return total;
     }
     const hits = finiteNumberOrNull(structure.hits);
@@ -22239,7 +22711,7 @@ function getStoredEnergy12(room) {
   return getEnergyInStore2(storage);
 }
 function getEnergyInStore2(object) {
-  if (!isRecord20(object) || !isRecord20(object.store)) {
+  if (!isRecord21(object) || !isRecord21(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -22250,8 +22722,8 @@ function getEnergyInStore2(object) {
   }
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
-function findRoomObjects14(room, constantName) {
-  const findConstant = getGlobalNumber11(constantName);
+function findRoomObjects15(room, constantName) {
+  const findConstant = getGlobalNumber12(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return [];
@@ -22263,7 +22735,7 @@ function findRoomObjects14(room, constantName) {
     return [];
   }
 }
-function matchesStructureType16(value, globalName, fallback) {
+function matchesStructureType17(value, globalName, fallback) {
   const globalValue = globalThis[globalName];
   return value === globalValue || value === fallback;
 }
@@ -22271,7 +22743,7 @@ function getResourceEnergy() {
   const value = globalThis.RESOURCE_ENERGY;
   return value != null ? value : "energy";
 }
-function getGlobalNumber11(name) {
+function getGlobalNumber12(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -22291,13 +22763,13 @@ function finiteNumberOrZero(value) {
 function finiteNumberOrNull(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function isRecord20(value) {
+function isRecord21(value) {
   return typeof value === "object" && value !== null;
 }
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
-var OK_CODE9 = 0;
+var OK_CODE10 = 0;
 var NEXT_EXPANSION_SCORING_REFRESH_INTERVAL = 50;
 var NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS = 5e3;
 function runEconomy(preludeTelemetryEvents = []) {
@@ -22309,6 +22781,7 @@ function runEconomy(preludeTelemetryEvents = []) {
   const usedSpawnsByRoom = /* @__PURE__ */ new Map();
   const reservedSpawnEnergyByRoom = /* @__PURE__ */ new Map();
   clearColonySurvivalAssessmentCache();
+  refreshClaimedRoomBootstrapperOwnership();
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = countCreepsByRole(creeps, colony.room.name);
@@ -22316,7 +22789,12 @@ function runEconomy(preludeTelemetryEvents = []) {
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     persistColonyStageAssessment(colony, survivalAssessment, Game.time);
     const bootstrapResult = refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
-    planCriticalConstructionSites(colony, bootstrapResult.spawnConstructionPending, survivalAssessment.mode === "BOOTSTRAP");
+    const claimedRoomBootstrapResult = runClaimedRoomBootstrapperForColony(colony);
+    planCriticalConstructionSites(
+      colony,
+      bootstrapResult.spawnConstructionPending,
+      survivalAssessment.mode === "BOOTSTRAP" || claimedRoomBootstrapResult !== null
+    );
     if (survivalAssessment.mode === "TERRITORY_READY") {
       refreshRemoteMiningSetup(colony, Game.time);
     }
@@ -22349,7 +22827,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         telemetryEvents,
         planningColony.spawns
       );
-      if (!outcome || outcome.result !== OK_CODE9) {
+      if (!outcome || outcome.result !== OK_CODE10) {
         break;
       }
       usedSpawns.add(outcome.spawn);
@@ -22438,7 +22916,7 @@ function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom
     telemetryEvents,
     candidateSpawns
   );
-  if (!outcome || outcome.result !== OK_CODE9) {
+  if (!outcome || outcome.result !== OK_CODE10) {
     return;
   }
   recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
@@ -22553,13 +23031,13 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber8(refreshedAt) || !isRecord21(rawSelection) || !isNonEmptyString19(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber9(refreshedAt) || !isRecord22(rawSelection) || !isNonEmptyString19(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord21(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord22(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
@@ -22571,7 +23049,7 @@ function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
       colony: colonyName,
       targetRoom: rawSelection.targetRoom,
       ...typeof rawSelection.controllerId === "string" ? { controllerId: rawSelection.controllerId } : {},
-      ...isFiniteNumber8(rawSelection.score) ? { score: rawSelection.score } : {}
+      ...isFiniteNumber9(rawSelection.score) ? { score: rawSelection.score } : {}
     };
   }
   const reason = normalizeNextExpansionTargetSelectionReason(rawSelection.reason);
@@ -22600,13 +23078,13 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord21(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord22(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
   const controller = colony.room.controller;
-  const controllerLevel = isFiniteNumber8(controller == null ? void 0 : controller.level) ? controller.level : "unknown";
-  const downgradeState = isFiniteNumber8(controller == null ? void 0 : controller.ticksToDowngrade) && controller.ticksToDowngrade < NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS ? "guarded" : "stable";
+  const controllerLevel = isFiniteNumber9(controller == null ? void 0 : controller.level) ? controller.level : "unknown";
+  const downgradeState = isFiniteNumber9(controller == null ? void 0 : controller.ticksToDowngrade) && controller.ticksToDowngrade < NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS ? "guarded" : "stable";
   return [
     colony.room.name,
     colony.energyCapacityAvailable,
@@ -22631,34 +23109,34 @@ function countVisibleOwnedRooms4() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord21(records)) {
+  if (!isRecord22(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord21(record) && record.status !== "ready"
+    (record) => isRecord22(record) && record.status !== "ready"
   ).length;
 }
 function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel;
-  if (!isRecord21(records)) {
+  if (!isRecord22(records)) {
     return 0;
   }
   let latestUpdatedAt = 0;
   for (const record of Object.values(records)) {
-    if (isRecord21(record) && record.colony === colony && isFiniteNumber8(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
+    if (isRecord22(record) && record.colony === colony && isFiniteNumber9(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
       latestUpdatedAt = record.updatedAt;
     }
   }
   return latestUpdatedAt;
 }
-function isRecord21(value) {
+function isRecord22(value) {
   return typeof value === "object" && value !== null;
 }
 function isNonEmptyString19(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isFiniteNumber8(value) {
+function isFiniteNumber9(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
 function createSpawnPlanningColony(colony, energyAvailable, usedSpawns) {
@@ -22776,7 +23254,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime20())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime21())
     );
   }
 };
@@ -22848,7 +23326,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime20() {
+function getGameTime21() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -23678,10 +24156,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord22(rawReplay)) {
+  if (!isRecord23(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString20(rawReplay.replayId) || !isNonEmptyString20(rawReplay.room) || !isFiniteNumber9(rawReplay.startTick) || !isFiniteNumber9(rawReplay.endTick) || !isFiniteNumber9(rawReplay.finalScore) || !isRecord22(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString20(rawReplay.replayId) || !isNonEmptyString20(rawReplay.room) || !isFiniteNumber10(rawReplay.startTick) || !isFiniteNumber10(rawReplay.endTick) || !isFiniteNumber10(rawReplay.finalScore) || !isRecord23(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -23706,13 +24184,13 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord22(value) {
+function isRecord23(value) {
   return typeof value === "object" && value !== null;
 }
 function isNonEmptyString20(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isFiniteNumber9(value) {
+function isFiniteNumber10(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
 

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -67,7 +67,12 @@ import {
   clearAdjacentRoomReservationIntent,
   refreshAdjacentRoomReservationIntent
 } from '../territory/reservationPlanner';
-import { logBestClaimTarget, runTerritoryControllerCreep } from '../territory/territoryRunner';
+import {
+  refreshClaimedRoomBootstrapperOwnership,
+  runClaimedRoomBootstrapperForColony,
+  logBestClaimTarget,
+  runTerritoryControllerCreep
+} from '../territory/territoryRunner';
 import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgrader';
 import {
   recordPostClaimBootstrapWorkerSpawn,
@@ -103,6 +108,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   const usedSpawnsByRoom = new Map<string, Set<StructureSpawn>>();
   const reservedSpawnEnergyByRoom = new Map<string, number>();
   clearColonySurvivalAssessmentCache();
+  refreshClaimedRoomBootstrapperOwnership();
 
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
@@ -111,7 +117,12 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     persistColonyStageAssessment(colony, survivalAssessment, Game.time);
     const bootstrapResult = refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
-    planCriticalConstructionSites(colony, bootstrapResult.spawnConstructionPending, survivalAssessment.mode === 'BOOTSTRAP');
+    const claimedRoomBootstrapResult = runClaimedRoomBootstrapperForColony(colony);
+    planCriticalConstructionSites(
+      colony,
+      bootstrapResult.spawnConstructionPending,
+      survivalAssessment.mode === 'BOOTSTRAP' || claimedRoomBootstrapResult !== null
+    );
     if (survivalAssessment.mode === 'TERRITORY_READY') {
       refreshRemoteMiningSetup(colony, Game.time);
     }

--- a/prod/src/territory/claimedRoomBootstrapper.ts
+++ b/prod/src/territory/claimedRoomBootstrapper.ts
@@ -15,8 +15,11 @@ const ROOM_EDGE_MIN = 1;
 const ROOM_EDGE_MAX = 48;
 const SPAWN_EDGE_MIN = 2;
 const SPAWN_EDGE_MAX = 47;
+const MAX_SPAWN_SITE_SCAN_RADIUS = 8;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
 const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_FULL_CODE = -8 as ScreepsReturnCode;
+const ERR_RCL_NOT_ENOUGH_CODE = -14 as ScreepsReturnCode;
 
 type FindConstantGlobal =
   | 'FIND_SOURCES'
@@ -31,6 +34,7 @@ type StructureConstantGlobal =
   | 'STRUCTURE_CONTAINER'
   | 'STRUCTURE_ROAD'
   | 'STRUCTURE_TOWER';
+type ReturnCodeGlobal = 'ERR_FULL' | 'ERR_RCL_NOT_ENOUGH';
 
 interface CandidatePosition {
   x: number;
@@ -219,7 +223,7 @@ function placeSpawnConstructionSite(room: Room): ScreepsReturnCode | null {
   const positions = findSpawnConstructionPositions(room);
   for (const position of positions) {
     const result = room.createConstructionSite(position.x, position.y, getStructureConstant('STRUCTURE_SPAWN', 'spawn'));
-    if (result === OK_CODE) {
+    if (result === OK_CODE || isFatalConstructionSiteResult(result)) {
       return result;
     }
   }
@@ -614,11 +618,14 @@ function isTerrainWall(terrain: RoomTerrain | null, position: CandidatePosition)
 }
 
 function getMaximumSpawnSiteScanRadius(anchor: CandidatePosition): number {
-  return Math.max(
-    anchor.x - SPAWN_EDGE_MIN,
-    SPAWN_EDGE_MAX - anchor.x,
-    anchor.y - SPAWN_EDGE_MIN,
-    SPAWN_EDGE_MAX - anchor.y
+  return Math.min(
+    MAX_SPAWN_SITE_SCAN_RADIUS,
+    Math.max(
+      anchor.x - SPAWN_EDGE_MIN,
+      SPAWN_EDGE_MAX - anchor.x,
+      anchor.y - SPAWN_EDGE_MIN,
+      SPAWN_EDGE_MAX - anchor.y
+    )
   );
 }
 
@@ -695,6 +702,18 @@ function getGlobalNumber(name: FindConstantGlobal): number | null {
 function getGlobalString(name: LookConstantGlobal): string | null {
   const value = (globalThis as Record<string, unknown>)[name];
   return typeof value === 'string' ? value : null;
+}
+
+function getGlobalReturnCode(name: ReturnCodeGlobal, fallback: ScreepsReturnCode): ScreepsReturnCode {
+  const value = (globalThis as Partial<Record<ReturnCodeGlobal, ScreepsReturnCode>>)[name];
+  return typeof value === 'number' ? value : fallback;
+}
+
+function isFatalConstructionSiteResult(result: ScreepsReturnCode): boolean {
+  return (
+    result === getGlobalReturnCode('ERR_FULL', ERR_FULL_CODE) ||
+    result === getGlobalReturnCode('ERR_RCL_NOT_ENOUGH', ERR_RCL_NOT_ENOUGH_CODE)
+  );
 }
 
 function getTerrainWallMask(): number {

--- a/prod/src/territory/claimedRoomBootstrapper.ts
+++ b/prod/src/territory/claimedRoomBootstrapper.ts
@@ -1,0 +1,716 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { getExtensionLimitForRcl, planExtensionConstruction } from '../construction/extensionPlanner';
+import { planEarlyRoadConstruction } from '../construction/roadPlanner';
+import { planTowerConstruction } from '../construction/constructionPriority';
+import {
+  findSourceContainer,
+  findSourceContainerConstructionSite,
+  getPositionKey,
+  getRangeBetweenPositions,
+  getRoomObjectPosition,
+  isSameRoomPosition
+} from '../economy/sourceContainers';
+
+const ROOM_EDGE_MIN = 1;
+const ROOM_EDGE_MAX = 48;
+const SPAWN_EDGE_MIN = 2;
+const SPAWN_EDGE_MAX = 47;
+const DEFAULT_TERRAIN_WALL_MASK = 1;
+const OK_CODE = 0 as ScreepsReturnCode;
+
+type FindConstantGlobal =
+  | 'FIND_SOURCES'
+  | 'FIND_STRUCTURES'
+  | 'FIND_CONSTRUCTION_SITES'
+  | 'FIND_MY_STRUCTURES'
+  | 'FIND_MY_CONSTRUCTION_SITES';
+type LookConstantGlobal = 'LOOK_STRUCTURES' | 'LOOK_CONSTRUCTION_SITES' | 'LOOK_MINERALS';
+type StructureConstantGlobal =
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_ROAD'
+  | 'STRUCTURE_TOWER';
+
+interface CandidatePosition {
+  x: number;
+  y: number;
+  roomName?: string;
+}
+
+interface SpawnPlacementLookups {
+  blockingPositions: Set<string>;
+  mineralPositions: Set<string>;
+  terrain: RoomTerrain | null;
+}
+
+interface SourceContainerLookups {
+  terrain: RoomTerrain;
+  blockedPositions: Set<string>;
+}
+
+export type ClaimedRoomBootstrapPhase =
+  | 'spawn'
+  | 'extension'
+  | 'sourceContainer'
+  | 'road'
+  | 'tower'
+  | 'complete';
+
+export interface ClaimedRoomBootstrapPlanResult {
+  roomName: string;
+  phase: ClaimedRoomBootstrapPhase;
+  result?: ScreepsReturnCode;
+  results?: ScreepsReturnCode[];
+}
+
+export interface ClaimedRoomOwnershipRefreshResult {
+  detectedRoomNames: string[];
+}
+
+export interface ClaimedRoomBootstrapRunResult extends ClaimedRoomOwnershipRefreshResult {
+  activeRoomNames: string[];
+  planned: ClaimedRoomBootstrapPlanResult[];
+}
+
+export function refreshClaimedRoomBootstrapperOwnership(): ClaimedRoomOwnershipRefreshResult {
+  const game = (globalThis as { Game?: Partial<Game> }).Game;
+  const rooms = game?.rooms;
+  const memory = getWritableBootstrapperMemory();
+  if (!rooms || !memory) {
+    return { detectedRoomNames: [] };
+  }
+
+  const detectedRoomNames: string[] = [];
+  for (const room of Object.values(rooms)) {
+    if (!room?.name || !room.controller) {
+      continue;
+    }
+
+    const owned = room.controller.my === true;
+    const previous = memory.rooms[room.name];
+    const activePostClaimRecord = getActivePostClaimBootstrapRecord(room.name);
+    const newlyClaimed = owned && previous?.owned === false;
+    if (newlyClaimed) {
+      detectedRoomNames.push(room.name);
+    }
+
+    const claimedAt = newlyClaimed
+      ? getGameTime()
+      : previous?.claimedAt ?? activePostClaimRecord?.claimedAt;
+    memory.rooms[room.name] = {
+      roomName: room.name,
+      owned,
+      updatedAt: getGameTime(),
+      ...(claimedAt !== undefined ? { claimedAt } : {}),
+      ...(newlyClaimed ? {} : previous?.completedAt !== undefined ? { completedAt: previous.completedAt } : {})
+    };
+  }
+
+  return { detectedRoomNames };
+}
+
+export function runClaimedRoomBootstrapper(colonies: ColonySnapshot[]): ClaimedRoomBootstrapRunResult {
+  const refreshResult = refreshClaimedRoomBootstrapperOwnership();
+  const activeRoomNames: string[] = [];
+  const planned: ClaimedRoomBootstrapPlanResult[] = [];
+
+  for (const colony of colonies) {
+    const result = runClaimedRoomBootstrapperForColony(colony);
+    if (!result) {
+      continue;
+    }
+
+    activeRoomNames.push(colony.room.name);
+    if (result.phase !== 'complete' && (result.phase !== 'spawn' || result.result !== undefined || result.results !== undefined)) {
+      planned.push(result);
+    }
+  }
+
+  return {
+    ...refreshResult,
+    activeRoomNames,
+    planned
+  };
+}
+
+export function runClaimedRoomBootstrapperForColony(
+  colony: ColonySnapshot
+): ClaimedRoomBootstrapPlanResult | null {
+  const room = colony.room;
+  if (room.controller?.my !== true || !isClaimedRoomBootstrapActive(room.name)) {
+    return null;
+  }
+
+  const spawnStatus = getSpawnBootstrapStatus(colony);
+  if (!spawnStatus.hasSpawn) {
+    if (!spawnStatus.hasSpawnSite) {
+      const result = placeSpawnConstructionSite(room);
+      return result === null ? { roomName: room.name, phase: 'spawn' } : { roomName: room.name, phase: 'spawn', result };
+    }
+
+    return { roomName: room.name, phase: 'spawn' };
+  }
+
+  if (countExistingAndPendingStructures(room, 'STRUCTURE_EXTENSION', 'extension') < getExtensionLimitForRcl(room.controller.level)) {
+    const result = planExtensionConstruction(colony);
+    if (result !== null) {
+      return { roomName: room.name, phase: 'extension', result };
+    }
+  }
+
+  const sourceContainerResults = planMissingSourceContainerConstructionSites(colony);
+  if (sourceContainerResults.length > 0) {
+    return { roomName: room.name, phase: 'sourceContainer', results: sourceContainerResults };
+  }
+
+  const roadResults = planEarlyRoadConstruction(colony, {
+    maxSitesPerTick: 1,
+    maxPendingRoadSites: 100,
+    maxTargetsPerTick: 3
+  });
+  if (roadResults.length > 0) {
+    return { roomName: room.name, phase: 'road', results: roadResults };
+  }
+
+  if ((room.controller.level ?? 0) >= 3 && countExistingAndPendingStructures(room, 'STRUCTURE_TOWER', 'tower') <= 0) {
+    const result = planTowerConstruction(colony);
+    if (result !== null) {
+      return { roomName: room.name, phase: 'tower', result };
+    }
+  }
+
+  if (isClaimedRoomBootstrapComplete(colony)) {
+    markClaimedRoomBootstrapComplete(room.name);
+    return { roomName: room.name, phase: 'complete' };
+  }
+
+  return { roomName: room.name, phase: 'complete' };
+}
+
+export function isClaimedRoomBootstrapActive(roomName: string): boolean {
+  const record = getBootstrapperRoomRecord(roomName);
+  if (record?.owned !== true) {
+    return false;
+  }
+
+  if (record.claimedAt === undefined && !getActivePostClaimBootstrapRecord(roomName)) {
+    return false;
+  }
+
+  return record.completedAt === undefined;
+}
+
+function getSpawnBootstrapStatus(colony: ColonySnapshot): { hasSpawn: boolean; hasSpawnSite: boolean } {
+  const room = colony.room;
+  return {
+    hasSpawn:
+      colony.spawns.some((spawn) => spawn.room?.name === room.name) ||
+      countExistingStructures(room, 'STRUCTURE_SPAWN', 'spawn') > 0,
+    hasSpawnSite: countPendingConstructionSites(room, 'STRUCTURE_SPAWN', 'spawn') > 0
+  };
+}
+
+function placeSpawnConstructionSite(room: Room): ScreepsReturnCode | null {
+  if (typeof room.createConstructionSite !== 'function') {
+    return null;
+  }
+
+  const positions = findSpawnConstructionPositions(room);
+  for (const position of positions) {
+    const result = room.createConstructionSite(position.x, position.y, getStructureConstant('STRUCTURE_SPAWN', 'spawn'));
+    if (result === OK_CODE) {
+      return result;
+    }
+  }
+
+  return null;
+}
+
+function findSpawnConstructionPositions(room: Room): CandidatePosition[] {
+  const anchor = selectInitialSpawnAnchor(room);
+  if (!anchor) {
+    return [];
+  }
+
+  const maximumScanRadius = getMaximumSpawnSiteScanRadius(anchor);
+  const lookups = buildSpawnPlacementLookups(room, anchor, maximumScanRadius);
+  const positions: CandidatePosition[] = [];
+  for (let radius = 0; radius <= maximumScanRadius; radius += 1) {
+    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
+      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
+          continue;
+        }
+
+        const position = { x, y, roomName: room.name };
+        if (canPlaceSpawn(lookups, position)) {
+          positions.push(position);
+        }
+      }
+    }
+  }
+
+  return positions;
+}
+
+function selectInitialSpawnAnchor(room: Room): CandidatePosition | null {
+  const controllerPosition = getRoomObjectPosition(room.controller as RoomObject);
+  if (!controllerPosition) {
+    return null;
+  }
+
+  const nearestSourcePosition = getSortedSources(room)
+    .map((source) => getRoomObjectPosition(source))
+    .filter((position): position is RoomPosition => position !== null)
+    .sort((left, right) => getRangeBetweenPositions(controllerPosition, left) - getRangeBetweenPositions(controllerPosition, right))[0];
+
+  if (!nearestSourcePosition) {
+    return clampSpawnPosition({ x: controllerPosition.x, y: controllerPosition.y, roomName: room.name });
+  }
+
+  return clampSpawnPosition({
+    x: Math.round((controllerPosition.x + nearestSourcePosition.x) / 2),
+    y: Math.round((controllerPosition.y + nearestSourcePosition.y) / 2),
+    roomName: room.name
+  });
+}
+
+function buildSpawnPlacementLookups(
+  room: Room,
+  anchor: CandidatePosition,
+  maximumScanRadius: number
+): SpawnPlacementLookups {
+  const blockingPositions = new Set<string>();
+  for (const object of [
+    room.controller,
+    ...getSortedSources(room),
+    ...lookForArea(room, 'LOOK_STRUCTURES', anchor, maximumScanRadius),
+    ...lookForArea(room, 'LOOK_CONSTRUCTION_SITES', anchor, maximumScanRadius)
+  ]) {
+    const position = getAnyObjectPosition(object);
+    if (position) {
+      blockingPositions.add(getPositionKey(position));
+    }
+  }
+
+  const mineralPositions = new Set<string>();
+  for (const object of lookForArea(room, 'LOOK_MINERALS', anchor, maximumScanRadius)) {
+    const position = getAnyObjectPosition(object);
+    if (position) {
+      mineralPositions.add(getPositionKey(position));
+    }
+  }
+
+  return {
+    blockingPositions,
+    mineralPositions,
+    terrain: getRoomTerrain(room)
+  };
+}
+
+function lookForArea(
+  room: Room,
+  lookConstantName: LookConstantGlobal,
+  anchor: CandidatePosition,
+  maximumScanRadius: number
+): unknown[] {
+  const lookConstant = getGlobalString(lookConstantName);
+  if (!lookConstant || typeof room.lookForAtArea !== 'function') {
+    return [];
+  }
+
+  const bounds = {
+    top: Math.max(SPAWN_EDGE_MIN, anchor.y - maximumScanRadius),
+    left: Math.max(SPAWN_EDGE_MIN, anchor.x - maximumScanRadius),
+    bottom: Math.min(SPAWN_EDGE_MAX, anchor.y + maximumScanRadius),
+    right: Math.min(SPAWN_EDGE_MAX, anchor.x + maximumScanRadius)
+  };
+
+  try {
+    const result = room.lookForAtArea(
+      lookConstant as LookConstant,
+      bounds.top,
+      bounds.left,
+      bounds.bottom,
+      bounds.right,
+      true
+    );
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+
+function canPlaceSpawn(lookups: SpawnPlacementLookups, position: CandidatePosition): boolean {
+  return (
+    position.x >= SPAWN_EDGE_MIN &&
+    position.x <= SPAWN_EDGE_MAX &&
+    position.y >= SPAWN_EDGE_MIN &&
+    position.y <= SPAWN_EDGE_MAX &&
+    !lookups.blockingPositions.has(getPositionKey(position)) &&
+    !lookups.mineralPositions.has(getPositionKey(position)) &&
+    !isTerrainWall(lookups.terrain, position)
+  );
+}
+
+function planMissingSourceContainerConstructionSites(colony: ColonySnapshot): ScreepsReturnCode[] {
+  const room = colony.room;
+  if (
+    typeof room.createConstructionSite !== 'function' ||
+    (room.controller?.level ?? 0) < 2 ||
+    typeof FIND_SOURCES !== 'number'
+  ) {
+    return [];
+  }
+
+  const sources = getSortedSources(room);
+  if (sources.length === 0 || sources.every((source) => hasSourceContainerCoverage(room, source))) {
+    return [];
+  }
+
+  const lookups = createSourceContainerLookups(room);
+  if (!lookups) {
+    return [];
+  }
+
+  const anchor = selectSourceContainerAnchor(colony);
+  const results: ScreepsReturnCode[] = [];
+  for (const source of sources) {
+    if (hasSourceContainerCoverage(room, source)) {
+      continue;
+    }
+
+    const position = selectSourceContainerPosition(source, lookups, anchor);
+    if (!position) {
+      continue;
+    }
+
+    const result = room.createConstructionSite(position.x, position.y, getStructureConstant('STRUCTURE_CONTAINER', 'container'));
+    results.push(result);
+    if (result !== OK_CODE) {
+      break;
+    }
+
+    lookups.blockedPositions.add(getPositionKey(position));
+  }
+
+  return results;
+}
+
+function hasSourceContainerCoverage(room: Room, source: Source): boolean {
+  return findSourceContainer(room, source) !== null || findSourceContainerConstructionSite(room, source) !== null;
+}
+
+function createSourceContainerLookups(room: Room): SourceContainerLookups | null {
+  if (typeof FIND_STRUCTURES !== 'number' || typeof FIND_CONSTRUCTION_SITES !== 'number') {
+    return null;
+  }
+
+  const terrain = getRoomTerrain(room);
+  if (!terrain) {
+    return null;
+  }
+
+  const blockedPositions = new Set<string>();
+  for (const object of [
+    ...findRoomObjects(room, 'FIND_STRUCTURES'),
+    ...findRoomObjects(room, 'FIND_CONSTRUCTION_SITES')
+  ]) {
+    const position = getAnyObjectPosition(object);
+    if (position && isSameRoomPosition(position, room.name)) {
+      blockedPositions.add(getPositionKey(position));
+    }
+  }
+
+  return { terrain, blockedPositions };
+}
+
+function selectSourceContainerAnchor(colony: ColonySnapshot): RoomPosition | null {
+  const [primarySpawn] = colony.spawns
+    .filter((spawn) => getRoomObjectPosition(spawn) !== null)
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  return getRoomObjectPosition(primarySpawn ?? (colony.room.controller as RoomObject | undefined));
+}
+
+function selectSourceContainerPosition(
+  source: Source,
+  lookups: SourceContainerLookups,
+  anchor: RoomPosition | null
+): CandidatePosition | null {
+  const sourcePosition = getRoomObjectPosition(source);
+  if (!sourcePosition || typeof sourcePosition.roomName !== 'string') {
+    return null;
+  }
+
+  const positions: CandidatePosition[] = [];
+  for (let dy = -1; dy <= 1; dy += 1) {
+    for (let dx = -1; dx <= 1; dx += 1) {
+      if (dx === 0 && dy === 0) {
+        continue;
+      }
+
+      positions.push({
+        x: sourcePosition.x + dx,
+        y: sourcePosition.y + dy,
+        roomName: sourcePosition.roomName
+      });
+    }
+  }
+
+  return positions
+    .filter((position) => canPlaceSourceContainer(lookups, position))
+    .sort((left, right) => compareSourceContainerPositions(left, right, anchor))[0] ?? null;
+}
+
+function canPlaceSourceContainer(lookups: SourceContainerLookups, position: CandidatePosition): boolean {
+  if (
+    position.x < ROOM_EDGE_MIN ||
+    position.x > ROOM_EDGE_MAX ||
+    position.y < ROOM_EDGE_MIN ||
+    position.y > ROOM_EDGE_MAX ||
+    isTerrainWall(lookups.terrain, position)
+  ) {
+    return false;
+  }
+
+  return !lookups.blockedPositions.has(getPositionKey(position));
+}
+
+function compareSourceContainerPositions(
+  left: CandidatePosition,
+  right: CandidatePosition,
+  anchor: RoomPosition | null
+): number {
+  if (anchor) {
+    const leftRange = getRangeBetweenPositions(left, anchor);
+    const rightRange = getRangeBetweenPositions(right, anchor);
+    if (leftRange !== rightRange) {
+      return leftRange - rightRange;
+    }
+  }
+
+  return left.y - right.y || left.x - right.x;
+}
+
+function isClaimedRoomBootstrapComplete(colony: ColonySnapshot): boolean {
+  const room = colony.room;
+  if (!getSpawnBootstrapStatus(colony).hasSpawn) {
+    return false;
+  }
+
+  if (countExistingAndPendingStructures(room, 'STRUCTURE_EXTENSION', 'extension') < getExtensionLimitForRcl(room.controller?.level)) {
+    return false;
+  }
+
+  if (getSortedSources(room).some((source) => !hasSourceContainerCoverage(room, source))) {
+    return false;
+  }
+
+  if ((room.controller?.level ?? 0) >= 3 && countExistingAndPendingStructures(room, 'STRUCTURE_TOWER', 'tower') <= 0) {
+    return false;
+  }
+
+  return true;
+}
+
+function markClaimedRoomBootstrapComplete(roomName: string): void {
+  const memory = getWritableBootstrapperMemory();
+  const record = memory?.rooms[roomName];
+  if (!memory || !record || record.completedAt !== undefined) {
+    return;
+  }
+
+  memory.rooms[roomName] = {
+    ...record,
+    completedAt: getGameTime(),
+    updatedAt: getGameTime()
+  };
+}
+
+function countExistingAndPendingStructures(
+  room: Room,
+  globalName: StructureConstantGlobal,
+  fallback: string
+): number {
+  return countExistingStructures(room, globalName, fallback) + countPendingConstructionSites(room, globalName, fallback);
+}
+
+function countExistingStructures(room: Room, globalName: StructureConstantGlobal, fallback: string): number {
+  return findRoomObjects(room, 'FIND_MY_STRUCTURES').filter((object) =>
+    matchesStructureType((object as { structureType?: string }).structureType, globalName, fallback)
+  ).length;
+}
+
+function countPendingConstructionSites(room: Room, globalName: StructureConstantGlobal, fallback: string): number {
+  return findRoomObjects(room, 'FIND_MY_CONSTRUCTION_SITES').filter((object) =>
+    matchesStructureType((object as { structureType?: string }).structureType, globalName, fallback)
+  ).length;
+}
+
+function getSortedSources(room: Room): Source[] {
+  return findRoomObjects(room, 'FIND_SOURCES')
+    .filter((source): source is Source => {
+      const position = getAnyObjectPosition(source);
+      return position !== null && isSameRoomPosition(position, room.name);
+    })
+    .sort((left, right) => String((left as { id?: string }).id).localeCompare(String((right as { id?: string }).id)));
+}
+
+function findRoomObjects(room: Room, globalName: FindConstantGlobal): unknown[] {
+  const findConstant = getGlobalNumber(globalName);
+  if (findConstant === null || typeof room.find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = room.find(findConstant as FindConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+
+function getAnyObjectPosition(object: unknown): CandidatePosition | null {
+  if (!isRecord(object)) {
+    return null;
+  }
+
+  if (isFiniteNumber(object.x) && isFiniteNumber(object.y)) {
+    return {
+      x: object.x,
+      y: object.y,
+      ...(typeof object.roomName === 'string' ? { roomName: object.roomName } : {})
+    };
+  }
+
+  const position = object.pos;
+  if (isRecord(position) && isFiniteNumber(position.x) && isFiniteNumber(position.y)) {
+    return {
+      x: position.x,
+      y: position.y,
+      ...(typeof position.roomName === 'string' ? { roomName: position.roomName } : {})
+    };
+  }
+
+  for (const value of Object.values(object)) {
+    const nestedPosition = getAnyObjectPosition(value);
+    if (nestedPosition) {
+      return nestedPosition;
+    }
+  }
+
+  return null;
+}
+
+function getRoomTerrain(room: Room): RoomTerrain | null {
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map;
+  return typeof gameMap?.getRoomTerrain === 'function' ? gameMap.getRoomTerrain(room.name) : null;
+}
+
+function isTerrainWall(terrain: RoomTerrain | null, position: CandidatePosition): boolean {
+  return terrain !== null && (terrain.get(position.x, position.y) & getTerrainWallMask()) !== 0;
+}
+
+function getMaximumSpawnSiteScanRadius(anchor: CandidatePosition): number {
+  return Math.max(
+    anchor.x - SPAWN_EDGE_MIN,
+    SPAWN_EDGE_MAX - anchor.x,
+    anchor.y - SPAWN_EDGE_MIN,
+    SPAWN_EDGE_MAX - anchor.y
+  );
+}
+
+function clampSpawnPosition(position: CandidatePosition): CandidatePosition {
+  return {
+    x: Math.max(SPAWN_EDGE_MIN, Math.min(SPAWN_EDGE_MAX, position.x)),
+    y: Math.max(SPAWN_EDGE_MIN, Math.min(SPAWN_EDGE_MAX, position.y)),
+    roomName: position.roomName
+  };
+}
+
+function getBootstrapperRoomRecord(roomName: string): TerritoryClaimedRoomBootstrapMemory | null {
+  const record = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.claimedRoomBootstrapper?.rooms?.[roomName];
+  return isBootstrapperRoomRecord(record, roomName) ? record : null;
+}
+
+function getWritableBootstrapperMemory(): TerritoryClaimedRoomBootstrapperMemory | null {
+  const memory = (globalThis as { Memory?: Partial<Memory> }).Memory;
+  if (!memory) {
+    return null;
+  }
+
+  if (!memory.territory) {
+    memory.territory = {};
+  }
+
+  if (!memory.territory.claimedRoomBootstrapper) {
+    memory.territory.claimedRoomBootstrapper = { rooms: {} };
+  }
+
+  return memory.territory.claimedRoomBootstrapper;
+}
+
+function getActivePostClaimBootstrapRecord(roomName: string): TerritoryPostClaimBootstrapMemory | null {
+  const record = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.postClaimBootstraps?.[roomName];
+  return isRecord(record) && record.roomName === roomName && record.status !== 'ready'
+    ? (record as TerritoryPostClaimBootstrapMemory)
+    : null;
+}
+
+function isBootstrapperRoomRecord(
+  value: unknown,
+  expectedRoomName: string
+): value is TerritoryClaimedRoomBootstrapMemory {
+  return (
+    isRecord(value) &&
+    value.roomName === expectedRoomName &&
+    typeof value.owned === 'boolean' &&
+    isFiniteNumber(value.updatedAt)
+  );
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: StructureConstantGlobal,
+  fallback: string
+): boolean {
+  return actual === getStructureConstant(globalName, fallback);
+}
+
+function getStructureConstant(
+  globalName: StructureConstantGlobal,
+  fallback: string
+): BuildableStructureConstant {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, BuildableStructureConstant>>;
+  return constants[globalName] ?? (fallback as BuildableStructureConstant);
+}
+
+function getGlobalNumber(name: FindConstantGlobal): number | null {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : null;
+}
+
+function getGlobalString(name: LookConstantGlobal): string | null {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'string' ? value : null;
+}
+
+function getTerrainWallMask(): number {
+  const terrainWallMask = (globalThis as unknown as { TERRAIN_MASK_WALL?: number }).TERRAIN_MASK_WALL;
+  return typeof terrainWallMask === 'number' ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK;
+}
+
+function getGameTime(): number {
+  const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof gameTime === 'number' && Number.isFinite(gameTime) ? gameTime : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/prod/src/territory/territoryRunner.ts
+++ b/prod/src/territory/territoryRunner.ts
@@ -18,6 +18,15 @@ import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 import { recordVisibleRoomScoutIntel } from './scoutIntel';
 import { selectBestClaimTarget } from './claimScoring';
 import { getRecordedColonyStageAssessment, suppressesTerritoryWork } from '../colony/colonyStage';
+export {
+  isClaimedRoomBootstrapActive,
+  refreshClaimedRoomBootstrapperOwnership,
+  runClaimedRoomBootstrapper,
+  runClaimedRoomBootstrapperForColony,
+  type ClaimedRoomBootstrapRunResult,
+  type ClaimedRoomBootstrapPlanResult,
+  type ClaimedRoomOwnershipRefreshResult
+} from './claimedRoomBootstrapper';
 
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 const ERR_INVALID_TARGET_CODE = -7 as ScreepsReturnCode;

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -254,6 +254,7 @@ declare global {
     intents?: TerritoryIntentMemory[];
     demands?: TerritoryFollowUpDemandMemory[];
     executionHints?: TerritoryExecutionHintMemory[];
+    claimedRoomBootstrapper?: TerritoryClaimedRoomBootstrapperMemory;
     postClaimBootstraps?: Record<string, TerritoryPostClaimBootstrapMemory>;
     remoteMining?: Record<string, TerritoryRemoteMiningRoomMemory>;
     reservations?: Record<string, TerritoryReservationMemory>;
@@ -434,6 +435,18 @@ declare global {
     controllerId?: Id<StructureController>;
     spawnSite?: TerritoryPostClaimBootstrapSpawnSiteMemory;
     lastResult?: ScreepsReturnCode;
+  }
+
+  interface TerritoryClaimedRoomBootstrapperMemory {
+    rooms: Record<string, TerritoryClaimedRoomBootstrapMemory>;
+  }
+
+  interface TerritoryClaimedRoomBootstrapMemory {
+    roomName: string;
+    owned: boolean;
+    updatedAt: number;
+    claimedAt?: number;
+    completedAt?: number;
   }
 
   type TerritoryRemoteMiningStatus =

--- a/prod/test/territory/claimedRoomBootstrapper.test.ts
+++ b/prod/test/territory/claimedRoomBootstrapper.test.ts
@@ -1,0 +1,404 @@
+import type { ColonySnapshot } from '../../src/colony/colonyRegistry';
+import {
+  refreshClaimedRoomBootstrapperOwnership,
+  runClaimedRoomBootstrapper
+} from '../../src/territory/claimedRoomBootstrapper';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+const TEST_GLOBALS = {
+  FIND_SOURCES: 1,
+  FIND_MY_STRUCTURES: 2,
+  FIND_MY_CONSTRUCTION_SITES: 3,
+  FIND_STRUCTURES: 4,
+  FIND_CONSTRUCTION_SITES: 5,
+  STRUCTURE_SPAWN: 'spawn',
+  STRUCTURE_EXTENSION: 'extension',
+  STRUCTURE_CONTAINER: 'container',
+  STRUCTURE_ROAD: 'road',
+  STRUCTURE_TOWER: 'tower',
+  TERRAIN_MASK_WALL: 1,
+  LOOK_STRUCTURES: 'structure',
+  LOOK_CONSTRUCTION_SITES: 'constructionSite',
+  LOOK_MINERALS: 'mineral',
+  OK: OK_CODE
+} as const;
+
+describe('claimed room bootstrapper', () => {
+  beforeEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const [key, value] of Object.entries(TEST_GLOBALS)) {
+      globals[key] = value;
+    }
+
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+  });
+
+  afterEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const key of Object.keys(TEST_GLOBALS)) {
+      delete globals[key];
+    }
+
+    delete globals.Game;
+    delete globals.Memory;
+    delete globals.PathFinder;
+  });
+
+  it('detects controller ownership transitions from previously unowned visible rooms', () => {
+    const { room } = makeBootstrapRoom({ controllerLevel: 1 });
+    Memory.territory = {
+      claimedRoomBootstrapper: {
+        rooms: {
+          W2N1: { roomName: 'W2N1', owned: false, updatedAt: 99 }
+        }
+      }
+    };
+    installGame(room, 100);
+
+    expect(refreshClaimedRoomBootstrapperOwnership()).toEqual({ detectedRoomNames: ['W2N1'] });
+    expect(Memory.territory?.claimedRoomBootstrapper?.rooms.W2N1).toEqual({
+      roomName: 'W2N1',
+      owned: true,
+      claimedAt: 100,
+      updatedAt: 100
+    });
+  });
+
+  it('places the initial spawn site before other infrastructure', () => {
+    const { room, colony } = makeBootstrapRoom({
+      controllerLevel: 1,
+      sources: [makeSource('source1', 21, 21)]
+    });
+    installActiveBootstrapMemory(90, false);
+    installGame(room, 101);
+
+    const result = runClaimedRoomBootstrapper([colony]);
+
+    expect(result.detectedRoomNames).toEqual(['W2N1']);
+    expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'spawn', result: OK_CODE }]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(23, 23, TEST_GLOBALS.STRUCTURE_SPAWN);
+  });
+
+  it('places extensions up to the current RCL limit after a spawn exists', () => {
+    const spawn = makeStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 25, 25);
+    const { room, colony } = makeBootstrapRoom({
+      controllerLevel: 2,
+      structures: [spawn],
+      spawns: [spawn as StructureSpawn]
+    });
+    installActiveBootstrapMemory();
+    installGame(room);
+
+    const result = runClaimedRoomBootstrapper([colony]);
+
+    expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'extension', result: OK_CODE }]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 24, TEST_GLOBALS.STRUCTURE_EXTENSION);
+  });
+
+  it('places one source container site per uncovered source after extension capacity is planned', () => {
+    const spawn = makeStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 25, 25);
+    const extensions = makeExtensions(5);
+    const { room, colony } = makeBootstrapRoom({
+      controllerLevel: 2,
+      sources: [makeSource('source-a', 10, 10), makeSource('source-b', 30, 10)],
+      structures: [spawn, ...extensions],
+      spawns: [spawn as StructureSpawn]
+    });
+    installActiveBootstrapMemory();
+    installGame(room);
+
+    const result = runClaimedRoomBootstrapper([colony]);
+
+    expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'sourceContainer', results: [OK_CODE, OK_CODE] }]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(2);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 11, 11, TEST_GLOBALS.STRUCTURE_CONTAINER);
+    expect(room.createConstructionSite).toHaveBeenNthCalledWith(2, 29, 11, TEST_GLOBALS.STRUCTURE_CONTAINER);
+  });
+
+  it('places source-to-spawn and spawn-to-controller roads after containers are covered', () => {
+    const spawn = makeStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 10, 10);
+    const source = makeSource('source-a', 20, 10);
+    const container = makeStructure('container-a', TEST_GLOBALS.STRUCTURE_CONTAINER, 20, 11);
+    const { room, colony } = makeBootstrapRoom({
+      controllerLevel: 2,
+      controllerPosition: { x: 10, y: 20 },
+      sources: [source],
+      structures: [spawn, container, ...makeExtensions(5)],
+      spawns: [spawn as StructureSpawn],
+      pathsByTarget: {
+        '20,10': [{ x: 11, y: 10 }],
+        '10,20': [{ x: 10, y: 11 }]
+      }
+    });
+    installActiveBootstrapMemory();
+    installGame(room);
+    installPathFinder(room);
+
+    const result = runClaimedRoomBootstrapper([colony]);
+
+    expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'road', results: [OK_CODE] }]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(11, 10, TEST_GLOBALS.STRUCTURE_ROAD);
+  });
+
+  it('gates tower placement until RCL3', () => {
+    const rcl2 = makeTowerReadyRoom(2);
+    installActiveBootstrapMemory();
+    installGame(rcl2.room);
+
+    expect(runClaimedRoomBootstrapper([rcl2.colony]).planned).toEqual([]);
+    expect(rcl2.room.createConstructionSite).not.toHaveBeenCalled();
+
+    const rcl3 = makeTowerReadyRoom(3);
+    installActiveBootstrapMemory();
+    installGame(rcl3.room);
+
+    expect(runClaimedRoomBootstrapper([rcl3.colony]).planned).toEqual([
+      { roomName: 'W2N1', phase: 'tower', result: OK_CODE }
+    ]);
+    expect(rcl3.room.createConstructionSite).toHaveBeenCalledWith(19, 19, TEST_GLOBALS.STRUCTURE_TOWER);
+  });
+
+  it('does not re-place construction sites that already exist', () => {
+    const spawnSite = makeConstructionSite('spawn-site', TEST_GLOBALS.STRUCTURE_SPAWN, 23, 23);
+    const { room, colony } = makeBootstrapRoom({
+      controllerLevel: 1,
+      constructionSites: [spawnSite],
+      sources: [makeSource('source1', 21, 21)]
+    });
+    installActiveBootstrapMemory();
+    installGame(room);
+
+    const result = runClaimedRoomBootstrapper([colony]);
+
+    expect(result.planned).toEqual([]);
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+});
+
+interface MockRoom extends Room {
+  find: jest.Mock;
+  lookForAtArea: jest.Mock;
+  createConstructionSite: jest.Mock;
+}
+
+interface TestPosition {
+  x: number;
+  y: number;
+}
+
+interface BootstrapRoomOptions {
+  controllerLevel: number;
+  controllerPosition?: TestPosition;
+  sources?: Source[];
+  structures?: Structure[];
+  constructionSites?: ConstructionSite[];
+  spawns?: StructureSpawn[];
+  wallPositions?: Set<string>;
+  pathsByTarget?: Record<string, TestPosition[]>;
+}
+
+class MockCostMatrix {
+  private readonly costs = new Map<string, number>();
+
+  set(x: number, y: number, cost: number): void {
+    this.costs.set(`${x},${y}`, cost);
+  }
+
+  get(x: number, y: number): number {
+    return this.costs.get(`${x},${y}`) ?? 0;
+  }
+
+  clone(): CostMatrix {
+    const clone = new MockCostMatrix();
+    for (const [key, cost] of this.costs.entries()) {
+      const [x, y] = key.split(',').map(Number);
+      clone.set(x, y, cost);
+    }
+
+    return clone as unknown as CostMatrix;
+  }
+
+  serialize(): number[] {
+    return [];
+  }
+}
+
+function makeBootstrapRoom(options: BootstrapRoomOptions): { room: MockRoom; colony: ColonySnapshot } {
+  const constructionSites = [...(options.constructionSites ?? [])];
+  const structures = [...(options.structures ?? [])];
+  const sources = options.sources ?? [];
+  const roomName = 'W2N1';
+  const controller = {
+    id: 'controller1',
+    my: true,
+    level: options.controllerLevel,
+    pos: makeRoomPosition(options.controllerPosition ?? { x: 25, y: 25 }, roomName)
+  } as unknown as StructureController;
+  const room = {
+    name: roomName,
+    energyAvailable: 300,
+    energyCapacityAvailable: 300,
+    controller,
+    find: jest.fn((findType: number, findOptions?: { filter?: (target: Source | Structure | ConstructionSite) => boolean }) => {
+      const targets =
+        findType === TEST_GLOBALS.FIND_SOURCES
+          ? sources
+          : findType === TEST_GLOBALS.FIND_MY_STRUCTURES || findType === TEST_GLOBALS.FIND_STRUCTURES
+            ? structures
+            : findType === TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES ||
+                findType === TEST_GLOBALS.FIND_CONSTRUCTION_SITES
+              ? constructionSites
+              : [];
+
+      return findOptions?.filter ? targets.filter(findOptions.filter) : targets;
+    }),
+    lookForAtArea: jest.fn((lookType: LookConstant, top: number, left: number, bottom: number, right: number) => {
+      if (lookType === TEST_GLOBALS.LOOK_STRUCTURES) {
+        return structures.flatMap((structure) => toLookResult('structure', structure, top, left, bottom, right));
+      }
+
+      if (lookType === TEST_GLOBALS.LOOK_CONSTRUCTION_SITES) {
+        return constructionSites.flatMap((site) => toLookResult('constructionSite', site, top, left, bottom, right));
+      }
+
+      return [];
+    }),
+    createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+      constructionSites.push(makeConstructionSite(`site-${x}-${y}`, structureType, x, y));
+      return OK_CODE;
+    }),
+    __pathsByTarget: options.pathsByTarget ?? {}
+  } as unknown as MockRoom & { __pathsByTarget: Record<string, TestPosition[]> };
+
+  for (const structure of structures) {
+    (structure as Structure & { room?: Room }).room = room;
+  }
+
+  return {
+    room,
+    colony: {
+      room,
+      spawns: options.spawns ?? [],
+      energyAvailable: room.energyAvailable,
+      energyCapacityAvailable: room.energyCapacityAvailable
+    }
+  };
+}
+
+function makeTowerReadyRoom(controllerLevel: number): { room: MockRoom; colony: ColonySnapshot } {
+  const spawn = makeStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 20, 20);
+  return makeBootstrapRoom({
+    controllerLevel,
+    sources: [],
+    structures: [
+      spawn,
+      ...makeExtensions(controllerLevel >= 3 ? 10 : 5)
+    ],
+    spawns: [spawn as StructureSpawn]
+  });
+}
+
+function installActiveBootstrapMemory(updatedAt = 90, owned = true): void {
+  Memory.territory = {
+    claimedRoomBootstrapper: {
+      rooms: {
+        W2N1: {
+          roomName: 'W2N1',
+          owned,
+          claimedAt: owned ? updatedAt : undefined,
+          updatedAt
+        }
+      }
+    }
+  };
+}
+
+function installGame(room: Room, time = 100): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time,
+    rooms: { [room.name]: room },
+    map: {
+      getRoomTerrain: jest.fn().mockReturnValue({
+        get: jest.fn().mockReturnValue(0)
+      })
+    } as unknown as GameMap
+  };
+}
+
+function installPathFinder(room: MockRoom): void {
+  const pathsByTarget = (room as MockRoom & { __pathsByTarget?: Record<string, TestPosition[]> }).__pathsByTarget ?? {};
+  const pathFinderSearch = jest.fn((origin: RoomPosition, goal: { pos: RoomPosition }) => ({
+    path: (pathsByTarget[getRouteKey(origin, goal)] ?? pathsByTarget[getPositionKey(goal.pos)] ?? []).map((position) =>
+      makeRoomPosition(position, room.name)
+    ),
+    ops: 1,
+    cost: 1,
+    incomplete: false
+  }));
+  (globalThis as unknown as { PathFinder: Partial<PathFinder> }).PathFinder = {
+    CostMatrix: MockCostMatrix as unknown as CostMatrix,
+    search: pathFinderSearch as unknown as PathFinder['search']
+  };
+}
+
+function makeExtensions(count: number): Structure[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeStructure(`extension-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 35 + (index % 5), 35 + Math.floor(index / 5))
+  );
+}
+
+function makeSource(id: string, x: number, y: number): Source {
+  return {
+    id,
+    pos: makeRoomPosition({ x, y }, 'W2N1')
+  } as unknown as Source;
+}
+
+function makeStructure(id: string, structureType: StructureConstant, x: number, y: number): Structure {
+  return {
+    id,
+    name: id,
+    structureType,
+    pos: makeRoomPosition({ x, y }, 'W2N1')
+  } as unknown as Structure;
+}
+
+function makeConstructionSite(id: string, structureType: StructureConstant, x: number, y: number): ConstructionSite {
+  return {
+    id,
+    structureType,
+    pos: makeRoomPosition({ x, y }, 'W2N1')
+  } as unknown as ConstructionSite;
+}
+
+function makeRoomPosition(position: TestPosition, roomName: string): RoomPosition {
+  return { ...position, roomName } as RoomPosition;
+}
+
+function toLookResult(
+  key: 'structure' | 'constructionSite',
+  object: Structure | ConstructionSite,
+  top: number,
+  left: number,
+  bottom: number,
+  right: number
+): LookAtResultWithPos[] {
+  const position = object.pos;
+  if (position.x < left || position.x > right || position.y < top || position.y > bottom) {
+    return [];
+  }
+
+  return [{ x: position.x, y: position.y, [key]: object } as unknown as LookAtResultWithPos];
+}
+
+function getPositionKey(position: TestPosition): string {
+  return `${position.x},${position.y}`;
+}
+
+function getRouteKey(origin: unknown, goal: unknown): string {
+  return `${getPositionKey(origin as TestPosition)}->${getPositionKey((goal as { pos: TestPosition }).pos)}`;
+}

--- a/prod/test/territory/claimedRoomBootstrapper.test.ts
+++ b/prod/test/territory/claimedRoomBootstrapper.test.ts
@@ -5,6 +5,9 @@ import {
 } from '../../src/territory/claimedRoomBootstrapper';
 
 const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_FULL_CODE = -8 as ScreepsReturnCode;
+const ERR_RCL_NOT_ENOUGH_CODE = -14 as ScreepsReturnCode;
+const MAX_SPAWN_SITE_SCAN_WIDTH = 17;
 
 const TEST_GLOBALS = {
   FIND_SOURCES: 1,
@@ -21,7 +24,9 @@ const TEST_GLOBALS = {
   LOOK_STRUCTURES: 'structure',
   LOOK_CONSTRUCTION_SITES: 'constructionSite',
   LOOK_MINERALS: 'mineral',
-  OK: OK_CODE
+  OK: OK_CODE,
+  ERR_FULL: ERR_FULL_CODE,
+  ERR_RCL_NOT_ENOUGH: ERR_RCL_NOT_ENOUGH_CODE
 } as const;
 
 describe('claimed room bootstrapper', () => {
@@ -79,6 +84,40 @@ describe('claimed room bootstrapper', () => {
     expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'spawn', result: OK_CODE }]);
     expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
     expect(room.createConstructionSite).toHaveBeenCalledWith(23, 23, TEST_GLOBALS.STRUCTURE_SPAWN);
+  });
+
+  it.each([
+    ['ERR_FULL', ERR_FULL_CODE],
+    ['ERR_RCL_NOT_ENOUGH', ERR_RCL_NOT_ENOUGH_CODE]
+  ])('stops spawn placement retries after fatal %s construction-site results', (_name, fatalResult) => {
+    const { room, colony } = makeBootstrapRoom({
+      controllerLevel: 1,
+      sources: [makeSource('source1', 21, 21)]
+    });
+    room.createConstructionSite = jest.fn().mockReturnValue(fatalResult);
+    installActiveBootstrapMemory(90, false);
+    installGame(room, 101);
+
+    const result = runClaimedRoomBootstrapper([colony]);
+
+    expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'spawn', result: fatalResult }]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds spawn placement area lookups to a local scan window', () => {
+    const { room, colony } = makeBootstrapRoom({
+      controllerLevel: 1
+    });
+    installActiveBootstrapMemory();
+    installGame(room);
+
+    runClaimedRoomBootstrapper([colony]);
+
+    expect(room.lookForAtArea).toHaveBeenCalled();
+    for (const [, top, left, bottom, right] of room.lookForAtArea.mock.calls) {
+      expect(bottom - top + 1).toBeLessThanOrEqual(MAX_SPAWN_SITE_SCAN_WIDTH);
+      expect(right - left + 1).toBeLessThanOrEqual(MAX_SPAWN_SITE_SCAN_WIDTH);
+    }
   });
 
   it('places extensions up to the current RCL limit after a spawn exists', () => {


### PR DESCRIPTION
## Summary
Implements claimed-room bootstrapping: after colony expansion claims a new adjacent room, the claimed room needs deliberate infrastructure setup. See #639.

## Implementation
- New: `prod/src/territory/claimedRoomBootstrapper.ts` — detects newly claimed rooms, plans and places construction sites in priority order: spawn → extensions (RCL-gated) → source containers → roads → tower (RCL 3+)
- Integration with `territoryRunner.ts` for per-tick execution
- Idempotent: does not re-place existing construction sites

## Verification
- `npm run typecheck` — clean
- `npm test -- --runInBand` — 51 suites, 1108 tests, all passed
- `npm run build` — successful

Closes #639
