### PR TITLE
feat(economy): workers withdraw energy from source containers when source spots are full (#643)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12512,7 +12512,7 @@ function findSourceContainerWithdrawCandidates(creep) {
     return [];
   }
   const context = createSourceContainerWithdrawalContext(creep, findVisibleHarvestSourcesInRooms(harvestRooms));
-  if (context.sources.length === 0 || context.hasAssignableHarvestSource) {
+  if (context.sources.length === 0) {
     return [];
   }
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
@@ -12525,6 +12525,9 @@ function findSourceContainerWithdrawCandidates(creep) {
     }
     const sourceRoom = findVisibleSourceRoom(creep, source);
     if (!sourceRoom) {
+      continue;
+    }
+    if (hasAssignableHarvestSourceInRoom(creep, sourceRoom, context.sources, context.assignmentLoads)) {
       continue;
     }
     if (!isSourceContainerWithdrawalSourceSaturated(
@@ -12567,7 +12570,7 @@ function selectSourceContainerHarvestTask(creep) {
     creep,
     findVisibleHarvestSourcesInRooms(harvestRooms).filter((candidate) => hasNonEmptyVisibleSourceContainer(creep, candidate))
   );
-  return source ? { type: "harvest", targetId: source.id } : null;
+  return source ? { type: "harvest", targetId: source.id, sourceContainerAssigned: true } : null;
 }
 function hasNonEmptyVisibleSourceContainer(creep, source) {
   const sourceContainer = findVisibleSourceContainer(creep, source);
@@ -12647,9 +12650,18 @@ function createSourceContainerWithdrawalContext(creep, sources = findVisibleHarv
   const assignmentLoads = getWorkerHarvestLoads(sources);
   return {
     assignmentLoads,
-    hasAssignableHarvestSource: hasAssignableHarvestSource(creep, sources, assignmentLoads),
     sources
   };
+}
+function hasAssignableHarvestSourceInRoom(creep, room, sources, assignmentLoads) {
+  return hasAssignableHarvestSource(
+    creep,
+    sources.filter((source) => {
+      var _a;
+      return ((_a = findVisibleSourceRoom(creep, source)) == null ? void 0 : _a.name) === room.name;
+    }),
+    assignmentLoads
+  );
 }
 function hasAssignableHarvestSource(creep, sources, assignmentLoads) {
   const viableSources = selectViableHarvestSources(sources, getHarvestEnergyTarget(creep));
@@ -12669,7 +12681,7 @@ function isSourceContainerWithdrawalSourceSaturated(creep, source, assignmentLoa
   return assignmentLoad.assignmentCount >= getHarvestSourceAccessCapacity(source) || hasOccupiedSourceContainerHarvestSlot(source, assignmentLoad);
 }
 function hasOccupiedSourceContainerHarvestSlot(source, assignmentLoad) {
-  return assignmentLoad.assignmentCount > 0 && getRoomObjectPosition3(source) !== null;
+  return assignmentLoad.hasContainerAssignment && getRoomObjectPosition3(source) !== null;
 }
 function findVisibleSourceRoom(creep, source) {
   var _a, _b, _c, _d, _e, _f;
@@ -12785,7 +12797,7 @@ function getHarvestSourceAssignmentLoad(assignmentLoads, source) {
   return (_a = assignmentLoads.get(source.id)) != null ? _a : createEmptyHarvestSourceAssignmentLoad();
 }
 function createEmptyHarvestSourceAssignmentLoad() {
-  return { assignedWorkParts: 0, assignmentCount: 0 };
+  return { assignedWorkParts: 0, assignmentCount: 0, hasContainerAssignment: false };
 }
 function getHarvestSourceAccessCapacity(source) {
   const position = getRoomObjectPosition3(source);
@@ -12991,10 +13003,14 @@ function getWorkerHarvestLoads(sources) {
     const currentLoad = (_c = assignmentLoads.get(sourceId)) != null ? _c : createEmptyHarvestSourceAssignmentLoad();
     assignmentLoads.set(sourceId, {
       assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts(assignedCreep),
-      assignmentCount: currentLoad.assignmentCount + 1
+      assignmentCount: currentLoad.assignmentCount + 1,
+      hasContainerAssignment: currentLoad.hasContainerAssignment || isSourceContainerHarvestAssignment(task)
     });
   }
   return assignmentLoads;
+}
+function isSourceContainerHarvestAssignment(task) {
+  return (task == null ? void 0 : task.type) === "harvest" && task.sourceContainerAssigned === true;
 }
 function getGameCreeps() {
   var _a;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9948,6 +9948,10 @@ function selectHeuristicWorkerTask(creep) {
       if (sourceContainerHarvestTask) {
         return sourceContainerHarvestTask;
       }
+      const sourceContainerWithdrawTask = selectSourceContainerWithdrawTask(creep);
+      if (sourceContainerWithdrawTask) {
+        return sourceContainerWithdrawTask;
+      }
       if (!hasPriorityEnergySink) {
         const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
         if (energyAcquisitionTask) {
@@ -12495,6 +12499,62 @@ function findClosestByRange(creep, objects) {
   }
   return typeof (position == null ? void 0 : position.findClosestByRange) === "function" ? position.findClosestByRange(objects) : null;
 }
+function selectSourceContainerWithdrawTask(creep) {
+  const candidates = findSourceContainerWithdrawCandidates(creep);
+  if (candidates.length === 0) {
+    return null;
+  }
+  return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+function findSourceContainerWithdrawCandidates(creep) {
+  const harvestRooms = findVisibleHarvestRooms(creep);
+  if (!harvestRooms.some(hasVisiblePositionedContainer)) {
+    return [];
+  }
+  const context = createSourceContainerWithdrawalContext(creep, findVisibleHarvestSourcesInRooms(harvestRooms));
+  if (context.sources.length === 0 || context.hasAssignableHarvestSource) {
+    return [];
+  }
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+  const candidates = [];
+  const seenContainerIds = /* @__PURE__ */ new Set();
+  for (const source of context.sources) {
+    const sourceContainer = findVisibleSourceContainer(creep, source);
+    if (!sourceContainer || seenContainerIds.has(String(sourceContainer.id))) {
+      continue;
+    }
+    const sourceRoom = findVisibleSourceRoom(creep, source);
+    if (!sourceRoom) {
+      continue;
+    }
+    if (!isSourceContainerWithdrawalSourceSaturated(
+      creep,
+      source,
+      getHarvestSourceAssignmentLoad(context.assignmentLoads, source)
+    )) {
+      continue;
+    }
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      sourceContainer,
+      getStoredEnergy4(sourceContainer),
+      {
+        type: "withdraw",
+        targetId: sourceContainer.id
+      },
+      reservationContext
+    );
+    if (candidate && isSafeStoredEnergySource(sourceContainer, {
+      creepOwnerUsername: getCreepOwnerUsername2(creep),
+      hasHostilePresence: hasVisibleHostilePresence(sourceRoom),
+      room: sourceRoom
+    })) {
+      candidates.push(candidate);
+      seenContainerIds.add(String(sourceContainer.id));
+    }
+  }
+  return candidates;
+}
 function selectSourceContainerHarvestTask(creep) {
   if (getActiveWorkParts(creep) <= 0 || typeof FIND_SOURCES !== "number") {
     return null;
@@ -12582,6 +12642,34 @@ function getAdjacentRoomNames3(roomName, gameMap) {
 function findVisibleSourceContainer(creep, source) {
   const sourceRoom = findVisibleSourceRoom(creep, source);
   return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
+}
+function createSourceContainerWithdrawalContext(creep, sources = findVisibleHarvestSources(creep)) {
+  const assignmentLoads = getWorkerHarvestLoads(sources);
+  return {
+    assignmentLoads,
+    hasAssignableHarvestSource: hasAssignableHarvestSource(creep, sources, assignmentLoads),
+    sources
+  };
+}
+function hasAssignableHarvestSource(creep, sources, assignmentLoads) {
+  const viableSources = selectViableHarvestSources(sources, getHarvestEnergyTarget(creep));
+  if (viableSources.length === 0) {
+    return false;
+  }
+  const assignableSources = selectReachableHarvestSources(
+    creep,
+    selectAssignableHarvestSources(creep, viableSources, assignmentLoads)
+  );
+  return assignableSources.length > 0;
+}
+function isSourceContainerWithdrawalSourceSaturated(creep, source, assignmentLoad) {
+  if (isWorkerAssignedToHarvestSource(creep, source) || assignmentLoad.assignmentCount <= 0) {
+    return false;
+  }
+  return assignmentLoad.assignmentCount >= getHarvestSourceAccessCapacity(source) || hasOccupiedSourceContainerHarvestSlot(source, assignmentLoad);
+}
+function hasOccupiedSourceContainerHarvestSlot(source, assignmentLoad) {
+  return assignmentLoad.assignmentCount > 0 && getRoomObjectPosition3(source) !== null;
 }
 function findVisibleSourceRoom(creep, source) {
   var _a, _b, _c, _d, _e, _f;
@@ -12921,6 +13009,7 @@ var BEHAVIOR_COUNTER_KEYS = [
   { key: "workTicks" },
   { key: "stuckTicks" },
   { key: "containerTransfers" },
+  { key: "sourceContainerWithdrawals" },
   { key: "pathLength" }
 ];
 var TOP_IDLE_WORKER_COUNT = 3;
@@ -12979,6 +13068,15 @@ function recordCreepBehaviorContainerTransfer(creep) {
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   telemetry.containerTransfers = ((_a = telemetry.containerTransfers) != null ? _a : 0) + 1;
 }
+function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime9()) {
+  var _a;
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastSourceContainerWithdrawalTick === tick) {
+    return;
+  }
+  telemetry.sourceContainerWithdrawals = ((_a = telemetry.sourceContainerWithdrawals) != null ? _a : 0) + 1;
+  telemetry.lastSourceContainerWithdrawalTick = tick;
+}
 function summarizeAndResetCreepBehaviorTelemetry(workers) {
   const creepSummaries = workers.map(toRuntimeCreepBehaviorSummary).filter((summary) => summary !== null).sort(compareRuntimeCreepBehaviorSummaries);
   if (creepSummaries.length === 0) {
@@ -13013,6 +13111,7 @@ function toRuntimeCreepBehaviorSummary(creep) {
     workTicks: getNonNegativeCounter(telemetry.workTicks),
     stuckTicks: getNonNegativeCounter(telemetry.stuckTicks),
     containerTransfers: getNonNegativeCounter(telemetry.containerTransfers),
+    sourceContainerWithdrawals: getNonNegativeCounter(telemetry.sourceContainerWithdrawals),
     pathLength: getNonNegativeCounter(telemetry.pathLength),
     ...typeof telemetry.repairTargetId === "string" && telemetry.repairTargetId.length > 0 ? { repairTargetId: telemetry.repairTargetId } : {}
   };
@@ -13031,6 +13130,7 @@ function resetCreepBehaviorCounters(creep) {
   delete telemetry.repairTargetId;
   delete telemetry.lastIdleTick;
   delete telemetry.lastWorkTick;
+  delete telemetry.lastSourceContainerWithdrawalTick;
   if (!telemetry.lastPosition && telemetry.lastMoveTick === void 0 && telemetry.lastObservedTick === void 0) {
     delete creep.memory.behaviorTelemetry;
   }
@@ -13043,6 +13143,7 @@ function summarizeBehaviorTotals(creeps) {
       workTicks: totals.workTicks + creep.workTicks,
       stuckTicks: totals.stuckTicks + creep.stuckTicks,
       containerTransfers: totals.containerTransfers + creep.containerTransfers,
+      sourceContainerWithdrawals: totals.sourceContainerWithdrawals + creep.sourceContainerWithdrawals,
       pathLength: totals.pathLength + creep.pathLength
     }),
     {
@@ -13051,6 +13152,7 @@ function summarizeBehaviorTotals(creeps) {
       workTicks: 0,
       stuckTicks: 0,
       containerTransfers: 0,
+      sourceContainerWithdrawals: 0,
       pathLength: 0
     }
   );
@@ -13762,8 +13864,12 @@ function executeTask(creep, task, target) {
       return executeHarvestTask(creep, target);
     case "pickup":
       return toTaskExecutionResult(creep.pickup(target), "work");
-    case "withdraw":
-      return toTaskExecutionResult(creep.withdraw(target, RESOURCE_ENERGY), "work");
+    case "withdraw": {
+      const withdrawTarget = target;
+      return toTaskExecutionResult(creep.withdraw(withdrawTarget, RESOURCE_ENERGY), "work", {
+        sourceContainerWithdrawal: isVisibleSourceContainer(creep, withdrawTarget)
+      });
+    }
     case "transfer":
       return toTaskExecutionResult(creep.transfer(target, RESOURCE_ENERGY), "work", {
         containerTransfer: isContainerStructure3(target)
@@ -13826,7 +13932,8 @@ function toTaskExecutionResult(result, successAction, options = {}) {
   return {
     result,
     ...result === OK_CODE5 ? { action: successAction } : {},
-    ...result === OK_CODE5 && options.containerTransfer ? { containerTransfer: true } : {}
+    ...result === OK_CODE5 && options.containerTransfer ? { containerTransfer: true } : {},
+    ...result === OK_CODE5 && options.sourceContainerWithdrawal ? { sourceContainerWithdrawal: true } : {}
   };
 }
 function recordTaskBehavior(creep, task, execution) {
@@ -13843,6 +13950,9 @@ function recordTaskBehavior(creep, task, execution) {
   if (execution.containerTransfer) {
     recordCreepBehaviorContainerTransfer(creep);
   }
+  if (execution.sourceContainerWithdrawal) {
+    recordCreepBehaviorSourceContainerWithdrawal(creep);
+  }
 }
 function isContainerStructure3(target) {
   const structureType = target == null ? void 0 : target.structureType;
@@ -13852,6 +13962,33 @@ function matchesContainerStructureType(actual) {
   var _a;
   const containerType = (_a = globalThis.STRUCTURE_CONTAINER) != null ? _a : "container";
   return actual === containerType;
+}
+function isVisibleSourceContainer(creep, target) {
+  if (!isContainerStructure3(target)) {
+    return false;
+  }
+  const container = target;
+  const targetRoom = findVisibleRoomForObject(creep, container);
+  if (!targetRoom || typeof FIND_SOURCES !== "number" || typeof targetRoom.find !== "function") {
+    return false;
+  }
+  return targetRoom.find(FIND_SOURCES).some((source) => {
+    const sourceContainer = findSourceContainer(targetRoom, source);
+    return sourceContainer !== null && String(sourceContainer.id) === String(container.id);
+  });
+}
+function findVisibleRoomForObject(creep, object) {
+  var _a, _b, _c, _d, _e;
+  const roomName = getRoomObjectRoomName(object);
+  if (!roomName || ((_a = creep.room) == null ? void 0 : _a.name) === roomName) {
+    return (_b = creep.room) != null ? _b : null;
+  }
+  return (_e = (_d = (_c = globalThis.Game) == null ? void 0 : _c.rooms) == null ? void 0 : _d[roomName]) != null ? _e : null;
+}
+function getRoomObjectRoomName(object) {
+  var _a;
+  const roomName = (_a = object.pos) == null ? void 0 : _a.roomName;
+  return typeof roomName === "string" && roomName.length > 0 ? roomName : null;
 }
 function isDedicatedSourceContainerHarvestTask(creep, task) {
   return task.type === "harvest" && findHarvestTaskSourceContainer(creep, task) !== null;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -17,6 +17,7 @@ import {
   recordCreepBehaviorIdle,
   recordCreepBehaviorMove,
   recordCreepBehaviorRepairTarget,
+  recordCreepBehaviorSourceContainerWithdrawal,
   recordCreepBehaviorWork
 } from '../telemetry/behaviorTelemetry';
 
@@ -49,6 +50,7 @@ interface TaskExecutionResult {
   result: ScreepsReturnCode;
   action?: 'move' | 'work';
   containerTransfer?: boolean;
+  sourceContainerWithdrawal?: boolean;
 }
 
 export function runWorker(creep: Creep): void {
@@ -1022,8 +1024,12 @@ function executeTask(
       return executeHarvestTask(creep, target as Source);
     case 'pickup':
       return toTaskExecutionResult(creep.pickup(target as Resource<ResourceConstant>), 'work');
-    case 'withdraw':
-      return toTaskExecutionResult(creep.withdraw(target as AnyStoreStructure, RESOURCE_ENERGY), 'work');
+    case 'withdraw': {
+      const withdrawTarget = target as AnyStoreStructure;
+      return toTaskExecutionResult(creep.withdraw(withdrawTarget, RESOURCE_ENERGY), 'work', {
+        sourceContainerWithdrawal: isVisibleSourceContainer(creep, withdrawTarget)
+      });
+    }
     case 'transfer':
       return toTaskExecutionResult(creep.transfer(target as AnyStoreStructure, RESOURCE_ENERGY), 'work', {
         containerTransfer: isContainerStructure(target)
@@ -1109,12 +1115,13 @@ function transferDedicatedHarvestEnergy(creep: Creep, sourceContainer: Structure
 function toTaskExecutionResult(
   result: ScreepsReturnCode,
   successAction: 'move' | 'work',
-  options: { containerTransfer?: boolean } = {}
+  options: { containerTransfer?: boolean; sourceContainerWithdrawal?: boolean } = {}
 ): TaskExecutionResult {
   return {
     result,
     ...(result === OK_CODE ? { action: successAction } : {}),
-    ...(result === OK_CODE && options.containerTransfer ? { containerTransfer: true } : {})
+    ...(result === OK_CODE && options.containerTransfer ? { containerTransfer: true } : {}),
+    ...(result === OK_CODE && options.sourceContainerWithdrawal ? { sourceContainerWithdrawal: true } : {})
   };
 }
 
@@ -1138,6 +1145,10 @@ function recordTaskBehavior(
   if (execution.containerTransfer) {
     recordCreepBehaviorContainerTransfer(creep);
   }
+
+  if (execution.sourceContainerWithdrawal) {
+    recordCreepBehaviorSourceContainerWithdrawal(creep);
+  }
 }
 
 function isContainerStructure(target: unknown): boolean {
@@ -1148,6 +1159,37 @@ function isContainerStructure(target: unknown): boolean {
 function matchesContainerStructureType(actual: string): boolean {
   const containerType = (globalThis as unknown as { STRUCTURE_CONTAINER?: string }).STRUCTURE_CONTAINER ?? 'container';
   return actual === containerType;
+}
+
+function isVisibleSourceContainer(creep: Creep, target: unknown): target is StructureContainer {
+  if (!isContainerStructure(target)) {
+    return false;
+  }
+
+  const container = target as StructureContainer;
+  const targetRoom = findVisibleRoomForObject(creep, container);
+  if (!targetRoom || typeof FIND_SOURCES !== 'number' || typeof targetRoom.find !== 'function') {
+    return false;
+  }
+
+  return (targetRoom.find(FIND_SOURCES) as Source[]).some((source) => {
+    const sourceContainer = findSourceContainer(targetRoom, source);
+    return sourceContainer !== null && String(sourceContainer.id) === String(container.id);
+  });
+}
+
+function findVisibleRoomForObject(creep: Creep, object: RoomObject): Room | null {
+  const roomName = getRoomObjectRoomName(object);
+  if (!roomName || creep.room?.name === roomName) {
+    return creep.room ?? null;
+  }
+
+  return (globalThis as unknown as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName] ?? null;
+}
+
+function getRoomObjectRoomName(object: RoomObject): string | null {
+  const roomName = (object as RoomObject & { pos?: { roomName?: unknown } }).pos?.roomName;
+  return typeof roomName === 'string' && roomName.length > 0 ? roomName : null;
 }
 
 function isDedicatedSourceContainerHarvestTask(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -172,6 +172,12 @@ interface HarvestSourceAssignmentLoad {
   assignmentCount: number;
 }
 
+interface SourceContainerWithdrawalContext {
+  assignmentLoads: Map<Id<Source>, HarvestSourceAssignmentLoad>;
+  hasAssignableHarvestSource: boolean;
+  sources: Source[];
+}
+
 let nearTermSpawnExtensionRefillReserveCache: NearTermSpawnExtensionRefillReserveCache | null = null;
 
 export function selectWorkerTask(creep: Creep): CreepTaskMemory | null {
@@ -255,6 +261,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       const sourceContainerHarvestTask = selectSourceContainerHarvestTask(creep);
       if (sourceContainerHarvestTask) {
         return sourceContainerHarvestTask;
+      }
+
+      const sourceContainerWithdrawTask = selectSourceContainerWithdrawTask(creep);
+      if (sourceContainerWithdrawTask) {
+        return sourceContainerWithdrawTask;
       }
 
       if (!hasPriorityEnergySink) {
@@ -2381,6 +2392,11 @@ function getGameObjectById<T extends RoomObject>(
 }
 
 export function selectWorkerEnergyFallbackTask(creep: Creep): CreepTaskMemory | null {
+  const sourceContainerWithdrawTask = selectSourceContainerWithdrawTask(creep);
+  if (sourceContainerWithdrawTask) {
+    return sourceContainerWithdrawTask;
+  }
+
   const energyAcquisitionTask = selectWorkerEnergyAcquisitionTask(creep);
   if (energyAcquisitionTask) {
     return energyAcquisitionTask;
@@ -4205,6 +4221,78 @@ function findClosestByRange<T extends RoomObject>(creep: Creep, objects: T[]): T
   return typeof position?.findClosestByRange === 'function' ? position.findClosestByRange(objects) : null;
 }
 
+function selectSourceContainerWithdrawTask(creep: Creep): WorkerEnergyAcquisitionTask | null {
+  const candidates = findSourceContainerWithdrawCandidates(creep);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  return candidates.sort(compareWorkerEnergyAcquisitionCandidates)[0].task;
+}
+
+function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquisitionCandidate[] {
+  const harvestRooms = findVisibleHarvestRooms(creep);
+  if (!harvestRooms.some(hasVisiblePositionedContainer)) {
+    return [];
+  }
+
+  const context = createSourceContainerWithdrawalContext(creep, findVisibleHarvestSourcesInRooms(harvestRooms));
+  if (context.sources.length === 0 || context.hasAssignableHarvestSource) {
+    return [];
+  }
+
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+  const candidates: WorkerEnergyAcquisitionCandidate[] = [];
+  const seenContainerIds = new Set<string>();
+
+  for (const source of context.sources) {
+    const sourceContainer = findVisibleSourceContainer(creep, source);
+    if (!sourceContainer || seenContainerIds.has(String(sourceContainer.id))) {
+      continue;
+    }
+
+    const sourceRoom = findVisibleSourceRoom(creep, source);
+    if (!sourceRoom) {
+      continue;
+    }
+
+    if (
+      !isSourceContainerWithdrawalSourceSaturated(
+        creep,
+        source,
+        getHarvestSourceAssignmentLoad(context.assignmentLoads, source)
+      )
+    ) {
+      continue;
+    }
+
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      sourceContainer,
+      getStoredEnergy(sourceContainer),
+      {
+        type: 'withdraw',
+        targetId: sourceContainer.id as Id<AnyStoreStructure>
+      },
+      reservationContext
+    );
+
+    if (
+      candidate &&
+      isSafeStoredEnergySource(sourceContainer as AnyStructure, {
+        creepOwnerUsername: getCreepOwnerUsername(creep),
+        hasHostilePresence: hasVisibleHostilePresence(sourceRoom),
+        room: sourceRoom
+      })
+    ) {
+      candidates.push(candidate);
+      seenContainerIds.add(String(sourceContainer.id));
+    }
+  }
+
+  return candidates;
+}
+
 function selectSourceContainerHarvestTask(creep: Creep): Extract<CreepTaskMemory, { type: 'harvest' }> | null {
   if (
     getActiveWorkParts(creep) <= 0 ||
@@ -4321,6 +4409,57 @@ function getAdjacentRoomNames(roomName: string, gameMap: Partial<GameMap> | unde
 function findVisibleSourceContainer(creep: Creep, source: Source): StructureContainer | null {
   const sourceRoom = findVisibleSourceRoom(creep, source);
   return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
+}
+
+function createSourceContainerWithdrawalContext(
+  creep: Creep,
+  sources = findVisibleHarvestSources(creep)
+): SourceContainerWithdrawalContext {
+  const assignmentLoads = getWorkerHarvestLoads(sources);
+  return {
+    assignmentLoads,
+    hasAssignableHarvestSource: hasAssignableHarvestSource(creep, sources, assignmentLoads),
+    sources
+  };
+}
+
+function hasAssignableHarvestSource(
+  creep: Creep,
+  sources: Source[],
+  assignmentLoads: Map<Id<Source>, HarvestSourceAssignmentLoad>
+): boolean {
+  const viableSources = selectViableHarvestSources(sources, getHarvestEnergyTarget(creep));
+  if (viableSources.length === 0) {
+    return false;
+  }
+
+  const assignableSources = selectReachableHarvestSources(
+    creep,
+    selectAssignableHarvestSources(creep, viableSources, assignmentLoads)
+  );
+  return assignableSources.length > 0;
+}
+
+function isSourceContainerWithdrawalSourceSaturated(
+  creep: Creep,
+  source: Source,
+  assignmentLoad: HarvestSourceAssignmentLoad
+): boolean {
+  if (isWorkerAssignedToHarvestSource(creep, source) || assignmentLoad.assignmentCount <= 0) {
+    return false;
+  }
+
+  return (
+    assignmentLoad.assignmentCount >= getHarvestSourceAccessCapacity(source) ||
+    hasOccupiedSourceContainerHarvestSlot(source, assignmentLoad)
+  );
+}
+
+function hasOccupiedSourceContainerHarvestSlot(
+  source: Source,
+  assignmentLoad: HarvestSourceAssignmentLoad
+): boolean {
+  return assignmentLoad.assignmentCount > 0 && getRoomObjectPosition(source) !== null;
 }
 
 function findVisibleSourceRoom(creep: Creep, source: Source): Room | null {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -170,11 +170,11 @@ interface HarvestSourceLoad {
 interface HarvestSourceAssignmentLoad {
   assignedWorkParts: number;
   assignmentCount: number;
+  hasContainerAssignment: boolean;
 }
 
 interface SourceContainerWithdrawalContext {
   assignmentLoads: Map<Id<Source>, HarvestSourceAssignmentLoad>;
-  hasAssignableHarvestSource: boolean;
   sources: Source[];
 }
 
@@ -4237,7 +4237,7 @@ function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquis
   }
 
   const context = createSourceContainerWithdrawalContext(creep, findVisibleHarvestSourcesInRooms(harvestRooms));
-  if (context.sources.length === 0 || context.hasAssignableHarvestSource) {
+  if (context.sources.length === 0) {
     return [];
   }
 
@@ -4253,6 +4253,10 @@ function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquis
 
     const sourceRoom = findVisibleSourceRoom(creep, source);
     if (!sourceRoom) {
+      continue;
+    }
+
+    if (hasAssignableHarvestSourceInRoom(creep, sourceRoom, context.sources, context.assignmentLoads)) {
       continue;
     }
 
@@ -4310,7 +4314,7 @@ function selectSourceContainerHarvestTask(creep: Creep): Extract<CreepTaskMemory
     creep,
     findVisibleHarvestSourcesInRooms(harvestRooms).filter((candidate) => hasNonEmptyVisibleSourceContainer(creep, candidate))
   );
-  return source ? { type: 'harvest', targetId: source.id } : null;
+  return source ? { type: 'harvest', targetId: source.id, sourceContainerAssigned: true } : null;
 }
 
 function hasNonEmptyVisibleSourceContainer(creep: Creep, source: Source): boolean {
@@ -4418,9 +4422,21 @@ function createSourceContainerWithdrawalContext(
   const assignmentLoads = getWorkerHarvestLoads(sources);
   return {
     assignmentLoads,
-    hasAssignableHarvestSource: hasAssignableHarvestSource(creep, sources, assignmentLoads),
     sources
   };
+}
+
+function hasAssignableHarvestSourceInRoom(
+  creep: Creep,
+  room: Room,
+  sources: Source[],
+  assignmentLoads: Map<Id<Source>, HarvestSourceAssignmentLoad>
+): boolean {
+  return hasAssignableHarvestSource(
+    creep,
+    sources.filter((source) => findVisibleSourceRoom(creep, source)?.name === room.name),
+    assignmentLoads
+  );
 }
 
 function hasAssignableHarvestSource(
@@ -4459,7 +4475,7 @@ function hasOccupiedSourceContainerHarvestSlot(
   source: Source,
   assignmentLoad: HarvestSourceAssignmentLoad
 ): boolean {
-  return assignmentLoad.assignmentCount > 0 && getRoomObjectPosition(source) !== null;
+  return assignmentLoad.hasContainerAssignment && getRoomObjectPosition(source) !== null;
 }
 
 function findVisibleSourceRoom(creep: Creep, source: Source): Room | null {
@@ -4616,7 +4632,7 @@ function getHarvestSourceAssignmentLoad(
 }
 
 function createEmptyHarvestSourceAssignmentLoad(): HarvestSourceAssignmentLoad {
-  return { assignedWorkParts: 0, assignmentCount: 0 };
+  return { assignedWorkParts: 0, assignmentCount: 0, hasContainerAssignment: false };
 }
 
 function getHarvestSourceAccessCapacity(source: Source): number {
@@ -4892,11 +4908,19 @@ function getWorkerHarvestLoads(sources: Source[]): Map<Id<Source>, HarvestSource
     const currentLoad = assignmentLoads.get(sourceId) ?? createEmptyHarvestSourceAssignmentLoad();
     assignmentLoads.set(sourceId, {
       assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts(assignedCreep),
-      assignmentCount: currentLoad.assignmentCount + 1
+      assignmentCount: currentLoad.assignmentCount + 1,
+      hasContainerAssignment: currentLoad.hasContainerAssignment || isSourceContainerHarvestAssignment(task)
     });
   }
 
   return assignmentLoads;
+}
+
+function isSourceContainerHarvestAssignment(task: Partial<CreepTaskMemory> | undefined): boolean {
+  return (
+    task?.type === 'harvest' &&
+    (task as Partial<Extract<CreepTaskMemory, { type: 'harvest' }>>).sourceContainerAssigned === true
+  );
 }
 
 function getGameCreeps(): Creep[] {

--- a/prod/src/telemetry/behaviorTelemetry.ts
+++ b/prod/src/telemetry/behaviorTelemetry.ts
@@ -5,6 +5,7 @@ export interface RuntimeCreepBehaviorSummary {
   workTicks: number;
   stuckTicks: number;
   containerTransfers: number;
+  sourceContainerWithdrawals: number;
   pathLength: number;
   repairTargetId?: string;
 }
@@ -21,13 +22,20 @@ interface RuntimeBehaviorTotals {
   workTicks: number;
   stuckTicks: number;
   containerTransfers: number;
+  sourceContainerWithdrawals: number;
   pathLength: number;
 }
 
 interface CreepBehaviorCounterKey {
   key: keyof Pick<
     CreepBehaviorTelemetryMemory,
-    'idleTicks' | 'moveTicks' | 'workTicks' | 'stuckTicks' | 'containerTransfers' | 'pathLength'
+    | 'idleTicks'
+    | 'moveTicks'
+    | 'workTicks'
+    | 'stuckTicks'
+    | 'containerTransfers'
+    | 'sourceContainerWithdrawals'
+    | 'pathLength'
   >;
 }
 
@@ -37,6 +45,7 @@ const BEHAVIOR_COUNTER_KEYS: CreepBehaviorCounterKey[] = [
   { key: 'workTicks' },
   { key: 'stuckTicks' },
   { key: 'containerTransfers' },
+  { key: 'sourceContainerWithdrawals' },
   { key: 'pathLength' }
 ];
 const TOP_IDLE_WORKER_COUNT = 3;
@@ -102,6 +111,16 @@ export function recordCreepBehaviorContainerTransfer(creep: Creep): void {
   telemetry.containerTransfers = (telemetry.containerTransfers ?? 0) + 1;
 }
 
+export function recordCreepBehaviorSourceContainerWithdrawal(creep: Creep, tick: number = getGameTime()): void {
+  const telemetry = ensureCreepBehaviorTelemetry(creep);
+  if (telemetry.lastSourceContainerWithdrawalTick === tick) {
+    return;
+  }
+
+  telemetry.sourceContainerWithdrawals = (telemetry.sourceContainerWithdrawals ?? 0) + 1;
+  telemetry.lastSourceContainerWithdrawalTick = tick;
+}
+
 export function summarizeAndResetCreepBehaviorTelemetry(workers: Creep[]): { behavior?: RuntimeBehaviorSummary } {
   const creepSummaries = workers
     .map(toRuntimeCreepBehaviorSummary)
@@ -146,6 +165,7 @@ function toRuntimeCreepBehaviorSummary(creep: Creep): RuntimeCreepBehaviorSummar
     workTicks: getNonNegativeCounter(telemetry.workTicks),
     stuckTicks: getNonNegativeCounter(telemetry.stuckTicks),
     containerTransfers: getNonNegativeCounter(telemetry.containerTransfers),
+    sourceContainerWithdrawals: getNonNegativeCounter(telemetry.sourceContainerWithdrawals),
     pathLength: getNonNegativeCounter(telemetry.pathLength),
     ...(typeof telemetry.repairTargetId === 'string' && telemetry.repairTargetId.length > 0
       ? { repairTargetId: telemetry.repairTargetId }
@@ -172,6 +192,7 @@ function resetCreepBehaviorCounters(creep: Creep): void {
   delete telemetry.repairTargetId;
   delete telemetry.lastIdleTick;
   delete telemetry.lastWorkTick;
+  delete telemetry.lastSourceContainerWithdrawalTick;
 
   if (!telemetry.lastPosition && telemetry.lastMoveTick === undefined && telemetry.lastObservedTick === undefined) {
     delete creep.memory.behaviorTelemetry;
@@ -186,6 +207,7 @@ function summarizeBehaviorTotals(creeps: RuntimeCreepBehaviorSummary[]): Runtime
       workTicks: totals.workTicks + creep.workTicks,
       stuckTicks: totals.stuckTicks + creep.stuckTicks,
       containerTransfers: totals.containerTransfers + creep.containerTransfers,
+      sourceContainerWithdrawals: totals.sourceContainerWithdrawals + creep.sourceContainerWithdrawals,
       pathLength: totals.pathLength + creep.pathLength
     }),
     {
@@ -194,6 +216,7 @@ function summarizeBehaviorTotals(creeps: RuntimeCreepBehaviorSummary[]): Runtime
       workTicks: 0,
       stuckTicks: 0,
       containerTransfers: 0,
+      sourceContainerWithdrawals: 0,
       pathLength: 0
     }
   );

--- a/prod/src/telemetry/runtimeSummary.ts
+++ b/prod/src/telemetry/runtimeSummary.ts
@@ -317,6 +317,7 @@ interface RuntimeCreepBehaviorSummary {
   workTicks: number;
   stuckTicks: number;
   containerTransfers: number;
+  sourceContainerWithdrawals: number;
   pathLength: number;
   repairTargetId?: string;
 }
@@ -327,6 +328,7 @@ interface RuntimeBehaviorTotals {
   workTicks: number;
   stuckTicks: number;
   containerTransfers: number;
+  sourceContainerWithdrawals: number;
   pathLength: number;
 }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -620,12 +620,14 @@ declare global {
     stuckTicks?: number;
     repairTargetId?: string;
     containerTransfers?: number;
+    sourceContainerWithdrawals?: number;
     pathLength?: number;
     lastPosition?: CreepBehaviorPositionMemory;
     lastMoveTick?: number;
     lastWorkTick?: number;
     lastObservedTick?: number;
     lastIdleTick?: number;
+    lastSourceContainerWithdrawalTick?: number;
   }
 
   type CreepTaskMemory =

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -631,7 +631,7 @@ declare global {
   }
 
   type CreepTaskMemory =
-    | { type: 'harvest'; targetId: Id<Source> }
+    | { type: 'harvest'; targetId: Id<Source>; sourceContainerAssigned?: true }
     | { type: 'pickup'; targetId: Id<Resource<ResourceConstant>> }
     | { type: 'withdraw'; targetId: Id<AnyStoreStructure> }
     | { type: 'transfer'; targetId: Id<AnyStoreStructure> }

--- a/prod/test/runtimeSummary.test.ts
+++ b/prod/test/runtimeSummary.test.ts
@@ -241,6 +241,7 @@ describe('runtime telemetry summaries', () => {
           workTicks: 2,
           stuckTicks: 1,
           containerTransfers: 1,
+          sourceContainerWithdrawals: 2,
           pathLength: 2,
           repairTargetId: 'road-damaged',
           lastPosition: { x: 10, y: 12, roomName: 'W1N1' },
@@ -265,6 +266,7 @@ describe('runtime telemetry summaries', () => {
           workTicks: 2,
           stuckTicks: 1,
           containerTransfers: 1,
+          sourceContainerWithdrawals: 2,
           pathLength: 2,
           repairTargetId: 'road-damaged'
         }
@@ -275,6 +277,7 @@ describe('runtime telemetry summaries', () => {
         workTicks: 2,
         stuckTicks: 1,
         containerTransfers: 1,
+        sourceContainerWithdrawals: 2,
         pathLength: 2
       },
       topIdleWorkers: [
@@ -285,6 +288,7 @@ describe('runtime telemetry summaries', () => {
           workTicks: 2,
           stuckTicks: 1,
           containerTransfers: 1,
+          sourceContainerWithdrawals: 2,
           pathLength: 2,
           repairTargetId: 'road-damaged'
         }
@@ -328,6 +332,7 @@ describe('runtime telemetry summaries', () => {
         workTicks: 0,
         stuckTicks: 0,
         containerTransfers: 0,
+        sourceContainerWithdrawals: 0,
         pathLength: 0
       },
       topIdleWorkers: [
@@ -1450,6 +1455,7 @@ function makeIdleBehaviorSummary(creepName: string, idleTicks: number): Record<s
     workTicks: 0,
     stuckTicks: 0,
     containerTransfers: 0,
+    sourceContainerWithdrawals: 0,
     pathLength: 0
   };
 }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -620,6 +620,52 @@ describe('runWorker', () => {
     expect(creep.moveTo).toHaveBeenCalledWith(container);
   });
 
+  it('records source container withdrawal telemetry on successful source-container withdraw', () => {
+    const source = {
+      id: 'source1',
+      pos: { x: 10, y: 10, roomName: 'W1N1' } as RoomPosition
+    } as Source;
+    const container = {
+      id: 'container1',
+      structureType: 'container',
+      pos: { x: 10, y: 11, roomName: 'W1N1' } as RoomPosition,
+      store: { getUsedCapacity: jest.fn().mockReturnValue(100) }
+    } as unknown as StructureContainer;
+    const room = {
+      name: 'W1N1',
+      find: jest.fn((type: number) => {
+        if (type === FIND_SOURCES) {
+          return [source];
+        }
+
+        return type === FIND_STRUCTURES ? [container] : [];
+      })
+    } as unknown as Room;
+    const creep = {
+      memory: { task: { type: 'withdraw', targetId: 'container1' as Id<AnyStoreStructure> } },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room,
+      withdraw: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 42,
+      getObjectById: jest.fn().mockReturnValue(container)
+    };
+
+    runWorker(creep);
+
+    expect(creep.withdraw).toHaveBeenCalledWith(container, 'energy');
+    expect(creep.memory.behaviorTelemetry).toMatchObject({
+      workTicks: 1,
+      sourceContainerWithdrawals: 1,
+      lastSourceContainerWithdrawalTick: 42
+    });
+  });
+
   it('reselects and executes when a withdraw target is drained before action', () => {
     const drainedContainer = {
       id: 'container-drained',

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2507,6 +2507,42 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toBeNull();
   });
 
+  it('withdraws from source containers when every source container harvest slot is occupied', () => {
+    const source1 = makeSource('source1', 10, 10);
+    const source2 = makeSource('source2', 30, 30);
+    const container1 = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 100, {
+      pos: makeRoomPosition(10, 11)
+    });
+    const container2 = makeStoredEnergyStructure('container2', 'container' as StructureConstant, 100, {
+      pos: makeRoomPosition(30, 31)
+    });
+    const room = makeWorkerTaskRoom({
+      controller: { id: 'controller1', my: true, level: 1 } as StructureController,
+      sources: [source1, source2],
+      structures: [container1, container2]
+    });
+    setGameCreeps({
+      Harvester1: {
+        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+        room
+      } as unknown as Creep,
+      Harvester2: {
+        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source2' as Id<Source> } },
+        room
+      } as unknown as Creep
+    });
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
+  });
+
   it('avoids depleted harvest sources when another source has energy', () => {
     const depletedSource = { id: 'source-empty', energy: 0 } as Source;
     const viableSource = { id: 'source-full', energy: 300 } as Source;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2398,7 +2398,11 @@ describe('selectWorkerTask', () => {
       room
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-near' });
+    expect(selectWorkerTask(creep)).toEqual({
+      type: 'harvest',
+      targetId: 'source-near',
+      sourceContainerAssigned: true
+    });
   });
 
   it('skips depleted source containers when assigning dedicated harvesters', () => {
@@ -2430,7 +2434,11 @@ describe('selectWorkerTask', () => {
       room
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-charged-container' });
+    expect(selectWorkerTask(creep)).toEqual({
+      type: 'harvest',
+      targetId: 'source-charged-container',
+      sourceContainerAssigned: true
+    });
   });
 
   it('does not assign a second harvester to a source container with a dedicated worker', () => {
@@ -2450,7 +2458,14 @@ describe('selectWorkerTask', () => {
     });
     setGameCreeps({
       DedicatedHarvester: {
-        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source-assigned-container' as Id<Source> } },
+        memory: {
+          role: 'worker',
+          task: {
+            type: 'harvest',
+            targetId: 'source-assigned-container' as Id<Source>,
+            sourceContainerAssigned: true
+          }
+        },
         room
       } as unknown as Creep
     });
@@ -2468,7 +2483,11 @@ describe('selectWorkerTask', () => {
       room
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-available-container' });
+    expect(selectWorkerTask(creep)).toEqual({
+      type: 'harvest',
+      targetId: 'source-available-container',
+      sourceContainerAssigned: true
+    });
   });
 
   it('waits for source-container hauling when every source already has a dedicated harvester', () => {
@@ -2487,11 +2506,17 @@ describe('selectWorkerTask', () => {
     });
     setGameCreeps({
       Harvester1: {
-        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+        memory: {
+          role: 'worker',
+          task: { type: 'harvest', targetId: 'source1' as Id<Source>, sourceContainerAssigned: true }
+        },
         room
       } as unknown as Creep,
       Harvester2: {
-        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source2' as Id<Source> } },
+        memory: {
+          role: 'worker',
+          task: { type: 'harvest', targetId: 'source2' as Id<Source>, sourceContainerAssigned: true }
+        },
         room
       } as unknown as Creep
     });
@@ -2523,11 +2548,17 @@ describe('selectWorkerTask', () => {
     });
     setGameCreeps({
       Harvester1: {
-        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+        memory: {
+          role: 'worker',
+          task: { type: 'harvest', targetId: 'source1' as Id<Source>, sourceContainerAssigned: true }
+        },
         room
       } as unknown as Creep,
       Harvester2: {
-        memory: { role: 'worker', task: { type: 'harvest', targetId: 'source2' as Id<Source> } },
+        memory: {
+          role: 'worker',
+          task: { type: 'harvest', targetId: 'source2' as Id<Source>, sourceContainerAssigned: true }
+        },
         room
       } as unknown as Creep
     });
@@ -2541,6 +2572,85 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
+  });
+
+  it('withdraws from a saturated local source container before traveling to an adjacent assignable source', () => {
+    const localSource = makeSource('source-local', 10, 10, 'W1N1');
+    const adjacentSource = makeSource('source-adjacent', 20, 20, 'W2N1');
+    const localContainer = makeStoredEnergyStructure('container-local', 'container' as StructureConstant, 100, {
+      pos: makeRoomPosition(10, 11, 'W1N1')
+    });
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const homeRoom = makeWorkerTaskRoom({
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [localSource],
+      structures: [localContainer]
+    });
+    const adjacentRoom = makeWorkerTaskRoom({
+      controller: { id: 'controller2', my: true, level: 2 } as StructureController,
+      name: 'W2N1',
+      sources: [adjacentSource]
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        LocalHarvester: {
+          memory: {
+            role: 'worker',
+            task: { type: 'harvest', targetId: 'source-local' as Id<Source>, sourceContainerAssigned: true }
+          },
+          room: homeRoom
+        } as unknown as Creep
+      },
+      map: { describeExits: jest.fn().mockReturnValue({ '3': 'W2N1' }) } as unknown as GameMap,
+      rooms: { W1N1: homeRoom, W2N1: adjacentRoom }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: homeRoom
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-local' });
+  });
+
+  it('does not treat an ordinary source assignment as an occupied source-container harvest slot', () => {
+    const source = makeSource('source1', 10, 10);
+    const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 100, {
+      pos: makeRoomPosition(10, 11)
+    });
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const room = makeWorkerTaskRoom({
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [source],
+      structures: [container]
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        OpenTileHarvester: {
+          memory: { role: 'worker', task: { type: 'harvest', targetId: 'source1' as Id<Source> } },
+          room
+        } as unknown as Creep
+      },
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({
+          get: jest.fn().mockReturnValue(0)
+        })
+      } as unknown as GameMap,
+      rooms: { W1N1: room }
+    };
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toBeNull();
   });
 
   it('avoids depleted harvest sources when another source has energy', () => {


### PR DESCRIPTION
## Summary
Workers can now withdraw energy from source containers when all source spots are occupied, reducing idle time and improving energy throughput in multi-worker colonies.

## Changes
- `workerTasks.ts`: Added source container as energy acquisition candidate when source spots are full
- `workerRunner.ts`: Updated worker energy logic to check source containers after source spots
- `behaviorTelemetry.ts` / `runtimeSummary.ts`: Track container energy withdrawals in telemetry
- `types.d.ts`: Added container energy memory field
- Tests: Updated for container withdrawal behavior

## Verification
Controller-side: typecheck clean, 52 suites / 1120 tests pass, build successful.

Closes #643
