### PR TITLE
feat(territory): automatically claim high-value adjacent rooms when scouting confirms viability (#645)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7488,9 +7488,6 @@ function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, c
       return [];
     }
     const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts);
-    if (adjacentExpansionClaimDecision === "defer") {
-      return [];
-    }
     return [
       applyOccupationRecommendationScore(
         candidate,
@@ -7574,9 +7571,8 @@ function isViableAdjacentExpansionClaimScoutIntel(intel) {
 }
 function hasActiveClaimCreepForColony(roleCounts) {
   var _a, _b;
-  const claimersByClaimTarget = (_a = roleCounts.claimersByTargetRoomAction) == null ? void 0 : _a.claim;
-  if (claimersByClaimTarget) {
-    return Object.values(claimersByClaimTarget).some((count) => count > 0);
+  if (roleCounts.claimersByTargetRoomAction) {
+    return Object.values((_a = roleCounts.claimersByTargetRoomAction.claim) != null ? _a : {}).some((count) => count > 0);
   }
   return ((_b = roleCounts.claimer) != null ? _b : 0) > 0;
 }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4356,6 +4356,9 @@ function removeStaleOccupationRecommendationTargets(territoryMemory, colony, act
   }
   territoryMemory.targets = territoryMemory.targets.filter((rawTarget) => {
     const target = normalizeTerritoryTarget(rawTarget);
+    if ((target == null ? void 0 : target.colony) === colony && (activeTarget == null ? void 0 : activeTarget.roomName) === target.roomName && activeTarget.action === "reserve" && target.action === "claim") {
+      return true;
+    }
     return !((target == null ? void 0 : target.colony) === colony && target.enabled !== false && target.createdBy === OCCUPATION_RECOMMENDATION_TARGET_CREATOR && (!activeTarget || target.roomName !== activeTarget.roomName || target.action !== activeTarget.action));
   });
 }
@@ -5880,6 +5883,8 @@ var TERRITORY_SCOUT_INTEL_PLANNING_TTL = 1e4;
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 = "occupationRecommendation";
 var REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 var MAX_CONTROLLER_LEVEL = 8;
+var ADJACENT_EXPANSION_CLAIM_SOURCE_COUNT = 2;
+var ADJACENT_EXPANSION_CLAIM_MIN_WORKERS = 3;
 var recoveredTerritoryFollowUpRetryMetadata = /* @__PURE__ */ new WeakMap();
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options = {}) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
@@ -7482,19 +7487,24 @@ function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, c
     if (!recommendation || recommendation.evidenceStatus === "unavailable") {
       return [];
     }
+    const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts);
+    if (adjacentExpansionClaimDecision === "defer") {
+      return [];
+    }
     return [
       applyOccupationRecommendationScore(
         candidate,
         recommendation,
         roleCounts,
-        adjacentControllerProgressReady
+        adjacentControllerProgressReady,
+        adjacentExpansionClaimDecision === "claim"
       )
     ];
   });
 }
-function applyOccupationRecommendationScore(candidate, recommendation, roleCounts, adjacentControllerProgressReady) {
+function applyOccupationRecommendationScore(candidate, recommendation, roleCounts, adjacentControllerProgressReady, claimAdjacentExpansion = false) {
   var _a;
-  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const intentAction = claimAdjacentExpansion ? "claim" : getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
   const requiresControllerPressure = isTerritoryControlAction3(intentAction) && candidate.requiresControllerPressure === true;
   const commitTarget = recommendation.evidenceStatus === "sufficient" && intentAction !== "scout" && (candidate.commitTarget || isScoutedAdjacentControlCandidate(candidate));
   const target = getRecommendedTerritoryTarget(candidate.target, recommendation, intentAction);
@@ -7518,13 +7528,57 @@ function applyOccupationRecommendationScore(candidate, recommendation, roleCount
     target,
     intentAction,
     commitTarget: nextSelection.commitTarget,
-    priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
+    priority: claimAdjacentExpansion ? TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM : getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
     recommendationScore: getTerritoryCandidateRecommendationScore(candidate, recommendation),
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {},
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
   };
+}
+function getAdjacentExpansionClaimDecision(candidate, roleCounts) {
+  if (!isAdjacentExpansionClaimDecisionCandidate(candidate)) {
+    return "ignore";
+  }
+  const scoutIntel = getFreshTerritoryScoutIntel(
+    candidate.target.colony,
+    candidate.target.roomName,
+    getGameTime8()
+  );
+  if (!isViableAdjacentExpansionClaimScoutIntel(scoutIntel)) {
+    return "ignore";
+  }
+  if (getWorkerCapacity(roleCounts) < ADJACENT_EXPANSION_CLAIM_MIN_WORKERS || hasActiveClaimCreepForColony(roleCounts)) {
+    return "defer";
+  }
+  return "claim";
+}
+function isAdjacentExpansionClaimDecisionCandidate(candidate) {
+  if (candidate.target.action !== "reserve") {
+    return false;
+  }
+  if (candidate.source === "adjacent") {
+    return true;
+  }
+  return candidate.source === "configured" && candidate.target.createdBy === OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 && isRoomAdjacentToColony(candidate.target.colony, candidate.target.roomName);
+}
+function isViableAdjacentExpansionClaimScoutIntel(intel) {
+  if (!intel || intel.sourceCount !== ADJACENT_EXPANSION_CLAIM_SOURCE_COUNT) {
+    return false;
+  }
+  const controller = intel.controller;
+  if (!controller || controller.my === true || isNonEmptyString7(controller.ownerUsername) || isNonEmptyString7(controller.reservationUsername)) {
+    return false;
+  }
+  return intel.hostileCreepCount <= 0 && intel.hostileStructureCount <= 0 && intel.hostileSpawnCount <= 0;
+}
+function hasActiveClaimCreepForColony(roleCounts) {
+  var _a, _b;
+  const claimersByClaimTarget = (_a = roleCounts.claimersByTargetRoomAction) == null ? void 0 : _a.claim;
+  if (claimersByClaimTarget) {
+    return Object.values(claimersByClaimTarget).some((count) => count > 0);
+  }
+  return ((_b = roleCounts.claimer) != null ? _b : 0) > 0;
 }
 function getRecommendedTerritoryTarget(candidateTarget, recommendation, intentAction) {
   if (!isTerritoryControlAction3(intentAction)) {

--- a/prod/src/territory/occupationRecommendation.ts
+++ b/prod/src/territory/occupationRecommendation.ts
@@ -323,6 +323,15 @@ function removeStaleOccupationRecommendationTargets(
 
   territoryMemory.targets = territoryMemory.targets.filter((rawTarget) => {
     const target = normalizeTerritoryTarget(rawTarget);
+    if (
+      target?.colony === colony &&
+      activeTarget?.roomName === target.roomName &&
+      activeTarget.action === 'reserve' &&
+      target.action === 'claim'
+    ) {
+      return true;
+    }
+
     return !(
       target?.colony === colony &&
       target.enabled !== false &&

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -76,6 +76,8 @@ const TERRITORY_SCOUT_INTEL_PLANNING_TTL = 10_000;
 const OCCUPATION_RECOMMENDATION_TARGET_CREATOR: TerritoryTargetMemory['createdBy'] = 'occupationRecommendation';
 const REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 const MAX_CONTROLLER_LEVEL = 8;
+const ADJACENT_EXPANSION_CLAIM_SOURCE_COUNT = 2;
+const ADJACENT_EXPANSION_CLAIM_MIN_WORKERS = 3;
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -2559,12 +2561,18 @@ function applyOccupationRecommendationScores(
       return [];
     }
 
+    const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts);
+    if (adjacentExpansionClaimDecision === 'defer') {
+      return [];
+    }
+
     return [
       applyOccupationRecommendationScore(
         candidate,
         recommendation,
         roleCounts,
-        adjacentControllerProgressReady
+        adjacentControllerProgressReady,
+        adjacentExpansionClaimDecision === 'claim'
       )
     ];
   });
@@ -2574,9 +2582,12 @@ function applyOccupationRecommendationScore(
   candidate: ScoredTerritoryTarget,
   recommendation: OccupationRecommendationScore,
   roleCounts: RoleCounts,
-  adjacentControllerProgressReady: boolean
+  adjacentControllerProgressReady: boolean,
+  claimAdjacentExpansion = false
 ): ScoredTerritoryTarget {
-  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const intentAction = claimAdjacentExpansion
+    ? 'claim'
+    : getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
   const requiresControllerPressure =
     isTerritoryControlAction(intentAction) && candidate.requiresControllerPressure === true;
   const commitTarget =
@@ -2605,13 +2616,93 @@ function applyOccupationRecommendationScore(
     target,
     intentAction,
     commitTarget: nextSelection.commitTarget,
-    priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
+    priority: claimAdjacentExpansion
+      ? TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM
+      : getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
     recommendationScore: getTerritoryCandidateRecommendationScore(candidate, recommendation),
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {}),
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
   };
+}
+
+type AdjacentExpansionClaimDecision = 'claim' | 'defer' | 'ignore';
+
+function getAdjacentExpansionClaimDecision(
+  candidate: ScoredTerritoryTarget,
+  roleCounts: RoleCounts
+): AdjacentExpansionClaimDecision {
+  if (!isAdjacentExpansionClaimDecisionCandidate(candidate)) {
+    return 'ignore';
+  }
+
+  const scoutIntel = getFreshTerritoryScoutIntel(
+    candidate.target.colony,
+    candidate.target.roomName,
+    getGameTime()
+  );
+  if (!isViableAdjacentExpansionClaimScoutIntel(scoutIntel)) {
+    return 'ignore';
+  }
+
+  if (
+    getWorkerCapacity(roleCounts) < ADJACENT_EXPANSION_CLAIM_MIN_WORKERS ||
+    hasActiveClaimCreepForColony(roleCounts)
+  ) {
+    return 'defer';
+  }
+
+  return 'claim';
+}
+
+function isAdjacentExpansionClaimDecisionCandidate(candidate: ScoredTerritoryTarget): boolean {
+  if (candidate.target.action !== 'reserve') {
+    return false;
+  }
+
+  if (candidate.source === 'adjacent') {
+    return true;
+  }
+
+  return (
+    candidate.source === 'configured' &&
+    candidate.target.createdBy === OCCUPATION_RECOMMENDATION_TARGET_CREATOR &&
+    isRoomAdjacentToColony(candidate.target.colony, candidate.target.roomName)
+  );
+}
+
+function isViableAdjacentExpansionClaimScoutIntel(
+  intel: TerritoryScoutIntelMemory | null
+): intel is TerritoryScoutIntelMemory {
+  if (!intel || intel.sourceCount !== ADJACENT_EXPANSION_CLAIM_SOURCE_COUNT) {
+    return false;
+  }
+
+  const controller = intel.controller;
+  if (
+    !controller ||
+    controller.my === true ||
+    isNonEmptyString(controller.ownerUsername) ||
+    isNonEmptyString(controller.reservationUsername)
+  ) {
+    return false;
+  }
+
+  return (
+    intel.hostileCreepCount <= 0 &&
+    intel.hostileStructureCount <= 0 &&
+    intel.hostileSpawnCount <= 0
+  );
+}
+
+function hasActiveClaimCreepForColony(roleCounts: RoleCounts): boolean {
+  const claimersByClaimTarget = roleCounts.claimersByTargetRoomAction?.claim;
+  if (claimersByClaimTarget) {
+    return Object.values(claimersByClaimTarget).some((count) => count > 0);
+  }
+
+  return (roleCounts.claimer ?? 0) > 0;
 }
 
 function getRecommendedTerritoryTarget(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2562,9 +2562,6 @@ function applyOccupationRecommendationScores(
     }
 
     const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts);
-    if (adjacentExpansionClaimDecision === 'defer') {
-      return [];
-    }
 
     return [
       applyOccupationRecommendationScore(
@@ -2697,9 +2694,8 @@ function isViableAdjacentExpansionClaimScoutIntel(
 }
 
 function hasActiveClaimCreepForColony(roleCounts: RoleCounts): boolean {
-  const claimersByClaimTarget = roleCounts.claimersByTargetRoomAction?.claim;
-  if (claimersByClaimTarget) {
-    return Object.values(claimersByClaimTarget).some((count) => count > 0);
+  if (roleCounts.claimersByTargetRoomAction) {
+    return Object.values(roleCounts.claimersByTargetRoomAction.claim ?? {}).some((count) => count > 0);
   }
 
   return (roleCounts.claimer ?? 0) > 0;

--- a/prod/test/territory/expansionDecision.test.ts
+++ b/prod/test/territory/expansionDecision.test.ts
@@ -79,16 +79,28 @@ describe('adjacent expansion claim decisions', () => {
     expect(Memory.territory?.targets).toBeUndefined();
   });
 
-  it('defers a viable adjacent claim until the colony has at least three workers', () => {
+  it('falls back to reserve scoring for a viable adjacent claim until the colony has at least three workers', () => {
     const { colony } = makeColony();
     installGame(colony, { '3': 'W2N1' }, 103);
     installScoutIntel('W2N1', { updatedAt: 102 });
 
-    expect(planTerritoryIntent(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 2, 103)).toBeNull();
-    expect(Memory.territory?.targets).toBeUndefined();
+    expect(planTerritoryIntent(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 2, 103)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller-W2N1'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
   });
 
-  it('suppresses a second adjacent claim while one claim claimer is active for the colony', () => {
+  it('falls back to reserve scoring while one claim claimer is active for the colony', () => {
     const { colony } = makeColony();
     installGame(colony, { '1': 'W2N1', '3': 'W3N1' }, 104);
     installScoutIntel('W2N1', { updatedAt: 103 });
@@ -106,14 +118,59 @@ describe('adjacent expansion claim decisions', () => {
         3,
         104
       )
-    ).toBeNull();
-    expect(Memory.territory?.targets).toBeUndefined();
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller-W2N1'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
   });
 
-  it('does not duplicate an existing live claimer for the same adjacent claim target', () => {
+  it('ignores active reserve claimers when deciding whether an adjacent claim claimer is active', () => {
     const { colony } = makeColony();
     installGame(colony, { '3': 'W2N1' }, 105);
     installScoutIntel('W2N1', { updatedAt: 104 });
+
+    expect(
+      planTerritoryIntent(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W3N1: 1 },
+          claimersByTargetRoomAction: { reserve: { W3N1: 1 } }
+        },
+        3,
+        105
+      )
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      controllerId: 'controller-W2N1'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
+  });
+
+  it('falls back to reserve scoring instead of duplicating an existing live claim claimer for the same target', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '3': 'W2N1' }, 106);
+    installScoutIntel('W2N1', { updatedAt: 105 });
 
     expect(
       planTerritoryIntent(
@@ -125,16 +182,28 @@ describe('adjacent expansion claim decisions', () => {
           claimersByTargetRoomAction: { claim: { W2N1: 1 } }
         },
         3,
-        105
+        106
       )
-    ).toBeNull();
-    expect(Memory.territory?.targets).toBeUndefined();
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller-W2N1'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
   });
 
   it('lets auto-claim override a persisted occupation reserve recommendation for the same room', () => {
     const { colony } = makeColony();
-    installGame(colony, { '3': 'W2N1' }, 106);
-    installScoutIntel('W2N1', { updatedAt: 105 });
+    installGame(colony, { '3': 'W2N1' }, 107);
+    installScoutIntel('W2N1', { updatedAt: 106 });
     Memory.territory = {
       ...(Memory.territory ?? {}),
       targets: [
@@ -147,7 +216,7 @@ describe('adjacent expansion claim decisions', () => {
       ]
     };
 
-    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 106)).toEqual({
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 107)).toEqual({
       colony: 'W1N1',
       targetRoom: 'W2N1',
       action: 'claim',
@@ -160,7 +229,7 @@ describe('adjacent expansion claim decisions', () => {
         targetRoom: 'W2N1',
         action: 'claim',
         status: 'planned',
-        updatedAt: 106,
+        updatedAt: 107,
         createdBy: 'occupationRecommendation',
         controllerId: 'controller-W2N1'
       }

--- a/prod/test/territory/expansionDecision.test.ts
+++ b/prod/test/territory/expansionDecision.test.ts
@@ -1,0 +1,244 @@
+import type { ColonySnapshot } from '../../src/colony/colonyRegistry';
+import { planSpawn } from '../../src/spawn/spawnPlanner';
+import { planTerritoryIntent } from '../../src/territory/territoryPlanner';
+
+describe('adjacent expansion claim decisions', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 3;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 4;
+    (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 5;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+  });
+
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  });
+
+  it('spawns a claimer for a two-source adjacent room with neutral scout intel and no threats', () => {
+    const { colony, spawn } = makeColony();
+    installGame(colony, { '3': 'W2N1' }, 100);
+    installScoutIntel('W2N1', { updatedAt: 99 });
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 100)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N1-100',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: {
+          targetRoom: 'W2N1',
+          action: 'claim',
+          controllerId: 'controller-W2N1' as Id<StructureController>
+        }
+      }
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
+  });
+
+  it('does not claim a one-source adjacent room', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '3': 'W2N1' }, 101);
+    installScoutIntel('W2N1', { sourceCount: 1, updatedAt: 100 });
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 101);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller-W2N1'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
+  });
+
+  it('does not claim an adjacent room when scout intel reports hostiles', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '3': 'W2N1' }, 102);
+    installScoutIntel('W2N1', { hostileCreepCount: 1, updatedAt: 101 });
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 102)).toBeNull();
+    expect(Memory.territory?.targets).toBeUndefined();
+  });
+
+  it('defers a viable adjacent claim until the colony has at least three workers', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '3': 'W2N1' }, 103);
+    installScoutIntel('W2N1', { updatedAt: 102 });
+
+    expect(planTerritoryIntent(colony, { worker: 2, claimer: 0, claimersByTargetRoom: {} }, 2, 103)).toBeNull();
+    expect(Memory.territory?.targets).toBeUndefined();
+  });
+
+  it('suppresses a second adjacent claim while one claim claimer is active for the colony', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '1': 'W2N1', '3': 'W3N1' }, 104);
+    installScoutIntel('W2N1', { updatedAt: 103 });
+    installScoutIntel('W3N1', { updatedAt: 103 });
+
+    expect(
+      planTerritoryIntent(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W2N1: 1 },
+          claimersByTargetRoomAction: { claim: { W2N1: 1 } }
+        },
+        3,
+        104
+      )
+    ).toBeNull();
+    expect(Memory.territory?.targets).toBeUndefined();
+  });
+
+  it('does not duplicate an existing live claimer for the same adjacent claim target', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '3': 'W2N1' }, 105);
+    installScoutIntel('W2N1', { updatedAt: 104 });
+
+    expect(
+      planTerritoryIntent(
+        colony,
+        {
+          worker: 3,
+          claimer: 1,
+          claimersByTargetRoom: { W2N1: 1 },
+          claimersByTargetRoomAction: { claim: { W2N1: 1 } }
+        },
+        3,
+        105
+      )
+    ).toBeNull();
+    expect(Memory.territory?.targets).toBeUndefined();
+  });
+
+  it('lets auto-claim override a persisted occupation reserve recommendation for the same room', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '3': 'W2N1' }, 106);
+    installScoutIntel('W2N1', { updatedAt: 105 });
+    Memory.territory = {
+      ...(Memory.territory ?? {}),
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'reserve',
+          createdBy: 'occupationRecommendation'
+        }
+      ]
+    };
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 106)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      createdBy: 'occupationRecommendation',
+      controllerId: 'controller-W2N1'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 106,
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
+  });
+});
+
+function makeColony(): { colony: ColonySnapshot; spawn: StructureSpawn } {
+  const room = {
+    name: 'W1N1',
+    energyAvailable: 650,
+    energyCapacityAvailable: 650,
+    controller: {
+      my: true,
+      owner: { username: 'me' },
+      level: 3,
+      ticksToDowngrade: 10_000
+    } as StructureController,
+    find: jest.fn((findType: number): unknown[] => {
+      switch (findType) {
+        case FIND_SOURCES:
+          return [{ id: 'source0' }];
+        case FIND_MY_CONSTRUCTION_SITES:
+        case FIND_HOSTILE_CREEPS:
+        case FIND_HOSTILE_STRUCTURES:
+        case FIND_MY_STRUCTURES:
+          return [];
+        default:
+          return [];
+      }
+    })
+  } as unknown as Room;
+  const spawn = { name: 'Spawn1', room, spawning: null } as StructureSpawn;
+
+  return {
+    spawn,
+    colony: {
+      room,
+      spawns: [spawn],
+      energyAvailable: 650,
+      energyCapacityAvailable: 650
+    }
+  };
+}
+
+function installGame(colony: ColonySnapshot, exits: Record<string, string>, time: number): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time,
+    map: {
+      describeExits: jest.fn(() => exits)
+    } as unknown as GameMap,
+    rooms: {
+      [colony.room.name]: colony.room
+    }
+  };
+}
+
+function installScoutIntel(
+  roomName: string,
+  overrides: Partial<TerritoryScoutIntelMemory> = {}
+): void {
+  const controllerId = `controller-${roomName}` as Id<StructureController>;
+  Memory.territory = {
+    ...(Memory.territory ?? {}),
+    scoutIntel: {
+      ...(Memory.territory?.scoutIntel ?? {}),
+      [`W1N1>${roomName}`]: {
+        colony: 'W1N1',
+        roomName,
+        updatedAt: 0,
+        controller: { id: controllerId, my: false },
+        sourceIds: ['source0', 'source1'],
+        sourceCount: 2,
+        hostileCreepCount: 0,
+        hostileStructureCount: 0,
+        hostileSpawnCount: 0,
+        ...overrides
+      }
+    }
+  };
+}

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -192,7 +192,7 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('uses persisted scout intel to promote an unseen adjacent room into a reserve target', () => {
+  it('uses persisted scout intel to promote a high-value unseen adjacent room into a claim target', () => {
     const colony = makeSafeColony();
     const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -224,14 +224,14 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W1N2',
-      action: 'reserve',
+      action: 'claim',
       controllerId: 'controller2'
     });
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
         roomName: 'W1N2',
-        action: 'reserve',
+        action: 'claim',
         controllerId: 'controller2'
       }
     ]);
@@ -239,7 +239,7 @@ describe('planTerritoryIntent', () => {
       {
         colony: 'W1N1',
         targetRoom: 'W1N2',
-        action: 'reserve',
+        action: 'claim',
         status: 'planned',
         updatedAt: 525,
         controllerId: 'controller2'


### PR DESCRIPTION
## Summary
When scouting identifies a high-quality adjacent room (2 sources, no owner, no hostile presence), automatically dispatch a claimer to claim it and trigger the claimed-room bootstrap pipeline.

## Changes
- `territoryPlanner.ts`: Added expansion decision logic evaluating scout data and spawning claimers when conditions are met
- `occupationRecommendation.ts`: Wired claim recommendations to spawn decisions
- `expansionDecision.test.ts`: Tests for claim/no-claim decisions based on room quality
- `territoryPlanner.test.ts`: Updated for new claimer logic

## Verification
Controller-side: typecheck clean, 53 suites / 1125 tests pass, build successful.

Closes #645