### PR TITLE
feat(territory): auto-place towers in newly claimed rooms for defense readiness (#647)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -22555,7 +22555,7 @@ function planClaimedRoomTowerConstruction(colony) {
   const structureType = getStructureConstant2("STRUCTURE_TOWER", "tower");
   for (const position of selectTowerConstructionPositions(anchor, lookups)) {
     const result = room.createConstructionSite(position.x, position.y, structureType);
-    if (result === OK_CODE8) {
+    if (result === OK_CODE8 || isFatalConstructionSiteResult(result)) {
       return result;
     }
     lookups.blockedPositions.add(getPositionKey4(position));

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -3028,7 +3028,7 @@ var CONSTRUCTION_SITE_IMPACT_PRIORITY = {
   claimedRoomSpawn: 110,
   extension: 100,
   spawn: 95,
-  tower: 90,
+  tower: 92,
   protectedRampart: 90,
   rampart: 85,
   sourceContainer: 70,
@@ -22156,6 +22156,7 @@ var ROOM_EDGE_MAX8 = 48;
 var SPAWN_EDGE_MIN = 2;
 var SPAWN_EDGE_MAX = 47;
 var MAX_SPAWN_SITE_SCAN_RADIUS = 8;
+var MAX_TOWER_SITE_SCAN_RADIUS = 8;
 var DEFAULT_TERRAIN_WALL_MASK11 = 1;
 var OK_CODE8 = 0;
 var ERR_FULL_CODE3 = -8;
@@ -22215,6 +22216,12 @@ function runClaimedRoomBootstrapperForColony(colony) {
   if (sourceContainerResults.length > 0) {
     return { roomName: room.name, phase: "sourceContainer", results: sourceContainerResults };
   }
+  if (((_b = room.controller.level) != null ? _b : 0) >= 3 && countExistingAndPendingStructures(room, "STRUCTURE_TOWER", "tower") <= 0) {
+    const result = planClaimedRoomTowerConstruction(colony);
+    if (result !== null) {
+      return { roomName: room.name, phase: "tower", result };
+    }
+  }
   const roadResults = planEarlyRoadConstruction(colony, {
     maxSitesPerTick: 1,
     maxPendingRoadSites: 100,
@@ -22222,12 +22229,6 @@ function runClaimedRoomBootstrapperForColony(colony) {
   });
   if (roadResults.length > 0) {
     return { roomName: room.name, phase: "road", results: roadResults };
-  }
-  if (((_b = room.controller.level) != null ? _b : 0) >= 3 && countExistingAndPendingStructures(room, "STRUCTURE_TOWER", "tower") <= 0) {
-    const result = planTowerConstruction(colony);
-    if (result !== null) {
-      return { roomName: room.name, phase: "tower", result };
-    }
   }
   if (isClaimedRoomBootstrapComplete(colony)) {
     markClaimedRoomBootstrapComplete(room.name);
@@ -22457,6 +22458,136 @@ function compareSourceContainerPositions3(left, right, anchor) {
   }
   return left.y - right.y || left.x - right.x;
 }
+function planClaimedRoomTowerConstruction(colony) {
+  const room = colony.room;
+  if (typeof room.createConstructionSite !== "function") {
+    return null;
+  }
+  const lookups = createTowerPlacementLookups(colony);
+  if (!lookups) {
+    return null;
+  }
+  const anchor = selectWeightedTowerAnchor(lookups.anchors, room.name);
+  if (!anchor) {
+    return null;
+  }
+  const structureType = getStructureConstant2("STRUCTURE_TOWER", "tower");
+  for (const position of selectTowerConstructionPositions(anchor, lookups)) {
+    const result = room.createConstructionSite(position.x, position.y, structureType);
+    if (result === OK_CODE8) {
+      return result;
+    }
+    lookups.blockedPositions.add(getPositionKey4(position));
+  }
+  return null;
+}
+function createTowerPlacementLookups(colony) {
+  const room = colony.room;
+  const terrain = getRoomTerrain11(room);
+  if (!terrain) {
+    return null;
+  }
+  const blockedPositions = /* @__PURE__ */ new Set();
+  const anchors = /* @__PURE__ */ new Map();
+  addTowerAnchor(anchors, room.controller, 4, room.name);
+  addBlockedPosition(blockedPositions, room.controller, room.name);
+  for (const source of getSortedSources3(room)) {
+    addBlockedPosition(blockedPositions, source, room.name);
+  }
+  for (const structure of findRoomObjects15(room, "FIND_STRUCTURES")) {
+    addBlockedPosition(blockedPositions, structure, room.name);
+    const structureType = structure.structureType;
+    if (matchesStructureType16(structureType, "STRUCTURE_SPAWN", "spawn")) {
+      addTowerAnchor(anchors, structure, 4, room.name);
+    } else if (matchesStructureType16(structureType, "STRUCTURE_STORAGE", "storage")) {
+      addTowerAnchor(anchors, structure, 3, room.name);
+    } else if (matchesStructureType16(structureType, "STRUCTURE_CONTAINER", "container")) {
+      addTowerAnchor(anchors, structure, 2, room.name);
+    }
+  }
+  for (const site of findRoomObjects15(room, "FIND_CONSTRUCTION_SITES")) {
+    addBlockedPosition(blockedPositions, site, room.name);
+    const structureType = site.structureType;
+    if (matchesStructureType16(structureType, "STRUCTURE_SPAWN", "spawn")) {
+      addTowerAnchor(anchors, site, 4, room.name);
+    } else if (matchesStructureType16(structureType, "STRUCTURE_STORAGE", "storage")) {
+      addTowerAnchor(anchors, site, 3, room.name);
+    } else if (matchesStructureType16(structureType, "STRUCTURE_CONTAINER", "container")) {
+      addTowerAnchor(anchors, site, 2, room.name);
+    }
+  }
+  for (const spawn of colony.spawns) {
+    addTowerAnchor(anchors, spawn, 4, room.name);
+    addBlockedPosition(blockedPositions, spawn, room.name);
+  }
+  return {
+    terrain,
+    blockedPositions,
+    anchors: [...anchors.values()]
+  };
+}
+function addTowerAnchor(anchors, object, weight, roomName) {
+  var _a;
+  const position = getAnyObjectPosition(object);
+  if (!position || !isSameRoomPosition4(position, roomName)) {
+    return;
+  }
+  const key = getPositionKey4(position);
+  const existing = anchors.get(key);
+  anchors.set(key, {
+    position: { x: position.x, y: position.y, roomName },
+    weight: Math.max((_a = existing == null ? void 0 : existing.weight) != null ? _a : 0, weight)
+  });
+}
+function addBlockedPosition(blockedPositions, object, roomName) {
+  const position = getAnyObjectPosition(object);
+  if (position && isSameRoomPosition4(position, roomName)) {
+    blockedPositions.add(getPositionKey4(position));
+  }
+}
+function selectWeightedTowerAnchor(anchors, roomName) {
+  if (anchors.length === 0) {
+    return null;
+  }
+  const totalWeight = anchors.reduce((sum, anchor) => sum + anchor.weight, 0);
+  if (totalWeight <= 0) {
+    return null;
+  }
+  return clampRoomPosition({
+    x: Math.round(anchors.reduce((sum, anchor) => sum + anchor.position.x * anchor.weight, 0) / totalWeight),
+    y: Math.round(anchors.reduce((sum, anchor) => sum + anchor.position.y * anchor.weight, 0) / totalWeight),
+    roomName
+  });
+}
+function selectTowerConstructionPositions(anchor, lookups) {
+  return getTowerCandidatePositions(anchor).filter((position) => canPlaceTower(lookups, position)).sort((left, right) => compareTowerPositions(left, right, anchor, lookups.anchors));
+}
+function getTowerCandidatePositions(anchor) {
+  const positions = [];
+  for (let radius = 0; radius <= MAX_TOWER_SITE_SCAN_RADIUS; radius += 1) {
+    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
+      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
+          continue;
+        }
+        positions.push({ x, y, roomName: anchor.roomName });
+      }
+    }
+  }
+  return positions;
+}
+function canPlaceTower(lookups, position) {
+  return position.x >= ROOM_EDGE_MIN8 && position.x <= ROOM_EDGE_MAX8 && position.y >= ROOM_EDGE_MIN8 && position.y <= ROOM_EDGE_MAX8 && !lookups.blockedPositions.has(getPositionKey4(position)) && !isTerrainWall6(lookups.terrain, position);
+}
+function compareTowerPositions(left, right, anchor, anchors) {
+  return getTowerPlacementScore(left, anchors) - getTowerPlacementScore(right, anchors) || getRangeBetweenPositions3(left, anchor) - getRangeBetweenPositions3(right, anchor) || left.y - right.y || left.x - right.x;
+}
+function getTowerPlacementScore(position, anchors) {
+  return anchors.reduce(
+    (score, anchor) => score + getRangeBetweenPositions3(position, anchor.position) * anchor.weight,
+    0
+  );
+}
 function isClaimedRoomBootstrapComplete(colony) {
   var _a, _b, _c;
   const room = colony.room;
@@ -22567,6 +22698,13 @@ function clampSpawnPosition(position) {
   return {
     x: Math.max(SPAWN_EDGE_MIN, Math.min(SPAWN_EDGE_MAX, position.x)),
     y: Math.max(SPAWN_EDGE_MIN, Math.min(SPAWN_EDGE_MAX, position.y)),
+    roomName: position.roomName
+  };
+}
+function clampRoomPosition(position) {
+  return {
+    x: Math.max(ROOM_EDGE_MIN8, Math.min(ROOM_EDGE_MAX8, position.x)),
+    y: Math.max(ROOM_EDGE_MIN8, Math.min(ROOM_EDGE_MAX8, position.y)),
     roomName: position.roomName
   };
 }

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -212,7 +212,7 @@ export const CONSTRUCTION_SITE_IMPACT_PRIORITY = {
   claimedRoomSpawn: 110,
   extension: 100,
   spawn: 95,
-  tower: 90,
+  tower: 92,
   protectedRampart: 90,
   rampart: 85,
   sourceContainer: 70,

--- a/prod/src/territory/claimedRoomBootstrapper.ts
+++ b/prod/src/territory/claimedRoomBootstrapper.ts
@@ -529,7 +529,7 @@ function planClaimedRoomTowerConstruction(colony: ColonySnapshot): ScreepsReturn
   const structureType = getStructureConstant('STRUCTURE_TOWER', 'tower');
   for (const position of selectTowerConstructionPositions(anchor, lookups)) {
     const result = room.createConstructionSite(position.x, position.y, structureType);
-    if (result === OK_CODE) {
+    if (result === OK_CODE || isFatalConstructionSiteResult(result)) {
       return result;
     }
 

--- a/prod/src/territory/claimedRoomBootstrapper.ts
+++ b/prod/src/territory/claimedRoomBootstrapper.ts
@@ -1,7 +1,6 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
 import { getExtensionLimitForRcl, planExtensionConstruction } from '../construction/extensionPlanner';
 import { planEarlyRoadConstruction } from '../construction/roadPlanner';
-import { planTowerConstruction } from '../construction/constructionPriority';
 import {
   findSourceContainer,
   findSourceContainerConstructionSite,
@@ -16,6 +15,7 @@ const ROOM_EDGE_MAX = 48;
 const SPAWN_EDGE_MIN = 2;
 const SPAWN_EDGE_MAX = 47;
 const MAX_SPAWN_SITE_SCAN_RADIUS = 8;
+const MAX_TOWER_SITE_SCAN_RADIUS = 8;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
 const OK_CODE = 0 as ScreepsReturnCode;
 const ERR_FULL_CODE = -8 as ScreepsReturnCode;
@@ -33,7 +33,8 @@ type StructureConstantGlobal =
   | 'STRUCTURE_EXTENSION'
   | 'STRUCTURE_CONTAINER'
   | 'STRUCTURE_ROAD'
-  | 'STRUCTURE_TOWER';
+  | 'STRUCTURE_TOWER'
+  | 'STRUCTURE_STORAGE';
 type ReturnCodeGlobal = 'ERR_FULL' | 'ERR_RCL_NOT_ENOUGH';
 
 interface CandidatePosition {
@@ -51,6 +52,17 @@ interface SpawnPlacementLookups {
 interface SourceContainerLookups {
   terrain: RoomTerrain;
   blockedPositions: Set<string>;
+}
+
+interface TowerPlacementAnchor {
+  position: CandidatePosition;
+  weight: number;
+}
+
+interface TowerPlacementLookups {
+  terrain: RoomTerrain;
+  blockedPositions: Set<string>;
+  anchors: TowerPlacementAnchor[];
 }
 
 export type ClaimedRoomBootstrapPhase =
@@ -168,6 +180,13 @@ export function runClaimedRoomBootstrapperForColony(
     return { roomName: room.name, phase: 'sourceContainer', results: sourceContainerResults };
   }
 
+  if ((room.controller.level ?? 0) >= 3 && countExistingAndPendingStructures(room, 'STRUCTURE_TOWER', 'tower') <= 0) {
+    const result = planClaimedRoomTowerConstruction(colony);
+    if (result !== null) {
+      return { roomName: room.name, phase: 'tower', result };
+    }
+  }
+
   const roadResults = planEarlyRoadConstruction(colony, {
     maxSitesPerTick: 1,
     maxPendingRoadSites: 100,
@@ -175,13 +194,6 @@ export function runClaimedRoomBootstrapperForColony(
   });
   if (roadResults.length > 0) {
     return { roomName: room.name, phase: 'road', results: roadResults };
-  }
-
-  if ((room.controller.level ?? 0) >= 3 && countExistingAndPendingStructures(room, 'STRUCTURE_TOWER', 'tower') <= 0) {
-    const result = planTowerConstruction(colony);
-    if (result !== null) {
-      return { roomName: room.name, phase: 'tower', result };
-    }
   }
 
   if (isClaimedRoomBootstrapComplete(colony)) {
@@ -498,6 +510,189 @@ function compareSourceContainerPositions(
   return left.y - right.y || left.x - right.x;
 }
 
+function planClaimedRoomTowerConstruction(colony: ColonySnapshot): ScreepsReturnCode | null {
+  const room = colony.room;
+  if (typeof room.createConstructionSite !== 'function') {
+    return null;
+  }
+
+  const lookups = createTowerPlacementLookups(colony);
+  if (!lookups) {
+    return null;
+  }
+
+  const anchor = selectWeightedTowerAnchor(lookups.anchors, room.name);
+  if (!anchor) {
+    return null;
+  }
+
+  const structureType = getStructureConstant('STRUCTURE_TOWER', 'tower');
+  for (const position of selectTowerConstructionPositions(anchor, lookups)) {
+    const result = room.createConstructionSite(position.x, position.y, structureType);
+    if (result === OK_CODE) {
+      return result;
+    }
+
+    lookups.blockedPositions.add(getPositionKey(position));
+  }
+
+  return null;
+}
+
+function createTowerPlacementLookups(colony: ColonySnapshot): TowerPlacementLookups | null {
+  const room = colony.room;
+  const terrain = getRoomTerrain(room);
+  if (!terrain) {
+    return null;
+  }
+
+  const blockedPositions = new Set<string>();
+  const anchors = new Map<string, TowerPlacementAnchor>();
+
+  addTowerAnchor(anchors, room.controller as RoomObject | undefined, 4, room.name);
+  addBlockedPosition(blockedPositions, room.controller as RoomObject | undefined, room.name);
+
+  for (const source of getSortedSources(room)) {
+    addBlockedPosition(blockedPositions, source, room.name);
+  }
+
+  for (const structure of findRoomObjects(room, 'FIND_STRUCTURES')) {
+    addBlockedPosition(blockedPositions, structure, room.name);
+    const structureType = (structure as { structureType?: string }).structureType;
+    if (matchesStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn')) {
+      addTowerAnchor(anchors, structure, 4, room.name);
+    } else if (matchesStructureType(structureType, 'STRUCTURE_STORAGE', 'storage')) {
+      addTowerAnchor(anchors, structure, 3, room.name);
+    } else if (matchesStructureType(structureType, 'STRUCTURE_CONTAINER', 'container')) {
+      addTowerAnchor(anchors, structure, 2, room.name);
+    }
+  }
+
+  for (const site of findRoomObjects(room, 'FIND_CONSTRUCTION_SITES')) {
+    addBlockedPosition(blockedPositions, site, room.name);
+    const structureType = (site as { structureType?: string }).structureType;
+    if (matchesStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn')) {
+      addTowerAnchor(anchors, site, 4, room.name);
+    } else if (matchesStructureType(structureType, 'STRUCTURE_STORAGE', 'storage')) {
+      addTowerAnchor(anchors, site, 3, room.name);
+    } else if (matchesStructureType(structureType, 'STRUCTURE_CONTAINER', 'container')) {
+      addTowerAnchor(anchors, site, 2, room.name);
+    }
+  }
+
+  for (const spawn of colony.spawns) {
+    addTowerAnchor(anchors, spawn, 4, room.name);
+    addBlockedPosition(blockedPositions, spawn, room.name);
+  }
+
+  return {
+    terrain,
+    blockedPositions,
+    anchors: [...anchors.values()]
+  };
+}
+
+function addTowerAnchor(
+  anchors: Map<string, TowerPlacementAnchor>,
+  object: unknown,
+  weight: number,
+  roomName: string
+): void {
+  const position = getAnyObjectPosition(object);
+  if (!position || !isSameRoomPosition(position, roomName)) {
+    return;
+  }
+
+  const key = getPositionKey(position);
+  const existing = anchors.get(key);
+  anchors.set(key, {
+    position: { x: position.x, y: position.y, roomName },
+    weight: Math.max(existing?.weight ?? 0, weight)
+  });
+}
+
+function addBlockedPosition(blockedPositions: Set<string>, object: unknown, roomName: string): void {
+  const position = getAnyObjectPosition(object);
+  if (position && isSameRoomPosition(position, roomName)) {
+    blockedPositions.add(getPositionKey(position));
+  }
+}
+
+function selectWeightedTowerAnchor(anchors: TowerPlacementAnchor[], roomName: string): CandidatePosition | null {
+  if (anchors.length === 0) {
+    return null;
+  }
+
+  const totalWeight = anchors.reduce((sum, anchor) => sum + anchor.weight, 0);
+  if (totalWeight <= 0) {
+    return null;
+  }
+
+  return clampRoomPosition({
+    x: Math.round(anchors.reduce((sum, anchor) => sum + anchor.position.x * anchor.weight, 0) / totalWeight),
+    y: Math.round(anchors.reduce((sum, anchor) => sum + anchor.position.y * anchor.weight, 0) / totalWeight),
+    roomName
+  });
+}
+
+function selectTowerConstructionPositions(
+  anchor: CandidatePosition,
+  lookups: TowerPlacementLookups
+): CandidatePosition[] {
+  return getTowerCandidatePositions(anchor)
+    .filter((position) => canPlaceTower(lookups, position))
+    .sort((left, right) => compareTowerPositions(left, right, anchor, lookups.anchors));
+}
+
+function getTowerCandidatePositions(anchor: CandidatePosition): CandidatePosition[] {
+  const positions: CandidatePosition[] = [];
+  for (let radius = 0; radius <= MAX_TOWER_SITE_SCAN_RADIUS; radius += 1) {
+    for (let y = anchor.y - radius; y <= anchor.y + radius; y += 1) {
+      for (let x = anchor.x - radius; x <= anchor.x + radius; x += 1) {
+        if (Math.max(Math.abs(x - anchor.x), Math.abs(y - anchor.y)) !== radius) {
+          continue;
+        }
+
+        positions.push({ x, y, roomName: anchor.roomName });
+      }
+    }
+  }
+
+  return positions;
+}
+
+function canPlaceTower(lookups: TowerPlacementLookups, position: CandidatePosition): boolean {
+  return (
+    position.x >= ROOM_EDGE_MIN &&
+    position.x <= ROOM_EDGE_MAX &&
+    position.y >= ROOM_EDGE_MIN &&
+    position.y <= ROOM_EDGE_MAX &&
+    !lookups.blockedPositions.has(getPositionKey(position)) &&
+    !isTerrainWall(lookups.terrain, position)
+  );
+}
+
+function compareTowerPositions(
+  left: CandidatePosition,
+  right: CandidatePosition,
+  anchor: CandidatePosition,
+  anchors: TowerPlacementAnchor[]
+): number {
+  return (
+    getTowerPlacementScore(left, anchors) - getTowerPlacementScore(right, anchors) ||
+    getRangeBetweenPositions(left, anchor) - getRangeBetweenPositions(right, anchor) ||
+    left.y - right.y ||
+    left.x - right.x
+  );
+}
+
+function getTowerPlacementScore(position: CandidatePosition, anchors: TowerPlacementAnchor[]): number {
+  return anchors.reduce(
+    (score, anchor) => score + getRangeBetweenPositions(position, anchor.position) * anchor.weight,
+    0
+  );
+}
+
 function isClaimedRoomBootstrapComplete(colony: ColonySnapshot): boolean {
   const room = colony.room;
   if (!getSpawnBootstrapStatus(colony).hasSpawn) {
@@ -633,6 +828,14 @@ function clampSpawnPosition(position: CandidatePosition): CandidatePosition {
   return {
     x: Math.max(SPAWN_EDGE_MIN, Math.min(SPAWN_EDGE_MAX, position.x)),
     y: Math.max(SPAWN_EDGE_MIN, Math.min(SPAWN_EDGE_MAX, position.y)),
+    roomName: position.roomName
+  };
+}
+
+function clampRoomPosition(position: CandidatePosition): CandidatePosition {
+  return {
+    x: Math.max(ROOM_EDGE_MIN, Math.min(ROOM_EDGE_MAX, position.x)),
+    y: Math.max(ROOM_EDGE_MIN, Math.min(ROOM_EDGE_MAX, position.y)),
     roomName: position.roomName
   };
 }

--- a/prod/test/defenseLoop.test.ts
+++ b/prod/test/defenseLoop.test.ts
@@ -56,6 +56,73 @@ describe('runDefense', () => {
     });
   });
 
+  it('runs tower defense in every owned room, including claimed rooms without local spawns', () => {
+    const homeHostile = makeHostile('home-hostile', 25, 25, 'W1N1');
+    const expansionHostile = makeHostile('expansion-hostile', 25, 25, 'W2N1');
+    let homeTowers: StructureTower[] = [];
+    let expansionTowers: StructureTower[] = [];
+    const homeRoom = makeRoom({
+      roomName: 'W1N1',
+      controller: makeController(),
+      hostiles: [homeHostile],
+      getTowers: () => homeTowers
+    });
+    const expansionRoom = makeRoom({
+      roomName: 'W2N1',
+      controller: makeController(),
+      hostiles: [expansionHostile],
+      getTowers: () => expansionTowers
+    });
+    const homeSpawn = {
+      id: 'spawn1',
+      name: 'Spawn1',
+      room: homeRoom,
+      structureType: TEST_GLOBALS.STRUCTURE_SPAWN,
+      hits: 5_000,
+      hitsMax: 5_000,
+      spawning: null
+    } as unknown as StructureSpawn;
+    const homeTower = makeTower(homeRoom, {
+      id: 'home-tower',
+      attack: jest.fn().mockReturnValue(OK_CODE),
+      energy: 500
+    });
+    const expansionTower = makeTower(expansionRoom, {
+      id: 'expansion-tower',
+      attack: jest.fn().mockReturnValue(OK_CODE),
+      energy: 500
+    });
+    homeTowers = [homeTower];
+    expansionTowers = [expansionTower];
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 104,
+      rooms: { W1N1: homeRoom, W2N1: expansionRoom },
+      spawns: { Spawn1: homeSpawn },
+      creeps: {}
+    };
+
+    const events = runDefense();
+
+    expect(homeTower.attack).toHaveBeenCalledWith(homeHostile);
+    expect(expansionTower.attack).toHaveBeenCalledWith(expansionHostile);
+    expect(events).toMatchObject([
+      {
+        type: 'defense',
+        action: 'towerAttack',
+        roomName: 'W1N1',
+        structureId: 'home-tower',
+        targetId: 'home-hostile'
+      },
+      {
+        type: 'defense',
+        action: 'towerAttack',
+        roomName: 'W2N1',
+        structureId: 'expansion-tower',
+        targetId: 'expansion-hostile'
+      }
+    ]);
+  });
+
   it('falls back to the nearest hostile structure when no hostile creep is visible', () => {
     const farStructure = makeHostileStructure('structure-a', 34, 25);
     const nearStructure = makeHostileStructure('structure-z', 26, 25);
@@ -679,7 +746,7 @@ function makeTower(
     attack,
     heal,
     repair,
-    pos: makePosition()
+    pos: makePosition(25, 25, room.name)
   } as unknown as StructureTower;
 }
 

--- a/prod/test/territory/claimedRoomBootstrapper.test.ts
+++ b/prod/test/territory/claimedRoomBootstrapper.test.ts
@@ -183,7 +183,7 @@ describe('claimed room bootstrapper', () => {
     expect(room.createConstructionSite).toHaveBeenCalledWith(11, 10, TEST_GLOBALS.STRUCTURE_ROAD);
   });
 
-  it('gates tower placement until RCL3', () => {
+  it('gates tower placement until RCL3 and places it between controller and spawn anchors', () => {
     const rcl2 = makeTowerReadyRoom(2);
     installActiveBootstrapMemory();
     installGame(rcl2.room);
@@ -198,7 +198,44 @@ describe('claimed room bootstrapper', () => {
     expect(runClaimedRoomBootstrapper([rcl3.colony]).planned).toEqual([
       { roomName: 'W2N1', phase: 'tower', result: OK_CODE }
     ]);
-    expect(rcl3.room.createConstructionSite).toHaveBeenCalledWith(19, 19, TEST_GLOBALS.STRUCTURE_TOWER);
+    expect(rcl3.room.createConstructionSite).toHaveBeenCalledWith(23, 23, TEST_GLOBALS.STRUCTURE_TOWER);
+  });
+
+  it('plans RCL3 claimed-room tower defense before adding more early roads', () => {
+    const spawn = makeStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 10, 10);
+    const source = makeSource('source-a', 20, 10);
+    const container = makeStructure('container-a', TEST_GLOBALS.STRUCTURE_CONTAINER, 20, 11);
+    const { room, colony } = makeBootstrapRoom({
+      controllerLevel: 3,
+      controllerPosition: { x: 10, y: 20 },
+      sources: [source],
+      structures: [spawn, container, ...makeExtensions(10)],
+      spawns: [spawn as StructureSpawn],
+      pathsByTarget: {
+        '20,10': [{ x: 11, y: 10 }],
+        '10,20': [{ x: 10, y: 11 }]
+      }
+    });
+    installActiveBootstrapMemory();
+    installGame(room);
+    installPathFinder(room);
+
+    const result = runClaimedRoomBootstrapper([colony]);
+
+    expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'tower', result: OK_CODE }]);
+    expect(room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(15, 15, TEST_GLOBALS.STRUCTURE_TOWER);
+  });
+
+  it('skips blocked strategic tower positions when selecting claimed-room tower sites', () => {
+    const rcl3 = makeTowerReadyRoom(3, new Set(['23,23']));
+    installActiveBootstrapMemory();
+    installGame(rcl3.room);
+
+    const result = runClaimedRoomBootstrapper([rcl3.colony]);
+
+    expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'tower', result: OK_CODE }]);
+    expect(rcl3.room.createConstructionSite).toHaveBeenCalledWith(22, 22, TEST_GLOBALS.STRUCTURE_TOWER);
   });
 
   it('does not re-place construction sites that already exist', () => {
@@ -310,8 +347,12 @@ function makeBootstrapRoom(options: BootstrapRoomOptions): { room: MockRoom; col
       constructionSites.push(makeConstructionSite(`site-${x}-${y}`, structureType, x, y));
       return OK_CODE;
     }),
-    __pathsByTarget: options.pathsByTarget ?? {}
-  } as unknown as MockRoom & { __pathsByTarget: Record<string, TestPosition[]> };
+    __pathsByTarget: options.pathsByTarget ?? {},
+    __wallPositions: options.wallPositions ?? new Set<string>()
+  } as unknown as MockRoom & {
+    __pathsByTarget: Record<string, TestPosition[]>;
+    __wallPositions: Set<string>;
+  };
 
   for (const structure of structures) {
     (structure as Structure & { room?: Room }).room = room;
@@ -328,7 +369,10 @@ function makeBootstrapRoom(options: BootstrapRoomOptions): { room: MockRoom; col
   };
 }
 
-function makeTowerReadyRoom(controllerLevel: number): { room: MockRoom; colony: ColonySnapshot } {
+function makeTowerReadyRoom(
+  controllerLevel: number,
+  wallPositions: Set<string> = new Set()
+): { room: MockRoom; colony: ColonySnapshot } {
   const spawn = makeStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 20, 20);
   return makeBootstrapRoom({
     controllerLevel,
@@ -337,7 +381,8 @@ function makeTowerReadyRoom(controllerLevel: number): { room: MockRoom; colony: 
       spawn,
       ...makeExtensions(controllerLevel >= 3 ? 10 : 5)
     ],
-    spawns: [spawn as StructureSpawn]
+    spawns: [spawn as StructureSpawn],
+    wallPositions
   });
 }
 
@@ -357,12 +402,15 @@ function installActiveBootstrapMemory(updatedAt = 90, owned = true): void {
 }
 
 function installGame(room: Room, time = 100): void {
+  const wallPositions = (room as Room & { __wallPositions?: Set<string> }).__wallPositions ?? new Set<string>();
   (globalThis as unknown as { Game: Partial<Game> }).Game = {
     time,
     rooms: { [room.name]: room },
     map: {
       getRoomTerrain: jest.fn().mockReturnValue({
-        get: jest.fn().mockReturnValue(0)
+        get: jest.fn((x: number, y: number) =>
+          wallPositions.has(`${x},${y}`) ? TEST_GLOBALS.TERRAIN_MASK_WALL : 0
+        )
       })
     } as unknown as GameMap
   };


### PR DESCRIPTION
Automatically place towers in newly claimed rooms for defense readiness.

Refs #647

## Verification
- typecheck: PASS
- Jest: 53 suites, 1133 tests PASS
- Build: esbuild clean
- Controller-verified 2026-05-06T09:22Z

## Summary
- Added tower placement to `claimedRoomBootstrapper` construction phase
- Towers prioritized in construction queue for defense readiness
- Tests cover tower placement in newly claimed rooms
