### PR TITLE
feat(economy): prefer nearby containers over distant sources for worker energy acquisition (#648)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9899,6 +9899,7 @@ var MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 var MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 var MIN_SPAWN_RECOVERY_DROPPED_ENERGY_PICKUP_AMOUNT = 10;
 var MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
+var COMPETITIVE_CONTAINER_WITHDRAW_MIN_ENERGY = 200;
 var ENERGY_ACQUISITION_RANGE_COST = 50;
 var ENERGY_ACQUISITION_ACTION_TICKS = 1;
 var WORKER_ENERGY_SURPLUS_SCORE_RATIO = 0.4;
@@ -9989,6 +9990,10 @@ function selectHeuristicWorkerTask(creep) {
       const storageRefillAcquisitionTask = selectStorageToSpawnExtensionRefillAcquisitionTask(creep);
       if (storageRefillAcquisitionTask) {
         return storageRefillAcquisitionTask;
+      }
+      const competitiveContainerEnergyAcquisitionTask = selectCompetitiveContainerEnergyAcquisitionTask(creep);
+      if (competitiveContainerEnergyAcquisitionTask) {
+        return competitiveContainerEnergyAcquisitionTask;
       }
       const source2ControllerLaneHarvestTask = selectSource2ControllerLaneHarvestTask(creep);
       if (source2ControllerLaneHarvestTask) {
@@ -11388,6 +11393,74 @@ function selectNearbyWorkerEnergyAcquisitionTask(creep) {
   }
   return candidates.sort(compareNearbyWorkerEnergyAcquisitionCandidates)[0].task;
 }
+function selectCompetitiveContainerEnergyAcquisitionTask(creep) {
+  const harvestCandidate = createPriorityHarvestEnergyAcquisitionCandidate(creep);
+  if (!harvestCandidate) {
+    return null;
+  }
+  const containerCandidates = findCompetitiveContainerEnergyAcquisitionCandidates(creep);
+  if (containerCandidates.length === 0) {
+    return null;
+  }
+  const selectedCandidate = [harvestCandidate, ...containerCandidates].sort(
+    compareCompetitiveWorkerEnergyAcquisitionCandidates
+  )[0];
+  return selectedCandidate.task.type === "withdraw" ? selectedCandidate.task : null;
+}
+function createPriorityHarvestEnergyAcquisitionCandidate(creep) {
+  var _a;
+  const source = (_a = selectSource2ControllerLaneHarvestSource(creep)) != null ? _a : selectSourceContainerHarvestSource(creep);
+  return source ? createCompetitiveHarvestEnergyAcquisitionCandidate(creep, source) : null;
+}
+function createCompetitiveHarvestEnergyAcquisitionCandidate(creep, source) {
+  const range = getHarvestSourceTravelCost(creep, source);
+  if (range === null) {
+    return null;
+  }
+  const energy = Math.min(getHarvestSourceAvailableEnergy(source), getHarvestEnergyTarget(creep));
+  if (energy <= 0) {
+    return null;
+  }
+  const score = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity3(creep));
+  return {
+    energy,
+    priority: getWorkerEnergyAcquisitionPriority(creep, source, energy, range),
+    range,
+    score: score - range * ENERGY_ACQUISITION_RANGE_COST,
+    source,
+    task: { type: "harvest", targetId: source.id }
+  };
+}
+function findCompetitiveContainerEnergyAcquisitionCandidates(creep) {
+  const context = {
+    creepOwnerUsername: getCreepOwnerUsername2(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+  return findVisibleRoomStructures(creep.room).filter(
+    (structure) => isSafeStoredEnergySource(structure, context) && isContainerEnergySource(structure)
+  ).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getStoredEnergy4(source),
+      {
+        type: "withdraw",
+        targetId: source.id
+      },
+      reservationContext,
+      COMPETITIVE_CONTAINER_WITHDRAW_MIN_ENERGY
+    );
+    if (!candidate || candidate.range === null) {
+      return [];
+    }
+    return [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)];
+  });
+}
+function compareCompetitiveWorkerEnergyAcquisitionCandidates(left, right) {
+  return left.priority - right.priority || right.score - left.score || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
+}
 function selectLowLoadWorkerEnergyAcquisitionCandidate(creep) {
   if (!shouldKeepLowLoadWorkerAcquiringEnergy(creep)) {
     return null;
@@ -12264,6 +12337,10 @@ function canLevelUpController(controller) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL2;
 }
 function selectSource2ControllerLaneHarvestTask(creep) {
+  const source = selectSource2ControllerLaneHarvestSource(creep);
+  return source ? { type: "harvest", targetId: source.id } : null;
+}
+function selectSource2ControllerLaneHarvestSource(creep) {
   const controller = creep.room.controller;
   if (!controller) {
     return null;
@@ -12272,7 +12349,7 @@ function selectSource2ControllerLaneHarvestTask(creep) {
   if (!topology || isSourceDepleted(topology.source) || hasOtherSource2ControllerLaneWorker(creep, topology)) {
     return null;
   }
-  return { type: "harvest", targetId: topology.source.id };
+  return topology.source;
 }
 function getSource2ControllerLaneTopology(room, controller) {
   if (controller.my !== true || typeof controller.level !== "number" || controller.level < 2 || getRoomObjectPosition3(controller) === null || !isHomeRoomName(room, controller) || hasVisibleHostilePresence(room)) {
@@ -12609,6 +12686,10 @@ function findSourceContainerWithdrawCandidates(creep) {
   return candidates;
 }
 function selectSourceContainerHarvestTask(creep) {
+  const source = selectSourceContainerHarvestSource(creep);
+  return source ? { type: "harvest", targetId: source.id, sourceContainerAssigned: true } : null;
+}
+function selectSourceContainerHarvestSource(creep) {
   if (getActiveWorkParts(creep) <= 0 || typeof FIND_SOURCES !== "number") {
     return null;
   }
@@ -12620,7 +12701,7 @@ function selectSourceContainerHarvestTask(creep) {
     creep,
     findVisibleHarvestSourcesInRooms(harvestRooms).filter((candidate) => hasNonEmptyVisibleSourceContainer(creep, candidate))
   );
-  return source ? { type: "harvest", targetId: source.id, sourceContainerAssigned: true } : null;
+  return source;
 }
 function hasNonEmptyVisibleSourceContainer(creep, source) {
   const sourceContainer = findVisibleSourceContainer(creep, source);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -52,6 +52,7 @@ const MIN_LOADED_WORKERS_FOR_TERRITORY_PRESSURE = 1;
 const MIN_DROPPED_ENERGY_PICKUP_AMOUNT = 25;
 const MIN_SPAWN_RECOVERY_DROPPED_ENERGY_PICKUP_AMOUNT = 10;
 const MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT = 2;
+const COMPETITIVE_CONTAINER_WITHDRAW_MIN_ENERGY = 200;
 const ENERGY_ACQUISITION_RANGE_COST = 50;
 const ENERGY_ACQUISITION_ACTION_TICKS = 1;
 const WORKER_ENERGY_SURPLUS_SCORE_RATIO = 0.4;
@@ -251,6 +252,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
       const storageRefillAcquisitionTask = selectStorageToSpawnExtensionRefillAcquisitionTask(creep);
       if (storageRefillAcquisitionTask) {
         return storageRefillAcquisitionTask;
+      }
+
+      const competitiveContainerEnergyAcquisitionTask = selectCompetitiveContainerEnergyAcquisitionTask(creep);
+      if (competitiveContainerEnergyAcquisitionTask) {
+        return competitiveContainerEnergyAcquisitionTask;
       }
 
       const source2ControllerLaneHarvestTask = selectSource2ControllerLaneHarvestTask(creep);
@@ -2422,6 +2428,105 @@ function selectNearbyWorkerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcqu
   return candidates.sort(compareNearbyWorkerEnergyAcquisitionCandidates)[0].task;
 }
 
+function selectCompetitiveContainerEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitionTask | null {
+  const harvestCandidate = createPriorityHarvestEnergyAcquisitionCandidate(creep);
+  if (!harvestCandidate) {
+    return null;
+  }
+
+  const containerCandidates = findCompetitiveContainerEnergyAcquisitionCandidates(creep);
+  if (containerCandidates.length === 0) {
+    return null;
+  }
+
+  const selectedCandidate = [harvestCandidate, ...containerCandidates].sort(
+    compareCompetitiveWorkerEnergyAcquisitionCandidates
+  )[0];
+  return selectedCandidate.task.type === 'withdraw' ? selectedCandidate.task : null;
+}
+
+function createPriorityHarvestEnergyAcquisitionCandidate(
+  creep: Creep
+): LowLoadWorkerEnergyAcquisitionCandidate | null {
+  const source = selectSource2ControllerLaneHarvestSource(creep) ?? selectSourceContainerHarvestSource(creep);
+  return source ? createCompetitiveHarvestEnergyAcquisitionCandidate(creep, source) : null;
+}
+
+function createCompetitiveHarvestEnergyAcquisitionCandidate(
+  creep: Creep,
+  source: Source
+): LowLoadWorkerEnergyAcquisitionCandidate | null {
+  const range = getHarvestSourceTravelCost(creep, source);
+  if (range === null) {
+    return null;
+  }
+
+  const energy = Math.min(getHarvestSourceAvailableEnergy(source), getHarvestEnergyTarget(creep));
+  if (energy <= 0) {
+    return null;
+  }
+
+  const score = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity(creep));
+  return {
+    energy,
+    priority: getWorkerEnergyAcquisitionPriority(creep, source, energy, range),
+    range,
+    score: score - range * ENERGY_ACQUISITION_RANGE_COST,
+    source,
+    task: { type: 'harvest', targetId: source.id }
+  };
+}
+
+function findCompetitiveContainerEnergyAcquisitionCandidates(
+  creep: Creep
+): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  const context: StoredEnergySourceContext = {
+    creepOwnerUsername: getCreepOwnerUsername(creep),
+    hasHostilePresence: hasVisibleHostilePresence(creep.room),
+    room: creep.room
+  };
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+
+  return findVisibleRoomStructures(creep.room)
+    .filter(
+      (structure): structure is StructureContainer =>
+        isSafeStoredEnergySource(structure, context) && isContainerEnergySource(structure)
+    )
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        getStoredEnergy(source),
+        {
+          type: 'withdraw',
+          targetId: source.id as Id<AnyStoreStructure>
+        },
+        reservationContext,
+        COMPETITIVE_CONTAINER_WITHDRAW_MIN_ENERGY
+      );
+
+      if (!candidate || candidate.range === null) {
+        return [];
+      }
+
+      return [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)];
+    });
+}
+
+function compareCompetitiveWorkerEnergyAcquisitionCandidates(
+  left: LowLoadWorkerEnergyAcquisitionCandidate,
+  right: LowLoadWorkerEnergyAcquisitionCandidate
+): number {
+  return (
+    left.priority - right.priority ||
+    right.score - left.score ||
+    compareOptionalRanges(left.range, right.range) ||
+    right.energy - left.energy ||
+    String(left.source.id).localeCompare(String(right.source.id)) ||
+    left.task.type.localeCompare(right.task.type)
+  );
+}
+
 function selectLowLoadWorkerEnergyAcquisitionCandidate(
   creep: Creep
 ): LowLoadWorkerEnergyAcquisitionCandidate | null {
@@ -3819,6 +3924,11 @@ export function canLevelUpController(controller: StructureController | undefined
 }
 
 function selectSource2ControllerLaneHarvestTask(creep: Creep): Extract<CreepTaskMemory, { type: 'harvest' }> | null {
+  const source = selectSource2ControllerLaneHarvestSource(creep);
+  return source ? { type: 'harvest', targetId: source.id } : null;
+}
+
+function selectSource2ControllerLaneHarvestSource(creep: Creep): Source | null {
   const controller = creep.room.controller;
   if (!controller) {
     return null;
@@ -3829,7 +3939,7 @@ function selectSource2ControllerLaneHarvestTask(creep: Creep): Extract<CreepTask
     return null;
   }
 
-  return { type: 'harvest', targetId: topology.source.id };
+  return topology.source;
 }
 
 function getSource2ControllerLaneTopology(
@@ -4298,6 +4408,11 @@ function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquis
 }
 
 function selectSourceContainerHarvestTask(creep: Creep): Extract<CreepTaskMemory, { type: 'harvest' }> | null {
+  const source = selectSourceContainerHarvestSource(creep);
+  return source ? { type: 'harvest', targetId: source.id, sourceContainerAssigned: true } : null;
+}
+
+function selectSourceContainerHarvestSource(creep: Creep): Source | null {
   if (
     getActiveWorkParts(creep) <= 0 ||
     typeof FIND_SOURCES !== 'number'
@@ -4314,7 +4429,7 @@ function selectSourceContainerHarvestTask(creep: Creep): Extract<CreepTaskMemory
     creep,
     findVisibleHarvestSourcesInRooms(harvestRooms).filter((candidate) => hasNonEmptyVisibleSourceContainer(creep, candidate))
   );
-  return source ? { type: 'harvest', targetId: source.id, sourceContainerAssigned: true } : null;
+  return source;
 }
 
 function hasNonEmptyVisibleSourceContainer(creep: Creep, source: Source): boolean {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2405,6 +2405,39 @@ describe('selectWorkerTask', () => {
     });
   });
 
+  it('withdraws from a stocked source container before assigning a distant dedicated harvester', () => {
+    const openSource = makeSource('source-open', 5, 5);
+    const bufferedSource = makeSource('source-buffered', 30, 30);
+    const bufferedContainer = makeStoredEnergyStructure('container-buffered', 'container' as StructureConstant, 200, {
+      pos: makeRoomPosition(30, 31)
+    });
+    const room = makeWorkerTaskRoom({
+      controller: { id: 'controller1', my: true, level: 1 } as StructureController,
+      sources: [openSource, bufferedSource],
+      structures: [bufferedContainer]
+    });
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'container-buffered': 5,
+            'source-buffered': 12,
+            'source-open': 1
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-buffered' });
+  });
+
   it('skips depleted source containers when assigning dedicated harvesters', () => {
     const emptyContainerSource = makeSource('source-empty-container', 10, 10);
     const chargedContainerSource = makeSource('source-charged-container', 30, 30);
@@ -9106,6 +9139,80 @@ describe('selectWorkerTask', () => {
     setGameCreeps({ LaneWorker: creep });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-near' });
+  });
+
+  it('withdraws from a stocked container before distant source2/controller lane harvesting', () => {
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const container = makeStoredEnergyStructure('container-buffered', 'container' as StructureConstant, 200, {
+      pos: makeRoomPosition(18, 18)
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ controller, sources: [source1, source2], structures: [container] });
+    const creep = {
+      name: 'LaneWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'container-buffered': 6,
+            source2: 12
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LaneWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-buffered' });
+  });
+
+  it('keeps close source2/controller lane harvesting before a very distant stocked container', () => {
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const container = makeStoredEnergyStructure('container-distant', 'container' as StructureConstant, 500, {
+      pos: makeRoomPosition(5, 5)
+    });
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({ controller, sources: [source1, source2], structures: [container] });
+    const creep = {
+      name: 'LaneWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => {
+          const ranges: Record<string, number> = {
+            'container-distant': 20,
+            source2: 2
+          };
+          return ranges[String(target.id)] ?? 99;
+        })
+      },
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LaneWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source2' });
   });
 
   it('picks up nearby dropped energy before direct source2/controller lane harvesting', () => {


### PR DESCRIPTION
Prefer nearby containers over distant sources when workers need energy.

Refs #648

## Verification
- typecheck: PASS
- Jest: 53 suites, 1133 tests PASS
- Build: esbuild clean
- Controller-verified 2026-05-06T09:22Z

## Summary
- Extended worker task acquisition candidate selection to prefer nearby containers
- Containers within range are ranked above distant source spots
- Tests cover container preference in worker energy acquisition
