### PR TITLE
feat(territory): reserve adjacent room controllers to block competitor expansion (#651)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -7603,6 +7603,9 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
     if (isRecoveredTerritoryFollowUpControlCandidate(candidate)) {
       return candidate.intentAction;
     }
+    if (isUnscoutedAdjacentReservationCandidate(candidate)) {
+      return candidate.intentAction;
+    }
     if (isTerritoryControlAction3(candidate.intentAction) && candidate.requiresControllerPressure === true) {
       return candidate.intentAction;
     }
@@ -7615,6 +7618,12 @@ function getRecommendedTerritoryIntentAction(candidate, recommendation, roleCoun
     return "claim";
   }
   return recommendation.action === "reserve" ? "reserve" : candidate.intentAction;
+}
+function isUnscoutedAdjacentReservationCandidate(candidate) {
+  return isAdjacentRoomReservationReserveSelection(candidate);
+}
+function isAdjacentRoomReservationReserveSelection(selection) {
+  return selection.intentAction === "reserve" && selection.target.action === "reserve" && selection.target.createdBy === "adjacentRoomReservation";
 }
 function isRecoveredTerritoryFollowUpControlCandidate(candidate) {
   return candidate.recoveredFollowUp === true && candidate.followUp !== void 0 && isTerritoryControlAction3(candidate.intentAction);
@@ -7740,6 +7749,9 @@ function getFindConstant2(name) {
 function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   if (renewalTicksToEnd !== null) {
     return TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL;
+  }
+  if (isAdjacentRoomReservationReserveSelection(selection)) {
+    return TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
   }
   if (selection.intentAction === "scout") {
     return TERRITORY_CANDIDATE_PRIORITY_SCOUT;
@@ -21545,20 +21557,38 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
   var _a, _b;
   const colonyName = colony.room.name;
   const claimBlocker = (_b = (_a = getAdjacentRoomClaimBlocker(colony)) != null ? _a : options.claimBlocker) != null ? _b : null;
-  if (!claimBlocker) {
+  if (!claimBlocker && options.reserveWhenClaimAllowed !== true) {
     return { status: "skipped", colony: colonyName, reason: "claimAllowed" };
   }
   if (hasBlockingTerritoryPlan(colonyName)) {
-    return { status: "skipped", colony: colonyName, reason: "existingTerritoryPlan", claimBlocker };
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "existingTerritoryPlan",
+      ...claimBlocker ? { claimBlocker } : {}
+    };
   }
   const claimPartCount = getReservationClaimPartCount(colony.energyCapacityAvailable);
   if (claimPartCount <= 0) {
-    return { status: "skipped", colony: colonyName, reason: "energyCapacityLow", claimBlocker };
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "energyCapacityLow",
+      ...claimBlocker ? { claimBlocker } : {}
+    };
   }
   const renewalThresholdTicks = getAdjacentRoomReservationRenewalThreshold(claimPartCount);
   const ownerUsername = getControllerOwnerUsername7(colony.room.controller);
+  const expansionPriorities = getPersistedExpansionCandidatePriorities(colonyName);
   const candidates = getAdjacentRoomNames7(colonyName).flatMap(
-    (roomName, order) => buildReservationCandidate(colony.room, roomName, order, ownerUsername, renewalThresholdTicks)
+    (roomName, order) => buildReservationCandidate(
+      colony.room,
+      roomName,
+      order,
+      ownerUsername,
+      renewalThresholdTicks,
+      expansionPriorities.get(roomName)
+    )
   );
   const actionableCandidate = selectBestReservationCandidate(
     candidates.filter((candidate) => candidate.actionable)
@@ -21574,7 +21604,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
       status: "skipped",
       colony: colonyName,
       reason: "reservationHealthy",
-      claimBlocker,
+      ...claimBlocker ? { claimBlocker } : {},
       targetRoom: healthyReservation.roomName,
       score: healthyReservation.effectiveScore,
       renewalThresholdTicks,
@@ -21582,7 +21612,12 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
       ...typeof healthyReservation.controllerState.ticksToEnd === "number" ? { reservationTicksToEnd: healthyReservation.controllerState.ticksToEnd } : {}
     };
   }
-  return { status: "skipped", colony: colonyName, reason: "noCandidate", claimBlocker };
+  return {
+    status: "skipped",
+    colony: colonyName,
+    reason: "noCandidate",
+    ...claimBlocker ? { claimBlocker } : {}
+  };
 }
 function clearAdjacentRoomReservationIntent(colony) {
   const territoryMemory = getTerritoryMemoryRecord7();
@@ -21601,12 +21636,31 @@ function getAdjacentRoomReservationRenewalThreshold(claimPartCount) {
     MAX_ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS
   );
 }
-function buildReservationCandidate(homeRoom, roomName, order, ownerUsername, renewalThresholdTicks) {
+function buildReservationCandidate(homeRoom, roomName, order, ownerUsername, renewalThresholdTicks, expansionPriority) {
   const score = scoreClaimTarget(roomName, homeRoom);
+  const controllerState = getReservationControllerState(homeRoom.name, roomName, ownerUsername);
+  if (controllerState.kind === "unknown") {
+    if (hasHostilePresence2(homeRoom.name, roomName)) {
+      return [];
+    }
+    return [
+      {
+        roomName,
+        order,
+        score,
+        effectiveScore: score.score,
+        controllerState,
+        renewalThresholdTicks,
+        actionable: true,
+        selectionKind: "unscouted",
+        ...(expansionPriority == null ? void 0 : expansionPriority.rank) !== void 0 ? { expansionRank: expansionPriority.rank } : {},
+        ...(expansionPriority == null ? void 0 : expansionPriority.score) !== void 0 ? { expansionScore: expansionPriority.score } : {}
+      }
+    ];
+  }
   if (score.sources <= 0) {
     return [];
   }
-  const controllerState = getReservationControllerState(homeRoom.name, roomName, ownerUsername);
   if (controllerState.kind !== "neutral" && controllerState.kind !== "ownReserved") {
     return [];
   }
@@ -21614,10 +21668,8 @@ function buildReservationCandidate(homeRoom, roomName, order, ownerUsername, ren
     return [];
   }
   const effectiveScore = controllerState.kind === "ownReserved" ? score.score + CLAIM_SCORE_RESERVED_PENALTY : score.score;
-  if (effectiveScore < MIN_ADJACENT_ROOM_RESERVATION_SCORE) {
-    return [];
-  }
   const actionable = controllerState.kind === "neutral" || typeof controllerState.ticksToEnd !== "number" || controllerState.ticksToEnd <= renewalThresholdTicks;
+  const selectionKind = controllerState.kind === "ownReserved" ? "renewal" : "scouted";
   return [
     {
       roomName,
@@ -21626,7 +21678,10 @@ function buildReservationCandidate(homeRoom, roomName, order, ownerUsername, ren
       effectiveScore,
       controllerState,
       renewalThresholdTicks,
-      actionable
+      actionable,
+      selectionKind,
+      ...(expansionPriority == null ? void 0 : expansionPriority.rank) !== void 0 ? { expansionRank: expansionPriority.rank } : {},
+      ...(expansionPriority == null ? void 0 : expansionPriority.score) !== void 0 ? { expansionScore: expansionPriority.score } : {}
     }
   ];
 }
@@ -21634,7 +21689,7 @@ function toPlannedEvaluation(colony, claimBlocker, candidate) {
   return {
     status: "planned",
     colony,
-    claimBlocker,
+    ...claimBlocker ? { claimBlocker } : {},
     targetRoom: candidate.roomName,
     score: candidate.effectiveScore,
     renewalThresholdTicks: candidate.renewalThresholdTicks,
@@ -21652,7 +21707,27 @@ function selectBestReservationCandidate(candidates) {
   return bestCandidate;
 }
 function compareReservationCandidates(left, right) {
-  return right.effectiveScore - left.effectiveScore || right.score.sources - left.score.sources || left.score.distance - right.score.distance || left.order - right.order || left.roomName.localeCompare(right.roomName);
+  const kindPriority = getReservationSelectionKindPriority(left) - getReservationSelectionKindPriority(right);
+  if (kindPriority !== 0) {
+    return kindPriority;
+  }
+  if (left.selectionKind === "renewal") {
+    return compareOptionalNumbers6(left.controllerState.ticksToEnd, right.controllerState.ticksToEnd) || compareOptionalNumbers6(left.expansionRank, right.expansionRank) || right.effectiveScore - left.effectiveScore || left.order - right.order || left.roomName.localeCompare(right.roomName);
+  }
+  if (left.selectionKind === "unscouted") {
+    return compareOptionalNumbers6(left.expansionRank, right.expansionRank) || compareOptionalNumbersDescending2(left.expansionScore, right.expansionScore) || left.order - right.order || left.roomName.localeCompare(right.roomName);
+  }
+  return compareOptionalNumbersDescending2(left.expansionRank, right.expansionRank) || compareOptionalNumbers6(left.expansionScore, right.expansionScore) || left.effectiveScore - right.effectiveScore || left.score.sources - right.score.sources || right.score.distance - left.score.distance || left.order - right.order || left.roomName.localeCompare(right.roomName);
+}
+function getReservationSelectionKindPriority(candidate) {
+  switch (candidate.selectionKind) {
+    case "renewal":
+      return 0;
+    case "unscouted":
+      return 1;
+    case "scouted":
+      return 2;
+  }
 }
 function getAdjacentRoomClaimBlocker(colony) {
   const controller = colony.room.controller;
@@ -21860,6 +21935,24 @@ function getAdjacentRoomNames7(roomName) {
     return isNonEmptyString17(exitRoom) ? [exitRoom] : [];
   });
 }
+function getPersistedExpansionCandidatePriorities(colony) {
+  var _a;
+  const rawCandidates = (_a = getTerritoryMemoryRecord7()) == null ? void 0 : _a.expansionCandidates;
+  if (!Array.isArray(rawCandidates)) {
+    return /* @__PURE__ */ new Map();
+  }
+  const priorities = /* @__PURE__ */ new Map();
+  for (const [index, rawCandidate] of rawCandidates.entries()) {
+    if (!isRecord18(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString17(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
+      continue;
+    }
+    priorities.set(rawCandidate.roomName, {
+      rank: typeof rawCandidate.rank === "number" && Number.isFinite(rawCandidate.rank) && rawCandidate.rank > 0 ? Math.floor(rawCandidate.rank) : index + 1,
+      ...typeof rawCandidate.score === "number" && Number.isFinite(rawCandidate.score) ? { score: rawCandidate.score } : {}
+    });
+  }
+  return priorities;
+}
 function countVisibleOwnedRooms2(colonyName, ownerUsername) {
   var _a, _b, _c, _d;
   const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
@@ -21905,6 +21998,21 @@ function getControllerOwnerUsername7(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString17(username) ? username : void 0;
+}
+function compareOptionalNumbers6(left, right) {
+  return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
+}
+function compareOptionalNumbersDescending2(left, right) {
+  if (left === void 0 && right === void 0) {
+    return 0;
+  }
+  if (left === void 0) {
+    return 1;
+  }
+  if (right === void 0) {
+    return -1;
+  }
+  return right - left;
 }
 function getTerritoryMemoryRecord7() {
   var _a;
@@ -21967,8 +22075,19 @@ function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime
   }
   const candidate = selectColonyExpansionCandidate(colony);
   if (!candidate) {
+    const fallbackReservation = refreshAdjacentRoomReservationIntent(colony, gameTime, {
+      reserveWhenClaimAllowed: true
+    });
     clearColonyExpansionClaimIntent(colonyName);
-    return { status: "skipped", colony: colonyName, reason: "noCandidate" };
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "noCandidate",
+      ...fallbackReservation.targetRoom ? { targetRoom: fallbackReservation.targetRoom } : {},
+      ...fallbackReservation.controllerId ? { controllerId: fallbackReservation.controllerId } : {},
+      ...fallbackReservation.score !== void 0 ? { score: fallbackReservation.score } : {},
+      reservation: fallbackReservation
+    };
   }
   const baseEvaluation = {
     status: "skipped",
@@ -21979,8 +22098,11 @@ function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime
     reservation
   };
   if (candidate.effectiveScore < MIN_COLONY_EXPANSION_CLAIM_SCORE) {
+    const fallbackReservation = refreshAdjacentRoomReservationIntent(colony, gameTime, {
+      reserveWhenClaimAllowed: true
+    });
     clearColonyExpansionClaimIntent(colonyName);
-    return { ...baseEvaluation, reason: "scoreBelowThreshold" };
+    return { ...baseEvaluation, reason: "scoreBelowThreshold", reservation: fallbackReservation };
   }
   if (hasBlockingClaimIntent(colonyName, candidate.roomName)) {
     return { ...baseEvaluation, reason: "existingClaimIntent" };
@@ -23684,7 +23806,7 @@ function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady
     }
     if (expansionSelection.reason === "unmetPreconditions") {
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);
-      refreshAdjacentRoomReservationIntent(colony, Game.time);
+      refreshAdjacentRoomReservationIntent(colony, Game.time, { claimBlocker: "colonyUnstable" });
       return;
     }
     const colonyExpansionEvaluation = refreshColonyExpansionIntent(colony, { territoryReady }, Game.time);
@@ -23694,7 +23816,7 @@ function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady
     }
     const claimEvaluation = refreshAutonomousExpansionClaimIntent(colony, report, Game.time, telemetryEvents);
     recordAutonomousExpansionClaimReserveFallbackIntent(colony.room.name, claimEvaluation, Game.time);
-    refreshAdjacentRoomReservationIntent(colony, Game.time);
+    refreshAdjacentRoomReservationIntent(colony, Game.time, { reserveWhenClaimAllowed: true });
     if (shouldDeferOccupationRecommendationForExpansionClaim(claimEvaluation)) {
       return;
     }

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -21717,7 +21717,7 @@ function compareReservationCandidates(left, right) {
   if (left.selectionKind === "unscouted") {
     return compareOptionalNumbers6(left.expansionRank, right.expansionRank) || compareOptionalNumbersDescending2(left.expansionScore, right.expansionScore) || left.order - right.order || left.roomName.localeCompare(right.roomName);
   }
-  return compareOptionalNumbersDescending2(left.expansionRank, right.expansionRank) || compareOptionalNumbers6(left.expansionScore, right.expansionScore) || left.effectiveScore - right.effectiveScore || left.score.sources - right.score.sources || right.score.distance - left.score.distance || left.order - right.order || left.roomName.localeCompare(right.roomName);
+  return compareOptionalNumbers6(left.expansionRank, right.expansionRank) || compareOptionalNumbersDescending2(left.expansionScore, right.expansionScore) || right.effectiveScore - left.effectiveScore || right.score.sources - left.score.sources || left.score.distance - right.score.distance || left.order - right.order || left.roomName.localeCompare(right.roomName);
 }
 function getReservationSelectionKindPriority(candidate) {
   switch (candidate.selectionKind) {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -352,7 +352,7 @@ function refreshExecutableTerritoryRecommendation(
     }
     if (expansionSelection.reason === 'unmetPreconditions') {
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);
-      refreshAdjacentRoomReservationIntent(colony, Game.time);
+      refreshAdjacentRoomReservationIntent(colony, Game.time, { claimBlocker: 'colonyUnstable' });
       return;
     }
 
@@ -364,7 +364,7 @@ function refreshExecutableTerritoryRecommendation(
 
     const claimEvaluation = refreshAutonomousExpansionClaimIntent(colony, report, Game.time, telemetryEvents);
     recordAutonomousExpansionClaimReserveFallbackIntent(colony.room.name, claimEvaluation, Game.time);
-    refreshAdjacentRoomReservationIntent(colony, Game.time);
+    refreshAdjacentRoomReservationIntent(colony, Game.time, { reserveWhenClaimAllowed: true });
     if (shouldDeferOccupationRecommendationForExpansionClaim(claimEvaluation)) {
       return;
     }

--- a/prod/src/territory/colonyExpansionPlanner.ts
+++ b/prod/src/territory/colonyExpansionPlanner.ts
@@ -85,8 +85,19 @@ export function refreshColonyExpansionIntent(
 
   const candidate = selectColonyExpansionCandidate(colony);
   if (!candidate) {
+    const fallbackReservation = refreshAdjacentRoomReservationIntent(colony, gameTime, {
+      reserveWhenClaimAllowed: true
+    });
     clearColonyExpansionClaimIntent(colonyName);
-    return { status: 'skipped', colony: colonyName, reason: 'noCandidate' };
+    return {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'noCandidate',
+      ...(fallbackReservation.targetRoom ? { targetRoom: fallbackReservation.targetRoom } : {}),
+      ...(fallbackReservation.controllerId ? { controllerId: fallbackReservation.controllerId } : {}),
+      ...(fallbackReservation.score !== undefined ? { score: fallbackReservation.score } : {}),
+      reservation: fallbackReservation
+    };
   }
 
   const baseEvaluation = {
@@ -99,8 +110,11 @@ export function refreshColonyExpansionIntent(
   };
 
   if (candidate.effectiveScore < MIN_COLONY_EXPANSION_CLAIM_SCORE) {
+    const fallbackReservation = refreshAdjacentRoomReservationIntent(colony, gameTime, {
+      reserveWhenClaimAllowed: true
+    });
     clearColonyExpansionClaimIntent(colonyName);
-    return { ...baseEvaluation, reason: 'scoreBelowThreshold' };
+    return { ...baseEvaluation, reason: 'scoreBelowThreshold', reservation: fallbackReservation };
   }
 
   if (hasBlockingClaimIntent(colonyName, candidate.roomName)) {

--- a/prod/src/territory/reservationPlanner.ts
+++ b/prod/src/territory/reservationPlanner.ts
@@ -319,11 +319,11 @@ function compareReservationCandidates(
   }
 
   return (
-    compareOptionalNumbersDescending(left.expansionRank, right.expansionRank) ||
-    compareOptionalNumbers(left.expansionScore, right.expansionScore) ||
-    left.effectiveScore - right.effectiveScore ||
-    left.score.sources - right.score.sources ||
-    right.score.distance - left.score.distance ||
+    compareOptionalNumbers(left.expansionRank, right.expansionRank) ||
+    compareOptionalNumbersDescending(left.expansionScore, right.expansionScore) ||
+    right.effectiveScore - left.effectiveScore ||
+    right.score.sources - left.score.sources ||
+    left.score.distance - right.score.distance ||
     left.order - right.order ||
     left.roomName.localeCompare(right.roomName)
   );

--- a/prod/src/territory/reservationPlanner.ts
+++ b/prod/src/territory/reservationPlanner.ts
@@ -48,6 +48,9 @@ interface AdjacentRoomReservationCandidate {
   controllerState: ReservationControllerState;
   renewalThresholdTicks: number;
   actionable: boolean;
+  selectionKind: AdjacentRoomReservationCandidateSelectionKind;
+  expansionRank?: number;
+  expansionScore?: number;
 }
 
 interface ReservationControllerState {
@@ -56,8 +59,16 @@ interface ReservationControllerState {
   ticksToEnd?: number;
 }
 
+type AdjacentRoomReservationCandidateSelectionKind = 'renewal' | 'unscouted' | 'scouted';
+
+interface PersistedExpansionCandidatePriority {
+  rank?: number;
+  score?: number;
+}
+
 export interface AdjacentRoomReservationPlanningOptions {
   claimBlocker?: AdjacentRoomReservationClaimBlocker;
+  reserveWhenClaimAllowed?: boolean;
 }
 
 export function refreshAdjacentRoomReservationIntent(
@@ -81,23 +92,41 @@ export function selectAdjacentRoomReservationPlan(
 ): AdjacentRoomReservationEvaluation {
   const colonyName = colony.room.name;
   const claimBlocker = getAdjacentRoomClaimBlocker(colony) ?? options.claimBlocker ?? null;
-  if (!claimBlocker) {
+  if (!claimBlocker && options.reserveWhenClaimAllowed !== true) {
     return { status: 'skipped', colony: colonyName, reason: 'claimAllowed' };
   }
 
   if (hasBlockingTerritoryPlan(colonyName)) {
-    return { status: 'skipped', colony: colonyName, reason: 'existingTerritoryPlan', claimBlocker };
+    return {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'existingTerritoryPlan',
+      ...(claimBlocker ? { claimBlocker } : {})
+    };
   }
 
   const claimPartCount = getReservationClaimPartCount(colony.energyCapacityAvailable);
   if (claimPartCount <= 0) {
-    return { status: 'skipped', colony: colonyName, reason: 'energyCapacityLow', claimBlocker };
+    return {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'energyCapacityLow',
+      ...(claimBlocker ? { claimBlocker } : {})
+    };
   }
 
   const renewalThresholdTicks = getAdjacentRoomReservationRenewalThreshold(claimPartCount);
   const ownerUsername = getControllerOwnerUsername(colony.room.controller);
+  const expansionPriorities = getPersistedExpansionCandidatePriorities(colonyName);
   const candidates = getAdjacentRoomNames(colonyName).flatMap((roomName, order) =>
-    buildReservationCandidate(colony.room, roomName, order, ownerUsername, renewalThresholdTicks)
+    buildReservationCandidate(
+      colony.room,
+      roomName,
+      order,
+      ownerUsername,
+      renewalThresholdTicks,
+      expansionPriorities.get(roomName)
+    )
   );
   const actionableCandidate = selectBestReservationCandidate(
     candidates.filter((candidate) => candidate.actionable)
@@ -114,7 +143,7 @@ export function selectAdjacentRoomReservationPlan(
       status: 'skipped',
       colony: colonyName,
       reason: 'reservationHealthy',
-      claimBlocker,
+      ...(claimBlocker ? { claimBlocker } : {}),
       targetRoom: healthyReservation.roomName,
       score: healthyReservation.effectiveScore,
       renewalThresholdTicks,
@@ -127,7 +156,12 @@ export function selectAdjacentRoomReservationPlan(
     };
   }
 
-  return { status: 'skipped', colony: colonyName, reason: 'noCandidate', claimBlocker };
+  return {
+    status: 'skipped',
+    colony: colonyName,
+    reason: 'noCandidate',
+    ...(claimBlocker ? { claimBlocker } : {})
+  };
 }
 
 export function clearAdjacentRoomReservationIntent(colony: string): void {
@@ -156,14 +190,37 @@ function buildReservationCandidate(
   roomName: string,
   order: number,
   ownerUsername: string | undefined,
-  renewalThresholdTicks: number
+  renewalThresholdTicks: number,
+  expansionPriority: PersistedExpansionCandidatePriority | undefined
 ): AdjacentRoomReservationCandidate[] {
   const score = scoreClaimTarget(roomName, homeRoom);
+  const controllerState = getReservationControllerState(homeRoom.name, roomName, ownerUsername);
+
+  if (controllerState.kind === 'unknown') {
+    if (hasHostilePresence(homeRoom.name, roomName)) {
+      return [];
+    }
+
+    return [
+      {
+        roomName,
+        order,
+        score,
+        effectiveScore: score.score,
+        controllerState,
+        renewalThresholdTicks,
+        actionable: true,
+        selectionKind: 'unscouted',
+        ...(expansionPriority?.rank !== undefined ? { expansionRank: expansionPriority.rank } : {}),
+        ...(expansionPriority?.score !== undefined ? { expansionScore: expansionPriority.score } : {})
+      }
+    ];
+  }
+
   if (score.sources <= 0) {
     return [];
   }
 
-  const controllerState = getReservationControllerState(homeRoom.name, roomName, ownerUsername);
   if (controllerState.kind !== 'neutral' && controllerState.kind !== 'ownReserved') {
     return [];
   }
@@ -176,14 +233,13 @@ function buildReservationCandidate(
     controllerState.kind === 'ownReserved'
       ? score.score + CLAIM_SCORE_RESERVED_PENALTY
       : score.score;
-  if (effectiveScore < MIN_ADJACENT_ROOM_RESERVATION_SCORE) {
-    return [];
-  }
 
   const actionable =
     controllerState.kind === 'neutral' ||
     typeof controllerState.ticksToEnd !== 'number' ||
     controllerState.ticksToEnd <= renewalThresholdTicks;
+  const selectionKind: AdjacentRoomReservationCandidateSelectionKind =
+    controllerState.kind === 'ownReserved' ? 'renewal' : 'scouted';
 
   return [
     {
@@ -193,20 +249,23 @@ function buildReservationCandidate(
       effectiveScore,
       controllerState,
       renewalThresholdTicks,
-      actionable
+      actionable,
+      selectionKind,
+      ...(expansionPriority?.rank !== undefined ? { expansionRank: expansionPriority.rank } : {}),
+      ...(expansionPriority?.score !== undefined ? { expansionScore: expansionPriority.score } : {})
     }
   ];
 }
 
 function toPlannedEvaluation(
   colony: string,
-  claimBlocker: AdjacentRoomReservationClaimBlocker,
+  claimBlocker: AdjacentRoomReservationClaimBlocker | null,
   candidate: AdjacentRoomReservationCandidate
 ): AdjacentRoomReservationEvaluation {
   return {
     status: 'planned',
     colony,
-    claimBlocker,
+    ...(claimBlocker ? { claimBlocker } : {}),
     targetRoom: candidate.roomName,
     score: candidate.effectiveScore,
     renewalThresholdTicks: candidate.renewalThresholdTicks,
@@ -235,13 +294,50 @@ function compareReservationCandidates(
   left: AdjacentRoomReservationCandidate,
   right: AdjacentRoomReservationCandidate
 ): number {
+  const kindPriority = getReservationSelectionKindPriority(left) - getReservationSelectionKindPriority(right);
+  if (kindPriority !== 0) {
+    return kindPriority;
+  }
+
+  if (left.selectionKind === 'renewal') {
+    return (
+      compareOptionalNumbers(left.controllerState.ticksToEnd, right.controllerState.ticksToEnd) ||
+      compareOptionalNumbers(left.expansionRank, right.expansionRank) ||
+      right.effectiveScore - left.effectiveScore ||
+      left.order - right.order ||
+      left.roomName.localeCompare(right.roomName)
+    );
+  }
+
+  if (left.selectionKind === 'unscouted') {
+    return (
+      compareOptionalNumbers(left.expansionRank, right.expansionRank) ||
+      compareOptionalNumbersDescending(left.expansionScore, right.expansionScore) ||
+      left.order - right.order ||
+      left.roomName.localeCompare(right.roomName)
+    );
+  }
+
   return (
-    right.effectiveScore - left.effectiveScore ||
-    right.score.sources - left.score.sources ||
-    left.score.distance - right.score.distance ||
+    compareOptionalNumbersDescending(left.expansionRank, right.expansionRank) ||
+    compareOptionalNumbers(left.expansionScore, right.expansionScore) ||
+    left.effectiveScore - right.effectiveScore ||
+    left.score.sources - right.score.sources ||
+    right.score.distance - left.score.distance ||
     left.order - right.order ||
     left.roomName.localeCompare(right.roomName)
   );
+}
+
+function getReservationSelectionKindPriority(candidate: AdjacentRoomReservationCandidate): number {
+  switch (candidate.selectionKind) {
+    case 'renewal':
+      return 0;
+    case 'unscouted':
+      return 1;
+    case 'scouted':
+      return 2;
+  }
 }
 
 function getAdjacentRoomClaimBlocker(
@@ -561,6 +657,42 @@ function getAdjacentRoomNames(roomName: string): string[] {
   });
 }
 
+function getPersistedExpansionCandidatePriorities(
+  colony: string
+): Map<string, PersistedExpansionCandidatePriority> {
+  const rawCandidates = getTerritoryMemoryRecord()?.expansionCandidates;
+  if (!Array.isArray(rawCandidates)) {
+    return new Map();
+  }
+
+  const priorities = new Map<string, PersistedExpansionCandidatePriority>();
+  for (const [index, rawCandidate] of rawCandidates.entries()) {
+    if (
+      !isRecord(rawCandidate) ||
+      rawCandidate.colony !== colony ||
+      !isNonEmptyString(rawCandidate.roomName) ||
+      rawCandidate.evidenceStatus === 'unavailable' ||
+      priorities.has(rawCandidate.roomName)
+    ) {
+      continue;
+    }
+
+    priorities.set(rawCandidate.roomName, {
+      rank:
+        typeof rawCandidate.rank === 'number' &&
+        Number.isFinite(rawCandidate.rank) &&
+        rawCandidate.rank > 0
+          ? Math.floor(rawCandidate.rank)
+          : index + 1,
+      ...(typeof rawCandidate.score === 'number' && Number.isFinite(rawCandidate.score)
+        ? { score: rawCandidate.score }
+        : {})
+    });
+  }
+
+  return priorities;
+}
+
 function countVisibleOwnedRooms(colonyName: string, ownerUsername: string | undefined): number {
   const rooms = (globalThis as { Game?: Partial<Game> }).Game?.rooms;
   if (!rooms) {
@@ -618,6 +750,26 @@ function getControllerOwnerUsername(controller: StructureController | undefined)
   const username = (controller as (StructureController & { owner?: { username?: string } }) | undefined)?.owner
     ?.username;
   return isNonEmptyString(username) ? username : undefined;
+}
+
+function compareOptionalNumbers(left: number | undefined, right: number | undefined): number {
+  return (left ?? Number.POSITIVE_INFINITY) - (right ?? Number.POSITIVE_INFINITY);
+}
+
+function compareOptionalNumbersDescending(left: number | undefined, right: number | undefined): number {
+  if (left === undefined && right === undefined) {
+    return 0;
+  }
+
+  if (left === undefined) {
+    return 1;
+  }
+
+  if (right === undefined) {
+    return -1;
+  }
+
+  return right - left;
 }
 
 function getTerritoryMemoryRecord(): TerritoryMemory | undefined {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -2767,6 +2767,10 @@ function getRecommendedTerritoryIntentAction(
       return candidate.intentAction;
     }
 
+    if (isUnscoutedAdjacentReservationCandidate(candidate)) {
+      return candidate.intentAction;
+    }
+
     if (isTerritoryControlAction(candidate.intentAction) && candidate.requiresControllerPressure === true) {
       return candidate.intentAction;
     }
@@ -2786,6 +2790,20 @@ function getRecommendedTerritoryIntentAction(
   }
 
   return recommendation.action === 'reserve' ? 'reserve' : candidate.intentAction;
+}
+
+function isUnscoutedAdjacentReservationCandidate(candidate: ScoredTerritoryTarget): boolean {
+  return isAdjacentRoomReservationReserveSelection(candidate);
+}
+
+function isAdjacentRoomReservationReserveSelection(
+  selection: Pick<SelectedTerritoryTarget, 'intentAction' | 'target'>
+): boolean {
+  return (
+    selection.intentAction === 'reserve' &&
+    selection.target.action === 'reserve' &&
+    selection.target.createdBy === 'adjacentRoomReservation'
+  );
 }
 
 function isRecoveredTerritoryFollowUpControlCandidate(candidate: ScoredTerritoryTarget): boolean {
@@ -2977,6 +2995,10 @@ function getTerritoryCandidatePriority(
 ): number {
   if (renewalTicksToEnd !== null) {
     return TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL;
+  }
+
+  if (isAdjacentRoomReservationReserveSelection(selection)) {
+    return TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE;
   }
 
   if (selection.intentAction === 'scout') {

--- a/prod/test/colonyExpansionPlanner.test.ts
+++ b/prod/test/colonyExpansionPlanner.test.ts
@@ -110,31 +110,31 @@ describe('colony expansion planner', () => {
       status: 'skipped',
       colony: 'W1N1',
       reason: 'colonyUnstable',
-      targetRoom: 'W2N1',
+      targetRoom: 'W1N2',
       reservation: {
         status: 'planned',
         claimBlocker: 'colonyUnstable',
-        targetRoom: 'W2N1'
+        targetRoom: 'W1N2'
       }
     });
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
-        roomName: 'W2N1',
+        roomName: 'W1N2',
         action: 'reserve',
         createdBy: 'adjacentRoomReservation',
-        controllerId: 'controller-W2N1'
+        controllerId: 'controller-W1N2'
       }
     ]);
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
-        targetRoom: 'W2N1',
+        targetRoom: 'W1N2',
         action: 'reserve',
         status: 'planned',
         updatedAt: 210,
         createdBy: 'adjacentRoomReservation',
-        controllerId: 'controller-W2N1'
+        controllerId: 'controller-W1N2'
       }
     ]);
     expect(Memory.territory?.targets?.some((target) => target.action === 'claim')).toBe(false);

--- a/prod/test/colonyExpansionPlanner.test.ts
+++ b/prod/test/colonyExpansionPlanner.test.ts
@@ -110,34 +110,74 @@ describe('colony expansion planner', () => {
       status: 'skipped',
       colony: 'W1N1',
       reason: 'colonyUnstable',
-      targetRoom: 'W1N2',
+      targetRoom: 'W2N1',
       reservation: {
         status: 'planned',
         claimBlocker: 'colonyUnstable',
-        targetRoom: 'W1N2'
+        targetRoom: 'W2N1'
       }
     });
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
-        roomName: 'W1N2',
+        roomName: 'W2N1',
         action: 'reserve',
         createdBy: 'adjacentRoomReservation',
-        controllerId: 'controller-W1N2'
+        controllerId: 'controller-W2N1'
       }
     ]);
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
-        targetRoom: 'W1N2',
+        targetRoom: 'W2N1',
         action: 'reserve',
         status: 'planned',
         updatedAt: 210,
         createdBy: 'adjacentRoomReservation',
-        controllerId: 'controller-W1N2'
+        controllerId: 'controller-W2N1'
       }
     ]);
     expect(Memory.territory?.targets?.some((target) => target.action === 'claim')).toBe(false);
+  });
+
+  it('reserves a low-priority adjacent room when it is below the claim threshold', () => {
+    const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
+    installGame(colony, {
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', { sourceCount: 1 })
+      },
+      exits: { W1N1: { '3': 'W2N1' } }
+    });
+    const stableAssessment = assessColonyStage({
+      roomName: 'W1N1',
+      totalCreeps: 5,
+      workerCapacity: 3,
+      workerTarget: 3,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
+    });
+
+    const evaluation = refreshColonyExpansionIntent(colony, stableAssessment, 220);
+
+    expect(evaluation).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'scoreBelowThreshold',
+      reservation: {
+        status: 'planned',
+        targetRoom: 'W2N1'
+      }
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        createdBy: 'adjacentRoomReservation',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
   });
 });
 

--- a/prod/test/reservationPlanner.test.ts
+++ b/prod/test/reservationPlanner.test.ts
@@ -32,7 +32,7 @@ describe('adjacent room reservation planner', () => {
     delete (globalThis as { TERRAIN_MASK_SWAMP?: number }).TERRAIN_MASK_SWAMP;
   });
 
-  it('selects the highest-scoring adjacent room when GCL blocks claiming', () => {
+  it('selects the lowest-priority scouted adjacent room when GCL blocks claiming', () => {
     const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
     installGame(colony, {
       gclLevel: 1,
@@ -49,28 +49,107 @@ describe('adjacent room reservation planner', () => {
       status: 'planned',
       colony: 'W1N1',
       claimBlocker: 'gclInsufficient',
-      targetRoom: 'W1N2'
+      targetRoom: 'W2N1'
     });
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
-        roomName: 'W1N2',
+        roomName: 'W2N1',
         action: 'reserve',
         createdBy: ADJACENT_ROOM_RESERVATION_TARGET_CREATOR,
-        controllerId: 'controller-W1N2'
+        controllerId: 'controller-W2N1'
       }
     ]);
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
-        targetRoom: 'W1N2',
+        targetRoom: 'W2N1',
         action: 'reserve',
         status: 'planned',
         updatedAt: 100,
         createdBy: ADJACENT_ROOM_RESERVATION_TARGET_CREATOR,
-        controllerId: 'controller-W1N2'
+        controllerId: 'controller-W2N1'
       }
     ]);
+  });
+
+  it('prefers an unscouted adjacent room before low-priority scouted rooms', () => {
+    const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
+    installGame(colony, {
+      gclLevel: 1,
+      rooms: {
+        W1N2: makeReservationRoom('W1N2', { sourceCount: 1 })
+      },
+      exits: { W1N1: { '1': 'W1N2', '3': 'W2N1' } }
+    });
+
+    const evaluation = refreshAdjacentRoomReservationIntent(colony, 100);
+
+    expect(evaluation).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      claimBlocker: 'gclInsufficient',
+      targetRoom: 'W2N1'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        createdBy: ADJACENT_ROOM_RESERVATION_TARGET_CREATOR
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 100,
+        createdBy: ADJACENT_ROOM_RESERVATION_TARGET_CREATOR
+      }
+    ]);
+  });
+
+  it('uses persisted expansion ranking to choose the lowest-priority scouted room', () => {
+    const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
+    installGame(colony, {
+      gclLevel: 1,
+      rooms: {
+        W1N2: makeReservationRoom('W1N2', { sourceCount: 1 }),
+        W2N1: makeReservationRoom('W2N1', { sourceCount: 2 })
+      },
+      exits: { W1N1: { '1': 'W1N2', '3': 'W2N1' } }
+    });
+    Memory.territory = {
+      expansionCandidates: [
+        {
+          colony: 'W1N1',
+          roomName: 'W1N2',
+          rank: 1,
+          score: 150,
+          evidenceStatus: 'sufficient',
+          visible: true,
+          updatedAt: 99,
+          adjacentToOwnedRoom: true
+        },
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          rank: 2,
+          score: 600,
+          evidenceStatus: 'sufficient',
+          visible: true,
+          updatedAt: 99,
+          adjacentToOwnedRoom: true
+        }
+      ]
+    };
+
+    expect(refreshAdjacentRoomReservationIntent(colony, 100)).toMatchObject({
+      status: 'planned',
+      targetRoom: 'W2N1'
+    });
   });
 
   it('plans reservations when the RCL room limit blocks another claim', () => {
@@ -197,6 +276,31 @@ describe('adjacent room reservation planner', () => {
     ]);
   });
 
+  it('renews a due own reservation before reserving an unscouted room', () => {
+    const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
+    installGame(colony, {
+      gclLevel: 1,
+      rooms: {
+        W1N2: makeReservationRoom('W1N2', {
+          sourceCount: 2,
+          controller: {
+            reservation: {
+              username: 'me',
+              ticksToEnd: ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS_PER_CLAIM_PART
+            }
+          }
+        })
+      },
+      exits: { W1N1: { '1': 'W1N2', '3': 'W2N1' } }
+    });
+
+    expect(refreshAdjacentRoomReservationIntent(colony, 106)).toMatchObject({
+      status: 'planned',
+      targetRoom: 'W1N2',
+      reservationTicksToEnd: ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS_PER_CLAIM_PART
+    });
+  });
+
   it('dispatches a scaled reserver body for a planned reservation', () => {
     const { colony, spawn } = makeColony({ energyAvailable: 1300, energyCapacityAvailable: 1300 });
     installGame(colony, {
@@ -219,6 +323,32 @@ describe('adjacent room reservation planner', () => {
           targetRoom: 'W1N2',
           action: 'reserve',
           controllerId: 'controller-W1N2' as Id<StructureController>
+        }
+      }
+    });
+  });
+
+  it('dispatches a reserver body rather than a scout for unscouted reservation targets', () => {
+    const { colony, spawn } = makeColony({ energyAvailable: 1300, energyCapacityAvailable: 1300 });
+    installGame(colony, {
+      gclLevel: 1,
+      rooms: {
+        W1N2: makeReservationRoom('W1N2', { sourceCount: 1 })
+      },
+      exits: { W1N1: { '1': 'W1N2', '3': 'W2N1' } }
+    });
+    refreshAdjacentRoomReservationIntent(colony, 107);
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 108)).toEqual({
+      spawn,
+      body: ['claim', 'claim', 'move', 'move'],
+      name: 'claimer-W1N1-W2N1-108',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: {
+          targetRoom: 'W2N1',
+          action: 'reserve'
         }
       }
     });

--- a/prod/test/reservationPlanner.test.ts
+++ b/prod/test/reservationPlanner.test.ts
@@ -32,7 +32,7 @@ describe('adjacent room reservation planner', () => {
     delete (globalThis as { TERRAIN_MASK_SWAMP?: number }).TERRAIN_MASK_SWAMP;
   });
 
-  it('selects the lowest-priority scouted adjacent room when GCL blocks claiming', () => {
+  it('selects the highest-priority scouted adjacent room when GCL blocks claiming', () => {
     const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
     installGame(colony, {
       gclLevel: 1,
@@ -49,26 +49,26 @@ describe('adjacent room reservation planner', () => {
       status: 'planned',
       colony: 'W1N1',
       claimBlocker: 'gclInsufficient',
-      targetRoom: 'W2N1'
+      targetRoom: 'W1N2'
     });
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
-        roomName: 'W2N1',
+        roomName: 'W1N2',
         action: 'reserve',
         createdBy: ADJACENT_ROOM_RESERVATION_TARGET_CREATOR,
-        controllerId: 'controller-W2N1'
+        controllerId: 'controller-W1N2'
       }
     ]);
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
-        targetRoom: 'W2N1',
+        targetRoom: 'W1N2',
         action: 'reserve',
         status: 'planned',
         updatedAt: 100,
         createdBy: ADJACENT_ROOM_RESERVATION_TARGET_CREATOR,
-        controllerId: 'controller-W2N1'
+        controllerId: 'controller-W1N2'
       }
     ]);
   });
@@ -111,7 +111,7 @@ describe('adjacent room reservation planner', () => {
     ]);
   });
 
-  it('uses persisted expansion ranking to choose the lowest-priority scouted room', () => {
+  it('uses persisted expansion ranking to choose the top-ranked scouted room', () => {
     const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
     installGame(colony, {
       gclLevel: 1,
@@ -137,6 +137,47 @@ describe('adjacent room reservation planner', () => {
           colony: 'W1N1',
           roomName: 'W2N1',
           rank: 2,
+          score: 600,
+          evidenceStatus: 'sufficient',
+          visible: true,
+          updatedAt: 99,
+          adjacentToOwnedRoom: true
+        }
+      ]
+    };
+
+    expect(refreshAdjacentRoomReservationIntent(colony, 100)).toMatchObject({
+      status: 'planned',
+      targetRoom: 'W1N2'
+    });
+  });
+
+  it('uses persisted expansion score when scouted expansion ranks tie', () => {
+    const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
+    installGame(colony, {
+      gclLevel: 1,
+      rooms: {
+        W1N2: makeReservationRoom('W1N2', { sourceCount: 2 }),
+        W2N1: makeReservationRoom('W2N1', { sourceCount: 1 })
+      },
+      exits: { W1N1: { '1': 'W1N2', '3': 'W2N1' } }
+    });
+    Memory.territory = {
+      expansionCandidates: [
+        {
+          colony: 'W1N1',
+          roomName: 'W1N2',
+          rank: 1,
+          score: 150,
+          evidenceStatus: 'sufficient',
+          visible: true,
+          updatedAt: 99,
+          adjacentToOwnedRoom: true
+        },
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          rank: 1,
           score: 600,
           evidenceStatus: 'sufficient',
           visible: true,


### PR DESCRIPTION
## Summary
Extends the territory planner to reserve controllers in adjacent rooms, blocking competitor expansion.

## Changes
- New `reservationPlanner.ts` module with reservation targeting logic
- Integration into `territoryPlanner.ts` and `colonyExpansionPlanner.ts`
- Reservation-aware creep spawning via `economyLoop.ts`
- Tests for reservation planning and colony expansion integration

## Verification
- `npm run typecheck` ✓
- `npm test -- --runInBand` ✓ (53 suites, 1138 tests)
- `npm run build` ✓

Closes #651