### PR TITLE
feat(economy): withdraw energy from links as fallback when containers and sources are empty (#652)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10015,7 +10015,13 @@ function selectHeuristicWorkerTask(creep) {
       }
     }
     const source = selectHarvestSource(creep);
-    return source ? { type: "harvest", targetId: source.id } : null;
+    if (source) {
+      return { type: "harvest", targetId: source.id };
+    }
+    if (getFreeEnergyCapacity3(creep) > 0) {
+      return selectWorkerLinkEnergyFallbackTask(creep);
+    }
+    return null;
   }
   if (urgentReservationRenewalTask) {
     return urgentReservationRenewalTask;
@@ -11497,11 +11503,15 @@ function shouldKeepLowLoadWorkerAcquiringEnergy(creep) {
   return getLowLoadWorkerEnergyContext(creep) !== null && !hasVisibleHostilePresence(creep.room);
 }
 function findLowLoadWorkerEnergyContinuationCandidates(creep) {
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
   return [
     ...findWorkerEnergyAcquisitionCandidates(creep, {
       maximumRange: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
     }).map(toLowLoadWorkerEnergyAcquisitionCandidate),
-    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
+    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep),
+    ...findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext, {
+      maximumRange: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+    }).map(toLowLoadWorkerEnergyAcquisitionCandidate)
   ];
 }
 function findLowLoadWorkerEnergyAcquisitionCandidates(creep) {
@@ -11510,7 +11520,10 @@ function findLowLoadWorkerEnergyAcquisitionCandidates(creep) {
     ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationContext),
     ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationContext),
     ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep, reservationContext),
-    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
+    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep),
+    ...findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext, {
+      maximumRange: LOW_LOAD_NEARBY_ENERGY_RANGE
+    }).map(toLowLoadWorkerEnergyAcquisitionCandidate)
   ];
 }
 function findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationContext) {
@@ -11519,7 +11532,9 @@ function findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationCo
     hasHostilePresence: hasVisibleHostilePresence(creep.room),
     room: creep.room
   };
-  return findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).flatMap((source) => {
+  return findVisibleRoomStructures(creep.room).filter(
+    (structure) => isSafeStoredEnergySource(structure, context) && !isLinkEnergySource(structure)
+  ).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).flatMap((source) => {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
@@ -11660,7 +11675,9 @@ function findWorkerEnergyAcquisitionCandidates(creep, options = {}) {
     room: creep.room
   };
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
-  const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter((structure) => isSafeStoredEnergySource(structure, context)).flatMap((source) => {
+  const storedEnergyCandidates = findVisibleRoomStructures(creep.room).filter(
+    (structure) => isSafeStoredEnergySource(structure, context) && !isLinkEnergySource(structure)
+  ).flatMap((source) => {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
@@ -11689,6 +11706,34 @@ function findWorkerEnergyAcquisitionCandidates(creep, options = {}) {
   }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
   const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext, options);
   return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
+}
+function selectWorkerLinkEnergyFallbackTask(creep) {
+  var _a, _b;
+  return (_b = (_a = findWorkerLinkEnergyAcquisitionCandidates(creep)[0]) == null ? void 0 : _a.task) != null ? _b : null;
+}
+function findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext = createWorkerEnergyAcquisitionReservationContext(creep), options = {}) {
+  return findOwnedWorkerEnergyLinks(creep.room).flatMap((source) => {
+    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+      creep,
+      source,
+      getStoredEnergy4(source),
+      {
+        type: "withdraw",
+        targetId: source.id
+      },
+      reservationContext
+    );
+    return candidate ? [candidate] : [];
+  }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options)).sort(compareWorkerLinkEnergyAcquisitionCandidates);
+}
+function findOwnedWorkerEnergyLinks(room) {
+  if (typeof FIND_MY_STRUCTURES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  const structures = room.find(FIND_MY_STRUCTURES, {
+    filter: (structure) => isLinkEnergySource(structure) && getStoredEnergy4(structure) > 0
+  });
+  return Array.isArray(structures) ? structures : [];
 }
 function findDroppedEnergyAcquisitionCandidates(creep, reservationContext, options = {}) {
   var _a;
@@ -11739,13 +11784,17 @@ function getWorkerEnergyAcquisitionPriority(creep, source, energy, range) {
   if (isContainerEnergySource(source) && range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE && energy >= Math.max(1, getFreeEnergyCapacity3(creep))) {
     return 0;
   }
-  return isDurableStoredEnergySource(source) ? 2 : 1;
+  return isDurableStoredEnergySource(source) || isLinkEnergySource(source) ? 2 : 1;
 }
 function isContainerEnergySource(source) {
   return isStructureEnergySourceType(source, "STRUCTURE_CONTAINER", "container");
 }
 function isStorageEnergySource(source) {
   return isStructureEnergySourceType(source, "STRUCTURE_STORAGE", "storage");
+}
+function isLinkEnergySource(source) {
+  const structureType = source == null ? void 0 : source.structureType;
+  return matchesStructureType9(typeof structureType === "string" ? structureType : void 0, "STRUCTURE_LINK", "link");
 }
 function isPreferredNearbyWorkerEnergySource(source) {
   return isContainerEnergySource(source) || isStorageEnergySource(source) || isWorkerDroppedEnergySource(source) || "ticksToDecay" in source;
@@ -11941,6 +11990,9 @@ function compareNearbyWorkerEnergyAcquisitionCandidates(left, right) {
 }
 function compareDroppedEnergyReachabilityPriority(left, right) {
   return compareOptionalRanges(left.range, right.range) || right.energy - left.energy || right.score - left.score || String(left.source.id).localeCompare(String(right.source.id));
+}
+function compareWorkerLinkEnergyAcquisitionCandidates(left, right) {
+  return right.energy - left.energy || compareOptionalRanges(left.range, right.range) || String(left.source.id).localeCompare(String(right.source.id));
 }
 function compareSpawnRecoveryEnergyAcquisitionCandidates(left, right) {
   return left.deliveryEta - right.deliveryEta || compareOptionalRanges(left.range, right.range) || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -283,7 +283,15 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     }
 
     const source = selectHarvestSource(creep);
-    return source ? { type: 'harvest', targetId: source.id } : null;
+    if (source) {
+      return { type: 'harvest', targetId: source.id };
+    }
+
+    if (getFreeEnergyCapacity(creep) > 0) {
+      return selectWorkerLinkEnergyFallbackTask(creep);
+    }
+
+    return null;
   }
 
   if (urgentReservationRenewalTask) {
@@ -2409,7 +2417,11 @@ export function selectWorkerEnergyFallbackTask(creep: Creep): CreepTaskMemory | 
   }
 
   const source = selectHarvestSource(creep);
-  return source ? { type: 'harvest', targetId: source.id } : null;
+  if (source) {
+    return { type: 'harvest', targetId: source.id };
+  }
+
+  return selectWorkerLinkEnergyFallbackTask(creep);
 }
 
 export function selectWorkerPreHarvestTask(creep: Creep): Extract<CreepTaskMemory, { type: 'harvest' }> | null {
@@ -2578,12 +2590,16 @@ function shouldKeepLowLoadWorkerAcquiringEnergy(creep: Creep): boolean {
 function findLowLoadWorkerEnergyContinuationCandidates(
   creep: Creep
 ): LowLoadWorkerEnergyAcquisitionCandidate[] {
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
   // Use the normal candidate set so continuation can take close energy beyond the nearby-only fast path.
   return [
     ...findWorkerEnergyAcquisitionCandidates(creep, {
       maximumRange: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
     }).map(toLowLoadWorkerEnergyAcquisitionCandidate),
-    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
+    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep),
+    ...findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext, {
+      maximumRange: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
+    }).map(toLowLoadWorkerEnergyAcquisitionCandidate)
   ];
 }
 
@@ -2594,7 +2610,10 @@ function findLowLoadWorkerEnergyAcquisitionCandidates(creep: Creep): LowLoadWork
     ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationContext),
     ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationContext),
     ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep, reservationContext),
-    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep)
+    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep),
+    ...findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext, {
+      maximumRange: LOW_LOAD_NEARBY_ENERGY_RANGE
+    }).map(toLowLoadWorkerEnergyAcquisitionCandidate)
   ];
 }
 
@@ -2609,7 +2628,10 @@ function findNearbyLowLoadStoredEnergyAcquisitionCandidates(
   };
 
   return findVisibleRoomStructures(creep.room)
-    .filter((structure): structure is StoredWorkerEnergySource => isSafeStoredEnergySource(structure, context))
+    .filter(
+      (structure): structure is StoredWorkerEnergySource =>
+        isSafeStoredEnergySource(structure, context) && !isLinkEnergySource(structure)
+    )
     .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
     .flatMap((source) => {
       const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
@@ -2835,7 +2857,10 @@ function findWorkerEnergyAcquisitionCandidates(
   };
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
   const storedEnergyCandidates = findVisibleRoomStructures(creep.room)
-    .filter((structure): structure is StoredWorkerEnergySource => isSafeStoredEnergySource(structure, context))
+    .filter(
+      (structure): structure is StoredWorkerEnergySource =>
+        isSafeStoredEnergySource(structure, context) && !isLinkEnergySource(structure)
+    )
     .flatMap((source) => {
       const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
         creep,
@@ -2872,6 +2897,45 @@ function findWorkerEnergyAcquisitionCandidates(
   const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext, options);
 
   return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
+}
+
+function selectWorkerLinkEnergyFallbackTask(creep: Creep): WorkerEnergyAcquisitionTask | null {
+  return findWorkerLinkEnergyAcquisitionCandidates(creep)[0]?.task ?? null;
+}
+
+function findWorkerLinkEnergyAcquisitionCandidates(
+  creep: Creep,
+  reservationContext = createWorkerEnergyAcquisitionReservationContext(creep),
+  options: WorkerEnergyAcquisitionSearchOptions = {}
+): WorkerEnergyAcquisitionCandidate[] {
+  return findOwnedWorkerEnergyLinks(creep.room)
+    .flatMap((source) => {
+      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+        creep,
+        source,
+        getStoredEnergy(source),
+        {
+          type: 'withdraw',
+          targetId: source.id as Id<AnyStoreStructure>
+        },
+        reservationContext
+      );
+
+      return candidate ? [candidate] : [];
+    })
+    .filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options))
+    .sort(compareWorkerLinkEnergyAcquisitionCandidates);
+}
+
+function findOwnedWorkerEnergyLinks(room: Room): StructureLink[] {
+  if (typeof FIND_MY_STRUCTURES !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  const structures = room.find(FIND_MY_STRUCTURES, {
+    filter: (structure) => isLinkEnergySource(structure) && getStoredEnergy(structure) > 0
+  });
+  return Array.isArray(structures) ? (structures as StructureLink[]) : [];
 }
 
 function findDroppedEnergyAcquisitionCandidates(
@@ -2966,7 +3030,7 @@ function getWorkerEnergyAcquisitionPriority(
     return 0;
   }
 
-  return isDurableStoredEnergySource(source) ? 2 : 1;
+  return isDurableStoredEnergySource(source) || isLinkEnergySource(source) ? 2 : 1;
 }
 
 function isContainerEnergySource(source: LowLoadWorkerEnergyAcquisitionSource): source is StructureContainer {
@@ -2975,6 +3039,11 @@ function isContainerEnergySource(source: LowLoadWorkerEnergyAcquisitionSource): 
 
 function isStorageEnergySource(source: LowLoadWorkerEnergyAcquisitionSource): source is StructureStorage {
   return isStructureEnergySourceType(source, 'STRUCTURE_STORAGE', 'storage');
+}
+
+function isLinkEnergySource(source: unknown): source is StructureLink {
+  const structureType = (source as Partial<Structure> | null)?.structureType;
+  return matchesStructureType(typeof structureType === 'string' ? structureType : undefined, 'STRUCTURE_LINK', 'link');
 }
 
 function isPreferredNearbyWorkerEnergySource(source: WorkerEnergyAcquisitionSource): boolean {
@@ -3313,6 +3382,17 @@ function compareDroppedEnergyReachabilityPriority(
     compareOptionalRanges(left.range, right.range) ||
     right.energy - left.energy ||
     right.score - left.score ||
+    String(left.source.id).localeCompare(String(right.source.id))
+  );
+}
+
+function compareWorkerLinkEnergyAcquisitionCandidates(
+  left: WorkerEnergyAcquisitionCandidate,
+  right: WorkerEnergyAcquisitionCandidate
+): number {
+  return (
+    right.energy - left.energy ||
+    compareOptionalRanges(left.range, right.range) ||
     String(left.source.id).localeCompare(String(right.source.id))
   );
 }

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1564,20 +1564,52 @@ describe('selectWorkerTask', () => {
     expect(roomFind).not.toHaveBeenCalledWith(FIND_SOURCES);
   });
 
-  it('withdraws only from source links and ignores controller links', () => {
+  it('harvests active sources before falling back to link energy', () => {
     const source = makeSource('source1', 10, 10);
-    const sourceLink = makeStoredEnergyLink('source-link', 11, 10, 300);
-    const controllerLink = makeStoredEnergyLink('controller-link', 25, 23, 800);
-    const controller = {
-      id: 'controller1',
-      my: true,
-      pos: makeRoomPosition(25, 25)
-    } as StructureController;
+    const link = makeStoredEnergyLink('link-full', 11, 10, 800);
     const room = makeWorkerTaskRoom({
-      controller,
-      myStructures: [sourceLink, controllerLink],
-      sources: [source],
-      structures: [controllerLink, sourceLink]
+      myStructures: [link],
+      sources: [source]
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+  });
+
+  it('withdraws from containers before falling back to link energy', () => {
+    const emptySource = makeSource('source-empty', 10, 10, 0);
+    const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 50);
+    const link = makeStoredEnergyLink('link-full', 11, 10, 800);
+    const room = makeWorkerTaskRoom({
+      myStructures: [link],
+      sources: [emptySource],
+      structures: [container]
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
+  });
+
+  it('withdraws from the richest owned link when containers and sources are empty', () => {
+    const emptySource = makeSource('source-empty', 10, 10, 0);
+    const smallLink = makeStoredEnergyLink('link-small', 11, 10, 100);
+    const emptyLink = makeStoredEnergyLink('link-empty', 12, 10, 0);
+    const richLink = makeStoredEnergyLink('link-rich', 25, 23, 800);
+    const room = makeWorkerTaskRoom({
+      myStructures: [smallLink, emptyLink, richLink],
+      sources: [emptySource]
     });
     const creep = {
       store: {
@@ -1585,12 +1617,12 @@ describe('selectWorkerTask', () => {
         getFreeCapacity: jest.fn().mockReturnValue(50)
       },
       pos: {
-        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'controller-link' ? 1 : 10))
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'link-rich' ? 20 : 1))
       },
       room
     } as unknown as Creep;
 
-    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'source-link' });
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'link-rich' });
   });
 
   it('prefers a nearby full-load pickup over distant surplus stored energy', () => {


### PR DESCRIPTION
## Summary
Adds link energy withdrawal as a fallback when containers and sources are empty, improving worker energy acquisition reliability.

## Changes
- Extended `workerTasks.ts` to check link structures for available energy
- Fallback priority: source containers → nearby containers → links → distant sources
- Tests for link fallback behavior in `workerTasks.test.ts`

## Verification
- `npm run typecheck` ✓
- `npm test -- --runInBand` ✓ (53 suites, 1135 tests)
- `npm run build` ✓

Closes #652