### PR TITLE
feat(territory): auto-scout stale adjacent rooms to refresh expansion candidate intel

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5865,6 +5865,8 @@ var TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS = 1500;
 var TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS2 = 50;
 var TERRITORY_RECOVERED_INTENT_SPAWN_PRIORITY = 1e3;
 var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
+var GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS = globalThis.TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS;
+var TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS = typeof GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS === "number" && Number.isFinite(GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS) && GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS > 0 ? Math.floor(GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS) : 1500;
 var TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 0;
 var EXIT_DIRECTION_ORDER2 = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
@@ -6566,7 +6568,8 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
       gameTime,
       roleCounts,
       routeDistanceLookupContext
-    )
+    ),
+    gameTime
   );
   const persistedIntentCandidates = applyOccupationRecommendationScores(
     colony,
@@ -6579,7 +6582,8 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
       intents,
       gameTime,
       routeDistanceLookupContext
-    )
+    ),
+    gameTime
   );
   const primaryCandidates = getSpawnCapableTerritoryCandidates(
     filterTerritoryCandidatesForPlanningOptions(
@@ -6625,7 +6629,8 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
             roleCounts,
             routeDistanceLookupContext
           ) : []
-        ]
+        ],
+        gameTime
       ),
       options
     );
@@ -6644,30 +6649,36 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
     );
   }
   const adjacentCandidates = filterTerritoryCandidatesForPlanningOptions(
-    applyOccupationRecommendationScores(colony, roleCounts, workerTarget, [
-      ...getAdjacentReserveCandidates(
-        colonyName,
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        !hasBlockingConfiguredTarget,
-        "adjacent",
-        0,
-        routeDistanceLookupContext
-      ),
-      ...getAdjacentFollowUpReserveCandidates(
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        roleCounts,
-        !hasBlockingConfiguredTarget,
-        routeDistanceLookupContext
-      )
-    ]),
+    applyOccupationRecommendationScores(
+      colony,
+      roleCounts,
+      workerTarget,
+      [
+        ...getAdjacentReserveCandidates(
+          colonyName,
+          colonyName,
+          colonyOwnerUsername,
+          territoryMemory,
+          intents,
+          gameTime,
+          !hasBlockingConfiguredTarget,
+          "adjacent",
+          0,
+          routeDistanceLookupContext
+        ),
+        ...getAdjacentFollowUpReserveCandidates(
+          colonyName,
+          colonyOwnerUsername,
+          territoryMemory,
+          intents,
+          gameTime,
+          roleCounts,
+          !hasBlockingConfiguredTarget,
+          routeDistanceLookupContext
+        )
+      ],
+      gameTime
+    ),
     options
   );
   const candidates = getSpawnCapableTerritoryCandidates([...primaryCandidates, ...adjacentCandidates], colony);
@@ -7465,7 +7476,7 @@ function scoreTerritoryCandidate(selection, source, order, colonyName, colonyOwn
 function getInferredTerritoryRouteDistance(source) {
   return source === "adjacent" ? 1 : void 0;
 }
-function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, candidates) {
+function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, candidates, gameTime) {
   var _a;
   const colonyOwnerUsername = (_a = getControllerOwnerUsername3(colony.room.controller)) != null ? _a : void 0;
   const adjacentControllerProgressReady = isTerritoryHomeReadyForAdjacentControllerProgress(
@@ -7482,12 +7493,12 @@ function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, c
       workerCount: getWorkerCapacity(roleCounts),
       ...typeof ((_a2 = colony.room.controller) == null ? void 0 : _a2.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
       ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
-      candidates: [buildOccupationRecommendationCandidate(candidate)]
+      candidates: [buildOccupationRecommendationCandidate(candidate, gameTime)]
     }).candidates[0];
     if (!recommendation || recommendation.evidenceStatus === "unavailable") {
       return [];
     }
-    const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts);
+    const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts, gameTime);
     return [
       applyOccupationRecommendationScore(
         candidate,
@@ -7533,14 +7544,22 @@ function applyOccupationRecommendationScore(candidate, recommendation, roleCount
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
   };
 }
-function getAdjacentExpansionClaimDecision(candidate, roleCounts) {
+function getAdjacentExpansionClaimDecision(candidate, roleCounts, gameTime) {
   if (!isAdjacentExpansionClaimDecisionCandidate(candidate)) {
+    return "ignore";
+  }
+  if (shouldRefreshExpansionCandidateScoutIntel(
+    candidate.target.colony,
+    candidate.target.roomName,
+    getTerritoryMemoryRecord4(),
+    gameTime
+  )) {
     return "ignore";
   }
   const scoutIntel = getFreshTerritoryScoutIntel(
     candidate.target.colony,
     candidate.target.roomName,
-    getGameTime8()
+    gameTime
   );
   if (!isViableAdjacentExpansionClaimScoutIntel(scoutIntel)) {
     return "ignore";
@@ -7628,9 +7647,14 @@ function isAdjacentRoomReservationReserveSelection(selection) {
 function isRecoveredTerritoryFollowUpControlCandidate(candidate) {
   return candidate.recoveredFollowUp === true && candidate.followUp !== void 0 && isTerritoryControlAction3(candidate.intentAction);
 }
-function buildOccupationRecommendationCandidate(candidate) {
+function buildOccupationRecommendationCandidate(candidate, gameTime) {
   const room = getVisibleRoom(candidate.target.roomName);
-  const scoutIntel = room ? null : getFreshTerritoryScoutIntel(candidate.target.colony, candidate.target.roomName, getGameTime8());
+  const scoutIntel = room || shouldRefreshExpansionCandidateScoutIntel(
+    candidate.target.colony,
+    candidate.target.roomName,
+    getTerritoryMemoryRecord4(),
+    gameTime
+  ) ? null : getFreshTerritoryScoutIntel(candidate.target.colony, candidate.target.roomName, gameTime);
   return {
     roomName: candidate.target.roomName,
     source: candidate.source === "configured" ? "configured" : "adjacent",
@@ -7643,6 +7667,33 @@ function buildOccupationRecommendationCandidate(candidate) {
     ...candidate.ignoreOwnHealthyReservation === true ? { ignoreOwnHealthyReservation: true } : {},
     ...room ? buildVisibleOccupationRecommendationEvidence(room, candidate.target.controllerId) : scoutIntel ? buildScoutedOccupationRecommendationEvidence(scoutIntel) : {}
   };
+}
+function shouldRefreshExpansionCandidateScoutIntel(colonyName, roomName, territoryMemory, gameTime) {
+  if (isVisibleRoomKnown(roomName) || !hasPersistedAdjacentExpansionCandidate(colonyName, roomName, territoryMemory)) {
+    return false;
+  }
+  const scoutIntel = getTerritoryScoutIntel(colonyName, roomName);
+  if (!scoutIntel) {
+    return true;
+  }
+  return isTerritoryScoutIntelStaleForExpansionCandidate(scoutIntel, gameTime);
+}
+function hasPersistedAdjacentExpansionCandidate(colonyName, roomName, territoryMemory) {
+  if (!territoryMemory || !Array.isArray(territoryMemory.expansionCandidates)) {
+    return false;
+  }
+  return territoryMemory.expansionCandidates.some((rawCandidate) => {
+    if (!isRecord7(rawCandidate)) {
+      return false;
+    }
+    return rawCandidate.colony === colonyName && rawCandidate.roomName === roomName && rawCandidate.adjacentToOwnedRoom === true && rawCandidate.evidenceStatus !== "unavailable" && (rawCandidate.recommendedAction === "claim" || rawCandidate.recommendedAction === "scout");
+  });
+}
+function isTerritoryScoutIntelStaleForExpansionCandidate(scoutIntel, gameTime) {
+  if (gameTime < scoutIntel.updatedAt) {
+    return false;
+  }
+  return gameTime - scoutIntel.updatedAt > TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS;
 }
 function getFreshTerritoryScoutIntel(colony, roomName, gameTime) {
   const intel = getTerritoryScoutIntel(colony, roomName);

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -56,6 +56,15 @@ export const TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS = 1_500;
 export const TERRITORY_RECOVERED_FOLLOW_UP_RETRY_COOLDOWN_TICKS = 50;
 export const TERRITORY_RECOVERED_INTENT_SPAWN_PRIORITY = 1_000;
 export const TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
+const GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS = (globalThis as {
+  TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS?: number;
+}).TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS;
+export const TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS =
+  typeof GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS === 'number' &&
+  Number.isFinite(GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS) &&
+  GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS > 0
+    ? Math.floor(GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS)
+    : 1_500;
 // TERRITORY_READY already proves local worker recovery; use that floor for adjacent visible controller progress.
 export const TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 0;
 
@@ -1102,7 +1111,8 @@ function selectTerritoryTarget(
       gameTime,
       roleCounts,
       routeDistanceLookupContext
-    )
+    ),
+    gameTime
   );
   const persistedIntentCandidates = applyOccupationRecommendationScores(
     colony,
@@ -1115,7 +1125,8 @@ function selectTerritoryTarget(
       intents,
       gameTime,
       routeDistanceLookupContext
-    )
+    ),
+    gameTime
   );
   const primaryCandidates = getSpawnCapableTerritoryCandidates(
     filterTerritoryCandidatesForPlanningOptions(
@@ -1169,7 +1180,8 @@ function selectTerritoryTarget(
                 routeDistanceLookupContext
               )
             : [])
-        ]
+        ],
+        gameTime
       ),
       options
     );
@@ -1190,30 +1202,36 @@ function selectTerritoryTarget(
   }
 
   const adjacentCandidates = filterTerritoryCandidatesForPlanningOptions(
-    applyOccupationRecommendationScores(colony, roleCounts, workerTarget, [
-      ...getAdjacentReserveCandidates(
-        colonyName,
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        !hasBlockingConfiguredTarget,
-        'adjacent',
-        0,
-        routeDistanceLookupContext
-      ),
-      ...getAdjacentFollowUpReserveCandidates(
-        colonyName,
-        colonyOwnerUsername,
-        territoryMemory,
-        intents,
-        gameTime,
-        roleCounts,
-        !hasBlockingConfiguredTarget,
-        routeDistanceLookupContext
-      )
-    ]),
+    applyOccupationRecommendationScores(
+      colony,
+      roleCounts,
+      workerTarget,
+      [
+        ...getAdjacentReserveCandidates(
+          colonyName,
+          colonyName,
+          colonyOwnerUsername,
+          territoryMemory,
+          intents,
+          gameTime,
+          !hasBlockingConfiguredTarget,
+          'adjacent',
+          0,
+          routeDistanceLookupContext
+        ),
+        ...getAdjacentFollowUpReserveCandidates(
+          colonyName,
+          colonyOwnerUsername,
+          territoryMemory,
+          intents,
+          gameTime,
+          roleCounts,
+          !hasBlockingConfiguredTarget,
+          routeDistanceLookupContext
+        )
+      ],
+      gameTime
+    ),
     options
   );
   const candidates = getSpawnCapableTerritoryCandidates([...primaryCandidates, ...adjacentCandidates], colony);
@@ -2536,7 +2554,8 @@ function applyOccupationRecommendationScores(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
   workerTarget: number,
-  candidates: ScoredTerritoryTarget[]
+  candidates: ScoredTerritoryTarget[],
+  gameTime: number
 ): ScoredTerritoryTarget[] {
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller) ?? undefined;
   const adjacentControllerProgressReady = isTerritoryHomeReadyForAdjacentControllerProgress(
@@ -2554,14 +2573,14 @@ function applyOccupationRecommendationScores(
       ...(typeof colony.room.controller?.ticksToDowngrade === 'number'
         ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade }
         : {}),
-      candidates: [buildOccupationRecommendationCandidate(candidate)]
+      candidates: [buildOccupationRecommendationCandidate(candidate, gameTime)]
     }).candidates[0];
 
     if (!recommendation || recommendation.evidenceStatus === 'unavailable') {
       return [];
     }
 
-    const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts);
+    const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts, gameTime);
 
     return [
       applyOccupationRecommendationScore(
@@ -2628,16 +2647,28 @@ type AdjacentExpansionClaimDecision = 'claim' | 'defer' | 'ignore';
 
 function getAdjacentExpansionClaimDecision(
   candidate: ScoredTerritoryTarget,
-  roleCounts: RoleCounts
+  roleCounts: RoleCounts,
+  gameTime: number
 ): AdjacentExpansionClaimDecision {
   if (!isAdjacentExpansionClaimDecisionCandidate(candidate)) {
+    return 'ignore';
+  }
+
+  if (
+    shouldRefreshExpansionCandidateScoutIntel(
+      candidate.target.colony,
+      candidate.target.roomName,
+      getTerritoryMemoryRecord(),
+      gameTime
+    )
+  ) {
     return 'ignore';
   }
 
   const scoutIntel = getFreshTerritoryScoutIntel(
     candidate.target.colony,
     candidate.target.roomName,
-    getGameTime()
+    gameTime
   );
   if (!isViableAdjacentExpansionClaimScoutIntel(scoutIntel)) {
     return 'ignore';
@@ -2815,12 +2846,20 @@ function isRecoveredTerritoryFollowUpControlCandidate(candidate: ScoredTerritory
 }
 
 function buildOccupationRecommendationCandidate(
-  candidate: ScoredTerritoryTarget
+  candidate: ScoredTerritoryTarget,
+  gameTime: number
 ): OccupationRecommendationCandidateInput {
   const room = getVisibleRoom(candidate.target.roomName);
-  const scoutIntel = room
-    ? null
-    : getFreshTerritoryScoutIntel(candidate.target.colony, candidate.target.roomName, getGameTime());
+  const scoutIntel =
+    room ||
+    shouldRefreshExpansionCandidateScoutIntel(
+      candidate.target.colony,
+      candidate.target.roomName,
+      getTerritoryMemoryRecord(),
+      gameTime
+    )
+      ? null
+      : getFreshTerritoryScoutIntel(candidate.target.colony, candidate.target.roomName, gameTime);
   return {
     roomName: candidate.target.roomName,
     source: candidate.source === 'configured' ? 'configured' : 'adjacent',
@@ -2837,6 +2876,59 @@ function buildOccupationRecommendationCandidate(
         ? buildScoutedOccupationRecommendationEvidence(scoutIntel)
         : {})
   };
+}
+
+function shouldRefreshExpansionCandidateScoutIntel(
+  colonyName: string,
+  roomName: string,
+  territoryMemory: Record<string, unknown> | null,
+  gameTime: number
+): boolean {
+  if (isVisibleRoomKnown(roomName) || !hasPersistedAdjacentExpansionCandidate(colonyName, roomName, territoryMemory)) {
+    return false;
+  }
+
+  const scoutIntel = getTerritoryScoutIntel(colonyName, roomName);
+  if (!scoutIntel) {
+    return true;
+  }
+
+  return isTerritoryScoutIntelStaleForExpansionCandidate(scoutIntel, gameTime);
+}
+
+function hasPersistedAdjacentExpansionCandidate(
+  colonyName: string,
+  roomName: string,
+  territoryMemory: Record<string, unknown> | null
+): boolean {
+  if (!territoryMemory || !Array.isArray(territoryMemory.expansionCandidates)) {
+    return false;
+  }
+
+  return territoryMemory.expansionCandidates.some((rawCandidate) => {
+    if (!isRecord(rawCandidate)) {
+      return false;
+    }
+
+    return (
+      rawCandidate.colony === colonyName &&
+      rawCandidate.roomName === roomName &&
+      rawCandidate.adjacentToOwnedRoom === true &&
+      rawCandidate.evidenceStatus !== 'unavailable' &&
+      (rawCandidate.recommendedAction === 'claim' || rawCandidate.recommendedAction === 'scout')
+    );
+  });
+}
+
+function isTerritoryScoutIntelStaleForExpansionCandidate(
+  scoutIntel: TerritoryScoutIntelMemory,
+  gameTime: number
+): boolean {
+  if (gameTime < scoutIntel.updatedAt) {
+    return false;
+  }
+
+  return gameTime - scoutIntel.updatedAt > TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS;
 }
 
 function getFreshTerritoryScoutIntel(

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -18,7 +18,8 @@ import {
   TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS,
   TERRITORY_RESERVATION_RENEWAL_TICKS,
   TERRITORY_CLAIM_READY_TICKS,
-  TERRITORY_SUPPRESSION_RETRY_TICKS
+  TERRITORY_SUPPRESSION_RETRY_TICKS,
+  TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS
 } from '../src/territory/territoryPlanner';
 import type { AutonomousExpansionClaimEvaluation } from '../src/territory/claimExecutor';
 
@@ -242,6 +243,93 @@ describe('planTerritoryIntent', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 525,
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
+  it('refreshes stale expansion candidate scout intel before generic adjacent scouting', () => {
+    const colony = makeSafeColony();
+    const gameTime = 2_000;
+    const staleIntelUpdatedAt = gameTime - TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS - 1;
+    const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        expansionCandidates: [
+          makeExpansionCandidateMemory('W2N1', {
+            recommendedAction: 'claim',
+            evidenceStatus: 'sufficient',
+            controllerId: 'controller2' as Id<StructureController>,
+            sourceCount: 2
+          })
+        ],
+        scoutIntel: {
+          'W1N1>W2N1': makeScoutIntel('W2N1', staleIntelUpdatedAt)
+        }
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, gameTime)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'scout'
+    });
+    expect(describeExits).toHaveBeenCalledWith('W1N1');
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'scout',
+        status: 'planned',
+        updatedAt: gameTime
+      }
+    ]);
+  });
+
+  it('uses fresh expansion candidate scout intel without creating a refresh scout intent', () => {
+    const colony = makeSafeColony();
+    const gameTime = 2_000;
+    const freshIntelUpdatedAt = gameTime - TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS;
+    const describeExits = jest.fn(() => ({ '3': 'W2N1' }));
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      map: { describeExits } as unknown as GameMap
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        expansionCandidates: [
+          makeExpansionCandidateMemory('W2N1', {
+            recommendedAction: 'claim',
+            evidenceStatus: 'sufficient',
+            controllerId: 'controller2' as Id<StructureController>,
+            sourceCount: 2
+          })
+        ],
+        scoutIntel: {
+          'W1N1>W2N1': makeScoutIntel('W2N1', freshIntelUpdatedAt)
+        }
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, gameTime)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: gameTime,
         controllerId: 'controller2'
       }
     ]);
@@ -6548,6 +6636,46 @@ function makeAssignedRemoteMiningCreep(role: 'remoteHarvester' | 'hauler', roomN
           })
     }
   } as Creep;
+}
+
+function makeExpansionCandidateMemory(
+  roomName: string,
+  overrides: Partial<TerritoryExpansionCandidateMemory> = {}
+): TerritoryExpansionCandidateMemory {
+  return {
+    colony: 'W1N1',
+    roomName,
+    rank: 1,
+    score: 900,
+    evidenceStatus: 'insufficient-evidence',
+    visible: false,
+    updatedAt: 1_999,
+    adjacentToOwnedRoom: true,
+    recommendedAction: 'scout',
+    ...overrides
+  };
+}
+
+function makeScoutIntel(
+  roomName: string,
+  updatedAt: number,
+  overrides: Partial<TerritoryScoutIntelMemory> = {}
+): TerritoryScoutIntelMemory {
+  return {
+    colony: 'W1N1',
+    roomName,
+    updatedAt,
+    controller: { id: 'controller2' as Id<StructureController>, my: false },
+    sourceIds: ['source1', 'source2'],
+    sourceCount: 2,
+    sourceAccessPoints: 7,
+    controllerSourceRange: 9,
+    terrain: { walkableRatio: 0.92, swampRatio: 0.03, wallRatio: 0.08 },
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    hostileSpawnCount: 0,
+    ...overrides
+  };
 }
 
 function makeSafeColony({


### PR DESCRIPTION
## Summary
Adds auto-scouting of stale adjacent rooms to refresh expansion candidate intel. When scouting data for an adjacent room is older than a configurable threshold, the territory planner dispatches scout creeps to refresh it.

## Changes
- `territoryPlanner.ts`: Added scout-intent planning for stale adjacent rooms
- Tests verify stale rooms get scout intents, fresh rooms do not

Closes #656
