### PR TITLE
fix(spawn): prioritize critical spawn repair for damaged owned spawns (#653)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9895,6 +9895,7 @@ function getGameTick2() {
 // src/tasks/workerTasks.ts
 var CONTROLLER_DOWNGRADE_GUARD_TICKS = 5e3;
 var CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
+var CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25;
 var IDLE_RAMPART_REPAIR_HITS_CEILING2 = 1e5;
 var TOWER_REFILL_ENERGY_FLOOR = 500;
 var CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
@@ -11087,6 +11088,10 @@ function selectCriticalRoadConstructionSite(creep, constructionSites, constructi
   );
 }
 function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controller, constructionReservationContext) {
+  const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep);
+  if (criticalSpawnRepairTarget) {
+    return { type: "repair", targetId: criticalSpawnRepairTarget.id };
+  }
   const controllerRange = getRangeBetweenRoomObjects2(creep, controller);
   if (controllerRange === null) {
     return null;
@@ -11103,7 +11108,7 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
         canCompleteConstructionSiteWithCarriedEnergy(creep, site, constructionReservationContext)
       )
     ),
-    ...findVisibleRoomStructures(creep.room).filter(isSafeRepairTarget).map(
+    ...findVisibleRoomStructures(creep.room).filter((structure) => isSafeRepairTargetForWorkerRoom(creep, structure)).map(
       (structure) => createProductiveEnergySinkCandidate(
         creep,
         structure,
@@ -12075,6 +12080,10 @@ function selectRepairTarget(creep) {
 function selectCriticalInfrastructureRepairTarget(creep) {
   var _a;
   const visibleStructures = findVisibleRoomStructures(creep.room);
+  const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep, visibleStructures);
+  if (criticalSpawnRepairTarget) {
+    return criticalSpawnRepairTarget;
+  }
   const criticalRoadContext = visibleStructures.some(isCriticalRoadRepairCandidate) ? buildWorkerCriticalRoadLogisticsContext(creep) : null;
   const canRepairOwnedInfrastructure = ((_a = creep.room.controller) == null ? void 0 : _a.my) === true;
   const canRepairRemoteCriticalRoads = !canRepairOwnedInfrastructure && criticalRoadContext !== null && canRepairRemoteCriticalRoadInfrastructure(creep);
@@ -12091,6 +12100,13 @@ function selectCriticalInfrastructureRepairTarget(creep) {
     return null;
   }
   return repairTargets.sort(compareRepairTargets)[0];
+}
+function selectCriticalOwnedSpawnRepairTarget(creep, visibleStructures = findVisibleRoomStructures(creep.room)) {
+  var _a, _b;
+  if (((_a = creep.room.controller) == null ? void 0 : _a.my) !== true) {
+    return null;
+  }
+  return (_b = visibleStructures.filter(isCriticalOwnedSpawnRepairTarget).sort(compareRepairTargets)[0]) != null ? _b : null;
 }
 function canRepairRemoteCriticalRoadInfrastructure(creep) {
   var _a;
@@ -12120,10 +12136,17 @@ function isSafeRepairTarget(structure) {
   if (isWorkerRepairTargetComplete(structure)) {
     return false;
   }
+  if (isOwnedSpawnRepairTarget(structure)) {
+    return true;
+  }
   if (isRoadOrContainerRepairTarget(structure)) {
     return true;
   }
   return matchesStructureType9(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+}
+function isSafeRepairTargetForWorkerRoom(creep, structure) {
+  var _a;
+  return isSafeRepairTarget(structure) && (!isSpawnRepairTarget(structure) || ((_a = creep.room.controller) == null ? void 0 : _a.my) === true);
 }
 function isCriticalInfrastructureRepairTarget(structure, criticalRoadContext, options) {
   if (!isSafeRepairTarget(structure) || !isRoadOrContainerRepairTarget(structure) || getHitsRatio(structure) > CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO) {
@@ -12143,6 +12166,15 @@ function isRoadRepairTarget(structure) {
 function isContainerRepairTarget(structure) {
   return matchesStructureType9(structure.structureType, "STRUCTURE_CONTAINER", "container");
 }
+function isCriticalOwnedSpawnRepairTarget(structure) {
+  return isOwnedSpawnRepairTarget(structure) && !isWorkerRepairTargetComplete(structure) && getHitsRatio(structure) <= CRITICAL_SPAWN_REPAIR_HITS_RATIO;
+}
+function isOwnedSpawnRepairTarget(structure) {
+  return isSpawnRepairTarget(structure) && structure.my === true;
+}
+function isSpawnRepairTarget(structure) {
+  return matchesStructureType9(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+}
 function isWorkerRepairTargetComplete(structure) {
   return structure.hits >= getWorkerRepairHitsCeiling(structure);
 }
@@ -12159,13 +12191,19 @@ function compareRepairTargets(left, right) {
   return getRepairPriority(left) - getRepairPriority(right) || getHitsRatio(left) - getHitsRatio(right) || left.hits - right.hits || String(left.id).localeCompare(String(right.id));
 }
 function getRepairPriority(structure) {
-  if (matchesStructureType9(structure.structureType, "STRUCTURE_ROAD", "road")) {
+  if (isCriticalOwnedSpawnRepairTarget(structure)) {
     return 0;
   }
-  if (matchesStructureType9(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType9(structure.structureType, "STRUCTURE_ROAD", "road")) {
     return 1;
   }
-  return 2;
+  if (matchesStructureType9(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+    return 2;
+  }
+  if (isSpawnRepairTarget(structure)) {
+    return 3;
+  }
+  return 4;
 }
 function getHitsRatio(structure) {
   return structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10102,6 +10102,13 @@ function selectHeuristicWorkerTask(creep) {
     recordLowLoadReturnTelemetry(creep, downgradeGuardTask, "controllerDowngradeGuard");
     return downgradeGuardTask;
   }
+  const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep);
+  if (criticalSpawnRepairTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: "repair",
+      targetId: criticalSpawnRepairTarget.id
+    });
+  }
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   if (spawnOrExtensionEnergySink) {
     const spawnOrExtensionRefillTask = {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -36,6 +36,7 @@ import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 // Low-downgrade safety floor: enough buffer for worker travel/recovery without treating healthy controllers as urgent.
 export const CONTROLLER_DOWNGRADE_GUARD_TICKS = 5_000;
 export const CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO = 0.5;
+export const CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25;
 export const IDLE_RAMPART_REPAIR_HITS_CEILING = 100_000;
 export const TOWER_REFILL_ENERGY_FLOOR = 500;
 export const CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
@@ -84,8 +85,8 @@ const HARVEST_SOURCE_RANGE = 1;
 const HARVEST_SOURCE_CONTAINER_RANGE = 0;
 const MAX_HARVEST_PATH_OPS = 2_000;
 
-type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart;
-type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer;
+type RepairableWorkerStructure = StructureRoad | StructureContainer | StructureRampart | StructureSpawn;
+type CriticalInfrastructureRepairTarget = StructureRoad | StructureContainer | StructureSpawn;
 type StoredWorkerEnergySource = StructureContainer | StructureStorage | StructureTerminal | StructureLink;
 type UpgraderBoostStoredEnergySource = StructureContainer | StructureStorage;
 type SalvageableWorkerEnergySource = Tombstone | Ruin;
@@ -1865,6 +1866,11 @@ function selectNearbyProductiveEnergySinkTask(
   controller: StructureController,
   constructionReservationContext: ConstructionReservationContext
 ): ProductiveEnergySinkTask | null {
+  const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep);
+  if (criticalSpawnRepairTarget) {
+    return { type: 'repair', targetId: criticalSpawnRepairTarget.id as Id<Structure> };
+  }
+
   const controllerRange = getRangeBetweenRoomObjects(creep, controller);
   if (controllerRange === null) {
     return null;
@@ -1887,7 +1893,7 @@ function selectNearbyProductiveEnergySinkTask(
         )
       ),
     ...findVisibleRoomStructures(creep.room)
-      .filter(isSafeRepairTarget)
+      .filter((structure) => isSafeRepairTargetForWorkerRoom(creep, structure))
       .map((structure) =>
         createProductiveEnergySinkCandidate(
           creep,
@@ -3500,6 +3506,11 @@ function selectRepairTarget(creep: Creep): RepairableWorkerStructure | null {
 
 function selectCriticalInfrastructureRepairTarget(creep: Creep): CriticalInfrastructureRepairTarget | null {
   const visibleStructures = findVisibleRoomStructures(creep.room);
+  const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep, visibleStructures);
+  if (criticalSpawnRepairTarget) {
+    return criticalSpawnRepairTarget;
+  }
+
   const criticalRoadContext = visibleStructures.some(isCriticalRoadRepairCandidate)
     ? buildWorkerCriticalRoadLogisticsContext(creep)
     : null;
@@ -3524,6 +3535,17 @@ function selectCriticalInfrastructureRepairTarget(creep: Creep): CriticalInfrast
   }
 
   return repairTargets.sort(compareRepairTargets)[0];
+}
+
+function selectCriticalOwnedSpawnRepairTarget(
+  creep: Creep,
+  visibleStructures = findVisibleRoomStructures(creep.room)
+): StructureSpawn | null {
+  if (creep.room.controller?.my !== true) {
+    return null;
+  }
+
+  return visibleStructures.filter(isCriticalOwnedSpawnRepairTarget).sort(compareRepairTargets)[0] ?? null;
 }
 
 function canRepairRemoteCriticalRoadInfrastructure(creep: Creep): boolean {
@@ -3565,11 +3587,22 @@ function isSafeRepairTarget(structure: AnyStructure): structure is RepairableWor
     return false;
   }
 
+  if (isOwnedSpawnRepairTarget(structure)) {
+    return true;
+  }
+
   if (isRoadOrContainerRepairTarget(structure)) {
     return true;
   }
 
   return matchesStructureType(structure.structureType, 'STRUCTURE_RAMPART', 'rampart') && isOwnedRampart(structure);
+}
+
+function isSafeRepairTargetForWorkerRoom(
+  creep: Creep,
+  structure: AnyStructure
+): structure is RepairableWorkerStructure {
+  return isSafeRepairTarget(structure) && (!isSpawnRepairTarget(structure) || creep.room.controller?.my === true);
 }
 
 function isCriticalInfrastructureRepairTarget(
@@ -3613,6 +3646,22 @@ function isContainerRepairTarget(structure: AnyStructure): structure is Structur
   return matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container');
 }
 
+function isCriticalOwnedSpawnRepairTarget(structure: AnyStructure): structure is StructureSpawn {
+  return (
+    isOwnedSpawnRepairTarget(structure) &&
+    !isWorkerRepairTargetComplete(structure) &&
+    getHitsRatio(structure) <= CRITICAL_SPAWN_REPAIR_HITS_RATIO
+  );
+}
+
+function isOwnedSpawnRepairTarget(structure: AnyStructure): structure is StructureSpawn {
+  return isSpawnRepairTarget(structure) && (structure as Partial<StructureSpawn>).my === true;
+}
+
+function isSpawnRepairTarget(structure: AnyStructure): structure is StructureSpawn {
+  return matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn');
+}
+
 export function isWorkerRepairTargetComplete(structure: Structure): boolean {
   return structure.hits >= getWorkerRepairHitsCeiling(structure);
 }
@@ -3639,15 +3688,23 @@ function compareRepairTargets(left: RepairableWorkerStructure, right: Repairable
 }
 
 function getRepairPriority(structure: RepairableWorkerStructure): number {
-  if (matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road')) {
+  if (isCriticalOwnedSpawnRepairTarget(structure)) {
     return 0;
   }
 
-  if (matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')) {
+  if (matchesStructureType(structure.structureType, 'STRUCTURE_ROAD', 'road')) {
     return 1;
   }
 
-  return 2;
+  if (matchesStructureType(structure.structureType, 'STRUCTURE_CONTAINER', 'container')) {
+    return 2;
+  }
+
+  if (isSpawnRepairTarget(structure)) {
+    return 3;
+  }
+
+  return 4;
 }
 
 function getHitsRatio(structure: Structure): number {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -318,6 +318,14 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return downgradeGuardTask;
   }
 
+  const criticalSpawnRepairTarget = selectCriticalOwnedSpawnRepairTarget(creep);
+  if (criticalSpawnRepairTarget) {
+    return applyMinimumUsefulLoadPolicy(creep, {
+      type: 'repair',
+      targetId: criticalSpawnRepairTarget.id as Id<Structure>
+    });
+  }
+
   const spawnOrExtensionEnergySink = selectSpawnOrExtensionEnergySink(creep);
   if (spawnOrExtensionEnergySink) {
     const spawnOrExtensionRefillTask: Extract<CreepTaskMemory, { type: 'transfer' }> = {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -2,6 +2,7 @@ import {
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   CRITICAL_ROAD_CONTAINER_REPAIR_HITS_RATIO,
+  CRITICAL_SPAWN_REPAIR_HITS_RATIO,
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   BUILDER_DROPPED_PICKUP_RANGE,
   BUILDER_STORAGE_WITHDRAW_MIN,
@@ -116,6 +117,19 @@ function makeSpawn(id: string, x: number, y: number, roomName = 'W1N1'): Structu
     pos: makeRoomPosition(x, y, roomName),
     store: { getFreeCapacity: jest.fn().mockReturnValue(0) }
   } as unknown as StructureSpawn;
+}
+
+function makeRepairSpawn(
+  id: string,
+  hits: number,
+  hitsMax = 5_000,
+  extra: Record<string, unknown> = {}
+): StructureSpawn {
+  return makeStructure(id, 'spawn' as StructureConstant, hits, hitsMax, {
+    my: true,
+    store: { getFreeCapacity: jest.fn().mockReturnValue(0) },
+    ...extra
+  }) as StructureSpawn;
 }
 
 function makeTowerEnergySink(id: string, usedEnergy: number, freeCapacity: number): StructureTower {
@@ -6277,6 +6291,63 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: `${structureType}-critical` });
   });
 
+  it('repairs a critically damaged owned spawn before roads, containers, and ramparts', () => {
+    const site = { id: 'generic-site1', structureType: 'tower' } as ConstructionSite;
+    const spawn = makeRepairSpawn(
+      'spawn-critical',
+      Math.floor(5_000 * CRITICAL_SPAWN_REPAIR_HITS_RATIO),
+      5_000,
+      { pos: makeRoomPosition(10, 10) }
+    );
+    const source = makeSource('source1', 20, 10);
+    const road = makeStructure('road-critical', 'road' as StructureConstant, 1_000, 5_000, {
+      pos: makeRoomPosition(12, 10)
+    });
+    const container = makeStructure('container-critical', 'container' as StructureConstant, 100, 2_000);
+    const rampart = makeStructure('rampart-low', 'rampart' as StructureConstant, 1, 300_000_000, {
+      my: true
+    });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        constructionSites: [site],
+        myStructures: [spawn as AnyOwnedStructure],
+        sources: [source],
+        structures: [road, container, rampart, spawn]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'spawn-critical' });
+  });
+
+  it('keeps healthy damaged spawns behind critical infrastructure repair', () => {
+    const spawn = makeRepairSpawn(
+      'spawn-damaged',
+      Math.floor(5_000 * CRITICAL_SPAWN_REPAIR_HITS_RATIO) + 1
+    );
+    const container = makeStructure('container-critical', 'container' as StructureConstant, 100, 2_000);
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({
+        myStructures: [spawn as AnyOwnedStructure],
+        structures: [spawn, container]
+      })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'container-critical' });
+  });
+
+  it('skips non-owned spawns as repair targets', () => {
+    const controller = { id: 'controller1', my: true } as StructureController;
+    const spawn = makeRepairSpawn('spawn-hostile', 100, 5_000, { my: false });
+    const creep = {
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      room: makeWorkerTaskRoom({ controller, structures: [spawn] })
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
   it('keeps non-critical road and container repair behind generic construction', () => {
     const site = { id: 'generic-site1', structureType: 'tower' } as ConstructionSite;
     const road = makeStructure(
@@ -9574,6 +9645,47 @@ describe('selectWorkerTask', () => {
     setGameCreeps({ LaneWorker: creep });
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'upgrade', targetId: 'controller1' });
+  });
+
+  it('routes a loaded source2/controller lane worker to critical spawn repair before upgrading', () => {
+    const source1 = makeSource('source1', 8, 8);
+    const source2 = makeSource('source2', 24, 23);
+    const spawn = makeRepairSpawn(
+      'spawn-critical',
+      Math.floor(5_000 * CRITICAL_SPAWN_REPAIR_HITS_RATIO),
+      5_000,
+      { pos: makeRoomPosition(10, 10) }
+    );
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS + 1,
+      pos: makeRoomPosition(25, 25)
+    } as StructureController;
+    const room = makeWorkerTaskRoom({
+      controller,
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [source1, source2],
+      structures: [spawn]
+    });
+    const getRangeTo = jest.fn((target: RoomObject) => {
+      const ranges: Record<string, number> = {
+        'spawn-critical': 8,
+        controller1: 1
+      };
+      return ranges[String((target as { id?: string }).id)] ?? 99;
+    });
+    const creep = {
+      name: 'LaneWorker',
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: { getUsedCapacity: jest.fn().mockReturnValue(50) },
+      pos: { ...makeRoomPosition(25, 24), getRangeTo } as unknown as RoomPosition,
+      room
+    } as unknown as Creep;
+    setGameCreeps({ LaneWorker: creep });
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'repair', targetId: 'spawn-critical' });
   });
 
   it('uses nearby generic construction before source2/controller lane upgrade', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -35,6 +35,8 @@ import {
   TERRITORY_RESERVATION_RENEWAL_TICKS
 } from '../src/territory/territoryPlanner';
 
+const TEST_CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25 as const;
+
 type TestEnergySink = StructureSpawn | StructureExtension | StructureTower;
 
 function makeLoadedWorker(room: Room, task?: CreepTaskMemory): Creep {
@@ -360,6 +362,10 @@ describe('selectWorkerTask', () => {
     delete (globalThis as unknown as { PathFinder?: Partial<PathFinder> }).PathFinder;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     (globalThis as unknown as { Game?: Partial<Game> }).Game = { creeps: {} };
+  });
+
+  it('pins the critical spawn repair threshold at 25 percent', () => {
+    expect(CRITICAL_SPAWN_REPAIR_HITS_RATIO).toBe(TEST_CRITICAL_SPAWN_REPAIR_HITS_RATIO);
   });
 
   it('selects harvest when worker has no energy', () => {
@@ -6421,7 +6427,7 @@ describe('selectWorkerTask', () => {
     const site = { id: 'generic-site1', structureType: 'tower' } as ConstructionSite;
     const spawn = makeRepairSpawn(
       'spawn-critical',
-      Math.floor(5_000 * CRITICAL_SPAWN_REPAIR_HITS_RATIO),
+      Math.floor(5_000 * TEST_CRITICAL_SPAWN_REPAIR_HITS_RATIO),
       5_000,
       { pos: makeRoomPosition(10, 10) }
     );
@@ -6449,7 +6455,7 @@ describe('selectWorkerTask', () => {
   it('keeps healthy damaged spawns behind critical infrastructure repair', () => {
     const spawn = makeRepairSpawn(
       'spawn-damaged',
-      Math.floor(5_000 * CRITICAL_SPAWN_REPAIR_HITS_RATIO) + 1
+      Math.floor(5_000 * TEST_CRITICAL_SPAWN_REPAIR_HITS_RATIO) + 1
     );
     const container = makeStructure('container-critical', 'container' as StructureConstant, 100, 2_000);
     const creep = {
@@ -9778,7 +9784,7 @@ describe('selectWorkerTask', () => {
     const source2 = makeSource('source2', 24, 23);
     const spawn = makeRepairSpawn(
       'spawn-critical',
-      Math.floor(5_000 * CRITICAL_SPAWN_REPAIR_HITS_RATIO),
+      Math.floor(5_000 * TEST_CRITICAL_SPAWN_REPAIR_HITS_RATIO),
       5_000,
       { pos: makeRoomPosition(10, 10) }
     );


### PR DESCRIPTION
## Summary
Adds critical spawn repair prioritization to the worker task system. When an owned spawn falls below 25% HP (CRITICAL_SPAWN_REPAIR_HITS_RATIO = 0.25), workers will prioritize repairing it over other infrastructure.

## Changes
- `prod/src/tasks/workerTasks.ts`: Added `CRITICAL_SPAWN_REPAIR_HITS_RATIO`, expanded `RepairableWorkerStructure` and `CriticalInfrastructureRepairTarget` to include `StructureSpawn`, added `selectCriticalOwnedSpawnRepairTarget()` helper, integrated spawn repair into `selectNearbyProductiveEnergySinkTask()` and `selectCriticalInfrastructureRepairTarget()`, updated `isSafeRepairTarget` to accept owned spawns
- `prod/test/workerTasks.test.ts`: 112 lines of new test coverage for critical spawn repair logic
- `prod/dist/main.js`: Generated bundle

## Verification
- TypeScript: ✅ passes
- Jest: ✅ 53 suites / 1148 tests pass
- Build: ✅ dist/main.js clean (no drift after rebuild)
- Controller-verified before commit

Closes #653
