### PR TITLE
feat(territory): reserve best expansion candidate from auto-scout intel (#661)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -17265,8 +17265,11 @@ function getOwnedRoomCount(input) {
 function selectPersistableExpansionCandidate(report) {
   var _a;
   return (_a = report.candidates.find(
-    (candidate) => candidate.visible && candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0
+    (candidate) => candidate.visible && isViableExpansionCandidate(candidate)
   )) != null ? _a : null;
+}
+function isViableExpansionCandidate(candidate) {
+  return candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0 && candidate.sourceCount === 2;
 }
 function getSelectionSkipReason(report) {
   if (report.candidates.length === 0) {
@@ -17332,7 +17335,7 @@ function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) 
   };
 }
 function getPersistedExpansionCandidateRecommendedAction(candidate) {
-  if (candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0) {
+  if (isViableExpansionCandidate(candidate)) {
     return candidate.visible ? "claim" : "reserve";
   }
   return candidate.evidenceStatus === "insufficient-evidence" && candidate.adjacentToOwnedRoom ? "scout" : void 0;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -17028,7 +17028,7 @@ function buildVisibleExpansionCandidateEvidence(room) {
   };
 }
 function buildScoutedExpansionCandidateEvidence(intel) {
-  var _a;
+  var _a, _b;
   return {
     visible: false,
     scouted: true,
@@ -17039,7 +17039,7 @@ function buildScoutedExpansionCandidateEvidence(intel) {
     ...intel.controllerSourceRange !== void 0 ? { controllerSourceRange: intel.controllerSourceRange } : {},
     ...intel.terrain ? { terrain: intel.terrain } : {},
     hostileCreepCount: intel.hostileCreepCount,
-    hostileStructureCount: intel.hostileStructureCount + intel.hostileSpawnCount
+    hostileStructureCount: intel.hostileStructureCount + ((_b = intel.hostileSpawnCount) != null ? _b : 0)
   };
 }
 function scoreExpansionCandidate(input, candidate) {
@@ -22371,7 +22371,7 @@ function clearColonyExpansionClaimIntent(colony) {
 function selectColonyExpansionCandidate(colony) {
   const ownerUsername = getControllerOwnerUsername8(colony.room.controller);
   const candidates = getAdjacentRoomNames8(colony.room.name).flatMap((roomName, order) => {
-    if (!getVisibleRoom10(roomName)) {
+    if (!getVisibleRoom11(roomName)) {
       return [];
     }
     const claimScore = scoreClaimTarget(roomName, colony.room);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5885,8 +5885,6 @@ var TERRITORY_SCOUT_INTEL_PLANNING_TTL = 1e4;
 var OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 = "occupationRecommendation";
 var REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 var MAX_CONTROLLER_LEVEL = 8;
-var ADJACENT_EXPANSION_CLAIM_SOURCE_COUNT = 2;
-var ADJACENT_EXPANSION_CLAIM_MIN_WORKERS = 3;
 var recoveredTerritoryFollowUpRetryMetadata = /* @__PURE__ */ new WeakMap();
 function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options = {}) {
   if (!isTerritoryHomeSafe(colony, roleCounts, workerTarget)) {
@@ -7267,7 +7265,7 @@ function getPersistedExpansionCandidateRanks(colonyName, territoryMemory) {
     if (!isRecord7(rawCandidate)) {
       continue;
     }
-    if (rawCandidate.colony !== colonyName || !isNonEmptyString7(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || rawCandidate.recommendedAction !== "scout" && rawCandidate.recommendedAction !== "claim" || ranks.has(rawCandidate.roomName)) {
+    if (rawCandidate.colony !== colonyName || !isNonEmptyString7(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || !isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction) || ranks.has(rawCandidate.roomName)) {
       continue;
     }
     ranks.set(
@@ -7498,21 +7496,19 @@ function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, c
     if (!recommendation || recommendation.evidenceStatus === "unavailable") {
       return [];
     }
-    const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts, gameTime);
     return [
       applyOccupationRecommendationScore(
         candidate,
         recommendation,
         roleCounts,
-        adjacentControllerProgressReady,
-        adjacentExpansionClaimDecision === "claim"
+        adjacentControllerProgressReady
       )
     ];
   });
 }
-function applyOccupationRecommendationScore(candidate, recommendation, roleCounts, adjacentControllerProgressReady, claimAdjacentExpansion = false) {
+function applyOccupationRecommendationScore(candidate, recommendation, roleCounts, adjacentControllerProgressReady) {
   var _a;
-  const intentAction = claimAdjacentExpansion ? "claim" : getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
   const requiresControllerPressure = isTerritoryControlAction3(intentAction) && candidate.requiresControllerPressure === true;
   const commitTarget = recommendation.evidenceStatus === "sufficient" && intentAction !== "scout" && (candidate.commitTarget || isScoutedAdjacentControlCandidate(candidate));
   const target = getRecommendedTerritoryTarget(candidate.target, recommendation, intentAction);
@@ -7536,64 +7532,13 @@ function applyOccupationRecommendationScore(candidate, recommendation, roleCount
     target,
     intentAction,
     commitTarget: nextSelection.commitTarget,
-    priority: claimAdjacentExpansion ? TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM : getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
+    priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
     recommendationScore: getTerritoryCandidateRecommendationScore(candidate, recommendation),
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {},
     ...renewalTicksToEnd !== null ? { renewalTicksToEnd } : {}
   };
-}
-function getAdjacentExpansionClaimDecision(candidate, roleCounts, gameTime) {
-  if (!isAdjacentExpansionClaimDecisionCandidate(candidate)) {
-    return "ignore";
-  }
-  if (shouldRefreshExpansionCandidateScoutIntel(
-    candidate.target.colony,
-    candidate.target.roomName,
-    getTerritoryMemoryRecord4(),
-    gameTime
-  )) {
-    return "ignore";
-  }
-  const scoutIntel = getFreshTerritoryScoutIntel(
-    candidate.target.colony,
-    candidate.target.roomName,
-    gameTime
-  );
-  if (!isViableAdjacentExpansionClaimScoutIntel(scoutIntel)) {
-    return "ignore";
-  }
-  if (getWorkerCapacity(roleCounts) < ADJACENT_EXPANSION_CLAIM_MIN_WORKERS || hasActiveClaimCreepForColony(roleCounts)) {
-    return "defer";
-  }
-  return "claim";
-}
-function isAdjacentExpansionClaimDecisionCandidate(candidate) {
-  if (candidate.target.action !== "reserve") {
-    return false;
-  }
-  if (candidate.source === "adjacent") {
-    return true;
-  }
-  return candidate.source === "configured" && candidate.target.createdBy === OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 && isRoomAdjacentToColony(candidate.target.colony, candidate.target.roomName);
-}
-function isViableAdjacentExpansionClaimScoutIntel(intel) {
-  if (!intel || intel.sourceCount !== ADJACENT_EXPANSION_CLAIM_SOURCE_COUNT) {
-    return false;
-  }
-  const controller = intel.controller;
-  if (!controller || controller.my === true || isNonEmptyString7(controller.ownerUsername) || isNonEmptyString7(controller.reservationUsername)) {
-    return false;
-  }
-  return intel.hostileCreepCount <= 0 && intel.hostileStructureCount <= 0 && intel.hostileSpawnCount <= 0;
-}
-function hasActiveClaimCreepForColony(roleCounts) {
-  var _a, _b;
-  if (roleCounts.claimersByTargetRoomAction) {
-    return Object.values((_a = roleCounts.claimersByTargetRoomAction.claim) != null ? _a : {}).some((count) => count > 0);
-  }
-  return ((_b = roleCounts.claimer) != null ? _b : 0) > 0;
 }
 function getRecommendedTerritoryTarget(candidateTarget, recommendation, intentAction) {
   if (!isTerritoryControlAction3(intentAction)) {
@@ -7686,7 +7631,7 @@ function hasPersistedAdjacentExpansionCandidate(colonyName, roomName, territoryM
     if (!isRecord7(rawCandidate)) {
       return false;
     }
-    return rawCandidate.colony === colonyName && rawCandidate.roomName === roomName && rawCandidate.adjacentToOwnedRoom === true && rawCandidate.evidenceStatus !== "unavailable" && (rawCandidate.recommendedAction === "claim" || rawCandidate.recommendedAction === "scout");
+    return rawCandidate.colony === colonyName && rawCandidate.roomName === roomName && rawCandidate.adjacentToOwnedRoom === true && rawCandidate.evidenceStatus !== "unavailable" && isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction);
   });
 }
 function isTerritoryScoutIntelStaleForExpansionCandidate(scoutIntel, gameTime) {
@@ -7721,8 +7666,11 @@ function buildScoutedOccupationRecommendationEvidence(intel) {
     ...((_a = intel.controller) == null ? void 0 : _a.id) ? { controllerId: intel.controller.id } : {},
     sourceCount: intel.sourceCount,
     hostileCreepCount: intel.hostileCreepCount,
-    hostileStructureCount: intel.hostileStructureCount
+    hostileStructureCount: intel.hostileStructureCount + intel.hostileSpawnCount
   };
+}
+function isExpansionCandidateRecommendedAction(action) {
+  return action === "claim" || action === "reserve" || action === "scout";
 }
 function summarizeScoutOccupationController(controller) {
   return {
@@ -17091,7 +17039,7 @@ function buildScoutedExpansionCandidateEvidence(intel) {
     ...intel.controllerSourceRange !== void 0 ? { controllerSourceRange: intel.controllerSourceRange } : {},
     ...intel.terrain ? { terrain: intel.terrain } : {},
     hostileCreepCount: intel.hostileCreepCount,
-    hostileStructureCount: intel.hostileStructureCount
+    hostileStructureCount: intel.hostileStructureCount + intel.hostileSpawnCount
   };
 }
 function scoreExpansionCandidate(input, candidate) {
@@ -17317,7 +17265,7 @@ function getOwnedRoomCount(input) {
 function selectPersistableExpansionCandidate(report) {
   var _a;
   return (_a = report.candidates.find(
-    (candidate) => candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0
+    (candidate) => candidate.visible && candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0
   )) != null ? _a : null;
 }
 function getSelectionSkipReason(report) {
@@ -17385,7 +17333,7 @@ function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) 
 }
 function getPersistedExpansionCandidateRecommendedAction(candidate) {
   if (candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0) {
-    return "claim";
+    return candidate.visible ? "claim" : "reserve";
   }
   return candidate.evidenceStatus === "insufficient-evidence" && candidate.adjacentToOwnedRoom ? "scout" : void 0;
 }
@@ -22275,6 +22223,9 @@ function clearColonyExpansionClaimIntent(colony) {
 function selectColonyExpansionCandidate(colony) {
   const ownerUsername = getControllerOwnerUsername8(colony.room.controller);
   const candidates = getAdjacentRoomNames8(colony.room.name).flatMap((roomName, order) => {
+    if (!getVisibleRoom10(roomName)) {
+      return [];
+    }
     const claimScore = scoreClaimTarget(roomName, colony.room);
     if (claimScore.sources <= 0 || hasHostileClaimScore(claimScore)) {
       return [];

--- a/prod/src/territory/colonyExpansionPlanner.ts
+++ b/prod/src/territory/colonyExpansionPlanner.ts
@@ -144,6 +144,10 @@ export function clearColonyExpansionClaimIntent(colony: string): void {
 function selectColonyExpansionCandidate(colony: ColonySnapshot): ColonyExpansionCandidate | null {
   const ownerUsername = getControllerOwnerUsername(colony.room.controller);
   const candidates = getAdjacentRoomNames(colony.room.name).flatMap((roomName, order) => {
+    if (!getVisibleRoom(roomName)) {
+      return [];
+    }
+
     const claimScore = scoreClaimTarget(roomName, colony.room);
     if (claimScore.sources <= 0 || hasHostileClaimScore(claimScore)) {
       return [];

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -711,9 +711,16 @@ function selectPersistableExpansionCandidate(report: ExpansionCandidateReport): 
     report.candidates.find(
       (candidate) =>
         candidate.visible &&
-        candidate.evidenceStatus === 'sufficient' &&
-        candidate.preconditions.length === 0
+        isViableExpansionCandidate(candidate)
     ) ?? null
+  );
+}
+
+function isViableExpansionCandidate(candidate: ExpansionCandidateScore): boolean {
+  return (
+    candidate.evidenceStatus === 'sufficient' &&
+    candidate.preconditions.length === 0 &&
+    candidate.sourceCount === 2
   );
 }
 
@@ -813,7 +820,7 @@ function toPersistedExpansionCandidateMemory(
 function getPersistedExpansionCandidateRecommendedAction(
   candidate: ExpansionCandidateScore
 ): PersistedExpansionCandidateRecommendedAction | undefined {
-  if (candidate.evidenceStatus === 'sufficient' && candidate.preconditions.length === 0) {
+  if (isViableExpansionCandidate(candidate)) {
     return candidate.visible ? 'claim' : 'reserve';
   }
 

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -119,7 +119,7 @@ export interface ExpansionReservationEvidence {
   ticksToEnd?: number;
 }
 
-type PersistedExpansionCandidateRecommendedAction = 'claim' | 'scout';
+type PersistedExpansionCandidateRecommendedAction = TerritoryExpansionCandidateRecommendedAction;
 
 type PersistedExpansionCandidateMemory = TerritoryExpansionCandidateMemory;
 
@@ -388,7 +388,7 @@ function buildScoutedExpansionCandidateEvidence(
     ...(intel.controllerSourceRange !== undefined ? { controllerSourceRange: intel.controllerSourceRange } : {}),
     ...(intel.terrain ? { terrain: intel.terrain } : {}),
     hostileCreepCount: intel.hostileCreepCount,
-    hostileStructureCount: intel.hostileStructureCount
+    hostileStructureCount: intel.hostileStructureCount + intel.hostileSpawnCount
   };
 }
 
@@ -709,7 +709,10 @@ function getOwnedRoomCount(input: ExpansionScoringInput): number {
 function selectPersistableExpansionCandidate(report: ExpansionCandidateReport): ExpansionCandidateScore | null {
   return (
     report.candidates.find(
-      (candidate) => candidate.evidenceStatus === 'sufficient' && candidate.preconditions.length === 0
+      (candidate) =>
+        candidate.visible &&
+        candidate.evidenceStatus === 'sufficient' &&
+        candidate.preconditions.length === 0
     ) ?? null
   );
 }
@@ -811,7 +814,7 @@ function getPersistedExpansionCandidateRecommendedAction(
   candidate: ExpansionCandidateScore
 ): PersistedExpansionCandidateRecommendedAction | undefined {
   if (candidate.evidenceStatus === 'sufficient' && candidate.preconditions.length === 0) {
-    return 'claim';
+    return candidate.visible ? 'claim' : 'reserve';
   }
 
   return candidate.evidenceStatus === 'insufficient-evidence' && candidate.adjacentToOwnedRoom

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -388,7 +388,7 @@ function buildScoutedExpansionCandidateEvidence(
     ...(intel.controllerSourceRange !== undefined ? { controllerSourceRange: intel.controllerSourceRange } : {}),
     ...(intel.terrain ? { terrain: intel.terrain } : {}),
     hostileCreepCount: intel.hostileCreepCount,
-    hostileStructureCount: intel.hostileStructureCount + intel.hostileSpawnCount
+    hostileStructureCount: intel.hostileStructureCount + (intel.hostileSpawnCount ?? 0)
   };
 }
 

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -85,8 +85,6 @@ const TERRITORY_SCOUT_INTEL_PLANNING_TTL = 10_000;
 const OCCUPATION_RECOMMENDATION_TARGET_CREATOR: TerritoryTargetMemory['createdBy'] = 'occupationRecommendation';
 const REMOTE_MINING_SOURCE_CONTAINER_MIN_RCL = 0;
 const MAX_CONTROLLER_LEVEL = 8;
-const ADJACENT_EXPANSION_CLAIM_SOURCE_COUNT = 2;
-const ADJACENT_EXPANSION_CLAIM_MIN_WORKERS = 3;
 
 export interface TerritoryIntentPlan {
   colony: string;
@@ -2210,7 +2208,7 @@ function getPersistedExpansionCandidateRanks(
       rawCandidate.colony !== colonyName ||
       !isNonEmptyString(rawCandidate.roomName) ||
       rawCandidate.evidenceStatus === 'unavailable' ||
-      (rawCandidate.recommendedAction !== 'scout' && rawCandidate.recommendedAction !== 'claim') ||
+      !isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction) ||
       ranks.has(rawCandidate.roomName)
     ) {
       continue;
@@ -2580,15 +2578,12 @@ function applyOccupationRecommendationScores(
       return [];
     }
 
-    const adjacentExpansionClaimDecision = getAdjacentExpansionClaimDecision(candidate, roleCounts, gameTime);
-
     return [
       applyOccupationRecommendationScore(
         candidate,
         recommendation,
         roleCounts,
-        adjacentControllerProgressReady,
-        adjacentExpansionClaimDecision === 'claim'
+        adjacentControllerProgressReady
       )
     ];
   });
@@ -2598,12 +2593,9 @@ function applyOccupationRecommendationScore(
   candidate: ScoredTerritoryTarget,
   recommendation: OccupationRecommendationScore,
   roleCounts: RoleCounts,
-  adjacentControllerProgressReady: boolean,
-  claimAdjacentExpansion = false
+  adjacentControllerProgressReady: boolean
 ): ScoredTerritoryTarget {
-  const intentAction = claimAdjacentExpansion
-    ? 'claim'
-    : getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
+  const intentAction = getRecommendedTerritoryIntentAction(candidate, recommendation, roleCounts);
   const requiresControllerPressure =
     isTerritoryControlAction(intentAction) && candidate.requiresControllerPressure === true;
   const commitTarget =
@@ -2632,104 +2624,13 @@ function applyOccupationRecommendationScore(
     target,
     intentAction,
     commitTarget: nextSelection.commitTarget,
-    priority: claimAdjacentExpansion
-      ? TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM
-      : getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
+    priority: getTerritoryCandidatePriority(nextSelection, renewalTicksToEnd),
     recommendationScore: getTerritoryCandidateRecommendationScore(candidate, recommendation),
     recommendationEvidenceStatus: recommendation.evidenceStatus,
     ...(requiresControllerPressure ? { requiresControllerPressure: true } : {}),
     ...(safeAdjacentControllerProgress ? { safeAdjacentControllerProgress: true } : {}),
     ...(renewalTicksToEnd !== null ? { renewalTicksToEnd } : {})
   };
-}
-
-type AdjacentExpansionClaimDecision = 'claim' | 'defer' | 'ignore';
-
-function getAdjacentExpansionClaimDecision(
-  candidate: ScoredTerritoryTarget,
-  roleCounts: RoleCounts,
-  gameTime: number
-): AdjacentExpansionClaimDecision {
-  if (!isAdjacentExpansionClaimDecisionCandidate(candidate)) {
-    return 'ignore';
-  }
-
-  if (
-    shouldRefreshExpansionCandidateScoutIntel(
-      candidate.target.colony,
-      candidate.target.roomName,
-      getTerritoryMemoryRecord(),
-      gameTime
-    )
-  ) {
-    return 'ignore';
-  }
-
-  const scoutIntel = getFreshTerritoryScoutIntel(
-    candidate.target.colony,
-    candidate.target.roomName,
-    gameTime
-  );
-  if (!isViableAdjacentExpansionClaimScoutIntel(scoutIntel)) {
-    return 'ignore';
-  }
-
-  if (
-    getWorkerCapacity(roleCounts) < ADJACENT_EXPANSION_CLAIM_MIN_WORKERS ||
-    hasActiveClaimCreepForColony(roleCounts)
-  ) {
-    return 'defer';
-  }
-
-  return 'claim';
-}
-
-function isAdjacentExpansionClaimDecisionCandidate(candidate: ScoredTerritoryTarget): boolean {
-  if (candidate.target.action !== 'reserve') {
-    return false;
-  }
-
-  if (candidate.source === 'adjacent') {
-    return true;
-  }
-
-  return (
-    candidate.source === 'configured' &&
-    candidate.target.createdBy === OCCUPATION_RECOMMENDATION_TARGET_CREATOR &&
-    isRoomAdjacentToColony(candidate.target.colony, candidate.target.roomName)
-  );
-}
-
-function isViableAdjacentExpansionClaimScoutIntel(
-  intel: TerritoryScoutIntelMemory | null
-): intel is TerritoryScoutIntelMemory {
-  if (!intel || intel.sourceCount !== ADJACENT_EXPANSION_CLAIM_SOURCE_COUNT) {
-    return false;
-  }
-
-  const controller = intel.controller;
-  if (
-    !controller ||
-    controller.my === true ||
-    isNonEmptyString(controller.ownerUsername) ||
-    isNonEmptyString(controller.reservationUsername)
-  ) {
-    return false;
-  }
-
-  return (
-    intel.hostileCreepCount <= 0 &&
-    intel.hostileStructureCount <= 0 &&
-    intel.hostileSpawnCount <= 0
-  );
-}
-
-function hasActiveClaimCreepForColony(roleCounts: RoleCounts): boolean {
-  if (roleCounts.claimersByTargetRoomAction) {
-    return Object.values(roleCounts.claimersByTargetRoomAction.claim ?? {}).some((count) => count > 0);
-  }
-
-  return (roleCounts.claimer ?? 0) > 0;
 }
 
 function getRecommendedTerritoryTarget(
@@ -2915,7 +2816,7 @@ function hasPersistedAdjacentExpansionCandidate(
       rawCandidate.roomName === roomName &&
       rawCandidate.adjacentToOwnedRoom === true &&
       rawCandidate.evidenceStatus !== 'unavailable' &&
-      (rawCandidate.recommendedAction === 'claim' || rawCandidate.recommendedAction === 'scout')
+      isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction)
     );
   });
 }
@@ -2984,8 +2885,14 @@ function buildScoutedOccupationRecommendationEvidence(
     ...(intel.controller?.id ? { controllerId: intel.controller.id } : {}),
     sourceCount: intel.sourceCount,
     hostileCreepCount: intel.hostileCreepCount,
-    hostileStructureCount: intel.hostileStructureCount
+    hostileStructureCount: intel.hostileStructureCount + intel.hostileSpawnCount
   };
+}
+
+function isExpansionCandidateRecommendedAction(
+  action: unknown
+): action is TerritoryExpansionCandidateRecommendedAction {
+  return action === 'claim' || action === 'reserve' || action === 'scout';
 }
 
 function summarizeScoutOccupationController(

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -199,7 +199,7 @@ declare global {
     | 'hostileSpawn'
     | 'sourcesMissing';
   type TerritoryExpansionCandidateEvidenceStatus = 'sufficient' | 'insufficient-evidence' | 'unavailable';
-  type TerritoryExpansionCandidateRecommendedAction = 'claim' | 'scout';
+  type TerritoryExpansionCandidateRecommendedAction = 'claim' | 'reserve' | 'scout';
   type TerritoryPostClaimBootstrapStatus =
     | 'detected'
     | 'spawnSitePending'

--- a/prod/test/claimerRunner.test.ts
+++ b/prod/test/claimerRunner.test.ts
@@ -1,6 +1,7 @@
 import { runClaimer } from '../src/creeps/claimerRunner';
 import { buildTerritoryControllerBody } from '../src/spawn/bodyBuilder';
 import { EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS } from '../src/territory/claimExecutor';
+import { TERRITORY_RESERVATION_RENEWAL_TICKS } from '../src/territory/territoryPlanner';
 
 describe('runClaimer', () => {
   beforeEach(() => {
@@ -414,6 +415,76 @@ describe('runClaimer', () => {
 
     expect(creep.moveTo).toHaveBeenCalledWith(controller);
     expect(creep.claimController).toHaveBeenCalledWith(controller);
+  });
+
+  it('reserves the target controller when in the target room', () => {
+    const controller = { id: 'controller1', my: false } as StructureController;
+    const getObjectById = jest.fn().mockReturnValue(controller);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 511,
+      rooms: {
+        W2N1: { name: 'W2N1', controller } as unknown as Room
+      },
+      getObjectById
+    };
+
+    const creep = {
+      name: 'Claimer1',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W2N1', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      reserveController: jest.fn().mockReturnValue(-9),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(getObjectById).toHaveBeenCalledWith('controller1');
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).toHaveBeenCalledWith(controller);
+  });
+
+  it('renews an own reservation when it reaches the renewal window', () => {
+    const controller = {
+      id: 'controller1',
+      my: false,
+      reservation: { username: 'me', ticksToEnd: TERRITORY_RESERVATION_RENEWAL_TICKS }
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 512,
+      rooms: {
+        W2N1: { name: 'W2N1', controller } as unknown as Room
+      },
+      getObjectById: jest.fn().mockReturnValue(controller)
+    };
+
+    const creep = {
+      name: 'Claimer1',
+      owner: { username: 'me' },
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W2N1', controller },
+      getActiveBodyparts: jest.fn().mockReturnValue(1),
+      reserveController: jest.fn().mockReturnValue(0),
+      moveTo: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.reserveController).toHaveBeenCalledWith(controller);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toEqual({
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller1'
+    });
   });
 
   it('suppresses the claim assignment after a fatal claim result', () => {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -2340,7 +2340,14 @@ function makeVisibleExpansionScoringRoom(
     } as StructureController,
     find: jest.fn((type: number) =>
       type === FIND_SOURCES
-        ? [{ id: `${roomName}-source`, pos: { x: 20, y: 20 } as RoomPosition } as Source]
+        ? Array.from(
+            { length: 2 },
+            (_value, index) =>
+              ({
+                id: `${roomName}-source${index}`,
+                pos: { x: 20 + index * 5, y: 20 + index * 5 } as RoomPosition
+              }) as Source
+          )
         : []
     )
   } as unknown as Room;

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -433,22 +433,21 @@ describe('next expansion scoring', () => {
     });
     expect(report.next?.rationale).toEqual(expect.arrayContaining(['2 sources scouted']));
 
-    expect(refreshNextExpansionTargetSelection(colony, report, 451)).toMatchObject({
-      status: 'planned',
+    expect(refreshNextExpansionTargetSelection(colony, report, 451)).toEqual({
+      status: 'skipped',
       colony: 'W1N1',
-      targetRoom: 'W2N1',
-      controllerId: 'controller2',
-      score: report.next?.score
+      reason: 'unavailable'
     });
     expect(getExpansionCandidateMemory()[0]).toMatchObject({
       colony: 'W1N1',
       roomName: 'W2N1',
       rank: 1,
       evidenceStatus: 'sufficient',
-      recommendedAction: 'claim',
+      recommendedAction: 'reserve',
       visible: false,
       updatedAt: 451
     });
+    expect(Memory.territory?.targets).toBeUndefined();
   });
 
   it('records terrain-based source accessibility for visible expansion candidates', () => {

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -551,6 +551,41 @@ describe('next expansion scoring', () => {
     });
   });
 
+  it('does not persist one-source rooms as next expansion claim targets or actions', () => {
+    const colony = makeSafeColony();
+    const report = scoreExpansionCandidates(
+      makeInput([
+        makeCandidate({
+          roomName: 'W3N1',
+          controllerId: 'controller3' as Id<StructureController>,
+          sourceCount: 1
+        })
+      ])
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W3N1',
+      evidenceStatus: 'sufficient',
+      sourceCount: 1
+    });
+    expect(refreshNextExpansionTargetSelection(colony, report, 102)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'unavailable'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toBeUndefined();
+    expect(getExpansionCandidateMemory()[0]).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W3N1',
+      evidenceStatus: 'sufficient',
+      sourceCount: 1,
+      visible: true,
+      updatedAt: 102
+    });
+    expect(getExpansionCandidateMemory()[0]).not.toHaveProperty('recommendedAction');
+  });
+
   it('preserves unrelated claim intents while pruning stale next expansion intents', () => {
     const colony = makeSafeColony();
     const manualIntent: TerritoryIntentMemory = {

--- a/prod/test/territory/expansionDecision.test.ts
+++ b/prod/test/territory/expansionDecision.test.ts
@@ -2,7 +2,7 @@ import type { ColonySnapshot } from '../../src/colony/colonyRegistry';
 import { planSpawn } from '../../src/spawn/spawnPlanner';
 import { planTerritoryIntent } from '../../src/territory/territoryPlanner';
 
-describe('adjacent expansion claim decisions', () => {
+describe('adjacent expansion reservation decisions', () => {
   beforeEach(() => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 2;
@@ -16,9 +16,10 @@ describe('adjacent expansion claim decisions', () => {
   afterEach(() => {
     delete (globalThis as { Game?: Partial<Game> }).Game;
     delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+    delete (globalThis as { ERR_NO_PATH?: ScreepsReturnCode }).ERR_NO_PATH;
   });
 
-  it('spawns a claimer for a two-source adjacent room with neutral scout intel and no threats', () => {
+  it('spawns a reserver for a two-source adjacent room with neutral scout intel and no threats', () => {
     const { colony, spawn } = makeColony();
     installGame(colony, { '3': 'W2N1' }, 100);
     installScoutIntel('W2N1', { updatedAt: 99 });
@@ -32,7 +33,7 @@ describe('adjacent expansion claim decisions', () => {
         colony: 'W1N1',
         territory: {
           targetRoom: 'W2N1',
-          action: 'claim',
+          action: 'reserve',
           controllerId: 'controller-W2N1' as Id<StructureController>
         }
       }
@@ -41,13 +42,13 @@ describe('adjacent expansion claim decisions', () => {
       {
         colony: 'W1N1',
         roomName: 'W2N1',
-        action: 'claim',
+        action: 'reserve',
         controllerId: 'controller-W2N1'
       }
     ]);
   });
 
-  it('does not claim a one-source adjacent room', () => {
+  it('reserves a one-source adjacent room only when no better scouted candidate exists', () => {
     const { colony } = makeColony();
     installGame(colony, { '3': 'W2N1' }, 101);
     installScoutIntel('W2N1', { sourceCount: 1, updatedAt: 100 });
@@ -70,7 +71,7 @@ describe('adjacent expansion claim decisions', () => {
     ]);
   });
 
-  it('does not claim an adjacent room when scout intel reports hostiles', () => {
+  it('does not reserve an adjacent room when scout intel reports hostiles', () => {
     const { colony } = makeColony();
     installGame(colony, { '3': 'W2N1' }, 102);
     installScoutIntel('W2N1', { hostileCreepCount: 1, updatedAt: 101 });
@@ -79,7 +80,7 @@ describe('adjacent expansion claim decisions', () => {
     expect(Memory.territory?.targets).toBeUndefined();
   });
 
-  it('falls back to reserve scoring for a viable adjacent claim until the colony has at least three workers', () => {
+  it('reserves viable scouted adjacent rooms even before claim-scale worker readiness', () => {
     const { colony } = makeColony();
     installGame(colony, { '3': 'W2N1' }, 103);
     installScoutIntel('W2N1', { updatedAt: 102 });
@@ -100,7 +101,7 @@ describe('adjacent expansion claim decisions', () => {
     ]);
   });
 
-  it('falls back to reserve scoring while one claim claimer is active for the colony', () => {
+  it('reserves a scouted adjacent room while one claim claimer is active for the colony', () => {
     const { colony } = makeColony();
     installGame(colony, { '1': 'W2N1', '3': 'W3N1' }, 104);
     installScoutIntel('W2N1', { updatedAt: 103 });
@@ -134,7 +135,7 @@ describe('adjacent expansion claim decisions', () => {
     ]);
   });
 
-  it('ignores active reserve claimers when deciding whether an adjacent claim claimer is active', () => {
+  it('does not let active reserve claimers for another room block a scouted reservation target', () => {
     const { colony } = makeColony();
     installGame(colony, { '3': 'W2N1' }, 105);
     installScoutIntel('W2N1', { updatedAt: 104 });
@@ -154,20 +155,20 @@ describe('adjacent expansion claim decisions', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W2N1',
-      action: 'claim',
+      action: 'reserve',
       controllerId: 'controller-W2N1'
     });
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
         roomName: 'W2N1',
-        action: 'claim',
+        action: 'reserve',
         controllerId: 'controller-W2N1'
       }
     ]);
   });
 
-  it('falls back to reserve scoring instead of duplicating an existing live claim claimer for the same target', () => {
+  it('keeps reserving from scout intel instead of duplicating an existing live claim claimer for the same target', () => {
     const { colony } = makeColony();
     installGame(colony, { '3': 'W2N1' }, 106);
     installScoutIntel('W2N1', { updatedAt: 105 });
@@ -200,7 +201,7 @@ describe('adjacent expansion claim decisions', () => {
     ]);
   });
 
-  it('lets auto-claim override a persisted occupation reserve recommendation for the same room', () => {
+  it('keeps a persisted occupation reserve recommendation as a reserve after scout intel confirms the room', () => {
     const { colony } = makeColony();
     installGame(colony, { '3': 'W2N1' }, 107);
     installScoutIntel('W2N1', { updatedAt: 106 });
@@ -219,7 +220,7 @@ describe('adjacent expansion claim decisions', () => {
     expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 107)).toEqual({
       colony: 'W1N1',
       targetRoom: 'W2N1',
-      action: 'claim',
+      action: 'reserve',
       createdBy: 'occupationRecommendation',
       controllerId: 'controller-W2N1'
     });
@@ -227,13 +228,107 @@ describe('adjacent expansion claim decisions', () => {
       {
         colony: 'W1N1',
         targetRoom: 'W2N1',
-        action: 'claim',
+        action: 'reserve',
         status: 'planned',
         updatedAt: 107,
         createdBy: 'occupationRecommendation',
         controllerId: 'controller-W2N1'
       }
     ]);
+  });
+
+  it('selects the best viable expansion reservation from scout intel', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '1': 'W1N2', '3': 'W2N1', '5': 'W1N0', '7': 'W0N1' }, 108);
+    installScoutIntel('W1N2', {
+      updatedAt: 107,
+      controller: { id: 'controller-W1N2' as Id<StructureController>, ownerUsername: 'enemy' }
+    });
+    installScoutIntel('W2N1', {
+      updatedAt: 107,
+      controller: {
+        id: 'controller-W2N1' as Id<StructureController>,
+        reservationUsername: 'enemy',
+        reservationTicksToEnd: 3_000
+      }
+    });
+    installScoutIntel('W1N0', {
+      updatedAt: 107,
+      hostileStructureCount: 0,
+      hostileSpawnCount: 1
+    });
+    installScoutIntel('W0N1', { updatedAt: 107 });
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 108)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W0N1',
+      action: 'reserve',
+      controllerId: 'controller-W0N1'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W0N1',
+        action: 'reserve',
+        controllerId: 'controller-W0N1'
+      }
+    ]);
+  });
+
+  it('prefers two-source scout intel over a one-source adjacent room', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '1': 'W1N2', '3': 'W2N1' }, 109);
+    installScoutIntel('W1N2', { sourceCount: 1, sourceIds: ['source0'], updatedAt: 108 });
+    installScoutIntel('W2N1', { updatedAt: 108 });
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 109)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller-W2N1'
+    });
+  });
+
+  it('skips a scouted expansion reservation when route lookup reports no path', () => {
+    const { colony } = makeColony();
+    (globalThis as unknown as { ERR_NO_PATH: ScreepsReturnCode }).ERR_NO_PATH = -2 as ScreepsReturnCode;
+    installGame(
+      colony,
+      { '1': 'W1N2', '3': 'W2N1' },
+      110,
+      jest.fn((_fromRoom: string, toRoom: string) =>
+        toRoom === 'W1N2' ? (-2 as ScreepsReturnCode) : [{ exit: 3, room: toRoom }]
+      )
+    );
+    installScoutIntel('W1N2', { updatedAt: 109 });
+    installScoutIntel('W2N1', { updatedAt: 109 });
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 110)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller-W2N1'
+    });
+  });
+
+  it('plans reservation renewal from scout intel when our reservation is nearly expired', () => {
+    const { colony } = makeColony();
+    installGame(colony, { '3': 'W2N1' }, 111);
+    installScoutIntel('W2N1', {
+      updatedAt: 110,
+      controller: {
+        id: 'controller-W2N1' as Id<StructureController>,
+        reservationUsername: 'me',
+        reservationTicksToEnd: 500
+      }
+    });
+
+    expect(planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 111)).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'reserve',
+      controllerId: 'controller-W2N1'
+    });
   });
 });
 
@@ -275,11 +370,17 @@ function makeColony(): { colony: ColonySnapshot; spawn: StructureSpawn } {
   };
 }
 
-function installGame(colony: ColonySnapshot, exits: Record<string, string>, time: number): void {
+function installGame(
+  colony: ColonySnapshot,
+  exits: Record<string, string>,
+  time: number,
+  findRoute?: (fromRoom: string, toRoom: string) => unknown
+): void {
   (globalThis as unknown as { Game: Partial<Game> }).Game = {
     time,
     map: {
-      describeExits: jest.fn(() => exits)
+      describeExits: jest.fn(() => exits),
+      ...(findRoute ? { findRoute } : {})
     } as unknown as GameMap,
     rooms: {
       [colony.room.name]: colony.room

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -193,7 +193,7 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
-  it('uses persisted scout intel to promote a high-value unseen adjacent room into a claim target', () => {
+  it('uses persisted scout intel to promote a high-value unseen adjacent room into a reserve target', () => {
     const colony = makeSafeColony();
     const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
@@ -225,14 +225,14 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W1N2',
-      action: 'claim',
+      action: 'reserve',
       controllerId: 'controller2'
     });
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
         roomName: 'W1N2',
-        action: 'claim',
+        action: 'reserve',
         controllerId: 'controller2'
       }
     ]);
@@ -240,7 +240,7 @@ describe('planTerritoryIntent', () => {
       {
         colony: 'W1N1',
         targetRoom: 'W1N2',
-        action: 'claim',
+        action: 'reserve',
         status: 'planned',
         updatedAt: 525,
         controllerId: 'controller2'
@@ -260,7 +260,7 @@ describe('planTerritoryIntent', () => {
       territory: {
         expansionCandidates: [
           makeExpansionCandidateMemory('W2N1', {
-            recommendedAction: 'claim',
+            recommendedAction: 'reserve',
             evidenceStatus: 'sufficient',
             controllerId: 'controller2' as Id<StructureController>,
             sourceCount: 2
@@ -303,7 +303,7 @@ describe('planTerritoryIntent', () => {
       territory: {
         expansionCandidates: [
           makeExpansionCandidateMemory('W2N1', {
-            recommendedAction: 'claim',
+            recommendedAction: 'reserve',
             evidenceStatus: 'sufficient',
             controllerId: 'controller2' as Id<StructureController>,
             sourceCount: 2
@@ -320,14 +320,14 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W2N1',
-      action: 'claim',
+      action: 'reserve',
       controllerId: 'controller2'
     });
     expect(Memory.territory?.intents).toEqual([
       {
         colony: 'W1N1',
         targetRoom: 'W2N1',
-        action: 'claim',
+        action: 'reserve',
         status: 'planned',
         updatedAt: gameTime,
         controllerId: 'controller2'


### PR DESCRIPTION
Implements reserve logic for the best expansion candidate identified by auto-scout intel.

- Typecheck: PASS
- Tests: 53 suites, 1161 tests PASS
- Build: verified via dist/main.js regeneration

Closes #661