### PR TITLE
feat(economy): implement link energy transfer network for efficient distribution

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -9364,30 +9364,71 @@ var CONTROLLER_LINK_RANGE = 3;
 var STORAGE_LINK_RANGE = 2;
 var OK_CODE4 = 0;
 function transferEnergy(room) {
-  var _a, _b, _c, _d;
   const network = classifyLinks(room);
   if (network.sourceLinks.length === 0) {
     return [];
   }
-  const destinationLinks = getDestinationLinks(network);
-  if (destinationLinks.length === 0) {
-    return [];
-  }
   const projectedState = createProjectedLinkState(network.links);
   const results = [];
-  for (const sourceLink of sortLinksByEnergy(network.sourceLinks, projectedState)) {
-    if (!canLinkSendEnergy(sourceLink, projectedState)) {
-      continue;
-    }
-    const destination = selectDestinationLink(sourceLink, destinationLinks, projectedState);
-    if (!destination) {
-      continue;
-    }
+  const spentSourceIds = /* @__PURE__ */ new Set();
+  if (shouldControllerLinkReceiveEnergy(room, network.controllerLink, projectedState)) {
+    transferSourceLinksToDestination(
+      sortSourceLinksByDistanceToDestination(network.sourceLinks, network.controllerLink),
+      { link: network.controllerLink, role: "controller" },
+      projectedState,
+      spentSourceIds,
+      results
+    );
+  }
+  if (shouldStorageLinkReceiveSurplus(network, projectedState)) {
+    transferSourceLinksToDestination(
+      sortSourceLinksBySurplusPriority(network.sourceLinks, network.storageLink, projectedState),
+      { link: network.storageLink, role: "storage" },
+      projectedState,
+      spentSourceIds,
+      results
+    );
+  }
+  return results;
+}
+function classifyLinks(room) {
+  var _a;
+  const links = findOwnedLinks(room);
+  const controllerLink = selectControllerLink(room, links);
+  const storage = (_a = room.storage) != null ? _a : findStorage(room);
+  const storageLink = selectStorageLink(room, links, controllerLink, storage);
+  const destinationIds = new Set(
+    [controllerLink, storageLink].filter((link) => link !== null).map((link) => getObjectId4(link))
+  );
+  return {
+    links,
+    sourceLinks: selectSourceLinks(room, links, destinationIds),
+    controllerLink,
+    storageLink,
+    storage
+  };
+}
+function isSourceLink(room, link) {
+  const linkId = getObjectId4(link);
+  return linkId !== "" && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId4(sourceLink) === linkId);
+}
+function transferLinkEnergy(sourceLink, destinationLink, amount) {
+  return sourceLink.transferEnergy(destinationLink, amount);
+}
+function transferSourceLinksToDestination(sourceLinks, destination, projectedState, spentSourceIds, results) {
+  var _a, _b, _c, _d, _e;
+  const destinationId = getObjectId4(destination.link);
+  for (const sourceLink of sourceLinks) {
     const sourceId = getObjectId4(sourceLink);
-    const destinationId = getObjectId4(destination.link);
+    if (spentSourceIds.has(sourceId) || !canLinkSendEnergy(sourceLink, projectedState)) {
+      continue;
+    }
+    if (destinationId === sourceId || ((_a = projectedState.freeCapacityById.get(destinationId)) != null ? _a : 0) <= 0) {
+      continue;
+    }
     const amount = Math.min(
-      (_a = projectedState.storedEnergyById.get(sourceId)) != null ? _a : 0,
-      (_b = projectedState.freeCapacityById.get(destinationId)) != null ? _b : 0
+      (_b = projectedState.storedEnergyById.get(sourceId)) != null ? _b : 0,
+      (_c = projectedState.freeCapacityById.get(destinationId)) != null ? _c : 0
     );
     if (amount <= 0) {
       continue;
@@ -9400,55 +9441,59 @@ function transferEnergy(room) {
       result,
       sourceId
     });
+    spentSourceIds.add(sourceId);
     if (result === OK_CODE4) {
-      projectedState.storedEnergyById.set(sourceId, Math.max(0, ((_c = projectedState.storedEnergyById.get(sourceId)) != null ? _c : 0) - amount));
+      projectedState.storedEnergyById.set(
+        sourceId,
+        Math.max(0, ((_d = projectedState.storedEnergyById.get(sourceId)) != null ? _d : 0) - amount)
+      );
       projectedState.freeCapacityById.set(
         destinationId,
-        Math.max(0, ((_d = projectedState.freeCapacityById.get(destinationId)) != null ? _d : 0) - amount)
+        Math.max(0, ((_e = projectedState.freeCapacityById.get(destinationId)) != null ? _e : 0) - amount)
       );
     }
   }
-  return results;
 }
-function classifyLinks(room) {
-  const links = findOwnedLinks(room);
-  const controllerLink = selectControllerLink(room, links);
-  const storageLink = selectStorageLink(room, links, controllerLink);
-  const destinationIds = new Set(
-    [controllerLink, storageLink].filter((link) => link !== null).map((link) => getObjectId4(link))
-  );
-  return {
-    links,
-    sourceLinks: selectSourceLinks(room, links, destinationIds),
-    controllerLink,
-    storageLink
-  };
-}
-function isSourceLink(room, link) {
-  const linkId = getObjectId4(link);
-  return linkId !== "" && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId4(sourceLink) === linkId);
-}
-function getDestinationLinks(network) {
-  const destinations = [];
-  if (network.controllerLink) {
-    destinations.push({ link: network.controllerLink, role: "controller" });
+function shouldControllerLinkReceiveEnergy(room, controllerLink, projectedState) {
+  var _a, _b;
+  if (!controllerLink || ((_a = room.controller) == null ? void 0 : _a.my) !== true) {
+    return false;
   }
-  if (network.storageLink && getObjectId4(network.storageLink) !== getObjectId4(network.controllerLink)) {
-    destinations.push({ link: network.storageLink, role: "storage" });
-  }
-  return destinations;
+  return ((_b = projectedState.freeCapacityById.get(getObjectId4(controllerLink))) != null ? _b : 0) > 0;
 }
-function transferLinkEnergy(sourceLink, destinationLink, amount) {
-  return sourceLink.transferEnergy(destinationLink, amount);
-}
-function selectDestinationLink(sourceLink, destinationLinks, projectedState) {
+function shouldStorageLinkReceiveSurplus(network, projectedState) {
   var _a;
-  const sourceId = getObjectId4(sourceLink);
-  return (_a = destinationLinks.find((destination) => {
-    var _a2;
-    const destinationId = getObjectId4(destination.link);
-    return destinationId !== sourceId && ((_a2 = projectedState.freeCapacityById.get(destinationId)) != null ? _a2 : 0) > 0;
-  })) != null ? _a : null;
+  if (!network.storageLink || getObjectId4(network.storageLink) === getObjectId4(network.controllerLink)) {
+    return false;
+  }
+  return ((_a = projectedState.freeCapacityById.get(getObjectId4(network.storageLink))) != null ? _a : 0) > 0 && hasStorageFreeCapacity(network.storage);
+}
+function hasStorageFreeCapacity(storage) {
+  if (!storage) {
+    return false;
+  }
+  const freeCapacity = getKnownFreeEnergyCapacity(storage);
+  return freeCapacity === null || freeCapacity > 0;
+}
+function getKnownFreeEnergyCapacity(structure) {
+  var _a, _b;
+  const freeCapacity = (_b = (_a = structure.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4());
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : null;
+}
+function sortSourceLinksByDistanceToDestination(links, destinationLink) {
+  const destinationPosition = getRoomObjectPosition2(destinationLink);
+  return [...links].sort(
+    (left, right) => compareRangeToPosition(destinationPosition, left, right) || getObjectId4(left).localeCompare(getObjectId4(right))
+  );
+}
+function sortSourceLinksBySurplusPriority(links, destinationLink, projectedState) {
+  const destinationPosition = getRoomObjectPosition2(destinationLink);
+  return [...links].sort(
+    (left, right) => {
+      var _a, _b;
+      return compareRangeToPosition(destinationPosition, left, right) || ((_a = projectedState.storedEnergyById.get(getObjectId4(right))) != null ? _a : 0) - ((_b = projectedState.storedEnergyById.get(getObjectId4(left))) != null ? _b : 0) || getObjectId4(left).localeCompare(getObjectId4(right));
+    }
+  );
 }
 function canLinkSendEnergy(link, projectedState) {
   var _a;
@@ -9459,14 +9504,6 @@ function createProjectedLinkState(links) {
     freeCapacityById: new Map(links.map((link) => [getObjectId4(link), getFreeEnergyCapacity(link)])),
     storedEnergyById: new Map(links.map((link) => [getObjectId4(link), getStoredEnergy3(link)]))
   };
-}
-function sortLinksByEnergy(links, projectedState) {
-  return [...links].sort(
-    (left, right) => {
-      var _a, _b;
-      return ((_a = projectedState.storedEnergyById.get(getObjectId4(right))) != null ? _a : 0) - ((_b = projectedState.storedEnergyById.get(getObjectId4(left))) != null ? _b : 0) || getObjectId4(left).localeCompare(getObjectId4(right));
-    }
-  );
 }
 function selectSourceLinks(room, links, destinationIds) {
   const sources = findSources2(room);
@@ -9482,9 +9519,7 @@ function selectControllerLink(room, links) {
   }
   return selectClosestLink(links, controller, room.name, CONTROLLER_LINK_RANGE);
 }
-function selectStorageLink(room, links, controllerLink) {
-  var _a;
-  const storage = (_a = room.storage) != null ? _a : findStorage(room);
+function selectStorageLink(room, links, controllerLink, storage) {
   if (!storage) {
     return null;
   }
@@ -9511,6 +9546,9 @@ function isNearRoomObject2(left, right, roomName, range) {
   return leftPosition !== null && rightPosition !== null && isSameRoomPosition4(leftPosition, roomName) && isSameRoomPosition4(rightPosition, roomName) && getRangeBetweenPositions3(leftPosition, rightPosition) <= range;
 }
 function compareRangeToPosition(position, left, right) {
+  if (!position) {
+    return 0;
+  }
   const leftPosition = getRoomObjectPosition2(left);
   const rightPosition = getRoomObjectPosition2(right);
   return (leftPosition ? getRangeBetweenPositions3(position, leftPosition) : Number.POSITIVE_INFINITY) - (rightPosition ? getRangeBetweenPositions3(position, rightPosition) : Number.POSITIVE_INFINITY);
@@ -10024,6 +10062,10 @@ function selectHeuristicWorkerTask(creep) {
         if (energyAcquisitionTask) {
           return energyAcquisitionTask;
         }
+      }
+      const linkEnergyAcquisitionTask = selectEfficientWorkerLinkEnergyAcquisitionTask(creep);
+      if (linkEnergyAcquisitionTask) {
+        return linkEnergyAcquisitionTask;
       }
     }
     const source = selectHarvestSource(creep);
@@ -11648,9 +11690,14 @@ function compareLowLoadWorkerEnergyAcquisitionCandidates(left, right) {
   return left.priority - right.priority || compareOptionalRanges(left.range, right.range) || right.score - left.score || right.energy - left.energy || String(left.source.id).localeCompare(String(right.source.id)) || left.task.type.localeCompare(right.task.type);
 }
 function selectSpawnRecoveryEnergyAcquisitionTask(creep, energySink, harvestEta = estimateHarvestDeliveryEta(creep, energySink)) {
-  const candidates = findWorkerEnergyAcquisitionCandidates(creep, {
-    minimumDroppedEnergy: MIN_SPAWN_RECOVERY_DROPPED_ENERGY_PICKUP_AMOUNT
-  }).map((candidate) => createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink)).filter((candidate) => candidate !== null).filter((candidate) => harvestEta === null || candidate.deliveryEta <= harvestEta);
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+  const recoverableEnergyCandidates = [
+    ...findWorkerEnergyAcquisitionCandidates(creep, {
+      minimumDroppedEnergy: MIN_SPAWN_RECOVERY_DROPPED_ENERGY_PICKUP_AMOUNT
+    }),
+    ...findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext)
+  ];
+  const candidates = recoverableEnergyCandidates.map((candidate) => createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink)).filter((candidate) => candidate !== null).filter((candidate) => harvestEta === null || candidate.deliveryEta <= harvestEta);
   if (candidates.length === 0) {
     return null;
   }
@@ -11734,7 +11781,19 @@ function selectWorkerLinkEnergyFallbackTask(creep) {
   var _a, _b;
   return (_b = (_a = findWorkerLinkEnergyAcquisitionCandidates(creep)[0]) == null ? void 0 : _a.task) != null ? _b : null;
 }
+function selectEfficientWorkerLinkEnergyAcquisitionTask(creep) {
+  const linkCandidate = findWorkerLinkEnergyAcquisitionCandidates(creep)[0];
+  if (!linkCandidate) {
+    return null;
+  }
+  const harvestSource = selectHarvestSource(creep);
+  if (!harvestSource) {
+    return linkCandidate.task;
+  }
+  return isWorkerLinkEnergyMoreEfficientThanHarvest(creep, linkCandidate, harvestSource) ? linkCandidate.task : null;
+}
 function findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext = createWorkerEnergyAcquisitionReservationContext(creep), options = {}) {
+  const minimumLinkEnergy = getMinimumWorkerLinkWithdrawalEnergy(creep);
   return findOwnedWorkerEnergyLinks(creep.room).flatMap((source) => {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
@@ -11744,7 +11803,8 @@ function findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext = c
         type: "withdraw",
         targetId: source.id
       },
-      reservationContext
+      reservationContext,
+      minimumLinkEnergy
     );
     return candidate ? [candidate] : [];
   }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options)).sort(compareWorkerLinkEnergyAcquisitionCandidates);
@@ -11757,6 +11817,36 @@ function findOwnedWorkerEnergyLinks(room) {
     filter: (structure) => isLinkEnergySource(structure) && getStoredEnergy4(structure) > 0
   });
   return Array.isArray(structures) ? structures : [];
+}
+function getMinimumWorkerLinkWithdrawalEnergy(creep) {
+  return Math.max(1, getFreeEnergyCapacity3(creep));
+}
+function isWorkerLinkEnergyMoreEfficientThanHarvest(creep, linkCandidate, harvestSource) {
+  const linkEta = estimateWorkerLinkEnergyAcquisitionEta(linkCandidate);
+  const harvestEta = estimateHarvestEnergyAcquisitionEta(creep, harvestSource);
+  return linkEta !== null && harvestEta !== null && linkEta < harvestEta;
+}
+function estimateWorkerLinkEnergyAcquisitionEta(candidate) {
+  return candidate.range === null ? null : candidate.range + ENERGY_ACQUISITION_ACTION_TICKS;
+}
+function estimateHarvestEnergyAcquisitionEta(creep, source) {
+  const sourceAvailabilityDelay = estimateHarvestSourceAvailabilityDelay(source);
+  const range = getHarvestSourceTravelCost(creep, source);
+  if (sourceAvailabilityDelay === null || range === null) {
+    return null;
+  }
+  return range + sourceAvailabilityDelay + estimateHarvestEnergyAcquisitionTicks(creep, source);
+}
+function estimateHarvestEnergyAcquisitionTicks(creep, source) {
+  const energy = Math.min(getHarvestSourceAvailableEnergy(source), getHarvestEnergyTarget(creep));
+  if (energy <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const workParts = getActiveWorkParts(creep);
+  if (workParts <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.ceil(energy / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
 }
 function findDroppedEnergyAcquisitionCandidates(creep, reservationContext, options = {}) {
   var _a;

--- a/prod/src/economy/linkManager.ts
+++ b/prod/src/economy/linkManager.ts
@@ -18,6 +18,7 @@ export interface LinkNetwork {
   sourceLinks: StructureLink[];
   controllerLink: StructureLink | null;
   storageLink: StructureLink | null;
+  storage: StructureStorage | null;
 }
 
 export interface LinkTransferResult {
@@ -39,26 +40,81 @@ export function transferEnergy(room: Room): LinkTransferResult[] {
     return [];
   }
 
-  const destinationLinks = getDestinationLinks(network);
-  if (destinationLinks.length === 0) {
-    return [];
-  }
-
   const projectedState = createProjectedLinkState(network.links);
   const results: LinkTransferResult[] = [];
+  const spentSourceIds = new Set<string>();
 
-  for (const sourceLink of sortLinksByEnergy(network.sourceLinks, projectedState)) {
-    if (!canLinkSendEnergy(sourceLink, projectedState)) {
-      continue;
-    }
+  if (shouldControllerLinkReceiveEnergy(room, network.controllerLink, projectedState)) {
+    transferSourceLinksToDestination(
+      sortSourceLinksByDistanceToDestination(network.sourceLinks, network.controllerLink),
+      { link: network.controllerLink, role: 'controller' },
+      projectedState,
+      spentSourceIds,
+      results
+    );
+  }
 
-    const destination = selectDestinationLink(sourceLink, destinationLinks, projectedState);
-    if (!destination) {
-      continue;
-    }
+  if (shouldStorageLinkReceiveSurplus(network, projectedState)) {
+    transferSourceLinksToDestination(
+      sortSourceLinksBySurplusPriority(network.sourceLinks, network.storageLink, projectedState),
+      { link: network.storageLink, role: 'storage' },
+      projectedState,
+      spentSourceIds,
+      results
+    );
+  }
 
+  return results;
+}
+
+export function classifyLinks(room: Room): LinkNetwork {
+  const links = findOwnedLinks(room);
+  const controllerLink = selectControllerLink(room, links);
+  const storage = room.storage ?? findStorage(room);
+  const storageLink = selectStorageLink(room, links, controllerLink, storage);
+  const destinationIds = new Set(
+    [controllerLink, storageLink]
+      .filter((link): link is StructureLink => link !== null)
+      .map((link) => getObjectId(link))
+  );
+
+  return {
+    links,
+    sourceLinks: selectSourceLinks(room, links, destinationIds),
+    controllerLink,
+    storageLink,
+    storage
+  };
+}
+
+export function isSourceLink(room: Room, link: StructureLink): boolean {
+  const linkId = getObjectId(link);
+  return linkId !== '' && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId(sourceLink) === linkId);
+}
+
+function transferLinkEnergy(sourceLink: StructureLink, destinationLink: StructureLink, amount: number): ScreepsReturnCode {
+  return sourceLink.transferEnergy(destinationLink, amount);
+}
+
+function transferSourceLinksToDestination(
+  sourceLinks: StructureLink[],
+  destination: { link: StructureLink; role: LinkDestinationRole },
+  projectedState: ProjectedLinkState,
+  spentSourceIds: Set<string>,
+  results: LinkTransferResult[]
+): void {
+  const destinationId = getObjectId(destination.link);
+
+  for (const sourceLink of sourceLinks) {
     const sourceId = getObjectId(sourceLink);
-    const destinationId = getObjectId(destination.link);
+    if (spentSourceIds.has(sourceId) || !canLinkSendEnergy(sourceLink, projectedState)) {
+      continue;
+    }
+
+    if (destinationId === sourceId || (projectedState.freeCapacityById.get(destinationId) ?? 0) <= 0) {
+      continue;
+    }
+
     const amount = Math.min(
       projectedState.storedEnergyById.get(sourceId) ?? 0,
       projectedState.freeCapacityById.get(destinationId) ?? 0
@@ -76,70 +132,84 @@ export function transferEnergy(room: Room): LinkTransferResult[] {
       sourceId
     });
 
+    spentSourceIds.add(sourceId);
     if (result === OK_CODE) {
-      projectedState.storedEnergyById.set(sourceId, Math.max(0, (projectedState.storedEnergyById.get(sourceId) ?? 0) - amount));
+      projectedState.storedEnergyById.set(
+        sourceId,
+        Math.max(0, (projectedState.storedEnergyById.get(sourceId) ?? 0) - amount)
+      );
       projectedState.freeCapacityById.set(
         destinationId,
         Math.max(0, (projectedState.freeCapacityById.get(destinationId) ?? 0) - amount)
       );
     }
   }
-
-  return results;
 }
 
-export function classifyLinks(room: Room): LinkNetwork {
-  const links = findOwnedLinks(room);
-  const controllerLink = selectControllerLink(room, links);
-  const storageLink = selectStorageLink(room, links, controllerLink);
-  const destinationIds = new Set(
-    [controllerLink, storageLink]
-      .filter((link): link is StructureLink => link !== null)
-      .map((link) => getObjectId(link))
-  );
-
-  return {
-    links,
-    sourceLinks: selectSourceLinks(room, links, destinationIds),
-    controllerLink,
-    storageLink
-  };
-}
-
-export function isSourceLink(room: Room, link: StructureLink): boolean {
-  const linkId = getObjectId(link);
-  return linkId !== '' && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId(sourceLink) === linkId);
-}
-
-function getDestinationLinks(
-  network: LinkNetwork
-): Array<{ link: StructureLink; role: LinkDestinationRole }> {
-  const destinations: Array<{ link: StructureLink; role: LinkDestinationRole }> = [];
-  if (network.controllerLink) {
-    destinations.push({ link: network.controllerLink, role: 'controller' });
-  }
-  if (network.storageLink && getObjectId(network.storageLink) !== getObjectId(network.controllerLink)) {
-    destinations.push({ link: network.storageLink, role: 'storage' });
-  }
-
-  return destinations;
-}
-
-function transferLinkEnergy(sourceLink: StructureLink, destinationLink: StructureLink, amount: number): ScreepsReturnCode {
-  return sourceLink.transferEnergy(destinationLink, amount);
-}
-
-function selectDestinationLink(
-  sourceLink: StructureLink,
-  destinationLinks: Array<{ link: StructureLink; role: LinkDestinationRole }>,
+function shouldControllerLinkReceiveEnergy(
+  room: Room,
+  controllerLink: StructureLink | null,
   projectedState: ProjectedLinkState
-): { link: StructureLink; role: LinkDestinationRole } | null {
-  const sourceId = getObjectId(sourceLink);
+): controllerLink is StructureLink {
+  if (!controllerLink || room.controller?.my !== true) {
+    return false;
+  }
+
+  return (projectedState.freeCapacityById.get(getObjectId(controllerLink)) ?? 0) > 0;
+}
+
+function shouldStorageLinkReceiveSurplus(
+  network: LinkNetwork,
+  projectedState: ProjectedLinkState
+): network is LinkNetwork & { storageLink: StructureLink } {
+  if (!network.storageLink || getObjectId(network.storageLink) === getObjectId(network.controllerLink)) {
+    return false;
+  }
+
   return (
-    destinationLinks.find((destination) => {
-      const destinationId = getObjectId(destination.link);
-      return destinationId !== sourceId && (projectedState.freeCapacityById.get(destinationId) ?? 0) > 0;
-    }) ?? null
+    (projectedState.freeCapacityById.get(getObjectId(network.storageLink)) ?? 0) > 0 &&
+    hasStorageFreeCapacity(network.storage)
+  );
+}
+
+function hasStorageFreeCapacity(storage: StructureStorage | null): boolean {
+  if (!storage) {
+    return false;
+  }
+
+  const freeCapacity = getKnownFreeEnergyCapacity(storage);
+  return freeCapacity === null || freeCapacity > 0;
+}
+
+function getKnownFreeEnergyCapacity(structure: StructureLink | StructureStorage): number | null {
+  const freeCapacity = structure.store?.getFreeCapacity?.(getEnergyResource());
+  return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : null;
+}
+
+function sortSourceLinksByDistanceToDestination(
+  links: StructureLink[],
+  destinationLink: StructureLink
+): StructureLink[] {
+  const destinationPosition = getRoomObjectPosition(destinationLink);
+  return [...links].sort(
+    (left, right) =>
+      compareRangeToPosition(destinationPosition, left, right) ||
+      getObjectId(left).localeCompare(getObjectId(right))
+  );
+}
+
+function sortSourceLinksBySurplusPriority(
+  links: StructureLink[],
+  destinationLink: StructureLink,
+  projectedState: ProjectedLinkState
+): StructureLink[] {
+  const destinationPosition = getRoomObjectPosition(destinationLink);
+  return [...links].sort(
+    (left, right) =>
+      compareRangeToPosition(destinationPosition, left, right) ||
+      (projectedState.storedEnergyById.get(getObjectId(right)) ?? 0) -
+        (projectedState.storedEnergyById.get(getObjectId(left)) ?? 0) ||
+      getObjectId(left).localeCompare(getObjectId(right))
   );
 }
 
@@ -152,15 +222,6 @@ function createProjectedLinkState(links: StructureLink[]): ProjectedLinkState {
     freeCapacityById: new Map(links.map((link) => [getObjectId(link), getFreeEnergyCapacity(link)])),
     storedEnergyById: new Map(links.map((link) => [getObjectId(link), getStoredEnergy(link)]))
   };
-}
-
-function sortLinksByEnergy(links: StructureLink[], projectedState: ProjectedLinkState): StructureLink[] {
-  return [...links].sort(
-    (left, right) =>
-      (projectedState.storedEnergyById.get(getObjectId(right)) ?? 0) -
-        (projectedState.storedEnergyById.get(getObjectId(left)) ?? 0) ||
-      getObjectId(left).localeCompare(getObjectId(right))
-  );
 }
 
 function selectSourceLinks(room: Room, links: StructureLink[], destinationIds: Set<string>): StructureLink[] {
@@ -187,9 +248,9 @@ function selectControllerLink(room: Room, links: StructureLink[]): StructureLink
 function selectStorageLink(
   room: Room,
   links: StructureLink[],
-  controllerLink: StructureLink | null
+  controllerLink: StructureLink | null,
+  storage: StructureStorage | null
 ): StructureLink | null {
-  const storage = room.storage ?? findStorage(room);
   if (!storage) {
     return null;
   }
@@ -235,7 +296,11 @@ function isNearRoomObject(left: RoomObject, right: RoomObject, roomName: string,
   );
 }
 
-function compareRangeToPosition(position: RoomPosition, left: RoomObject, right: RoomObject): number {
+function compareRangeToPosition(position: RoomPosition | null, left: RoomObject, right: RoomObject): number {
+  if (!position) {
+    return 0;
+  }
+
   const leftPosition = getRoomObjectPosition(left);
   const rightPosition = getRoomObjectPosition(right);
   return (

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -281,6 +281,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
           return energyAcquisitionTask;
         }
       }
+
+      const linkEnergyAcquisitionTask = selectEfficientWorkerLinkEnergyAcquisitionTask(creep);
+      if (linkEnergyAcquisitionTask) {
+        return linkEnergyAcquisitionTask;
+      }
     }
 
     const source = selectHarvestSource(creep);
@@ -2430,6 +2435,11 @@ export function selectWorkerEnergyFallbackTask(creep: Creep): CreepTaskMemory | 
     return energyAcquisitionTask;
   }
 
+  const linkEnergyAcquisitionTask = selectEfficientWorkerLinkEnergyAcquisitionTask(creep);
+  if (linkEnergyAcquisitionTask) {
+    return linkEnergyAcquisitionTask;
+  }
+
   const source = selectHarvestSource(creep);
   if (source) {
     return { type: 'harvest', targetId: source.id };
@@ -2795,9 +2805,14 @@ function selectSpawnRecoveryEnergyAcquisitionTask(
   energySink: FillableEnergySink,
   harvestEta: number | null = estimateHarvestDeliveryEta(creep, energySink)
 ): WorkerEnergyAcquisitionTask | null {
-  const candidates = findWorkerEnergyAcquisitionCandidates(creep, {
-    minimumDroppedEnergy: MIN_SPAWN_RECOVERY_DROPPED_ENERGY_PICKUP_AMOUNT
-  })
+  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
+  const recoverableEnergyCandidates = [
+    ...findWorkerEnergyAcquisitionCandidates(creep, {
+      minimumDroppedEnergy: MIN_SPAWN_RECOVERY_DROPPED_ENERGY_PICKUP_AMOUNT
+    }),
+    ...findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext)
+  ];
+  const candidates = recoverableEnergyCandidates
     .map((candidate) => createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink))
     .filter((candidate): candidate is SpawnRecoveryEnergyAcquisitionCandidate => candidate !== null)
     .filter((candidate) => harvestEta === null || candidate.deliveryEta <= harvestEta);
@@ -2917,11 +2932,28 @@ function selectWorkerLinkEnergyFallbackTask(creep: Creep): WorkerEnergyAcquisiti
   return findWorkerLinkEnergyAcquisitionCandidates(creep)[0]?.task ?? null;
 }
 
+function selectEfficientWorkerLinkEnergyAcquisitionTask(creep: Creep): WorkerEnergyAcquisitionTask | null {
+  const linkCandidate = findWorkerLinkEnergyAcquisitionCandidates(creep)[0];
+  if (!linkCandidate) {
+    return null;
+  }
+
+  const harvestSource = selectHarvestSource(creep);
+  if (!harvestSource) {
+    return linkCandidate.task;
+  }
+
+  return isWorkerLinkEnergyMoreEfficientThanHarvest(creep, linkCandidate, harvestSource)
+    ? linkCandidate.task
+    : null;
+}
+
 function findWorkerLinkEnergyAcquisitionCandidates(
   creep: Creep,
   reservationContext = createWorkerEnergyAcquisitionReservationContext(creep),
   options: WorkerEnergyAcquisitionSearchOptions = {}
 ): WorkerEnergyAcquisitionCandidate[] {
+  const minimumLinkEnergy = getMinimumWorkerLinkWithdrawalEnergy(creep);
   return findOwnedWorkerEnergyLinks(creep.room)
     .flatMap((source) => {
       const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
@@ -2932,7 +2964,8 @@ function findWorkerLinkEnergyAcquisitionCandidates(
           type: 'withdraw',
           targetId: source.id as Id<AnyStoreStructure>
         },
-        reservationContext
+        reservationContext,
+        minimumLinkEnergy
       );
 
       return candidate ? [candidate] : [];
@@ -2950,6 +2983,48 @@ function findOwnedWorkerEnergyLinks(room: Room): StructureLink[] {
     filter: (structure) => isLinkEnergySource(structure) && getStoredEnergy(structure) > 0
   });
   return Array.isArray(structures) ? (structures as StructureLink[]) : [];
+}
+
+function getMinimumWorkerLinkWithdrawalEnergy(creep: Creep): number {
+  return Math.max(1, getFreeEnergyCapacity(creep));
+}
+
+function isWorkerLinkEnergyMoreEfficientThanHarvest(
+  creep: Creep,
+  linkCandidate: WorkerEnergyAcquisitionCandidate,
+  harvestSource: Source
+): boolean {
+  const linkEta = estimateWorkerLinkEnergyAcquisitionEta(linkCandidate);
+  const harvestEta = estimateHarvestEnergyAcquisitionEta(creep, harvestSource);
+  return linkEta !== null && harvestEta !== null && linkEta < harvestEta;
+}
+
+function estimateWorkerLinkEnergyAcquisitionEta(candidate: WorkerEnergyAcquisitionCandidate): number | null {
+  return candidate.range === null ? null : candidate.range + ENERGY_ACQUISITION_ACTION_TICKS;
+}
+
+function estimateHarvestEnergyAcquisitionEta(creep: Creep, source: Source): number | null {
+  const sourceAvailabilityDelay = estimateHarvestSourceAvailabilityDelay(source);
+  const range = getHarvestSourceTravelCost(creep, source);
+  if (sourceAvailabilityDelay === null || range === null) {
+    return null;
+  }
+
+  return range + sourceAvailabilityDelay + estimateHarvestEnergyAcquisitionTicks(creep, source);
+}
+
+function estimateHarvestEnergyAcquisitionTicks(creep: Creep, source: Source): number {
+  const energy = Math.min(getHarvestSourceAvailableEnergy(source), getHarvestEnergyTarget(creep));
+  if (energy <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const workParts = getActiveWorkParts(creep);
+  if (workParts <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return Math.ceil(energy / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
 }
 
 function findDroppedEnergyAcquisitionCandidates(

--- a/prod/test/linkManager.test.ts
+++ b/prod/test/linkManager.test.ts
@@ -38,13 +38,15 @@ describe('linkManager', () => {
     });
   });
 
-  it('transfers source link energy to the controller link first', () => {
+  it('transfers source link energy to the controller link before storage surplus', () => {
     const sourceLink = makeLink('source-link', 11, 10, 400, 400);
+    const storageLink = makeLink('storage-link', 20, 21, 0, 800);
     const controllerLink = makeLink('controller-link', 25, 23, 0, 300);
     const room = makeRoom({
       controller: makeController(25, 25),
-      links: [sourceLink, controllerLink],
-      sources: [makeSource('source1', 10, 10)]
+      links: [sourceLink, controllerLink, storageLink],
+      sources: [makeSource('source1', 10, 10)],
+      storage: makeStorage('storage1', 20, 20, 5_000)
     });
 
     expect(transferEnergy(room)).toEqual([
@@ -57,6 +59,7 @@ describe('linkManager', () => {
       }
     ]);
     expect(sourceLink.transferEnergy).toHaveBeenCalledWith(controllerLink, 300);
+    expect(sourceLink.transferEnergy).not.toHaveBeenCalledWith(storageLink, expect.any(Number));
   });
 
   it('falls back to the storage link when the controller link is full', () => {
@@ -96,7 +99,7 @@ describe('linkManager', () => {
     expect(emptySourceLink.transferEnergy).not.toHaveBeenCalled();
   });
 
-  it('tracks projected destination capacity across multiple source links', () => {
+  it('prioritizes the closest source links when filling controller capacity', () => {
     const sourceLinkA = makeLink('source-a', 11, 10, 400, 400);
     const sourceLinkB = makeLink('source-b', 13, 10, 400, 400);
     const controllerLink = makeLink('controller-link', 25, 23, 0, 500);
@@ -107,11 +110,56 @@ describe('linkManager', () => {
     });
 
     expect(transferEnergy(room)).toMatchObject([
-      { amount: 400, sourceId: 'source-a', destinationId: 'controller-link' },
-      { amount: 100, sourceId: 'source-b', destinationId: 'controller-link' }
+      { amount: 400, sourceId: 'source-b', destinationId: 'controller-link' },
+      { amount: 100, sourceId: 'source-a', destinationId: 'controller-link' }
     ]);
-    expect(sourceLinkA.transferEnergy).toHaveBeenCalledWith(controllerLink, 400);
-    expect(sourceLinkB.transferEnergy).toHaveBeenCalledWith(controllerLink, 100);
+    expect(sourceLinkB.transferEnergy).toHaveBeenCalledWith(controllerLink, 400);
+    expect(sourceLinkA.transferEnergy).toHaveBeenCalledWith(controllerLink, 100);
+  });
+
+  it('sends surplus source link energy to storage after controller demand is covered', () => {
+    const controllerSourceLink = makeLink('source-controller', 23, 22, 100, 700);
+    const surplusSourceLink = makeLink('source-surplus', 11, 10, 800, 0);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 100);
+    const storageLink = makeLink('storage-link', 20, 21, 0, 800);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [surplusSourceLink, storageLink, controllerSourceLink, controllerLink],
+      sources: [makeSource('source1', 10, 10), makeSource('source2', 23, 21)],
+      storage: makeStorage('storage1', 20, 20, 5_000, 10_000)
+    });
+
+    expect(transferEnergy(room)).toMatchObject([
+      {
+        amount: 100,
+        destinationId: 'controller-link',
+        destinationRole: 'controller',
+        sourceId: 'source-controller'
+      },
+      {
+        amount: 800,
+        destinationId: 'storage-link',
+        destinationRole: 'storage',
+        sourceId: 'source-surplus'
+      }
+    ]);
+    expect(controllerSourceLink.transferEnergy).toHaveBeenCalledWith(controllerLink, 100);
+    expect(surplusSourceLink.transferEnergy).toHaveBeenCalledWith(storageLink, 800);
+  });
+
+  it('does not send surplus to the storage link when storage is full', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 250, 550);
+    const controllerLink = makeLink('controller-link', 25, 23, 800, 0);
+    const storageLink = makeLink('storage-link', 20, 21, 0, 800);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLink, controllerLink, storageLink],
+      sources: [makeSource('source1', 10, 10)],
+      storage: makeStorage('storage1', 20, 20, 1_000_000, 0)
+    });
+
+    expect(transferEnergy(room)).toEqual([]);
+    expect(sourceLink.transferEnergy).not.toHaveBeenCalled();
   });
 });
 
@@ -166,12 +214,15 @@ function makeLink(
   } as unknown as TestStructureLink;
 }
 
-function makeStorage(id: string, x: number, y: number, energy: number): StructureStorage {
+function makeStorage(id: string, x: number, y: number, energy: number, freeCapacity = 100_000): StructureStorage {
   return {
     id,
     structureType: 'storage',
     pos: makeRoomPosition(x, y),
-    store: { getUsedCapacity: jest.fn().mockReturnValue(energy) }
+    store: {
+      getFreeCapacity: jest.fn().mockReturnValue(freeCapacity),
+      getUsedCapacity: jest.fn().mockReturnValue(energy)
+    }
   } as unknown as StructureStorage;
 }
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -1623,6 +1623,48 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
   });
 
+  it('withdraws from a full nearby link before an inefficient harvest trip', () => {
+    const source = makeSource('source-far', 30, 30, 300);
+    const link = makeStoredEnergyLink('link-near', 11, 10, 800);
+    const room = makeWorkerTaskRoom({
+      myStructures: [link],
+      sources: [source]
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'link-near' ? 1 : 12))
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'link-near' });
+  });
+
+  it('keeps harvesting when a nearby link cannot fill the worker load', () => {
+    const source = makeSource('source-far', 30, 30, 300);
+    const link = makeStoredEnergyLink('link-low', 11, 10, 49);
+    const room = makeWorkerTaskRoom({
+      myStructures: [link],
+      sources: [source]
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'link-low' ? 1 : 12))
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source-far' });
+  });
+
   it('withdraws from containers before falling back to link energy', () => {
     const emptySource = makeSource('source-empty', 10, 10, 0);
     const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 50);


### PR DESCRIPTION
## Summary
Implements link energy transfer network for efficient distribution between link-enabled structures.

## Changes
- `prod/src/economy/linkManager.ts`: Link energy transfer logic with priority-based routing
- `prod/src/tasks/workerTasks.ts`: Worker integration for link-assisted energy delivery
- `prod/test/linkManager.test.ts`: Tests for link transfer priority and throughput
- `prod/test/workerTasks.test.ts`: Tests for worker-link interaction
- `prod/dist/main.js`: Generated bundle

## Verification
- `npx tsc --noEmit`: PASS
- `npx jest --runInBand`: 53 suites, 1169 tests PASS
- `npm run build`: PASS (1.0MB)
- `git diff --check`: clean

## Deployment
Refs #667
