### PR TITLE
feat(economy): optimize worker energy acquisition with link-aware source preference

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12942,7 +12942,11 @@ function findOwnedWorkerEnergyLinks(room) {
   return Array.isArray(structures) ? structures : [];
 }
 function findOwnedSourceWorkerEnergyLinks(room) {
-  return findOwnedWorkerEnergyLinks(room).filter((link) => isSourceLink(room, link)).sort((left, right) => String(left.id).localeCompare(String(right.id)));
+  const workerLinkIds = new Set(findOwnedWorkerEnergyLinks(room).map((link) => String(link.id)));
+  if (workerLinkIds.size === 0) {
+    return [];
+  }
+  return classifyLinks(room).sourceLinks.filter((link) => workerLinkIds.has(String(link.id)));
 }
 function getMinimumWorkerLinkWithdrawalEnergy(creep) {
   return Math.max(1, getFreeEnergyCapacity3(creep));

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -12893,7 +12893,12 @@ function findWorkerEnergyAcquisitionCandidates(creep, options = {}) {
     return candidate ? [candidate] : [];
   }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
   const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext, options);
-  return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
+  const sourceLinkEnergyCandidates = findWorkerSourceLinkEnergyAcquisitionCandidates(
+    creep,
+    reservationContext,
+    options
+  );
+  return [...sourceLinkEnergyCandidates, ...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
 }
 function selectWorkerLinkEnergyFallbackTask(creep) {
   var _a, _b;
@@ -12935,6 +12940,9 @@ function findOwnedWorkerEnergyLinks(room) {
     filter: (structure) => isLinkEnergySource(structure) && getStoredEnergy4(structure) > 0
   });
   return Array.isArray(structures) ? structures : [];
+}
+function findOwnedSourceWorkerEnergyLinks(room) {
+  return findOwnedWorkerEnergyLinks(room).filter((link) => isSourceLink(room, link)).sort((left, right) => String(left.id).localeCompare(String(right.id)));
 }
 function getMinimumWorkerLinkWithdrawalEnergy(creep) {
   return Math.max(1, getFreeEnergyCapacity3(creep));
@@ -12983,6 +12991,12 @@ function findDroppedEnergyAcquisitionCandidates(creep, reservationContext, optio
     );
     return candidate ? [candidate] : [];
   }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options)).sort(compareDroppedEnergyReachabilityPriority).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
+}
+function findWorkerSourceLinkEnergyAcquisitionCandidates(creep, reservationContext, options = {}) {
+  return findOwnedSourceWorkerEnergyLinks(creep.room).flatMap((link) => {
+    const candidate = createSourceLinkEnergyAcquisitionCandidate(creep, link, reservationContext);
+    return candidate ? [candidate] : [];
+  }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
 }
 function isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options) {
   return options.maximumRange === void 0 || candidate.range !== null && candidate.range <= options.maximumRange;
@@ -13961,6 +13975,7 @@ function findSourceContainerWithdrawCandidates(creep) {
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
   const candidates = [];
   const seenContainerIds = /* @__PURE__ */ new Set();
+  const seenLinkIds = /* @__PURE__ */ new Set();
   for (const source of context.sources) {
     const sourceContainer = findVisibleSourceContainer(creep, source);
     if (!sourceContainer || seenContainerIds.has(String(sourceContainer.id))) {
@@ -13979,6 +13994,18 @@ function findSourceContainerWithdrawCandidates(creep) {
       getHarvestSourceAssignmentLoad(context.assignmentLoads, source)
     )) {
       continue;
+    }
+    const sourceLink = findVisibleSourceLink(creep, source);
+    if (sourceLink && !seenLinkIds.has(String(sourceLink.id))) {
+      const sourceLinkCandidate = createSourceLinkEnergyAcquisitionCandidate(
+        creep,
+        sourceLink,
+        reservationContext
+      );
+      if (sourceLinkCandidate) {
+        candidates.push(sourceLinkCandidate);
+        seenLinkIds.add(String(sourceLink.id));
+      }
     }
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
@@ -14000,6 +14027,19 @@ function findSourceContainerWithdrawCandidates(creep) {
     }
   }
   return candidates;
+}
+function createSourceLinkEnergyAcquisitionCandidate(creep, sourceLink, reservationContext) {
+  const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+    creep,
+    sourceLink,
+    getStoredEnergy4(sourceLink),
+    {
+      type: "withdraw",
+      targetId: sourceLink.id
+    },
+    reservationContext
+  );
+  return candidate && candidate.range !== null ? { ...candidate, priority: 1 } : null;
 }
 function selectSourceContainerHarvestTask(creep) {
   const source = selectSourceContainerHarvestSource(creep);
@@ -14092,6 +14132,21 @@ function getAdjacentRoomNames4(roomName, gameMap) {
 function findVisibleSourceContainer(creep, source) {
   const sourceRoom = findVisibleSourceRoom(creep, source);
   return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
+}
+function findVisibleSourceLink(creep, source) {
+  var _a;
+  const sourceRoom = findVisibleSourceRoom(creep, source);
+  if (!sourceRoom) {
+    return null;
+  }
+  return (_a = findOwnedSourceWorkerEnergyLinks(sourceRoom).filter((link) => isSourceLinkNearSource(source, link)).sort((left, right) => compareSourceLinksForSource(source, left, right))[0]) != null ? _a : null;
+}
+function isSourceLinkNearSource(source, link) {
+  const range = getRangeBetweenRoomObjectPositions(source, link);
+  return range !== null && range <= SOURCE_LINK_RANGE;
+}
+function compareSourceLinksForSource(source, left, right) {
+  return compareOptionalRanges(getRangeBetweenRoomObjectPositions(source, left), getRangeBetweenRoomObjectPositions(source, right)) || String(left.id).localeCompare(String(right.id));
 }
 function createSourceContainerWithdrawalContext(creep, sources = findVisibleHarvestSources(creep)) {
   const assignmentLoads = getWorkerHarvestLoads(sources);

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -29,7 +29,7 @@ import {
   withdrawFromStorage
 } from '../economy/energyBuffer';
 import { findSourceContainer } from '../economy/sourceContainers';
-import { isSourceLink } from '../economy/linkManager';
+import { isSourceLink, SOURCE_LINK_RANGE } from '../economy/linkManager';
 import { recordWorkerTaskBehaviorTrace } from '../rl/workerTaskBehavior';
 import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 
@@ -2924,8 +2924,13 @@ function findWorkerEnergyAcquisitionCandidates(
     })
     .filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
   const droppedEnergyCandidates = findDroppedEnergyAcquisitionCandidates(creep, reservationContext, options);
+  const sourceLinkEnergyCandidates = findWorkerSourceLinkEnergyAcquisitionCandidates(
+    creep,
+    reservationContext,
+    options
+  );
 
-  return [...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
+  return [...sourceLinkEnergyCandidates, ...storedEnergyCandidates, ...salvageEnergyCandidates, ...droppedEnergyCandidates];
 }
 
 function selectWorkerLinkEnergyFallbackTask(creep: Creep): WorkerEnergyAcquisitionTask | null {
@@ -2983,6 +2988,12 @@ function findOwnedWorkerEnergyLinks(room: Room): StructureLink[] {
     filter: (structure) => isLinkEnergySource(structure) && getStoredEnergy(structure) > 0
   });
   return Array.isArray(structures) ? (structures as StructureLink[]) : [];
+}
+
+function findOwnedSourceWorkerEnergyLinks(room: Room): StructureLink[] {
+  return findOwnedWorkerEnergyLinks(room)
+    .filter((link) => isSourceLink(room, link))
+    .sort((left, right) => String(left.id).localeCompare(String(right.id)));
 }
 
 function getMinimumWorkerLinkWithdrawalEnergy(creep: Creep): number {
@@ -3055,6 +3066,19 @@ function findDroppedEnergyAcquisitionCandidates(
     .sort(compareDroppedEnergyReachabilityPriority)
     .slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS)
     .filter((candidate) => isReachable(creep, candidate.source));
+}
+
+function findWorkerSourceLinkEnergyAcquisitionCandidates(
+  creep: Creep,
+  reservationContext: WorkerEnergyAcquisitionReservationContext,
+  options: WorkerEnergyAcquisitionSearchOptions = {}
+): WorkerEnergyAcquisitionCandidate[] {
+  return findOwnedSourceWorkerEnergyLinks(creep.room)
+    .flatMap((link) => {
+      const candidate = createSourceLinkEnergyAcquisitionCandidate(creep, link, reservationContext);
+      return candidate ? [candidate] : [];
+    })
+    .filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
 }
 
 function isWorkerEnergyAcquisitionCandidateWithinSearchRange(
@@ -4574,6 +4598,7 @@ function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquis
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
   const candidates: WorkerEnergyAcquisitionCandidate[] = [];
   const seenContainerIds = new Set<string>();
+  const seenLinkIds = new Set<string>();
 
   for (const source of context.sources) {
     const sourceContainer = findVisibleSourceContainer(creep, source);
@@ -4598,6 +4623,19 @@ function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquis
       )
     ) {
       continue;
+    }
+
+    const sourceLink = findVisibleSourceLink(creep, source);
+    if (sourceLink && !seenLinkIds.has(String(sourceLink.id))) {
+      const sourceLinkCandidate = createSourceLinkEnergyAcquisitionCandidate(
+        creep,
+        sourceLink,
+        reservationContext
+      );
+      if (sourceLinkCandidate) {
+        candidates.push(sourceLinkCandidate);
+        seenLinkIds.add(String(sourceLink.id));
+      }
     }
 
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
@@ -4625,6 +4663,25 @@ function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquis
   }
 
   return candidates;
+}
+
+function createSourceLinkEnergyAcquisitionCandidate(
+  creep: Creep,
+  sourceLink: StructureLink,
+  reservationContext: WorkerEnergyAcquisitionReservationContext
+): WorkerEnergyAcquisitionCandidate | null {
+  const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
+    creep,
+    sourceLink,
+    getStoredEnergy(sourceLink),
+    {
+      type: 'withdraw',
+      targetId: sourceLink.id as Id<AnyStoreStructure>
+    },
+    reservationContext
+  );
+
+  return candidate && candidate.range !== null ? { ...candidate, priority: 1 } : null;
 }
 
 function selectSourceContainerHarvestTask(creep: Creep): Extract<CreepTaskMemory, { type: 'harvest' }> | null {
@@ -4748,6 +4805,31 @@ function getAdjacentRoomNames(roomName: string, gameMap: Partial<GameMap> | unde
 function findVisibleSourceContainer(creep: Creep, source: Source): StructureContainer | null {
   const sourceRoom = findVisibleSourceRoom(creep, source);
   return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
+}
+
+function findVisibleSourceLink(creep: Creep, source: Source): StructureLink | null {
+  const sourceRoom = findVisibleSourceRoom(creep, source);
+  if (!sourceRoom) {
+    return null;
+  }
+
+  return (
+    findOwnedSourceWorkerEnergyLinks(sourceRoom)
+      .filter((link) => isSourceLinkNearSource(source, link))
+      .sort((left, right) => compareSourceLinksForSource(source, left, right))[0] ?? null
+  );
+}
+
+function isSourceLinkNearSource(source: Source, link: StructureLink): boolean {
+  const range = getRangeBetweenRoomObjectPositions(source, link);
+  return range !== null && range <= SOURCE_LINK_RANGE;
+}
+
+function compareSourceLinksForSource(source: Source, left: StructureLink, right: StructureLink): number {
+  return (
+    compareOptionalRanges(getRangeBetweenRoomObjectPositions(source, left), getRangeBetweenRoomObjectPositions(source, right)) ||
+    String(left.id).localeCompare(String(right.id))
+  );
 }
 
 function createSourceContainerWithdrawalContext(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -29,7 +29,7 @@ import {
   withdrawFromStorage
 } from '../economy/energyBuffer';
 import { findSourceContainer } from '../economy/sourceContainers';
-import { isSourceLink, SOURCE_LINK_RANGE } from '../economy/linkManager';
+import { classifyLinks, isSourceLink, SOURCE_LINK_RANGE } from '../economy/linkManager';
 import { recordWorkerTaskBehaviorTrace } from '../rl/workerTaskBehavior';
 import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 
@@ -2991,9 +2991,12 @@ function findOwnedWorkerEnergyLinks(room: Room): StructureLink[] {
 }
 
 function findOwnedSourceWorkerEnergyLinks(room: Room): StructureLink[] {
-  return findOwnedWorkerEnergyLinks(room)
-    .filter((link) => isSourceLink(room, link))
-    .sort((left, right) => String(left.id).localeCompare(String(right.id)));
+  const workerLinkIds = new Set(findOwnedWorkerEnergyLinks(room).map((link) => String(link.id)));
+  if (workerLinkIds.size === 0) {
+    return [];
+  }
+
+  return classifyLinks(room).sourceLinks.filter((link) => workerLinkIds.has(String(link.id)));
 }
 
 function getMinimumWorkerLinkWithdrawalEnergy(creep: Creep): number {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -66,6 +66,22 @@ function setGameSpawns(spawns: Record<string, StructureSpawn>): void {
   globalScope.Game = { ...(globalScope.Game ?? {}), spawns };
 }
 
+function setSourceContainerHarvester(room: Room, sourceId: string): void {
+  setGameCreeps({
+    SourceHarvester: {
+      memory: {
+        role: 'worker',
+        task: {
+          type: 'harvest',
+          targetId: sourceId as Id<Source>,
+          sourceContainerAssigned: true
+        }
+      },
+      room
+    } as unknown as Creep
+  });
+}
+
 function makeStructure(
   id: string,
   structureType: StructureConstant,
@@ -1685,6 +1701,29 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
   });
 
+  it('withdraws from a nearby source link before a distant ordinary container', () => {
+    const emptySource = makeSource('source-empty', 10, 10, 0);
+    const distantContainer = makeStoredEnergyStructure('container-distant', 'container' as StructureConstant, 200);
+    const sourceLink = makeStoredEnergyLink('link-source', 10, 12, 25);
+    const room = makeWorkerTaskRoom({
+      myStructures: [sourceLink],
+      sources: [emptySource],
+      structures: [distantContainer]
+    });
+    const creep = {
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'link-source' ? 1 : 12))
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'link-source' });
+  });
+
   it('withdraws from the closest owned link when containers and sources are empty', () => {
     const emptySource = makeSource('source-empty', 10, 10, 0);
     const closeLink = makeStoredEnergyLink('link-close', 11, 10, 100);
@@ -2825,6 +2864,88 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
+  });
+
+  it('falls back to a source container when the saturated source has no link', () => {
+    const source = makeSource('source1', 10, 10);
+    const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 200, {
+      pos: makeRoomPosition(10, 11)
+    });
+    const room = makeWorkerTaskRoom({
+      controller: { id: 'controller1', my: true, level: 1 } as StructureController,
+      sources: [source],
+      structures: [container]
+    });
+    setSourceContainerHarvester(room, 'source1');
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'container1' ? 12 : 99))
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
+  });
+
+  it('falls back to a source container when the nearby source link is empty', () => {
+    const source = makeSource('source1', 10, 10);
+    const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 200, {
+      pos: makeRoomPosition(10, 11)
+    });
+    const link = makeStoredEnergyLink('link-empty', 10, 12, 0);
+    const room = makeWorkerTaskRoom({
+      controller: { id: 'controller1', my: true, level: 1 } as StructureController,
+      myStructures: [link],
+      sources: [source],
+      structures: [container]
+    });
+    setSourceContainerHarvester(room, 'source1');
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'link-empty' ? 1 : 12))
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container1' });
+  });
+
+  it('withdraws from a same-source link before walking to a distant source container', () => {
+    const source = makeSource('source1', 10, 10);
+    const container = makeStoredEnergyStructure('container1', 'container' as StructureConstant, 200, {
+      pos: makeRoomPosition(10, 11)
+    });
+    const link = makeStoredEnergyLink('link-source', 10, 12, 25);
+    const room = makeWorkerTaskRoom({
+      controller: { id: 'controller1', my: true, level: 1 } as StructureController,
+      myStructures: [link],
+      sources: [source],
+      structures: [container]
+    });
+    setSourceContainerHarvester(room, 'source1');
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'link-source' ? 1 : 12))
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'link-source' });
   });
 
   it('withdraws from a saturated local source container before traveling to an adjacent assignable source', () => {


### PR DESCRIPTION
Closes #670

## Summary
Optimizes worker energy acquisition to prefer link energy when available, reducing spawn energy drain and improving worker efficiency when link networks are active.

## Changes
- `prod/src/tasks/workerTasks.ts`: Link-aware source preference logic for worker energy acquisition
- `prod/test/workerTasks.test.ts`: Tests for link-aware source selection
- `prod/dist/main.js`: Generated build artifact

## Verification
```
npm run typecheck: PASS
npm test -- --runInBand: 53 suites, 1179 tests PASS
npm run build: PASS
```

Commit: `3781474` by `lanyusea's bot <lanyusea@gmail.com>`
