### PR TITLE
feat(economy): improve link network energy routing for source-to-controller/storage flow

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10653,16 +10653,16 @@ function isSourceLink(room, link) {
   const linkId = getObjectId4(link);
   return linkId !== "" && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId4(sourceLink) === linkId);
 }
-function getSourceLinkWorkerEnergyAvailable(room, link) {
+function getSourceLinkWorkerEnergyAvailable(room, link, network) {
   var _a;
   const linkId = getObjectId4(link);
-  const network = classifyLinks(room);
-  const sourceLink = network.sourceLinks.find((candidate) => getObjectId4(candidate) === linkId);
+  const linkNetwork = network != null ? network : classifyLinks(room);
+  const sourceLink = linkNetwork.sourceLinks.find((candidate) => getObjectId4(candidate) === linkId);
   if (!sourceLink) {
     return getStoredEnergy3(link);
   }
-  const projectedState = createProjectedLinkState(network.links);
-  const routingReserve = (_a = createSourceLinkRoutingReserve(room, network, projectedState).get(linkId)) != null ? _a : 0;
+  const projectedState = createProjectedLinkState(linkNetwork.links);
+  const routingReserve = (_a = createSourceLinkRoutingReserve(room, linkNetwork, projectedState).get(linkId)) != null ? _a : 0;
   return Math.max(0, getStoredEnergy3(sourceLink) - routingReserve);
 }
 function transferLinkEnergy(sourceLink, destinationLink, amount) {
@@ -10738,11 +10738,13 @@ function shouldStorageReceiveLinkEnergy(storage) {
 }
 function createSourceLinkRoutingReserve(room, network, projectedState) {
   const reserveById = /* @__PURE__ */ new Map();
+  const spentSourceIds = /* @__PURE__ */ new Set();
   if (shouldControllerLinkReceiveEnergy(room, network.controllerLink, projectedState)) {
     reserveSourceLinksForDestination(
       sortSourceLinksByDistanceToDestination(network.sourceLinks, network.controllerLink),
       network.controllerLink,
       projectedState,
+      spentSourceIds,
       reserveById
     );
   }
@@ -10751,19 +10753,20 @@ function createSourceLinkRoutingReserve(room, network, projectedState) {
       sortSourceLinksBySurplusPriority(network.sourceLinks, network.storageLink, projectedState),
       network.storageLink,
       projectedState,
+      spentSourceIds,
       reserveById
     );
   }
   return reserveById;
 }
-function reserveSourceLinksForDestination(sourceLinks, destinationLink, projectedState, reserveById) {
+function reserveSourceLinksForDestination(sourceLinks, destinationLink, projectedState, spentSourceIds, reserveById) {
   var _a, _b, _c;
   const destinationId = getObjectId4(destinationLink);
   for (const sourceLink of sourceLinks) {
     const sourceId = getObjectId4(sourceLink);
     const destinationFreeCapacity = (_a = projectedState.freeCapacityById.get(destinationId)) != null ? _a : 0;
     const sourceEnergy = (_b = projectedState.storedEnergyById.get(sourceId)) != null ? _b : 0;
-    if (destinationId === sourceId || destinationFreeCapacity <= 0 || sourceEnergy <= 0) {
+    if (spentSourceIds.has(sourceId) || !canLinkSendEnergy(sourceLink, projectedState) || destinationId === sourceId || destinationFreeCapacity <= 0 || sourceEnergy <= 0) {
       continue;
     }
     const amount = Math.min(sourceEnergy, destinationFreeCapacity);
@@ -10771,6 +10774,7 @@ function reserveSourceLinksForDestination(sourceLinks, destinationLink, projecte
       continue;
     }
     reserveById.set(sourceId, ((_c = reserveById.get(sourceId)) != null ? _c : 0) + amount);
+    spentSourceIds.add(sourceId);
     projectedState.storedEnergyById.set(sourceId, sourceEnergy - amount);
     projectedState.freeCapacityById.set(destinationId, destinationFreeCapacity - amount);
   }
@@ -13108,8 +13112,13 @@ function selectEfficientWorkerLinkEnergyAcquisitionTask(creep) {
 }
 function findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext = createWorkerEnergyAcquisitionReservationContext(creep), options = {}) {
   const minimumLinkEnergy = getMinimumWorkerLinkWithdrawalEnergy(creep);
-  return findOwnedWorkerEnergyLinks(creep.room).flatMap((source) => {
-    const availableEnergy = getWorkerLinkEnergyAvailable(creep.room, source);
+  const workerLinks = findOwnedWorkerEnergyLinks(creep.room);
+  if (workerLinks.length === 0) {
+    return [];
+  }
+  const network = classifyLinks(creep.room);
+  return workerLinks.flatMap((source) => {
+    const availableEnergy = getWorkerLinkEnergyAvailable(creep.room, source, network);
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
@@ -13133,18 +13142,21 @@ function findOwnedWorkerEnergyLinks(room) {
   });
   return Array.isArray(structures) ? structures : [];
 }
-function findOwnedSourceWorkerEnergyLinks(room) {
+function findOwnedSourceWorkerEnergyLinks(room, network) {
   const workerLinkIds = new Set(findOwnedWorkerEnergyLinks(room).map((link) => String(link.id)));
   if (workerLinkIds.size === 0) {
     return [];
   }
-  return classifyLinks(room).sourceLinks.filter((link) => workerLinkIds.has(String(link.id)));
+  return selectOwnedSourceWorkerEnergyLinks(network != null ? network : classifyLinks(room), workerLinkIds);
+}
+function selectOwnedSourceWorkerEnergyLinks(network, workerLinkIds) {
+  return network.sourceLinks.filter((link) => workerLinkIds.has(String(link.id)));
 }
 function getMinimumWorkerLinkWithdrawalEnergy(creep) {
   return Math.max(1, getFreeEnergyCapacity3(creep));
 }
-function getWorkerLinkEnergyAvailable(room, link) {
-  return getSourceLinkWorkerEnergyAvailable(room, link);
+function getWorkerLinkEnergyAvailable(room, link, network) {
+  return getSourceLinkWorkerEnergyAvailable(room, link, network);
 }
 function isWorkerLinkEnergyMoreEfficientThanHarvest(creep, linkCandidate, harvestSource) {
   const linkEta = estimateWorkerLinkEnergyAcquisitionEta(linkCandidate);
@@ -13192,8 +13204,13 @@ function findDroppedEnergyAcquisitionCandidates(creep, reservationContext, optio
   }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options)).sort(compareDroppedEnergyReachabilityPriority).slice(0, MAX_DROPPED_ENERGY_REACHABILITY_CHECKS).filter((candidate) => isReachable(creep, candidate.source));
 }
 function findWorkerSourceLinkEnergyAcquisitionCandidates(creep, reservationContext, options = {}) {
-  return findOwnedSourceWorkerEnergyLinks(creep.room).flatMap((link) => {
-    const candidate = createSourceLinkEnergyAcquisitionCandidate(creep, link, reservationContext);
+  const workerLinkIds = new Set(findOwnedWorkerEnergyLinks(creep.room).map((link) => String(link.id)));
+  if (workerLinkIds.size === 0) {
+    return [];
+  }
+  const network = classifyLinks(creep.room);
+  return selectOwnedSourceWorkerEnergyLinks(network, workerLinkIds).flatMap((link) => {
+    const candidate = createSourceLinkEnergyAcquisitionCandidate(creep, link, reservationContext, network);
     return candidate ? [candidate] : [];
   }).filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
 }
@@ -14175,6 +14192,7 @@ function findSourceContainerWithdrawCandidates(creep) {
   const candidates = [];
   const seenContainerIds = /* @__PURE__ */ new Set();
   const seenLinkIds = /* @__PURE__ */ new Set();
+  const linkNetworksByRoomName = /* @__PURE__ */ new Map();
   for (const source of context.sources) {
     const sourceContainer = findVisibleSourceContainer(creep, source);
     if (!sourceContainer || seenContainerIds.has(String(sourceContainer.id))) {
@@ -14194,12 +14212,15 @@ function findSourceContainerWithdrawCandidates(creep) {
     )) {
       continue;
     }
-    const sourceLink = findVisibleSourceLink(creep, source);
+    const linkNetwork = getCachedLinkNetwork(sourceRoom, linkNetworksByRoomName);
+    const sourceLink = findVisibleSourceLink(sourceRoom, source, linkNetwork);
     if (sourceLink && !seenLinkIds.has(String(sourceLink.id))) {
       const sourceLinkCandidate = createSourceLinkEnergyAcquisitionCandidate(
         creep,
         sourceLink,
-        reservationContext
+        reservationContext,
+        linkNetwork,
+        sourceRoom
       );
       if (sourceLinkCandidate) {
         candidates.push(sourceLinkCandidate);
@@ -14227,8 +14248,8 @@ function findSourceContainerWithdrawCandidates(creep) {
   }
   return candidates;
 }
-function createSourceLinkEnergyAcquisitionCandidate(creep, sourceLink, reservationContext) {
-  const availableEnergy = getSourceLinkWorkerEnergyAvailable(creep.room, sourceLink);
+function createSourceLinkEnergyAcquisitionCandidate(creep, sourceLink, reservationContext, network, room = creep.room) {
+  const availableEnergy = getSourceLinkWorkerEnergyAvailable(room, sourceLink, network);
   const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
     creep,
     sourceLink,
@@ -14333,13 +14354,18 @@ function findVisibleSourceContainer(creep, source) {
   const sourceRoom = findVisibleSourceRoom(creep, source);
   return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
 }
-function findVisibleSourceLink(creep, source) {
+function findVisibleSourceLink(sourceRoom, source, network) {
   var _a;
-  const sourceRoom = findVisibleSourceRoom(creep, source);
-  if (!sourceRoom) {
-    return null;
+  return (_a = findOwnedSourceWorkerEnergyLinks(sourceRoom, network).filter((link) => isSourceLinkNearSource(source, link)).sort((left, right) => compareSourceLinksForSource(source, left, right))[0]) != null ? _a : null;
+}
+function getCachedLinkNetwork(room, networksByRoomName) {
+  const cached = networksByRoomName.get(room.name);
+  if (cached) {
+    return cached;
   }
-  return (_a = findOwnedSourceWorkerEnergyLinks(sourceRoom).filter((link) => isSourceLinkNearSource(source, link)).sort((left, right) => compareSourceLinksForSource(source, left, right))[0]) != null ? _a : null;
+  const network = classifyLinks(room);
+  networksByRoomName.set(room.name, network);
+  return network;
 }
 function isSourceLinkNearSource(source, link) {
   const range = getRangeBetweenRoomObjectPositions(source, link);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10790,13 +10790,13 @@ function getKnownStoredEnergy(structure) {
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : null;
 }
 function getKnownFreeEnergyCapacity(structure) {
-  var _a, _b;
-  const freeCapacity = (_b = (_a = structure.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4());
+  var _a, _b, _c, _d, _e;
+  const freeCapacity = (_e = (_b = (_a = structure.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4())) != null ? _e : (_d = (_c = structure.store) == null ? void 0 : _c.getFreeCapacity) == null ? void 0 : _d.call(_c);
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : null;
 }
 function getKnownEnergyCapacity(structure) {
-  var _a, _b;
-  const capacity = (_b = (_a = structure.store) == null ? void 0 : _a.getCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4());
+  var _a, _b, _c, _d, _e;
+  const capacity = (_e = (_b = (_a = structure.store) == null ? void 0 : _a.getCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4())) != null ? _e : (_d = (_c = structure.store) == null ? void 0 : _c.getCapacity) == null ? void 0 : _d.call(_c);
   return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : null;
 }
 function sortSourceLinksByDistanceToDestination(links, destinationLink) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10602,6 +10602,7 @@ function matchesStructureType7(actual, globalName, fallback) {
 var SOURCE_LINK_RANGE = 2;
 var CONTROLLER_LINK_RANGE = 3;
 var STORAGE_LINK_RANGE = 2;
+var STORAGE_LINK_ROUTING_TARGET_RATIO = 0.3;
 var OK_CODE4 = 0;
 function transferEnergy(room) {
   const network = classifyLinks(room);
@@ -10651,6 +10652,18 @@ function classifyLinks(room) {
 function isSourceLink(room, link) {
   const linkId = getObjectId4(link);
   return linkId !== "" && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId4(sourceLink) === linkId);
+}
+function getSourceLinkWorkerEnergyAvailable(room, link) {
+  var _a;
+  const linkId = getObjectId4(link);
+  const network = classifyLinks(room);
+  const sourceLink = network.sourceLinks.find((candidate) => getObjectId4(candidate) === linkId);
+  if (!sourceLink) {
+    return getStoredEnergy3(link);
+  }
+  const projectedState = createProjectedLinkState(network.links);
+  const routingReserve = (_a = createSourceLinkRoutingReserve(room, network, projectedState).get(linkId)) != null ? _a : 0;
+  return Math.max(0, getStoredEnergy3(sourceLink) - routingReserve);
 }
 function transferLinkEnergy(sourceLink, destinationLink, amount) {
   return sourceLink.transferEnergy(destinationLink, amount);
@@ -10706,19 +10719,76 @@ function shouldStorageLinkReceiveSurplus(network, projectedState) {
   if (!network.storageLink || getObjectId4(network.storageLink) === getObjectId4(network.controllerLink)) {
     return false;
   }
-  return ((_a = projectedState.freeCapacityById.get(getObjectId4(network.storageLink))) != null ? _a : 0) > 0 && hasStorageFreeCapacity(network.storage);
+  return ((_a = projectedState.freeCapacityById.get(getObjectId4(network.storageLink))) != null ? _a : 0) > 0 && shouldStorageReceiveLinkEnergy(network.storage);
 }
-function hasStorageFreeCapacity(storage) {
+function shouldStorageReceiveLinkEnergy(storage) {
   if (!storage) {
     return false;
   }
   const freeCapacity = getKnownFreeEnergyCapacity(storage);
-  return freeCapacity === null || freeCapacity > 0;
+  if (freeCapacity !== null && freeCapacity <= 0) {
+    return false;
+  }
+  const capacity = getKnownEnergyCapacity(storage);
+  const storedEnergy = getKnownStoredEnergy(storage);
+  if (capacity !== null && storedEnergy !== null && capacity > 0) {
+    return storedEnergy < Math.ceil(capacity * STORAGE_LINK_ROUTING_TARGET_RATIO);
+  }
+  return true;
+}
+function createSourceLinkRoutingReserve(room, network, projectedState) {
+  const reserveById = /* @__PURE__ */ new Map();
+  if (shouldControllerLinkReceiveEnergy(room, network.controllerLink, projectedState)) {
+    reserveSourceLinksForDestination(
+      sortSourceLinksByDistanceToDestination(network.sourceLinks, network.controllerLink),
+      network.controllerLink,
+      projectedState,
+      reserveById
+    );
+  }
+  if (shouldStorageLinkReceiveSurplus(network, projectedState)) {
+    reserveSourceLinksForDestination(
+      sortSourceLinksBySurplusPriority(network.sourceLinks, network.storageLink, projectedState),
+      network.storageLink,
+      projectedState,
+      reserveById
+    );
+  }
+  return reserveById;
+}
+function reserveSourceLinksForDestination(sourceLinks, destinationLink, projectedState, reserveById) {
+  var _a, _b, _c;
+  const destinationId = getObjectId4(destinationLink);
+  for (const sourceLink of sourceLinks) {
+    const sourceId = getObjectId4(sourceLink);
+    const destinationFreeCapacity = (_a = projectedState.freeCapacityById.get(destinationId)) != null ? _a : 0;
+    const sourceEnergy = (_b = projectedState.storedEnergyById.get(sourceId)) != null ? _b : 0;
+    if (destinationId === sourceId || destinationFreeCapacity <= 0 || sourceEnergy <= 0) {
+      continue;
+    }
+    const amount = Math.min(sourceEnergy, destinationFreeCapacity);
+    if (amount <= 0) {
+      continue;
+    }
+    reserveById.set(sourceId, ((_c = reserveById.get(sourceId)) != null ? _c : 0) + amount);
+    projectedState.storedEnergyById.set(sourceId, sourceEnergy - amount);
+    projectedState.freeCapacityById.set(destinationId, destinationFreeCapacity - amount);
+  }
+}
+function getKnownStoredEnergy(structure) {
+  var _a, _b;
+  const storedEnergy = (_b = (_a = structure.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4());
+  return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : null;
 }
 function getKnownFreeEnergyCapacity(structure) {
   var _a, _b;
   const freeCapacity = (_b = (_a = structure.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4());
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : null;
+}
+function getKnownEnergyCapacity(structure) {
+  var _a, _b;
+  const capacity = (_b = (_a = structure.store) == null ? void 0 : _a.getCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4());
+  return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : null;
 }
 function sortSourceLinksByDistanceToDestination(links, destinationLink) {
   const destinationPosition = getRoomObjectPosition2(destinationLink);
@@ -10817,9 +10887,8 @@ function findSources2(room) {
   return Array.isArray(result) ? result : [];
 }
 function getStoredEnergy3(structure) {
-  var _a, _b;
-  const storedEnergy = (_b = (_a = structure.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, getEnergyResource4());
-  return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+  var _a;
+  return (_a = getKnownStoredEnergy(structure)) != null ? _a : 0;
 }
 function getFreeEnergyCapacity(structure) {
   var _a, _b;
@@ -11711,7 +11780,7 @@ function recordSpawnCriticalRefillTelemetry(creep, spawn) {
     tick: (_a = getGameTick3()) != null ? _a : 0,
     targetId: String(spawn.id),
     carriedEnergy: getUsedEnergy2(creep),
-    spawnEnergy: (_b = getKnownStoredEnergy(spawn)) != null ? _b : 0,
+    spawnEnergy: (_b = getKnownStoredEnergy2(spawn)) != null ? _b : 0,
     freeCapacity: getFreeStoredEnergyCapacity(spawn),
     threshold: CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD
   };
@@ -11879,7 +11948,7 @@ function isLowEnergySpawn(structure) {
   return isSpawnEnergySink(structure) && getStoredEnergy4(structure) < getSpawnEnergyCapacity();
 }
 function isCriticalSpawnEnergySink(structure) {
-  const storedEnergy = getKnownStoredEnergy(structure);
+  const storedEnergy = getKnownStoredEnergy2(structure);
   return isSpawnEnergySink(structure) && storedEnergy !== null && storedEnergy < CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 function getSpawnEnergyCapacity() {
@@ -13040,10 +13109,11 @@ function selectEfficientWorkerLinkEnergyAcquisitionTask(creep) {
 function findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext = createWorkerEnergyAcquisitionReservationContext(creep), options = {}) {
   const minimumLinkEnergy = getMinimumWorkerLinkWithdrawalEnergy(creep);
   return findOwnedWorkerEnergyLinks(creep.room).flatMap((source) => {
+    const availableEnergy = getWorkerLinkEnergyAvailable(creep.room, source);
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy4(source),
+      availableEnergy,
       {
         type: "withdraw",
         targetId: source.id
@@ -13072,6 +13142,9 @@ function findOwnedSourceWorkerEnergyLinks(room) {
 }
 function getMinimumWorkerLinkWithdrawalEnergy(creep) {
   return Math.max(1, getFreeEnergyCapacity3(creep));
+}
+function getWorkerLinkEnergyAvailable(room, link) {
+  return getSourceLinkWorkerEnergyAvailable(room, link);
 }
 function isWorkerLinkEnergyMoreEfficientThanHarvest(creep, linkCandidate, harvestSource) {
   const linkEta = estimateWorkerLinkEnergyAcquisitionEta(linkCandidate);
@@ -14001,9 +14074,9 @@ function getFreeEnergyCapacity3(creep) {
 }
 function getStoredEnergy4(object) {
   var _a;
-  return (_a = getKnownStoredEnergy(object)) != null ? _a : 0;
+  return (_a = getKnownStoredEnergy2(object)) != null ? _a : 0;
 }
-function getKnownStoredEnergy(object) {
+function getKnownStoredEnergy2(object) {
   var _a;
   const store = getStore(object);
   if (store) {
@@ -14155,10 +14228,11 @@ function findSourceContainerWithdrawCandidates(creep) {
   return candidates;
 }
 function createSourceLinkEnergyAcquisitionCandidate(creep, sourceLink, reservationContext) {
+  const availableEnergy = getSourceLinkWorkerEnergyAvailable(creep.room, sourceLink);
   const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
     creep,
     sourceLink,
-    getStoredEnergy4(sourceLink),
+    availableEnergy,
     {
       type: "withdraw",
       targetId: sourceLink.id

--- a/prod/src/economy/linkManager.ts
+++ b/prod/src/economy/linkManager.ts
@@ -93,16 +93,16 @@ export function isSourceLink(room: Room, link: StructureLink): boolean {
   return linkId !== '' && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId(sourceLink) === linkId);
 }
 
-export function getSourceLinkWorkerEnergyAvailable(room: Room, link: StructureLink): number {
+export function getSourceLinkWorkerEnergyAvailable(room: Room, link: StructureLink, network?: LinkNetwork): number {
   const linkId = getObjectId(link);
-  const network = classifyLinks(room);
-  const sourceLink = network.sourceLinks.find((candidate) => getObjectId(candidate) === linkId);
+  const linkNetwork = network ?? classifyLinks(room);
+  const sourceLink = linkNetwork.sourceLinks.find((candidate) => getObjectId(candidate) === linkId);
   if (!sourceLink) {
     return getStoredEnergy(link);
   }
 
-  const projectedState = createProjectedLinkState(network.links);
-  const routingReserve = createSourceLinkRoutingReserve(room, network, projectedState).get(linkId) ?? 0;
+  const projectedState = createProjectedLinkState(linkNetwork.links);
+  const routingReserve = createSourceLinkRoutingReserve(room, linkNetwork, projectedState).get(linkId) ?? 0;
   return Math.max(0, getStoredEnergy(sourceLink) - routingReserve);
 }
 
@@ -211,12 +211,14 @@ function createSourceLinkRoutingReserve(
   projectedState: ProjectedLinkState
 ): Map<string, number> {
   const reserveById = new Map<string, number>();
+  const spentSourceIds = new Set<string>();
 
   if (shouldControllerLinkReceiveEnergy(room, network.controllerLink, projectedState)) {
     reserveSourceLinksForDestination(
       sortSourceLinksByDistanceToDestination(network.sourceLinks, network.controllerLink),
       network.controllerLink,
       projectedState,
+      spentSourceIds,
       reserveById
     );
   }
@@ -226,6 +228,7 @@ function createSourceLinkRoutingReserve(
       sortSourceLinksBySurplusPriority(network.sourceLinks, network.storageLink, projectedState),
       network.storageLink,
       projectedState,
+      spentSourceIds,
       reserveById
     );
   }
@@ -237,6 +240,7 @@ function reserveSourceLinksForDestination(
   sourceLinks: StructureLink[],
   destinationLink: StructureLink,
   projectedState: ProjectedLinkState,
+  spentSourceIds: Set<string>,
   reserveById: Map<string, number>
 ): void {
   const destinationId = getObjectId(destinationLink);
@@ -245,7 +249,13 @@ function reserveSourceLinksForDestination(
     const sourceId = getObjectId(sourceLink);
     const destinationFreeCapacity = projectedState.freeCapacityById.get(destinationId) ?? 0;
     const sourceEnergy = projectedState.storedEnergyById.get(sourceId) ?? 0;
-    if (destinationId === sourceId || destinationFreeCapacity <= 0 || sourceEnergy <= 0) {
+    if (
+      spentSourceIds.has(sourceId) ||
+      !canLinkSendEnergy(sourceLink, projectedState) ||
+      destinationId === sourceId ||
+      destinationFreeCapacity <= 0 ||
+      sourceEnergy <= 0
+    ) {
       continue;
     }
 
@@ -255,6 +265,7 @@ function reserveSourceLinksForDestination(
     }
 
     reserveById.set(sourceId, (reserveById.get(sourceId) ?? 0) + amount);
+    spentSourceIds.add(sourceId);
     projectedState.storedEnergyById.set(sourceId, sourceEnergy - amount);
     projectedState.freeCapacityById.set(destinationId, destinationFreeCapacity - amount);
   }

--- a/prod/src/economy/linkManager.ts
+++ b/prod/src/economy/linkManager.ts
@@ -277,12 +277,14 @@ function getKnownStoredEnergy(structure: StructureLink | StructureStorage): numb
 }
 
 function getKnownFreeEnergyCapacity(structure: StructureLink | StructureStorage): number | null {
-  const freeCapacity = structure.store?.getFreeCapacity?.(getEnergyResource());
+  const freeCapacity =
+    structure.store?.getFreeCapacity?.(getEnergyResource()) ?? structure.store?.getFreeCapacity?.();
   return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : null;
 }
 
 function getKnownEnergyCapacity(structure: StructureLink | StructureStorage): number | null {
-  const capacity = structure.store?.getCapacity?.(getEnergyResource());
+  const capacity =
+    structure.store?.getCapacity?.(getEnergyResource()) ?? structure.store?.getCapacity?.();
   return typeof capacity === 'number' && Number.isFinite(capacity) ? Math.max(0, capacity) : null;
 }
 

--- a/prod/src/economy/linkManager.ts
+++ b/prod/src/economy/linkManager.ts
@@ -9,6 +9,7 @@ type LinkStructureConstantGlobal = 'STRUCTURE_LINK' | 'STRUCTURE_STORAGE';
 export const SOURCE_LINK_RANGE = 2;
 export const CONTROLLER_LINK_RANGE = 3;
 export const STORAGE_LINK_RANGE = 2;
+export const STORAGE_LINK_ROUTING_TARGET_RATIO = 0.3;
 const OK_CODE = 0 as ScreepsReturnCode;
 
 export type LinkDestinationRole = 'controller' | 'storage';
@@ -92,6 +93,19 @@ export function isSourceLink(room: Room, link: StructureLink): boolean {
   return linkId !== '' && classifyLinks(room).sourceLinks.some((sourceLink) => getObjectId(sourceLink) === linkId);
 }
 
+export function getSourceLinkWorkerEnergyAvailable(room: Room, link: StructureLink): number {
+  const linkId = getObjectId(link);
+  const network = classifyLinks(room);
+  const sourceLink = network.sourceLinks.find((candidate) => getObjectId(candidate) === linkId);
+  if (!sourceLink) {
+    return getStoredEnergy(link);
+  }
+
+  const projectedState = createProjectedLinkState(network.links);
+  const routingReserve = createSourceLinkRoutingReserve(room, network, projectedState).get(linkId) ?? 0;
+  return Math.max(0, getStoredEnergy(sourceLink) - routingReserve);
+}
+
 function transferLinkEnergy(sourceLink: StructureLink, destinationLink: StructureLink, amount: number): ScreepsReturnCode {
   return sourceLink.transferEnergy(destinationLink, amount);
 }
@@ -168,22 +182,97 @@ function shouldStorageLinkReceiveSurplus(
 
   return (
     (projectedState.freeCapacityById.get(getObjectId(network.storageLink)) ?? 0) > 0 &&
-    hasStorageFreeCapacity(network.storage)
+    shouldStorageReceiveLinkEnergy(network.storage)
   );
 }
 
-function hasStorageFreeCapacity(storage: StructureStorage | null): boolean {
+function shouldStorageReceiveLinkEnergy(storage: StructureStorage | null): boolean {
   if (!storage) {
     return false;
   }
 
   const freeCapacity = getKnownFreeEnergyCapacity(storage);
-  return freeCapacity === null || freeCapacity > 0;
+  if (freeCapacity !== null && freeCapacity <= 0) {
+    return false;
+  }
+
+  const capacity = getKnownEnergyCapacity(storage);
+  const storedEnergy = getKnownStoredEnergy(storage);
+  if (capacity !== null && storedEnergy !== null && capacity > 0) {
+    return storedEnergy < Math.ceil(capacity * STORAGE_LINK_ROUTING_TARGET_RATIO);
+  }
+
+  return true;
+}
+
+function createSourceLinkRoutingReserve(
+  room: Room,
+  network: LinkNetwork,
+  projectedState: ProjectedLinkState
+): Map<string, number> {
+  const reserveById = new Map<string, number>();
+
+  if (shouldControllerLinkReceiveEnergy(room, network.controllerLink, projectedState)) {
+    reserveSourceLinksForDestination(
+      sortSourceLinksByDistanceToDestination(network.sourceLinks, network.controllerLink),
+      network.controllerLink,
+      projectedState,
+      reserveById
+    );
+  }
+
+  if (shouldStorageLinkReceiveSurplus(network, projectedState)) {
+    reserveSourceLinksForDestination(
+      sortSourceLinksBySurplusPriority(network.sourceLinks, network.storageLink, projectedState),
+      network.storageLink,
+      projectedState,
+      reserveById
+    );
+  }
+
+  return reserveById;
+}
+
+function reserveSourceLinksForDestination(
+  sourceLinks: StructureLink[],
+  destinationLink: StructureLink,
+  projectedState: ProjectedLinkState,
+  reserveById: Map<string, number>
+): void {
+  const destinationId = getObjectId(destinationLink);
+
+  for (const sourceLink of sourceLinks) {
+    const sourceId = getObjectId(sourceLink);
+    const destinationFreeCapacity = projectedState.freeCapacityById.get(destinationId) ?? 0;
+    const sourceEnergy = projectedState.storedEnergyById.get(sourceId) ?? 0;
+    if (destinationId === sourceId || destinationFreeCapacity <= 0 || sourceEnergy <= 0) {
+      continue;
+    }
+
+    const amount = Math.min(sourceEnergy, destinationFreeCapacity);
+    if (amount <= 0) {
+      continue;
+    }
+
+    reserveById.set(sourceId, (reserveById.get(sourceId) ?? 0) + amount);
+    projectedState.storedEnergyById.set(sourceId, sourceEnergy - amount);
+    projectedState.freeCapacityById.set(destinationId, destinationFreeCapacity - amount);
+  }
+}
+
+function getKnownStoredEnergy(structure: StructureLink | StructureStorage): number | null {
+  const storedEnergy = structure.store?.getUsedCapacity?.(getEnergyResource());
+  return typeof storedEnergy === 'number' && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : null;
 }
 
 function getKnownFreeEnergyCapacity(structure: StructureLink | StructureStorage): number | null {
   const freeCapacity = structure.store?.getFreeCapacity?.(getEnergyResource());
   return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : null;
+}
+
+function getKnownEnergyCapacity(structure: StructureLink | StructureStorage): number | null {
+  const capacity = structure.store?.getCapacity?.(getEnergyResource());
+  return typeof capacity === 'number' && Number.isFinite(capacity) ? Math.max(0, capacity) : null;
 }
 
 function sortSourceLinksByDistanceToDestination(
@@ -342,8 +431,7 @@ function findSources(room: Room): Source[] {
 }
 
 function getStoredEnergy(structure: StructureLink): number {
-  const storedEnergy = structure.store?.getUsedCapacity?.(getEnergyResource());
-  return typeof storedEnergy === 'number' && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
+  return getKnownStoredEnergy(structure) ?? 0;
 }
 
 function getFreeEnergyCapacity(structure: StructureLink): number {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -29,7 +29,12 @@ import {
   withdrawFromStorage
 } from '../economy/energyBuffer';
 import { findSourceContainer } from '../economy/sourceContainers';
-import { classifyLinks, isSourceLink, SOURCE_LINK_RANGE } from '../economy/linkManager';
+import {
+  classifyLinks,
+  getSourceLinkWorkerEnergyAvailable,
+  isSourceLink,
+  SOURCE_LINK_RANGE
+} from '../economy/linkManager';
 import { recordWorkerTaskBehaviorTrace } from '../rl/workerTaskBehavior';
 import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 
@@ -2961,10 +2966,11 @@ function findWorkerLinkEnergyAcquisitionCandidates(
   const minimumLinkEnergy = getMinimumWorkerLinkWithdrawalEnergy(creep);
   return findOwnedWorkerEnergyLinks(creep.room)
     .flatMap((source) => {
+      const availableEnergy = getWorkerLinkEnergyAvailable(creep.room, source);
       const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
         creep,
         source,
-        getStoredEnergy(source),
+        availableEnergy,
         {
           type: 'withdraw',
           targetId: source.id as Id<AnyStoreStructure>
@@ -3001,6 +3007,10 @@ function findOwnedSourceWorkerEnergyLinks(room: Room): StructureLink[] {
 
 function getMinimumWorkerLinkWithdrawalEnergy(creep: Creep): number {
   return Math.max(1, getFreeEnergyCapacity(creep));
+}
+
+function getWorkerLinkEnergyAvailable(room: Room, link: StructureLink): number {
+  return getSourceLinkWorkerEnergyAvailable(room, link);
 }
 
 function isWorkerLinkEnergyMoreEfficientThanHarvest(
@@ -4673,10 +4683,11 @@ function createSourceLinkEnergyAcquisitionCandidate(
   sourceLink: StructureLink,
   reservationContext: WorkerEnergyAcquisitionReservationContext
 ): WorkerEnergyAcquisitionCandidate | null {
+  const availableEnergy = getSourceLinkWorkerEnergyAvailable(creep.room, sourceLink);
   const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
     creep,
     sourceLink,
-    getStoredEnergy(sourceLink),
+    availableEnergy,
     {
       type: 'withdraw',
       targetId: sourceLink.id as Id<AnyStoreStructure>

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -33,6 +33,7 @@ import {
   classifyLinks,
   getSourceLinkWorkerEnergyAvailable,
   isSourceLink,
+  type LinkNetwork,
   SOURCE_LINK_RANGE
 } from '../economy/linkManager';
 import { recordWorkerTaskBehaviorTrace } from '../rl/workerTaskBehavior';
@@ -2964,9 +2965,15 @@ function findWorkerLinkEnergyAcquisitionCandidates(
   options: WorkerEnergyAcquisitionSearchOptions = {}
 ): WorkerEnergyAcquisitionCandidate[] {
   const minimumLinkEnergy = getMinimumWorkerLinkWithdrawalEnergy(creep);
-  return findOwnedWorkerEnergyLinks(creep.room)
+  const workerLinks = findOwnedWorkerEnergyLinks(creep.room);
+  if (workerLinks.length === 0) {
+    return [];
+  }
+
+  const network = classifyLinks(creep.room);
+  return workerLinks
     .flatMap((source) => {
-      const availableEnergy = getWorkerLinkEnergyAvailable(creep.room, source);
+      const availableEnergy = getWorkerLinkEnergyAvailable(creep.room, source, network);
       const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
         creep,
         source,
@@ -2996,21 +3003,25 @@ function findOwnedWorkerEnergyLinks(room: Room): StructureLink[] {
   return Array.isArray(structures) ? (structures as StructureLink[]) : [];
 }
 
-function findOwnedSourceWorkerEnergyLinks(room: Room): StructureLink[] {
+function findOwnedSourceWorkerEnergyLinks(room: Room, network?: LinkNetwork): StructureLink[] {
   const workerLinkIds = new Set(findOwnedWorkerEnergyLinks(room).map((link) => String(link.id)));
   if (workerLinkIds.size === 0) {
     return [];
   }
 
-  return classifyLinks(room).sourceLinks.filter((link) => workerLinkIds.has(String(link.id)));
+  return selectOwnedSourceWorkerEnergyLinks(network ?? classifyLinks(room), workerLinkIds);
+}
+
+function selectOwnedSourceWorkerEnergyLinks(network: LinkNetwork, workerLinkIds: Set<string>): StructureLink[] {
+  return network.sourceLinks.filter((link) => workerLinkIds.has(String(link.id)));
 }
 
 function getMinimumWorkerLinkWithdrawalEnergy(creep: Creep): number {
   return Math.max(1, getFreeEnergyCapacity(creep));
 }
 
-function getWorkerLinkEnergyAvailable(room: Room, link: StructureLink): number {
-  return getSourceLinkWorkerEnergyAvailable(room, link);
+function getWorkerLinkEnergyAvailable(room: Room, link: StructureLink, network?: LinkNetwork): number {
+  return getSourceLinkWorkerEnergyAvailable(room, link, network);
 }
 
 function isWorkerLinkEnergyMoreEfficientThanHarvest(
@@ -3086,9 +3097,15 @@ function findWorkerSourceLinkEnergyAcquisitionCandidates(
   reservationContext: WorkerEnergyAcquisitionReservationContext,
   options: WorkerEnergyAcquisitionSearchOptions = {}
 ): WorkerEnergyAcquisitionCandidate[] {
-  return findOwnedSourceWorkerEnergyLinks(creep.room)
+  const workerLinkIds = new Set(findOwnedWorkerEnergyLinks(creep.room).map((link) => String(link.id)));
+  if (workerLinkIds.size === 0) {
+    return [];
+  }
+
+  const network = classifyLinks(creep.room);
+  return selectOwnedSourceWorkerEnergyLinks(network, workerLinkIds)
     .flatMap((link) => {
-      const candidate = createSourceLinkEnergyAcquisitionCandidate(creep, link, reservationContext);
+      const candidate = createSourceLinkEnergyAcquisitionCandidate(creep, link, reservationContext, network);
       return candidate ? [candidate] : [];
     })
     .filter((candidate) => isWorkerEnergyAcquisitionCandidateWithinSearchRange(candidate, options));
@@ -4612,6 +4629,7 @@ function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquis
   const candidates: WorkerEnergyAcquisitionCandidate[] = [];
   const seenContainerIds = new Set<string>();
   const seenLinkIds = new Set<string>();
+  const linkNetworksByRoomName = new Map<string, LinkNetwork>();
 
   for (const source of context.sources) {
     const sourceContainer = findVisibleSourceContainer(creep, source);
@@ -4638,12 +4656,15 @@ function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquis
       continue;
     }
 
-    const sourceLink = findVisibleSourceLink(creep, source);
+    const linkNetwork = getCachedLinkNetwork(sourceRoom, linkNetworksByRoomName);
+    const sourceLink = findVisibleSourceLink(sourceRoom, source, linkNetwork);
     if (sourceLink && !seenLinkIds.has(String(sourceLink.id))) {
       const sourceLinkCandidate = createSourceLinkEnergyAcquisitionCandidate(
         creep,
         sourceLink,
-        reservationContext
+        reservationContext,
+        linkNetwork,
+        sourceRoom
       );
       if (sourceLinkCandidate) {
         candidates.push(sourceLinkCandidate);
@@ -4681,9 +4702,11 @@ function findSourceContainerWithdrawCandidates(creep: Creep): WorkerEnergyAcquis
 function createSourceLinkEnergyAcquisitionCandidate(
   creep: Creep,
   sourceLink: StructureLink,
-  reservationContext: WorkerEnergyAcquisitionReservationContext
+  reservationContext: WorkerEnergyAcquisitionReservationContext,
+  network?: LinkNetwork,
+  room = creep.room
 ): WorkerEnergyAcquisitionCandidate | null {
-  const availableEnergy = getSourceLinkWorkerEnergyAvailable(creep.room, sourceLink);
+  const availableEnergy = getSourceLinkWorkerEnergyAvailable(room, sourceLink, network);
   const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
     creep,
     sourceLink,
@@ -4821,17 +4844,23 @@ function findVisibleSourceContainer(creep: Creep, source: Source): StructureCont
   return sourceRoom ? findSourceContainer(sourceRoom, source) : null;
 }
 
-function findVisibleSourceLink(creep: Creep, source: Source): StructureLink | null {
-  const sourceRoom = findVisibleSourceRoom(creep, source);
-  if (!sourceRoom) {
-    return null;
-  }
-
+function findVisibleSourceLink(sourceRoom: Room, source: Source, network?: LinkNetwork): StructureLink | null {
   return (
-    findOwnedSourceWorkerEnergyLinks(sourceRoom)
+    findOwnedSourceWorkerEnergyLinks(sourceRoom, network)
       .filter((link) => isSourceLinkNearSource(source, link))
       .sort((left, right) => compareSourceLinksForSource(source, left, right))[0] ?? null
   );
+}
+
+function getCachedLinkNetwork(room: Room, networksByRoomName: Map<string, LinkNetwork>): LinkNetwork {
+  const cached = networksByRoomName.get(room.name);
+  if (cached) {
+    return cached;
+  }
+
+  const network = classifyLinks(room);
+  networksByRoomName.set(room.name, network);
+  return network;
 }
 
 function isSourceLinkNearSource(source: Source, link: StructureLink): boolean {

--- a/prod/test/linkManager.test.ts
+++ b/prod/test/linkManager.test.ts
@@ -212,7 +212,7 @@ describe('linkManager', () => {
     expect(sourceLink.transferEnergy).not.toHaveBeenCalled();
   });
 
-  it('reserves source-link energy from worker withdrawal for controller and storage routing demand', () => {
+  it('does not double-reserve one source link for controller and storage routing demand', () => {
     const sourceLink = makeLink('source-link', 11, 10, 800, 0);
     const controllerLink = makeLink('controller-link', 25, 23, 0, 100);
     const storageLink = makeLink('storage-link', 20, 21, 0, 400);
@@ -223,7 +223,34 @@ describe('linkManager', () => {
       storage: makeStorage('storage1', 20, 20, 2_000, 8_000, 10_000)
     });
 
-    expect(getSourceLinkWorkerEnergyAvailable(room, sourceLink)).toBe(300);
+    expect(getSourceLinkWorkerEnergyAvailable(room, sourceLink)).toBe(700);
+  });
+
+  it('does not reserve worker-withdrawable energy from cooling source links', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 800, 0, 3);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 500);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLink, controllerLink],
+      sources: [makeSource('source1', 10, 10)]
+    });
+
+    expect(getSourceLinkWorkerEnergyAvailable(room, sourceLink)).toBe(800);
+  });
+
+  it('uses a precomputed link network for worker availability without finding links again', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 800, 0);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 500);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLink, controllerLink],
+      sources: [makeSource('source1', 10, 10)]
+    });
+    const network = classifyLinks(room);
+    (room.find as jest.Mock).mockClear();
+
+    expect(getSourceLinkWorkerEnergyAvailable(room, sourceLink, network)).toBe(300);
+    expect(room.find).not.toHaveBeenCalled();
   });
 });
 

--- a/prod/test/linkManager.test.ts
+++ b/prod/test/linkManager.test.ts
@@ -1,4 +1,9 @@
-import { classifyLinks, transferEnergy } from '../src/economy/linkManager';
+import {
+  classifyLinks,
+  getSourceLinkWorkerEnergyAvailable,
+  STORAGE_LINK_ROUTING_TARGET_RATIO,
+  transferEnergy
+} from '../src/economy/linkManager';
 
 const OK_CODE = 0 as ScreepsReturnCode;
 type TestStructureLink = StructureLink & { transferEnergy: jest.Mock };
@@ -161,6 +166,65 @@ describe('linkManager', () => {
     expect(transferEnergy(room)).toEqual([]);
     expect(sourceLink.transferEnergy).not.toHaveBeenCalled();
   });
+
+  it('routes source energy to storage while known storage is below the link routing target', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 250, 550);
+    const controllerLink = makeLink('controller-link', 25, 23, 800, 0);
+    const storageLink = makeLink('storage-link', 20, 21, 0, 200);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLink, controllerLink, storageLink],
+      sources: [makeSource('source1', 10, 10)],
+      storage: makeStorage('storage1', 20, 20, 2_000, 8_000, 10_000)
+    });
+
+    expect(transferEnergy(room)).toMatchObject([
+      {
+        amount: 200,
+        destinationId: 'storage-link',
+        destinationRole: 'storage',
+        sourceId: 'source-link'
+      }
+    ]);
+    expect(sourceLink.transferEnergy).toHaveBeenCalledWith(storageLink, 200);
+  });
+
+  it('does not route source energy to storage when known storage is above the link routing target', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 250, 550);
+    const controllerLink = makeLink('controller-link', 25, 23, 800, 0);
+    const storageLink = makeLink('storage-link', 20, 21, 0, 200);
+    const capacity = 10_000;
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLink, controllerLink, storageLink],
+      sources: [makeSource('source1', 10, 10)],
+      storage: makeStorage(
+        'storage1',
+        20,
+        20,
+        Math.ceil(capacity * STORAGE_LINK_ROUTING_TARGET_RATIO),
+        7_000,
+        capacity
+      )
+    });
+
+    expect(transferEnergy(room)).toEqual([]);
+    expect(sourceLink.transferEnergy).not.toHaveBeenCalled();
+  });
+
+  it('reserves source-link energy from worker withdrawal for controller and storage routing demand', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 800, 0);
+    const controllerLink = makeLink('controller-link', 25, 23, 0, 100);
+    const storageLink = makeLink('storage-link', 20, 21, 0, 400);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      links: [sourceLink, controllerLink, storageLink],
+      sources: [makeSource('source1', 10, 10)],
+      storage: makeStorage('storage1', 20, 20, 2_000, 8_000, 10_000)
+    });
+
+    expect(getSourceLinkWorkerEnergyAvailable(room, sourceLink)).toBe(300);
+  });
 });
 
 function makeRoom({
@@ -214,13 +278,21 @@ function makeLink(
   } as unknown as TestStructureLink;
 }
 
-function makeStorage(id: string, x: number, y: number, energy: number, freeCapacity = 100_000): StructureStorage {
+function makeStorage(
+  id: string,
+  x: number,
+  y: number,
+  energy: number,
+  freeCapacity = 100_000,
+  capacity?: number
+): StructureStorage {
   return {
     id,
     structureType: 'storage',
     pos: makeRoomPosition(x, y),
     store: {
       getFreeCapacity: jest.fn().mockReturnValue(freeCapacity),
+      ...(capacity === undefined ? {} : { getCapacity: jest.fn().mockReturnValue(capacity) }),
       getUsedCapacity: jest.fn().mockReturnValue(energy)
     }
   } as unknown as StructureStorage;

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -184,13 +184,16 @@ function makeStoredEnergyStructure(
   } as unknown as StructureContainer | StructureStorage | StructureTerminal;
 }
 
-function makeStoredEnergyLink(id: string, x: number, y: number, energy: number): StructureLink {
+function makeStoredEnergyLink(id: string, x: number, y: number, energy: number, freeCapacity = 0): StructureLink {
   return {
     id,
     my: true,
     structureType: 'link',
     pos: makeRoomPosition(x, y),
-    store: { getUsedCapacity: jest.fn().mockReturnValue(energy) }
+    store: {
+      getFreeCapacity: jest.fn().mockReturnValue(freeCapacity),
+      getUsedCapacity: jest.fn().mockReturnValue(energy)
+    }
   } as unknown as StructureLink;
 }
 
@@ -2946,6 +2949,37 @@ describe('selectWorkerTask', () => {
     } as unknown as Creep;
 
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'link-source' });
+  });
+
+  it('does not withdraw source-link energy reserved for controller link routing', () => {
+    const emptySource = makeSource('source-empty', 10, 10, 0);
+    const distantContainer = makeStoredEnergyStructure('container-distant', 'container' as StructureConstant, 200);
+    const sourceLink = makeStoredEnergyLink('link-source', 10, 12, 50);
+    const controllerLink = makeStoredEnergyLink('link-controller', 25, 23, 0, 300);
+    const room = makeWorkerTaskRoom({
+      controller: {
+        id: 'controller1',
+        my: true,
+        level: 3,
+        pos: makeRoomPosition(25, 25)
+      } as StructureController,
+      myStructures: [sourceLink as AnyOwnedStructure, controllerLink as AnyOwnedStructure],
+      sources: [emptySource],
+      structures: [distantContainer]
+    });
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'link-source' ? 1 : 12))
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-distant' });
   });
 
   it('withdraws from a saturated local source container before traveling to an adjacent assignable source', () => {


### PR DESCRIPTION
## Summary
Improve link network energy routing for source-to-controller and source-to-storage flow.

## Changes
- `linkManager.ts`: add source-to-controller/storage routing logic with energy thresholds
- `workerTasks.ts`: wire link-aware energy tasks into worker behavior
- Tests: link manager + worker tasks coverage for source-to-controller/storage paths

## Verification
- Typecheck: clean
- Jest: 53 suites / 1186 tests pass
- Build: esbuild produces valid prod/dist/main.js
- Controller verified at commit 6203359

Closes #675
