### PR TITLE
feat(territory): implement scalable claimer/reserver body builder and spawn dispatch

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1797,10 +1797,7 @@ var HIGH_RCL_WORKER_PATTERN = ["work", "work", "work", "carry", "move", "move"];
 var HIGH_RCL_WORKER_PATTERN_COST = 450;
 var TERRITORY_SCOUT_BODY = ["move"];
 var TERRITORY_SCOUT_BODY_COST = 50;
-var TERRITORY_RESERVER_BODY = ["claim", "move"];
-var TERRITORY_RESERVER_BODY_COST = 650;
-var TERRITORY_RESERVER_SCALED_BODY = ["claim", "claim", "move", "move"];
-var TERRITORY_RESERVER_SCALED_BODY_COST = 1300;
+var TERRITORY_RESERVER_PAIR_COST = 650;
 var MAX_CREEP_PARTS2 = 50;
 var MAX_REMOTE_HARVESTER_WORK_PARTS = 5;
 var MAX_REMOTE_HAULER_CARRY_MOVE_PAIRS = 10;
@@ -1930,13 +1927,17 @@ function buildTerritoryControllerBody(energyAvailable) {
   return buildTerritoryClaimerBody(energyAvailable);
 }
 function buildTerritoryReserverBody(energyAvailable) {
-  if (energyAvailable >= TERRITORY_RESERVER_SCALED_BODY_COST) {
-    return [...TERRITORY_RESERVER_SCALED_BODY];
+  const pairCount = Math.min(
+    Math.floor(energyAvailable / TERRITORY_RESERVER_PAIR_COST),
+    Math.floor(MAX_CREEP_PARTS2 / 2)
+  );
+  if (pairCount <= 0) {
+    return [];
   }
-  if (energyAvailable >= TERRITORY_RESERVER_BODY_COST) {
-    return [...TERRITORY_RESERVER_BODY];
-  }
-  return [];
+  return [
+    ...Array.from({ length: pairCount }, () => "claim"),
+    ...Array.from({ length: pairCount }, () => "move")
+  ];
 }
 function buildTerritoryControllerPressureBody(energyAvailable) {
   if (energyAvailable < TERRITORY_CONTROLLER_PRESSURE_BODY_COST) {

--- a/prod/src/spawn/bodyBuilder.ts
+++ b/prod/src/spawn/bodyBuilder.ts
@@ -14,10 +14,7 @@ const EMERGENCY_DEFENDER_BODY: BodyPartConstant[] = ['tough', 'attack', 'move'];
 const EMERGENCY_DEFENDER_BODY_COST = 140;
 export const TERRITORY_SCOUT_BODY: BodyPartConstant[] = ['move'];
 export const TERRITORY_SCOUT_BODY_COST = 50;
-const TERRITORY_RESERVER_BODY: BodyPartConstant[] = ['claim', 'move'];
-const TERRITORY_RESERVER_BODY_COST = 650;
-const TERRITORY_RESERVER_SCALED_BODY: BodyPartConstant[] = ['claim', 'claim', 'move', 'move'];
-const TERRITORY_RESERVER_SCALED_BODY_COST = 1300;
+const TERRITORY_RESERVER_PAIR_COST = 650;
 import {
   buildTerritoryClaimerBody,
   TERRITORY_CONTROLLER_PRESSURE_BODY,
@@ -243,15 +240,18 @@ export function buildTerritoryControllerBody(energyAvailable: number): BodyPartC
 }
 
 export function buildTerritoryReserverBody(energyAvailable: number): BodyPartConstant[] {
-  if (energyAvailable >= TERRITORY_RESERVER_SCALED_BODY_COST) {
-    return [...TERRITORY_RESERVER_SCALED_BODY];
+  const pairCount = Math.min(
+    Math.floor(energyAvailable / TERRITORY_RESERVER_PAIR_COST),
+    Math.floor(MAX_CREEP_PARTS / 2)
+  );
+  if (pairCount <= 0) {
+    return [];
   }
 
-  if (energyAvailable >= TERRITORY_RESERVER_BODY_COST) {
-    return [...TERRITORY_RESERVER_BODY];
-  }
-
-  return [];
+  return [
+    ...Array.from({ length: pairCount }, () => 'claim' as BodyPartConstant),
+    ...Array.from({ length: pairCount }, () => 'move' as BodyPartConstant)
+  ];
 }
 
 export function buildTerritoryControllerPressureBody(energyAvailable: number): BodyPartConstant[] {

--- a/prod/test/bodyBuilder.test.ts
+++ b/prod/test/bodyBuilder.test.ts
@@ -214,10 +214,26 @@ describe('buildTerritoryReserverBody', () => {
     expect(buildTerritoryReserverBody(650)).toEqual(['claim', 'move']);
   });
 
-  it('scales to two claim parts when energy allows', () => {
+  it('scales claim and move pairs with available energy', () => {
     expect(buildTerritoryReserverBody(1299)).toEqual(['claim', 'move']);
     expect(buildTerritoryReserverBody(1300)).toEqual(['claim', 'claim', 'move', 'move']);
     expect(getBodyCost(buildTerritoryReserverBody(1300))).toBe(1300);
+    expect(buildTerritoryReserverBody(1950)).toEqual([
+      'claim',
+      'claim',
+      'claim',
+      'move',
+      'move',
+      'move'
+    ]);
+  });
+
+  it('caps high-energy reserver bodies at the creep size limit', () => {
+    const body = buildTerritoryReserverBody(20_000);
+
+    expect(body).toHaveLength(50);
+    expect(body.filter((part) => part === 'claim')).toHaveLength(25);
+    expect(body.filter((part) => part === 'move')).toHaveLength(25);
   });
 });
 

--- a/prod/test/claimerRunner.test.ts
+++ b/prod/test/claimerRunner.test.ts
@@ -33,6 +33,24 @@ describe('runClaimer', () => {
     expect(creep.claimController).not.toHaveBeenCalled();
   });
 
+  it('moves to the target room before reserving', () => {
+    const creep = {
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'reserve', controllerId: 'controller1' as Id<StructureController> }
+      },
+      room: { name: 'W1N1' },
+      moveTo: jest.fn(),
+      reserveController: jest.fn()
+    } as unknown as Creep;
+
+    runClaimer(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W2N1' });
+    expect(creep.reserveController).not.toHaveBeenCalled();
+  });
+
   it('routes recommended expansion claimers toward the visible target controller', () => {
     const colonyRoom = makeColonyRoom();
     const controller = { id: 'controller1', my: false } as StructureController;

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -1476,6 +1476,63 @@ describe('planSpawn', () => {
     ]);
   });
 
+  it('dispatches a scaled reserver for a persisted planned reservation intent', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 1_950,
+      energyCapacityAvailable: 1_950,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W3N1: makeTerritoryRoom(
+          'W3N1',
+          { id: 'controller-W3N1', my: false } as StructureController,
+          2
+        )
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W3N1',
+            action: 'reserve',
+            status: 'planned',
+            updatedAt: 154,
+            controllerId: 'controller-W3N1' as Id<StructureController>
+          }
+        ]
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 155)).toEqual({
+      spawn,
+      body: ['claim', 'claim', 'claim', 'move', 'move', 'move'],
+      name: 'claimer-W1N1-W3N1-155',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: {
+          targetRoom: 'W3N1',
+          action: 'reserve',
+          controllerId: 'controller-W3N1' as Id<StructureController>
+        }
+      }
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 155,
+        controllerId: 'controller-W3N1'
+      }
+    ]);
+  });
+
   it('plans a claimer-role claimer for a claim-ready configured reserve target', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,


### PR DESCRIPTION
feat(territory): scalable claimer/reserver body builder and spawn dispatch

Implements dynamic claimer/reserver body construction with CLAIM+MOVE pair scaling instead of hardcoded body sizes, suitable for varied energy capacities in expanding colonies.

## Changes
- **bodyBuilder.ts**: `buildTerritoryReserverBody()` now scales claim/move pairs from available energy with MAX_CREEP_PARTS cap
- **spawnPlanner.test.ts**: test for scaled reserver dispatch from persisted planned reservation intent (3-CLAIM body at 1950 energy)
- **bodyBuilder.test.ts**: scaling test (claim/move pairs at 650/1300/1950) + MAX_CREEP_PARTS cap test
- **claimerRunner.test.ts**: test for move-to-target-room-before-reserving behavior

## Verification (controller-side)
- `npm run typecheck`: PASS
- `npm test -- --runInBand`: 53 suites, 1188 tests PASS
- `npm run build`: OK
- `git diff --check`: clean

Closes #678
