### PR TITLE
feat(economy): implement spawn energy buffer guard to prevent starvation-spiral spawn attempts (#683)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -17031,7 +17031,7 @@ var CROSS_ROOM_HAULER_REPLACEMENT_TICKS = 100;
 var CROSS_ROOM_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var ERR_NO_PATH_CODE6 = -2;
 var ERR_NOT_IN_RANGE_CODE6 = -9;
-function planCrossRoomHauler() {
+function planCrossRoomHauler(getEnergyBudget = getDefaultCrossRoomHaulerEnergyBudget) {
   const transfer = selectCrossRoomEnergyTransfer();
   if (!transfer) {
     return null;
@@ -17051,7 +17051,7 @@ function planCrossRoomHauler() {
   }
   const sourceState = getRoomStoredEnergyState(sourceRoom);
   const transferableEnergy = Math.min(transfer.amount, sourceState.exportableEnergy);
-  const body = buildCrossRoomHaulerBody(sourceRoom.energyAvailable, transferableEnergy);
+  const body = buildCrossRoomHaulerBody(getEnergyBudget(sourceRoom.name), transferableEnergy);
   if (body.length === 0) {
     return null;
   }
@@ -17075,6 +17075,10 @@ function planCrossRoomHauler() {
       }
     }
   };
+}
+function getDefaultCrossRoomHaulerEnergyBudget(sourceRoomName) {
+  var _a, _b;
+  return (_b = (_a = getVisibleRoom5(sourceRoomName)) == null ? void 0 : _a.energyAvailable) != null ? _b : 0;
 }
 function buildCrossRoomHaulerBody(energyAvailable, transferableEnergy) {
   const energyBudget = Math.max(0, Math.floor(energyAvailable));
@@ -17701,7 +17705,7 @@ function hasControllerDowngradeGuardSpawnCapacity(context) {
   return context.colony.spawns.filter((spawn) => !spawn.spawning).length > 1;
 }
 function hasRecoveryWorkerSpawnEnergy(colony) {
-  return colony.energyAvailable >= MINIMUM_EMERGENCY_WORKER_BODY_COST;
+  return getSpawnEnergyBudget(colony) >= MINIMUM_EMERGENCY_WORKER_BODY_COST;
 }
 function planPostClaimControllerSustainSpawn(context) {
   if (context.survival.mode !== "TERRITORY_READY" || !hasPostClaimSustainSpawnEnergy(context.colony)) {
@@ -17929,7 +17933,7 @@ function planDefenseSpawnForRoom(colony, activeDefenderCount, gameTime, options)
   if (!spawn) {
     return null;
   }
-  const body = buildDefenseBody(colony.energyAvailable, hostileCount);
+  const body = buildDefenseBody(getSpawnEnergyBudget(colony), hostileCount);
   if (body.length === 0) {
     return null;
   }
@@ -17955,7 +17959,7 @@ function planRemoteEconomySpawn(context) {
   }
   const remoteHarvesterAssignment = selectRemoteHarvesterAssignment(context.colony.room.name);
   if (remoteHarvesterAssignment) {
-    const body2 = buildRemoteHarvesterBody(context.colony.energyAvailable);
+    const body2 = buildRemoteHarvesterBody(getSpawnEnergyBudget(context.colony));
     if (body2.length > 0) {
       return {
         spawn,
@@ -17981,7 +17985,7 @@ function planRemoteEconomySpawn(context) {
   if (!remoteHaulerAssignment) {
     return null;
   }
-  const body = buildRemoteHaulerBody(context.colony.energyAvailable, remoteHaulerAssignment.routeDistance);
+  const body = buildRemoteHaulerBody(getSpawnEnergyBudget(context.colony), remoteHaulerAssignment.routeDistance);
   if (body.length === 0) {
     return null;
   }
@@ -18079,7 +18083,7 @@ function planMultiRoomControllerUpgradeSpawn(context) {
     return null;
   }
   for (const upgradePlan of upgradePlans) {
-    const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
+    const body = buildMultiRoomUpgraderBody(getSpawnEnergyBudget(context.colony), upgradePlan);
     if (body.length === 0) {
       continue;
     }
@@ -18179,7 +18183,7 @@ function planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, optio
   if (!spawn) {
     return null;
   }
-  const body = buildTerritorySpawnBody(colony.energyAvailable, territoryIntent);
+  const body = buildTerritorySpawnBody(getSpawnEnergyBudget(colony), territoryIntent);
   if (body.length === 0) {
     return null;
   }
@@ -18218,23 +18222,28 @@ function appendSpawnNameSuffix(baseName, options) {
 }
 function selectWorkerBody(colony, roleCounts) {
   var _a;
+  const spawnEnergyBudget = getSpawnEnergyBudget(colony);
   if (shouldUseSourceHarvesterBody(colony, roleCounts)) {
     const sourceDistance = estimateLocalSourceDistance(colony);
     const fullCapacityBody = generateHarvesterBody(colony.energyCapacityAvailable, sourceDistance);
-    if (canAffordBody(fullCapacityBody, colony.energyAvailable)) {
+    if (canAffordBody(fullCapacityBody, spawnEnergyBudget)) {
       return fullCapacityBody;
     }
-    return generateHarvesterBody(colony.energyAvailable, sourceDistance);
+    return generateHarvesterBody(spawnEnergyBudget, sourceDistance);
   }
   const controllerLevel = (_a = colony.room.controller) == null ? void 0 : _a.level;
   const normalBody = buildWorkerBody(colony.energyCapacityAvailable, controllerLevel);
-  if (canAffordBody(normalBody, colony.energyAvailable)) {
+  if (canAffordBody(normalBody, spawnEnergyBudget)) {
     return normalBody;
   }
   if (roleCounts.worker === 0) {
-    return buildEmergencyWorkerBody(colony.energyAvailable);
+    return buildEmergencyWorkerBody(spawnEnergyBudget);
   }
-  return buildWorkerBody(colony.energyAvailable, controllerLevel);
+  return buildWorkerBody(spawnEnergyBudget, controllerLevel);
+}
+function getSpawnEnergyBudget(colony) {
+  var _a;
+  return normalizeNonNegativeInteger2((_a = colony.spawnEnergyBudget) != null ? _a : colony.energyAvailable);
 }
 function generateHarvesterBody(availableEnergy, sourceDistance) {
   const energyBudget = normalizeNonNegativeInteger2(availableEnergy);
@@ -24619,22 +24628,19 @@ function runEconomy(preludeTelemetryEvents = []) {
     let successfulSpawnCount = 0;
     const usedSpawns = new Set((_b = usedSpawnsByRoom.get(colony.room.name)) != null ? _b : []);
     while (true) {
-      const planningColony = createSpawnPlanningColony(colony, availableEnergy, usedSpawns);
-      const spawnRequest = planSpawn(
-        planningColony,
+      const spawnPlan = selectSpawnPlanWithinEnergyBuffer(
+        colony,
+        availableEnergy,
+        usedSpawns,
         roleCounts,
         Game.time,
         getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp)
       );
-      if (!spawnRequest) {
+      if (!spawnPlan) {
         break;
       }
+      const { planningColony, spawnRequest, bodyCost } = spawnPlan;
       if (successfulSpawnCount > 0 && !isAllowedPostSpawnRequest(spawnRequest)) {
-        break;
-      }
-      const bodyCost = getBodyCost(spawnRequest.body);
-      if (isSpawnEnergyBufferViolated(availableEnergy, bodyCost)) {
-        logSpawnEnergyBufferWarning(spawnRequest, colony.room.name, availableEnergy, bodyCost);
         break;
       }
       const outcome = attemptSpawnRequest(
@@ -24723,16 +24729,21 @@ function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom
   if (candidateSpawns.length === 0) {
     return;
   }
-  const bodyCost = getBodyCost(spawnRequest.body);
   const availableEnergy = getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom);
-  if (bodyCost > availableEnergy) {
+  const spawnPlan = selectCrossRoomHaulerSpawnPlanWithinEnergyBuffer(spawnRequest, availableEnergy);
+  if (!spawnPlan) {
+    const originalBodyCost = getBodyCost(spawnRequest.body);
+    if (originalBodyCost <= availableEnergy && isSpawnEnergyBufferViolated(availableEnergy, originalBodyCost)) {
+      logSpawnEnergyBufferWarning(spawnRequest, sourceRoomName, availableEnergy, originalBodyCost);
+    }
     return;
   }
+  const { spawnRequest: bufferedSpawnRequest, bodyCost } = spawnPlan;
   if (isSpawnEnergyBufferViolated(availableEnergy, bodyCost)) {
     logSpawnEnergyBufferWarning(spawnRequest, sourceRoomName, availableEnergy, bodyCost);
     return;
   }
-  const request = candidateSpawns.includes(spawnRequest.spawn) ? spawnRequest : { ...spawnRequest, spawn: candidateSpawns[0] };
+  const request = candidateSpawns.includes(bufferedSpawnRequest.spawn) ? bufferedSpawnRequest : { ...bufferedSpawnRequest, spawn: candidateSpawns[0] };
   const outcome = attemptSpawnRequest(
     request,
     sourceRoomName,
@@ -24964,6 +24975,87 @@ function createSpawnPlanningColony(colony, energyAvailable, usedSpawns) {
     energyAvailable,
     spawns: colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
   };
+}
+function selectSpawnPlanWithinEnergyBuffer(colony, availableEnergy, usedSpawns, roleCounts, gameTime, options) {
+  const spawnPlan = planSpawnWithEnergyBudget(
+    colony,
+    availableEnergy,
+    usedSpawns,
+    roleCounts,
+    gameTime,
+    options
+  );
+  if (!spawnPlan) {
+    return null;
+  }
+  if (roleCounts.worker === 0 || !isSpawnEnergyBufferViolated(availableEnergy, spawnPlan.bodyCost)) {
+    return spawnPlan;
+  }
+  const fallbackSpawnPlan = planSpawnWithEnergyBudget(
+    colony,
+    getBufferedSpawnEnergyBudget(availableEnergy),
+    usedSpawns,
+    roleCounts,
+    gameTime,
+    options
+  );
+  if (fallbackSpawnPlan && !isSpawnEnergyBufferViolated(availableEnergy, fallbackSpawnPlan.bodyCost)) {
+    return fallbackSpawnPlan;
+  }
+  logSpawnEnergyBufferWarning(spawnPlan.spawnRequest, colony.room.name, availableEnergy, spawnPlan.bodyCost);
+  return null;
+}
+function planSpawnWithEnergyBudget(colony, energyBudget, usedSpawns, roleCounts, gameTime, options) {
+  const planningColony = createSpawnPlanningColony(colony, energyBudget, usedSpawns);
+  const spawnRequest = planSpawn(planningColony, roleCounts, gameTime, options);
+  if (!spawnRequest) {
+    return null;
+  }
+  return {
+    planningColony,
+    spawnRequest,
+    bodyCost: getBodyCost(spawnRequest.body)
+  };
+}
+function getBufferedSpawnEnergyBudget(availableEnergy) {
+  return Math.max(0, availableEnergy - MIN_SPAWN_ENERGY_BUFFER);
+}
+function selectCrossRoomHaulerSpawnPlanWithinEnergyBuffer(spawnRequest, availableEnergy) {
+  const bodyCost = getBodyCost(spawnRequest.body);
+  if (bodyCost <= getBufferedSpawnEnergyBudget(availableEnergy)) {
+    return {
+      spawnRequest,
+      bodyCost
+    };
+  }
+  const fallbackBody = buildAffordableCrossRoomHaulerBody(
+    spawnRequest.body,
+    getBufferedSpawnEnergyBudget(availableEnergy)
+  );
+  if (fallbackBody.length === 0) {
+    return null;
+  }
+  return {
+    spawnRequest: { ...spawnRequest, body: fallbackBody },
+    bodyCost: getBodyCost(fallbackBody)
+  };
+}
+function buildAffordableCrossRoomHaulerBody(body, energyBudget) {
+  const affordableBody = [];
+  let bodyCost = 0;
+  for (let index = 0; index + 1 < body.length; index += 2) {
+    const pair = body.slice(index, index + 2);
+    if (pair[0] !== "carry" || pair[1] !== "move") {
+      return [];
+    }
+    const pairCost = getBodyCost(pair);
+    if (bodyCost + pairCost > energyBudget) {
+      break;
+    }
+    affordableBody.push(...pair);
+    bodyCost += pairCost;
+  }
+  return affordableBody;
 }
 function getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp) {
   const allowTerritoryFollowUp = successfulSpawnCount > 0 || hasPendingTerritoryFollowUp;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -16413,6 +16413,9 @@ function isNonEmptyString10(value) {
   return typeof value === "string" && value.length > 0;
 }
 
+// src/spawn/spawnConfig.ts
+var MIN_SPAWN_ENERGY_BUFFER = 50;
+
 // src/territory/multiRoomUpgrader.ts
 var MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO = 0.8;
 var MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP = 1;
@@ -24629,6 +24632,11 @@ function runEconomy(preludeTelemetryEvents = []) {
       if (successfulSpawnCount > 0 && !isAllowedPostSpawnRequest(spawnRequest)) {
         break;
       }
+      const bodyCost = getBodyCost(spawnRequest.body);
+      if (isSpawnEnergyBufferViolated(availableEnergy, bodyCost)) {
+        logSpawnEnergyBufferWarning(spawnRequest, colony.room.name, availableEnergy, bodyCost);
+        break;
+      }
       const outcome = attemptSpawnRequest(
         spawnRequest,
         colony.room.name,
@@ -24639,7 +24647,6 @@ function runEconomy(preludeTelemetryEvents = []) {
         break;
       }
       usedSpawns.add(outcome.spawn);
-      const bodyCost = getBodyCost(spawnRequest.body);
       recordUsedSpawn(usedSpawnsByRoom, colony.room.name, outcome.spawn);
       recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, colony.room.name, bodyCost);
       availableEnergy = Math.max(0, availableEnergy - bodyCost);
@@ -24716,7 +24723,13 @@ function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom
   if (candidateSpawns.length === 0) {
     return;
   }
-  if (getBodyCost(spawnRequest.body) > getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom)) {
+  const bodyCost = getBodyCost(spawnRequest.body);
+  const availableEnergy = getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom);
+  if (bodyCost > availableEnergy) {
+    return;
+  }
+  if (isSpawnEnergyBufferViolated(availableEnergy, bodyCost)) {
+    logSpawnEnergyBufferWarning(spawnRequest, sourceRoomName, availableEnergy, bodyCost);
     return;
   }
   const request = candidateSpawns.includes(spawnRequest.spawn) ? spawnRequest : { ...spawnRequest, spawn: candidateSpawns[0] };
@@ -24730,7 +24743,7 @@ function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom
     return;
   }
   recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
-  recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, sourceRoomName, getBodyCost(spawnRequest.body));
+  recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, sourceRoomName, bodyCost);
 }
 function getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom) {
   var _a, _b;
@@ -24988,6 +25001,14 @@ function attemptSpawnRequest(spawnRequest, roomName, telemetryEvents, spawns) {
     }
   }
   return lastOutcome;
+}
+function isSpawnEnergyBufferViolated(availableEnergy, bodyCost) {
+  return availableEnergy - bodyCost < MIN_SPAWN_ENERGY_BUFFER;
+}
+function logSpawnEnergyBufferWarning(spawnRequest, roomName, availableEnergy, bodyCost) {
+  console.log(
+    `[spawn] warning: deferred ${spawnRequest.name} in ${roomName}; available energy ${availableEnergy}, body cost ${bodyCost}, required buffer ${MIN_SPAWN_ENERGY_BUFFER}`
+  );
 }
 function addPlannedWorker(roleCounts) {
   const nextRoleCounts = {

--- a/prod/src/colony/colonyRegistry.ts
+++ b/prod/src/colony/colonyRegistry.ts
@@ -4,6 +4,7 @@ export interface ColonySnapshot {
   spawns: StructureSpawn[];
   energyAvailable: number;
   energyCapacityAvailable: number;
+  spawnEnergyBudget?: number;
 }
 
 export function getOwnedColonies(): ColonySnapshot[] {

--- a/prod/src/economy/crossRoomHauler.ts
+++ b/prod/src/economy/crossRoomHauler.ts
@@ -6,6 +6,7 @@ import {
 
 export const CROSS_ROOM_HAULER_ROLE = 'crossRoomHauler';
 export type SpawnPlan = SpawnRequest;
+export type CrossRoomHaulerEnergyBudgetProvider = (sourceRoomName: string) => number;
 
 const CARRY_MOVE_PAIR_COST = 100;
 const CARRY_CAPACITY_PER_PART = 50;
@@ -35,7 +36,9 @@ interface LogisticsRoute {
   rooms: string[];
 }
 
-export function planCrossRoomHauler(): SpawnPlan | null {
+export function planCrossRoomHauler(
+  getEnergyBudget: CrossRoomHaulerEnergyBudgetProvider = getDefaultCrossRoomHaulerEnergyBudget
+): SpawnPlan | null {
   const transfer = selectCrossRoomEnergyTransfer();
   if (!transfer) {
     return null;
@@ -59,7 +62,7 @@ export function planCrossRoomHauler(): SpawnPlan | null {
 
   const sourceState = getRoomStoredEnergyState(sourceRoom);
   const transferableEnergy = Math.min(transfer.amount, sourceState.exportableEnergy);
-  const body = buildCrossRoomHaulerBody(sourceRoom.energyAvailable, transferableEnergy);
+  const body = buildCrossRoomHaulerBody(getEnergyBudget(sourceRoom.name), transferableEnergy);
   if (body.length === 0) {
     return null;
   }
@@ -85,6 +88,10 @@ export function planCrossRoomHauler(): SpawnPlan | null {
       }
     }
   };
+}
+
+function getDefaultCrossRoomHaulerEnergyBudget(sourceRoomName: string): number {
+  return getVisibleRoom(sourceRoomName)?.energyAvailable ?? 0;
 }
 
 export function buildCrossRoomHaulerBody(

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -13,6 +13,7 @@ import { runWorker } from '../creeps/workerRunner';
 import { HAULER_ROLE, runHauler } from '../creeps/hauler';
 import { REMOTE_HARVESTER_ROLE, runRemoteHarvester } from '../creeps/remoteHarvester';
 import { getBodyCost, TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS } from '../spawn/bodyBuilder';
+import { MIN_SPAWN_ENERGY_BUFFER } from '../spawn/spawnConfig';
 import {
   orderColoniesForSpawnPlanning,
   planSpawn,
@@ -155,6 +156,12 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
         break;
       }
 
+      const bodyCost = getBodyCost(spawnRequest.body);
+      if (isSpawnEnergyBufferViolated(availableEnergy, bodyCost)) {
+        logSpawnEnergyBufferWarning(spawnRequest, colony.room.name, availableEnergy, bodyCost);
+        break;
+      }
+
       const outcome = attemptSpawnRequest(
         spawnRequest,
         colony.room.name,
@@ -166,7 +173,6 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       }
 
       usedSpawns.add(outcome.spawn);
-      const bodyCost = getBodyCost(spawnRequest.body);
       recordUsedSpawn(usedSpawnsByRoom, colony.room.name, outcome.spawn);
       recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, colony.room.name, bodyCost);
       availableEnergy = Math.max(0, availableEnergy - bodyCost);
@@ -266,10 +272,14 @@ function attemptCrossRoomHaulerSpawn(
     return;
   }
 
-  if (
-    getBodyCost(spawnRequest.body) >
-    getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom)
-  ) {
+  const bodyCost = getBodyCost(spawnRequest.body);
+  const availableEnergy = getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom);
+  if (bodyCost > availableEnergy) {
+    return;
+  }
+
+  if (isSpawnEnergyBufferViolated(availableEnergy, bodyCost)) {
+    logSpawnEnergyBufferWarning(spawnRequest, sourceRoomName, availableEnergy, bodyCost);
     return;
   }
 
@@ -287,7 +297,7 @@ function attemptCrossRoomHaulerSpawn(
   }
 
   recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
-  recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, sourceRoomName, getBodyCost(spawnRequest.body));
+  recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, sourceRoomName, bodyCost);
 }
 
 function getAvailableSpawnEnergyAfterReservations(
@@ -678,6 +688,21 @@ function attemptSpawnRequest(
   }
 
   return lastOutcome;
+}
+
+function isSpawnEnergyBufferViolated(availableEnergy: number, bodyCost: number): boolean {
+  return availableEnergy - bodyCost < MIN_SPAWN_ENERGY_BUFFER;
+}
+
+function logSpawnEnergyBufferWarning(
+  spawnRequest: SpawnRequest,
+  roomName: string,
+  availableEnergy: number,
+  bodyCost: number
+): void {
+  console.log(
+    `[spawn] warning: deferred ${spawnRequest.name} in ${roomName}; available energy ${availableEnergy}, body cost ${bodyCost}, required buffer ${MIN_SPAWN_ENERGY_BUFFER}`
+  );
 }
 
 function addPlannedWorker(roleCounts: RoleCounts): RoleCounts {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -104,6 +104,15 @@ interface SpawnAttemptOutcome {
   result: ScreepsReturnCode;
 }
 
+interface SpawnRequestSelection {
+  spawnRequest: SpawnRequest;
+  bodyCost: number;
+}
+
+interface SpawnPlanSelection extends SpawnRequestSelection {
+  planningColony: ColonySnapshot;
+}
+
 export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = []): RuntimeSummary | undefined {
   const creeps = Object.values(Game.creeps);
   balanceStorage();
@@ -141,24 +150,20 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
     const usedSpawns = new Set<StructureSpawn>(usedSpawnsByRoom.get(colony.room.name) ?? []);
 
     while (true) {
-      const planningColony = createSpawnPlanningColony(colony, availableEnergy, usedSpawns);
-      const spawnRequest = planSpawn(
-        planningColony,
+      const spawnPlan = selectSpawnPlanWithinEnergyBuffer(
+        colony,
+        availableEnergy,
+        usedSpawns,
         roleCounts,
         Game.time,
         getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp)
       );
-      if (!spawnRequest) {
+      if (!spawnPlan) {
         break;
       }
 
+      const { planningColony, spawnRequest, bodyCost } = spawnPlan;
       if (successfulSpawnCount > 0 && !isAllowedPostSpawnRequest(spawnRequest)) {
-        break;
-      }
-
-      const bodyCost = getBodyCost(spawnRequest.body);
-      if (isSpawnEnergyBufferViolated(availableEnergy, bodyCost)) {
-        logSpawnEnergyBufferWarning(spawnRequest, colony.room.name, availableEnergy, bodyCost);
         break;
       }
 
@@ -272,20 +277,25 @@ function attemptCrossRoomHaulerSpawn(
     return;
   }
 
-  const bodyCost = getBodyCost(spawnRequest.body);
   const availableEnergy = getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom);
-  if (bodyCost > availableEnergy) {
+  const spawnPlan = selectCrossRoomHaulerSpawnPlanWithinEnergyBuffer(spawnRequest, availableEnergy);
+  if (!spawnPlan) {
+    const originalBodyCost = getBodyCost(spawnRequest.body);
+    if (originalBodyCost <= availableEnergy && isSpawnEnergyBufferViolated(availableEnergy, originalBodyCost)) {
+      logSpawnEnergyBufferWarning(spawnRequest, sourceRoomName, availableEnergy, originalBodyCost);
+    }
     return;
   }
 
+  const { spawnRequest: bufferedSpawnRequest, bodyCost } = spawnPlan;
   if (isSpawnEnergyBufferViolated(availableEnergy, bodyCost)) {
     logSpawnEnergyBufferWarning(spawnRequest, sourceRoomName, availableEnergy, bodyCost);
     return;
   }
 
-  const request = candidateSpawns.includes(spawnRequest.spawn)
-    ? spawnRequest
-    : { ...spawnRequest, spawn: candidateSpawns[0] };
+  const request = candidateSpawns.includes(bufferedSpawnRequest.spawn)
+    ? bufferedSpawnRequest
+    : { ...bufferedSpawnRequest, spawn: candidateSpawns[0] };
   const outcome = attemptSpawnRequest(
     request,
     sourceRoomName,
@@ -623,6 +633,122 @@ function createSpawnPlanningColony(
     energyAvailable,
     spawns: colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
   };
+}
+
+function selectSpawnPlanWithinEnergyBuffer(
+  colony: ColonySnapshot,
+  availableEnergy: number,
+  usedSpawns: Set<StructureSpawn>,
+  roleCounts: RoleCounts,
+  gameTime: number,
+  options: SpawnPlanningOptions
+): SpawnPlanSelection | null {
+  const spawnPlan = planSpawnWithEnergyBudget(
+    colony,
+    availableEnergy,
+    usedSpawns,
+    roleCounts,
+    gameTime,
+    options
+  );
+  if (!spawnPlan) {
+    return null;
+  }
+
+  if (roleCounts.worker === 0 || !isSpawnEnergyBufferViolated(availableEnergy, spawnPlan.bodyCost)) {
+    return spawnPlan;
+  }
+
+  const fallbackSpawnPlan = planSpawnWithEnergyBudget(
+    colony,
+    getBufferedSpawnEnergyBudget(availableEnergy),
+    usedSpawns,
+    roleCounts,
+    gameTime,
+    options
+  );
+  if (fallbackSpawnPlan && !isSpawnEnergyBufferViolated(availableEnergy, fallbackSpawnPlan.bodyCost)) {
+    return fallbackSpawnPlan;
+  }
+
+  logSpawnEnergyBufferWarning(spawnPlan.spawnRequest, colony.room.name, availableEnergy, spawnPlan.bodyCost);
+  return null;
+}
+
+function planSpawnWithEnergyBudget(
+  colony: ColonySnapshot,
+  energyBudget: number,
+  usedSpawns: Set<StructureSpawn>,
+  roleCounts: RoleCounts,
+  gameTime: number,
+  options: SpawnPlanningOptions
+): SpawnPlanSelection | null {
+  const planningColony = createSpawnPlanningColony(colony, energyBudget, usedSpawns);
+  const spawnRequest = planSpawn(planningColony, roleCounts, gameTime, options);
+  if (!spawnRequest) {
+    return null;
+  }
+
+  return {
+    planningColony,
+    spawnRequest,
+    bodyCost: getBodyCost(spawnRequest.body)
+  };
+}
+
+function getBufferedSpawnEnergyBudget(availableEnergy: number): number {
+  return Math.max(0, availableEnergy - MIN_SPAWN_ENERGY_BUFFER);
+}
+
+function selectCrossRoomHaulerSpawnPlanWithinEnergyBuffer(
+  spawnRequest: SpawnRequest,
+  availableEnergy: number
+): SpawnRequestSelection | null {
+  const bodyCost = getBodyCost(spawnRequest.body);
+  if (bodyCost <= getBufferedSpawnEnergyBudget(availableEnergy)) {
+    return {
+      spawnRequest,
+      bodyCost
+    };
+  }
+
+  const fallbackBody = buildAffordableCrossRoomHaulerBody(
+    spawnRequest.body,
+    getBufferedSpawnEnergyBudget(availableEnergy)
+  );
+  if (fallbackBody.length === 0) {
+    return null;
+  }
+
+  return {
+    spawnRequest: { ...spawnRequest, body: fallbackBody },
+    bodyCost: getBodyCost(fallbackBody)
+  };
+}
+
+function buildAffordableCrossRoomHaulerBody(
+  body: BodyPartConstant[],
+  energyBudget: number
+): BodyPartConstant[] {
+  const affordableBody: BodyPartConstant[] = [];
+  let bodyCost = 0;
+
+  for (let index = 0; index + 1 < body.length; index += 2) {
+    const pair = body.slice(index, index + 2);
+    if (pair[0] !== 'carry' || pair[1] !== 'move') {
+      return [];
+    }
+
+    const pairCost = getBodyCost(pair);
+    if (bodyCost + pairCost > energyBudget) {
+      break;
+    }
+
+    affordableBody.push(...pair);
+    bodyCost += pairCost;
+  }
+
+  return affordableBody;
 }
 
 function getSpawnPlanningOptions(

--- a/prod/src/spawn/spawnConfig.ts
+++ b/prod/src/spawn/spawnConfig.ts
@@ -1,0 +1,1 @@
+export const MIN_SPAWN_ENERGY_BUFFER = 50;

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -280,7 +280,7 @@ function hasControllerDowngradeGuardSpawnCapacity(context: SpawnPlanningContext)
 }
 
 function hasRecoveryWorkerSpawnEnergy(colony: ColonySnapshot): boolean {
-  return colony.energyAvailable >= MINIMUM_EMERGENCY_WORKER_BODY_COST;
+  return getSpawnEnergyBudget(colony) >= MINIMUM_EMERGENCY_WORKER_BODY_COST;
 }
 
 interface PostClaimControllerSustainPlan {
@@ -646,7 +646,7 @@ function planDefenseSpawnForRoom(
     return null;
   }
 
-  const body = buildDefenseBody(colony.energyAvailable, hostileCount);
+  const body = buildDefenseBody(getSpawnEnergyBudget(colony), hostileCount);
   if (body.length === 0) {
     return null;
   }
@@ -681,7 +681,7 @@ function planRemoteEconomySpawn(context: SpawnPlanningContext): SpawnRequest | n
 
   const remoteHarvesterAssignment = selectRemoteHarvesterAssignment(context.colony.room.name);
   if (remoteHarvesterAssignment) {
-    const body = buildRemoteHarvesterBody(context.colony.energyAvailable);
+    const body = buildRemoteHarvesterBody(getSpawnEnergyBudget(context.colony));
     if (body.length > 0) {
       return {
         spawn,
@@ -709,7 +709,7 @@ function planRemoteEconomySpawn(context: SpawnPlanningContext): SpawnRequest | n
     return null;
   }
 
-  const body = buildRemoteHaulerBody(context.colony.energyAvailable, remoteHaulerAssignment.routeDistance);
+  const body = buildRemoteHaulerBody(getSpawnEnergyBudget(context.colony), remoteHaulerAssignment.routeDistance);
   if (body.length === 0) {
     return null;
   }
@@ -835,7 +835,7 @@ function planMultiRoomControllerUpgradeSpawn(context: SpawnPlanningContext): Spa
   }
 
   for (const upgradePlan of upgradePlans) {
-    const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
+    const body = buildMultiRoomUpgraderBody(getSpawnEnergyBudget(context.colony), upgradePlan);
     if (body.length === 0) {
       continue;
     }
@@ -1001,7 +1001,7 @@ function planTerritorySpawn(
     return null;
   }
 
-  const body = buildTerritorySpawnBody(colony.energyAvailable, territoryIntent);
+  const body = buildTerritorySpawnBody(getSpawnEnergyBudget(colony), territoryIntent);
   if (body.length === 0) {
     return null;
   }
@@ -1061,27 +1061,32 @@ function appendSpawnNameSuffix(baseName: string, options: SpawnPlanningOptions):
 }
 
 function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyPartConstant[] {
+  const spawnEnergyBudget = getSpawnEnergyBudget(colony);
   if (shouldUseSourceHarvesterBody(colony, roleCounts)) {
     const sourceDistance = estimateLocalSourceDistance(colony);
     const fullCapacityBody = generateHarvesterBody(colony.energyCapacityAvailable, sourceDistance);
-    if (canAffordBody(fullCapacityBody, colony.energyAvailable)) {
+    if (canAffordBody(fullCapacityBody, spawnEnergyBudget)) {
       return fullCapacityBody;
     }
 
-    return generateHarvesterBody(colony.energyAvailable, sourceDistance);
+    return generateHarvesterBody(spawnEnergyBudget, sourceDistance);
   }
 
   const controllerLevel = colony.room.controller?.level;
   const normalBody = buildWorkerBody(colony.energyCapacityAvailable, controllerLevel);
-  if (canAffordBody(normalBody, colony.energyAvailable)) {
+  if (canAffordBody(normalBody, spawnEnergyBudget)) {
     return normalBody;
   }
 
   if (roleCounts.worker === 0) {
-    return buildEmergencyWorkerBody(colony.energyAvailable);
+    return buildEmergencyWorkerBody(spawnEnergyBudget);
   }
 
-  return buildWorkerBody(colony.energyAvailable, controllerLevel);
+  return buildWorkerBody(spawnEnergyBudget, controllerLevel);
+}
+
+function getSpawnEnergyBudget(colony: ColonySnapshot): number {
+  return normalizeNonNegativeInteger(colony.spawnEnergyBudget ?? colony.energyAvailable);
 }
 
 export function generateHarvesterBody(

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1,4 +1,5 @@
 import { runEconomy } from '../src/economy/economyLoop';
+import { MIN_SPAWN_ENERGY_BUFFER } from '../src/spawn/spawnConfig';
 import { CONTROLLER_DOWNGRADE_GUARD_TICKS } from '../src/tasks/workerTasks';
 import { RUNTIME_SUMMARY_PREFIX } from '../src/telemetry/runtimeSummary';
 
@@ -41,10 +42,38 @@ describe('runEconomy', () => {
     });
   });
 
-  it('spawns an emergency bootstrap worker at the minimum body cost', () => {
+  it('defers an emergency bootstrap worker when spawning would violate the energy buffer', () => {
     const room = {
       name: 'W1N1',
       energyAvailable: 200,
+      energyCapacityAvailable: 400,
+      controller: { my: true } as StructureController
+    } as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(0)
+    } as unknown as StructureSpawn;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 125,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: {}
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      `[spawn] warning: deferred worker-W1N1-125 in W1N1; available energy 200, body cost 200, required buffer ${MIN_SPAWN_ENERGY_BUFFER}`
+    );
+  });
+
+  it('spawns an emergency bootstrap worker when the energy buffer is satisfied', () => {
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 200 + MIN_SPAWN_ENERGY_BUFFER,
       energyCapacityAvailable: 400,
       controller: { my: true } as StructureController
     } as Room;
@@ -264,7 +293,7 @@ describe('runEconomy', () => {
     );
     const room = {
       name: 'W1N1',
-      energyAvailable: 400,
+      energyAvailable: 400 + MIN_SPAWN_ENERGY_BUFFER,
       energyCapacityAvailable: 650,
       controller: { my: true, level: 2, ticksToDowngrade: 10_000 } as StructureController,
       find: jest.fn((type: number, options?: { filter?: (structure: StructureExtension) => boolean }) => {
@@ -2225,7 +2254,7 @@ function createLifecycleSpawn(room: Room, creeps: Record<string, Creep>, spawnTi
 }
 
 function makeTerritoryReadyEconomyRoom({
-  energyAvailable = 650,
+  energyAvailable = 650 + MIN_SPAWN_ENERGY_BUFFER,
   energyCapacityAvailable = 650
 }: {
   energyAvailable?: number;

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -42,7 +42,7 @@ describe('runEconomy', () => {
     });
   });
 
-  it('defers an emergency bootstrap worker when spawning would violate the energy buffer', () => {
+  it('spawns an emergency bootstrap worker without requiring the energy buffer', () => {
     const room = {
       name: 'W1N1',
       energyAvailable: 200,
@@ -64,8 +64,10 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    expect(spawn.spawnCreep).not.toHaveBeenCalled();
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-125', {
+      memory: { role: 'worker', colony: 'W1N1' }
+    });
+    expect(logSpy).not.toHaveBeenCalledWith(
       `[spawn] warning: deferred worker-W1N1-125 in W1N1; available energy 200, body cost 200, required buffer ${MIN_SPAWN_ENERGY_BUFFER}`
     );
   });
@@ -331,6 +333,44 @@ describe('runEconomy', () => {
     expect(spawn.spawnCreep).toHaveBeenCalledWith(
       ['work', 'carry', 'move', 'work', 'carry', 'move'],
       'worker-W1N1-127',
+      {
+        memory: { role: 'worker', colony: 'W1N1' }
+      }
+    );
+  });
+
+  it('sizes a refill worker against buffered energy when raw room energy would consume the buffer', () => {
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 4;
+    const room = {
+      name: 'W1N1',
+      energyAvailable: 400,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 } as StructureController,
+      find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: 'source1' } as Source] : []))
+    } as unknown as Room;
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 128,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: workers
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(
+      ['work', 'carry', 'move'],
+      'worker-W1N1-128',
       {
         memory: { role: 'worker', colony: 'W1N1' }
       }
@@ -944,7 +984,7 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    room.energyCapacityAvailable = 700;
+    room.energyCapacityAvailable = 750;
     (globalThis as unknown as { Game: Partial<Game> }).Game.time = 502;
 
     runEconomy();
@@ -2253,13 +2293,13 @@ function createLifecycleSpawn(room: Room, creeps: Record<string, Creep>, spawnTi
   return spawn as unknown as LifecycleSpawn;
 }
 
-function makeTerritoryReadyEconomyRoom({
-  energyAvailable = 650 + MIN_SPAWN_ENERGY_BUFFER,
-  energyCapacityAvailable = 650
-}: {
+function makeTerritoryReadyEconomyRoom(options: {
   energyAvailable?: number;
   energyCapacityAvailable?: number;
 } = {}): Room {
+  const energyCapacityAvailable = options.energyCapacityAvailable ?? 650 + MIN_SPAWN_ENERGY_BUFFER;
+  const energyAvailable = Math.min(options.energyAvailable ?? energyCapacityAvailable, energyCapacityAvailable);
+
   return {
     name: 'W1N1',
     energyAvailable,

--- a/prod/test/mvpEconomyLifecycle.test.ts
+++ b/prod/test/mvpEconomyLifecycle.test.ts
@@ -1,5 +1,6 @@
 import { runEconomy } from '../src/economy/economyLoop';
 import { WORKER_REPLACEMENT_TICKS_TO_LIVE } from '../src/creeps/roleCounts';
+import { MIN_SPAWN_ENERGY_BUFFER } from '../src/spawn/spawnConfig';
 import { URGENT_SPAWN_REFILL_ENERGY_THRESHOLD } from '../src/tasks/workerTasks';
 
 describe('MVP economy lifecycle', () => {
@@ -188,8 +189,8 @@ describe('MVP economy lifecycle', () => {
   it('plans a replacement before a colony worker expires without counting unrelated workers', () => {
     const room = {
       name: 'W1N1',
-      energyAvailable: 600,
-      energyCapacityAvailable: 800,
+      energyAvailable: 600 + MIN_SPAWN_ENERGY_BUFFER,
+      energyCapacityAvailable: 600,
       controller: { my: true, id: 'controller1' } as StructureController,
       find: jest.fn().mockReturnValue([])
     } as unknown as Room;

--- a/prod/test/spawnSurvival.test.ts
+++ b/prod/test/spawnSurvival.test.ts
@@ -43,9 +43,15 @@ describe('spawn survival integration', () => {
       suppressionReasons: ['bootstrapWorkerFloor', 'spawnEnergyCritical']
     });
 
-    harness.runTick(102, 200 + MIN_SPAWN_ENERGY_BUFFER - 1);
+    harness.runTick(102, 200);
     expectSpawnHasEnergyOrWorker(harness);
-    expect(harness.spawn.spawnCreep).not.toHaveBeenCalled();
+    expect(harness.spawn.spawnCreep).toHaveBeenLastCalledWith(
+      ['work', 'carry', 'move'],
+      'worker-W1N1-102',
+      { memory: { role: 'worker', colony: 'W1N1' } }
+    );
+    expect(harness.spawnedBodies()).toEqual([['work', 'carry', 'move']]);
+    expect(harness.workerNames()).toEqual(['worker-W1N1-102']);
     expect(harness.room.memory.colonyStage).toEqual({
       mode: 'BOOTSTRAP',
       updatedAt: 102,
@@ -59,8 +65,11 @@ describe('spawn survival integration', () => {
       'worker-W1N1-103',
       { memory: { role: 'worker', colony: 'W1N1' } }
     );
-    expect(harness.spawnedBodies()).toEqual([['work', 'carry', 'move']]);
-    expect(harness.workerNames()).toEqual(['worker-W1N1-103']);
+    expect(harness.spawnedBodies()).toEqual([
+      ['work', 'carry', 'move'],
+      ['work', 'carry', 'move']
+    ]);
+    expect(harness.workerNames()).toEqual(['worker-W1N1-102', 'worker-W1N1-103']);
     expect(harness.room.memory.colonyStage).toEqual({
       mode: 'BOOTSTRAP',
       updatedAt: 103,
@@ -71,7 +80,11 @@ describe('spawn survival integration', () => {
     expectSpawnHasEnergyOrWorker(harness);
     harness.runTick(105, 200 + MIN_SPAWN_ENERGY_BUFFER);
     expectSpawnHasEnergyOrWorker(harness);
-    expect(harness.workerNames()).toEqual(['worker-W1N1-103', 'worker-W1N1-104', 'worker-W1N1-105']);
+    expect(harness.workerNames()).toEqual([
+      'worker-W1N1-102',
+      'worker-W1N1-103',
+      'worker-W1N1-104'
+    ]);
     expect(harness.spawnedBodies().slice(0, 3)).toEqual([
       ['work', 'carry', 'move'],
       ['work', 'carry', 'move'],
@@ -93,8 +106,8 @@ describe('spawn survival integration', () => {
 
     harness.runTick(107, 500);
     expectSpawnHasEnergyOrWorker(harness);
-    expect(harness.spawnedBodies()).toHaveLength(4);
-    expect(harness.workerNames()).toHaveLength(4);
+    expect(harness.spawnedBodies()[4]).toEqual(['work', 'work', 'work', 'carry', 'move', 'move']);
+    expect(harness.workerNames()).toHaveLength(5);
     expect(harness.room.memory.colonyStage).toMatchObject({
       mode: 'BOOTSTRAP',
       updatedAt: 107,
@@ -103,25 +116,11 @@ describe('spawn survival integration', () => {
 
     harness.runTick(108, 800);
     expectSpawnHasEnergyOrWorker(harness);
-    expect(harness.spawnedBodies()[4]).toEqual([
-      'work',
-      'work',
-      'work',
-      'carry',
-      'move',
-      'move',
-      'work',
-      'move',
-      'carry',
-      'move',
-      'move'
-    ]);
     expect(harness.workerNames()).toHaveLength(5);
     expect(harness.spawn.spawnCreep).toHaveBeenCalledTimes(5);
-    expect(harness.room.memory.colonyStage).toMatchObject({
-      mode: 'BOOTSTRAP',
-      updatedAt: 108,
-      suppressionReasons: ['bootstrapRecovery']
+    expect(harness.room.memory.colonyStage).toEqual({
+      mode: 'TERRITORY_READY',
+      updatedAt: 108
     });
 
     harness.runTick(109, 800);

--- a/prod/test/spawnSurvival.test.ts
+++ b/prod/test/spawnSurvival.test.ts
@@ -1,4 +1,5 @@
 import { runEconomy } from '../src/economy/economyLoop';
+import { MIN_SPAWN_ENERGY_BUFFER } from '../src/spawn/spawnConfig';
 
 const OK_CODE = 0 as ScreepsReturnCode;
 const ERR_BUSY_CODE = -4 as ScreepsReturnCode;
@@ -42,26 +43,35 @@ describe('spawn survival integration', () => {
       suppressionReasons: ['bootstrapWorkerFloor', 'spawnEnergyCritical']
     });
 
-    harness.runTick(102, 200);
+    harness.runTick(102, 200 + MIN_SPAWN_ENERGY_BUFFER - 1);
     expectSpawnHasEnergyOrWorker(harness);
-    expect(harness.spawn.spawnCreep).toHaveBeenLastCalledWith(
-      ['work', 'carry', 'move'],
-      'worker-W1N1-102',
-      { memory: { role: 'worker', colony: 'W1N1' } }
-    );
-    expect(harness.spawnedBodies()).toEqual([['work', 'carry', 'move']]);
-    expect(harness.workerNames()).toEqual(['worker-W1N1-102']);
+    expect(harness.spawn.spawnCreep).not.toHaveBeenCalled();
     expect(harness.room.memory.colonyStage).toEqual({
       mode: 'BOOTSTRAP',
       updatedAt: 102,
       suppressionReasons: ['bootstrapWorkerFloor', 'spawnEnergyCritical']
     });
 
-    harness.runTick(103, 200);
+    harness.runTick(103, 200 + MIN_SPAWN_ENERGY_BUFFER);
     expectSpawnHasEnergyOrWorker(harness);
-    harness.runTick(104, 200);
+    expect(harness.spawn.spawnCreep).toHaveBeenLastCalledWith(
+      ['work', 'carry', 'move'],
+      'worker-W1N1-103',
+      { memory: { role: 'worker', colony: 'W1N1' } }
+    );
+    expect(harness.spawnedBodies()).toEqual([['work', 'carry', 'move']]);
+    expect(harness.workerNames()).toEqual(['worker-W1N1-103']);
+    expect(harness.room.memory.colonyStage).toEqual({
+      mode: 'BOOTSTRAP',
+      updatedAt: 103,
+      suppressionReasons: ['bootstrapWorkerFloor', 'spawnEnergyCritical']
+    });
+
+    harness.runTick(104, 200 + MIN_SPAWN_ENERGY_BUFFER);
     expectSpawnHasEnergyOrWorker(harness);
-    expect(harness.workerNames()).toEqual(['worker-W1N1-102', 'worker-W1N1-103', 'worker-W1N1-104']);
+    harness.runTick(105, 200 + MIN_SPAWN_ENERGY_BUFFER);
+    expectSpawnHasEnergyOrWorker(harness);
+    expect(harness.workerNames()).toEqual(['worker-W1N1-103', 'worker-W1N1-104', 'worker-W1N1-105']);
     expect(harness.spawnedBodies().slice(0, 3)).toEqual([
       ['work', 'carry', 'move'],
       ['work', 'carry', 'move'],
@@ -69,55 +79,68 @@ describe('spawn survival integration', () => {
     ]);
     expect(harness.room.memory.colonyStage).toMatchObject({
       mode: 'BOOTSTRAP',
-      updatedAt: 104
+      updatedAt: 105
     });
 
-    harness.runTick(105, 300);
+    harness.runTick(106, 300);
     expectSpawnHasEnergyOrWorker(harness);
     expect(harness.spawnedBodies()[3]).toEqual(['work', 'carry', 'move', 'move']);
-    expect(harness.room.memory.colonyStage).toMatchObject({
-      mode: 'BOOTSTRAP',
-      updatedAt: 105,
-      suppressionReasons: ['bootstrapRecovery']
-    });
-
-    harness.runTick(106, 400);
-    expectSpawnHasEnergyOrWorker(harness);
-    expect(harness.spawnedBodies()[4]).toEqual(['work', 'carry', 'move', 'work', 'carry', 'move']);
-    expect(harness.workerNames()).toHaveLength(5);
     expect(harness.room.memory.colonyStage).toMatchObject({
       mode: 'BOOTSTRAP',
       updatedAt: 106,
       suppressionReasons: ['bootstrapRecovery']
     });
 
-    harness.runTick(107, 800);
+    harness.runTick(107, 500);
     expectSpawnHasEnergyOrWorker(harness);
-    expectTerritoryReadyKeepsWorkers(harness);
-    expect(harness.workerNames()).toHaveLength(5);
-    expect(harness.spawn.spawnCreep).toHaveBeenCalledTimes(5);
-    expect(harness.room.memory.colonyStage).toEqual({
-      mode: 'TERRITORY_READY',
-      updatedAt: 107
+    expect(harness.spawnedBodies()).toHaveLength(4);
+    expect(harness.workerNames()).toHaveLength(4);
+    expect(harness.room.memory.colonyStage).toMatchObject({
+      mode: 'BOOTSTRAP',
+      updatedAt: 107,
+      suppressionReasons: ['bootstrapRecovery']
     });
 
     harness.runTick(108, 800);
     expectSpawnHasEnergyOrWorker(harness);
+    expect(harness.spawnedBodies()[4]).toEqual([
+      'work',
+      'work',
+      'work',
+      'carry',
+      'move',
+      'move',
+      'work',
+      'move',
+      'carry',
+      'move',
+      'move'
+    ]);
+    expect(harness.workerNames()).toHaveLength(5);
+    expect(harness.spawn.spawnCreep).toHaveBeenCalledTimes(5);
+    expect(harness.room.memory.colonyStage).toMatchObject({
+      mode: 'BOOTSTRAP',
+      updatedAt: 108,
+      suppressionReasons: ['bootstrapRecovery']
+    });
+
+    harness.runTick(109, 800);
+    expectSpawnHasEnergyOrWorker(harness);
     expectTerritoryReadyKeepsWorkers(harness);
     expect(harness.spawn.spawnCreep).toHaveBeenCalledTimes(5);
     expect(harness.workerNames()).toHaveLength(5);
     expect(harness.room.memory.colonyStage).toEqual({
       mode: 'TERRITORY_READY',
-      updatedAt: 108
+      updatedAt: 109
     });
-    expect(Memory.economy?.sourceWorkloads?.W1N1?.updatedAt).toBe(108);
+    expect(Memory.economy?.sourceWorkloads?.W1N1?.updatedAt).toBe(109);
     expect(
       harness
         .spawnedBodies()
-        .every((body) => body.length > 0 && body.reduce((total, part) => total + getBodyPartCost(part), 0) <= 400)
+        .every((body) => body.length > 0 && body.reduce((total, part) => total + getBodyPartCost(part), 0) <= 750)
     ).toBe(true);
 
-    for (let tick = 109; tick <= 300; tick += 1) {
+    for (let tick = 110; tick <= 300; tick += 1) {
       harness.runTick(tick, 800);
       expectSpawnHasEnergyOrWorker(harness);
       expectTerritoryReadyKeepsWorkers(harness);


### PR DESCRIPTION
Implements spawn energy buffer guard to prevent starvation-spiral spawn attempts.

When the room's available energy is below a configurable buffer threshold, spawn requests are held until energy recovers. This prevents the bot from spawning partial or minimal creeps that drain the last energy and cause a death spiral.

- Adds spawnConfig.ts with buffer threshold configuration
- Guards spawn dispatch in economyLoop with energy check
- Tests cover: buffer threshold enforcement, recovery after energy rise, interaction with survival mode

Closes #683
