### PR TITLE
feat(territory): implement multi-room spawn coordination for claimed secondary rooms (#682)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -794,10 +794,19 @@ function cleanupDeadCreepMemory() {
 
 // src/colony/colonyRegistry.ts
 function getOwnedColonies() {
-  return Object.values(Game.rooms).filter((room) => {
-    var _a;
-    return (_a = room.controller) == null ? void 0 : _a.my;
-  }).map((room) => ({
+  var _a, _b;
+  const ownedRoomsByName = /* @__PURE__ */ new Map();
+  for (const room of Object.values(Game.rooms)) {
+    if ((_a = room.controller) == null ? void 0 : _a.my) {
+      ownedRoomsByName.set(room.name, room);
+    }
+  }
+  for (const spawn of Object.values(Game.spawns)) {
+    if (((_b = spawn.room.controller) == null ? void 0 : _b.my) && !ownedRoomsByName.has(spawn.room.name)) {
+      ownedRoomsByName.set(spawn.room.name, spawn.room);
+    }
+  }
+  return [...ownedRoomsByName.values()].map((room) => ({
     room,
     memory: room.memory,
     spawns: Object.values(Game.spawns).filter((spawn) => spawn.room.name === room.name),
@@ -14998,6 +15007,9 @@ function runWorker(creep) {
   if (runControllerSustainMovement(creep)) {
     return;
   }
+  if (runSpawnSupportMovement(creep)) {
+    return;
+  }
   observeCreepBehaviorTick(creep);
   const selectedTask = selectWorkerTaskForRunner(creep);
   const currentTask = creep.memory.task;
@@ -15116,6 +15128,23 @@ function selectControllerSustainDestinationRoom(creep, sustain, roomName) {
     return sustain.targetRoom;
   }
   return roomName === sustain.homeRoom ? sustain.targetRoom : sustain.homeRoom;
+}
+function runSpawnSupportMovement(creep) {
+  var _a;
+  const support = creep.memory.spawnSupport;
+  if (!isSpawnSupportMemory(support)) {
+    return false;
+  }
+  if (((_a = creep.room) == null ? void 0 : _a.name) === support.targetRoom) {
+    return false;
+  }
+  clearAssignedTask(creep);
+  moveTowardRoom(creep, support.targetRoom);
+  return true;
+}
+function isSpawnSupportMemory(value) {
+  const support = value;
+  return typeof value === "object" && value !== null && typeof support.originRoom === "string" && typeof support.targetRoom === "string" && support.originRoom.length > 0 && support.targetRoom.length > 0;
 }
 function clearAssignedTask(creep) {
   delete creep.memory.task;
@@ -24581,18 +24610,19 @@ var OK_CODE10 = 0;
 var NEXT_EXPANSION_SCORING_REFRESH_INTERVAL = 50;
 var NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS = 5e3;
 function runEconomy(preludeTelemetryEvents = []) {
-  var _a, _b;
   const creeps = Object.values(Game.creeps);
   balanceStorage();
   const colonies = orderColoniesForSpawnPlanning(getOwnedColonies());
   const telemetryEvents = [...preludeTelemetryEvents];
   const usedSpawnsByRoom = /* @__PURE__ */ new Map();
   const reservedSpawnEnergyByRoom = /* @__PURE__ */ new Map();
+  const plannedRoleCountsByRoom = /* @__PURE__ */ new Map();
   clearColonySurvivalAssessmentCache();
   refreshClaimedRoomBootstrapperOwnership();
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
-    let roleCounts = countCreepsByRole(creeps, colony.room.name);
+    let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
+    plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     persistColonyStageAssessment(colony, survivalAssessment, Game.time);
@@ -24612,37 +24642,39 @@ function runEconomy(preludeTelemetryEvents = []) {
       roleCounts,
       Game.time
     );
-    let availableEnergy = Math.max(0, colony.energyAvailable - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0));
     let successfulSpawnCount = 0;
-    const usedSpawns = new Set((_b = usedSpawnsByRoom.get(colony.room.name)) != null ? _b : []);
     while (true) {
-      const planningColony = createSpawnPlanningColony(colony, availableEnergy, usedSpawns);
-      const spawnRequest = planSpawn(
-        planningColony,
+      const coordinatedPlan = planCoordinatedSpawn(
+        colony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp)
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp),
+        colonies,
+        creeps,
+        usedSpawnsByRoom,
+        reservedSpawnEnergyByRoom,
+        plannedRoleCountsByRoom
       );
-      if (!spawnRequest) {
+      if (!coordinatedPlan) {
         break;
       }
+      const spawnRequest = coordinatedPlan.spawnRequest;
       if (successfulSpawnCount > 0 && !isAllowedPostSpawnRequest(spawnRequest)) {
         break;
       }
       const outcome = attemptSpawnRequest(
         spawnRequest,
-        colony.room.name,
+        coordinatedPlan.sourceRoomName,
         telemetryEvents,
-        planningColony.spawns
+        coordinatedPlan.spawns
       );
       if (!outcome || outcome.result !== OK_CODE10) {
         break;
       }
-      usedSpawns.add(outcome.spawn);
+      const spawnRoomName = outcome.spawn.room.name;
       const bodyCost = getBodyCost(spawnRequest.body);
-      recordUsedSpawn(usedSpawnsByRoom, colony.room.name, outcome.spawn);
-      recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, colony.room.name, bodyCost);
-      availableEnergy = Math.max(0, availableEnergy - bodyCost);
+      recordUsedSpawn(usedSpawnsByRoom, spawnRoomName, outcome.spawn);
+      recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, spawnRoomName, bodyCost);
       successfulSpawnCount += 1;
       recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
       if (spawnRequest.memory.role !== "worker") {
@@ -24652,6 +24684,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         continue;
       }
       roleCounts = addPlannedWorker(roleCounts);
+      plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
     }
     transferEnergy(colony.room);
     manageStorage(colony.room);
@@ -24945,11 +24978,139 @@ function isNonEmptyString19(value) {
 function isFiniteNumber9(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function createSpawnPlanningColony(colony, energyAvailable, usedSpawns) {
+function normalizeNonNegativeInteger3(value) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+function planCoordinatedSpawn(colony, roleCounts, gameTime, options, colonies, creeps, usedSpawnsByRoom, reservedSpawnEnergyByRoom, plannedRoleCountsByRoom) {
+  for (const sourceColony of getCoordinatedSpawnSourceColonies(
+    colony,
+    colonies,
+    creeps,
+    usedSpawnsByRoom,
+    reservedSpawnEnergyByRoom,
+    plannedRoleCountsByRoom
+  )) {
+    const planningColony = createSpawnPlanningColony(
+      colony,
+      sourceColony,
+      usedSpawnsByRoom,
+      reservedSpawnEnergyByRoom
+    );
+    if (planningColony.spawns.length === 0) {
+      continue;
+    }
+    const spawnRequest = planSpawn(planningColony, roleCounts, gameTime, options);
+    if (!spawnRequest) {
+      continue;
+    }
+    const sourceRoomName = sourceColony.room.name;
+    if (sourceRoomName !== colony.room.name && !isAllowedCrossRoomSpawnRequest(spawnRequest, colony.room.name)) {
+      continue;
+    }
+    return {
+      spawnRequest: withCrossRoomSpawnSupportMemory(spawnRequest, sourceRoomName, colony.room.name),
+      spawns: planningColony.spawns,
+      sourceRoomName
+    };
+  }
+  return null;
+}
+function createSpawnPlanningColony(colony, sourceColony, usedSpawnsByRoom, reservedSpawnEnergyByRoom) {
+  var _a;
+  const sourceRoomName = sourceColony.room.name;
+  const usedSpawns = (_a = usedSpawnsByRoom.get(sourceRoomName)) != null ? _a : /* @__PURE__ */ new Set();
   return {
     ...colony,
-    energyAvailable,
-    spawns: colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
+    energyAvailable: getAvailableSpawnEnergy(sourceColony, reservedSpawnEnergyByRoom),
+    energyCapacityAvailable: normalizeNonNegativeInteger3(sourceColony.energyCapacityAvailable),
+    spawns: sourceColony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
+  };
+}
+function getCoordinatedSpawnSourceColonies(targetColony, colonies, creeps, usedSpawnsByRoom, reservedSpawnEnergyByRoom, plannedRoleCountsByRoom) {
+  const localSource = colonies.find((colony) => colony.room.name === targetColony.room.name);
+  const remoteSources = colonies.filter((colony) => colony.room.name !== targetColony.room.name).filter(
+    (sourceColony) => canUseCrossRoomSpawnSource(
+      sourceColony,
+      creeps,
+      usedSpawnsByRoom,
+      reservedSpawnEnergyByRoom,
+      plannedRoleCountsByRoom
+    )
+  ).sort(
+    (left, right) => compareCoordinatedSpawnSources(left, right, reservedSpawnEnergyByRoom)
+  );
+  return localSource ? [localSource, ...remoteSources] : remoteSources;
+}
+function canUseCrossRoomSpawnSource(sourceColony, creeps, usedSpawnsByRoom, reservedSpawnEnergyByRoom, plannedRoleCountsByRoom) {
+  if (getUnusedSpawnCount(sourceColony, usedSpawnsByRoom) === 0) {
+    return false;
+  }
+  if (!hasFullSpawnEnergyAfterReservations(sourceColony, reservedSpawnEnergyByRoom)) {
+    return false;
+  }
+  const roleCounts = getPlannedOrCurrentRoleCounts(
+    creeps,
+    sourceColony.room.name,
+    plannedRoleCountsByRoom
+  );
+  const workerTarget = getWorkerTarget(sourceColony, roleCounts);
+  if (getWorkerCapacity(roleCounts) < workerTarget) {
+    return false;
+  }
+  if (shouldSuppressWorkerSpawnForCrossRoomImport(sourceColony)) {
+    return false;
+  }
+  const survival = assessColonySnapshotSurvival(sourceColony, roleCounts);
+  return survival.mode === "TERRITORY_READY" && !survival.controllerDowngradeGuard && !survival.hostilePresence;
+}
+function compareCoordinatedSpawnSources(left, right, reservedSpawnEnergyByRoom) {
+  return getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger3(right.energyCapacityAvailable) - normalizeNonNegativeInteger3(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
+}
+function getUnusedSpawnCount(colony, usedSpawnsByRoom) {
+  var _a;
+  const usedSpawns = (_a = usedSpawnsByRoom.get(colony.room.name)) != null ? _a : /* @__PURE__ */ new Set();
+  return colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn)).length;
+}
+function hasFullSpawnEnergyAfterReservations(colony, reservedSpawnEnergyByRoom) {
+  const energyCapacity = normalizeNonNegativeInteger3(colony.energyCapacityAvailable);
+  return energyCapacity > 0 && getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) >= energyCapacity;
+}
+function getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) {
+  var _a;
+  if (!colony) {
+    return 0;
+  }
+  return Math.max(
+    0,
+    normalizeNonNegativeInteger3(colony.energyAvailable) - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0)
+  );
+}
+function getPlannedOrCurrentRoleCounts(creeps, roomName, plannedRoleCountsByRoom) {
+  var _a;
+  return (_a = plannedRoleCountsByRoom.get(roomName)) != null ? _a : countCreepsByRole(creeps, roomName);
+}
+function isAllowedCrossRoomSpawnRequest(spawnRequest, targetRoomName) {
+  if (spawnRequest.memory.colony !== targetRoomName) {
+    return false;
+  }
+  if (spawnRequest.memory.role === "worker") {
+    return !spawnRequest.memory.controllerSustain;
+  }
+  return spawnRequest.memory.role === TERRITORY_CLAIMER_ROLE || spawnRequest.memory.role === TERRITORY_SCOUT_ROLE;
+}
+function withCrossRoomSpawnSupportMemory(spawnRequest, sourceRoomName, targetRoomName) {
+  if (sourceRoomName === targetRoomName || spawnRequest.memory.role !== "worker" || spawnRequest.memory.controllerSustain) {
+    return spawnRequest;
+  }
+  return {
+    ...spawnRequest,
+    memory: {
+      ...spawnRequest.memory,
+      spawnSupport: {
+        originRoom: sourceRoomName,
+        targetRoom: targetRoomName
+      }
+    }
   };
 }
 function getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -802,8 +802,9 @@ function getOwnedColonies() {
     }
   }
   for (const spawn of Object.values(Game.spawns)) {
-    if (((_b = spawn.room.controller) == null ? void 0 : _b.my) && !ownedRoomsByName.has(spawn.room.name)) {
-      ownedRoomsByName.set(spawn.room.name, spawn.room);
+    const room = spawn.room;
+    if (room && ((_b = room.controller) == null ? void 0 : _b.my) && !ownedRoomsByName.has(room.name)) {
+      ownedRoomsByName.set(room.name, room);
     }
   }
   return [...ownedRoomsByName.values()].map((room) => ({
@@ -24610,6 +24611,7 @@ var OK_CODE10 = 0;
 var NEXT_EXPANSION_SCORING_REFRESH_INTERVAL = 50;
 var NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS = 5e3;
 function runEconomy(preludeTelemetryEvents = []) {
+  var _a, _b;
   const creeps = Object.values(Game.creeps);
   balanceStorage();
   const colonies = orderColoniesForSpawnPlanning(getOwnedColonies());
@@ -24671,7 +24673,7 @@ function runEconomy(preludeTelemetryEvents = []) {
       if (!outcome || outcome.result !== OK_CODE10) {
         break;
       }
-      const spawnRoomName = outcome.spawn.room.name;
+      const spawnRoomName = (_b = (_a = outcome.spawn.room) == null ? void 0 : _a.name) != null ? _b : "unknown";
       const bodyCost = getBodyCost(spawnRequest.body);
       recordUsedSpawn(usedSpawnsByRoom, spawnRoomName, outcome.spawn);
       recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, spawnRoomName, bodyCost);

--- a/prod/src/colony/colonyRegistry.ts
+++ b/prod/src/colony/colonyRegistry.ts
@@ -7,8 +7,20 @@ export interface ColonySnapshot {
 }
 
 export function getOwnedColonies(): ColonySnapshot[] {
-  return Object.values(Game.rooms)
-    .filter((room) => room.controller?.my)
+  const ownedRoomsByName = new Map<string, Room>();
+  for (const room of Object.values(Game.rooms)) {
+    if (room.controller?.my) {
+      ownedRoomsByName.set(room.name, room);
+    }
+  }
+
+  for (const spawn of Object.values(Game.spawns)) {
+    if (spawn.room.controller?.my && !ownedRoomsByName.has(spawn.room.name)) {
+      ownedRoomsByName.set(spawn.room.name, spawn.room);
+    }
+  }
+
+  return [...ownedRoomsByName.values()]
     .map((room) => ({
       room,
       memory: room.memory,

--- a/prod/src/colony/colonyRegistry.ts
+++ b/prod/src/colony/colonyRegistry.ts
@@ -15,8 +15,9 @@ export function getOwnedColonies(): ColonySnapshot[] {
   }
 
   for (const spawn of Object.values(Game.spawns)) {
-    if (spawn.room.controller?.my && !ownedRoomsByName.has(spawn.room.name)) {
-      ownedRoomsByName.set(spawn.room.name, spawn.room);
+    const room = spawn.room;
+    if (room && room.controller?.my && !ownedRoomsByName.has(room.name)) {
+      ownedRoomsByName.set(room.name, room);
     }
   }
 

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -57,6 +57,9 @@ export function runWorker(creep: Creep): void {
   if (runControllerSustainMovement(creep)) {
     return;
   }
+  if (runSpawnSupportMovement(creep)) {
+    return;
+  }
   observeCreepBehaviorTick(creep);
 
   const selectedTask = selectWorkerTaskForRunner(creep);
@@ -216,6 +219,33 @@ function selectControllerSustainDestinationRoom(
   }
 
   return roomName === sustain.homeRoom ? sustain.targetRoom : sustain.homeRoom;
+}
+
+function runSpawnSupportMovement(creep: Creep): boolean {
+  const support = creep.memory.spawnSupport;
+  if (!isSpawnSupportMemory(support)) {
+    return false;
+  }
+
+  if (creep.room?.name === support.targetRoom) {
+    return false;
+  }
+
+  clearAssignedTask(creep);
+  moveTowardRoom(creep, support.targetRoom);
+  return true;
+}
+
+function isSpawnSupportMemory(value: unknown): value is CreepSpawnSupportMemory {
+  const support = value as Partial<CreepSpawnSupportMemory>;
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof support.originRoom === 'string' &&
+    typeof support.targetRoom === 'string' &&
+    support.originRoom.length > 0 &&
+    support.targetRoom.length > 0
+  );
 }
 
 function clearAssignedTask(creep: Creep): void {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -178,7 +178,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
         break;
       }
 
-      const spawnRoomName = outcome.spawn.room.name;
+      const spawnRoomName = outcome.spawn.room?.name ?? 'unknown';
       const bodyCost = getBodyCost(spawnRequest.body);
       recordUsedSpawn(usedSpawnsByRoom, spawnRoomName, outcome.spawn);
       recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, spawnRoomName, bodyCost);

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -2,6 +2,7 @@ import { getOwnedColonies, type ColonySnapshot } from '../colony/colonyRegistry'
 import {
   assessColonySnapshotSurvival,
   clearColonySurvivalAssessmentCache,
+  getWorkerTarget,
   persistColonyStageAssessment,
   recordColonySurvivalAssessment
 } from '../colony/colonyStage';
@@ -16,6 +17,7 @@ import { getBodyCost, TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS } from '../spawn
 import {
   orderColoniesForSpawnPlanning,
   planSpawn,
+  shouldSuppressWorkerSpawnForCrossRoomImport,
   type SpawnPlanningOptions,
   type SpawnRequest
 } from '../spawn/spawnPlanner';
@@ -103,6 +105,12 @@ interface SpawnAttemptOutcome {
   result: ScreepsReturnCode;
 }
 
+interface CoordinatedSpawnPlan {
+  spawnRequest: SpawnRequest;
+  spawns: StructureSpawn[];
+  sourceRoomName: string;
+}
+
 export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = []): RuntimeSummary | undefined {
   const creeps = Object.values(Game.creeps);
   balanceStorage();
@@ -110,12 +118,14 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   const telemetryEvents: RuntimeTelemetryEvent[] = [...preludeTelemetryEvents];
   const usedSpawnsByRoom = new Map<string, Set<StructureSpawn>>();
   const reservedSpawnEnergyByRoom = new Map<string, number>();
+  const plannedRoleCountsByRoom = new Map<string, RoleCounts>();
   clearColonySurvivalAssessmentCache();
   refreshClaimedRoomBootstrapperOwnership();
 
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
-    let roleCounts = countCreepsByRole(creeps, colony.room.name);
+    let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
+    plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     persistColonyStageAssessment(colony, survivalAssessment, Game.time);
@@ -135,21 +145,24 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       roleCounts,
       Game.time
     );
-    let availableEnergy = Math.max(0, colony.energyAvailable - (reservedSpawnEnergyByRoom.get(colony.room.name) ?? 0));
     let successfulSpawnCount = 0;
-    const usedSpawns = new Set<StructureSpawn>(usedSpawnsByRoom.get(colony.room.name) ?? []);
 
     while (true) {
-      const planningColony = createSpawnPlanningColony(colony, availableEnergy, usedSpawns);
-      const spawnRequest = planSpawn(
-        planningColony,
+      const coordinatedPlan = planCoordinatedSpawn(
+        colony,
         roleCounts,
         Game.time,
-        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp)
+        getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp),
+        colonies,
+        creeps,
+        usedSpawnsByRoom,
+        reservedSpawnEnergyByRoom,
+        plannedRoleCountsByRoom
       );
-      if (!spawnRequest) {
+      if (!coordinatedPlan) {
         break;
       }
+      const spawnRequest = coordinatedPlan.spawnRequest;
 
       if (successfulSpawnCount > 0 && !isAllowedPostSpawnRequest(spawnRequest)) {
         break;
@@ -157,19 +170,18 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
 
       const outcome = attemptSpawnRequest(
         spawnRequest,
-        colony.room.name,
+        coordinatedPlan.sourceRoomName,
         telemetryEvents,
-        planningColony.spawns
+        coordinatedPlan.spawns
       );
       if (!outcome || outcome.result !== OK_CODE) {
         break;
       }
 
-      usedSpawns.add(outcome.spawn);
+      const spawnRoomName = outcome.spawn.room.name;
       const bodyCost = getBodyCost(spawnRequest.body);
-      recordUsedSpawn(usedSpawnsByRoom, colony.room.name, outcome.spawn);
-      recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, colony.room.name, bodyCost);
-      availableEnergy = Math.max(0, availableEnergy - bodyCost);
+      recordUsedSpawn(usedSpawnsByRoom, spawnRoomName, outcome.spawn);
+      recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, spawnRoomName, bodyCost);
       successfulSpawnCount += 1;
       recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
 
@@ -182,6 +194,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       }
 
       roleCounts = addPlannedWorker(roleCounts);
+      plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
     }
 
     transferLinkEnergy(colony.room);
@@ -603,15 +616,232 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
+function normalizeNonNegativeInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function planCoordinatedSpawn(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  gameTime: number,
+  options: SpawnPlanningOptions,
+  colonies: ColonySnapshot[],
+  creeps: Creep[],
+  usedSpawnsByRoom: Map<string, Set<StructureSpawn>>,
+  reservedSpawnEnergyByRoom: Map<string, number>,
+  plannedRoleCountsByRoom: Map<string, RoleCounts>
+): CoordinatedSpawnPlan | null {
+  for (const sourceColony of getCoordinatedSpawnSourceColonies(
+    colony,
+    colonies,
+    creeps,
+    usedSpawnsByRoom,
+    reservedSpawnEnergyByRoom,
+    plannedRoleCountsByRoom
+  )) {
+    const planningColony = createSpawnPlanningColony(
+      colony,
+      sourceColony,
+      usedSpawnsByRoom,
+      reservedSpawnEnergyByRoom
+    );
+    if (planningColony.spawns.length === 0) {
+      continue;
+    }
+
+    const spawnRequest = planSpawn(planningColony, roleCounts, gameTime, options);
+    if (!spawnRequest) {
+      continue;
+    }
+
+    const sourceRoomName = sourceColony.room.name;
+    if (
+      sourceRoomName !== colony.room.name &&
+      !isAllowedCrossRoomSpawnRequest(spawnRequest, colony.room.name)
+    ) {
+      continue;
+    }
+
+    return {
+      spawnRequest: withCrossRoomSpawnSupportMemory(spawnRequest, sourceRoomName, colony.room.name),
+      spawns: planningColony.spawns,
+      sourceRoomName
+    };
+  }
+
+  return null;
+}
+
 function createSpawnPlanningColony(
   colony: ColonySnapshot,
-  energyAvailable: number,
-  usedSpawns: Set<StructureSpawn>
+  sourceColony: ColonySnapshot,
+  usedSpawnsByRoom: Map<string, Set<StructureSpawn>>,
+  reservedSpawnEnergyByRoom: Map<string, number>
 ): ColonySnapshot {
+  const sourceRoomName = sourceColony.room.name;
+  const usedSpawns = usedSpawnsByRoom.get(sourceRoomName) ?? new Set<StructureSpawn>();
   return {
     ...colony,
-    energyAvailable,
-    spawns: colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
+    energyAvailable: getAvailableSpawnEnergy(sourceColony, reservedSpawnEnergyByRoom),
+    energyCapacityAvailable: normalizeNonNegativeInteger(sourceColony.energyCapacityAvailable),
+    spawns: sourceColony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
+  };
+}
+
+function getCoordinatedSpawnSourceColonies(
+  targetColony: ColonySnapshot,
+  colonies: ColonySnapshot[],
+  creeps: Creep[],
+  usedSpawnsByRoom: Map<string, Set<StructureSpawn>>,
+  reservedSpawnEnergyByRoom: Map<string, number>,
+  plannedRoleCountsByRoom: Map<string, RoleCounts>
+): ColonySnapshot[] {
+  const localSource = colonies.find((colony) => colony.room.name === targetColony.room.name);
+  const remoteSources = colonies
+    .filter((colony) => colony.room.name !== targetColony.room.name)
+    .filter((sourceColony) =>
+      canUseCrossRoomSpawnSource(
+        sourceColony,
+        creeps,
+        usedSpawnsByRoom,
+        reservedSpawnEnergyByRoom,
+        plannedRoleCountsByRoom
+      )
+    )
+    .sort((left, right) =>
+      compareCoordinatedSpawnSources(left, right, reservedSpawnEnergyByRoom)
+    );
+
+  return localSource ? [localSource, ...remoteSources] : remoteSources;
+}
+
+function canUseCrossRoomSpawnSource(
+  sourceColony: ColonySnapshot,
+  creeps: Creep[],
+  usedSpawnsByRoom: Map<string, Set<StructureSpawn>>,
+  reservedSpawnEnergyByRoom: Map<string, number>,
+  plannedRoleCountsByRoom: Map<string, RoleCounts>
+): boolean {
+  if (getUnusedSpawnCount(sourceColony, usedSpawnsByRoom) === 0) {
+    return false;
+  }
+
+  if (!hasFullSpawnEnergyAfterReservations(sourceColony, reservedSpawnEnergyByRoom)) {
+    return false;
+  }
+
+  const roleCounts = getPlannedOrCurrentRoleCounts(
+    creeps,
+    sourceColony.room.name,
+    plannedRoleCountsByRoom
+  );
+  const workerTarget = getWorkerTarget(sourceColony, roleCounts);
+  if (getWorkerCapacity(roleCounts) < workerTarget) {
+    return false;
+  }
+
+  if (shouldSuppressWorkerSpawnForCrossRoomImport(sourceColony)) {
+    return false;
+  }
+
+  const survival = assessColonySnapshotSurvival(sourceColony, roleCounts);
+  return (
+    survival.mode === 'TERRITORY_READY' &&
+    !survival.controllerDowngradeGuard &&
+    !survival.hostilePresence
+  );
+}
+
+function compareCoordinatedSpawnSources(
+  left: ColonySnapshot,
+  right: ColonySnapshot,
+  reservedSpawnEnergyByRoom: Map<string, number>
+): number {
+  return (
+    getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) -
+      getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) ||
+    normalizeNonNegativeInteger(right.energyCapacityAvailable) -
+      normalizeNonNegativeInteger(left.energyCapacityAvailable) ||
+    left.room.name.localeCompare(right.room.name)
+  );
+}
+
+function getUnusedSpawnCount(
+  colony: ColonySnapshot,
+  usedSpawnsByRoom: Map<string, Set<StructureSpawn>>
+): number {
+  const usedSpawns = usedSpawnsByRoom.get(colony.room.name) ?? new Set<StructureSpawn>();
+  return colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn)).length;
+}
+
+function hasFullSpawnEnergyAfterReservations(
+  colony: ColonySnapshot,
+  reservedSpawnEnergyByRoom: Map<string, number>
+): boolean {
+  const energyCapacity = normalizeNonNegativeInteger(colony.energyCapacityAvailable);
+  return energyCapacity > 0 && getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) >= energyCapacity;
+}
+
+function getAvailableSpawnEnergy(
+  colony: ColonySnapshot | undefined,
+  reservedSpawnEnergyByRoom: Map<string, number>
+): number {
+  if (!colony) {
+    return 0;
+  }
+
+  return Math.max(
+    0,
+    normalizeNonNegativeInteger(colony.energyAvailable) -
+      (reservedSpawnEnergyByRoom.get(colony.room.name) ?? 0)
+  );
+}
+
+function getPlannedOrCurrentRoleCounts(
+  creeps: Creep[],
+  roomName: string,
+  plannedRoleCountsByRoom: Map<string, RoleCounts>
+): RoleCounts {
+  return plannedRoleCountsByRoom.get(roomName) ?? countCreepsByRole(creeps, roomName);
+}
+
+function isAllowedCrossRoomSpawnRequest(
+  spawnRequest: SpawnRequest,
+  targetRoomName: string
+): boolean {
+  if (spawnRequest.memory.colony !== targetRoomName) {
+    return false;
+  }
+
+  if (spawnRequest.memory.role === 'worker') {
+    return !spawnRequest.memory.controllerSustain;
+  }
+
+  return spawnRequest.memory.role === TERRITORY_CLAIMER_ROLE || spawnRequest.memory.role === TERRITORY_SCOUT_ROLE;
+}
+
+function withCrossRoomSpawnSupportMemory(
+  spawnRequest: SpawnRequest,
+  sourceRoomName: string,
+  targetRoomName: string
+): SpawnRequest {
+  if (
+    sourceRoomName === targetRoomName ||
+    spawnRequest.memory.role !== 'worker' ||
+    spawnRequest.memory.controllerSustain
+  ) {
+    return spawnRequest;
+  }
+
+  return {
+    ...spawnRequest,
+    memory: {
+      ...spawnRequest.memory,
+      spawnSupport: {
+        originRoom: sourceRoomName,
+        targetRoom: targetRoomName
+      }
+    }
   };
 }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -50,6 +50,7 @@ declare global {
     workerTaskPolicyShadow?: WorkerTaskPolicyShadowMemory;
     behaviorTelemetry?: CreepBehaviorTelemetryMemory;
     crossRoomHauler?: CreepCrossRoomHaulerMemory;
+    spawnSupport?: CreepSpawnSupportMemory;
   }
 
   type DefenseActionType =
@@ -155,6 +156,11 @@ declare global {
     sourceId?: Id<AnyStoreStructure> | null;
     state?: 'collecting' | 'delivering' | 'returning' | 'unassigned';
     route?: string[];
+  }
+
+  interface CreepSpawnSupportMemory {
+    originRoom: string;
+    targetRoom: string;
   }
 
   interface EconomyRoomSourceWorkloadMemory {

--- a/prod/test/colonyRegistry.test.ts
+++ b/prod/test/colonyRegistry.test.ts
@@ -89,4 +89,30 @@ describe('getOwnedColonies', () => {
       }
     ]);
   });
+
+  it('discovers owned spawn rooms from Game.spawns even when the room map is incomplete', () => {
+    const spawnedRoom = {
+      name: 'W4N4',
+      controller: { my: true },
+      energyAvailable: 300,
+      energyCapacityAvailable: 300
+    } as Room;
+    const spawn = { name: 'Spawn4', room: spawnedRoom, spawning: null } as StructureSpawn;
+
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {},
+      spawns: {
+        Spawn4: spawn
+      }
+    };
+
+    expect(getOwnedColonies()).toEqual([
+      {
+        room: spawnedRoom,
+        spawns: [spawn],
+        energyAvailable: 300,
+        energyCapacityAvailable: 300
+      }
+    ]);
+  });
 });

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -140,6 +140,220 @@ describe('runEconomy', () => {
     );
   });
 
+  it('uses a stable secondary-room spawn for primary worker recovery when the primary spawn is busy', () => {
+    installSpawnCoordinationGlobals();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const primaryRoom = makeSpawnCoordinationRoom({
+      roomName: 'W1N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controllerLevel: 1
+    });
+    const secondaryRoom = makeSpawnCoordinationRoom({
+      roomName: 'W2N1',
+      energyAvailable: 800,
+      energyCapacityAvailable: 800
+    });
+    const primarySpawn = {
+      name: 'Spawn1',
+      room: primaryRoom,
+      spawning: { name: 'busy-worker' } as Spawning,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const secondarySpawn = {
+      name: 'Spawn2',
+      room: secondaryRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const secondaryWorkers = {
+      Worker1: makeEconomyWorker(secondaryRoom),
+      Worker2: makeEconomyWorker(secondaryRoom),
+      Worker3: makeEconomyWorker(secondaryRoom),
+      Worker4: makeEconomyWorker(secondaryRoom)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 131,
+      rooms: { W1N1: primaryRoom, W2N1: secondaryRoom },
+      spawns: { Spawn1: primarySpawn, Spawn2: secondarySpawn },
+      creeps: secondaryWorkers
+    };
+
+    runEconomy();
+
+    expect(primarySpawn.spawnCreep).not.toHaveBeenCalled();
+    expect(secondarySpawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W1N1-131', {
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        spawnSupport: { originRoom: 'W2N1', targetRoom: 'W1N1' }
+      }
+    });
+  });
+
+  it('keeps secondary bootstrap energy local instead of borrowing it for primary territory control', () => {
+    installSpawnCoordinationGlobals();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: { targets: [{ colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }] }
+    };
+    const primaryRoom = makeSpawnCoordinationRoom({
+      roomName: 'W1N1',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650
+    });
+    const secondaryRoom = makeSpawnCoordinationRoom({
+      roomName: 'W2N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controllerLevel: 1
+    });
+    const reserveRoom = makeVisibleReserveRoom('W3N1', 'controller3' as Id<StructureController>);
+    const primarySpawn = {
+      name: 'Spawn1',
+      room: primaryRoom,
+      spawning: { name: 'busy-worker' } as Spawning,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const secondarySpawn = {
+      name: 'Spawn2',
+      room: secondaryRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const primaryWorkers = {
+      Worker1: makeEconomyWorker(primaryRoom),
+      Worker2: makeEconomyWorker(primaryRoom),
+      Worker3: makeEconomyWorker(primaryRoom)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 132,
+      rooms: { W1N1: primaryRoom, W2N1: secondaryRoom, W3N1: reserveRoom },
+      spawns: { Spawn1: primarySpawn, Spawn2: secondarySpawn },
+      creeps: primaryWorkers,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    runEconomy();
+
+    expect(primarySpawn.spawnCreep).not.toHaveBeenCalled();
+    expect(secondarySpawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W2N1-132', {
+      memory: { role: 'worker', colony: 'W2N1' }
+    });
+  });
+
+  it('keeps primary claimer production working while a secondary room bootstraps local workers', () => {
+    installSpawnCoordinationGlobals();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: { targets: [{ colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }] }
+    };
+    const primaryRoom = makeSpawnCoordinationRoom({
+      roomName: 'W1N1',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650
+    });
+    const secondaryRoom = makeSpawnCoordinationRoom({
+      roomName: 'W2N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      controllerLevel: 1
+    });
+    const reserveRoom = makeVisibleReserveRoom('W3N1', 'controller3' as Id<StructureController>);
+    const primarySpawn = {
+      name: 'Spawn1',
+      room: primaryRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const secondarySpawn = {
+      name: 'Spawn2',
+      room: secondaryRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const primaryWorkers = {
+      Worker1: makeEconomyWorker(primaryRoom),
+      Worker2: makeEconomyWorker(primaryRoom),
+      Worker3: makeEconomyWorker(primaryRoom)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 133,
+      rooms: { W1N1: primaryRoom, W2N1: secondaryRoom, W3N1: reserveRoom },
+      spawns: { Spawn1: primarySpawn, Spawn2: secondarySpawn },
+      creeps: primaryWorkers,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    runEconomy();
+
+    expect(primarySpawn.spawnCreep).toHaveBeenCalledWith(['claim', 'move'], 'claimer-W1N1-W3N1-133', {
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W3N1', action: 'reserve', controllerId: 'controller3' }
+      }
+    });
+    expect(secondarySpawn.spawnCreep).toHaveBeenCalledWith(['work', 'carry', 'move'], 'worker-W2N1-133', {
+      memory: { role: 'worker', colony: 'W2N1' }
+    });
+  });
+
+  it('can use a stable secondary-room spawn for primary reserver production when the primary spawn is busy', () => {
+    installSpawnCoordinationGlobals();
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: { targets: [{ colony: 'W1N1', roomName: 'W3N1', action: 'reserve' }] }
+    };
+    const primaryRoom = makeSpawnCoordinationRoom({
+      roomName: 'W1N1',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650
+    });
+    const secondaryRoom = makeSpawnCoordinationRoom({
+      roomName: 'W2N1',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650
+    });
+    const reserveRoom = makeVisibleReserveRoom('W3N1', 'controller3' as Id<StructureController>);
+    const primarySpawn = {
+      name: 'Spawn1',
+      room: primaryRoom,
+      spawning: { name: 'busy-worker' } as Spawning,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const secondarySpawn = {
+      name: 'Spawn2',
+      room: secondaryRoom,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const creeps = {
+      PrimaryWorker1: makeEconomyWorker(primaryRoom),
+      PrimaryWorker2: makeEconomyWorker(primaryRoom),
+      PrimaryWorker3: makeEconomyWorker(primaryRoom),
+      SecondaryWorker1: makeEconomyWorker(secondaryRoom),
+      SecondaryWorker2: makeEconomyWorker(secondaryRoom),
+      SecondaryWorker3: makeEconomyWorker(secondaryRoom),
+      SecondaryWorker4: makeEconomyWorker(secondaryRoom)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 134,
+      rooms: { W1N1: primaryRoom, W2N1: secondaryRoom, W3N1: reserveRoom },
+      spawns: { Spawn1: primarySpawn, Spawn2: secondarySpawn },
+      creeps,
+      getObjectById: jest.fn().mockReturnValue(null)
+    };
+
+    runEconomy();
+
+    expect(primarySpawn.spawnCreep).not.toHaveBeenCalled();
+    expect(secondarySpawn.spawnCreep).toHaveBeenCalledWith(['claim', 'move'], 'claimer-W1N1-W3N1-134', {
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W3N1', action: 'reserve', controllerId: 'controller3' }
+      }
+    });
+  });
+
   it('keeps a single source-room spawn on local recovery before cross-room hauling', () => {
     (globalThis as unknown as { FIND_SOURCES: number; RESOURCE_ENERGY: ResourceConstant }).FIND_SOURCES = 1;
     (globalThis as unknown as { RESOURCE_ENERGY: ResourceConstant }).RESOURCE_ENERGY = 'energy';
@@ -2254,6 +2468,47 @@ function makeOwnedEconomyRoom(roomName: string): Room {
       level: 3,
       ticksToDowngrade: 10_000
     } as StructureController,
+    find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
+  } as unknown as Room;
+}
+
+function installSpawnCoordinationGlobals(): void {
+  (globalThis as unknown as {
+    FIND_SOURCES: number;
+    FIND_MY_STRUCTURES: number;
+    FIND_MY_CONSTRUCTION_SITES: number;
+    FIND_CONSTRUCTION_SITES: number;
+    STRUCTURE_EXTENSION: StructureConstant;
+  }).FIND_SOURCES = 1;
+  (globalThis as unknown as { FIND_MY_STRUCTURES: number }).FIND_MY_STRUCTURES = 2;
+  (globalThis as unknown as { FIND_MY_CONSTRUCTION_SITES: number }).FIND_MY_CONSTRUCTION_SITES = 3;
+  (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 4;
+  (globalThis as unknown as { STRUCTURE_EXTENSION: StructureConstant }).STRUCTURE_EXTENSION = 'extension';
+}
+
+function makeSpawnCoordinationRoom({
+  roomName,
+  energyAvailable,
+  energyCapacityAvailable,
+  controllerLevel = 3
+}: {
+  roomName: string;
+  energyAvailable: number;
+  energyCapacityAvailable: number;
+  controllerLevel?: number;
+}): Room {
+  return {
+    name: roomName,
+    energyAvailable,
+    energyCapacityAvailable,
+    controller: {
+      id: `${roomName}-controller`,
+      my: true,
+      owner: { username: 'me' },
+      level: controllerLevel,
+      ticksToDowngrade: 10_000
+    } as StructureController,
+    memory: {},
     find: jest.fn((type: number) => (type === FIND_SOURCES ? [{ id: `${roomName}-source` } as Source] : []))
   } as unknown as Room;
 }

--- a/prod/test/workerRunner.test.ts
+++ b/prod/test/workerRunner.test.ts
@@ -94,6 +94,41 @@ describe('runWorker', () => {
     expect(homeRoom.find).not.toHaveBeenCalled();
   });
 
+  it('routes a cross-room spawn support worker to its colony before local work', () => {
+    const targetController = { id: 'controller2', my: true } as StructureController;
+    const originRoom = {
+      name: 'W2N1',
+      find: jest.fn().mockReturnValue([{ id: 'source1' } as Source])
+    } as unknown as Room;
+    const creep = {
+      memory: {
+        role: 'worker',
+        colony: 'W1N1',
+        task: { type: 'harvest', targetId: 'source1' as Id<Source> },
+        spawnSupport: { originRoom: 'W2N1', targetRoom: 'W1N1' }
+      },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      room: originRoom,
+      moveTo: jest.fn()
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: { name: 'W1N1', controller: targetController } as Room,
+        W2N1: originRoom
+      },
+      creeps: {}
+    };
+
+    runWorker(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith(targetController);
+    expect(creep.memory.task).toBeUndefined();
+    expect(originRoom.find).not.toHaveBeenCalled();
+  });
+
   it('loads a post-claim energy hauler in the home room before sending it to the claimed room', () => {
     const storage = {
       id: 'storage1',


### PR DESCRIPTION
Implements multi-room spawn coordination for claimed secondary rooms.

When the bot claims or acquires a secondary room with a spawn, the colony registry now tracks multiple spawns and coordinates creep production across rooms. Workers can be dispatched from any available spawn, and the economy loop considers all rooms' energy availability.

- colonyRegistry extended with multi-spawn tracking
- workerRunner supports cross-room dispatch
- economyLoop coordinates spawn queues across rooms
- types.d.ts updated with multi-room types
- Comprehensive tests for multi-spawn coordination

Closes #682
