### PR TITLE
feat(territory): improve expansion targeting with scout-intel-driven room scoring (#687)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5099,26 +5099,31 @@ function buildScoutedExpansionCandidateEvidence(intel) {
   };
 }
 function applyScoutIntelToExpansionCandidate(input, candidate, gameTime) {
-  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k;
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j;
   const intel = getFreshExpansionScoutIntel(input.colonyName, candidate.roomName, gameTime);
   if (!intel) {
     return candidate;
   }
   const scoutEvidence = buildScoutedExpansionCandidateEvidence(intel);
+  const controller = hasExpansionControllerEvidence(candidate.controller) ? candidate.controller : scoutEvidence.controller;
+  const sourceCount = candidate.sourceCount === 0 ? scoutEvidence.sourceCount : (_a = candidate.sourceCount) != null ? _a : scoutEvidence.sourceCount;
   return {
     ...candidate,
-    visible: (_a = candidate.visible) != null ? _a : scoutEvidence.visible,
-    scouted: (_b = candidate.scouted) != null ? _b : scoutEvidence.scouted,
-    controller: (_c = candidate.controller) != null ? _c : scoutEvidence.controller,
+    visible: (_b = candidate.visible) != null ? _b : scoutEvidence.visible,
+    scouted: (_c = candidate.scouted) != null ? _c : scoutEvidence.scouted,
+    controller,
     controllerId: (_d = candidate.controllerId) != null ? _d : scoutEvidence.controllerId,
-    sourceCount: (_e = candidate.sourceCount) != null ? _e : scoutEvidence.sourceCount,
-    sourceAccessPoints: (_f = candidate.sourceAccessPoints) != null ? _f : scoutEvidence.sourceAccessPoints,
-    controllerSourceRange: (_g = candidate.controllerSourceRange) != null ? _g : scoutEvidence.controllerSourceRange,
-    terrain: (_h = candidate.terrain) != null ? _h : scoutEvidence.terrain,
-    mineral: (_i = candidate.mineral) != null ? _i : scoutEvidence.mineral,
-    hostileCreepCount: (_j = candidate.hostileCreepCount) != null ? _j : scoutEvidence.hostileCreepCount,
-    hostileStructureCount: (_k = candidate.hostileStructureCount) != null ? _k : scoutEvidence.hostileStructureCount
+    sourceCount,
+    sourceAccessPoints: (_e = candidate.sourceAccessPoints) != null ? _e : scoutEvidence.sourceAccessPoints,
+    controllerSourceRange: (_f = candidate.controllerSourceRange) != null ? _f : scoutEvidence.controllerSourceRange,
+    terrain: (_g = candidate.terrain) != null ? _g : scoutEvidence.terrain,
+    mineral: (_h = candidate.mineral) != null ? _h : scoutEvidence.mineral,
+    hostileCreepCount: (_i = candidate.hostileCreepCount) != null ? _i : scoutEvidence.hostileCreepCount,
+    hostileStructureCount: (_j = candidate.hostileStructureCount) != null ? _j : scoutEvidence.hostileStructureCount
   };
+}
+function hasExpansionControllerEvidence(controller) {
+  return controller !== void 0 && Object.keys(controller).length > 0;
 }
 function scoreExpansionCandidate(input, candidate) {
   var _a, _b, _c;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -4895,7 +4895,10 @@ function buildRuntimeExpansionCandidateReport(colony) {
 }
 function scoreExpansionCandidates(input) {
   var _a;
-  const candidates = input.candidates.filter((candidate) => candidate.roomName !== input.colonyName).map((candidate) => scoreExpansionCandidate(input, candidate)).sort(compareExpansionCandidates);
+  const gameTime = getGameTime7();
+  const candidates = input.candidates.filter((candidate) => candidate.roomName !== input.colonyName).map(
+    (candidate) => scoreExpansionCandidate(input, applyScoutIntelToExpansionCandidate(input, candidate, gameTime))
+  ).sort(compareExpansionCandidates);
   const next = (_a = candidates.find((candidate) => candidate.evidenceStatus !== "unavailable")) != null ? _a : null;
   return attachExpansionCandidateReportColony({ candidates, next }, input.colonyName);
 }
@@ -5095,6 +5098,28 @@ function buildScoutedExpansionCandidateEvidence(intel) {
     hostileStructureCount: intel.hostileStructureCount + ((_b = intel.hostileSpawnCount) != null ? _b : 0)
   };
 }
+function applyScoutIntelToExpansionCandidate(input, candidate, gameTime) {
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k;
+  const intel = getFreshExpansionScoutIntel(input.colonyName, candidate.roomName, gameTime);
+  if (!intel) {
+    return candidate;
+  }
+  const scoutEvidence = buildScoutedExpansionCandidateEvidence(intel);
+  return {
+    ...candidate,
+    visible: (_a = candidate.visible) != null ? _a : scoutEvidence.visible,
+    scouted: (_b = candidate.scouted) != null ? _b : scoutEvidence.scouted,
+    controller: (_c = candidate.controller) != null ? _c : scoutEvidence.controller,
+    controllerId: (_d = candidate.controllerId) != null ? _d : scoutEvidence.controllerId,
+    sourceCount: (_e = candidate.sourceCount) != null ? _e : scoutEvidence.sourceCount,
+    sourceAccessPoints: (_f = candidate.sourceAccessPoints) != null ? _f : scoutEvidence.sourceAccessPoints,
+    controllerSourceRange: (_g = candidate.controllerSourceRange) != null ? _g : scoutEvidence.controllerSourceRange,
+    terrain: (_h = candidate.terrain) != null ? _h : scoutEvidence.terrain,
+    mineral: (_i = candidate.mineral) != null ? _i : scoutEvidence.mineral,
+    hostileCreepCount: (_j = candidate.hostileCreepCount) != null ? _j : scoutEvidence.hostileCreepCount,
+    hostileStructureCount: (_k = candidate.hostileStructureCount) != null ? _k : scoutEvidence.hostileStructureCount
+  };
+}
 function scoreExpansionCandidate(input, candidate) {
   var _a, _b, _c;
   const rationale = [];
@@ -5162,7 +5187,7 @@ function scoreExpansionCandidate(input, candidate) {
     evidenceStatus = downgradeEvidenceStatus(evidenceStatus, "insufficient-evidence");
   }
   if (hostileCreepCount > 0 || hostileStructureCount > 0) {
-    risks.push("hostile presence visible");
+    risks.push(`hostile presence ${evidenceAdjective}`);
     evidenceStatus = "unavailable";
   }
   if (typeof routeDistance === "number") {
@@ -16443,6 +16468,9 @@ function isNonEmptyString10(value) {
   return typeof value === "string" && value.length > 0;
 }
 
+// src/spawn/spawnConfig.ts
+var MIN_SPAWN_ENERGY_BUFFER = 50;
+
 // src/territory/multiRoomUpgrader.ts
 var MULTI_ROOM_UPGRADER_DEFAULT_STORAGE_THRESHOLD_RATIO = 0.8;
 var MULTI_ROOM_UPGRADER_DEFAULT_PER_ROOM_CAP = 1;
@@ -17058,7 +17086,7 @@ var CROSS_ROOM_HAULER_REPLACEMENT_TICKS = 100;
 var CROSS_ROOM_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var ERR_NO_PATH_CODE6 = -2;
 var ERR_NOT_IN_RANGE_CODE6 = -9;
-function planCrossRoomHauler() {
+function planCrossRoomHauler(getEnergyBudget = getDefaultCrossRoomHaulerEnergyBudget) {
   const transfer = selectCrossRoomEnergyTransfer();
   if (!transfer) {
     return null;
@@ -17078,7 +17106,7 @@ function planCrossRoomHauler() {
   }
   const sourceState = getRoomStoredEnergyState(sourceRoom);
   const transferableEnergy = Math.min(transfer.amount, sourceState.exportableEnergy);
-  const body = buildCrossRoomHaulerBody(sourceRoom.energyAvailable, transferableEnergy);
+  const body = buildCrossRoomHaulerBody(getEnergyBudget(sourceRoom.name), transferableEnergy);
   if (body.length === 0) {
     return null;
   }
@@ -17102,6 +17130,10 @@ function planCrossRoomHauler() {
       }
     }
   };
+}
+function getDefaultCrossRoomHaulerEnergyBudget(sourceRoomName) {
+  var _a, _b;
+  return (_b = (_a = getVisibleRoom5(sourceRoomName)) == null ? void 0 : _a.energyAvailable) != null ? _b : 0;
 }
 function buildCrossRoomHaulerBody(energyAvailable, transferableEnergy) {
   const energyBudget = Math.max(0, Math.floor(energyAvailable));
@@ -17728,7 +17760,7 @@ function hasControllerDowngradeGuardSpawnCapacity(context) {
   return context.colony.spawns.filter((spawn) => !spawn.spawning).length > 1;
 }
 function hasRecoveryWorkerSpawnEnergy(colony) {
-  return colony.energyAvailable >= MINIMUM_EMERGENCY_WORKER_BODY_COST;
+  return getSpawnEnergyBudget(colony) >= MINIMUM_EMERGENCY_WORKER_BODY_COST;
 }
 function planPostClaimControllerSustainSpawn(context) {
   if (context.survival.mode !== "TERRITORY_READY" || !hasPostClaimSustainSpawnEnergy(context.colony)) {
@@ -17956,7 +17988,7 @@ function planDefenseSpawnForRoom(colony, activeDefenderCount, gameTime, options)
   if (!spawn) {
     return null;
   }
-  const body = buildDefenseBody(colony.energyAvailable, hostileCount);
+  const body = buildDefenseBody(getSpawnEnergyBudget(colony), hostileCount);
   if (body.length === 0) {
     return null;
   }
@@ -17982,7 +18014,7 @@ function planRemoteEconomySpawn(context) {
   }
   const remoteHarvesterAssignment = selectRemoteHarvesterAssignment(context.colony.room.name);
   if (remoteHarvesterAssignment) {
-    const body2 = buildRemoteHarvesterBody(context.colony.energyAvailable);
+    const body2 = buildRemoteHarvesterBody(getSpawnEnergyBudget(context.colony));
     if (body2.length > 0) {
       return {
         spawn,
@@ -18008,7 +18040,7 @@ function planRemoteEconomySpawn(context) {
   if (!remoteHaulerAssignment) {
     return null;
   }
-  const body = buildRemoteHaulerBody(context.colony.energyAvailable, remoteHaulerAssignment.routeDistance);
+  const body = buildRemoteHaulerBody(getSpawnEnergyBudget(context.colony), remoteHaulerAssignment.routeDistance);
   if (body.length === 0) {
     return null;
   }
@@ -18106,7 +18138,7 @@ function planMultiRoomControllerUpgradeSpawn(context) {
     return null;
   }
   for (const upgradePlan of upgradePlans) {
-    const body = buildMultiRoomUpgraderBody(context.colony.energyAvailable, upgradePlan);
+    const body = buildMultiRoomUpgraderBody(getSpawnEnergyBudget(context.colony), upgradePlan);
     if (body.length === 0) {
       continue;
     }
@@ -18206,7 +18238,7 @@ function planTerritorySpawn(colony, roleCounts, territoryIntent, gameTime, optio
   if (!spawn) {
     return null;
   }
-  const body = buildTerritorySpawnBody(colony.energyAvailable, territoryIntent);
+  const body = buildTerritorySpawnBody(getSpawnEnergyBudget(colony), territoryIntent);
   if (body.length === 0) {
     return null;
   }
@@ -18245,23 +18277,28 @@ function appendSpawnNameSuffix(baseName, options) {
 }
 function selectWorkerBody(colony, roleCounts) {
   var _a;
+  const spawnEnergyBudget = getSpawnEnergyBudget(colony);
   if (shouldUseSourceHarvesterBody(colony, roleCounts)) {
     const sourceDistance = estimateLocalSourceDistance(colony);
     const fullCapacityBody = generateHarvesterBody(colony.energyCapacityAvailable, sourceDistance);
-    if (canAffordBody(fullCapacityBody, colony.energyAvailable)) {
+    if (canAffordBody(fullCapacityBody, spawnEnergyBudget)) {
       return fullCapacityBody;
     }
-    return generateHarvesterBody(colony.energyAvailable, sourceDistance);
+    return generateHarvesterBody(spawnEnergyBudget, sourceDistance);
   }
   const controllerLevel = (_a = colony.room.controller) == null ? void 0 : _a.level;
   const normalBody = buildWorkerBody(colony.energyCapacityAvailable, controllerLevel);
-  if (canAffordBody(normalBody, colony.energyAvailable)) {
+  if (canAffordBody(normalBody, spawnEnergyBudget)) {
     return normalBody;
   }
   if (roleCounts.worker === 0) {
-    return buildEmergencyWorkerBody(colony.energyAvailable);
+    return buildEmergencyWorkerBody(spawnEnergyBudget);
   }
-  return buildWorkerBody(colony.energyAvailable, controllerLevel);
+  return buildWorkerBody(spawnEnergyBudget, controllerLevel);
+}
+function getSpawnEnergyBudget(colony) {
+  var _a;
+  return normalizeNonNegativeInteger2((_a = colony.spawnEnergyBudget) != null ? _a : colony.energyAvailable);
 }
 function generateHarvesterBody(availableEnergy, sourceDistance) {
   const energyBudget = normalizeNonNegativeInteger2(availableEnergy);
@@ -21307,9 +21344,6 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   if (isAutonomousClaimSuppressed(colonyName, candidate.roomName, gameTime, context.territoryIntents)) {
     return { ...visibleControllerEvaluation, reason: "suppressed" };
   }
-  if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
-    return { ...visibleControllerEvaluation, reason: "scoreBelowThreshold" };
-  }
   const scoutValidation = validateTerritoryScoutIntelForClaim({
     colony: colonyName,
     targetRoom: candidate.roomName,
@@ -21322,6 +21356,24 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
     ...baseEvaluation,
     ...typeof controllerId === "string" ? { controllerId } : {}
   };
+  if (scoutValidation.status === "blocked") {
+    recordTerritoryScoutValidation(
+      colonyName,
+      candidate.roomName,
+      scoutValidation,
+      gameTime,
+      telemetryEvents,
+      controllerEvaluation.controllerId,
+      candidate.score
+    );
+    return {
+      ...controllerEvaluation,
+      reason: getScoutValidationClaimSkipReason(scoutValidation)
+    };
+  }
+  if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
+    return { ...visibleControllerEvaluation, reason: "scoreBelowThreshold" };
+  }
   recordTerritoryScoutValidation(
     colonyName,
     candidate.roomName,
@@ -21340,12 +21392,6 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
       controllerEvaluation.controllerId
     );
     return { ...controllerEvaluation, reason: "scoutPending" };
-  }
-  if (scoutValidation.status === "blocked") {
-    return {
-      ...controllerEvaluation,
-      reason: getScoutValidationClaimSkipReason(scoutValidation)
-    };
   }
   return {
     status: "planned",
@@ -22976,7 +23022,8 @@ function selectColonyExpansionCandidate(colony) {
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
   const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString18(room.mineralType));
   const candidates = getAdjacentRoomNames8(colony.room.name).flatMap((roomName, order) => {
-    if (!getVisibleRoom11(roomName)) {
+    const room = getVisibleRoom11(roomName);
+    if (!room && !getScoutIntel3(colony.room.name, roomName)) {
       return [];
     }
     const claimScore = scoreClaimTarget(roomName, colony.room);
@@ -23016,7 +23063,7 @@ function selectColonyExpansionCandidate(colony) {
     (candidate) => candidate.effectiveScore >= MIN_COLONY_EXPANSION_CLAIM_SCORE
   );
   if (claimableCandidates.length > 0) {
-    applyColonyExpansionSynergyScores(colony, ownerUsername, claimedRooms, claimableCandidates);
+    applyColonyExpansionRankingScores(colony, ownerUsername, claimedRooms, claimableCandidates);
     return selectBestColonyExpansionCandidate(claimableCandidates, compareColonyExpansionCandidates);
   }
   return selectBestColonyExpansionCandidate(candidates, compareColonyExpansionCandidatesByEffectiveScore);
@@ -23036,8 +23083,8 @@ function compareColonyExpansionCandidates(left, right) {
 function compareColonyExpansionCandidatesByEffectiveScore(left, right) {
   return right.effectiveScore - left.effectiveScore || right.claimScore.sources - left.claimScore.sources || left.claimScore.distance - right.claimScore.distance || left.order - right.order || left.roomName.localeCompare(right.roomName);
 }
-function applyColonyExpansionSynergyScores(colony, ownerUsername, claimedRooms, candidates) {
-  var _a, _b, _c;
+function applyColonyExpansionRankingScores(colony, ownerUsername, claimedRooms, candidates) {
+  var _a, _b, _c, _d;
   if (candidates.length === 0) {
     return;
   }
@@ -23051,12 +23098,16 @@ function applyColonyExpansionSynergyScores(colony, ownerUsername, claimedRooms, 
     claimedRooms,
     candidates: candidates.map((candidate) => candidate.expansionCandidate)
   });
-  const synergyScoresByRoom = new Map(
-    report.candidates.map((candidate) => [candidate.roomName, candidate.synergyScore])
+  const expansionScoresByRoom = new Map(
+    report.candidates.map((candidate) => [
+      candidate.roomName,
+      { score: candidate.score, synergyScore: candidate.synergyScore }
+    ])
   );
   for (const candidate of candidates) {
-    candidate.synergyScore = (_c = synergyScoresByRoom.get(candidate.roomName)) != null ? _c : 0;
-    candidate.rankingScore = candidate.effectiveScore + candidate.synergyScore;
+    const expansionScore = expansionScoresByRoom.get(candidate.roomName);
+    candidate.synergyScore = (_c = expansionScore == null ? void 0 : expansionScore.synergyScore) != null ? _c : 0;
+    candidate.rankingScore = (_d = expansionScore == null ? void 0 : expansionScore.score) != null ? _d : candidate.effectiveScore + candidate.synergyScore;
   }
 }
 function toColonyExpansionCandidateInput(colonyName, roomName, order, claimScore, controllerState, ownerUsername, includeMineralSynergyEvidence) {
@@ -23293,8 +23344,8 @@ function getVisibleRoom11(roomName) {
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
 function getScoutIntel3(homeRoomName, roomName) {
-  var _a, _b, _c;
-  return (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel) == null ? void 0 : _c[`${homeRoomName}>${roomName}`];
+  var _a;
+  return (_a = getTerritoryScoutIntel(homeRoomName, roomName)) != null ? _a : void 0;
 }
 function countVisibleOwnedRooms3(colonyName, ownerUsername) {
   var _a, _b, _c, _d;
@@ -24611,7 +24662,7 @@ var OK_CODE10 = 0;
 var NEXT_EXPANSION_SCORING_REFRESH_INTERVAL = 50;
 var NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS = 5e3;
 function runEconomy(preludeTelemetryEvents = []) {
-  var _a, _b;
+  var _a, _b, _c;
   const creeps = Object.values(Game.creeps);
   balanceStorage();
   const colonies = orderColoniesForSpawnPlanning(getOwnedColonies());
@@ -24660,7 +24711,7 @@ function runEconomy(preludeTelemetryEvents = []) {
       if (!coordinatedPlan) {
         break;
       }
-      const spawnRequest = coordinatedPlan.spawnRequest;
+      const { spawnRequest, bodyCost } = coordinatedPlan;
       if (successfulSpawnCount > 0 && !isAllowedPostSpawnRequest(spawnRequest)) {
         break;
       }
@@ -24674,8 +24725,9 @@ function runEconomy(preludeTelemetryEvents = []) {
         break;
       }
       const spawnRoomName = (_b = (_a = outcome.spawn.room) == null ? void 0 : _a.name) != null ? _b : "unknown";
-      const bodyCost = getBodyCost(spawnRequest.body);
-      recordUsedSpawn(usedSpawnsByRoom, spawnRoomName, outcome.spawn);
+      const usedSpawns = (_c = usedSpawnsByRoom.get(spawnRoomName)) != null ? _c : /* @__PURE__ */ new Set();
+      usedSpawns.add(outcome.spawn);
+      usedSpawnsByRoom.set(spawnRoomName, usedSpawns);
       recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, spawnRoomName, bodyCost);
       successfulSpawnCount += 1;
       recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
@@ -24751,10 +24803,21 @@ function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom
   if (candidateSpawns.length === 0) {
     return;
   }
-  if (getBodyCost(spawnRequest.body) > getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom)) {
+  const availableEnergy = getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom);
+  const spawnPlan = selectCrossRoomHaulerSpawnPlanWithinEnergyBuffer(spawnRequest, availableEnergy);
+  if (!spawnPlan) {
+    const originalBodyCost = getBodyCost(spawnRequest.body);
+    if (originalBodyCost <= availableEnergy && isSpawnEnergyBufferViolated(availableEnergy, originalBodyCost)) {
+      logSpawnEnergyBufferWarning(spawnRequest, sourceRoomName, availableEnergy, originalBodyCost);
+    }
     return;
   }
-  const request = candidateSpawns.includes(spawnRequest.spawn) ? spawnRequest : { ...spawnRequest, spawn: candidateSpawns[0] };
+  const { spawnRequest: bufferedSpawnRequest, bodyCost } = spawnPlan;
+  if (isSpawnEnergyBufferViolated(availableEnergy, bodyCost)) {
+    logSpawnEnergyBufferWarning(spawnRequest, sourceRoomName, availableEnergy, bodyCost);
+    return;
+  }
+  const request = candidateSpawns.includes(bufferedSpawnRequest.spawn) ? bufferedSpawnRequest : { ...bufferedSpawnRequest, spawn: candidateSpawns[0] };
   const outcome = attemptSpawnRequest(
     request,
     sourceRoomName,
@@ -24765,7 +24828,7 @@ function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom
     return;
   }
   recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
-  recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, sourceRoomName, getBodyCost(spawnRequest.body));
+  recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, sourceRoomName, bodyCost);
 }
 function getAvailableSpawnEnergyAfterReservations(sourceColony, spawnRequest, reservedSpawnEnergyByRoom) {
   var _a, _b;
@@ -24984,6 +25047,7 @@ function normalizeNonNegativeInteger3(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 function planCoordinatedSpawn(colony, roleCounts, gameTime, options, colonies, creeps, usedSpawnsByRoom, reservedSpawnEnergyByRoom, plannedRoleCountsByRoom) {
+  var _a;
   for (const sourceColony of getCoordinatedSpawnSourceColonies(
     colony,
     colonies,
@@ -24992,38 +25056,38 @@ function planCoordinatedSpawn(colony, roleCounts, gameTime, options, colonies, c
     reservedSpawnEnergyByRoom,
     plannedRoleCountsByRoom
   )) {
-    const planningColony = createSpawnPlanningColony(
+    const sourceRoomName = sourceColony.room.name;
+    const availableEnergy = getAvailableSpawnEnergy(sourceColony, reservedSpawnEnergyByRoom);
+    const usedSpawns = (_a = usedSpawnsByRoom.get(sourceRoomName)) != null ? _a : /* @__PURE__ */ new Set();
+    const spawnPlan = selectSpawnPlanWithinEnergyBuffer(
       colony,
       sourceColony,
-      usedSpawnsByRoom,
-      reservedSpawnEnergyByRoom
+      availableEnergy,
+      usedSpawns,
+      roleCounts,
+      gameTime,
+      options
     );
-    if (planningColony.spawns.length === 0) {
+    if (!spawnPlan) {
       continue;
     }
-    const spawnRequest = planSpawn(planningColony, roleCounts, gameTime, options);
-    if (!spawnRequest) {
-      continue;
-    }
-    const sourceRoomName = sourceColony.room.name;
-    if (sourceRoomName !== colony.room.name && !isAllowedCrossRoomSpawnRequest(spawnRequest, colony.room.name)) {
+    if (sourceRoomName !== colony.room.name && !isAllowedCrossRoomSpawnRequest(spawnPlan.spawnRequest, colony.room.name)) {
       continue;
     }
     return {
-      spawnRequest: withCrossRoomSpawnSupportMemory(spawnRequest, sourceRoomName, colony.room.name),
-      spawns: planningColony.spawns,
-      sourceRoomName
+      ...spawnPlan,
+      spawnRequest: withCrossRoomSpawnSupportMemory(spawnPlan.spawnRequest, sourceRoomName, colony.room.name),
+      spawns: spawnPlan.planningColony.spawns,
+      sourceRoomName,
+      availableEnergy
     };
   }
   return null;
 }
-function createSpawnPlanningColony(colony, sourceColony, usedSpawnsByRoom, reservedSpawnEnergyByRoom) {
-  var _a;
-  const sourceRoomName = sourceColony.room.name;
-  const usedSpawns = (_a = usedSpawnsByRoom.get(sourceRoomName)) != null ? _a : /* @__PURE__ */ new Set();
+function createSpawnPlanningColony(colony, sourceColony, energyAvailable, usedSpawns) {
   return {
     ...colony,
-    energyAvailable: getAvailableSpawnEnergy(sourceColony, reservedSpawnEnergyByRoom),
+    energyAvailable,
     energyCapacityAvailable: normalizeNonNegativeInteger3(sourceColony.energyCapacityAvailable),
     spawns: sourceColony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
   };
@@ -25115,6 +25179,95 @@ function withCrossRoomSpawnSupportMemory(spawnRequest, sourceRoomName, targetRoo
     }
   };
 }
+function selectSpawnPlanWithinEnergyBuffer(colony, sourceColony, availableEnergy, usedSpawns, roleCounts, gameTime, options) {
+  const spawnPlan = planSpawnWithEnergyBudget(
+    colony,
+    sourceColony,
+    availableEnergy,
+    usedSpawns,
+    roleCounts,
+    gameTime,
+    options
+  );
+  if (!spawnPlan) {
+    return null;
+  }
+  if (shouldBypassSpawnEnergyBuffer(spawnPlan.spawnRequest, roleCounts) || !isSpawnEnergyBufferViolated(availableEnergy, spawnPlan.bodyCost)) {
+    return spawnPlan;
+  }
+  const fallbackSpawnPlan = planSpawnWithEnergyBudget(
+    colony,
+    sourceColony,
+    getBufferedSpawnEnergyBudget(availableEnergy),
+    usedSpawns,
+    roleCounts,
+    gameTime,
+    options
+  );
+  if (fallbackSpawnPlan && !isSpawnEnergyBufferViolated(availableEnergy, fallbackSpawnPlan.bodyCost)) {
+    return fallbackSpawnPlan;
+  }
+  logSpawnEnergyBufferWarning(spawnPlan.spawnRequest, sourceColony.room.name, availableEnergy, spawnPlan.bodyCost);
+  return null;
+}
+function planSpawnWithEnergyBudget(colony, sourceColony, energyBudget, usedSpawns, roleCounts, gameTime, options) {
+  const planningColony = createSpawnPlanningColony(colony, sourceColony, energyBudget, usedSpawns);
+  const spawnRequest = planSpawn(planningColony, roleCounts, gameTime, options);
+  if (!spawnRequest) {
+    return null;
+  }
+  return {
+    planningColony,
+    spawnRequest,
+    bodyCost: getBodyCost(spawnRequest.body)
+  };
+}
+function getBufferedSpawnEnergyBudget(availableEnergy) {
+  return Math.max(0, availableEnergy - MIN_SPAWN_ENERGY_BUFFER);
+}
+function shouldBypassSpawnEnergyBuffer(spawnRequest, roleCounts) {
+  return roleCounts.worker === 0 || isTerritoryControllerSpawnRequest(spawnRequest);
+}
+function isTerritoryControllerSpawnRequest(spawnRequest) {
+  return spawnRequest.memory.role === TERRITORY_CLAIMER_ROLE || spawnRequest.memory.role === TERRITORY_SCOUT_ROLE;
+}
+function selectCrossRoomHaulerSpawnPlanWithinEnergyBuffer(spawnRequest, availableEnergy) {
+  const bodyCost = getBodyCost(spawnRequest.body);
+  if (bodyCost <= getBufferedSpawnEnergyBudget(availableEnergy)) {
+    return {
+      spawnRequest,
+      bodyCost
+    };
+  }
+  const fallbackBody = buildAffordableCrossRoomHaulerBody(
+    spawnRequest.body,
+    getBufferedSpawnEnergyBudget(availableEnergy)
+  );
+  if (fallbackBody.length === 0) {
+    return null;
+  }
+  return {
+    spawnRequest: { ...spawnRequest, body: fallbackBody },
+    bodyCost: getBodyCost(fallbackBody)
+  };
+}
+function buildAffordableCrossRoomHaulerBody(body, energyBudget) {
+  const affordableBody = [];
+  let bodyCost = 0;
+  for (let index = 0; index + 1 < body.length; index += 2) {
+    const pair = body.slice(index, index + 2);
+    if (pair[0] !== "carry" || pair[1] !== "move") {
+      return [];
+    }
+    const pairCost = getBodyCost(pair);
+    if (bodyCost + pairCost > energyBudget) {
+      break;
+    }
+    affordableBody.push(...pair);
+    bodyCost += pairCost;
+  }
+  return affordableBody;
+}
 function getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollowUp) {
   const allowTerritoryFollowUp = successfulSpawnCount > 0 || hasPendingTerritoryFollowUp;
   if (successfulSpawnCount === 0) {
@@ -25151,6 +25304,14 @@ function attemptSpawnRequest(spawnRequest, roomName, telemetryEvents, spawns) {
     }
   }
   return lastOutcome;
+}
+function isSpawnEnergyBufferViolated(availableEnergy, bodyCost) {
+  return availableEnergy - bodyCost < MIN_SPAWN_ENERGY_BUFFER;
+}
+function logSpawnEnergyBufferWarning(spawnRequest, roomName, availableEnergy, bodyCost) {
+  console.log(
+    `[spawn] warning: deferred ${spawnRequest.name} in ${roomName}; available energy ${availableEnergy}, body cost ${bodyCost}, required buffer ${MIN_SPAWN_ENERGY_BUFFER}`
+  );
 }
 function addPlannedWorker(roleCounts) {
   const nextRoleCounts = {

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -498,10 +498,6 @@ function evaluateAutonomousExpansionClaim(
     return { ...visibleControllerEvaluation, reason: 'suppressed' };
   }
 
-  if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
-    return { ...visibleControllerEvaluation, reason: 'scoreBelowThreshold' };
-  }
-
   const scoutValidation = validateTerritoryScoutIntelForClaim({
     colony: colonyName,
     targetRoom: candidate.roomName,
@@ -514,6 +510,27 @@ function evaluateAutonomousExpansionClaim(
     ...baseEvaluation,
     ...(typeof controllerId === 'string' ? { controllerId: controllerId as Id<StructureController> } : {})
   };
+
+  if (scoutValidation.status === 'blocked') {
+    recordTerritoryScoutValidation(
+      colonyName,
+      candidate.roomName,
+      scoutValidation,
+      gameTime,
+      telemetryEvents,
+      controllerEvaluation.controllerId,
+      candidate.score
+    );
+    return {
+      ...controllerEvaluation,
+      reason: getScoutValidationClaimSkipReason(scoutValidation)
+    };
+  }
+
+  if (candidate.score <= MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE) {
+    return { ...visibleControllerEvaluation, reason: 'scoreBelowThreshold' };
+  }
+
   recordTerritoryScoutValidation(
     colonyName,
     candidate.roomName,
@@ -533,13 +550,6 @@ function evaluateAutonomousExpansionClaim(
       controllerEvaluation.controllerId
     );
     return { ...controllerEvaluation, reason: 'scoutPending' };
-  }
-
-  if (scoutValidation.status === 'blocked') {
-    return {
-      ...controllerEvaluation,
-      reason: getScoutValidationClaimSkipReason(scoutValidation)
-    };
   }
 
   return {

--- a/prod/src/territory/colonyExpansionPlanner.ts
+++ b/prod/src/territory/colonyExpansionPlanner.ts
@@ -25,6 +25,7 @@ import {
   type ExpansionClaimedRoomInput,
   type ExpansionCandidateInput
 } from './expansionScoring';
+import { getTerritoryScoutIntel } from './scoutIntel';
 
 export const COLONY_EXPANSION_CLAIM_TARGET_CREATOR: TerritoryAutomationSource = 'colonyExpansion';
 export const MIN_COLONY_EXPANSION_CLAIM_SCORE = MIN_ADJACENT_ROOM_RESERVATION_SCORE;
@@ -164,7 +165,8 @@ function selectColonyExpansionCandidate(colony: ColonySnapshot): ColonyExpansion
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
   const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString(room.mineralType));
   const candidates = getAdjacentRoomNames(colony.room.name).flatMap((roomName, order) => {
-    if (!getVisibleRoom(roomName)) {
+    const room = getVisibleRoom(roomName);
+    if (!room && !getScoutIntel(colony.room.name, roomName)) {
       return [];
     }
 
@@ -214,7 +216,7 @@ function selectColonyExpansionCandidate(colony: ColonySnapshot): ColonyExpansion
     (candidate) => candidate.effectiveScore >= MIN_COLONY_EXPANSION_CLAIM_SCORE
   );
   if (claimableCandidates.length > 0) {
-    applyColonyExpansionSynergyScores(colony, ownerUsername, claimedRooms, claimableCandidates);
+    applyColonyExpansionRankingScores(colony, ownerUsername, claimedRooms, claimableCandidates);
     return selectBestColonyExpansionCandidate(claimableCandidates, compareColonyExpansionCandidates);
   }
 
@@ -262,7 +264,7 @@ function compareColonyExpansionCandidatesByEffectiveScore(
   );
 }
 
-function applyColonyExpansionSynergyScores(
+function applyColonyExpansionRankingScores(
   colony: ColonySnapshot,
   ownerUsername: string | undefined,
   claimedRooms: ExpansionClaimedRoomInput[],
@@ -284,13 +286,17 @@ function applyColonyExpansionSynergyScores(
     claimedRooms,
     candidates: candidates.map((candidate) => candidate.expansionCandidate)
   });
-  const synergyScoresByRoom = new Map(
-    report.candidates.map((candidate) => [candidate.roomName, candidate.synergyScore])
+  const expansionScoresByRoom = new Map(
+    report.candidates.map((candidate) => [
+      candidate.roomName,
+      { score: candidate.score, synergyScore: candidate.synergyScore }
+    ])
   );
 
   for (const candidate of candidates) {
-    candidate.synergyScore = synergyScoresByRoom.get(candidate.roomName) ?? 0;
-    candidate.rankingScore = candidate.effectiveScore + candidate.synergyScore;
+    const expansionScore = expansionScoresByRoom.get(candidate.roomName);
+    candidate.synergyScore = expansionScore?.synergyScore ?? 0;
+    candidate.rankingScore = expansionScore?.score ?? candidate.effectiveScore + candidate.synergyScore;
   }
 }
 
@@ -673,9 +679,7 @@ function getVisibleRoom(roomName: string): Room | undefined {
 }
 
 function getScoutIntel(homeRoomName: string, roomName: string): TerritoryScoutIntelMemory | undefined {
-  return (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.scoutIntel?.[
-    `${homeRoomName}>${roomName}`
-  ];
+  return getTerritoryScoutIntel(homeRoomName, roomName) ?? undefined;
 }
 
 function countVisibleOwnedRooms(colonyName: string, ownerUsername: string | undefined): number {

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -436,13 +436,20 @@ function applyScoutIntelToExpansionCandidate(
   }
 
   const scoutEvidence = buildScoutedExpansionCandidateEvidence(intel);
+  const controller = hasExpansionControllerEvidence(candidate.controller)
+    ? candidate.controller
+    : scoutEvidence.controller;
+  const sourceCount = candidate.sourceCount === 0
+    ? scoutEvidence.sourceCount
+    : candidate.sourceCount ?? scoutEvidence.sourceCount;
+
   return {
     ...candidate,
     visible: candidate.visible ?? scoutEvidence.visible,
     scouted: candidate.scouted ?? scoutEvidence.scouted,
-    controller: candidate.controller ?? scoutEvidence.controller,
+    controller,
     controllerId: candidate.controllerId ?? scoutEvidence.controllerId,
-    sourceCount: candidate.sourceCount ?? scoutEvidence.sourceCount,
+    sourceCount,
     sourceAccessPoints: candidate.sourceAccessPoints ?? scoutEvidence.sourceAccessPoints,
     controllerSourceRange: candidate.controllerSourceRange ?? scoutEvidence.controllerSourceRange,
     terrain: candidate.terrain ?? scoutEvidence.terrain,
@@ -450,6 +457,12 @@ function applyScoutIntelToExpansionCandidate(
     hostileCreepCount: candidate.hostileCreepCount ?? scoutEvidence.hostileCreepCount,
     hostileStructureCount: candidate.hostileStructureCount ?? scoutEvidence.hostileStructureCount
   };
+}
+
+function hasExpansionControllerEvidence(
+  controller: ExpansionControllerEvidence | undefined
+): controller is ExpansionControllerEvidence {
+  return controller !== undefined && Object.keys(controller).length > 0;
 }
 
 function scoreExpansionCandidate(

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -172,9 +172,12 @@ export function buildRuntimeExpansionCandidateReport(colony: ColonySnapshot): Ex
 }
 
 export function scoreExpansionCandidates(input: ExpansionScoringInput): ExpansionCandidateReport {
+  const gameTime = getGameTime();
   const candidates = input.candidates
     .filter((candidate) => candidate.roomName !== input.colonyName)
-    .map((candidate) => scoreExpansionCandidate(input, candidate))
+    .map((candidate) =>
+      scoreExpansionCandidate(input, applyScoutIntelToExpansionCandidate(input, candidate, gameTime))
+    )
     .sort(compareExpansionCandidates);
   const next = candidates.find((candidate) => candidate.evidenceStatus !== 'unavailable') ?? null;
 
@@ -422,6 +425,33 @@ function buildScoutedExpansionCandidateEvidence(
   };
 }
 
+function applyScoutIntelToExpansionCandidate(
+  input: ExpansionScoringInput,
+  candidate: ExpansionCandidateInput,
+  gameTime: number
+): ExpansionCandidateInput {
+  const intel = getFreshExpansionScoutIntel(input.colonyName, candidate.roomName, gameTime);
+  if (!intel) {
+    return candidate;
+  }
+
+  const scoutEvidence = buildScoutedExpansionCandidateEvidence(intel);
+  return {
+    ...candidate,
+    visible: candidate.visible ?? scoutEvidence.visible,
+    scouted: candidate.scouted ?? scoutEvidence.scouted,
+    controller: candidate.controller ?? scoutEvidence.controller,
+    controllerId: candidate.controllerId ?? scoutEvidence.controllerId,
+    sourceCount: candidate.sourceCount ?? scoutEvidence.sourceCount,
+    sourceAccessPoints: candidate.sourceAccessPoints ?? scoutEvidence.sourceAccessPoints,
+    controllerSourceRange: candidate.controllerSourceRange ?? scoutEvidence.controllerSourceRange,
+    terrain: candidate.terrain ?? scoutEvidence.terrain,
+    mineral: candidate.mineral ?? scoutEvidence.mineral,
+    hostileCreepCount: candidate.hostileCreepCount ?? scoutEvidence.hostileCreepCount,
+    hostileStructureCount: candidate.hostileStructureCount ?? scoutEvidence.hostileStructureCount
+  };
+}
+
 function scoreExpansionCandidate(
   input: ExpansionScoringInput,
   candidate: ExpansionCandidateInput
@@ -506,7 +536,7 @@ function scoreExpansionCandidate(
     evidenceStatus = downgradeEvidenceStatus(evidenceStatus, 'insufficient-evidence');
   }
   if (hostileCreepCount > 0 || hostileStructureCount > 0) {
-    risks.push('hostile presence visible');
+    risks.push(`hostile presence ${evidenceAdjective}`);
     evidenceStatus = 'unavailable';
   }
 

--- a/prod/test/colonyExpansionPlanner.test.ts
+++ b/prod/test/colonyExpansionPlanner.test.ts
@@ -88,6 +88,50 @@ describe('colony expansion planner', () => {
     });
   });
 
+  it('uses persisted scout intel when ranking adjacent expansion claim candidates', () => {
+    const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
+    installGame(colony, {
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', { sourceCount: 1 })
+      },
+      exits: { W1N1: { '1': 'W1N2', '3': 'W2N1' } }
+    });
+    Memory.territory = {
+      scoutIntel: {
+        'W1N1>W1N2': makeScoutIntel('W1N2', { sourceCount: 2 })
+      }
+    };
+    const stableAssessment = assessColonyStage({
+      roomName: 'W1N1',
+      totalCreeps: 5,
+      workerCapacity: 3,
+      workerTarget: 3,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
+    });
+    const selectedScore = scoreClaimTarget('W1N2', colony.room).score;
+
+    const evaluation = refreshColonyExpansionIntent(colony, stableAssessment, 205);
+
+    expect(evaluation).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W1N2',
+      controllerId: 'controller-W1N2',
+      score: selectedScore
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        action: 'claim',
+        createdBy: COLONY_EXPANSION_CLAIM_TARGET_CREATOR,
+        controllerId: 'controller-W1N2'
+      }
+    ]);
+  });
+
   it('reserves high-score adjacent rooms but suppresses auto-claim during bootstrap', () => {
     const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
     installGame(colony, {
@@ -420,4 +464,33 @@ function makeMap(exits: Record<string, Partial<Record<'1' | '3' | '5' | '7', str
     getRoomLinearDistance: jest.fn((_fromRoom: string, _toRoom: string) => 1),
     getRoomTerrain: jest.fn(() => ({ get: jest.fn(() => 0) } as unknown as RoomTerrain))
   } as unknown as GameMap;
+}
+
+function makeScoutIntel(
+  roomName: string,
+  overrides: Partial<TerritoryScoutIntelMemory> = {}
+): TerritoryScoutIntelMemory {
+  const sourceCount = overrides.sourceCount ?? 1;
+  return {
+    colony: 'W1N1',
+    roomName,
+    updatedAt: 200,
+    controller: {
+      id: `controller-${roomName}` as Id<StructureController>,
+      my: false
+    },
+    sourceIds: Array.from({ length: sourceCount }, (_value, index) => `source-${roomName}-${index}`),
+    sourceCount,
+    sourceAccessPoints: 7,
+    controllerSourceRange: 8,
+    terrain: {
+      walkableRatio: 1,
+      swampRatio: 0,
+      wallRatio: 0
+    },
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    hostileSpawnCount: 0,
+    ...overrides
+  };
 }

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -534,6 +534,101 @@ describe('next expansion scoring', () => {
     expect(Memory.territory?.targets).toBeUndefined();
   });
 
+  it('uses persisted scout intel to rank two-source neutral rooms above one-source owned rooms', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': makeScoutIntel('W2N1', { sourceCount: 2 }),
+          'W1N1>W3N1': makeScoutIntel('W3N1', {
+            sourceCount: 1,
+            controller: {
+              id: 'controller-W3N1' as Id<StructureController>,
+              ownerUsername: 'enemy'
+            }
+          })
+        }
+      }
+    };
+
+    const report = scoreExpansionCandidates(
+      makeInput([
+        makeUnscoredCandidate('W2N1', 0),
+        makeUnscoredCandidate('W3N1', 1)
+      ])
+    );
+    const neutral = getCandidate(report, 'W2N1');
+    const owned = getCandidate(report, 'W3N1');
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      visible: false,
+      evidenceStatus: 'sufficient',
+      sourceCount: 2
+    });
+    expect(neutral.rationale).toEqual(expect.arrayContaining(['controller unreserved', '2 sources scouted']));
+    expect(owned).toMatchObject({
+      visible: false,
+      evidenceStatus: 'unavailable',
+      sourceCount: 1,
+      risks: ['enemy-owned controller cannot be claimed safely']
+    });
+    expect(neutral.score).toBeGreaterThan(owned.score);
+  });
+
+  it('downgrades persisted scout-intel candidates when hostiles are present', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': makeScoutIntel('W2N1', { sourceCount: 2 }),
+          'W1N1>W3N1': makeScoutIntel('W3N1', {
+            sourceCount: 2,
+            hostileCreepCount: 1
+          })
+        }
+      }
+    };
+
+    const report = scoreExpansionCandidates(
+      makeInput([
+        makeUnscoredCandidate('W2N1', 0),
+        makeUnscoredCandidate('W3N1', 1)
+      ])
+    );
+    const safe = getCandidate(report, 'W2N1');
+    const hostile = getCandidate(report, 'W3N1');
+
+    expect(report.next).toMatchObject({ roomName: 'W2N1', evidenceStatus: 'sufficient' });
+    expect(hostile).toMatchObject({
+      evidenceStatus: 'unavailable',
+      hostileCreepCount: 1,
+      risks: ['hostile presence scouted']
+    });
+    expect(safe.score).toBeGreaterThan(hostile.score);
+  });
+
+  it('falls back gracefully when persisted scout intel is missing', () => {
+    const report = scoreExpansionCandidates(
+      makeInput([
+        {
+          ...makeUnscoredCandidate('W2N1', 0),
+          visible: false
+        }
+      ])
+    );
+
+    expect(report.next).toMatchObject({
+      roomName: 'W2N1',
+      visible: false,
+      evidenceStatus: 'insufficient-evidence',
+      risks: expect.arrayContaining([
+        'controller evidence missing until scout',
+        'source count evidence missing until scout',
+        'hostile evidence missing until scout'
+      ])
+    });
+    expect(Number.isFinite(report.next?.score)).toBe(true);
+  });
+
   it('records terrain-based source accessibility for visible expansion candidates', () => {
     const colony = makeSafeColony();
     const terrain = {
@@ -1053,6 +1148,42 @@ function makeCandidate(overrides: Partial<ExpansionCandidateInput> = {}): Expans
     terrain: { walkableRatio: 0.85, swampRatio: 0.1, wallRatio: 0.15 },
     hostileCreepCount: 0,
     hostileStructureCount: 0,
+    ...overrides
+  };
+}
+
+function makeUnscoredCandidate(roomName: string, order: number): ExpansionCandidateInput {
+  return {
+    roomName,
+    order,
+    adjacentToOwnedRoom: true,
+    routeDistance: 1,
+    nearestOwnedRoom: 'W1N1',
+    nearestOwnedRoomDistance: 1
+  };
+}
+
+function makeScoutIntel(
+  roomName: string,
+  overrides: Partial<TerritoryScoutIntelMemory> = {}
+): TerritoryScoutIntelMemory {
+  const sourceCount = overrides.sourceCount ?? 1;
+  return {
+    colony: 'W1N1',
+    roomName,
+    updatedAt: 100,
+    controller: {
+      id: `controller-${roomName}` as Id<StructureController>,
+      my: false
+    },
+    sourceIds: Array.from({ length: sourceCount }, (_value, index) => `${roomName}-source${index}`),
+    sourceCount,
+    sourceAccessPoints: 6,
+    controllerSourceRange: 8,
+    terrain: { walkableRatio: 0.85, swampRatio: 0.1, wallRatio: 0.15 },
+    hostileCreepCount: 0,
+    hostileStructureCount: 0,
+    hostileSpawnCount: 0,
     ...overrides
   };
 }

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -575,6 +575,43 @@ describe('next expansion scoring', () => {
     expect(neutral.score).toBeGreaterThan(owned.score);
   });
 
+  it('uses scout intel when candidate source count is zero and controller evidence is empty', () => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': makeScoutIntel('W2N1', {
+            sourceCount: 2,
+            controller: {
+              id: 'controller-W2N1' as Id<StructureController>,
+              ownerUsername: 'enemy'
+            }
+          })
+        }
+      }
+    };
+
+    const report = scoreExpansionCandidates(
+      makeInput([
+        makeCandidate({
+          roomName: 'W2N1',
+          controller: {},
+          sourceCount: 0
+        })
+      ])
+    );
+    const candidate = getCandidate(report, 'W2N1');
+
+    expect(candidate).toMatchObject({
+      controllerId: 'controller-W2N1',
+      evidenceStatus: 'unavailable',
+      sourceCount: 2,
+      risks: ['enemy-owned controller cannot be claimed safely']
+    });
+    expect(candidate.rationale).toEqual(
+      expect.arrayContaining(['controller owned by another account', '2 sources scouted'])
+    );
+  });
+
   it('downgrades persisted scout-intel candidates when hostiles are present', () => {
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {


### PR DESCRIPTION
## Summary
- Reads persistent scout intel data for candidate expansion rooms
- Factors scout intel into expansion scoring: source count, controller owner/reservation status, hostile creep presence, terrain passability
- Modified `colonyExpansionPlanner.ts` to use improved scores for expansion recommendations
- Added tests covering: 2-source/no-owner scoring higher, hostile presence downgrade, missing scout data graceful fallback

## Verification
- TypeScript: passes
- Tests: 53 suites, 1208 tests pass
- Build: succeeds

Refs #687