### PR TITLE
feat(territory): expand to highest-scoring available room using scout intel and construction planner (#695)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5678,6 +5678,8 @@ var DOWNGRADE_GUARD_TICKS = 5e3;
 var MIN_CONTROLLER_LEVEL = 2;
 var MAX_PERSISTED_EXPANSION_CANDIDATES = 5;
 var EXPANSION_SCOUT_INTEL_TTL = 1e4;
+var EXPANSION_CLAIM_ROUTE_ROOM_TICKS = 50;
+var EXPANSION_CLAIM_READY_BUFFER_TICKS = 10;
 var EXPANSION_SOURCE_COVERAGE_TARGET_PER_ROOM = 2;
 var EXPANSION_ENERGY_CAPACITY_CONSTRAINED_THRESHOLD = 800;
 var SYNERGY_MINERAL_GAP_BONUS = 220;
@@ -6225,13 +6227,27 @@ function getOwnedRoomCount(input) {
 }
 function selectPersistableExpansionCandidate(report) {
   var _a;
-  return (_a = report.candidates.find(
-    (candidate) => candidate.visible && isViableExpansionCandidate(candidate)
-  )) != null ? _a : null;
+  return (_a = report.candidates.find(isViableExpansionCandidate)) != null ? _a : null;
 }
 function isViableExpansionCandidate(candidate) {
+  return candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0 && typeof candidate.sourceCount === "number" && candidate.sourceCount > 0 && isExpansionControllerAvailableForClaim(candidate);
+}
+function isExpansionControllerAvailableForClaim(candidate) {
   var _a;
-  return candidate.evidenceStatus === "sufficient" && candidate.preconditions.length === 0 && candidate.sourceCount === 2 && ((_a = candidate.reservation) == null ? void 0 : _a.relation) !== "own";
+  if (((_a = candidate.reservation) == null ? void 0 : _a.relation) !== "own") {
+    return true;
+  }
+  return isOwnReservationClaimArrivalWindowOpen(candidate);
+}
+function isOwnReservationClaimArrivalWindowOpen(candidate) {
+  var _a;
+  const ticksToEnd = (_a = candidate.reservation) == null ? void 0 : _a.ticksToEnd;
+  return typeof ticksToEnd === "number" && ticksToEnd <= estimateExpansionClaimArrivalTicks(candidate);
+}
+function estimateExpansionClaimArrivalTicks(candidate) {
+  var _a, _b;
+  const roomDistance = (_b = (_a = candidate.routeDistance) != null ? _a : candidate.nearestOwnedRoomDistance) != null ? _b : candidate.adjacentToOwnedRoom ? 1 : MAX_NEARBY_EXPANSION_ROUTE_DISTANCE;
+  return Math.max(1, Math.ceil(roomDistance)) * EXPANSION_CLAIM_ROUTE_ROOM_TICKS + EXPANSION_CLAIM_READY_BUFFER_TICKS;
 }
 function getSelectionSkipReason(report) {
   if (report.candidates.length === 0) {
@@ -6299,7 +6315,7 @@ function toPersistedExpansionCandidateMemory(colony, candidate, gameTime, rank) 
 }
 function getPersistedExpansionCandidateRecommendedAction(candidate) {
   if (isViableExpansionCandidate(candidate)) {
-    return candidate.visible ? "claim" : "reserve";
+    return "claim";
   }
   return candidate.evidenceStatus === "insufficient-evidence" && candidate.adjacentToOwnedRoom ? "scout" : void 0;
 }
@@ -19104,6 +19120,7 @@ function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
     workerTarget: (_b = existing == null ? void 0 : existing.workerTarget) != null ? _b : POST_CLAIM_BOOTSTRAP_WORKER_TARGET,
     ...input.controllerId ? { controllerId: input.controllerId } : {}
   };
+  recordClaimedRoomOccupation(input.roomName, claimedAt, gameTime);
   telemetryEvents.push({
     type: "postClaimBootstrap",
     roomName: input.roomName,
@@ -19113,6 +19130,26 @@ function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
     workerTarget: POST_CLAIM_BOOTSTRAP_WORKER_TARGET
   });
   placePostClaimSpawnConstructionSite(input.roomName, telemetryEvents);
+}
+function recordClaimedRoomOccupation(roomName, claimedAt, gameTime) {
+  var _a;
+  const memory = globalThis.Memory;
+  if (!memory) {
+    return;
+  }
+  if (!memory.territory) {
+    memory.territory = {};
+  }
+  if (!memory.territory.claimedRoomBootstrapper) {
+    memory.territory.claimedRoomBootstrapper = { rooms: {} };
+  }
+  memory.territory.claimedRoomBootstrapper.rooms[roomName] = {
+    roomName,
+    owned: true,
+    claimedAt,
+    updatedAt: gameTime,
+    ...((_a = memory.territory.claimedRoomBootstrapper.rooms[roomName]) == null ? void 0 : _a.completedAt) !== void 0 ? { completedAt: memory.territory.claimedRoomBootstrapper.rooms[roomName].completedAt } : {}
+  };
 }
 function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents = []) {
   var _a, _b;
@@ -19352,6 +19389,10 @@ function planInitialSpawnConstructionSite(room) {
   if (typeof room.createConstructionSite !== "function") {
     return { result: ERR_INVALID_TARGET_CODE2 };
   }
+  const plannerResult = planInitialSpawnConstructionSiteWithPlanner(room);
+  if (plannerResult) {
+    return plannerResult;
+  }
   const positions = findInitialSpawnConstructionPositions(room);
   if (positions.length === 0) {
     return { result: ERR_INVALID_TARGET_CODE2 };
@@ -19367,6 +19408,39 @@ function planInitialSpawnConstructionSite(room) {
     }
   }
   return { result: lastResult };
+}
+function planInitialSpawnConstructionSiteWithPlanner(room) {
+  const result = planConstructionForColony({
+    room,
+    spawns: getRoomSpawns(room.name),
+    energyAvailable: getRoomEnergyAvailable3(room),
+    energyCapacityAvailable: getRoomEnergyCapacityAvailable2(room)
+  });
+  const spawnPlacement = result.placements.find((placement) => placement.priority === "spawn");
+  if (!spawnPlacement) {
+    return null;
+  }
+  return {
+    result: spawnPlacement.result,
+    ...spawnPlacement.result === OK_CODE7 && typeof spawnPlacement.x === "number" && typeof spawnPlacement.y === "number" ? { position: { roomName: room.name, x: spawnPlacement.x, y: spawnPlacement.y } } : {}
+  };
+}
+function getRoomSpawns(roomName) {
+  var _a;
+  const spawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
+  if (!spawns) {
+    return [];
+  }
+  return Object.values(spawns).filter((spawn) => {
+    var _a2;
+    return ((_a2 = spawn == null ? void 0 : spawn.room) == null ? void 0 : _a2.name) === roomName;
+  });
+}
+function getRoomEnergyAvailable3(room) {
+  return typeof room.energyAvailable === "number" && Number.isFinite(room.energyAvailable) ? Math.max(0, room.energyAvailable) : 0;
+}
+function getRoomEnergyCapacityAvailable2(room) {
+  return typeof room.energyCapacityAvailable === "number" && Number.isFinite(room.energyCapacityAvailable) ? Math.max(0, room.energyCapacityAvailable) : getRoomEnergyAvailable3(room);
 }
 function findInitialSpawnConstructionPositions(room) {
   const anchor = selectInitialSpawnAnchor2(room);

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -26,6 +26,8 @@ const DOWNGRADE_GUARD_TICKS = 5_000;
 const MIN_CONTROLLER_LEVEL = 2;
 const MAX_PERSISTED_EXPANSION_CANDIDATES = 5;
 const EXPANSION_SCOUT_INTEL_TTL = 10_000;
+const EXPANSION_CLAIM_ROUTE_ROOM_TICKS = 50;
+const EXPANSION_CLAIM_READY_BUFFER_TICKS = 10;
 const EXPANSION_SOURCE_COVERAGE_TARGET_PER_ROOM = 2;
 const EXPANSION_ENERGY_CAPACITY_CONSTRAINED_THRESHOLD = 800;
 const SYNERGY_MINERAL_GAP_BONUS = 220;
@@ -878,22 +880,38 @@ function getOwnedRoomCount(input: ExpansionScoringInput): number {
 }
 
 function selectPersistableExpansionCandidate(report: ExpansionCandidateReport): ExpansionCandidateScore | null {
-  return (
-    report.candidates.find(
-      (candidate) =>
-        candidate.visible &&
-        isViableExpansionCandidate(candidate)
-    ) ?? null
-  );
+  return report.candidates.find(isViableExpansionCandidate) ?? null;
 }
 
 function isViableExpansionCandidate(candidate: ExpansionCandidateScore): boolean {
   return (
     candidate.evidenceStatus === 'sufficient' &&
     candidate.preconditions.length === 0 &&
-    candidate.sourceCount === 2 &&
-    candidate.reservation?.relation !== 'own'
+    typeof candidate.sourceCount === 'number' &&
+    candidate.sourceCount > 0 &&
+    isExpansionControllerAvailableForClaim(candidate)
   );
+}
+
+function isExpansionControllerAvailableForClaim(candidate: ExpansionCandidateScore): boolean {
+  if (candidate.reservation?.relation !== 'own') {
+    return true;
+  }
+
+  return isOwnReservationClaimArrivalWindowOpen(candidate);
+}
+
+function isOwnReservationClaimArrivalWindowOpen(candidate: ExpansionCandidateScore): boolean {
+  const ticksToEnd = candidate.reservation?.ticksToEnd;
+  return typeof ticksToEnd === 'number' && ticksToEnd <= estimateExpansionClaimArrivalTicks(candidate);
+}
+
+function estimateExpansionClaimArrivalTicks(candidate: ExpansionCandidateScore): number {
+  const roomDistance =
+    candidate.routeDistance ??
+    candidate.nearestOwnedRoomDistance ??
+    (candidate.adjacentToOwnedRoom ? 1 : MAX_NEARBY_EXPANSION_ROUTE_DISTANCE);
+  return Math.max(1, Math.ceil(roomDistance)) * EXPANSION_CLAIM_ROUTE_ROOM_TICKS + EXPANSION_CLAIM_READY_BUFFER_TICKS;
 }
 
 function getSelectionSkipReason(report: ExpansionCandidateReport): NextExpansionTargetSelectionReason {
@@ -994,7 +1012,7 @@ function getPersistedExpansionCandidateRecommendedAction(
   candidate: ExpansionCandidateScore
 ): PersistedExpansionCandidateRecommendedAction | undefined {
   if (isViableExpansionCandidate(candidate)) {
-    return candidate.visible ? 'claim' : 'reserve';
+    return 'claim';
   }
 
   return candidate.evidenceStatus === 'insufficient-evidence' && candidate.adjacentToOwnedRoom

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -1,4 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { planConstructionForColony } from '../construction/planner';
 import type { RoleCounts } from '../creeps/roleCounts';
 import type { RuntimeTelemetryEvent } from '../telemetry/runtimeSummary';
 
@@ -75,6 +76,7 @@ export function recordPostClaimBootstrapClaimSuccess(
     workerTarget: existing?.workerTarget ?? POST_CLAIM_BOOTSTRAP_WORKER_TARGET,
     ...(input.controllerId ? { controllerId: input.controllerId } : {})
   };
+  recordClaimedRoomOccupation(input.roomName, claimedAt, gameTime);
 
   telemetryEvents.push({
     type: 'postClaimBootstrap',
@@ -86,6 +88,31 @@ export function recordPostClaimBootstrapClaimSuccess(
   });
 
   placePostClaimSpawnConstructionSite(input.roomName, telemetryEvents);
+}
+
+function recordClaimedRoomOccupation(roomName: string, claimedAt: number, gameTime: number): void {
+  const memory = (globalThis as { Memory?: Partial<Memory> }).Memory;
+  if (!memory) {
+    return;
+  }
+
+  if (!memory.territory) {
+    memory.territory = {};
+  }
+
+  if (!memory.territory.claimedRoomBootstrapper) {
+    memory.territory.claimedRoomBootstrapper = { rooms: {} };
+  }
+
+  memory.territory.claimedRoomBootstrapper.rooms[roomName] = {
+    roomName,
+    owned: true,
+    claimedAt,
+    updatedAt: gameTime,
+    ...(memory.territory.claimedRoomBootstrapper.rooms[roomName]?.completedAt !== undefined
+      ? { completedAt: memory.territory.claimedRoomBootstrapper.rooms[roomName].completedAt }
+      : {})
+  };
 }
 
 export function refreshPostClaimBootstrap(
@@ -366,6 +393,11 @@ function planInitialSpawnConstructionSite(room: Room): SpawnSitePlanResult {
     return { result: ERR_INVALID_TARGET_CODE };
   }
 
+  const plannerResult = planInitialSpawnConstructionSiteWithPlanner(room);
+  if (plannerResult) {
+    return plannerResult;
+  }
+
   const positions = findInitialSpawnConstructionPositions(room);
   if (positions.length === 0) {
     return { result: ERR_INVALID_TARGET_CODE };
@@ -383,6 +415,49 @@ function planInitialSpawnConstructionSite(room: Room): SpawnSitePlanResult {
   }
 
   return { result: lastResult };
+}
+
+function planInitialSpawnConstructionSiteWithPlanner(room: Room): SpawnSitePlanResult | null {
+  const result = planConstructionForColony({
+    room,
+    spawns: getRoomSpawns(room.name),
+    energyAvailable: getRoomEnergyAvailable(room),
+    energyCapacityAvailable: getRoomEnergyCapacityAvailable(room)
+  });
+  const spawnPlacement = result.placements.find((placement) => placement.priority === 'spawn');
+  if (!spawnPlacement) {
+    return null;
+  }
+
+  return {
+    result: spawnPlacement.result,
+    ...(spawnPlacement.result === OK_CODE &&
+    typeof spawnPlacement.x === 'number' &&
+    typeof spawnPlacement.y === 'number'
+      ? { position: { roomName: room.name, x: spawnPlacement.x, y: spawnPlacement.y } }
+      : {})
+  };
+}
+
+function getRoomSpawns(roomName: string): StructureSpawn[] {
+  const spawns = (globalThis as { Game?: Partial<Game> }).Game?.spawns;
+  if (!spawns) {
+    return [];
+  }
+
+  return Object.values(spawns).filter((spawn) => spawn?.room?.name === roomName);
+}
+
+function getRoomEnergyAvailable(room: Room): number {
+  return typeof room.energyAvailable === 'number' && Number.isFinite(room.energyAvailable)
+    ? Math.max(0, room.energyAvailable)
+    : 0;
+}
+
+function getRoomEnergyCapacityAvailable(room: Room): number {
+  return typeof room.energyCapacityAvailable === 'number' && Number.isFinite(room.energyCapacityAvailable)
+    ? Math.max(0, room.energyCapacityAvailable)
+    : getRoomEnergyAvailable(room);
 }
 
 function findInitialSpawnConstructionPositions(room: Room): CandidatePosition[] {

--- a/prod/test/claimerRunner.test.ts
+++ b/prod/test/claimerRunner.test.ts
@@ -164,6 +164,12 @@ describe('runClaimer', () => {
       updatedAt: 520,
       controllerId: 'controller1'
     });
+    expect(Memory.territory?.claimedRoomBootstrapper?.rooms.W2N1).toEqual({
+      roomName: 'W2N1',
+      owned: true,
+      claimedAt: 520,
+      updatedAt: 520
+    });
     expect((colonyRoom.memory.cachedExpansionSelection as unknown as Record<string, unknown>).claimExecution).toEqual({
       status: 'claimed',
       targetRoom: 'W2N1',

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1095,6 +1095,94 @@ describe('runEconomy', () => {
     ]);
   });
 
+  it('spawns a next-expansion claimer from sufficient scout-intel scoring', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_HOSTILE_CREEPS: number;
+      FIND_HOSTILE_STRUCTURES: number;
+      TERRAIN_MASK_WALL: number;
+      TERRAIN_MASK_SWAMP: number;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 2;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 3;
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { TERRAIN_MASK_SWAMP: number }).TERRAIN_MASK_SWAMP = 2;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        scoutIntel: {
+          'W1N1>W2N1': {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            updatedAt: 500,
+            controller: { id: 'controller2' as Id<StructureController>, my: false },
+            sourceIds: ['source-a', 'source-b'],
+            sourceCount: 2,
+            sourceAccessPoints: 7,
+            controllerSourceRange: 8,
+            terrain: { walkableRatio: 0.92, swampRatio: 0.04, wallRatio: 0.08 },
+            hostileCreepCount: 0,
+            hostileStructureCount: 0,
+            hostileSpawnCount: 0
+          }
+        }
+      }
+    };
+    const room = makeTerritoryReadyEconomyRoom();
+    const spawn = {
+      name: 'Spawn1',
+      room,
+      spawning: null,
+      spawnCreep: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as StructureSpawn;
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 505,
+      rooms: { W1N1: room },
+      spawns: { Spawn1: spawn },
+      creeps: workers,
+      getObjectById: jest.fn().mockReturnValue(null),
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' })),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain: jest.fn(() => ({ get: jest.fn().mockReturnValue(0) } as unknown as RoomTerrain))
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(spawn.spawnCreep).toHaveBeenCalledWith(['claim', 'move'], 'claimer-W1N1-W2N1-505', {
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: {
+          targetRoom: 'W2N1',
+          action: 'claim',
+          controllerId: 'controller2'
+        }
+      }
+    });
+    expect(room.memory.cachedExpansionSelection).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
   it('reuses cached next expansion scoring between refresh ticks', () => {
     (globalThis as unknown as {
       FIND_SOURCES: number;
@@ -2006,8 +2094,8 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_STRUCTURES, 2, 2, 47, 47, true);
-    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_CONSTRUCTION_SITES, 2, 2, 47, 47, true);
+    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_STRUCTURES, 15, 15, 31, 31, true);
+    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_CONSTRUCTION_SITES, 15, 15, 31, 31, true);
     expect(room.createConstructionSite).toHaveBeenCalledWith(16, 16, STRUCTURE_SPAWN);
     expect(Memory.territory?.postClaimBootstraps?.W2N1).toMatchObject({
       status: 'spawnSitePending',
@@ -2101,7 +2189,7 @@ describe('runEconomy', () => {
 
     runEconomy();
 
-    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_MINERALS, 2, 2, 47, 47, true);
+    expect(room.lookForAtArea).toHaveBeenCalledWith(LOOK_MINERALS, 15, 15, 31, 31, true);
     expect(room.createConstructionSite).not.toHaveBeenCalledWith(23, 23, STRUCTURE_SPAWN);
     expect(room.createConstructionSite).toHaveBeenNthCalledWith(1, 22, 22, STRUCTURE_SPAWN);
     expect(room.createConstructionSite).toHaveBeenNthCalledWith(2, 23, 22, STRUCTURE_SPAWN);

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -518,20 +518,30 @@ describe('next expansion scoring', () => {
     expect(report.next?.rationale).toEqual(expect.arrayContaining(['2 sources scouted']));
 
     expect(refreshNextExpansionTargetSelection(colony, report, 451)).toEqual({
-      status: 'skipped',
+      status: 'planned',
       colony: 'W1N1',
-      reason: 'unavailable'
+      targetRoom: 'W2N1',
+      controllerId: 'controller2',
+      score: report.candidates[0].score
     });
     expect(getExpansionCandidateMemory()[0]).toMatchObject({
       colony: 'W1N1',
       roomName: 'W2N1',
       rank: 1,
       evidenceStatus: 'sufficient',
-      recommendedAction: 'reserve',
+      recommendedAction: 'claim',
       visible: false,
       updatedAt: 451
     });
-    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller2'
+      }
+    ]);
   });
 
   it('uses persisted scout intel to rank two-source neutral rooms above one-source owned rooms', () => {
@@ -767,7 +777,7 @@ describe('next expansion scoring', () => {
     });
   });
 
-  it('does not persist own-reserved rooms as generic next-expansion claims', () => {
+  it('does not persist own-reserved rooms before the claim arrival window opens', () => {
     const colony = makeSafeColony();
     const report = scoreExpansionCandidates(
       makeInput([
@@ -795,7 +805,46 @@ describe('next expansion scoring', () => {
     expect(getExpansionCandidateMemory()[0]).not.toHaveProperty('recommendedAction');
   });
 
-  it('does not persist one-source rooms as next expansion claim targets or actions', () => {
+  it('persists own-reserved rooms when the reservation will expire before arrival', () => {
+    const colony = makeSafeColony();
+    const report = scoreExpansionCandidates(
+      makeInput([
+        makeCandidate({
+          roomName: 'W3N1',
+          controllerId: 'controller3' as Id<StructureController>,
+          sourceCount: 2,
+          controller: { reservationUsername: 'me', reservationTicksToEnd: 55 }
+        })
+      ])
+    );
+
+    expect(refreshNextExpansionTargetSelection(colony, report, 104)).toEqual({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      controllerId: 'controller3',
+      score: report.candidates[0].score
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W3N1',
+        action: 'claim',
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller3'
+      }
+    ]);
+    expect(getExpansionCandidateMemory()[0]).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W3N1',
+      evidenceStatus: 'sufficient',
+      recommendedAction: 'claim',
+      visible: true,
+      updatedAt: 104
+    });
+  });
+
+  it('persists one-source rooms as next expansion claim targets when they are the best available candidate', () => {
     const colony = makeSafeColony();
     const report = scoreExpansionCandidates(
       makeInput([
@@ -813,21 +862,41 @@ describe('next expansion scoring', () => {
       sourceCount: 1
     });
     expect(refreshNextExpansionTargetSelection(colony, report, 102)).toEqual({
-      status: 'skipped',
+      status: 'planned',
       colony: 'W1N1',
-      reason: 'unavailable'
+      targetRoom: 'W3N1',
+      controllerId: 'controller3',
+      score: report.candidates[0].score
     });
-    expect(Memory.territory?.targets).toBeUndefined();
-    expect(Memory.territory?.intents).toBeUndefined();
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W3N1',
+        action: 'claim',
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller3'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 102,
+        createdBy: 'nextExpansionScoring',
+        controllerId: 'controller3'
+      }
+    ]);
     expect(getExpansionCandidateMemory()[0]).toMatchObject({
       colony: 'W1N1',
       roomName: 'W3N1',
       evidenceStatus: 'sufficient',
       sourceCount: 1,
       visible: true,
-      updatedAt: 102
+      updatedAt: 102,
+      recommendedAction: 'claim'
     });
-    expect(getExpansionCandidateMemory()[0]).not.toHaveProperty('recommendedAction');
   });
 
   it('preserves unrelated claim intents while pruning stale next expansion intents', () => {


### PR DESCRIPTION
## Summary
Implement expansion targeting to highest-scoring available room using scout intel and construction planner.

## Changes
- Expand territory/expansionScoring with improved room selection
- Add postClaimBootstrap for claimed-room infrastructure setup
- Update tests for claimerRunner, economyLoop, expansionScoring
- Rebuild dist/main.js

## Verification
- TypeScript typecheck: pass
- All 1226 tests pass (55 suites)
- Build succeeds

Closes #695