### PR TITLE
feat(territory): implement controller sign and upgrade management with RCL progression (#700)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -17800,7 +17800,7 @@ function buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTim
   const controllerId = controller.id;
   const activeUpgraderCount = (_a = options.activeUpgraderCount) != null ? _a : countActiveControllerUpgraders(roomName, controllerId);
   const upgradePriority = getControllerUpgradePriority(controller, {
-    energyAvailable: colony.energyAvailable,
+    energyAvailable: options.allowReservedSpawnEnergy === true ? colony.energyCapacityAvailable : colony.energyAvailable,
     energyCapacityAvailable: colony.energyCapacityAvailable,
     competingSpawnDemand: options.competingSpawnDemand
   });
@@ -17836,18 +17836,26 @@ function buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTim
   return plan;
 }
 function shouldCreateControllerUpgradeSpawnDemand(colony, roleCounts, workerTarget, upgradePriority, desiredUpgraderCount, activeUpgraderCount, options) {
-  return upgradePriority === "rclProgress" && desiredUpgraderCount > activeUpgraderCount && options.competingSpawnDemand !== true && getWorkerCapacity(roleCounts) >= workerTarget && colony.energyCapacityAvailable >= CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY && colony.energyAvailable >= colony.energyCapacityAvailable;
+  return upgradePriority === "rclProgress" && desiredUpgraderCount > activeUpgraderCount && options.competingSpawnDemand !== true && getWorkerCapacity(roleCounts) >= workerTarget && hasControllerProgressDemandSpawnEnergy(colony, options);
+}
+function hasControllerProgressDemandSpawnEnergy(colony, options) {
+  if (colony.energyCapacityAvailable < CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY) {
+    return false;
+  }
+  if (options.allowReservedSpawnEnergy === true) {
+    return colony.energyAvailable >= CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY;
+  }
+  return colony.energyAvailable >= colony.energyCapacityAvailable;
 }
 function getDesiredControllerUpgraderCount(priority) {
   return priority === "rclProgress" ? CONTROLLER_PROGRESS_DEMAND_UPGRADERS : 0;
 }
 function countActiveControllerUpgraders(roomName, controllerId) {
-  var _a;
-  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  if (!creeps) {
+  const game = globalThis.Game;
+  if (!(game == null ? void 0 : game.creeps)) {
     return 0;
   }
-  return Object.values(creeps).filter(
+  return Object.values(game.creeps).filter(
     (creep) => canSatisfyControllerUpgradeDemand(creep, roomName, controllerId)
   ).length;
 }
@@ -19158,14 +19166,15 @@ function planControllerUpgradeSurplusSpawn(context) {
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
 }
 function planControllerUpgradeDemandSpawn(context) {
-  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) {
+  if (context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) {
     return null;
   }
   const demand = selectControllerUpgradeSpawnDemand(
     context.colony,
     context.roleCounts,
     context.workerTarget,
-    context.gameTime
+    context.gameTime,
+    { allowReservedSpawnEnergy: isWorkerOnlyFollowUpPass(context.options) }
   );
   if (!demand) {
     return null;
@@ -19337,6 +19346,9 @@ function planWorkerSpawnWithBody(colony, body, gameTime, options) {
 }
 function appendSpawnNameSuffix(baseName, options) {
   return options.nameSuffix ? `${baseName}-${options.nameSuffix}` : baseName;
+}
+function isWorkerOnlyFollowUpPass(options) {
+  return options.workersOnly === true && isNonEmptyString14(options.nameSuffix);
 }
 function selectWorkerBody(colony, roleCounts) {
   var _a;
@@ -25579,7 +25591,7 @@ function runEconomy(preludeTelemetryEvents = []) {
       recordReservedSpawnEnergy(reservedSpawnEnergyByRoom, spawnRoomName, bodyCost);
       successfulSpawnCount += 1;
       recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
-      if (spawnRequest.memory.role !== "worker") {
+      if (spawnRequest.memory.role !== "worker" || isControllerUpgradeSpawnRequest(spawnRequest)) {
         break;
       }
       if (spawnRequest.memory.colony !== colony.room.name) {
@@ -26141,6 +26153,9 @@ function getSpawnPlanningOptions(successfulSpawnCount, hasPendingTerritoryFollow
 }
 function isAllowedPostSpawnRequest(spawnRequest) {
   return spawnRequest.memory.role === "worker" || isTerritoryControllerPressureSpawnRequest(spawnRequest) || isTerritoryControllerFollowUpSpawnRequest(spawnRequest);
+}
+function isControllerUpgradeSpawnRequest(spawnRequest) {
+  return spawnRequest.memory.role === "worker" && spawnRequest.memory.controllerUpgrade !== void 0;
 }
 function isTerritoryControllerPressureSpawnRequest(spawnRequest) {
   const territory = spawnRequest.memory.territory;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -11294,6 +11294,55 @@ function isRecord9(value) {
   return typeof value === "object" && value !== null;
 }
 
+// src/creeps/upgraderRunner.ts
+var CONTROLLER_UPGRADE_PROGRESS_PRESSURE_RATIO = 0.85;
+var CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS = 5e3;
+var MAX_CONTROLLER_LEVEL2 = 8;
+function runUpgrader(creep, controller) {
+  signOccupiedControllerIfNeeded(creep, controller);
+  return creep.upgradeController(controller);
+}
+function getControllerUpgradePriority(controller, context = {}) {
+  if ((controller == null ? void 0 : controller.my) !== true) {
+    return "none";
+  }
+  if (shouldGuardControllerDowngrade(controller)) {
+    return "downgradeGuard";
+  }
+  if (!canLevelUpController(controller)) {
+    return "fallback";
+  }
+  if (controller.level === 1) {
+    return "rcl1Rush";
+  }
+  if (isControllerProgressPressure(controller) && hasFullRoomSpawnEnergy(context) && context.competingSpawnDemand !== true) {
+    return "rclProgress";
+  }
+  if (context.hasEnergySurplus === true && context.competingSpawnDemand !== true) {
+    return "energySurplus";
+  }
+  return "fallback";
+}
+function isControllerProgressPressure(controller) {
+  if (!canLevelUpController(controller)) {
+    return false;
+  }
+  const progress = controller.progress;
+  const progressTotal = controller.progressTotal;
+  return typeof progress === "number" && Number.isFinite(progress) && typeof progressTotal === "number" && Number.isFinite(progressTotal) && progressTotal > 0 && Math.max(0, progress) / progressTotal >= CONTROLLER_UPGRADE_PROGRESS_PRESSURE_RATIO;
+}
+function canLevelUpController(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL2;
+}
+function shouldGuardControllerDowngrade(controller) {
+  return typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS;
+}
+function hasFullRoomSpawnEnergy(context) {
+  const energyAvailable = context.energyAvailable;
+  const energyCapacityAvailable = context.energyCapacityAvailable;
+  return typeof energyAvailable === "number" && Number.isFinite(energyAvailable) && typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable) && energyCapacityAvailable > 0 && energyAvailable >= energyCapacityAvailable;
+}
+
 // src/economy/linkManager.ts
 var SOURCE_LINK_RANGE = 2;
 var CONTROLLER_LINK_RANGE = 3;
@@ -11973,7 +12022,7 @@ var FINISHABLE_CONSTRUCTION_SITE_PRIORITY_MULTIPLIER = 2;
 var MAX_DROPPED_ENERGY_REACHABILITY_CHECKS = 5;
 var DEFAULT_SOURCE_ENERGY_CAPACITY = 3e3;
 var DEFAULT_SOURCE_ENERGY_REGEN_TICKS = 300;
-var MAX_CONTROLLER_LEVEL2 = 8;
+var MAX_CONTROLLER_LEVEL3 = 8;
 var UPGRADER_BOOST_CONTROLLER_PROGRESS_RATIO = 0.9;
 var UPGRADER_BOOST_LOW_ENERGY_RATIO = 0.5;
 var SOURCE2_CONTROLLER_LANE_SOURCE_INDEX = 1;
@@ -12098,7 +12147,7 @@ function selectHeuristicWorkerTask(creep) {
     return territoryControllerTask;
   }
   const controller = creep.room.controller;
-  if (controller && shouldGuardControllerDowngrade(controller) && canUpgradeController(controller) && !remoteProductiveSpendingSuppressed) {
+  if (controller && shouldGuardControllerDowngrade2(controller) && canUpgradeController(controller) && !remoteProductiveSpendingSuppressed) {
     const downgradeGuardTask = {
       type: "upgrade",
       targetId: controller.id
@@ -12142,6 +12191,10 @@ function selectHeuristicWorkerTask(creep) {
   const controllerSustainUpgradeTask = selectControllerSustainUpgradeTask(creep, controller);
   if (controllerSustainUpgradeTask) {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainUpgradeTask);
+  }
+  const managedControllerUpgradeTask = selectManagedControllerUpgradeTask(creep, controller, carriedEnergy);
+  if (managedControllerUpgradeTask) {
+    return applyMinimumUsefulLoadPolicy(creep, managedControllerUpgradeTask);
   }
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
   const constructionReservationContext = constructionSites.length > 0 ? createConstructionReservationContext(creep.room) : createEmptyConstructionReservationContext();
@@ -12215,7 +12268,7 @@ function selectHeuristicWorkerTask(creep) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "build", targetId: capacityConstructionSite.id });
   }
   if (controller && shouldRushRcl1Controller(controller)) {
-    return canLevelUpController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
+    return canLevelUpController2(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
   }
   const criticalRepairTarget = selectCriticalInfrastructureRepairTarget(creep);
   if (criticalRepairTarget) {
@@ -12251,7 +12304,7 @@ function selectHeuristicWorkerTask(creep) {
     if (productiveEnergySinkTask) {
       return applyMinimumUsefulLoadPolicy(creep, productiveEnergySinkTask);
     }
-    return canLevelUpController(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
+    return canLevelUpController2(controller) ? applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id }) : null;
   }
   const constructionSite = selectUnreservedConstructionSite(
     creep,
@@ -12312,7 +12365,15 @@ function selectColonyRecallEnergySink(room) {
 function selectControllerSustainUpgradeTask(creep, controller) {
   var _a, _b;
   const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-  if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || sustain.targetRoom !== ((_b = creep.room) == null ? void 0 : _b.name) || (controller == null ? void 0 : controller.my) !== true || !canLevelUpController(controller)) {
+  if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || sustain.targetRoom !== ((_b = creep.room) == null ? void 0 : _b.name) || (controller == null ? void 0 : controller.my) !== true || !canLevelUpController2(controller)) {
+    return null;
+  }
+  return { type: "upgrade", targetId: controller.id };
+}
+function selectManagedControllerUpgradeTask(creep, controller, carriedEnergy) {
+  var _a, _b;
+  const upgrade = (_a = creep.memory) == null ? void 0 : _a.controllerUpgrade;
+  if (carriedEnergy <= 0 || !upgrade || upgrade.roomName !== ((_b = creep.room) == null ? void 0 : _b.name) || (controller == null ? void 0 : controller.my) !== true || controller.id !== upgrade.controllerId || !canUpgradeController(controller)) {
     return null;
   }
   return { type: "upgrade", targetId: controller.id };
@@ -12357,11 +12418,11 @@ function isUpgraderBoostActive(creep, controller) {
   return isUpgraderCreep(creep) && !hasVisibleHostilePresence(creep.room) && isControllerNearLevelUp(controller);
 }
 function isUpgraderCreep(creep) {
-  var _a, _b, _c;
-  return ((_a = creep.memory) == null ? void 0 : _a.role) === "upgrader" || ((_c = (_b = creep.memory) == null ? void 0 : _b.controllerSustain) == null ? void 0 : _c.role) === "upgrader";
+  var _a, _b, _c, _d;
+  return ((_a = creep.memory) == null ? void 0 : _a.role) === "upgrader" || ((_c = (_b = creep.memory) == null ? void 0 : _b.controllerSustain) == null ? void 0 : _c.role) === "upgrader" || ((_d = creep.memory) == null ? void 0 : _d.controllerUpgrade) !== void 0;
 }
 function isControllerNearLevelUp(controller) {
-  if (!controller || !canLevelUpController(controller)) {
+  if (!controller || !canLevelUpController2(controller)) {
     return false;
   }
   const progress = controller.progress;
@@ -12382,7 +12443,7 @@ function selectFirstEnergySinkByStableId(energySinks) {
   return (_a = [...energySinks].sort(compareEnergySinkId)[0]) != null ? _a : null;
 }
 function selectBootstrapSurvivalSpendingTask(creep, controller, constructionSites, constructionReservationContext, recoveryOnlyWorkSuppressed) {
-  if (controller && shouldRushRcl1Controller(controller) && canLevelUpController(controller) && !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)) {
+  if (controller && shouldRushRcl1Controller(controller) && canLevelUpController2(controller) && !shouldSuppressBootstrapControllerSpending(creep, recoveryOnlyWorkSuppressed)) {
     return applyMinimumUsefulLoadPolicy(creep, { type: "upgrade", targetId: controller.id });
   }
   if (recoveryOnlyWorkSuppressed && !isWorkerInColonyRoom(creep)) {
@@ -14414,7 +14475,7 @@ function getRepairPriority(structure) {
 function getHitsRatio(structure) {
   return structure.hitsMax > 0 ? structure.hits / structure.hitsMax : 1;
 }
-function shouldGuardControllerDowngrade(controller) {
+function shouldGuardControllerDowngrade2(controller) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade <= CONTROLLER_DOWNGRADE_GUARD_TICKS;
 }
 function shouldRushRcl1Controller(controller) {
@@ -14573,13 +14634,20 @@ function getControllerProgressWorkerLimit(creep, loadedWorkerCount, hasTerritory
   return loadedWorkerCount >= MIN_LOADED_WORKERS_FOR_SECOND_SUSTAINED_CONTROLLER_PROGRESS ? MAX_SUSTAINED_CONTROLLER_PROGRESS_WORKERS : 1;
 }
 function shouldUseSurplusForControllerProgress(creep, controller) {
+  var _a, _b;
   if (isControllerUpgradeSaturated(creep, controller)) {
     return false;
   }
   if (shouldApplyControllerPressureLane(creep, controller)) {
     return true;
   }
-  if (controller.my === true && controller.level >= 2 && hasRecoverableSurplusEnergy(creep)) {
+  const hasRecoverableEnergySurplus = hasRecoverableSurplusEnergy(creep);
+  const upgradePriority = getControllerUpgradePriority(controller, {
+    energyAvailable: (_a = getRoomEnergyAvailable2(creep.room)) != null ? _a : void 0,
+    energyCapacityAvailable: (_b = getRoomEnergyCapacityAvailable(creep.room)) != null ? _b : void 0,
+    hasEnergySurplus: hasRecoverableEnergySurplus
+  });
+  if (controller.my === true && controller.level >= 2 && (upgradePriority === "rclProgress" || upgradePriority === "energySurplus")) {
     return true;
   }
   return false;
@@ -14599,7 +14667,7 @@ function hasNonControllerWorkerEnergyDemand(creep) {
   return selectCriticalInfrastructureRepairTarget(creep) !== null || selectRepairTarget(creep) !== null;
 }
 function isControllerUpgradeSaturated(creep, controller) {
-  if (controller.my !== true || shouldGuardControllerDowngrade(controller)) {
+  if (controller.my !== true || shouldGuardControllerDowngrade2(controller)) {
     return false;
   }
   const loadedWorkers = getSameRoomLoadedWorkers(creep);
@@ -14641,8 +14709,8 @@ function selectSource2ControllerLaneLoadedTask(creep, controller, constructionSi
 function canUpgradeController(controller) {
   return (controller == null ? void 0 : controller.my) === true;
 }
-function canLevelUpController(controller) {
-  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL2;
+function canLevelUpController2(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < MAX_CONTROLLER_LEVEL3;
 }
 function selectSource2ControllerLaneHarvestTask(creep) {
   const source = selectSource2ControllerLaneHarvestSource(creep);
@@ -16468,8 +16536,7 @@ function executeTask(creep, task, target) {
       }
       return toTaskExecutionResult(creep.reserveController(target), "work");
     case "upgrade":
-      signOccupiedControllerIfNeeded(creep, target);
-      return toTaskExecutionResult(creep.upgradeController(target), "work");
+      return toTaskExecutionResult(runUpgrader(creep, target), "work");
   }
 }
 function executeHarvestTask(creep, source) {
@@ -17280,7 +17347,7 @@ var REMOTE_UPGRADER_PATTERN_COST = 200;
 var MOVE_PART_COST = 50;
 var MAX_CREEP_PARTS3 = 50;
 var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
-var MAX_CONTROLLER_LEVEL3 = 8;
+var MAX_CONTROLLER_LEVEL4 = 8;
 var ERR_NO_PATH_CODE5 = -2;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR4 = ">";
 var ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
@@ -17410,7 +17477,7 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgra
   };
 }
 function getEligibleControllerState(controller) {
-  return controller.my === true && getControllerLevel(controller) < MAX_CONTROLLER_LEVEL3 ? "owned" : null;
+  return controller.my === true && getControllerLevel(controller) < MAX_CONTROLLER_LEVEL4 ? "owned" : null;
 }
 function hasPrimaryRoomStorageSurplus(colony, storageEnergyThresholdRatio) {
   const storage = colony.room.storage;
@@ -17563,7 +17630,7 @@ function isActiveMultiRoomUpgrader(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
 }
 function getControllerLevel(controller) {
-  return typeof controller.level === "number" && Number.isFinite(controller.level) ? controller.level : MAX_CONTROLLER_LEVEL3;
+  return typeof controller.level === "number" && Number.isFinite(controller.level) ? controller.level : MAX_CONTROLLER_LEVEL4;
 }
 function getControllerTicksToDowngradePlanField(controller) {
   return typeof controller.ticksToDowngrade === "number" && Number.isFinite(controller.ticksToDowngrade) ? { controllerTicksToDowngrade: Math.max(0, Math.floor(controller.ticksToDowngrade)) } : {};
@@ -17689,6 +17756,159 @@ function isRecord12(value) {
   return typeof value === "object" && value !== null;
 }
 function isNonEmptyString11(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+// src/territory/controllerManager.ts
+var CONTROLLER_PROGRESS_DEMAND_UPGRADERS = 1;
+var CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY = 550;
+function refreshControllerManagement(colony, roleCounts, workerTarget, gameTime, options = {}) {
+  const plan = buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTime, options);
+  persistControllerManagementPlan(plan);
+  return plan;
+}
+function selectControllerUpgradeSpawnDemand(colony, roleCounts, workerTarget, gameTime, options = {}) {
+  var _a;
+  return (_a = buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTime, options).spawnDemand) != null ? _a : null;
+}
+function buildControllerUpgradeCreepMemory(demand, gameTime) {
+  return {
+    role: "worker",
+    colony: demand.roomName,
+    controllerUpgrade: {
+      roomName: demand.roomName,
+      controllerId: demand.controllerId,
+      priority: demand.priority,
+      assignedAt: gameTime
+    }
+  };
+}
+function buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTime, options = {}) {
+  var _a;
+  const roomName = colony.room.name;
+  const controller = colony.room.controller;
+  if ((controller == null ? void 0 : controller.my) !== true || !isNonEmptyString12(controller.id)) {
+    return {
+      roomName,
+      updatedAt: gameTime,
+      signNeeded: false,
+      upgradePriority: "none",
+      desiredUpgraderCount: 0,
+      activeUpgraderCount: 0
+    };
+  }
+  const controllerId = controller.id;
+  const activeUpgraderCount = (_a = options.activeUpgraderCount) != null ? _a : countActiveControllerUpgraders(roomName, controllerId);
+  const upgradePriority = getControllerUpgradePriority(controller, {
+    energyAvailable: colony.energyAvailable,
+    energyCapacityAvailable: colony.energyCapacityAvailable,
+    competingSpawnDemand: options.competingSpawnDemand
+  });
+  const desiredUpgraderCount = getDesiredControllerUpgraderCount(upgradePriority);
+  const plan = {
+    roomName,
+    updatedAt: gameTime,
+    controllerId,
+    signNeeded: shouldSignOccupiedController(controller),
+    upgradePriority,
+    desiredUpgraderCount,
+    activeUpgraderCount,
+    ...getControllerProgressRatioField(controller),
+    ...getControllerTicksToDowngradeField(controller)
+  };
+  if (shouldCreateControllerUpgradeSpawnDemand(
+    colony,
+    roleCounts,
+    workerTarget,
+    upgradePriority,
+    desiredUpgraderCount,
+    activeUpgraderCount,
+    options
+  )) {
+    plan.spawnDemand = {
+      roomName,
+      controllerId,
+      priority: upgradePriority,
+      desiredUpgraderCount,
+      activeUpgraderCount
+    };
+  }
+  return plan;
+}
+function shouldCreateControllerUpgradeSpawnDemand(colony, roleCounts, workerTarget, upgradePriority, desiredUpgraderCount, activeUpgraderCount, options) {
+  return upgradePriority === "rclProgress" && desiredUpgraderCount > activeUpgraderCount && options.competingSpawnDemand !== true && getWorkerCapacity(roleCounts) >= workerTarget && colony.energyCapacityAvailable >= CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY && colony.energyAvailable >= colony.energyCapacityAvailable;
+}
+function getDesiredControllerUpgraderCount(priority) {
+  return priority === "rclProgress" ? CONTROLLER_PROGRESS_DEMAND_UPGRADERS : 0;
+}
+function countActiveControllerUpgraders(roomName, controllerId) {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  if (!creeps) {
+    return 0;
+  }
+  return Object.values(creeps).filter(
+    (creep) => canSatisfyControllerUpgradeDemand(creep, roomName, controllerId)
+  ).length;
+}
+function canSatisfyControllerUpgradeDemand(creep, roomName, controllerId) {
+  var _a;
+  if (creep.ticksToLive !== void 0 && creep.ticksToLive <= WORKER_REPLACEMENT_TICKS_TO_LIVE) {
+    return false;
+  }
+  const upgradeMemory = creep.memory.controllerUpgrade;
+  if (creep.memory.role === "worker" && (upgradeMemory == null ? void 0 : upgradeMemory.roomName) === roomName && upgradeMemory.controllerId === controllerId) {
+    return true;
+  }
+  const task = creep.memory.task;
+  return creep.memory.role === "worker" && creep.memory.colony === roomName && ((_a = creep.room) == null ? void 0 : _a.name) === roomName && (task == null ? void 0 : task.type) === "upgrade" && task.targetId === controllerId;
+}
+function persistControllerManagementPlan(plan) {
+  var _a, _b;
+  const memory = globalThis.Memory;
+  if (!memory) {
+    return;
+  }
+  const territory = (_a = memory.territory) != null ? _a : {};
+  memory.territory = territory;
+  const controllers = (_b = territory.controllers) != null ? _b : {};
+  territory.controllers = controllers;
+  if (!plan.controllerId) {
+    delete controllers[plan.roomName];
+    return;
+  }
+  controllers[plan.roomName] = {
+    roomName: plan.roomName,
+    controllerId: plan.controllerId,
+    signNeeded: plan.signNeeded,
+    upgradePriority: plan.upgradePriority,
+    desiredUpgraderCount: plan.desiredUpgraderCount,
+    activeUpgraderCount: plan.activeUpgraderCount,
+    updatedAt: plan.updatedAt,
+    ...typeof plan.progressRatio === "number" ? { progressRatio: plan.progressRatio } : {},
+    ...typeof plan.ticksToDowngrade === "number" ? { ticksToDowngrade: plan.ticksToDowngrade } : {},
+    ...plan.spawnDemand ? {
+      spawnDemand: {
+        controllerId: plan.spawnDemand.controllerId,
+        priority: plan.spawnDemand.priority,
+        desiredUpgraderCount: plan.spawnDemand.desiredUpgraderCount,
+        activeUpgraderCount: plan.spawnDemand.activeUpgraderCount
+      }
+    } : {}
+  };
+}
+function getControllerProgressRatioField(controller) {
+  if (!isControllerProgressPressure(controller)) {
+    return {};
+  }
+  const progress = controller.progress;
+  const progressTotal = controller.progressTotal;
+  return typeof progress === "number" && typeof progressTotal === "number" && Number.isFinite(progress) && Number.isFinite(progressTotal) && progressTotal > 0 ? { progressRatio: Math.max(0, progress) / progressTotal } : {};
+}
+function getControllerTicksToDowngradeField(controller) {
+  return typeof controller.ticksToDowngrade === "number" && Number.isFinite(controller.ticksToDowngrade) ? { ticksToDowngrade: controller.ticksToDowngrade } : {};
+}
+function isNonEmptyString12(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -18253,7 +18473,7 @@ function moveTowardRoom3(creep, assignment, destinationRoom) {
 function getAssignmentRoute(assignment) {
   const route = findOwnedLogisticsRoute(assignment.homeRoom, assignment.targetRoom);
   if (!route) {
-    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString12) : null;
+    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString13) : null;
   }
   assignment.route = route.rooms;
   return route.rooms;
@@ -18335,17 +18555,17 @@ function normalizeCrossRoomHaulerMemory(value) {
   if (!isRecord13(value)) {
     return null;
   }
-  if (!isNonEmptyString12(value.homeRoom) || !isNonEmptyString12(value.targetRoom)) {
+  if (!isNonEmptyString13(value.homeRoom) || !isNonEmptyString13(value.targetRoom)) {
     return null;
   }
-  const sourceId = isNonEmptyString12(value.sourceId) ? value.sourceId : null;
+  const sourceId = isNonEmptyString13(value.sourceId) ? value.sourceId : null;
   const state = value.state === "collecting" || value.state === "delivering" || value.state === "returning" || value.state === "unassigned" ? value.state : void 0;
   return {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId,
     ...state ? { state: sourceId ? state : "unassigned" } : sourceId ? {} : { state: "unassigned" },
-    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString12) } : {}
+    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString13) } : {}
   };
 }
 function getMutableCrossRoomHaulerMemory(creep) {
@@ -18425,7 +18645,7 @@ function getGlobalNumber7(name) {
 function isRecord13(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString12(value) {
+function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -18433,7 +18653,7 @@ function isNonEmptyString12(value) {
 var CONTROLLER_UPGRADE_SURPLUS_WORKER_BONUS = 1;
 var CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY = 650;
 var CONTROLLER_UPGRADE_SURPLUS_MAX_WORKER_TARGET = 6;
-var MAX_CONTROLLER_LEVEL4 = 8;
+var MAX_CONTROLLER_LEVEL5 = 8;
 var SOURCE_ENERGY_CAPACITY = 3e3;
 var SOURCE_REGEN_TICKS = 300;
 var SOURCE_ENERGY_PER_TICK = SOURCE_ENERGY_CAPACITY / SOURCE_REGEN_TICKS;
@@ -18458,6 +18678,7 @@ var SPAWN_PRIORITY_TIERS = [
   "postClaimControllerSustain",
   "remoteEconomy",
   "territoryRemote",
+  "controllerUpgradeDemand",
   "multiRoomControllerUpgrade",
   "controllerUpgradeSurplus"
 ];
@@ -18533,6 +18754,8 @@ function planSpawnForPriorityTier(tier, context) {
       return planDefenseSpawnForContext(context);
     case "territoryRemote":
       return planTerritoryRemoteSpawn(context);
+    case "controllerUpgradeDemand":
+      return planControllerUpgradeDemandSpawn(context);
     case "multiRoomControllerUpgrade":
       return planMultiRoomControllerUpgradeSpawn(context);
     case "controllerUpgradeSurplus":
@@ -18706,7 +18929,7 @@ function getPostClaimControllerSustainRecords(colonyName) {
   ).sort(comparePostClaimControllerSustainRecords);
 }
 function isPostClaimControllerSustainRecord(record, colonyName) {
-  return isRecord14(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString13(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord14(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString14(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function comparePostClaimControllerSustainRecords(left, right) {
   const leftHasSpawn = hasOperationalSpawnInRoom(left.roomName);
@@ -18719,7 +18942,7 @@ function comparePostClaimControllerSustainRecords(left, right) {
 function getVisibleControllerLevel(roomName) {
   var _a, _b;
   const level = (_b = (_a = getVisibleRoom6(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
-  return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL4 + 1;
+  return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL5 + 1;
 }
 function hasOperationalSpawnInRoom(roomName) {
   var _a;
@@ -18934,6 +19157,37 @@ function planControllerUpgradeSurplusSpawn(context) {
   }
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
 }
+function planControllerUpgradeDemandSpawn(context) {
+  if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony)) {
+    return null;
+  }
+  const demand = selectControllerUpgradeSpawnDemand(
+    context.colony,
+    context.roleCounts,
+    context.workerTarget,
+    context.gameTime
+  );
+  if (!demand) {
+    return null;
+  }
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+  const body = selectWorkerBody(context.colony, context.roleCounts);
+  if (body.length === 0) {
+    return null;
+  }
+  return {
+    spawn,
+    body,
+    name: appendSpawnNameSuffix(
+      `worker-${context.colony.room.name}-controller-upgrader-${context.gameTime}`,
+      context.options
+    ),
+    memory: buildControllerUpgradeCreepMemory(demand, context.gameTime)
+  };
+}
 function planMultiRoomControllerUpgradeSpawn(context) {
   if (context.options.workersOnly || context.territoryIntentPending || context.survival.mode !== "TERRITORY_READY" || hasControllerUpgradeBlockingTerritoryWork(context.colony) || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {
     return null;
@@ -18977,7 +19231,7 @@ function hasControllerUpgradeSurplusEnergy(colony) {
   return colony.energyCapacityAvailable >= CONTROLLER_UPGRADE_SURPLUS_MIN_ENERGY_CAPACITY && colony.energyAvailable >= colony.energyCapacityAvailable;
 }
 function isControllerUpgradeableForSurplus(controller) {
-  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && controller.level < MAX_CONTROLLER_LEVEL4;
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && controller.level >= 2 && controller.level < MAX_CONTROLLER_LEVEL5;
 }
 function hasControllerUpgradeBlockingTerritoryWork(colony) {
   return hasActiveTerritoryIntentBacklog(colony.room.name) || hasVisibleForeignReservedTerritoryTarget(colony);
@@ -19224,7 +19478,7 @@ function getStorageBalanceMemory() {
 function isRecord14(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString13(value) {
+function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
 function getGlobalNumber8(name) {
@@ -19241,7 +19495,7 @@ var ROOM_EDGE_MAX6 = 47;
 var DEFAULT_TERRAIN_WALL_MASK8 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
-  if (!isNonEmptyString14(input.colony) || !isNonEmptyString14(input.roomName)) {
+  if (!isNonEmptyString15(input.colony) || !isNonEmptyString15(input.roomName)) {
     return;
   }
   const bootstraps = getWritablePostClaimBootstrapRecords();
@@ -19385,7 +19639,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   return { active: true, spawnConstructionPending: true };
 }
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
-  if (!isNonEmptyString14(roomName)) {
+  if (!isNonEmptyString15(roomName)) {
     return;
   }
   const record = getPostClaimBootstrapRecord(roomName);
@@ -19562,7 +19816,7 @@ function planInitialSpawnConstructionSiteWithPlanner(room) {
   }
   return {
     result: spawnPlacement.result,
-    ...spawnPlacement.result === OK_CODE7 && typeof spawnPlacement.x === "number" && typeof spawnPlacement.y === "number" ? { position: { roomName: room.name, x: spawnPlacement.x, y: spawnPlacement.y } } : {}
+    ...spawnPlacement.result === OK_CODE9 && typeof spawnPlacement.x === "number" && typeof spawnPlacement.y === "number" ? { position: { roomName: room.name, x: spawnPlacement.x, y: spawnPlacement.y } } : {}
   };
 }
 function getRoomSpawns(roomName) {
@@ -19751,7 +20005,7 @@ function getWritablePostClaimBootstrapRecords() {
   return memory.territory.postClaimBootstraps;
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
-  return isRecord15(value) && value.roomName === expectedRoomName && isNonEmptyString14(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber8(value.claimedAt) && isFiniteNumber8(value.updatedAt);
+  return isRecord15(value) && value.roomName === expectedRoomName && isNonEmptyString15(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber8(value.claimedAt) && isFiniteNumber8(value.updatedAt);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
@@ -19814,7 +20068,7 @@ function getGameTime14() {
 function isRecord15(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString14(value) {
+function isNonEmptyString15(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber8(value) {
@@ -22026,10 +22280,10 @@ function getMutableMineralHarvesterMemory(creep) {
   return memory;
 }
 function normalizeMineralHarvesterMemory(value) {
-  if (!isRecord18(value) || !isNonEmptyString15(value.homeRoom) || !isNonEmptyString15(value.mineralId)) {
+  if (!isRecord18(value) || !isNonEmptyString16(value.homeRoom) || !isNonEmptyString16(value.mineralId)) {
     return null;
   }
-  const targetId = isNonEmptyString15(value.targetId) ? value.targetId : void 0;
+  const targetId = isNonEmptyString16(value.targetId) ? value.targetId : void 0;
   if (!targetId) {
     return null;
   }
@@ -22037,7 +22291,7 @@ function normalizeMineralHarvesterMemory(value) {
     homeRoom: value.homeRoom,
     mineralId: value.mineralId,
     targetId,
-    ...isNonEmptyString15(value.mineralType) ? { mineralType: value.mineralType } : {}
+    ...isNonEmptyString16(value.mineralType) ? { mineralType: value.mineralType } : {}
   };
 }
 function getAssignedMineral(assignment, room) {
@@ -22160,7 +22414,7 @@ function normalizeNonNegativeInteger3(value) {
 function isRecord18(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString15(value) {
+function isNonEmptyString16(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -22584,11 +22838,11 @@ function buildAutonomousExpansionScoringInput(colony, report, context) {
   const ownedRoomNames = getVisibleOwnedRoomNames4(colonyName, colonyOwnerUsername);
   const adjacentRoomNamesByOwnedRoom = getAdjacentRoomNamesByOwnedRoom2(ownedRoomNames, context);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, colonyOwnerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString16(room.mineralType));
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString17(room.mineralType));
   const seenRooms = /* @__PURE__ */ new Set();
   const candidates = [];
   report.candidates.forEach((candidate, order) => {
-    if (!isNonEmptyString16(candidate.roomName) || seenRooms.has(candidate.roomName)) {
+    if (!isNonEmptyString17(candidate.roomName) || seenRooms.has(candidate.roomName)) {
       return;
     }
     seenRooms.add(candidate.roomName);
@@ -22654,7 +22908,7 @@ function summarizeExpansionController2(controller) {
   return {
     ...typeof controller.my === "boolean" ? { my: controller.my } : {},
     ...ownerUsername ? { ownerUsername } : {},
-    ...isNonEmptyString16(reservationUsername) ? { reservationUsername } : {},
+    ...isNonEmptyString17(reservationUsername) ? { reservationUsername } : {},
     ...typeof ((_b = controller.reservation) == null ? void 0 : _b.ticksToEnd) === "number" ? { reservationTicksToEnd: controller.reservation.ticksToEnd } : {}
   };
 }
@@ -22675,7 +22929,7 @@ function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString16(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString17(room.name) && (!ownerUsername || getControllerOwnerUsername6(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -22719,7 +22973,7 @@ function getAdjacentRoomNames5(roomName, gameMap = ((_a) => (_a = globalThis.Gam
   }
   return EXIT_DIRECTION_ORDER4.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString16(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString17(exitRoom) ? [exitRoom] : [];
   });
 }
 function countActivePostClaimBootstraps2() {
@@ -22835,7 +23089,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord19(target) && isNonEmptyString16(target.roomName) && target.action === "claim") {
+    if (isRecord19(target) && isNonEmptyString17(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -22922,7 +23176,7 @@ function isClaimExecutionAssignment(assignment) {
 }
 function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   var _a;
-  if (!isNonEmptyString16(colony)) {
+  if (!isNonEmptyString17(colony)) {
     return null;
   }
   const territoryMemory = getTerritoryMemoryRecord6();
@@ -23227,12 +23481,12 @@ function getClaimColony(creep, controller) {
   return (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller == null ? void 0 : controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown";
 }
 function isForeignOwnedController(controller) {
-  return controller.my !== true && isNonEmptyString16(getControllerOwnerUsername6(controller));
+  return controller.my !== true && isNonEmptyString17(getControllerOwnerUsername6(controller));
 }
 function isForeignReservedController3(controller, colony) {
   var _a, _b;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  if (!isNonEmptyString16(reservationUsername)) {
+  if (!isNonEmptyString17(reservationUsername)) {
     return false;
   }
   return reservationUsername !== getControllerOwnerUsername6((_b = getVisibleRoom9(colony != null ? colony : "")) == null ? void 0 : _b.controller);
@@ -23308,22 +23562,22 @@ function isControllerOwned2(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString16(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString17(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
 function isOwnReservedController2(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString16(colonyOwnerUsername) && reservationUsername === colonyOwnerUsername;
+  return isNonEmptyString17(colonyOwnerUsername) && reservationUsername === colonyOwnerUsername;
 }
 function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString16(username) ? username : void 0;
+  return isNonEmptyString17(username) ? username : void 0;
 }
 function isRecord19(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString16(value) {
+function isNonEmptyString17(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -23487,20 +23741,20 @@ function getControllerStatus2(room, scoutIntel) {
     if (!controller) {
       return "missing";
     }
-    if (controller.my === true || isNonEmptyString17((_a = controller.owner) == null ? void 0 : _a.username)) {
+    if (controller.my === true || isNonEmptyString18((_a = controller.owner) == null ? void 0 : _a.username)) {
       return "owned";
     }
-    if (isNonEmptyString17((_b = controller.reservation) == null ? void 0 : _b.username)) {
+    if (isNonEmptyString18((_b = controller.reservation) == null ? void 0 : _b.username)) {
       return "reserved";
     }
     return "neutral";
   }
   if (scoutIntel == null ? void 0 : scoutIntel.controller) {
     const controller = scoutIntel.controller;
-    if (controller.my === true || isNonEmptyString17(controller.ownerUsername)) {
+    if (controller.my === true || isNonEmptyString18(controller.ownerUsername)) {
       return "owned";
     }
-    if (isNonEmptyString17(controller.reservationUsername)) {
+    if (isNonEmptyString18(controller.reservationUsername)) {
       return "reserved";
     }
     return "neutral";
@@ -23543,7 +23797,7 @@ function getAdjacentRoomNames6(roomName) {
   }
   return EXIT_DIRECTION_ORDER5.flatMap((direction) => {
     const adjacentRoom = exits[direction];
-    return isNonEmptyString17(adjacentRoom) ? [adjacentRoom] : [];
+    return isNonEmptyString18(adjacentRoom) ? [adjacentRoom] : [];
   });
 }
 function getRoomTerrain11(roomName) {
@@ -23580,7 +23834,7 @@ function getGlobalNumber12(name) {
 function isRecord20(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString17(value) {
+function isNonEmptyString18(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -23812,11 +24066,11 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString18(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString19(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString18(controller.reservationUsername)) {
-    if (isNonEmptyString18(ownerUsername) && controller.reservationUsername === ownerUsername) {
+  if (isNonEmptyString19(controller.reservationUsername)) {
+    if (isNonEmptyString19(ownerUsername) && controller.reservationUsername === ownerUsername) {
       return {
         kind: "ownReserved",
         ...controller.id ? { controllerId: controller.id } : {},
@@ -23830,12 +24084,12 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
 function getVisibleControllerReservationState(controller, ownerUsername) {
   var _a;
   const controllerId = controller.id;
-  if (controller.my === true || isNonEmptyString18((_a = controller.owner) == null ? void 0 : _a.username)) {
+  if (controller.my === true || isNonEmptyString19((_a = controller.owner) == null ? void 0 : _a.username)) {
     return { kind: "owned", controllerId };
   }
   const reservation = controller.reservation;
-  if (isNonEmptyString18(reservation == null ? void 0 : reservation.username)) {
-    if (isNonEmptyString18(ownerUsername) && reservation.username === ownerUsername) {
+  if (isNonEmptyString19(reservation == null ? void 0 : reservation.username)) {
+    if (isNonEmptyString19(ownerUsername) && reservation.username === ownerUsername) {
       return {
         kind: "ownReserved",
         controllerId,
@@ -23978,7 +24232,7 @@ function getAdjacentRoomNames7(roomName) {
   }
   return EXIT_DIRECTION_ORDER6.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString18(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString19(exitRoom) ? [exitRoom] : [];
   });
 }
 function getPersistedExpansionCandidatePriorities(colony) {
@@ -23989,7 +24243,7 @@ function getPersistedExpansionCandidatePriorities(colony) {
   }
   const priorities = /* @__PURE__ */ new Map();
   for (const [index, rawCandidate] of rawCandidates.entries()) {
-    if (!isRecord21(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString18(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
+    if (!isRecord21(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString19(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
       continue;
     }
     priorities.set(rawCandidate.roomName, {
@@ -24007,7 +24261,7 @@ function countVisibleOwnedRooms2(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString18(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString19(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
@@ -24043,7 +24297,7 @@ function getFindConstant6(name) {
 function getControllerOwnerUsername7(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString18(username) ? username : void 0;
+  return isNonEmptyString19(username) ? username : void 0;
 }
 function compareOptionalNumbers6(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
@@ -24079,7 +24333,7 @@ function getGameTime17() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString18(value) {
+function isNonEmptyString19(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isRecord21(value) {
@@ -24173,7 +24427,7 @@ function clearColonyExpansionClaimIntent(colony) {
 function selectColonyExpansionCandidate(colony) {
   const ownerUsername = getControllerOwnerUsername8(colony.room.controller);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString19(room.mineralType));
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString20(room.mineralType));
   const candidates = getAdjacentRoomNames8(colony.room.name).flatMap((roomName, order) => {
     const room = getVisibleRoom12(roomName);
     if (!room && !getScoutIntel3(colony.room.name, roomName)) {
@@ -24324,11 +24578,11 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
       return { kind: "missing" };
     }
     const controllerId = controller2.id;
-    if (controller2.my === true || isNonEmptyString19((_a = controller2.owner) == null ? void 0 : _a.username)) {
+    if (controller2.my === true || isNonEmptyString20((_a = controller2.owner) == null ? void 0 : _a.username)) {
       return { kind: "owned", controllerId };
     }
     const reservationUsername = (_b = controller2.reservation) == null ? void 0 : _b.username;
-    if (isNonEmptyString19(reservationUsername)) {
+    if (isNonEmptyString20(reservationUsername)) {
       return reservationUsername === ownerUsername ? {
         kind: "ownReserved",
         controllerId,
@@ -24345,10 +24599,10 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString19(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString20(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString19(controller.reservationUsername)) {
+  if (isNonEmptyString20(controller.reservationUsername)) {
     return controller.reservationUsername === ownerUsername ? {
       kind: "ownReserved",
       ...controller.id ? { controllerId: controller.id } : {},
@@ -24415,7 +24669,7 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
       if (activeTarget && isSameTarget4(target, activeTarget)) {
         return true;
       }
-      if (isNonEmptyString19(target.roomName)) {
+      if (isNonEmptyString20(target.roomName)) {
         removedRooms.add(target.roomName);
       }
       return false;
@@ -24489,7 +24743,7 @@ function getAdjacentRoomNames8(roomName) {
   }
   return EXIT_DIRECTION_ORDER7.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString19(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString20(exitRoom) ? [exitRoom] : [];
   });
 }
 function getVisibleRoom12(roomName) {
@@ -24508,7 +24762,7 @@ function countVisibleOwnedRooms3(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString19(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString20(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
@@ -24532,7 +24786,7 @@ function hasActivePostClaimBootstrap2(colonyName) {
 function getControllerOwnerUsername8(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString19(username) ? username : void 0;
+  return isNonEmptyString20(username) ? username : void 0;
 }
 function getTerritoryMemoryRecord8() {
   var _a;
@@ -24556,7 +24810,7 @@ function getGameTime18() {
 function isRecord22(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString19(value) {
+function isNonEmptyString20(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -25265,9 +25519,19 @@ function runEconomy(preludeTelemetryEvents = []) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
+    const workerTarget = getWorkerTarget(colony, roleCounts);
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     persistColonyStageAssessment(colony, survivalAssessment, Game.time);
+    refreshControllerManagement(
+      colony,
+      roleCounts,
+      workerTarget,
+      Game.time,
+      {
+        competingSpawnDemand: survivalAssessment.mode !== "TERRITORY_READY" || survivalAssessment.hostilePresence || survivalAssessment.controllerDowngradeGuard
+      }
+    );
     refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
     planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
     if (survivalAssessment.mode === "TERRITORY_READY") {
@@ -25530,7 +25794,7 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber9(refreshedAt) || !isRecord25(rawSelection) || !isNonEmptyString20(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber9(refreshedAt) || !isRecord25(rawSelection) || !isNonEmptyString21(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
@@ -25540,7 +25804,7 @@ function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString20(rawSelection.targetRoom)) {
+    if (!isNonEmptyString21(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -25632,7 +25896,7 @@ function getLatestTerritoryScoutIntelUpdatedAt(colony) {
 function isRecord25(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString20(value) {
+function isNonEmptyString21(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber9(value) {
@@ -26884,7 +27148,7 @@ function normalizeHistoricalReplay(rawReplay) {
   if (!isRecord26(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString21(rawReplay.replayId) || !isNonEmptyString21(rawReplay.room) || !isFiniteNumber10(rawReplay.startTick) || !isFiniteNumber10(rawReplay.endTick) || !isFiniteNumber10(rawReplay.finalScore) || !isRecord26(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString22(rawReplay.replayId) || !isNonEmptyString22(rawReplay.room) || !isFiniteNumber10(rawReplay.startTick) || !isFiniteNumber10(rawReplay.endTick) || !isFiniteNumber10(rawReplay.finalScore) || !isRecord26(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -26912,7 +27176,7 @@ function formatCorrelation(correlation) {
 function isRecord26(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString21(value) {
+function isNonEmptyString22(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber10(value) {

--- a/prod/src/creeps/upgraderRunner.ts
+++ b/prod/src/creeps/upgraderRunner.ts
@@ -1,0 +1,107 @@
+import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
+
+export type ControllerUpgradePriority =
+  | 'none'
+  | 'downgradeGuard'
+  | 'rcl1Rush'
+  | 'rclProgress'
+  | 'energySurplus'
+  | 'fallback';
+
+export interface ControllerUpgradePriorityContext {
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
+  competingSpawnDemand?: boolean;
+  hasEnergySurplus?: boolean;
+}
+
+export const CONTROLLER_UPGRADE_PROGRESS_PRESSURE_RATIO = 0.85;
+export const CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS = 5_000;
+
+const MAX_CONTROLLER_LEVEL = 8;
+
+export function runUpgrader(creep: Creep, controller: StructureController): ScreepsReturnCode {
+  signOccupiedControllerIfNeeded(creep, controller);
+  return creep.upgradeController(controller);
+}
+
+export function getControllerUpgradePriority(
+  controller: StructureController | undefined,
+  context: ControllerUpgradePriorityContext = {}
+): ControllerUpgradePriority {
+  if (controller?.my !== true) {
+    return 'none';
+  }
+
+  if (shouldGuardControllerDowngrade(controller)) {
+    return 'downgradeGuard';
+  }
+
+  if (!canLevelUpController(controller)) {
+    return 'fallback';
+  }
+
+  if (controller.level === 1) {
+    return 'rcl1Rush';
+  }
+
+  if (
+    isControllerProgressPressure(controller) &&
+    hasFullRoomSpawnEnergy(context) &&
+    context.competingSpawnDemand !== true
+  ) {
+    return 'rclProgress';
+  }
+
+  if (context.hasEnergySurplus === true && context.competingSpawnDemand !== true) {
+    return 'energySurplus';
+  }
+
+  return 'fallback';
+}
+
+export function isControllerProgressPressure(controller: StructureController | undefined): boolean {
+  if (!canLevelUpController(controller)) {
+    return false;
+  }
+
+  const progress = controller.progress;
+  const progressTotal = controller.progressTotal;
+  return (
+    typeof progress === 'number' &&
+    Number.isFinite(progress) &&
+    typeof progressTotal === 'number' &&
+    Number.isFinite(progressTotal) &&
+    progressTotal > 0 &&
+    Math.max(0, progress) / progressTotal >= CONTROLLER_UPGRADE_PROGRESS_PRESSURE_RATIO
+  );
+}
+
+export function canLevelUpController(controller: StructureController | undefined): controller is StructureController {
+  return (
+    controller?.my === true &&
+    typeof controller.level === 'number' &&
+    Number.isFinite(controller.level) &&
+    controller.level < MAX_CONTROLLER_LEVEL
+  );
+}
+
+function shouldGuardControllerDowngrade(controller: StructureController): boolean {
+  return (
+    typeof controller.ticksToDowngrade === 'number' &&
+    controller.ticksToDowngrade <= CONTROLLER_UPGRADE_DOWNGRADE_GUARD_TICKS
+  );
+}
+
+function hasFullRoomSpawnEnergy(context: ControllerUpgradePriorityContext): boolean {
+  const energyAvailable = context.energyAvailable;
+  const energyCapacityAvailable = context.energyCapacityAvailable;
+  return (
+    typeof energyAvailable === 'number' &&
+    Number.isFinite(energyAvailable) &&
+    typeof energyCapacityAvailable === 'number' &&
+    Number.isFinite(energyCapacityAvailable) &&
+    energyCapacityAvailable > 0 &&
+    energyAvailable >= energyCapacityAvailable
+  );
+}

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -7,7 +7,7 @@ import {
   selectWorkerTask,
   shouldReserveCarriedEnergyForNearTermSpawnExtensionRefill
 } from '../tasks/workerTasks';
-import { signOccupiedControllerIfNeeded } from '../territory/controllerSigning';
+import { runUpgrader } from './upgraderRunner';
 import { canCreepPressureTerritoryController } from '../territory/territoryPlanner';
 import { checkEnergyBufferForSpending } from '../economy/energyBuffer';
 import { findSourceContainer } from '../economy/sourceContainers';
@@ -1105,8 +1105,7 @@ function executeTask(
 
       return toTaskExecutionResult(creep.reserveController(target as StructureController), 'work');
     case 'upgrade':
-      signOccupiedControllerIfNeeded(creep, target as StructureController);
-      return toTaskExecutionResult(creep.upgradeController(target as StructureController), 'work');
+      return toTaskExecutionResult(runUpgrader(creep, target as StructureController), 'work');
   }
 }
 

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -208,7 +208,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       successfulSpawnCount += 1;
       recordPlannedMultiRoomUpgraderSpawn(spawnRequest.memory);
 
-      if (spawnRequest.memory.role !== 'worker') {
+      if (spawnRequest.memory.role !== 'worker' || isControllerUpgradeSpawnRequest(spawnRequest)) {
         break;
       }
 
@@ -1042,6 +1042,10 @@ function isAllowedPostSpawnRequest(spawnRequest: SpawnRequest): boolean {
     isTerritoryControllerPressureSpawnRequest(spawnRequest) ||
     isTerritoryControllerFollowUpSpawnRequest(spawnRequest)
   );
+}
+
+function isControllerUpgradeSpawnRequest(spawnRequest: SpawnRequest): boolean {
+  return spawnRequest.memory.role === 'worker' && spawnRequest.memory.controllerUpgrade !== undefined;
 }
 
 function isTerritoryControllerPressureSpawnRequest(spawnRequest: SpawnRequest): boolean {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -81,6 +81,7 @@ import {
   runTerritoryControllerCreep
 } from '../territory/territoryRunner';
 import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgrader';
+import { refreshControllerManagement } from '../territory/controllerManager';
 import {
   recordPostClaimBootstrapWorkerSpawn,
   refreshPostClaimBootstrap
@@ -140,9 +141,22 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
     plannedRoleCountsByRoom.set(colony.room.name, roleCounts);
+    const workerTarget = getWorkerTarget(colony, roleCounts);
     const survivalAssessment = assessColonySnapshotSurvival(colony, roleCounts);
     recordColonySurvivalAssessment(colony.room.name, survivalAssessment, Game.time);
     persistColonyStageAssessment(colony, survivalAssessment, Game.time);
+    refreshControllerManagement(
+      colony,
+      roleCounts,
+      workerTarget,
+      Game.time,
+      {
+        competingSpawnDemand:
+          survivalAssessment.mode !== 'TERRITORY_READY' ||
+          survivalAssessment.hostilePresence ||
+          survivalAssessment.controllerDowngradeGuard
+      }
+    );
     refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
     planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
     if (survivalAssessment.mode === 'TERRITORY_READY') {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -46,6 +46,10 @@ import {
   buildMultiRoomUpgraderMemory,
   selectMultiRoomUpgradePlans
 } from '../territory/multiRoomUpgrader';
+import {
+  buildControllerUpgradeCreepMemory,
+  selectControllerUpgradeSpawnDemand
+} from '../territory/controllerManager';
 import { isLiveTransferCandidate } from '../economy/crossRoomHauler';
 
 type SpawnPriorityTier =
@@ -56,6 +60,7 @@ type SpawnPriorityTier =
   | 'postClaimControllerSustain'
   | 'remoteEconomy'
   | 'territoryRemote'
+  | 'controllerUpgradeDemand'
   | 'multiRoomControllerUpgrade'
   | 'controllerUpgradeSurplus';
 
@@ -123,6 +128,7 @@ const SPAWN_PRIORITY_TIERS: SpawnPriorityTier[] = [
   'postClaimControllerSustain',
   'remoteEconomy',
   'territoryRemote',
+  'controllerUpgradeDemand',
   'multiRoomControllerUpgrade',
   'controllerUpgradeSurplus'
 ];
@@ -222,6 +228,8 @@ function planSpawnForPriorityTier(
       return planDefenseSpawnForContext(context);
     case 'territoryRemote':
       return planTerritoryRemoteSpawn(context);
+    case 'controllerUpgradeDemand':
+      return planControllerUpgradeDemandSpawn(context);
     case 'multiRoomControllerUpgrade':
       return planMultiRoomControllerUpgradeSpawn(context);
     case 'controllerUpgradeSurplus':
@@ -810,6 +818,48 @@ function planControllerUpgradeSurplusSpawn(context: SpawnPlanningContext): Spawn
   }
 
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
+}
+
+function planControllerUpgradeDemandSpawn(context: SpawnPlanningContext): SpawnRequest | null {
+  if (
+    context.options.workersOnly ||
+    context.territoryIntentPending ||
+    context.survival.mode !== 'TERRITORY_READY' ||
+    hasControllerUpgradeBlockingTerritoryWork(context.colony) ||
+    (context.workerCapacity > 0 && shouldSuppressWorkerSpawnForCrossRoomImport(context.colony))
+  ) {
+    return null;
+  }
+
+  const demand = selectControllerUpgradeSpawnDemand(
+    context.colony,
+    context.roleCounts,
+    context.workerTarget,
+    context.gameTime
+  );
+  if (!demand) {
+    return null;
+  }
+
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+
+  const body = selectWorkerBody(context.colony, context.roleCounts);
+  if (body.length === 0) {
+    return null;
+  }
+
+  return {
+    spawn,
+    body,
+    name: appendSpawnNameSuffix(
+      `worker-${context.colony.room.name}-controller-upgrader-${context.gameTime}`,
+      context.options
+    ),
+    memory: buildControllerUpgradeCreepMemory(demand, context.gameTime)
+  };
 }
 
 function planMultiRoomControllerUpgradeSpawn(context: SpawnPlanningContext): SpawnRequest | null {

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -822,7 +822,6 @@ function planControllerUpgradeSurplusSpawn(context: SpawnPlanningContext): Spawn
 
 function planControllerUpgradeDemandSpawn(context: SpawnPlanningContext): SpawnRequest | null {
   if (
-    context.options.workersOnly ||
     context.territoryIntentPending ||
     context.survival.mode !== 'TERRITORY_READY' ||
     hasControllerUpgradeBlockingTerritoryWork(context.colony) ||
@@ -835,7 +834,8 @@ function planControllerUpgradeDemandSpawn(context: SpawnPlanningContext): SpawnR
     context.colony,
     context.roleCounts,
     context.workerTarget,
-    context.gameTime
+    context.gameTime,
+    { allowReservedSpawnEnergy: isWorkerOnlyFollowUpPass(context.options) }
   );
   if (!demand) {
     return null;
@@ -1108,6 +1108,10 @@ function planWorkerSpawnWithBody(
 
 function appendSpawnNameSuffix(baseName: string, options: SpawnPlanningOptions): string {
   return options.nameSuffix ? `${baseName}-${options.nameSuffix}` : baseName;
+}
+
+function isWorkerOnlyFollowUpPass(options: SpawnPlanningOptions): boolean {
+  return options.workersOnly === true && isNonEmptyString(options.nameSuffix);
 }
 
 function selectWorkerBody(colony: ColonySnapshot, roleCounts: RoleCounts): BodyPartConstant[] {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -4,6 +4,9 @@ import {
   selectVisibleTerritoryControllerTask
 } from '../territory/territoryPlanner';
 import {
+  getControllerUpgradePriority
+} from '../creeps/upgraderRunner';
+import {
   getRecordedColonySurvivalAssessment,
   suppressesBootstrapNonCriticalWork,
   suppressesTerritoryWork,
@@ -380,6 +383,11 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
     return applyMinimumUsefulLoadPolicy(creep, controllerSustainUpgradeTask);
   }
 
+  const managedControllerUpgradeTask = selectManagedControllerUpgradeTask(creep, controller, carriedEnergy);
+  if (managedControllerUpgradeTask) {
+    return applyMinimumUsefulLoadPolicy(creep, managedControllerUpgradeTask);
+  }
+
   const constructionSites = creep.room.find(FIND_CONSTRUCTION_SITES);
   const constructionReservationContext =
     constructionSites.length > 0
@@ -604,6 +612,26 @@ function selectControllerSustainUpgradeTask(
   return { type: 'upgrade', targetId: controller.id };
 }
 
+function selectManagedControllerUpgradeTask(
+  creep: Creep,
+  controller: StructureController | undefined,
+  carriedEnergy: number
+): Extract<CreepTaskMemory, { type: 'upgrade' }> | null {
+  const upgrade = creep.memory?.controllerUpgrade;
+  if (
+    carriedEnergy <= 0 ||
+    !upgrade ||
+    upgrade.roomName !== creep.room?.name ||
+    controller?.my !== true ||
+    controller.id !== upgrade.controllerId ||
+    !canUpgradeController(controller)
+  ) {
+    return null;
+  }
+
+  return { type: 'upgrade', targetId: controller.id };
+}
+
 function selectUpgraderBoostUpgradeTask(
   creep: Creep,
   controller: StructureController | undefined,
@@ -669,7 +697,11 @@ export function isUpgraderBoostActive(
 }
 
 function isUpgraderCreep(creep: Creep): boolean {
-  return creep.memory?.role === 'upgrader' || creep.memory?.controllerSustain?.role === 'upgrader';
+  return (
+    creep.memory?.role === 'upgrader' ||
+    creep.memory?.controllerSustain?.role === 'upgrader' ||
+    creep.memory?.controllerUpgrade !== undefined
+  );
 }
 
 function isControllerNearLevelUp(controller: StructureController | undefined): controller is StructureController {
@@ -4204,7 +4236,17 @@ function shouldUseSurplusForControllerProgress(creep: Creep, controller: Structu
     return true;
   }
 
-  if (controller.my === true && controller.level >= 2 && hasRecoverableSurplusEnergy(creep)) {
+  const hasRecoverableEnergySurplus = hasRecoverableSurplusEnergy(creep);
+  const upgradePriority = getControllerUpgradePriority(controller, {
+    energyAvailable: getRoomEnergyAvailable(creep.room) ?? undefined,
+    energyCapacityAvailable: getRoomEnergyCapacityAvailable(creep.room) ?? undefined,
+    hasEnergySurplus: hasRecoverableEnergySurplus
+  });
+  if (
+    controller.my === true &&
+    controller.level >= 2 &&
+    (upgradePriority === 'rclProgress' || upgradePriority === 'energySurplus')
+  ) {
     return true;
   }
 

--- a/prod/src/territory/controllerManager.ts
+++ b/prod/src/territory/controllerManager.ts
@@ -1,0 +1,274 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { getWorkerCapacity, WORKER_REPLACEMENT_TICKS_TO_LIVE, type RoleCounts } from '../creeps/roleCounts';
+import {
+  getControllerUpgradePriority,
+  isControllerProgressPressure,
+  type ControllerUpgradePriority
+} from '../creeps/upgraderRunner';
+import { shouldSignOccupiedController } from './controllerSigning';
+
+export interface ControllerManagementOptions {
+  competingSpawnDemand?: boolean;
+  activeUpgraderCount?: number;
+}
+
+export interface ControllerUpgradeSpawnDemand {
+  roomName: string;
+  controllerId: Id<StructureController>;
+  priority: ControllerUpgradePriority;
+  desiredUpgraderCount: number;
+  activeUpgraderCount: number;
+}
+
+export interface ControllerManagementPlan {
+  roomName: string;
+  updatedAt: number;
+  controllerId?: Id<StructureController>;
+  signNeeded: boolean;
+  upgradePriority: ControllerUpgradePriority;
+  desiredUpgraderCount: number;
+  activeUpgraderCount: number;
+  progressRatio?: number;
+  ticksToDowngrade?: number;
+  spawnDemand?: ControllerUpgradeSpawnDemand;
+}
+
+const CONTROLLER_PROGRESS_DEMAND_UPGRADERS = 1;
+const CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY = 550;
+
+export function refreshControllerManagement(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  workerTarget: number,
+  gameTime: number,
+  options: ControllerManagementOptions = {}
+): ControllerManagementPlan {
+  const plan = buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTime, options);
+  persistControllerManagementPlan(plan);
+  return plan;
+}
+
+export function selectControllerUpgradeSpawnDemand(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  workerTarget: number,
+  gameTime: number,
+  options: ControllerManagementOptions = {}
+): ControllerUpgradeSpawnDemand | null {
+  return buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTime, options).spawnDemand ?? null;
+}
+
+export function buildControllerUpgradeCreepMemory(
+  demand: ControllerUpgradeSpawnDemand,
+  gameTime: number
+): CreepMemory {
+  return {
+    role: 'worker',
+    colony: demand.roomName,
+    controllerUpgrade: {
+      roomName: demand.roomName,
+      controllerId: demand.controllerId,
+      priority: demand.priority,
+      assignedAt: gameTime
+    }
+  };
+}
+
+export function buildControllerManagementPlan(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  workerTarget: number,
+  gameTime: number,
+  options: ControllerManagementOptions = {}
+): ControllerManagementPlan {
+  const roomName = colony.room.name;
+  const controller = colony.room.controller;
+  if (controller?.my !== true || !isNonEmptyString(controller.id)) {
+    return {
+      roomName,
+      updatedAt: gameTime,
+      signNeeded: false,
+      upgradePriority: 'none',
+      desiredUpgraderCount: 0,
+      activeUpgraderCount: 0
+    };
+  }
+
+  const controllerId = controller.id;
+  const activeUpgraderCount =
+    options.activeUpgraderCount ?? countActiveControllerUpgraders(roomName, controllerId);
+  const upgradePriority = getControllerUpgradePriority(controller, {
+    energyAvailable: colony.energyAvailable,
+    energyCapacityAvailable: colony.energyCapacityAvailable,
+    competingSpawnDemand: options.competingSpawnDemand
+  });
+  const desiredUpgraderCount = getDesiredControllerUpgraderCount(upgradePriority);
+  const plan: ControllerManagementPlan = {
+    roomName,
+    updatedAt: gameTime,
+    controllerId,
+    signNeeded: shouldSignOccupiedController(controller),
+    upgradePriority,
+    desiredUpgraderCount,
+    activeUpgraderCount,
+    ...getControllerProgressRatioField(controller),
+    ...getControllerTicksToDowngradeField(controller)
+  };
+
+  if (
+    shouldCreateControllerUpgradeSpawnDemand(
+      colony,
+      roleCounts,
+      workerTarget,
+      upgradePriority,
+      desiredUpgraderCount,
+      activeUpgraderCount,
+      options
+    )
+  ) {
+    plan.spawnDemand = {
+      roomName,
+      controllerId,
+      priority: upgradePriority,
+      desiredUpgraderCount,
+      activeUpgraderCount
+    };
+  }
+
+  return plan;
+}
+
+function shouldCreateControllerUpgradeSpawnDemand(
+  colony: ColonySnapshot,
+  roleCounts: RoleCounts,
+  workerTarget: number,
+  upgradePriority: ControllerUpgradePriority,
+  desiredUpgraderCount: number,
+  activeUpgraderCount: number,
+  options: ControllerManagementOptions
+): boolean {
+  return (
+    upgradePriority === 'rclProgress' &&
+    desiredUpgraderCount > activeUpgraderCount &&
+    options.competingSpawnDemand !== true &&
+    getWorkerCapacity(roleCounts) >= workerTarget &&
+    colony.energyCapacityAvailable >= CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY &&
+    colony.energyAvailable >= colony.energyCapacityAvailable
+  );
+}
+
+function getDesiredControllerUpgraderCount(priority: ControllerUpgradePriority): number {
+  return priority === 'rclProgress' ? CONTROLLER_PROGRESS_DEMAND_UPGRADERS : 0;
+}
+
+function countActiveControllerUpgraders(
+  roomName: string,
+  controllerId: Id<StructureController>
+): number {
+  const creeps = (globalThis as unknown as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  if (!creeps) {
+    return 0;
+  }
+
+  return Object.values(creeps).filter((creep) =>
+    canSatisfyControllerUpgradeDemand(creep, roomName, controllerId)
+  ).length;
+}
+
+function canSatisfyControllerUpgradeDemand(
+  creep: Creep,
+  roomName: string,
+  controllerId: Id<StructureController>
+): boolean {
+  if (creep.ticksToLive !== undefined && creep.ticksToLive <= WORKER_REPLACEMENT_TICKS_TO_LIVE) {
+    return false;
+  }
+
+  const upgradeMemory = creep.memory.controllerUpgrade;
+  if (
+    creep.memory.role === 'worker' &&
+    upgradeMemory?.roomName === roomName &&
+    upgradeMemory.controllerId === controllerId
+  ) {
+    return true;
+  }
+
+  const task = creep.memory.task;
+  return (
+    creep.memory.role === 'worker' &&
+    creep.memory.colony === roomName &&
+    creep.room?.name === roomName &&
+    task?.type === 'upgrade' &&
+    task.targetId === controllerId
+  );
+}
+
+function persistControllerManagementPlan(plan: ControllerManagementPlan): void {
+  const memory = (globalThis as unknown as { Memory?: Partial<Memory> }).Memory;
+  if (!memory) {
+    return;
+  }
+
+  const territory = memory.territory ?? {};
+  memory.territory = territory;
+  const controllers = territory.controllers ?? {};
+  territory.controllers = controllers;
+
+  if (!plan.controllerId) {
+    delete controllers[plan.roomName];
+    return;
+  }
+
+  controllers[plan.roomName] = {
+    roomName: plan.roomName,
+    controllerId: plan.controllerId,
+    signNeeded: plan.signNeeded,
+    upgradePriority: plan.upgradePriority,
+    desiredUpgraderCount: plan.desiredUpgraderCount,
+    activeUpgraderCount: plan.activeUpgraderCount,
+    updatedAt: plan.updatedAt,
+    ...(typeof plan.progressRatio === 'number' ? { progressRatio: plan.progressRatio } : {}),
+    ...(typeof plan.ticksToDowngrade === 'number' ? { ticksToDowngrade: plan.ticksToDowngrade } : {}),
+    ...(plan.spawnDemand
+      ? {
+          spawnDemand: {
+            controllerId: plan.spawnDemand.controllerId,
+            priority: plan.spawnDemand.priority,
+            desiredUpgraderCount: plan.spawnDemand.desiredUpgraderCount,
+            activeUpgraderCount: plan.spawnDemand.activeUpgraderCount
+          }
+        }
+      : {})
+  };
+}
+
+function getControllerProgressRatioField(
+  controller: StructureController
+): Pick<ControllerManagementPlan, 'progressRatio'> {
+  if (!isControllerProgressPressure(controller)) {
+    return {};
+  }
+
+  const progress = controller.progress;
+  const progressTotal = controller.progressTotal;
+  return typeof progress === 'number' &&
+    typeof progressTotal === 'number' &&
+    Number.isFinite(progress) &&
+    Number.isFinite(progressTotal) &&
+    progressTotal > 0
+    ? { progressRatio: Math.max(0, progress) / progressTotal }
+    : {};
+}
+
+function getControllerTicksToDowngradeField(
+  controller: StructureController
+): Pick<ControllerManagementPlan, 'ticksToDowngrade'> {
+  return typeof controller.ticksToDowngrade === 'number' &&
+    Number.isFinite(controller.ticksToDowngrade)
+    ? { ticksToDowngrade: controller.ticksToDowngrade }
+    : {};
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/prod/src/territory/controllerManager.ts
+++ b/prod/src/territory/controllerManager.ts
@@ -10,6 +10,7 @@ import { shouldSignOccupiedController } from './controllerSigning';
 export interface ControllerManagementOptions {
   competingSpawnDemand?: boolean;
   activeUpgraderCount?: number;
+  allowReservedSpawnEnergy?: boolean;
 }
 
 export interface ControllerUpgradeSpawnDemand {
@@ -98,7 +99,8 @@ export function buildControllerManagementPlan(
   const activeUpgraderCount =
     options.activeUpgraderCount ?? countActiveControllerUpgraders(roomName, controllerId);
   const upgradePriority = getControllerUpgradePriority(controller, {
-    energyAvailable: colony.energyAvailable,
+    energyAvailable:
+      options.allowReservedSpawnEnergy === true ? colony.energyCapacityAvailable : colony.energyAvailable,
     energyCapacityAvailable: colony.energyCapacityAvailable,
     competingSpawnDemand: options.competingSpawnDemand
   });
@@ -152,9 +154,23 @@ function shouldCreateControllerUpgradeSpawnDemand(
     desiredUpgraderCount > activeUpgraderCount &&
     options.competingSpawnDemand !== true &&
     getWorkerCapacity(roleCounts) >= workerTarget &&
-    colony.energyCapacityAvailable >= CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY &&
-    colony.energyAvailable >= colony.energyCapacityAvailable
+    hasControllerProgressDemandSpawnEnergy(colony, options)
   );
+}
+
+function hasControllerProgressDemandSpawnEnergy(
+  colony: ColonySnapshot,
+  options: ControllerManagementOptions
+): boolean {
+  if (colony.energyCapacityAvailable < CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY) {
+    return false;
+  }
+
+  if (options.allowReservedSpawnEnergy === true) {
+    return colony.energyAvailable >= CONTROLLER_PROGRESS_DEMAND_MIN_ENERGY_CAPACITY;
+  }
+
+  return colony.energyAvailable >= colony.energyCapacityAvailable;
 }
 
 function getDesiredControllerUpgraderCount(priority: ControllerUpgradePriority): number {
@@ -165,12 +181,12 @@ function countActiveControllerUpgraders(
   roomName: string,
   controllerId: Id<StructureController>
 ): number {
-  const creeps = (globalThis as unknown as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
-  if (!creeps) {
+  const game = (globalThis as unknown as { Game?: Partial<Pick<Game, 'creeps'>> }).Game;
+  if (!game?.creeps) {
     return 0;
   }
 
-  return Object.values(creeps).filter((creep) =>
+  return Object.values(game.creeps).filter((creep) =>
     canSatisfyControllerUpgradeDemand(creep, roomName, controllerId)
   ).length;
 }

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -41,6 +41,7 @@ declare global {
     defense?: CreepDefenseMemory;
     territory?: CreepTerritoryMemory;
     controllerSustain?: CreepControllerSustainMemory;
+    controllerUpgrade?: CreepControllerUpgradeMemory;
     remoteHarvester?: CreepRemoteHarvesterMemory;
     remoteHauler?: CreepRemoteHaulerMemory;
     workerEfficiency?: WorkerEfficiencySampleMemory;
@@ -99,11 +100,25 @@ declare global {
   }
 
   type CreepControllerSustainRole = 'upgrader' | 'hauler';
+  type ControllerUpgradePriority =
+    | 'none'
+    | 'downgradeGuard'
+    | 'rcl1Rush'
+    | 'rclProgress'
+    | 'energySurplus'
+    | 'fallback';
 
   interface CreepControllerSustainMemory {
     homeRoom: string;
     targetRoom: string;
     role: CreepControllerSustainRole;
+  }
+
+  interface CreepControllerUpgradeMemory {
+    roomName: string;
+    controllerId: Id<StructureController>;
+    priority: ControllerUpgradePriority;
+    assignedAt?: number;
   }
 
   interface CreepRemoteHarvesterMemory {
@@ -272,6 +287,7 @@ declare global {
     postClaimBootstraps?: Record<string, TerritoryPostClaimBootstrapMemory>;
     remoteMining?: Record<string, TerritoryRemoteMiningRoomMemory>;
     reservations?: Record<string, TerritoryReservationMemory>;
+    controllers?: Record<string, TerritoryControllerManagementMemory>;
     scoutAttempts?: Record<string, TerritoryScoutAttemptMemory>;
     scoutIntel?: Record<string, TerritoryScoutIntelMemory>;
     expansionCandidates?: TerritoryExpansionCandidateMemory[];
@@ -317,6 +333,26 @@ declare global {
     ticksToEnd: number;
     updatedAt: number;
     controllerId?: Id<StructureController>;
+  }
+
+  interface TerritoryControllerManagementMemory {
+    roomName: string;
+    controllerId: Id<StructureController>;
+    signNeeded: boolean;
+    upgradePriority: ControllerUpgradePriority;
+    desiredUpgraderCount: number;
+    activeUpgraderCount: number;
+    updatedAt: number;
+    progressRatio?: number;
+    ticksToDowngrade?: number;
+    spawnDemand?: TerritoryControllerUpgradeDemandMemory;
+  }
+
+  interface TerritoryControllerUpgradeDemandMemory {
+    controllerId: Id<StructureController>;
+    priority: ControllerUpgradePriority;
+    desiredUpgraderCount: number;
+    activeUpgraderCount: number;
   }
 
   interface TerritoryScoutControllerIntelMemory {

--- a/prod/test/controllerManager.test.ts
+++ b/prod/test/controllerManager.test.ts
@@ -68,6 +68,19 @@ describe('controller manager', () => {
     expect(plan.spawnDemand).toBeUndefined();
   });
 
+  it('treats missing Game state as no active controller upgraders', () => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+
+    const plan = buildControllerManagementPlan(makeColony(), { worker: 3 }, 3, 204);
+
+    expect(plan.activeUpgraderCount).toBe(0);
+    expect(plan.spawnDemand).toMatchObject({
+      roomName: 'W1N1',
+      controllerId: 'controller1',
+      priority: 'rclProgress'
+    });
+  });
+
   it('counts active controller upgraders before requesting another dedicated worker', () => {
     (globalThis as unknown as { Game: Partial<Game> }).Game = {
       creeps: {

--- a/prod/test/controllerManager.test.ts
+++ b/prod/test/controllerManager.test.ts
@@ -1,0 +1,152 @@
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import {
+  buildControllerUpgradeCreepMemory,
+  buildControllerManagementPlan,
+  refreshControllerManagement
+} from '../src/territory/controllerManager';
+
+describe('controller manager', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {} };
+  });
+
+  it('records owned controller sign state and near-level upgrade demand', () => {
+    const colony = makeColony({
+      controller: makeController({
+        sign: { username: 'other', text: 'legacy sign', time: 1, datetime: new Date('2026-05-07T00:00:00.000Z') }
+      })
+    });
+
+    const plan = refreshControllerManagement(colony, { worker: 3 }, 3, 200);
+
+    expect(plan).toMatchObject({
+      roomName: 'W1N1',
+      controllerId: 'controller1',
+      signNeeded: true,
+      upgradePriority: 'rclProgress',
+      desiredUpgraderCount: 1,
+      activeUpgraderCount: 0,
+      progressRatio: 0.9,
+      spawnDemand: {
+        roomName: 'W1N1',
+        controllerId: 'controller1',
+        priority: 'rclProgress',
+        desiredUpgraderCount: 1,
+        activeUpgraderCount: 0
+      }
+    });
+    expect(Memory.territory?.controllers?.W1N1).toEqual({
+      roomName: 'W1N1',
+      controllerId: 'controller1',
+      signNeeded: true,
+      upgradePriority: 'rclProgress',
+      desiredUpgraderCount: 1,
+      activeUpgraderCount: 0,
+      updatedAt: 200,
+      progressRatio: 0.9,
+      ticksToDowngrade: 10_000,
+      spawnDemand: {
+        controllerId: 'controller1',
+        priority: 'rclProgress',
+        desiredUpgraderCount: 1,
+        activeUpgraderCount: 0
+      }
+    });
+  });
+
+  it('suppresses progression spawn demand behind competing spawn work', () => {
+    const plan = buildControllerManagementPlan(
+      makeColony(),
+      { worker: 3 },
+      3,
+      201,
+      { competingSpawnDemand: true }
+    );
+
+    expect(plan.upgradePriority).toBe('fallback');
+    expect(plan.spawnDemand).toBeUndefined();
+  });
+
+  it('counts active controller upgraders before requesting another dedicated worker', () => {
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      creeps: {
+        Upgrader1: {
+          ticksToLive: 1_000,
+          memory: {
+            role: 'worker',
+            colony: 'W1N1',
+            controllerUpgrade: {
+              roomName: 'W1N1',
+              controllerId: 'controller1' as Id<StructureController>,
+              priority: 'rclProgress'
+            }
+          }
+        } as Creep
+      }
+    };
+
+    const plan = buildControllerManagementPlan(makeColony(), { worker: 3 }, 3, 202);
+
+    expect(plan.activeUpgraderCount).toBe(1);
+    expect(plan.spawnDemand).toBeUndefined();
+  });
+
+  it('builds dedicated controller-upgrade worker memory', () => {
+    expect(
+      buildControllerUpgradeCreepMemory(
+        {
+          roomName: 'W1N1',
+          controllerId: 'controller1' as Id<StructureController>,
+          priority: 'rclProgress',
+          desiredUpgraderCount: 1,
+          activeUpgraderCount: 0
+        },
+        203
+      )
+    ).toEqual({
+      role: 'worker',
+      colony: 'W1N1',
+      controllerUpgrade: {
+        roomName: 'W1N1',
+        controllerId: 'controller1',
+        priority: 'rclProgress',
+        assignedAt: 203
+      }
+    });
+  });
+
+  function makeColony({
+    controller = makeController(),
+    energyAvailable = 650,
+    energyCapacityAvailable = 650
+  }: {
+    controller?: StructureController;
+    energyAvailable?: number;
+    energyCapacityAvailable?: number;
+  } = {}): ColonySnapshot {
+    const room = {
+      name: 'W1N1',
+      controller
+    } as Room;
+    const spawn = { name: 'Spawn1', room } as StructureSpawn;
+    return {
+      room,
+      spawns: [spawn],
+      energyAvailable,
+      energyCapacityAvailable
+    };
+  }
+
+  function makeController(overrides: Partial<StructureController> = {}): StructureController {
+    return {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      progress: 900,
+      progressTotal: 1_000,
+      ticksToDowngrade: 10_000,
+      ...overrides
+    } as StructureController;
+  }
+});

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -538,6 +538,38 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 4 }, 127)).toBeNull();
   });
 
+  it('plans a dedicated local controller upgrader when RCL progress is near completion', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N19',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: {
+        ...makeSafeOwnedController(),
+        id: 'controller1' as Id<StructureController>,
+        progress: 900,
+        progressTotal: 1_000
+      } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {} };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(planSpawn(colony, { worker: 3 }, 129)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
+      name: 'worker-W1N19-controller-upgrader-129',
+      memory: {
+        role: 'worker',
+        colony: 'W1N19',
+        controllerUpgrade: {
+          roomName: 'W1N19',
+          controllerId: 'controller1',
+          priority: 'rclProgress',
+          assignedAt: 129
+        }
+      }
+    });
+  });
+
   it('waits on surplus controller workers until spawn energy is full', () => {
     const { colony } = makeColony({
       roomName: 'W1N18',

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -570,6 +570,70 @@ describe('planSpawn', () => {
     });
   });
 
+  it('keeps controller-upgrade demand eligible during worker-only follow-up passes', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N20',
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: {
+        ...makeSafeOwnedController(),
+        id: 'controller1' as Id<StructureController>,
+        progress: 900,
+        progressTotal: 1_000
+      } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {} };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(planSpawn(colony, { worker: 3 }, 130, { workersOnly: true, nameSuffix: '2' })).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move', 'move'],
+      name: 'worker-W1N20-controller-upgrader-130-2',
+      memory: {
+        role: 'worker',
+        colony: 'W1N20',
+        controllerUpgrade: {
+          roomName: 'W1N20',
+          controllerId: 'controller1',
+          priority: 'rclProgress',
+          assignedAt: 130
+        }
+      }
+    });
+  });
+
+  it('allows controller-upgrade demand to use reserved-energy worker-only follow-up budget', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N21',
+      energyAvailable: 600,
+      energyCapacityAvailable: 650,
+      controller: {
+        ...makeSafeOwnedController(),
+        id: 'controller1' as Id<StructureController>,
+        progress: 900,
+        progressTotal: 1_000
+      } as StructureController
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {} };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+
+    expect(planSpawn(colony, { worker: 3 }, 131, { workersOnly: true, nameSuffix: '2' })).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move', 'work', 'carry', 'move'],
+      name: 'worker-W1N21-controller-upgrader-131-2',
+      memory: {
+        role: 'worker',
+        colony: 'W1N21',
+        controllerUpgrade: {
+          roomName: 'W1N21',
+          controllerId: 'controller1',
+          priority: 'rclProgress',
+          assignedAt: 131
+        }
+      }
+    });
+  });
+
   it('waits on surplus controller workers until spawn energy is full', () => {
     const { colony } = makeColony({
       roomName: 'W1N18',

--- a/prod/test/upgraderRunner.test.ts
+++ b/prod/test/upgraderRunner.test.ts
@@ -1,0 +1,70 @@
+import {
+  getControllerUpgradePriority,
+  runUpgrader
+} from '../src/creeps/upgraderRunner';
+import { OCCUPIED_CONTROLLER_SIGN_TEXT } from '../src/territory/controllerSigning';
+
+describe('upgrader runner', () => {
+  it('prioritizes near-level controller progress only when spawn energy is ready', () => {
+    const controller = makeController({ progress: 900, progressTotal: 1_000 });
+
+    expect(
+      getControllerUpgradePriority(controller, {
+        energyAvailable: 650,
+        energyCapacityAvailable: 650
+      })
+    ).toBe('rclProgress');
+    expect(
+      getControllerUpgradePriority(controller, {
+        energyAvailable: 400,
+        energyCapacityAvailable: 650
+      })
+    ).toBe('fallback');
+  });
+
+  it('suppresses progression priority behind competing spawn demand', () => {
+    expect(
+      getControllerUpgradePriority(makeController({ progress: 900, progressTotal: 1_000 }), {
+        energyAvailable: 650,
+        energyCapacityAvailable: 650,
+        competingSpawnDemand: true
+      })
+    ).toBe('fallback');
+  });
+
+  it('keeps downgrade guard above normal progression scoring', () => {
+    expect(
+      getControllerUpgradePriority(makeController({ ticksToDowngrade: 1_000 }), {
+        energyAvailable: 650,
+        energyCapacityAvailable: 650
+      })
+    ).toBe('downgradeGuard');
+  });
+
+  it('signs owned controllers before upgrading', () => {
+    const controller = makeController({
+      sign: { username: 'other', text: 'old', time: 1, datetime: new Date('2026-05-07T00:00:00.000Z') }
+    });
+    const creep = {
+      signController: jest.fn().mockReturnValue(0),
+      upgradeController: jest.fn().mockReturnValue(0)
+    } as unknown as Creep;
+
+    expect(runUpgrader(creep, controller)).toBe(0);
+
+    expect(creep.signController).toHaveBeenCalledWith(controller, OCCUPIED_CONTROLLER_SIGN_TEXT);
+    expect(creep.upgradeController).toHaveBeenCalledWith(controller);
+  });
+
+  function makeController(overrides: Partial<StructureController> = {}): StructureController {
+    return {
+      id: 'controller1',
+      my: true,
+      level: 3,
+      progress: 100,
+      progressTotal: 1_000,
+      ticksToDowngrade: 10_000,
+      ...overrides
+    } as StructureController;
+  }
+});


### PR DESCRIPTION
Implements controller sign and upgrade management with RCL progression tracking.

## Changes
- `controllerManager.ts` — new module for controller signing and upgrade logic
- `upgraderRunner.ts` — new upgrader creep runner for RCL progression
- `economyLoop.ts` — controller upgrade integration into economy loop
- `workerTasks.ts` — upgrade task creation and reservation
- `workerRunner.ts` — worker upgrade behavior coordination
- `spawnPlanner.ts` — upgrader body planning and spawn scheduling
- `types.d.ts` — new types for controller and upgrade state

## Verification
- TypeScript typecheck: PASS
- All 1239 tests pass (57 suites)
- Build succeeds
- git diff --check clean

Refs #700