### PR TITLE
feat(territory): post-expansion room sustain with controller-attack prevention and downgrade guard hardening (#703)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -19217,6 +19217,9 @@ function planDefenseSpawnForRoom(colony, activeDefenderCount, gameTime, options)
   };
 }
 function planPostClaimControllerDefenseSpawn(context) {
+  if (context.survival.mode !== "TERRITORY_READY") {
+    return null;
+  }
   const defensePlan = selectPostClaimControllerDefensePlan(context.colony);
   if (!defensePlan) {
     return null;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -19035,8 +19035,9 @@ function isActiveRoomDefender(creep, roomName) {
   return isAssignedRoomDefender(creep, roomName) && ((_a = creep.room) == null ? void 0 : _a.name) === roomName && canSatisfyDefenderSpawnCapacity(creep);
 }
 function isAssignedRoomDefender(creep, roomName) {
-  var _a;
-  return creep.memory.role === DEFENDER_ROLE && ((_a = creep.memory.defense) == null ? void 0 : _a.homeRoom) === roomName && canSatisfyDefenderSpawnCapacity(creep);
+  var _a, _b;
+  const assignedRoom = (_b = (_a = creep.memory.defense) == null ? void 0 : _a.homeRoom) != null ? _b : creep.memory.colony;
+  return creep.memory.role === DEFENDER_ROLE && assignedRoom === roomName && canSatisfyDefenderSpawnCapacity(creep);
 }
 function canSatisfyDefenderSpawnCapacity(creep) {
   return (creep.ticksToLive === void 0 || creep.ticksToLive > 100) && hasActiveAttackPart2(creep);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1199,11 +1199,12 @@ function getDesiredDefenderCount(hostileCount) {
 }
 function planDefenderSpawn(input) {
   const hostileCreepCount = normalizeNonNegativeInteger(input.hostileCreepCount);
+  const pressureCount = Math.max(hostileCreepCount, input.controllerUnderAttack === true ? 1 : 0);
   const activeDefenderCount = normalizeNonNegativeInteger(input.activeDefenderCount);
-  if (hostileCreepCount <= 0 || activeDefenderCount >= getDesiredDefenderCount(hostileCreepCount)) {
+  if (pressureCount <= 0 || activeDefenderCount >= getDesiredDefenderCount(pressureCount)) {
     return null;
   }
-  const body = buildDefenderBody(input.energyAvailable, hostileCreepCount);
+  const body = buildDefenderBody(input.energyAvailable, pressureCount);
   if (body.length === 0) {
     return null;
   }
@@ -1235,6 +1236,9 @@ function shouldActivateSafeMode(input) {
     return true;
   }
   return input.hostileCreeps.length > SAFE_MODE_HOSTILE_COUNT_THRESHOLD && isControllerUnderAttack(controller, input.hostileCreeps);
+}
+function hasControllerAttackPressure(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.upgradeBlocked === "number" && controller.upgradeBlocked > 0;
 }
 function selectClosestTarget(origin, targets, options = {}) {
   const eligibleTargets = options.sameRoomOnly ? targets.filter((target) => isTargetInOriginRoom(origin, target)) : targets;
@@ -1296,7 +1300,7 @@ function isCriticalSpawnLossThreat(ownedSpawns, hostileCreeps) {
   return ownedSpawns.length === 0 || ownedSpawns.some(isCriticallyDamagedSpawn);
 }
 function isControllerUnderAttack(controller, hostileCreeps) {
-  if (typeof controller.upgradeBlocked === "number" && controller.upgradeBlocked > 0) {
+  if (hasControllerAttackPressure(controller)) {
     return true;
   }
   if (!controller.pos) {
@@ -1562,6 +1566,9 @@ function runDefender(creep, telemetryEvents) {
     return;
   }
   const target = selectDefenderTarget(creep);
+  if (!target && moveTowardAssignedDefenseRoom(creep)) {
+    return;
+  }
   if (target && typeof creep.attack === "function") {
     const attackResult = creep.attack(target);
     if (attackResult === ERR_NOT_IN_RANGE_CODE) {
@@ -1576,6 +1583,24 @@ function runDefender(creep, telemetryEvents) {
     }
     recordDefenderAction(creep, "defenderAttack", target, attackResult, telemetryEvents);
   }
+}
+function moveTowardAssignedDefenseRoom(creep) {
+  var _a, _b, _c, _d;
+  const defenseRoom = (_a = creep.memory.defense) == null ? void 0 : _a.homeRoom;
+  if (!defenseRoom || ((_b = creep.room) == null ? void 0 : _b.name) === defenseRoom || typeof creep.moveTo !== "function") {
+    return false;
+  }
+  const visibleRoom = (_d = (_c = globalThis.Game) == null ? void 0 : _c.rooms) == null ? void 0 : _d[defenseRoom];
+  if (visibleRoom == null ? void 0 : visibleRoom.controller) {
+    creep.moveTo(visibleRoom.controller);
+    return true;
+  }
+  const RoomPositionCtor = globalThis.RoomPosition;
+  if (typeof RoomPositionCtor !== "function") {
+    return false;
+  }
+  creep.moveTo(new RoomPositionCtor(25, 25, defenseRoom));
+  return true;
 }
 function shouldSuppressDefenderMove(creep, target) {
   var _a;
@@ -8607,6 +8632,15 @@ function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, optio
   const colonyOwnerUsername = getControllerOwnerUsername4(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord5();
   let intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
+  const refreshedExpiredClaims = refreshExpiredPostClaimClaimIntents(
+    territoryMemory,
+    intents,
+    colonyName,
+    gameTime
+  );
+  if (refreshedExpiredClaims.changed) {
+    intents = refreshedExpiredClaims.intents;
+  }
   const refreshedHostileSuspensions = refreshHostileTerritoryIntentSuspensions(
     territoryMemory,
     intents,
@@ -9060,6 +9094,56 @@ function hasActivePostClaimBootstrap(colonyName) {
   return Object.values(records).some(
     (record) => isRecord9(record) && record.colony === colonyName && record.status !== "ready"
   );
+}
+function refreshExpiredPostClaimClaimIntents(territoryMemory, intents, colonyName, gameTime) {
+  if (!territoryMemory || !isRecord9(territoryMemory.postClaimBootstraps)) {
+    return { intents, changed: false };
+  }
+  let changed = false;
+  const nextIntents = intents;
+  for (const record of getExpiredPostClaimClaimRefreshRecords(territoryMemory, colonyName)) {
+    const controller = getVisibleController2(record.roomName, record.controllerId);
+    if (!controller || controller.my === true || isControllerOwned(controller)) {
+      continue;
+    }
+    if (isSuppressedTerritoryIntentForAction(nextIntents, colonyName, record.roomName, "claim", gameTime) || isTerritoryIntentSuspendedForAction(nextIntents, colonyName, record.roomName, "claim", gameTime)) {
+      continue;
+    }
+    const controllerId = isNonEmptyString8(controller.id) ? controller.id : record.controllerId;
+    const claimTarget = {
+      colony: colonyName,
+      roomName: record.roomName,
+      action: "claim",
+      ...controllerId ? { controllerId } : {}
+    };
+    appendTerritoryTargetIfMissing(territoryMemory, claimTarget);
+    territoryMemory.intents = nextIntents;
+    upsertTerritoryIntent3(nextIntents, {
+      colony: colonyName,
+      targetRoom: record.roomName,
+      action: "claim",
+      status: "planned",
+      updatedAt: gameTime,
+      ...controllerId ? { controllerId } : {}
+    });
+    changed = true;
+  }
+  return { intents: nextIntents, changed };
+}
+function getExpiredPostClaimClaimRefreshRecords(territoryMemory, colonyName) {
+  const records = territoryMemory.postClaimBootstraps;
+  if (!isRecord9(records)) {
+    return [];
+  }
+  return Object.values(records).filter(
+    (record) => isPostClaimClaimRefreshRecord(record, colonyName)
+  ).sort(comparePostClaimClaimRefreshRecords);
+}
+function isPostClaimClaimRefreshRecord(record, colonyName) {
+  return isRecord9(record) && record.colony === colonyName && isNonEmptyString8(record.roomName) && record.roomName !== colonyName && isFiniteNumber7(record.claimedAt) && isFiniteNumber7(record.updatedAt) && isPostClaimRemoteMiningStatus(record.status);
+}
+function comparePostClaimClaimRefreshRecords(left, right) {
+  return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
 }
 function getGclLevel() {
   var _a, _b;
@@ -18939,9 +19023,20 @@ function countActiveRoomDefenders(roomName) {
   }
   return Object.values(game.creeps).filter((creep) => isActiveRoomDefender(creep, roomName)).length;
 }
+function countAssignedRoomDefenders(roomName) {
+  const game = globalThis.Game;
+  if (!(game == null ? void 0 : game.creeps)) {
+    return 0;
+  }
+  return Object.values(game.creeps).filter((creep) => isAssignedRoomDefender(creep, roomName)).length;
+}
 function isActiveRoomDefender(creep, roomName) {
-  var _a, _b;
-  return creep.memory.role === DEFENDER_ROLE && ((_a = creep.memory.defense) == null ? void 0 : _a.homeRoom) === roomName && ((_b = creep.room) == null ? void 0 : _b.name) === roomName && canSatisfyDefenderSpawnCapacity(creep);
+  var _a;
+  return isAssignedRoomDefender(creep, roomName) && ((_a = creep.room) == null ? void 0 : _a.name) === roomName && canSatisfyDefenderSpawnCapacity(creep);
+}
+function isAssignedRoomDefender(creep, roomName) {
+  var _a;
+  return creep.memory.role === DEFENDER_ROLE && ((_a = creep.memory.defense) == null ? void 0 : _a.homeRoom) === roomName && canSatisfyDefenderSpawnCapacity(creep);
 }
 function canSatisfyDefenderSpawnCapacity(creep) {
   return (creep.ticksToLive === void 0 || creep.ticksToLive > 100) && hasActiveAttackPart2(creep);
@@ -19076,19 +19171,27 @@ function isClaimedRoomEnergyInsufficient(room) {
   return typeof energyAvailable !== "number" || energyAvailable < POST_CLAIM_SUSTAIN_MIN_HAULER_ENERGY;
 }
 function planDefenseSpawnForContext(context) {
-  if (!context.survival.hostilePresence || context.options.workersOnly) {
+  if (context.options.workersOnly) {
     return null;
   }
-  return planDefenseSpawnForRoom(
-    context.colony,
-    countActiveRoomDefenders(context.colony.room.name),
-    context.gameTime,
-    context.options
-  );
+  if (context.survival.hostilePresence || hasControllerAttackPressure(context.colony.room.controller)) {
+    const localDefenseSpawn = planDefenseSpawnForRoom(
+      context.colony,
+      countActiveRoomDefenders(context.colony.room.name),
+      context.gameTime,
+      context.options
+    );
+    if (localDefenseSpawn) {
+      return localDefenseSpawn;
+    }
+  }
+  return planPostClaimControllerDefenseSpawn(context);
 }
 function planDefenseSpawnForRoom(colony, activeDefenderCount, gameTime, options) {
   const hostileCount = getRoomHostileCreepCount(colony.room);
-  if (hostileCount === 0 || activeDefenderCount >= getDesiredDefenderCount(hostileCount)) {
+  const controllerUnderAttack = hasControllerAttackPressure(colony.room.controller);
+  const pressureCount = Math.max(hostileCount, controllerUnderAttack ? 1 : 0);
+  if (pressureCount === 0 || activeDefenderCount >= getDesiredDefenderCount(pressureCount)) {
     return null;
   }
   const spawn = colony.spawns.find((candidate) => !candidate.spawning);
@@ -19098,6 +19201,7 @@ function planDefenseSpawnForRoom(colony, activeDefenderCount, gameTime, options)
   const defenderPlan = planDefenderSpawn({
     roomName: colony.room.name,
     hostileCreepCount: hostileCount,
+    controllerUnderAttack,
     activeDefenderCount,
     energyAvailable: getSpawnEnergyBudget(colony),
     gameTime,
@@ -19110,6 +19214,48 @@ function planDefenseSpawnForRoom(colony, activeDefenderCount, gameTime, options)
     spawn,
     ...defenderPlan
   };
+}
+function planPostClaimControllerDefenseSpawn(context) {
+  const defensePlan = selectPostClaimControllerDefensePlan(context.colony);
+  if (!defensePlan) {
+    return null;
+  }
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+  const defenderPlan = planDefenderSpawn({
+    roomName: defensePlan.targetRoom,
+    hostileCreepCount: defensePlan.hostileCreepCount,
+    controllerUnderAttack: defensePlan.controllerUnderAttack,
+    activeDefenderCount: countAssignedRoomDefenders(defensePlan.targetRoom),
+    energyAvailable: getSpawnEnergyBudget(context.colony),
+    gameTime: context.gameTime,
+    nameSuffix: context.options.nameSuffix
+  });
+  if (!defenderPlan) {
+    return null;
+  }
+  return {
+    spawn,
+    ...defenderPlan
+  };
+}
+function selectPostClaimControllerDefensePlan(colony) {
+  var _a;
+  for (const record of getPostClaimControllerSustainRecords(colony.room.name)) {
+    const targetRoom = getVisibleRoom6(record.roomName);
+    const controllerUnderAttack = hasControllerAttackPressure(targetRoom == null ? void 0 : targetRoom.controller);
+    if (((_a = targetRoom == null ? void 0 : targetRoom.controller) == null ? void 0 : _a.my) !== true || !controllerUnderAttack) {
+      continue;
+    }
+    return {
+      targetRoom: record.roomName,
+      hostileCreepCount: getRoomHostileCreepCount(targetRoom),
+      controllerUnderAttack
+    };
+  }
+  return null;
 }
 function planRemoteEconomySpawn(context) {
   if (context.options.workersOnly || context.survival.mode !== "TERRITORY_READY" || context.workerCapacity < context.workerTarget || context.colony.energyAvailable < context.colony.energyCapacityAvailable) {

--- a/prod/src/defense/defenseLoop.ts
+++ b/prod/src/defense/defenseLoop.ts
@@ -19,6 +19,7 @@ export { DEFENDER_ROLE } from './defensePlanner';
 const MAX_RECORDED_DEFENSE_ACTIONS = 20;
 const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
 
+type RoomPositionConstructor = new (x: number, y: number, roomName: string) => RoomPosition;
 type CriticalOwnedStructure = StructureSpawn | StructureTower;
 type HostileTarget = Creep | Structure;
 type DefenseActionReason =
@@ -116,6 +117,10 @@ function runDefender(creep: Creep, telemetryEvents: RuntimeTelemetryEvent[]): vo
   }
 
   const target = selectDefenderTarget(creep);
+  if (!target && moveTowardAssignedDefenseRoom(creep)) {
+    return;
+  }
+
   if (target && typeof creep.attack === 'function') {
     const attackResult = creep.attack(target);
     if (attackResult === ERR_NOT_IN_RANGE_CODE) {
@@ -132,6 +137,27 @@ function runDefender(creep: Creep, telemetryEvents: RuntimeTelemetryEvent[]): vo
 
     recordDefenderAction(creep, 'defenderAttack', target, attackResult, telemetryEvents);
   }
+}
+
+function moveTowardAssignedDefenseRoom(creep: Creep): boolean {
+  const defenseRoom = creep.memory.defense?.homeRoom;
+  if (!defenseRoom || creep.room?.name === defenseRoom || typeof creep.moveTo !== 'function') {
+    return false;
+  }
+
+  const visibleRoom = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[defenseRoom];
+  if (visibleRoom?.controller) {
+    creep.moveTo(visibleRoom.controller);
+    return true;
+  }
+
+  const RoomPositionCtor = (globalThis as { RoomPosition?: RoomPositionConstructor }).RoomPosition;
+  if (typeof RoomPositionCtor !== 'function') {
+    return false;
+  }
+
+  creep.moveTo(new RoomPositionCtor(25, 25, defenseRoom));
+  return true;
 }
 
 function shouldSuppressDefenderMove(creep: Creep, target: HostileTarget): boolean {

--- a/prod/src/defense/defensePlanner.ts
+++ b/prod/src/defense/defensePlanner.ts
@@ -19,6 +19,7 @@ export interface DefensePressureSummary {
 export interface DefenderSpawnPlanInput {
   roomName: string;
   hostileCreepCount: number;
+  controllerUnderAttack?: boolean;
   activeDefenderCount: number;
   energyAvailable: number;
   gameTime: number;
@@ -72,13 +73,14 @@ export function getDesiredDefenderCount(hostileCount: number): number {
 
 export function planDefenderSpawn(input: DefenderSpawnPlanInput): DefenderSpawnPlan | null {
   const hostileCreepCount = normalizeNonNegativeInteger(input.hostileCreepCount);
+  const pressureCount = Math.max(hostileCreepCount, input.controllerUnderAttack === true ? 1 : 0);
   const activeDefenderCount = normalizeNonNegativeInteger(input.activeDefenderCount);
 
-  if (hostileCreepCount <= 0 || activeDefenderCount >= getDesiredDefenderCount(hostileCreepCount)) {
+  if (pressureCount <= 0 || activeDefenderCount >= getDesiredDefenderCount(pressureCount)) {
     return null;
   }
 
-  const body = buildDefenderBody(input.energyAvailable, hostileCreepCount);
+  const body = buildDefenderBody(input.energyAvailable, pressureCount);
   if (body.length === 0) {
     return null;
   }
@@ -132,6 +134,14 @@ export function shouldActivateSafeMode(input: SafeModePlanInput): boolean {
   return (
     input.hostileCreeps.length > SAFE_MODE_HOSTILE_COUNT_THRESHOLD &&
     isControllerUnderAttack(controller, input.hostileCreeps)
+  );
+}
+
+export function hasControllerAttackPressure(controller: StructureController | undefined): boolean {
+  return (
+    controller?.my === true &&
+    typeof controller.upgradeBlocked === 'number' &&
+    controller.upgradeBlocked > 0
   );
 }
 
@@ -226,7 +236,7 @@ function isCriticalSpawnLossThreat(ownedSpawns: StructureSpawn[], hostileCreeps:
 }
 
 function isControllerUnderAttack(controller: StructureController, hostileCreeps: Creep[]): boolean {
-  if (typeof controller.upgradeBlocked === 'number' && controller.upgradeBlocked > 0) {
+  if (hasControllerAttackPressure(controller)) {
     return true;
   }
 

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -394,9 +394,11 @@ function isActiveRoomDefender(creep: Creep, roomName: string): boolean {
 }
 
 function isAssignedRoomDefender(creep: Creep, roomName: string): boolean {
+  const assignedRoom = creep.memory.defense?.homeRoom ?? creep.memory.colony;
+
   return (
     creep.memory.role === DEFENDER_ROLE &&
-    creep.memory.defense?.homeRoom === roomName &&
+    assignedRoom === roomName &&
     canSatisfyDefenderSpawnCapacity(creep)
   );
 }

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -688,6 +688,10 @@ interface PostClaimControllerDefensePlan {
 }
 
 function planPostClaimControllerDefenseSpawn(context: SpawnPlanningContext): SpawnRequest | null {
+  if (context.survival.mode !== 'TERRITORY_READY') {
+    return null;
+  }
+
   const defensePlan = selectPostClaimControllerDefensePlan(context.colony);
   if (!defensePlan) {
     return null;

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -21,6 +21,7 @@ import {
 import {
   DEFENDER_ROLE,
   getDesiredDefenderCount,
+  hasControllerAttackPressure,
   planDefenderSpawn
 } from '../defense/defensePlanner';
 import {
@@ -375,11 +376,27 @@ function countActiveRoomDefenders(roomName: string): number {
   return Object.values(game.creeps).filter((creep) => isActiveRoomDefender(creep, roomName)).length;
 }
 
+function countAssignedRoomDefenders(roomName: string): number {
+  const game = (globalThis as unknown as { Game?: Partial<Pick<Game, 'creeps'>> }).Game;
+  if (!game?.creeps) {
+    return 0;
+  }
+
+  return Object.values(game.creeps).filter((creep) => isAssignedRoomDefender(creep, roomName)).length;
+}
+
 function isActiveRoomDefender(creep: Creep, roomName: string): boolean {
+  return (
+    isAssignedRoomDefender(creep, roomName) &&
+    creep.room?.name === roomName &&
+    canSatisfyDefenderSpawnCapacity(creep)
+  );
+}
+
+function isAssignedRoomDefender(creep: Creep, roomName: string): boolean {
   return (
     creep.memory.role === DEFENDER_ROLE &&
     creep.memory.defense?.homeRoom === roomName &&
-    creep.room?.name === roomName &&
     canSatisfyDefenderSpawnCapacity(creep)
   );
 }
@@ -606,16 +623,23 @@ export function planDefenseSpawn(room: Room): SpawnPlan | null {
 }
 
 function planDefenseSpawnForContext(context: SpawnPlanningContext): SpawnRequest | null {
-  if (!context.survival.hostilePresence || context.options.workersOnly) {
+  if (context.options.workersOnly) {
     return null;
   }
 
-  return planDefenseSpawnForRoom(
-    context.colony,
-    countActiveRoomDefenders(context.colony.room.name),
-    context.gameTime,
-    context.options
-  );
+  if (context.survival.hostilePresence || hasControllerAttackPressure(context.colony.room.controller)) {
+    const localDefenseSpawn = planDefenseSpawnForRoom(
+      context.colony,
+      countActiveRoomDefenders(context.colony.room.name),
+      context.gameTime,
+      context.options
+    );
+    if (localDefenseSpawn) {
+      return localDefenseSpawn;
+    }
+  }
+
+  return planPostClaimControllerDefenseSpawn(context);
 }
 
 function planDefenseSpawnForRoom(
@@ -625,7 +649,9 @@ function planDefenseSpawnForRoom(
   options: SpawnPlanningOptions
 ): SpawnRequest | null {
   const hostileCount = getRoomHostileCreepCount(colony.room);
-  if (hostileCount === 0 || activeDefenderCount >= getDesiredDefenderCount(hostileCount)) {
+  const controllerUnderAttack = hasControllerAttackPressure(colony.room.controller);
+  const pressureCount = Math.max(hostileCount, controllerUnderAttack ? 1 : 0);
+  if (pressureCount === 0 || activeDefenderCount >= getDesiredDefenderCount(pressureCount)) {
     return null;
   }
 
@@ -637,6 +663,7 @@ function planDefenseSpawnForRoom(
   const defenderPlan = planDefenderSpawn({
     roomName: colony.room.name,
     hostileCreepCount: hostileCount,
+    controllerUnderAttack,
     activeDefenderCount,
     energyAvailable: getSpawnEnergyBudget(colony),
     gameTime,
@@ -650,6 +677,60 @@ function planDefenseSpawnForRoom(
     spawn,
     ...defenderPlan
   };
+}
+
+interface PostClaimControllerDefensePlan {
+  targetRoom: string;
+  hostileCreepCount: number;
+  controllerUnderAttack: boolean;
+}
+
+function planPostClaimControllerDefenseSpawn(context: SpawnPlanningContext): SpawnRequest | null {
+  const defensePlan = selectPostClaimControllerDefensePlan(context.colony);
+  if (!defensePlan) {
+    return null;
+  }
+
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+
+  const defenderPlan = planDefenderSpawn({
+    roomName: defensePlan.targetRoom,
+    hostileCreepCount: defensePlan.hostileCreepCount,
+    controllerUnderAttack: defensePlan.controllerUnderAttack,
+    activeDefenderCount: countAssignedRoomDefenders(defensePlan.targetRoom),
+    energyAvailable: getSpawnEnergyBudget(context.colony),
+    gameTime: context.gameTime,
+    nameSuffix: context.options.nameSuffix
+  });
+  if (!defenderPlan) {
+    return null;
+  }
+
+  return {
+    spawn,
+    ...defenderPlan
+  };
+}
+
+function selectPostClaimControllerDefensePlan(colony: ColonySnapshot): PostClaimControllerDefensePlan | null {
+  for (const record of getPostClaimControllerSustainRecords(colony.room.name)) {
+    const targetRoom = getVisibleRoom(record.roomName);
+    const controllerUnderAttack = hasControllerAttackPressure(targetRoom?.controller);
+    if (targetRoom?.controller?.my !== true || !controllerUnderAttack) {
+      continue;
+    }
+
+    return {
+      targetRoom: record.roomName,
+      hostileCreepCount: getRoomHostileCreepCount(targetRoom),
+      controllerUnderAttack
+    };
+  }
+
+  return null;
 }
 
 function planRemoteEconomySpawn(context: SpawnPlanningContext): SpawnRequest | null {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1076,6 +1076,15 @@ function selectTerritoryTarget(
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
   const territoryMemory = getTerritoryMemoryRecord();
   let intents = normalizeTerritoryIntents(territoryMemory?.intents);
+  const refreshedExpiredClaims = refreshExpiredPostClaimClaimIntents(
+    territoryMemory,
+    intents,
+    colonyName,
+    gameTime
+  );
+  if (refreshedExpiredClaims.changed) {
+    intents = refreshedExpiredClaims.intents;
+  }
   const refreshedHostileSuspensions = refreshHostileTerritoryIntentSuspensions(
     territoryMemory,
     intents,
@@ -1728,6 +1737,94 @@ function hasActivePostClaimBootstrap(colonyName: string): boolean {
       record.colony === colonyName &&
       record.status !== 'ready'
   );
+}
+
+function refreshExpiredPostClaimClaimIntents(
+  territoryMemory: Record<string, unknown> | null,
+  intents: TerritoryIntentMemory[],
+  colonyName: string,
+  gameTime: number
+): { intents: TerritoryIntentMemory[]; changed: boolean } {
+  if (!territoryMemory || !isRecord(territoryMemory.postClaimBootstraps)) {
+    return { intents, changed: false };
+  }
+
+  let changed = false;
+  const nextIntents = intents;
+  for (const record of getExpiredPostClaimClaimRefreshRecords(territoryMemory, colonyName)) {
+    const controller = getVisibleController(record.roomName, record.controllerId);
+    if (!controller || controller.my === true || isControllerOwned(controller)) {
+      continue;
+    }
+
+    if (
+      isSuppressedTerritoryIntentForAction(nextIntents, colonyName, record.roomName, 'claim', gameTime) ||
+      isTerritoryIntentSuspendedForAction(nextIntents, colonyName, record.roomName, 'claim', gameTime)
+    ) {
+      continue;
+    }
+
+    const controllerId = isNonEmptyString(controller.id)
+      ? (controller.id as Id<StructureController>)
+      : record.controllerId;
+    const claimTarget: TerritoryTargetMemory = {
+      colony: colonyName,
+      roomName: record.roomName,
+      action: 'claim',
+      ...(controllerId ? { controllerId } : {})
+    };
+    appendTerritoryTargetIfMissing(territoryMemory as TerritoryMemory, claimTarget);
+    territoryMemory.intents = nextIntents;
+    upsertTerritoryIntent(nextIntents, {
+      colony: colonyName,
+      targetRoom: record.roomName,
+      action: 'claim',
+      status: 'planned',
+      updatedAt: gameTime,
+      ...(controllerId ? { controllerId } : {})
+    });
+    changed = true;
+  }
+
+  return { intents: nextIntents, changed };
+}
+
+function getExpiredPostClaimClaimRefreshRecords(
+  territoryMemory: Record<string, unknown>,
+  colonyName: string
+): TerritoryPostClaimBootstrapMemory[] {
+  const records = territoryMemory.postClaimBootstraps;
+  if (!isRecord(records)) {
+    return [];
+  }
+
+  return Object.values(records)
+    .filter((record): record is TerritoryPostClaimBootstrapMemory =>
+      isPostClaimClaimRefreshRecord(record, colonyName)
+    )
+    .sort(comparePostClaimClaimRefreshRecords);
+}
+
+function isPostClaimClaimRefreshRecord(
+  record: unknown,
+  colonyName: string
+): record is TerritoryPostClaimBootstrapMemory {
+  return (
+    isRecord(record) &&
+    record.colony === colonyName &&
+    isNonEmptyString(record.roomName) &&
+    record.roomName !== colonyName &&
+    isFiniteNumber(record.claimedAt) &&
+    isFiniteNumber(record.updatedAt) &&
+    isPostClaimRemoteMiningStatus(record.status)
+  );
+}
+
+function comparePostClaimClaimRefreshRecords(
+  left: TerritoryPostClaimBootstrapMemory,
+  right: TerritoryPostClaimBootstrapMemory
+): number {
+  return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
 }
 
 function getGclLevel(): number | null {

--- a/prod/test/defense.test.ts
+++ b/prod/test/defense.test.ts
@@ -146,6 +146,30 @@ describe('automatic room defense response', () => {
     expect(planDefenseSpawn(installSpawnPlanningRoom({ hostileCount: 1, energyAvailable: 139 }))).toBeNull();
   });
 
+  it('plans a defender when a claimed room controller is attack-blocked without visible hostiles', () => {
+    const controller = makeController({ upgradeBlocked: 12 });
+    const spawn = makeSpawn('spawn1');
+    const room = makeRoom({
+      controller,
+      structures: [spawn],
+      energyAvailable: 300,
+      energyCapacityAvailable: 300
+    });
+    attachRoom([spawn], room);
+    installGame(room, spawn);
+
+    expect(planDefenseSpawn(room)).toMatchObject({
+      spawn,
+      body: ['tough', 'attack', 'move'],
+      name: 'defender-W1N1-200',
+      memory: {
+        role: 'defender',
+        colony: 'W1N1',
+        defense: { homeRoom: 'W1N1' }
+      }
+    });
+  });
+
   it('activates safe mode when hostile pressure exceeds threshold and the controller is under attack', () => {
     const controller = makeController({
       safeModeAvailable: 1,
@@ -240,7 +264,6 @@ describe('automatic room defense response', () => {
   it('no-ops across towers, defender spawning, and safe mode when no hostiles are present', () => {
     const controller = makeController({
       safeModeAvailable: 1,
-      upgradeBlocked: 10,
       activateSafeMode: jest.fn().mockReturnValue(OK_CODE)
     });
     const spawn = makeSpawn('spawn1');

--- a/prod/test/defenseLoop.test.ts
+++ b/prod/test/defenseLoop.test.ts
@@ -463,6 +463,37 @@ describe('runDefense', () => {
     ]);
   });
 
+  it('moves an assigned post-claim defender toward its defense room before contact is visible', () => {
+    (globalThis as unknown as { RoomPosition: typeof RoomPosition }).RoomPosition = jest.fn(
+      (x: number, y: number, roomName: string) => ({ x, y, roomName }) as RoomPosition
+    ) as unknown as typeof RoomPosition;
+    const homeRoom = makeRoom({
+      roomName: 'W1N1',
+      controller: makeController()
+    });
+    const defender = {
+      name: 'Defender1',
+      memory: { role: 'defender', colony: 'W2N1', defense: { homeRoom: 'W2N1' } },
+      pos: makePosition(25, 25, 'W1N1'),
+      room: homeRoom,
+      attack: jest.fn().mockReturnValue(ERR_NOT_IN_RANGE_CODE),
+      moveTo: jest.fn().mockReturnValue(OK_CODE)
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 106,
+      rooms: { W1N1: homeRoom },
+      spawns: {},
+      creeps: { Defender1: defender }
+    };
+
+    const events = runDefense();
+
+    expect(defender.attack).not.toHaveBeenCalled();
+    expect(defender.moveTo).toHaveBeenCalledWith({ x: 25, y: 25, roomName: 'W2N1' });
+    expect(events).toEqual([]);
+    delete (globalThis as { RoomPosition?: typeof RoomPosition }).RoomPosition;
+  });
+
   it('does not path a defender toward a known enemy tower room when no safe route exists', () => {
     const hostileTower = makeHostileStructure('enemy-tower', 25, 25, 'W2N1', TEST_GLOBALS.STRUCTURE_TOWER);
     const deadZoneRoom = makeRoom({

--- a/prod/test/defensePlanner.test.ts
+++ b/prod/test/defensePlanner.test.ts
@@ -99,6 +99,27 @@ describe('defensePlanner', () => {
     ).toBeNull();
   });
 
+  it('plans a defender when an owned controller is attack-blocked even after hostiles leave vision', () => {
+    expect(
+      planDefenderSpawn({
+        roomName: 'W1N1',
+        hostileCreepCount: 0,
+        controllerUnderAttack: true,
+        activeDefenderCount: 0,
+        energyAvailable: 300,
+        gameTime: 124
+      })
+    ).toEqual({
+      body: ['tough', 'attack', 'move'],
+      name: 'defender-W1N1-124',
+      memory: {
+        role: 'defender',
+        colony: 'W1N1',
+        defense: { homeRoom: 'W1N1' }
+      }
+    });
+  });
+
   it('selects tower attack targets by hostile creep priority, range, and tower room', () => {
     const tower = { pos: makePosition(25, 25, 'W1N1') };
     const farHostile = makeCreep('hostile-z', 40, 25, 'W1N1');

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -849,7 +849,7 @@ describe('planSpawn', () => {
     expect(planSpawn(colony, { worker: 4 }, 173)).toBeNull();
   });
 
-  it('does not sustain a stale post-claim record after target room ownership is lost', () => {
+  it('reissues a claim instead of worker sustain after target room ownership is lost', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,
       energyCapacityAvailable: 650,
@@ -883,7 +883,63 @@ describe('planSpawn', () => {
       }
     };
 
-    expect(planSpawn(colony, { worker: 4 }, 174)).toBeNull();
+    expect(planSpawn(colony, { worker: 4 }, 174)).toEqual({
+      spawn,
+      body: ['claim', 'move'],
+      name: 'claimer-W1N1-W2N1-174',
+      memory: {
+        role: 'claimer',
+        colony: 'W1N1',
+        territory: { targetRoom: 'W2N1', action: 'claim', controllerId: 'controller2' }
+      }
+    });
+  });
+
+  it('uses the home spawn for a post-claim room defender when the target controller is attack-blocked', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTerritoryRoom('W2N1', {
+          id: 'controller2',
+          my: true,
+          level: 1,
+          upgradeBlocked: 20
+        } as StructureController)
+      },
+      spawns: { Spawn1: spawn },
+      creeps: {}
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'ready',
+            claimedAt: 174,
+            updatedAt: 175,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        }
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3 }, 176)).toEqual({
+      spawn,
+      body: ['tough', 'attack', 'move'],
+      name: 'defender-W2N1-176',
+      memory: {
+        role: 'defender',
+        colony: 'W2N1',
+        defense: { homeRoom: 'W2N1' }
+      }
+    });
   });
 
   it('keeps home worker recovery ahead of post-claim controller sustain', () => {
@@ -1325,6 +1381,25 @@ describe('planSpawn', () => {
       body: ['work', 'carry', 'move'],
       name: 'worker-W1N9-150',
       memory: { role: 'worker', colony: 'W1N9' }
+    });
+  });
+
+  it('plans a downgrade-guard worker for a non-primary claimed room through an available remote spawn', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W2N1',
+      energyAvailable: 300,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 1_500 } as StructureController
+    });
+    const homeRoom = { name: 'W1N1' } as Room;
+    const homeSpawn = { ...spawn, room: homeRoom } as StructureSpawn;
+    colony.spawns = [homeSpawn];
+
+    expect(planSpawn(colony, { worker: 3 }, 151)).toEqual({
+      spawn: homeSpawn,
+      body: ['work', 'carry', 'move'],
+      name: 'worker-W2N1-151',
+      memory: { role: 'worker', colony: 'W2N1' }
     });
   });
 

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -942,6 +942,44 @@ describe('planSpawn', () => {
     });
   });
 
+  it('suppresses post-claim room defenders while the home colony is in bootstrap recovery', () => {
+    const { colony, spawn } = makeColony({
+      energyAvailable: 140,
+      energyCapacityAvailable: 650,
+      controller: makeSafeOwnedController()
+    });
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: makeTerritoryRoom('W2N1', {
+          id: 'controller2',
+          my: true,
+          level: 1,
+          upgradeBlocked: 20
+        } as StructureController)
+      },
+      spawns: { Spawn1: spawn },
+      creeps: {}
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'ready',
+            claimedAt: 174,
+            updatedAt: 175,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          }
+        }
+      }
+    };
+
+    expect(planSpawn(colony, { worker: 3 }, 177)).toBeNull();
+  });
+
   it('keeps home worker recovery ahead of post-claim controller sustain', () => {
     const { colony, spawn } = makeColony({
       energyAvailable: 650,

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -6377,6 +6377,55 @@ describe('planTerritoryIntent', () => {
     });
   });
 
+  it('reissues a claim intent when a previously claimed post-expansion room becomes unowned', () => {
+    const colony = makeSafeColony();
+    const expiredController = {
+      id: 'controller2',
+      my: false,
+      level: 0
+    } as StructureController;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W1N1: colony.room,
+        W2N1: { name: 'W2N1', controller: expiredController } as Room
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: makeRemoteMiningBootstrap()
+        }
+      }
+    };
+
+    const plan = planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 706);
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      controllerId: 'controller2'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        controllerId: 'controller2'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 706,
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
   it('plans remote source container construction and records pending remote mining state', () => {
     (globalThis as unknown as {
       FIND_STRUCTURES: number;


### PR DESCRIPTION
## Summary
Implements post-expansion room sustain with controller-attack prevention and downgrade guard hardening for territory control.

## Changes
- **defenseLoop.ts**: Enhanced auto-defense with post-expansion sustain logic
- **defensePlanner.ts**: Defense planner updates for sustained territory protection
- **spawnPlanner.ts**: Spawn planning for territory sustain (controller guard, downgrade prevention)
- **territoryPlanner.ts**: Territory planning updates for sustained occupation
- Plus corresponding test updates

## Verification
- Typecheck: PASS
- Tests: 1254/1254 passing
- Build: OK
- git diff --check: clean

Refs #703