### PR TITLE
feat(territory): implement room claim with GCL-based expansion, scouting, and room evaluation (#711)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -5802,6 +5802,7 @@ var SYNERGY_SOURCE_DUPLICATE_PENALTY_PER_SOURCE = 40;
 var SYNERGY_DUAL_SOURCE_DUPLICATE_PENALTY = 80;
 var FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = "foreign reservation requires controller pressure";
 var ROOM_LIMIT_PRECONDITION_PREFIX = "limit expansion to ";
+var GCL_LIMIT_PRECONDITION = "wait for GCL capacity to claim another room";
 var MAX_ROOM_COUNT_BY_RCL = {
   1: 1,
   2: 1,
@@ -5887,10 +5888,12 @@ function validateVisibleNextExpansionScoutIntel(colony, candidate, gameTime, tel
 }
 function buildRuntimeExpansionScoringInput(colony) {
   var _a, _b;
+  const gclLevel = getGclLevel();
   return {
     colonyName: colony.room.name,
     ...getControllerOwnerUsername2(colony.room.controller) ? { colonyOwnerUsername: getControllerOwnerUsername2(colony.room.controller) } : {},
     energyCapacityAvailable: colony.energyCapacityAvailable,
+    ...gclLevel !== null ? { gclLevel } : {},
     ...typeof ((_a = colony.room.controller) == null ? void 0 : _a.level) === "number" ? { controllerLevel: colony.room.controller.level } : {},
     ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername2(colony.room.controller)),
     ...typeof ((_b = colony.room.controller) == null ? void 0 : _b.ticksToDowngrade) === "number" ? { ticksToDowngrade: colony.room.controller.ticksToDowngrade } : {},
@@ -6319,6 +6322,10 @@ function getExpansionPreconditions(input) {
     preconditions.push("reach controller level 2 before expansion");
   }
   const ownedRoomCount = getOwnedRoomCount(input);
+  const gclRoomCapacity = getGclClaimRoomCapacity(input);
+  if (gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity) {
+    preconditions.push(GCL_LIMIT_PRECONDITION);
+  }
   const maxRoomCount = maxRoomsForRcl(input.controllerLevel);
   if (ownedRoomCount >= maxRoomCount) {
     preconditions.push(`limit expansion to ${maxRoomCount} owned rooms for current controller level`);
@@ -6330,6 +6337,13 @@ function getExpansionPreconditions(input) {
     preconditions.push("finish active post-claim bootstrap before next expansion");
   }
   return preconditions;
+}
+function getGclClaimRoomCapacity(input) {
+  const level = input.gclLevel;
+  if (typeof level !== "number" || !Number.isFinite(level) || level <= 0) {
+    return null;
+  }
+  return Math.max(0, Math.floor(level));
 }
 function getOwnedRoomCount(input) {
   if (typeof input.ownedRoomCount !== "number" || !Number.isFinite(input.ownedRoomCount)) {
@@ -6365,6 +6379,9 @@ function getSelectionSkipReason(report) {
   if (report.candidates.length === 0) {
     return "noCandidate";
   }
+  if (report.candidates.some(hasGclLimitPrecondition)) {
+    return "gclInsufficient";
+  }
   if (report.candidates.some(hasRoomLimitPrecondition)) {
     return "roomLimitReached";
   }
@@ -6375,6 +6392,9 @@ function getSelectionSkipReason(report) {
     return "insufficientEvidence";
   }
   return "unavailable";
+}
+function hasGclLimitPrecondition(candidate) {
+  return candidate.preconditions.includes(GCL_LIMIT_PRECONDITION);
 }
 function hasRoomLimitPrecondition(candidate) {
   return candidate.preconditions.some(
@@ -6911,6 +6931,11 @@ function getGameTime7() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
+}
+function getGclLevel() {
+  var _a, _b;
+  const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
+  return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
 }
 function getTerritoryMemoryRecord3() {
   var _a;
@@ -9082,7 +9107,7 @@ function isColonyReadyForAdjacentReservationAutoClaim(colony) {
   if (ownedRoomCount >= maxRoomsForRcl(controllerLevel)) {
     return false;
   }
-  const gclLevel = getGclLevel();
+  const gclLevel = getGclLevel2();
   return typeof gclLevel !== "number" || ownedRoomCount < gclLevel;
 }
 function hasActivePostClaimBootstrap(colonyName) {
@@ -9145,7 +9170,7 @@ function isPostClaimClaimRefreshRecord(record, colonyName) {
 function comparePostClaimClaimRefreshRecords(left, right) {
   return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
 }
-function getGclLevel() {
+function getGclLevel2() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
@@ -24938,7 +24963,7 @@ function getAdjacentRoomClaimBlocker(colony) {
   }
   const ownerUsername = getControllerOwnerUsername7(controller);
   const ownedRoomCount = countVisibleOwnedRooms2(colony.room.name, ownerUsername);
-  const gclLevel = getGclLevel2();
+  const gclLevel = getGclLevel3();
   if (typeof gclLevel === "number" && ownedRoomCount >= gclLevel) {
     return "gclInsufficient";
   }
@@ -25168,7 +25193,7 @@ function countVisibleOwnedRooms2(colonyName, ownerUsername) {
   }
   return Math.max(1, ownedRoomCount || (((_d = (_c = rooms[colonyName]) == null ? void 0 : _c.controller) == null ? void 0 : _d.my) === true ? 1 : 0));
 }
-function getGclLevel2() {
+function getGclLevel3() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   if (typeof level !== "number" || !Number.isFinite(level) || level <= 0) {
@@ -25467,7 +25492,7 @@ function isColonyReadyToClaimMatureReservation(colony, controllerState) {
   if (ownedRoomCount >= maxRoomsForRcl(controllerLevel)) {
     return false;
   }
-  const gclLevel = getGclLevel3();
+  const gclLevel = getGclLevel4();
   return typeof gclLevel !== "number" || ownedRoomCount < gclLevel;
 }
 function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) {
@@ -25669,7 +25694,7 @@ function countVisibleOwnedRooms3(colonyName, ownerUsername) {
   }
   return Math.max(1, ownedRoomCount || (((_d = (_c = rooms[colonyName]) == null ? void 0 : _c.controller) == null ? void 0 : _d.my) === true ? 1 : 0));
 }
-function getGclLevel3() {
+function getGclLevel4() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
@@ -26631,7 +26656,7 @@ function refreshExecutableTerritoryRecommendation(colony, creeps, territoryReady
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);
       return;
     }
-    if (expansionSelection.reason === "roomLimitReached") {
+    if (expansionSelection.reason === "roomLimitReached" || expansionSelection.reason === "gclInsufficient") {
       const colonyName = colony.room.name;
       clearNextExpansionTargetIntent(colonyName);
       clearAutonomousExpansionClaimIntent(colonyName);
@@ -26732,7 +26757,7 @@ function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
   };
 }
 function normalizeNextExpansionTargetSelectionReason(reason) {
-  return reason === "noCandidate" || reason === "roomLimitReached" || reason === "unmetPreconditions" || reason === "insufficientEvidence" || reason === "unavailable" ? reason : void 0;
+  return reason === "noCandidate" || reason === "gclInsufficient" || reason === "roomLimitReached" || reason === "unmetPreconditions" || reason === "insufficientEvidence" || reason === "unavailable" ? reason : void 0;
 }
 function isNextExpansionTargetSelectionCacheReusable(cachedSelection, colony, gameTime, stateKey) {
   if (cachedSelection.stateKey !== stateKey || gameTime < cachedSelection.refreshedAt || gameTime - cachedSelection.refreshedAt >= NEXT_EXPANSION_SCORING_REFRESH_INTERVAL) {
@@ -26751,6 +26776,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
+  var _a;
   const controller = colony.room.controller;
   const controllerLevel = isFiniteNumber9(controller == null ? void 0 : controller.level) ? controller.level : "unknown";
   const downgradeState = isFiniteNumber9(controller == null ? void 0 : controller.ticksToDowngrade) && controller.ticksToDowngrade < NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS ? "guarded" : "stable";
@@ -26758,6 +26784,7 @@ function getNextExpansionSelectionCacheStateKey(colony) {
     colony.room.name,
     colony.energyCapacityAvailable,
     controllerLevel,
+    (_a = getGclLevel5()) != null ? _a : "unknown",
     countVisibleOwnedRooms5(),
     downgradeState,
     countActivePostClaimBootstraps3(),
@@ -26774,6 +26801,11 @@ function countVisibleOwnedRooms5() {
     var _a2;
     return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
   }).length;
+}
+function getGclLevel5() {
+  var _a, _b;
+  const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
+  return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
 }
 function countActivePostClaimBootstraps3() {
   var _a, _b;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -406,7 +406,7 @@ function refreshExecutableTerritoryRecommendation(
       persistOccupationRecommendationFollowUpIntent(clearOccupationRecommendationFollowUpIntent(report), Game.time);
       return;
     }
-    if (expansionSelection.reason === 'roomLimitReached') {
+    if (expansionSelection.reason === 'roomLimitReached' || expansionSelection.reason === 'gclInsufficient') {
       const colonyName = colony.room.name;
       clearNextExpansionTargetIntent(colonyName);
       clearAutonomousExpansionClaimIntent(colonyName);
@@ -546,6 +546,7 @@ function normalizeNextExpansionTargetSelectionReason(
   reason: unknown
 ): NextExpansionTargetSelection['reason'] | undefined {
   return reason === 'noCandidate' ||
+    reason === 'gclInsufficient' ||
     reason === 'roomLimitReached' ||
     reason === 'unmetPreconditions' ||
     reason === 'insufficientEvidence' ||
@@ -605,6 +606,7 @@ function getNextExpansionSelectionCacheStateKey(colony: ColonySnapshot): string 
     colony.room.name,
     colony.energyCapacityAvailable,
     controllerLevel,
+    getGclLevel() ?? 'unknown',
     countVisibleOwnedRooms(),
     downgradeState,
     countActivePostClaimBootstraps(),
@@ -619,6 +621,11 @@ function countVisibleOwnedRooms(): number {
   }
 
   return Object.values(rooms).filter((room) => room?.controller?.my === true).length;
+}
+
+function getGclLevel(): number | null {
+  const level = (globalThis as { Game?: Partial<Game> & { gcl?: { level?: number } } }).Game?.gcl?.level;
+  return typeof level === 'number' && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
 }
 
 function countActivePostClaimBootstraps(): number {

--- a/prod/src/territory/expansionScoring.ts
+++ b/prod/src/territory/expansionScoring.ts
@@ -38,6 +38,7 @@ const SYNERGY_SOURCE_DUPLICATE_PENALTY_PER_SOURCE = 40;
 const SYNERGY_DUAL_SOURCE_DUPLICATE_PENALTY = 80;
 const FOREIGN_RESERVATION_CONTROLLER_PRESSURE_RISK = 'foreign reservation requires controller pressure';
 const ROOM_LIMIT_PRECONDITION_PREFIX = 'limit expansion to ';
+const GCL_LIMIT_PRECONDITION = 'wait for GCL capacity to claim another room';
 const MAX_ROOM_COUNT_BY_RCL: Record<number, number> = {
   1: 1,
   2: 1,
@@ -86,6 +87,7 @@ export interface ExpansionScoringInput {
   colonyName: string;
   colonyOwnerUsername?: string;
   energyCapacityAvailable: number;
+  gclLevel?: number;
   controllerLevel?: number;
   ownedRoomCount?: number;
   ticksToDowngrade?: number;
@@ -155,6 +157,7 @@ type TerritoryMemoryWithExpansionCandidates = TerritoryMemory & {
 export type NextExpansionTargetSelectionStatus = 'planned' | 'skipped';
 export type NextExpansionTargetSelectionReason =
   | 'noCandidate'
+  | 'gclInsufficient'
   | 'roomLimitReached'
   | 'unmetPreconditions'
   | 'insufficientEvidence'
@@ -263,12 +266,14 @@ function validateVisibleNextExpansionScoutIntel(
 }
 
 function buildRuntimeExpansionScoringInput(colony: ColonySnapshot): ExpansionScoringInput {
+  const gclLevel = getGclLevel();
   return {
     colonyName: colony.room.name,
     ...(getControllerOwnerUsername(colony.room.controller)
       ? { colonyOwnerUsername: getControllerOwnerUsername(colony.room.controller) }
       : {}),
     energyCapacityAvailable: colony.energyCapacityAvailable,
+    ...(gclLevel !== null ? { gclLevel } : {}),
     ...(typeof colony.room.controller?.level === 'number' ? { controllerLevel: colony.room.controller.level } : {}),
     ownedRoomCount: countVisibleOwnedRooms(colony.room.name, getControllerOwnerUsername(colony.room.controller)),
     ...(typeof colony.room.controller?.ticksToDowngrade === 'number'
@@ -855,6 +860,11 @@ function getExpansionPreconditions(input: ExpansionScoringInput): string[] {
   }
 
   const ownedRoomCount = getOwnedRoomCount(input);
+  const gclRoomCapacity = getGclClaimRoomCapacity(input);
+  if (gclRoomCapacity !== null && ownedRoomCount >= gclRoomCapacity) {
+    preconditions.push(GCL_LIMIT_PRECONDITION);
+  }
+
   const maxRoomCount = maxRoomsForRcl(input.controllerLevel);
   if (ownedRoomCount >= maxRoomCount) {
     preconditions.push(`limit expansion to ${maxRoomCount} owned rooms for current controller level`);
@@ -869,6 +879,15 @@ function getExpansionPreconditions(input: ExpansionScoringInput): string[] {
   }
 
   return preconditions;
+}
+
+function getGclClaimRoomCapacity(input: ExpansionScoringInput): number | null {
+  const level = input.gclLevel;
+  if (typeof level !== 'number' || !Number.isFinite(level) || level <= 0) {
+    return null;
+  }
+
+  return Math.max(0, Math.floor(level));
 }
 
 function getOwnedRoomCount(input: ExpansionScoringInput): number {
@@ -919,6 +938,10 @@ function getSelectionSkipReason(report: ExpansionCandidateReport): NextExpansion
     return 'noCandidate';
   }
 
+  if (report.candidates.some(hasGclLimitPrecondition)) {
+    return 'gclInsufficient';
+  }
+
   if (report.candidates.some(hasRoomLimitPrecondition)) {
     return 'roomLimitReached';
   }
@@ -932,6 +955,10 @@ function getSelectionSkipReason(report: ExpansionCandidateReport): NextExpansion
   }
 
   return 'unavailable';
+}
+
+function hasGclLimitPrecondition(candidate: ExpansionCandidateScore): boolean {
+  return candidate.preconditions.includes(GCL_LIMIT_PRECONDITION);
 }
 
 function hasRoomLimitPrecondition(candidate: ExpansionCandidateScore): boolean {
@@ -1670,6 +1697,11 @@ function getVisibleRoom(roomName: string): Room | undefined {
 function getGameTime(): number {
   const gameTime = (globalThis as { Game?: Partial<Game> }).Game?.time;
   return typeof gameTime === 'number' ? gameTime : 0;
+}
+
+function getGclLevel(): number | null {
+  const level = (globalThis as { Game?: Partial<Game> & { gcl?: { level?: number } } }).Game?.gcl?.level;
+  return typeof level === 'number' && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
 }
 
 function getTerritoryMemoryRecord(): TerritoryMemory | undefined {

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -278,6 +278,7 @@ declare global {
   type RoomExpansionSelectionStatus = 'planned' | 'skipped';
   type RoomExpansionSelectionReason =
     | 'noCandidate'
+    | 'gclInsufficient'
     | 'roomLimitReached'
     | 'unmetPreconditions'
     | 'insufficientEvidence'

--- a/prod/test/colonyExpansionPlanner.test.ts
+++ b/prod/test/colonyExpansionPlanner.test.ts
@@ -187,6 +187,51 @@ describe('colony expansion planner', () => {
     expect(Memory.territory?.targets?.some((target) => target.action === 'claim')).toBe(false);
   });
 
+  it('reserves adjacent rooms instead of claiming when GCL capacity is full', () => {
+    const { colony } = makeColony({ energyAvailable: 650, energyCapacityAvailable: 650 });
+    installGame(colony, {
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', { sourceCount: 1 }),
+        W1N2: makeExpansionRoom('W1N2', { sourceCount: 2 })
+      },
+      exits: { W1N1: { '1': 'W1N2', '3': 'W2N1' } }
+    });
+    (Game as { gcl: GlobalControlLevel }).gcl = { level: 1, progress: 0, progressTotal: 0 } as GlobalControlLevel;
+    const stableAssessment = assessColonyStage({
+      roomName: 'W1N1',
+      totalCreeps: 5,
+      workerCapacity: 3,
+      workerTarget: 3,
+      energyAvailable: 650,
+      energyCapacityAvailable: 650,
+      controller: { my: true, level: 3, ticksToDowngrade: 10_000 }
+    });
+
+    const evaluation = refreshColonyExpansionIntent(colony, stableAssessment, 215);
+
+    expect(evaluation).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'claimBlocked',
+      targetRoom: 'W1N2',
+      reservation: {
+        status: 'planned',
+        claimBlocker: 'gclInsufficient',
+        targetRoom: 'W1N2'
+      }
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        action: 'reserve',
+        createdBy: 'adjacentRoomReservation',
+        controllerId: 'controller-W1N2'
+      }
+    ]);
+    expect(Memory.territory?.targets?.some((target) => target.action === 'claim')).toBe(false);
+  });
+
   it('uses resource synergy to rank otherwise equal expansion claim candidates', () => {
     const { colony } = makeColony({
       energyAvailable: 1_000,

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -1426,6 +1426,70 @@ describe('runEconomy', () => {
     ]);
   });
 
+  it('keeps next expansion claims reserved while GCL capacity is full', () => {
+    (globalThis as unknown as {
+      FIND_SOURCES: number;
+      FIND_HOSTILE_CREEPS: number;
+      FIND_HOSTILE_STRUCTURES: number;
+      TERRAIN_MASK_WALL: number;
+      TERRAIN_MASK_SWAMP: number;
+      Memory: Partial<Memory>;
+    }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 2;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 3;
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { TERRAIN_MASK_SWAMP: number }).TERRAIN_MASK_SWAMP = 2;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    const room = makeTerritoryReadyEconomyRoom();
+    const targetRoom = makeVisibleExpansionScoringRoom('W2N1', 'controller2' as Id<StructureController>);
+    const workers = {
+      Worker1: makeEconomyWorker(room),
+      Worker2: makeEconomyWorker(room),
+      Worker3: makeEconomyWorker(room)
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 506,
+      gcl: { level: 1 } as GlobalControlLevel,
+      rooms: { W1N1: room, W2N1: targetRoom },
+      spawns: {},
+      creeps: workers,
+      getObjectById: jest.fn().mockReturnValue(null),
+      map: {
+        describeExits: jest.fn(() => ({ '3': 'W2N1' })),
+        findRoute: jest.fn(() => [{ exit: 3, room: 'W2N1' }]),
+        getRoomTerrain: jest.fn(() => ({ get: jest.fn().mockReturnValue(0) } as unknown as RoomTerrain))
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(room.memory.cachedExpansionSelection).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'gclInsufficient'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'planned',
+        updatedAt: 506,
+        createdBy: 'occupationRecommendation',
+        controllerId: 'controller2'
+      }
+    ]);
+  });
+
   it('refreshes recommendation reserve targets when the RCL room limit caps expansion claims', () => {
     (globalThis as unknown as {
       FIND_SOURCES: number;

--- a/prod/test/expansionScoring.test.ts
+++ b/prod/test/expansionScoring.test.ts
@@ -1082,6 +1082,27 @@ describe('next expansion scoring', () => {
     expect(Memory.territory?.intents).toBeUndefined();
   });
 
+  it('does not persist next expansion claim intents when GCL capacity is already full', () => {
+    const colony = makeSafeColony({ controllerLevel: 3 });
+    const report = scoreExpansionCandidates(
+      makeInput([makeCandidate({ roomName: 'W3N1', sourceCount: 2 })], {
+        controllerLevel: 3,
+        ownedRoomCount: 1,
+        gclLevel: 1
+      })
+    );
+
+    expect(report.next?.preconditions).toContain('wait for GCL capacity to claim another room');
+    expect(refreshNextExpansionTargetSelection(colony, report, 214)).toEqual({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'gclInsufficient'
+    });
+    expect(Memory.territory?.targets).toBeUndefined();
+    expect(Memory.territory?.intents).toBeUndefined();
+    expect(getExpansionCandidateMemory()[0]).not.toHaveProperty('recommendedAction');
+  });
+
   it('reports the RCL room limit even when another expansion precondition is also unmet', () => {
     const colony = makeSafeColony({ controllerLevel: 3 });
     const report = scoreExpansionCandidates(


### PR DESCRIPTION
## Summary
Implements room claim with GCL-based expansion, scouting, and room evaluation.

## Changes
- `expansionScoring.ts`: room scoring and evaluation logic
- `economyLoop.ts`: economy integration with expansion planning
- `colonyExpansionPlanner.test.ts`: tests for expansion planner
- `economyLoop.test.ts`: tests for economy loop integration
- `expansionScoring.test.ts`: tests for scoring functions
- `types.d.ts`: type definitions for expansion data structures

## Verification
- TypeScript typecheck: OK
- All 1276 tests pass (including 3 new test files)
- Build: OK

Closes #711