### PR TITLE
feat(territory): basic room expansion planner for claiming and reserving nearby rooms (#723)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2871,7 +2871,7 @@ function hasRemoteTerritoryReference(value, roomName, roomKey) {
     if (!isRecord2(entry)) {
       return false;
     }
-    return entry[roomKey] === roomName && isNonEmptyString3(entry.colony) && entry.colony !== roomName && isTerritoryControlAction(entry.action) && entry.status !== "suppressed" && entry.enabled !== false;
+    return entry[roomKey] === roomName && isNonEmptyString3(entry.colony) && entry.colony !== roomName && isTerritoryControlAction(entry.action) && (entry.status === void 0 || entry.status === "planned" || entry.status === "active") && entry.enabled !== false;
   });
 }
 function isSelfReservedRoom(room) {
@@ -5216,7 +5216,7 @@ function isTerritoryIntentAction(action) {
   return action === "claim" || action === "reserve" || action === "scout";
 }
 function isTerritoryIntentStatus(status) {
-  return status === "planned" || status === "active" || status === "suppressed";
+  return status === "planned" || status === "active" || status === "suppressed" || status === "inactive" || status === "completed";
 }
 function isTerritoryIntentSuppressionReason(reason) {
   return reason === "deadZoneTarget" || reason === "deadZoneRoute";
@@ -5225,7 +5225,7 @@ function isTerritoryFollowUpSource(source) {
   return source === "satisfiedClaimAdjacent" || source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent";
 }
 function isTerritoryAutomationSource(source) {
-  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
+  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "expansionPlanner" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function isFiniteNumber4(value) {
   return typeof value === "number" && Number.isFinite(value);
@@ -8243,6 +8243,7 @@ var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
 var ERR_NO_PATH_CODE4 = -2;
 var SOURCE_SCORE_WEIGHT = 1e3;
 var DISTANCE_SCORE_WEIGHT = 100;
+var EXPANSION_PLANNER_TARGET_CREATOR = "expansionPlanner";
 function evaluateExpansionRoomSuitability(room) {
   var _a;
   const ownerUsername = getControllerOwnerUsername4(room.controller);
@@ -8310,6 +8311,9 @@ function refreshExpansionPlannerIntent(colony, gameTime = getGameTime11()) {
     };
   }
   const territoryMemory = getTerritoryMemoryRecord5();
+  if (territoryMemory) {
+    refreshTerminalExpansionPlans(territoryMemory, colonyName, gameTime);
+  }
   if (territoryMemory && hasBlockingTerritoryPlan(territoryMemory, colonyName)) {
     return {
       status: "skipped",
@@ -8349,31 +8353,49 @@ function refreshExpansionPlannerIntent(colony, gameTime = getGameTime11()) {
   };
 }
 function createExpansionIntent(candidate, action, gameTime = getGameTime11()) {
-  if (!candidate.suitable) {
-    return null;
-  }
   const territoryMemory = getWritableTerritoryMemoryRecord4();
   if (!territoryMemory) {
+    return null;
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIntent = findExpansionIntent(intents, candidate.colony, candidate.roomName, action);
+  const existingTarget = findExpansionTarget(territoryMemory, candidate.colony, candidate.roomName, action);
+  const terminalStatus = getCandidateTerminalExpansionStatus(candidate, action, existingIntent);
+  if (terminalStatus && (existingIntent || existingTarget)) {
+    persistTerminalExpansionPlan(
+      territoryMemory,
+      intents,
+      {
+        colony: candidate.colony,
+        roomName: candidate.roomName,
+        action,
+        createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+        ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
+      },
+      terminalStatus,
+      gameTime
+    );
+    return null;
+  }
+  if (!candidate.suitable) {
     return null;
   }
   const target = {
     colony: candidate.colony,
     roomName: candidate.roomName,
     action,
+    createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
   };
   upsertTerritoryTarget2(territoryMemory, target);
-  const intents = normalizeTerritoryIntents(territoryMemory.intents);
-  territoryMemory.intents = intents;
-  const existingIntent = intents.find(
-    (intent) => intent.colony === candidate.colony && intent.targetRoom === candidate.roomName && intent.action === action
-  );
   upsertTerritoryIntent3(intents, {
     colony: candidate.colony,
     targetRoom: candidate.roomName,
     action,
     status: (existingIntent == null ? void 0 : existingIntent.status) === "active" ? "active" : "planned",
     updatedAt: gameTime,
+    createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
   });
   return {
@@ -8455,28 +8477,90 @@ function selectExpansionIntentAction(colony) {
   }
   return "claim";
 }
+function refreshTerminalExpansionPlans(territoryMemory, colony, gameTime) {
+  var _a, _b;
+  const ownerUsername = getVisibleColonyOwnerUsername2(colony);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  const refreshedPlans = /* @__PURE__ */ new Set();
+  let changed = false;
+  for (const rawTarget of Array.isArray(territoryMemory.targets) ? territoryMemory.targets : []) {
+    const target = normalizeTerritoryTarget2(rawTarget);
+    if (!target || target.colony !== colony || target.roomName === colony || target.enabled === false || target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || !isExpansionControlAction(target.action)) {
+      continue;
+    }
+    const existingIntent = findExpansionIntent(intents, target.colony, target.roomName, target.action);
+    const terminalStatus = (_a = getTerminalIntentStatus(existingIntent)) != null ? _a : getVisibleExpansionTargetTerminalStatus(target, ownerUsername);
+    if (!terminalStatus) {
+      continue;
+    }
+    persistTerminalExpansionPlan(territoryMemory, intents, target, terminalStatus, gameTime);
+    refreshedPlans.add(getExpansionPlanKey(target.colony, target.roomName, target.action));
+    changed = true;
+  }
+  for (const intent of intents) {
+    if (intent.colony !== colony || intent.targetRoom === colony || !isExpansionControlAction(intent.action) || intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR) {
+      continue;
+    }
+    const planKey = getExpansionPlanKey(intent.colony, intent.targetRoom, intent.action);
+    if (refreshedPlans.has(planKey)) {
+      continue;
+    }
+    const target = {
+      colony: intent.colony,
+      roomName: intent.targetRoom,
+      action: intent.action,
+      createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+      ...intent.controllerId ? { controllerId: intent.controllerId } : {}
+    };
+    const terminalStatus = (_b = getTerminalIntentStatus(intent)) != null ? _b : getVisibleExpansionTargetTerminalStatus(target, ownerUsername);
+    if (!terminalStatus) {
+      continue;
+    }
+    persistTerminalExpansionPlan(territoryMemory, intents, target, terminalStatus, gameTime);
+    changed = true;
+  }
+  if (changed) {
+    territoryMemory.intents = intents;
+  }
+}
 function hasBlockingTerritoryPlan(territoryMemory, colony) {
-  if (normalizeTerritoryIntents(territoryMemory.intents).some(
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  if (intents.some(
     (intent) => intent.colony === colony && intent.targetRoom !== colony && (intent.action === "claim" || intent.action === "reserve" || intent.action === "scout") && (intent.status === "planned" || intent.status === "active")
   )) {
     return true;
   }
   return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some(
-    (target) => isRecord9(target) && target.colony === colony && target.roomName !== colony && target.enabled !== false && (target.action === "claim" || target.action === "reserve")
+    (target) => isBlockingExpansionTarget(target, colony, intents)
   ) : false;
+}
+function persistTerminalExpansionPlan(territoryMemory, intents, target, status, gameTime) {
+  if (findExpansionTarget(territoryMemory, target.colony, target.roomName, target.action)) {
+    upsertTerritoryTarget2(territoryMemory, { ...target, enabled: false });
+  }
+  upsertTerritoryIntent3(intents, {
+    colony: target.colony,
+    targetRoom: target.roomName,
+    action: target.action,
+    status,
+    updatedAt: gameTime,
+    createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+    ...target.controllerId ? { controllerId: target.controllerId } : {}
+  });
 }
 function upsertTerritoryTarget2(territoryMemory, target) {
   if (!Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = [];
   }
   const existingTarget = territoryMemory.targets.find(
-    (candidate) => isRecord9(candidate) && candidate.colony === target.colony && candidate.roomName === target.roomName && candidate.action === target.action
+    (candidate) => isRecord9(candidate) && candidate.colony === target.colony && candidate.roomName === target.roomName && candidate.action === target.action && candidate.createdBy === target.createdBy
   );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
   }
   existingTarget.enabled = target.enabled;
+  existingTarget.createdBy = target.createdBy;
   if (target.controllerId) {
     existingTarget.controllerId = target.controllerId;
   } else {
@@ -8485,13 +8569,117 @@ function upsertTerritoryTarget2(territoryMemory, target) {
 }
 function upsertTerritoryIntent3(intents, nextIntent) {
   const existingIndex = intents.findIndex(
-    (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action
+    (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action && intent.createdBy === nextIntent.createdBy
   );
   if (existingIndex >= 0) {
     intents[existingIndex] = nextIntent;
     return;
   }
   intents.push(nextIntent);
+}
+function findExpansionIntent(intents, colony, targetRoom, action) {
+  return intents.find(
+    (intent) => intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action && intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR
+  );
+}
+function findExpansionTarget(territoryMemory, colony, roomName, action) {
+  var _a;
+  if (!Array.isArray(territoryMemory.targets)) {
+    return null;
+  }
+  return (_a = territoryMemory.targets.map(normalizeTerritoryTarget2).find(
+    (target) => target !== null && target.colony === colony && target.roomName === roomName && target.action === action && target.createdBy === EXPANSION_PLANNER_TARGET_CREATOR
+  )) != null ? _a : null;
+}
+function isBlockingExpansionTarget(rawTarget, colony, intents) {
+  if (!isRecord9(rawTarget)) {
+    return false;
+  }
+  const target = normalizeTerritoryTarget2(rawTarget);
+  if (!target || target.colony !== colony || target.roomName === colony || target.enabled === false || !isExpansionControlAction(target.action)) {
+    return false;
+  }
+  if (target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR) {
+    return true;
+  }
+  const matchingIntent = findExpansionIntent(intents, target.colony, target.roomName, target.action);
+  return getTerminalIntentStatus(matchingIntent) === null;
+}
+function getExpansionPlanKey(colony, targetRoom, action) {
+  return `${colony}:${targetRoom}:${action}`;
+}
+function getCandidateTerminalExpansionStatus(candidate, action, existingIntent) {
+  const terminalStatus = getTerminalIntentStatus(existingIntent);
+  if (terminalStatus) {
+    return terminalStatus;
+  }
+  if (candidate.suitable) {
+    return null;
+  }
+  const ownerUsername = getVisibleColonyOwnerUsername2(candidate.colony);
+  if (action === "claim" && candidate.ownerUsername && candidate.ownerUsername === ownerUsername) {
+    return "completed";
+  }
+  if (action === "reserve" && candidate.reservationUsername && candidate.reservationUsername === ownerUsername) {
+    return "completed";
+  }
+  return "inactive";
+}
+function getTerminalIntentStatus(intent) {
+  return (intent == null ? void 0 : intent.status) === "completed" || (intent == null ? void 0 : intent.status) === "inactive" ? intent.status : null;
+}
+function getVisibleExpansionTargetTerminalStatus(target, ownerUsername) {
+  var _a;
+  const room = (_a = getGameRooms3()) == null ? void 0 : _a[target.roomName];
+  if (!room) {
+    return null;
+  }
+  if (findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_CREEPS")).length > 0 || findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_STRUCTURES")).length > 0) {
+    return "inactive";
+  }
+  const controller = room.controller;
+  if (!controller) {
+    return "inactive";
+  }
+  if (target.action === "claim") {
+    if (isControllerOwnedByUsername(controller, ownerUsername)) {
+      return "completed";
+    }
+    return isControllerOwned(controller) ? "inactive" : null;
+  }
+  if (isControllerOwnedByUsername(controller, ownerUsername)) {
+    return "completed";
+  }
+  if (isControllerOwned(controller)) {
+    return "inactive";
+  }
+  const reservationUsername = getControllerReservationUsername3(controller);
+  if (!reservationUsername) {
+    return null;
+  }
+  return reservationUsername === ownerUsername ? "completed" : "inactive";
+}
+function normalizeTerritoryTarget2(rawTarget) {
+  if (!isRecord9(rawTarget)) {
+    return null;
+  }
+  if (!isNonEmptyString9(rawTarget.colony) || !isNonEmptyString9(rawTarget.roomName) || !isExpansionControlAction(rawTarget.action)) {
+    return null;
+  }
+  return {
+    colony: rawTarget.colony,
+    roomName: rawTarget.roomName,
+    action: rawTarget.action,
+    ...typeof rawTarget.controllerId === "string" ? { controllerId: rawTarget.controllerId } : {},
+    ...rawTarget.enabled === false ? { enabled: false } : {},
+    ...isTerritoryAutomationSource2(rawTarget.createdBy) ? { createdBy: rawTarget.createdBy } : {}
+  };
+}
+function isExpansionControlAction(action) {
+  return action === "claim" || action === "reserve";
+}
+function isTerritoryAutomationSource2(source) {
+  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "expansionPlanner" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function getNearestOwnedRoomDistance2(ownedRoomNames, roomName) {
   let nearestDistance = null;
@@ -8563,10 +8751,21 @@ function getControllerOwnerUsername4(controller) {
   }
   return (controller == null ? void 0 : controller.my) === true ? "me" : void 0;
 }
+function getVisibleColonyOwnerUsername2(colony) {
+  var _a, _b;
+  return getControllerOwnerUsername4((_b = (_a = getGameRooms3()) == null ? void 0 : _a[colony]) == null ? void 0 : _b.controller);
+}
 function getControllerReservationUsername3(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.reservation) == null ? void 0 : _a.username;
   return isNonEmptyString9(username) ? username : void 0;
+}
+function isControllerOwnedByUsername(controller, ownerUsername) {
+  const controllerOwnerUsername = getControllerOwnerUsername4(controller);
+  return (controller == null ? void 0 : controller.my) === true || isNonEmptyString9(ownerUsername) && isNonEmptyString9(controllerOwnerUsername) && controllerOwnerUsername === ownerUsername;
+}
+function isControllerOwned(controller) {
+  return (controller == null ? void 0 : controller.my) === true || (controller == null ? void 0 : controller.owner) != null;
 }
 function findRoomObjects12(room, findConstant) {
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
@@ -8747,7 +8946,7 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
     plan.targetRoom,
     plan.action,
     plan.controllerId,
-    getVisibleColonyOwnerUsername2(plan.colony)
+    getVisibleColonyOwnerUsername3(plan.colony)
   )) {
     return false;
   }
@@ -8762,7 +8961,7 @@ function requiresTerritoryControllerPressure(plan) {
     plan.targetRoom,
     plan.action,
     plan.controllerId,
-    getVisibleColonyOwnerUsername2(plan.colony)
+    getVisibleColonyOwnerUsername3(plan.colony)
   ));
 }
 function isTerritoryIntentPlanSpawnCapable(plan) {
@@ -8795,7 +8994,7 @@ function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTim
     plan.targetRoom,
     plan.action,
     plan.controllerId,
-    getVisibleColonyOwnerUsername2(plan.colony)
+    getVisibleColonyOwnerUsername3(plan.colony)
   )) {
     return 0;
   }
@@ -8827,7 +9026,7 @@ function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGam
       intent.targetRoom,
       intent.action,
       intent.controllerId,
-      getVisibleColonyOwnerUsername2(intent.colony)
+      getVisibleColonyOwnerUsername3(intent.colony)
     ) && (intent.status === "planned" || isRecoveredTerritoryFollowUpIntent(intent, gameTime) || intent.status === "active" && getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action) === 0)
   );
 }
@@ -8928,7 +9127,7 @@ function canCreepReserveTerritoryController(creep, controller, colony) {
   if (activeClaimParts <= 0) {
     return false;
   }
-  if (isControllerOwned(controller)) {
+  if (isControllerOwned2(controller)) {
     return false;
   }
   const reservation = controller.reservation;
@@ -9134,12 +9333,12 @@ function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation,
   if (!territoryMemory) {
     return null;
   }
-  const colonyOwnerUsername = getVisibleColonyOwnerUsername2(colony);
+  const colonyOwnerUsername = getVisibleColonyOwnerUsername3(colony);
   if (!isNonEmptyString10(colonyOwnerUsername)) {
     return null;
   }
   const controller = getVisibleController2(targetRoom, evaluation.controllerId);
-  if (!controller || isControllerOwned(controller) || isForeignReservedController(controller, colonyOwnerUsername)) {
+  if (!controller || isControllerOwned2(controller) || isForeignReservedController(controller, colonyOwnerUsername)) {
     return null;
   }
   if (isOwnReservedController(controller, colonyOwnerUsername)) {
@@ -9606,7 +9805,7 @@ function getConfiguredTerritoryCandidates(colony, colonyName, colonyOwnerUsernam
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName) {
       return [];
     }
@@ -9715,7 +9914,7 @@ function shouldAutoClaimAdjacentReservationTarget(target, colony, colonyOwnerUse
     return false;
   }
   const controller = getVisibleController2(target.roomName, target.controllerId);
-  if (!controller || isControllerOwned(controller)) {
+  if (!controller || isControllerOwned2(controller)) {
     return false;
   }
   return isTerritoryAutoClaimReservationMature(
@@ -9765,7 +9964,7 @@ function refreshExpiredPostClaimClaimIntents(territoryMemory, intents, colonyNam
   const nextIntents = intents;
   for (const record of getExpiredPostClaimClaimRefreshRecords(territoryMemory, colonyName)) {
     const controller = getVisibleController2(record.roomName, record.controllerId);
-    if (!controller || controller.my === true || isControllerOwned(controller)) {
+    if (!controller || controller.my === true || isControllerOwned2(controller)) {
       continue;
     }
     if (isSuppressedTerritoryIntentForAction(nextIntents, colonyName, record.roomName, "claim", gameTime) || isTerritoryIntentSuspendedForAction(nextIntents, colonyName, record.roomName, "claim", gameTime)) {
@@ -9858,7 +10057,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
     return false;
   }
   return territoryMemory.targets.some((rawTarget) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.colony !== colonyName) {
       return false;
     }
@@ -9906,7 +10105,7 @@ function refreshTerritoryReservationMemory(territoryMemory, colonyName, colonyOw
   const activeConfiguredReserveKeys = /* @__PURE__ */ new Set();
   let changed = hasMalformedTerritoryReservationMemory(territoryMemory.reservations, reservations);
   for (const rawTarget of territoryMemory.targets) {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName) {
       continue;
     }
@@ -10030,7 +10229,7 @@ function suppressDeadZoneTerritoryTargets(territoryMemory, intents, colonyName, 
   let nextIntents = intents;
   let changed = false;
   for (const rawTarget of territoryMemory.targets) {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName) {
       continue;
     }
@@ -10337,7 +10536,7 @@ function getActiveCoveredConfiguredReserveTargets(colonyName, colonyOwnerUsernam
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName || isKnownDeadZoneRoom(target.roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || !isVisibleRoomKnown(target.roomName) || getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
@@ -10360,7 +10559,7 @@ function getSatisfiedConfiguredTargets(colonyName, colonyOwnerUsername, territor
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.action !== action || target.roomName === colonyName || isKnownDeadZoneRoom(target.roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
       return [];
     }
@@ -10648,13 +10847,13 @@ function getOccupationIntentActionableTicks(selection, colonyOwnerUsername) {
     return void 0;
   }
   if (selection.intentAction === "reserve") {
-    if (isControllerOwned(controller)) {
+    if (isControllerOwned2(controller)) {
       return void 0;
     }
     const ownReservationTicksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
     return (_a = ownReservationTicksToEnd != null ? ownReservationTicksToEnd : getControllerReservationTicksToEnd3(controller)) != null ? _a : 0;
   }
-  if (isControllerOwned(controller)) {
+  if (isControllerOwned2(controller)) {
     return typeof controller.ticksToDowngrade === "number" ? controller.ticksToDowngrade : void 0;
   }
   return (_b = getControllerReservationTicksToEnd3(controller)) != null ? _b : 0;
@@ -10906,7 +11105,7 @@ function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
   }
   return new Set(
     territoryMemory.targets.flatMap((rawTarget) => {
-      const target = normalizeTerritoryTarget2(rawTarget);
+      const target = normalizeTerritoryTarget3(rawTarget);
       return (target == null ? void 0 : target.colony) === colonyName ? [target.roomName] : [];
     })
   );
@@ -10919,7 +11118,7 @@ function appendTerritoryTarget(territoryMemory, target) {
 }
 function appendTerritoryTargetIfMissing(territoryMemory, target) {
   if (Array.isArray(territoryMemory.targets) && territoryMemory.targets.some((rawTarget) => {
-    const existingTarget = normalizeTerritoryTarget2(rawTarget);
+    const existingTarget = normalizeTerritoryTarget3(rawTarget);
     return (existingTarget == null ? void 0 : existingTarget.colony) === target.colony && existingTarget.roomName === target.roomName && existingTarget.action === target.action;
   })) {
     return;
@@ -10944,7 +11143,7 @@ function getAdjacentRoomNames4(roomName) {
 function isRoomAdjacentToColony(colonyName, targetRoom) {
   return getAdjacentRoomNames4(colonyName).includes(targetRoom);
 }
-function normalizeTerritoryTarget2(rawTarget) {
+function normalizeTerritoryTarget3(rawTarget) {
   if (!isRecord10(rawTarget)) {
     return null;
   }
@@ -10957,12 +11156,12 @@ function normalizeTerritoryTarget2(rawTarget) {
     action: rawTarget.action,
     ...typeof rawTarget.controllerId === "string" ? { controllerId: rawTarget.controllerId } : {},
     ...rawTarget.enabled === false ? { enabled: false } : {},
-    ...isTerritoryAutomationSource2(rawTarget.createdBy) ? { createdBy: rawTarget.createdBy } : {},
+    ...isTerritoryAutomationSource3(rawTarget.createdBy) ? { createdBy: rawTarget.createdBy } : {},
     ...isPositiveFiniteNumber2(rawTarget.postClaimBootstrapReserveEnergy) ? { postClaimBootstrapReserveEnergy: Math.floor(rawTarget.postClaimBootstrapReserveEnergy) } : {}
   };
 }
-function isTerritoryAutomationSource2(source) {
-  return source === OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
+function isTerritoryAutomationSource3(source) {
+  return source === OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "expansionPlanner" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function recordTerritoryIntent(plan, status, gameTime, seededTarget = null, routeDistanceLookupContext = createRouteDistanceLookupContext()) {
   const territoryMemory = getWritableTerritoryMemoryRecord5();
@@ -11042,7 +11241,7 @@ function shouldRecordTerritoryIntentControllerPressure(nextIntent, controllerId,
     nextIntent.targetRoom,
     nextIntent.action,
     controllerId,
-    getVisibleColonyOwnerUsername2(nextIntent.colony)
+    getVisibleColonyOwnerUsername3(nextIntent.colony)
   ) || existingIntent !== void 0 && shouldPreservePersistedTerritoryIntentPressureRequirement2(existingIntent, controllerId);
 }
 function refreshHostileTerritoryIntentSuspensions(territoryMemory, intents, colonyName, gameTime) {
@@ -11107,7 +11306,7 @@ function sanitizeSatisfiedClaimReserveHandoffs(territoryMemory, intents, colonyN
     return { intents, changed: false };
   }
   const nextTargets = territoryMemory.targets.filter((rawTarget) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     return !((target == null ? void 0 : target.colony) === colonyName && target.action === "reserve" && satisfiedClaimRooms.has(target.roomName));
   });
   const nextIntents = intents.filter(
@@ -11128,7 +11327,7 @@ function sanitizeSatisfiedClaimReserveHandoffs(territoryMemory, intents, colonyN
 function getSatisfiedConfiguredClaimRoomNames(rawTargets, colonyName, colonyOwnerUsername) {
   const satisfiedClaimRooms = /* @__PURE__ */ new Set();
   for (const rawTarget of rawTargets) {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if ((target == null ? void 0 : target.colony) === colonyName && target.action === "claim" && getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) === "satisfied") {
       satisfiedClaimRooms.add(target.roomName);
     }
@@ -11375,7 +11574,7 @@ function isTerritoryFollowUpExecutionHintStillActive(hint, intents, routeDistanc
     matchingIntent.targetRoom,
     matchingIntent.action,
     matchingIntent.controllerId,
-    getVisibleColonyOwnerUsername2(matchingIntent.colony)
+    getVisibleColonyOwnerUsername3(matchingIntent.colony)
   );
   return currentReason === hint.reason;
 }
@@ -11402,7 +11601,7 @@ function buildTerritoryFollowUpExecutionHint(plan, gameTime) {
     plan.targetRoom,
     plan.action,
     plan.controllerId,
-    getVisibleColonyOwnerUsername2(plan.colony)
+    getVisibleColonyOwnerUsername3(plan.colony)
   );
   if (reason === null) {
     return null;
@@ -11718,11 +11917,11 @@ function getTerritoryControllerTargetState(controller, action, colonyOwnerUserna
   return getClaimControllerTargetState(controller);
 }
 function getClaimControllerTargetState(controller) {
-  return isControllerOwned(controller) ? "unavailable" : "available";
+  return isControllerOwned2(controller) ? "unavailable" : "available";
 }
 function getTerritoryActorUsername(creep, colony) {
   var _a;
-  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString10(colony) ? getVisibleColonyOwnerUsername2(colony) : null;
+  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString10(colony) ? getVisibleColonyOwnerUsername3(colony) : null;
 }
 function getCreepOwnerUsername(creep) {
   var _a;
@@ -11836,7 +12035,7 @@ function isVisibleRoomMissingController(targetRoom) {
   const room = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom];
   return room != null && room.controller == null;
 }
-function isControllerOwned(controller) {
+function isControllerOwned2(controller) {
   return controller.owner != null || controller.my === true;
 }
 function isHostileOwnedController(controller) {
@@ -11850,7 +12049,7 @@ function isControllerOwnedByColony2(controller, colonyOwnerUsername) {
   return controller.my === true || isNonEmptyString10(ownerUsername) && ownerUsername === colonyOwnerUsername;
 }
 function getReserveControllerTargetState(controller, colonyOwnerUsername) {
-  if (isControllerOwned(controller)) {
+  if (isControllerOwned2(controller)) {
     return "unavailable";
   }
   const reservation = controller.reservation;
@@ -11863,7 +12062,7 @@ function getReserveControllerTargetState(controller, colonyOwnerUsername) {
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) === null ? "satisfied" : "available";
 }
 function isForeignReservedController(controller, actorUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString10(actorUsername)) {
+  if (isControllerOwned2(controller) || !isNonEmptyString10(actorUsername)) {
     return false;
   }
   const reservation = controller.reservation;
@@ -11896,7 +12095,7 @@ function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
     return null;
   }
   const controller = getVisibleController2(target.roomName, target.controllerId);
-  if (!controller || isControllerOwned(controller)) {
+  if (!controller || isControllerOwned2(controller)) {
     return null;
   }
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername);
@@ -11906,10 +12105,10 @@ function shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount) {
     return false;
   }
   const controller = getVisibleController2(plan.targetRoom, plan.controllerId);
-  if (!controller || isControllerOwned(controller)) {
+  if (!controller || isControllerOwned2(controller)) {
     return false;
   }
-  const colonyOwnerUsername = getVisibleColonyOwnerUsername2(plan.colony);
+  const colonyOwnerUsername = getVisibleColonyOwnerUsername3(plan.colony);
   const ticksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
   return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
 }
@@ -11918,7 +12117,7 @@ function getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? ticksToEnd : null;
 }
 function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString10(colonyOwnerUsername)) {
+  if (isControllerOwned2(controller) || !isNonEmptyString10(colonyOwnerUsername)) {
     return null;
   }
   const reservation = controller.reservation;
@@ -11927,7 +12126,7 @@ function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   }
   return reservation.ticksToEnd;
 }
-function getVisibleColonyOwnerUsername2(colonyName) {
+function getVisibleColonyOwnerUsername3(colonyName) {
   const controller = getVisibleController2(colonyName);
   return getControllerOwnerUsername5(controller != null ? controller : void 0);
 }
@@ -24882,7 +25081,7 @@ function reserveRoomForPlannedClaim(creep) {
       targetRoom: assignment.targetRoom
     };
   }
-  if (isControllerOwned2(controller)) {
+  if (isControllerOwned3(controller)) {
     return {
       status: "skipped",
       reason: "controllerOwned",
@@ -24997,7 +25196,7 @@ function canReserveControllerForColony(controller, creep) {
   const actorUsername = getActorUsername(creep);
   return isNonEmptyString20(actorUsername) && reservationUsername === actorUsername;
 }
-function isControllerOwned2(controller) {
+function isControllerOwned3(controller) {
   return controller.my === true || isNonEmptyString20(getControllerOwnerUsername7(controller));
 }
 function getActiveClaimPartCount(creep) {
@@ -25359,7 +25558,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   if (room && !controller) {
     return { ...visibleControllerEvaluation, reason: "controllerMissing" };
   }
-  if (controller && isControllerOwned3(controller)) {
+  if (controller && isControllerOwned4(controller)) {
     return { ...visibleControllerEvaluation, reason: "controllerOwned" };
   }
   const colonyOwnerUsername = getControllerOwnerUsername8(colony.room.controller);
@@ -26065,7 +26264,7 @@ function hasRecommendedClaimTarget(territoryMemory, colony, targetRoom) {
   return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom)) : false;
 }
 function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
-  return isRecord20(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
+  return isRecord20(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource4(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
 }
 function recordColonyExpansionClaimVerification(input) {
   var _a;
@@ -26136,8 +26335,8 @@ function getBodyPartConstant6(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function isTerritoryAutomationSource3(source) {
-  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
+function isTerritoryAutomationSource4(source) {
+  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "expansionPlanner" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
   return isRecord20(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
@@ -26180,7 +26379,7 @@ function findVisibleHostileCreeps2(room) {
 function findVisibleHostileStructures2(room) {
   return typeof FIND_HOSTILE_STRUCTURES === "number" && typeof room.find === "function" ? room.find(FIND_HOSTILE_STRUCTURES) : [];
 }
-function isControllerOwned3(controller) {
+function isControllerOwned4(controller) {
   return controller.my === true || controller.owner != null;
 }
 function isControllerReserved(controller, colonyOwnerUsername) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8736,7 +8736,7 @@ function getVisibleExpansionTargetTerminalStatus(target, ownerUsername) {
   if (!reservationUsername) {
     return null;
   }
-  return reservationUsername === ownerUsername ? "completed" : "inactive";
+  return reservationUsername === ownerUsername ? null : "inactive";
 }
 function normalizeTerritoryTarget2(rawTarget) {
   if (!isRecord9(rawTarget)) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8236,6 +8236,397 @@ function getOkCode4() {
   return (_a = globalThis.OK) != null ? _a : 0;
 }
 
+// src/territory/expansionPlanner.ts
+var EXPANSION_PLANNER_MIN_SOURCE_COUNT = 2;
+var EXPANSION_PLANNER_MAX_ROUTE_DISTANCE = 2;
+var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
+var ERR_NO_PATH_CODE4 = -2;
+var SOURCE_SCORE_WEIGHT = 1e3;
+var DISTANCE_SCORE_WEIGHT = 100;
+function evaluateExpansionRoomSuitability(room) {
+  var _a;
+  const ownerUsername = getControllerOwnerUsername4(room.controller);
+  const reservationUsername = getControllerReservationUsername3(room.controller);
+  return evaluateExpansionSuitability({
+    sourceCount: findRoomObjects12(room, getFindConstant4("FIND_SOURCES")).length,
+    hostileCreepCount: findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_CREEPS")).length,
+    hostileStructureCount: findRoomObjects12(
+      room,
+      getFindConstant4("FIND_HOSTILE_STRUCTURES")
+    ).length,
+    ...((_a = room.controller) == null ? void 0 : _a.id) ? { controllerId: room.controller.id } : {},
+    ...ownerUsername ? { ownerUsername } : {},
+    ...reservationUsername ? { reservationUsername } : {},
+    hasController: room.controller !== void 0
+  });
+}
+function buildRuntimeExpansionPlannerCandidates(colony) {
+  const colonyName = colony.room.name;
+  const rooms = getGameRooms3();
+  if (!rooms) {
+    return [];
+  }
+  const ownerUsername = getControllerOwnerUsername4(colony.room.controller);
+  const ownedRoomNames = getVisibleOwnedRoomNames3(colonyName, ownerUsername);
+  const candidates = [];
+  const seenRooms = /* @__PURE__ */ new Set();
+  let order = 0;
+  for (const ownedRoomName of ownedRoomNames) {
+    for (const adjacentRoomName of getAdjacentRoomNames3(ownedRoomName)) {
+      if (seenRooms.has(adjacentRoomName) || ownedRoomNames.has(adjacentRoomName)) {
+        continue;
+      }
+      seenRooms.add(adjacentRoomName);
+      const room = rooms[adjacentRoomName];
+      if (!room) {
+        continue;
+      }
+      candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, 1, order));
+      order += 1;
+    }
+  }
+  for (const room of Object.values(rooms)) {
+    if (!room || !isNonEmptyString9(room.name) || room.name === colonyName || ownedRoomNames.has(room.name) || seenRooms.has(room.name)) {
+      continue;
+    }
+    const distance = getNearestOwnedRoomDistance2(ownedRoomNames, room.name);
+    if (distance === null || distance > EXPANSION_PLANNER_MAX_ROUTE_DISTANCE) {
+      continue;
+    }
+    seenRooms.add(room.name);
+    candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, distance, order));
+    order += 1;
+  }
+  return candidates.filter((candidate) => candidate.suitable).sort(compareExpansionPlannerCandidates);
+}
+function refreshExpansionPlannerIntent(colony, gameTime = getGameTime11()) {
+  const colonyName = colony.room.name;
+  if (!getMemoryRecord()) {
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "memoryUnavailable",
+      candidates: []
+    };
+  }
+  const territoryMemory = getTerritoryMemoryRecord5();
+  if (territoryMemory && hasBlockingTerritoryPlan(territoryMemory, colonyName)) {
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "existingTerritoryPlan",
+      candidates: []
+    };
+  }
+  const candidates = buildRuntimeExpansionPlannerCandidates(colony);
+  const candidate = candidates[0];
+  if (!candidate) {
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "noCandidate",
+      candidates
+    };
+  }
+  const action = selectExpansionIntentAction(colony);
+  const intent = createExpansionIntent(candidate, action, gameTime);
+  if (!intent) {
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "memoryUnavailable",
+      candidates
+    };
+  }
+  return {
+    status: "planned",
+    colony: colonyName,
+    candidates,
+    targetRoom: intent.targetRoom,
+    action: intent.action,
+    score: intent.score,
+    ...intent.controllerId ? { controllerId: intent.controllerId } : {}
+  };
+}
+function createExpansionIntent(candidate, action, gameTime = getGameTime11()) {
+  if (!candidate.suitable) {
+    return null;
+  }
+  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  if (!territoryMemory) {
+    return null;
+  }
+  const target = {
+    colony: candidate.colony,
+    roomName: candidate.roomName,
+    action,
+    ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
+  };
+  upsertTerritoryTarget2(territoryMemory, target);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIntent = intents.find(
+    (intent) => intent.colony === candidate.colony && intent.targetRoom === candidate.roomName && intent.action === action
+  );
+  upsertTerritoryIntent3(intents, {
+    colony: candidate.colony,
+    targetRoom: candidate.roomName,
+    action,
+    status: (existingIntent == null ? void 0 : existingIntent.status) === "active" ? "active" : "planned",
+    updatedAt: gameTime,
+    ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
+  });
+  return {
+    colony: candidate.colony,
+    targetRoom: candidate.roomName,
+    action,
+    score: candidate.score,
+    ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
+  };
+}
+function evaluateExpansionSuitability({
+  sourceCount,
+  hostileCreepCount,
+  hostileStructureCount,
+  controllerId,
+  ownerUsername,
+  reservationUsername,
+  hasController
+}) {
+  const normalizedSourceCount = normalizeNonNegativeInteger4(sourceCount);
+  const normalizedHostileCreepCount = normalizeNonNegativeInteger4(hostileCreepCount);
+  const normalizedHostileStructureCount = normalizeNonNegativeInteger4(hostileStructureCount);
+  const reasons = [];
+  if (normalizedSourceCount < EXPANSION_PLANNER_MIN_SOURCE_COUNT) {
+    reasons.push("sourceCountBelowMinimum");
+  }
+  if (normalizedHostileCreepCount > 0 || normalizedHostileStructureCount > 0) {
+    reasons.push("hostilePresence");
+  }
+  if (!hasController) {
+    reasons.push("controllerMissing");
+  } else if (isNonEmptyString9(ownerUsername)) {
+    reasons.push("controllerOwned");
+  } else if (isNonEmptyString9(reservationUsername)) {
+    reasons.push("controllerReserved");
+  }
+  return {
+    suitable: reasons.length === 0,
+    sourceCount: normalizedSourceCount,
+    hostileCreepCount: normalizedHostileCreepCount,
+    hostileStructureCount: normalizedHostileStructureCount,
+    reasons,
+    ...controllerId ? { controllerId } : {},
+    ...ownerUsername ? { ownerUsername } : {},
+    ...reservationUsername ? { reservationUsername } : {}
+  };
+}
+function toRuntimeExpansionPlannerCandidate(colony, room, distance, order) {
+  const suitability = evaluateExpansionRoomSuitability(room);
+  const normalizedDistance = Math.max(1, normalizeNonNegativeInteger4(distance));
+  return {
+    colony,
+    roomName: room.name,
+    distance: normalizedDistance,
+    order,
+    score: scoreExpansionPlannerCandidate(suitability.sourceCount, normalizedDistance),
+    ...suitability
+  };
+}
+function compareExpansionPlannerCandidates(left, right) {
+  return right.sourceCount - left.sourceCount || left.distance - right.distance || right.score - left.score || left.order - right.order || left.roomName.localeCompare(right.roomName);
+}
+function scoreExpansionPlannerCandidate(sourceCount, distance) {
+  return sourceCount * SOURCE_SCORE_WEIGHT - distance * DISTANCE_SCORE_WEIGHT;
+}
+function selectExpansionIntentAction(colony) {
+  var _a;
+  const gclLevel = getGclLevel2();
+  if (gclLevel === null) {
+    return "reserve";
+  }
+  const ownerUsername = getControllerOwnerUsername4(colony.room.controller);
+  const ownedRoomCount = getVisibleOwnedRoomNames3(colony.room.name, ownerUsername).size;
+  if (ownedRoomCount >= gclLevel) {
+    return "reserve";
+  }
+  if (ownedRoomCount >= maxRoomsForRcl((_a = colony.room.controller) == null ? void 0 : _a.level)) {
+    return "reserve";
+  }
+  return "claim";
+}
+function hasBlockingTerritoryPlan(territoryMemory, colony) {
+  if (normalizeTerritoryIntents(territoryMemory.intents).some(
+    (intent) => intent.colony === colony && intent.targetRoom !== colony && (intent.action === "claim" || intent.action === "reserve" || intent.action === "scout") && (intent.status === "planned" || intent.status === "active")
+  )) {
+    return true;
+  }
+  return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some(
+    (target) => isRecord9(target) && target.colony === colony && target.roomName !== colony && target.enabled !== false && (target.action === "claim" || target.action === "reserve")
+  ) : false;
+}
+function upsertTerritoryTarget2(territoryMemory, target) {
+  if (!Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = [];
+  }
+  const existingTarget = territoryMemory.targets.find(
+    (candidate) => isRecord9(candidate) && candidate.colony === target.colony && candidate.roomName === target.roomName && candidate.action === target.action
+  );
+  if (!existingTarget) {
+    territoryMemory.targets.push(target);
+    return;
+  }
+  existingTarget.enabled = target.enabled;
+  if (target.controllerId) {
+    existingTarget.controllerId = target.controllerId;
+  } else {
+    delete existingTarget.controllerId;
+  }
+}
+function upsertTerritoryIntent3(intents, nextIntent) {
+  const existingIndex = intents.findIndex(
+    (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action
+  );
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+  intents.push(nextIntent);
+}
+function getNearestOwnedRoomDistance2(ownedRoomNames, roomName) {
+  let nearestDistance = null;
+  for (const ownedRoomName of ownedRoomNames) {
+    const distance = getRouteDistance(ownedRoomName, roomName);
+    if (distance === null) {
+      continue;
+    }
+    if (nearestDistance === null || distance < nearestDistance) {
+      nearestDistance = distance;
+    }
+  }
+  return nearestDistance;
+}
+function getRouteDistance(fromRoom, targetRoom) {
+  var _a, _b, _c;
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+  if (getAdjacentRoomNames3(fromRoom).includes(targetRoom)) {
+    return 1;
+  }
+  const route = (_c = (_b = (_a = globalThis.Game) == null ? void 0 : _a.map) == null ? void 0 : _b.findRoute) == null ? void 0 : _c.call(_b, fromRoom, targetRoom);
+  if (Array.isArray(route)) {
+    return route.length;
+  }
+  return route === ERR_NO_PATH_CODE4 ? null : null;
+}
+function getAdjacentRoomNames3(roomName) {
+  var _a, _b;
+  const describeExits = (_b = (_a = globalThis.Game) == null ? void 0 : _a.map) == null ? void 0 : _b.describeExits;
+  if (typeof describeExits !== "function") {
+    return [];
+  }
+  const exits = describeExits(roomName);
+  if (!isRecord9(exits)) {
+    return [];
+  }
+  const orderedRooms = EXIT_DIRECTION_ORDER3.flatMap((direction) => {
+    const adjacentRoom = exits[direction];
+    return isNonEmptyString9(adjacentRoom) ? [adjacentRoom] : [];
+  });
+  const remainingRooms = Object.entries(exits).filter(([direction, adjacentRoom]) => !EXIT_DIRECTION_ORDER3.includes(direction) && isNonEmptyString9(adjacentRoom)).map(([, adjacentRoom]) => adjacentRoom).sort();
+  return [...orderedRooms, ...remainingRooms];
+}
+function getVisibleOwnedRoomNames3(colonyName, ownerUsername) {
+  var _a;
+  const rooms = getGameRooms3();
+  const roomNames = /* @__PURE__ */ new Set([colonyName]);
+  if (!rooms) {
+    return roomNames;
+  }
+  for (const room of Object.values(rooms)) {
+    if (!room || !isNonEmptyString9(room.name) || ((_a = room.controller) == null ? void 0 : _a.my) !== true) {
+      continue;
+    }
+    const roomOwnerUsername = getControllerOwnerUsername4(room.controller);
+    if (!ownerUsername || !roomOwnerUsername || ownerUsername === roomOwnerUsername) {
+      roomNames.add(room.name);
+    }
+  }
+  return roomNames;
+}
+function getControllerOwnerUsername4(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  if (isNonEmptyString9(username)) {
+    return username;
+  }
+  return (controller == null ? void 0 : controller.my) === true ? "me" : void 0;
+}
+function getControllerReservationUsername3(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.reservation) == null ? void 0 : _a.username;
+  return isNonEmptyString9(username) ? username : void 0;
+}
+function findRoomObjects12(room, findConstant) {
+  if (typeof findConstant !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function getFindConstant4(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function getGclLevel2() {
+  var _a, _b;
+  const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
+  return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
+}
+function getGameTime11() {
+  var _a;
+  const time = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof time === "number" && Number.isFinite(time) ? time : 0;
+}
+function getGameRooms3() {
+  var _a;
+  return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+}
+function getWritableTerritoryMemoryRecord4() {
+  const memory = getMemoryRecord();
+  if (!memory) {
+    return null;
+  }
+  if (!isRecord9(memory.territory)) {
+    memory.territory = {};
+  }
+  return memory.territory;
+}
+function getTerritoryMemoryRecord5() {
+  const memory = getMemoryRecord();
+  if (!memory || !isRecord9(memory.territory)) {
+    return null;
+  }
+  return memory.territory;
+}
+function getMemoryRecord() {
+  return globalThis.Memory;
+}
+function normalizeNonNegativeInteger4(value) {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+function isNonEmptyString9(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function isRecord9(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/territory/territoryPlanner.ts
 var TERRITORY_CLAIMER_ROLE = "claimer";
 var TERRITORY_SCOUT_ROLE = "scout";
@@ -8257,9 +8648,9 @@ var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 var GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS = globalThis.TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS;
 var TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS = typeof GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS === "number" && Number.isFinite(GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS) && GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS > 0 ? Math.floor(GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS) : 1500;
 var TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 0;
-var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
+var EXIT_DIRECTION_ORDER4 = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
-var ERR_NO_PATH_CODE4 = -2;
+var ERR_NO_PATH_CODE5 = -2;
 var TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL = 0;
 var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM = 1;
 var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE = 2;
@@ -8307,7 +8698,7 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options
   );
   return plan;
 }
-function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime11()) {
+function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime12()) {
   if (!plan || !plan.followUp || !isTerritoryControlAction3(plan.action)) {
     return;
   }
@@ -8315,7 +8706,7 @@ function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameT
   if (!recoveredFollowUpMetadata) {
     return;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
@@ -8339,7 +8730,7 @@ function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameT
   removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, plan.colony, plan.targetRoom, plan.action);
 }
-function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime11()) {
+function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime12()) {
   if (isKnownDeadZoneRoom(plan.targetRoom)) {
     return false;
   }
@@ -8389,7 +8780,7 @@ function isTerritoryIntentPlanSpawnCapable(plan) {
   const energyCapacityAvailable = (_b = getVisibleRoom3(plan.colony)) == null ? void 0 : _b.energyCapacityAvailable;
   return typeof energyCapacityAvailable !== "number" || energyCapacityAvailable >= TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
 }
-function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime11()) {
+function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime12()) {
   var _a;
   if (!plan || !isTerritoryControlAction3(plan.action)) {
     return 0;
@@ -8411,11 +8802,11 @@ function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTim
   const demand = getCurrentTerritoryFollowUpDemand(plan, gameTime);
   return (_a = demand == null ? void 0 : demand.workerCount) != null ? _a : 0;
 }
-function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime11()) {
-  if (!isNonEmptyString9(colony)) {
+function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime12()) {
+  if (!isNonEmptyString10(colony)) {
     return false;
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return false;
   }
@@ -8423,11 +8814,11 @@ function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameT
     (demand) => demand.updatedAt === gameTime && demand.colony === colony && demand.workerCount > 0
   );
 }
-function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime11()) {
-  if (!isNonEmptyString9(colony)) {
+function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime12()) {
+  if (!isNonEmptyString10(colony)) {
     return false;
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return false;
   }
@@ -8441,7 +8832,7 @@ function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGam
   );
 }
 function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return [];
   }
@@ -8449,17 +8840,17 @@ function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
   return getBoundedActiveTerritoryFollowUpExecutionHints(
     normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
     intents
-  ).filter((hint) => !isNonEmptyString9(colony) || hint.colony === colony);
+  ).filter((hint) => !isNonEmptyString10(colony) || hint.colony === colony);
 }
 function getTerritoryIntentProgressSummaries(colony, roleCounts) {
-  if (!isNonEmptyString9(colony)) {
+  if (!isNonEmptyString10(colony)) {
     return [];
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return [];
   }
-  const gameTime = getGameTime11();
+  const gameTime = getGameTime12();
   return normalizeTerritoryIntents(territoryMemory.intents).filter(
     (intent) => isTerritoryIntentProgressVisibleForColony(intent, colony, gameTime)
   ).map((intent) => {
@@ -8479,12 +8870,12 @@ function getTerritoryIntentProgressSummaries(colony, roleCounts) {
     };
   }).sort(compareTerritoryIntentProgressSummaries);
 }
-function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime11()) {
+function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime12()) {
   var _a;
-  if (!isNonEmptyString9(colony)) {
+  if (!isNonEmptyString10(colony)) {
     return {};
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return {};
   }
@@ -8545,7 +8936,7 @@ function canCreepReserveTerritoryController(creep, controller, colony) {
     return true;
   }
   const actorUsername = getTerritoryActorUsername(creep, colony);
-  if (!isNonEmptyString9(actorUsername) || !isNonEmptyString9(reservation.username) || reservation.username !== actorUsername || typeof reservation.ticksToEnd !== "number") {
+  if (!isNonEmptyString10(actorUsername) || !isNonEmptyString10(reservation.username) || reservation.username !== actorUsername || typeof reservation.ticksToEnd !== "number") {
     return false;
   }
   const reservationTicksToEnd = reservation.ticksToEnd;
@@ -8577,7 +8968,7 @@ function selectUrgentVisibleReservationRenewalTask(creep) {
   return { type: "reserve", targetId: controller.id };
 }
 function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
-  if (!isNonEmptyString9(assignment.targetRoom)) {
+  if (!isNonEmptyString10(assignment.targetRoom)) {
     return false;
   }
   if (isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
@@ -8589,7 +8980,7 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   if (!isTerritoryControlAction3(assignment.action)) {
     return false;
   }
-  if (isNonEmptyString9(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
+  if (isNonEmptyString10(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
@@ -8608,14 +8999,14 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   return targetState === "available" || assignment.action === "reserve" && targetState === "satisfied";
 }
 function isVisibleTerritoryAssignmentComplete(assignment, creep) {
-  if (assignment.action !== "claim" || !isNonEmptyString9(assignment.targetRoom)) {
+  if (assignment.action !== "claim" || !isNonEmptyString10(assignment.targetRoom)) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
   return (controller == null ? void 0 : controller.my) === true && !shouldSignOccupiedController(controller);
 }
 function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, creep) {
-  if (assignment.action !== "claim" || !isNonEmptyString9(assignment.targetRoom)) {
+  if (assignment.action !== "claim" || !isNonEmptyString10(assignment.targetRoom)) {
     return false;
   }
   if (!isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
@@ -8625,10 +9016,10 @@ function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, cree
   return (controller == null ? void 0 : controller.my) === true && shouldSignOccupiedController(controller);
 }
 function suppressTerritoryIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString9(colony) || !isNonEmptyString9(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
+  if (!isNonEmptyString10(colony) || !isNonEmptyString10(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
     return;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
@@ -8652,7 +9043,7 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...followUp ? { followUp } : {}
   };
-  upsertTerritoryIntent3(intents, suppressedIntent);
+  upsertTerritoryIntent4(intents, suppressedIntent);
   removeTerritoryFollowUpDemand(territoryMemory, colony, assignment.targetRoom, assignment.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
@@ -8678,10 +9069,10 @@ function suppressSameRoomClaimTerritoryIntents(territoryMemory, intents, colony,
   setTerritoryIntents(territoryMemory, intents);
 }
 function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString9(colony) || !isNonEmptyString9(assignment.targetRoom) || assignment.action !== "reserve" || isTerritoryIntentSuppressed(colony, assignment.targetRoom, "reserve", gameTime)) {
+  if (!isNonEmptyString10(colony) || !isNonEmptyString10(assignment.targetRoom) || assignment.action !== "reserve" || isTerritoryIntentSuppressed(colony, assignment.targetRoom, "reserve", gameTime)) {
     return null;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return null;
   }
@@ -8716,7 +9107,7 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
     action: "reserve",
     ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
   });
-  upsertTerritoryIntent3(intents, {
+  upsertTerritoryIntent4(intents, {
     colony: plan.colony,
     targetRoom: plan.targetRoom,
     action: plan.action,
@@ -8732,19 +9123,19 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
   return reserveAssignment;
 }
 function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation, gameTime) {
-  if (evaluation.status !== "skipped" || evaluation.reason !== "gclInsufficient" && evaluation.reason !== "controllerCooldown" || !isNonEmptyString9(colony) || !isNonEmptyString9(evaluation.targetRoom) || isTerritoryIntentSuppressed(colony, evaluation.targetRoom, "reserve", gameTime)) {
+  if (evaluation.status !== "skipped" || evaluation.reason !== "gclInsufficient" && evaluation.reason !== "controllerCooldown" || !isNonEmptyString10(colony) || !isNonEmptyString10(evaluation.targetRoom) || isTerritoryIntentSuppressed(colony, evaluation.targetRoom, "reserve", gameTime)) {
     return null;
   }
   const targetRoom = evaluation.targetRoom;
-  if (!isNonEmptyString9(targetRoom)) {
+  if (!isNonEmptyString10(targetRoom)) {
     return null;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return null;
   }
   const colonyOwnerUsername = getVisibleColonyOwnerUsername2(colony);
-  if (!isNonEmptyString9(colonyOwnerUsername)) {
+  if (!isNonEmptyString10(colonyOwnerUsername)) {
     return null;
   }
   const controller = getVisibleController2(targetRoom, evaluation.controllerId);
@@ -8775,9 +9166,9 @@ function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation,
     gameTime
   );
 }
-function refreshRemoteMiningSetup(colony, gameTime = getGameTime11()) {
+function refreshRemoteMiningSetup(colony, gameTime = getGameTime12()) {
   var _a, _b, _c, _d;
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
@@ -8788,7 +9179,7 @@ function refreshRemoteMiningSetup(colony, gameTime = getGameTime11()) {
     return;
   }
   let remoteMining;
-  if (isRecord9(storedRemoteMining) && !Array.isArray(storedRemoteMining)) {
+  if (isRecord10(storedRemoteMining) && !Array.isArray(storedRemoteMining)) {
     remoteMining = storedRemoteMining;
   } else {
     remoteMining = {};
@@ -8897,8 +9288,11 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
 function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, options = {}) {
   var _a, _b, _c;
   const colonyName = colony.room.name;
-  const colonyOwnerUsername = getControllerOwnerUsername4(colony.room.controller);
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const colonyOwnerUsername = getControllerOwnerUsername5(colony.room.controller);
+  if (options.controllerPressureOnly !== true && options.followUpOnly !== true) {
+    refreshExpansionPlannerIntent(colony, gameTime);
+  }
+  const territoryMemory = getTerritoryMemoryRecord6();
   let intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
   const refreshedExpiredClaims = refreshExpiredPostClaimClaimIntents(
     territoryMemory,
@@ -9298,7 +9692,7 @@ function getConfiguredTerritoryCandidates(colony, colonyName, colonyOwnerUsernam
   });
 }
 function getConfiguredTerritoryCandidateAction(target, colony, colonyOwnerUsername, territoryMemory, gameTime) {
-  if (target.action !== "reserve" || !isNonEmptyString9(colonyOwnerUsername)) {
+  if (target.action !== "reserve" || !isNonEmptyString10(colonyOwnerUsername)) {
     return target.action;
   }
   if (target.createdBy === "adjacentRoomReservation") {
@@ -9346,25 +9740,25 @@ function isColonyReadyForAdjacentReservationAutoClaim(colony) {
   if (hasActivePostClaimBootstrap(colony.room.name)) {
     return false;
   }
-  const ownedRoomCount = getVisibleOwnedRoomNames3(colony.room.name).length;
+  const ownedRoomCount = getVisibleOwnedRoomNames4(colony.room.name).length;
   if (ownedRoomCount >= maxRoomsForRcl(controllerLevel)) {
     return false;
   }
-  const gclLevel = getGclLevel2();
+  const gclLevel = getGclLevel3();
   return typeof gclLevel !== "number" || ownedRoomCount < gclLevel;
 }
 function hasActivePostClaimBootstrap(colonyName) {
   var _a;
-  const records = (_a = getTerritoryMemoryRecord5()) == null ? void 0 : _a.postClaimBootstraps;
-  if (!isRecord9(records)) {
+  const records = (_a = getTerritoryMemoryRecord6()) == null ? void 0 : _a.postClaimBootstraps;
+  if (!isRecord10(records)) {
     return false;
   }
   return Object.values(records).some(
-    (record) => isRecord9(record) && record.colony === colonyName && record.status !== "ready"
+    (record) => isRecord10(record) && record.colony === colonyName && record.status !== "ready"
   );
 }
 function refreshExpiredPostClaimClaimIntents(territoryMemory, intents, colonyName, gameTime) {
-  if (!territoryMemory || !isRecord9(territoryMemory.postClaimBootstraps)) {
+  if (!territoryMemory || !isRecord10(territoryMemory.postClaimBootstraps)) {
     return { intents, changed: false };
   }
   let changed = false;
@@ -9377,7 +9771,7 @@ function refreshExpiredPostClaimClaimIntents(territoryMemory, intents, colonyNam
     if (isSuppressedTerritoryIntentForAction(nextIntents, colonyName, record.roomName, "claim", gameTime) || isTerritoryIntentSuspendedForAction(nextIntents, colonyName, record.roomName, "claim", gameTime)) {
       continue;
     }
-    const controllerId = isNonEmptyString9(controller.id) ? controller.id : record.controllerId;
+    const controllerId = isNonEmptyString10(controller.id) ? controller.id : record.controllerId;
     const claimTarget = {
       colony: colonyName,
       roomName: record.roomName,
@@ -9386,7 +9780,7 @@ function refreshExpiredPostClaimClaimIntents(territoryMemory, intents, colonyNam
     };
     appendTerritoryTargetIfMissing(territoryMemory, claimTarget);
     territoryMemory.intents = nextIntents;
-    upsertTerritoryIntent3(nextIntents, {
+    upsertTerritoryIntent4(nextIntents, {
       colony: colonyName,
       targetRoom: record.roomName,
       action: "claim",
@@ -9400,7 +9794,7 @@ function refreshExpiredPostClaimClaimIntents(territoryMemory, intents, colonyNam
 }
 function getExpiredPostClaimClaimRefreshRecords(territoryMemory, colonyName) {
   const records = territoryMemory.postClaimBootstraps;
-  if (!isRecord9(records)) {
+  if (!isRecord10(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -9408,12 +9802,12 @@ function getExpiredPostClaimClaimRefreshRecords(territoryMemory, colonyName) {
   ).sort(comparePostClaimClaimRefreshRecords);
 }
 function isPostClaimClaimRefreshRecord(record, colonyName) {
-  return isRecord9(record) && record.colony === colonyName && isNonEmptyString9(record.roomName) && record.roomName !== colonyName && isFiniteNumber7(record.claimedAt) && isFiniteNumber7(record.updatedAt) && isPostClaimRemoteMiningStatus(record.status);
+  return isRecord10(record) && record.colony === colonyName && isNonEmptyString10(record.roomName) && record.roomName !== colonyName && isFiniteNumber7(record.claimedAt) && isFiniteNumber7(record.updatedAt) && isPostClaimRemoteMiningStatus(record.status);
 }
 function comparePostClaimClaimRefreshRecords(left, right) {
   return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
 }
-function getGclLevel2() {
+function getGclLevel3() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
@@ -9571,7 +9965,7 @@ function getStoredTerritoryReservation(territoryMemory, target) {
     return null;
   }
   const reservation = normalizeTerritoryReservation(
-    isRecord9(territoryMemory.reservations) ? territoryMemory.reservations[getTerritoryReservationMemoryKey(target.colony, target.roomName)] : void 0
+    isRecord10(territoryMemory.reservations) ? territoryMemory.reservations[getTerritoryReservationMemoryKey(target.colony, target.roomName)] : void 0
   );
   if (!reservation || reservation.colony !== target.colony || reservation.roomName !== target.roomName || target.controllerId !== void 0 && reservation.controllerId !== void 0 && reservation.controllerId !== target.controllerId) {
     return null;
@@ -9583,7 +9977,7 @@ function getTerritoryReservationPreRenewScoutLeadTicks(colonyName, targetRoom, r
   return TERRITORY_RESERVATION_RENEWAL_TICKS + (typeof routeDistance === "number" ? routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS * 2 : 0);
 }
 function normalizeTerritoryReservations(rawReservations) {
-  if (!isRecord9(rawReservations)) {
+  if (!isRecord10(rawReservations)) {
     return {};
   }
   const reservations = {};
@@ -9596,10 +9990,10 @@ function normalizeTerritoryReservations(rawReservations) {
   return reservations;
 }
 function normalizeTerritoryReservation(rawReservation) {
-  if (!isRecord9(rawReservation)) {
+  if (!isRecord10(rawReservation)) {
     return null;
   }
-  if (!isNonEmptyString9(rawReservation.colony) || !isNonEmptyString9(rawReservation.roomName) || !isFiniteNumber7(rawReservation.ticksToEnd) || !isFiniteNumber7(rawReservation.updatedAt)) {
+  if (!isNonEmptyString10(rawReservation.colony) || !isNonEmptyString10(rawReservation.roomName) || !isFiniteNumber7(rawReservation.ticksToEnd) || !isFiniteNumber7(rawReservation.updatedAt)) {
     return null;
   }
   return {
@@ -9611,7 +10005,7 @@ function normalizeTerritoryReservation(rawReservation) {
   };
 }
 function hasMalformedTerritoryReservationMemory(rawReservations, reservations) {
-  return isRecord9(rawReservations) && Object.keys(rawReservations).length !== Object.keys(reservations).length;
+  return isRecord10(rawReservations) && Object.keys(rawReservations).length !== Object.keys(reservations).length;
 }
 function getTerritoryReservationMemoryKey(colonyName, roomName) {
   return `${colonyName}${TERRITORY_ROUTE_DISTANCE_SEPARATOR3}${roomName}`;
@@ -9655,7 +10049,7 @@ function suppressDeadZoneTerritoryTargets(territoryMemory, intents, colonyName, 
       continue;
     }
     territoryMemory.intents = nextIntents;
-    upsertTerritoryIntent3(nextIntents, {
+    upsertTerritoryIntent4(nextIntents, {
       colony: target.colony,
       targetRoom: target.roomName,
       action: target.action,
@@ -9726,7 +10120,7 @@ function isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts,
 }
 function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, source, orderOffset, routeDistanceLookupContext) {
   const adjacentRooms = sortAdjacentRoomsByPersistedExpansionScore(
-    getAdjacentRoomNames3(originRoomName),
+    getAdjacentRoomNames4(originRoomName),
     colonyName,
     territoryMemory
   );
@@ -9796,10 +10190,10 @@ function getPersistedExpansionCandidateRanks(colonyName, territoryMemory) {
   }
   const ranks = /* @__PURE__ */ new Map();
   for (const [index, rawCandidate] of territoryMemory.expansionCandidates.entries()) {
-    if (!isRecord9(rawCandidate)) {
+    if (!isRecord10(rawCandidate)) {
       continue;
     }
-    if (rawCandidate.colony !== colonyName || !isNonEmptyString9(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || !isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction) || ranks.has(rawCandidate.roomName)) {
+    if (rawCandidate.colony !== colonyName || !isNonEmptyString10(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || !isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction) || ranks.has(rawCandidate.roomName)) {
       continue;
     }
     ranks.set(
@@ -9885,7 +10279,7 @@ function getSatisfiedClaimAdjacentReserveCandidates(colonyName, colonyOwnerUsern
       gameTime,
       includeScoutCandidates,
       "satisfiedClaimAdjacent",
-      (order + 1) * EXIT_DIRECTION_ORDER3.length,
+      (order + 1) * EXIT_DIRECTION_ORDER4.length,
       routeDistanceLookupContext
     )
   );
@@ -9909,7 +10303,7 @@ function getSatisfiedReserveAdjacentReserveCandidates(colonyName, colonyOwnerUse
       gameTime,
       includeScoutCandidates,
       "satisfiedReserveAdjacent",
-      (order + 1) * EXIT_DIRECTION_ORDER3.length,
+      (order + 1) * EXIT_DIRECTION_ORDER4.length,
       routeDistanceLookupContext
     )
   );
@@ -9933,7 +10327,7 @@ function getActiveReserveAdjacentReserveCandidates(colonyName, colonyOwnerUserna
       gameTime,
       includeScoutCandidates,
       "activeReserveAdjacent",
-      (order + 1) * EXIT_DIRECTION_ORDER3.length,
+      (order + 1) * EXIT_DIRECTION_ORDER4.length,
       routeDistanceLookupContext
     )
   );
@@ -10010,7 +10404,7 @@ function getInferredTerritoryRouteDistance(source) {
 }
 function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, candidates, gameTime) {
   var _a;
-  const colonyOwnerUsername = (_a = getControllerOwnerUsername4(colony.room.controller)) != null ? _a : void 0;
+  const colonyOwnerUsername = (_a = getControllerOwnerUsername5(colony.room.controller)) != null ? _a : void 0;
   const adjacentControllerProgressReady = isTerritoryHomeReadyForAdjacentControllerProgress(
     colony,
     roleCounts,
@@ -10140,7 +10534,7 @@ function buildOccupationRecommendationCandidate(candidate, gameTime) {
   const scoutIntel = room || shouldRefreshExpansionCandidateScoutIntel(
     candidate.target.colony,
     candidate.target.roomName,
-    getTerritoryMemoryRecord5(),
+    getTerritoryMemoryRecord6(),
     gameTime
   ) ? null : getFreshTerritoryScoutIntel(candidate.target.colony, candidate.target.roomName, gameTime);
   return {
@@ -10171,7 +10565,7 @@ function hasPersistedAdjacentExpansionCandidate(colonyName, roomName, territoryM
     return false;
   }
   return territoryMemory.expansionCandidates.some((rawCandidate) => {
-    if (!isRecord9(rawCandidate)) {
+    if (!isRecord10(rawCandidate)) {
       return false;
     }
     return rawCandidate.colony === colonyName && rawCandidate.roomName === roomName && rawCandidate.adjacentToOwnedRoom === true && rawCandidate.evidenceStatus !== "unavailable" && isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction);
@@ -10194,11 +10588,11 @@ function buildVisibleOccupationRecommendationEvidence(room, controllerId) {
   const controller = getVisibleController2(room.name, controllerId);
   return {
     ...controller ? { controller: summarizeOccupationController(controller) } : {},
-    sourceCount: countVisibleRoomObjects(room, getFindConstant4("FIND_SOURCES")),
+    sourceCount: countVisibleRoomObjects(room, getFindConstant5("FIND_SOURCES")),
     hostileCreepCount: findVisibleHostileCreeps(room).length,
     hostileStructureCount: findVisibleHostileStructures(room).length,
-    constructionSiteCount: countVisibleRoomObjects(room, getFindConstant4("FIND_MY_CONSTRUCTION_SITES")),
-    ownedStructureCount: countVisibleRoomObjects(room, getFindConstant4("FIND_MY_STRUCTURES"))
+    constructionSiteCount: countVisibleRoomObjects(room, getFindConstant5("FIND_MY_CONSTRUCTION_SITES")),
+    ownedStructureCount: countVisibleRoomObjects(room, getFindConstant5("FIND_MY_STRUCTURES"))
   };
 }
 function buildScoutedOccupationRecommendationEvidence(intel) {
@@ -10224,8 +10618,8 @@ function summarizeScoutOccupationController(controller) {
   };
 }
 function summarizeOccupationController(controller) {
-  const ownerUsername = getControllerOwnerUsername4(controller);
-  const reservationUsername = getControllerReservationUsername3(controller);
+  const ownerUsername = getControllerOwnerUsername5(controller);
+  const reservationUsername = getControllerReservationUsername4(controller);
   const reservationTicksToEnd = getControllerReservationTicksToEnd3(controller);
   return {
     ...controller.my === true ? { my: true } : {},
@@ -10234,10 +10628,10 @@ function summarizeOccupationController(controller) {
     ...typeof reservationTicksToEnd === "number" ? { reservationTicksToEnd } : {}
   };
 }
-function getControllerReservationUsername3(controller) {
+function getControllerReservationUsername4(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : void 0;
+  return isNonEmptyString10(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd3(controller) {
   var _a;
@@ -10284,7 +10678,7 @@ function countVisibleRoomObjects(room, findConstant) {
     return 0;
   }
 }
-function getFindConstant4(name) {
+function getFindConstant5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -10390,7 +10784,7 @@ function getTerritoryCandidateSourcePriority(source) {
 }
 function buildTerritoryFollowUp(source, originRoom) {
   const originAction = getTerritoryFollowUpOriginAction2(source);
-  if (originAction === null || !isTerritoryFollowUpSource2(source) || !isNonEmptyString9(originRoom)) {
+  if (originAction === null || !isTerritoryFollowUpSource2(source) || !isNonEmptyString10(originRoom)) {
     return {};
   }
   return {
@@ -10418,7 +10812,7 @@ function hasKnownNoRoute(fromRoom, targetRoom, routeDistanceLookupContext) {
 }
 function getNearestOwnedRoomRouteDistance(colonyName, targetRoom, fallbackRouteDistance, routeDistanceLookupContext) {
   let nearestDistance = fallbackRouteDistance;
-  for (const ownedRoomName of getVisibleOwnedRoomNames3(colonyName)) {
+  for (const ownedRoomName of getVisibleOwnedRoomNames4(colonyName)) {
     const routeDistance = ownedRoomName === colonyName ? fallbackRouteDistance : getKnownRouteLength2(ownedRoomName, targetRoom, routeDistanceLookupContext);
     if (typeof routeDistance !== "number") {
       continue;
@@ -10427,7 +10821,7 @@ function getNearestOwnedRoomRouteDistance(colonyName, targetRoom, fallbackRouteD
   }
   return nearestDistance;
 }
-function getVisibleOwnedRoomNames3(fallbackRoomName) {
+function getVisibleOwnedRoomNames4(fallbackRoomName) {
   var _a, _b;
   const roomNames = /* @__PURE__ */ new Set([fallbackRoomName]);
   const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
@@ -10435,7 +10829,7 @@ function getVisibleOwnedRoomNames3(fallbackRoomName) {
     return Array.from(roomNames);
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString9(room.name)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString10(room.name)) {
       roomNames.add(room.name);
     }
   }
@@ -10476,11 +10870,11 @@ function getKnownRouteLength2(fromRoom, targetRoom, routeDistanceLookupContext) 
   return route.length;
 }
 function getTerritoryRouteDistanceCache2() {
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord9(territoryMemory.routeDistances)) {
+  if (!isRecord10(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
@@ -10490,7 +10884,7 @@ function getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom) {
 }
 function getNoPathResultCode4() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE4;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE5;
 }
 function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
   if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
@@ -10532,29 +10926,29 @@ function appendTerritoryTargetIfMissing(territoryMemory, target) {
   }
   appendTerritoryTarget(territoryMemory, target);
 }
-function getAdjacentRoomNames3(roomName) {
+function getAdjacentRoomNames4(roomName) {
   const game = globalThis.Game;
   const gameMap = game == null ? void 0 : game.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord9(exits)) {
+  if (!isRecord10(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER3.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER4.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString9(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString10(exitRoom) ? [exitRoom] : [];
   });
 }
 function isRoomAdjacentToColony(colonyName, targetRoom) {
-  return getAdjacentRoomNames3(colonyName).includes(targetRoom);
+  return getAdjacentRoomNames4(colonyName).includes(targetRoom);
 }
 function normalizeTerritoryTarget2(rawTarget) {
-  if (!isRecord9(rawTarget)) {
+  if (!isRecord10(rawTarget)) {
     return null;
   }
-  if (!isNonEmptyString9(rawTarget.colony) || !isNonEmptyString9(rawTarget.roomName) || !isTerritoryControlAction3(rawTarget.action)) {
+  if (!isNonEmptyString10(rawTarget.colony) || !isNonEmptyString10(rawTarget.roomName) || !isTerritoryControlAction3(rawTarget.action)) {
     return null;
   }
   return {
@@ -10571,7 +10965,7 @@ function isTerritoryAutomationSource2(source) {
   return source === OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function recordTerritoryIntent(plan, status, gameTime, seededTarget = null, routeDistanceLookupContext = createRouteDistanceLookupContext()) {
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
@@ -10592,11 +10986,11 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null, rout
     ...plan.followUp ? { followUp: plan.followUp } : {},
     ...plan.postClaimBootstrapReserveEnergy ? { postClaimBootstrapReserveEnergy: plan.postClaimBootstrapReserveEnergy } : {}
   };
-  upsertTerritoryIntent3(intents, nextIntent);
+  upsertTerritoryIntent4(intents, nextIntent);
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
   recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime, routeDistanceLookupContext);
 }
-function upsertTerritoryIntent3(intents, nextIntent) {
+function upsertTerritoryIntent4(intents, nextIntent) {
   var _a, _b;
   const existingIndex = findTerritoryIntentIndex(intents, nextIntent);
   if (existingIndex >= 0) {
@@ -10917,7 +11311,7 @@ function removeTerritoryFollowUpDemand(territoryMemory, colony, targetRoom, acti
 }
 function getCurrentTerritoryFollowUpDemand(plan, gameTime) {
   var _a;
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return null;
   }
@@ -10998,7 +11392,7 @@ function hasActiveTerritoryFollowUpIntentForColony(intents, colony) {
   return intents.some((intent) => intent.colony === colony && isActiveTerritoryFollowUpIntent(intent));
 }
 function isActiveTerritoryFollowUpIntent(intent) {
-  return (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0 && !isTerritoryIntentSuspensionActive(intent, getGameTime11());
+  return (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0 && !isTerritoryIntentSuspensionActive(intent, getGameTime12());
 }
 function buildTerritoryFollowUpExecutionHint(plan, gameTime) {
   if (!plan.followUp) {
@@ -11067,10 +11461,10 @@ function normalizeTerritoryFollowUpExecutionHints(rawHints) {
   }) : [];
 }
 function normalizeTerritoryFollowUpExecutionHint(rawHint) {
-  if (!isRecord9(rawHint)) {
+  if (!isRecord10(rawHint)) {
     return null;
   }
-  if (rawHint.type !== "activeFollowUpExecution" || !isNonEmptyString9(rawHint.colony) || !isNonEmptyString9(rawHint.targetRoom) || !isTerritoryIntentAction2(rawHint.action) || !isTerritoryExecutionHintReason(rawHint.reason) || typeof rawHint.updatedAt !== "number") {
+  if (rawHint.type !== "activeFollowUpExecution" || !isNonEmptyString10(rawHint.colony) || !isNonEmptyString10(rawHint.targetRoom) || !isTerritoryIntentAction2(rawHint.action) || !isTerritoryExecutionHintReason(rawHint.reason) || typeof rawHint.updatedAt !== "number") {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(rawHint.followUp);
@@ -11098,10 +11492,10 @@ function normalizeTerritoryFollowUpDemands(rawDemands) {
   }) : [];
 }
 function normalizeTerritoryFollowUpDemand(rawDemand) {
-  if (!isRecord9(rawDemand)) {
+  if (!isRecord10(rawDemand)) {
     return null;
   }
-  if (rawDemand.type !== "followUpPreparation" || !isNonEmptyString9(rawDemand.colony) || !isNonEmptyString9(rawDemand.targetRoom) || !isTerritoryControlAction3(rawDemand.action) || typeof rawDemand.updatedAt !== "number") {
+  if (rawDemand.type !== "followUpPreparation" || !isNonEmptyString10(rawDemand.colony) || !isNonEmptyString10(rawDemand.targetRoom) || !isTerritoryControlAction3(rawDemand.action) || typeof rawDemand.updatedAt !== "number") {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(rawDemand.followUp);
@@ -11152,8 +11546,8 @@ function withoutTerritoryIntentSuspension(intent) {
 function isHostileTerritoryIntentSuspensionCoolingDown(suspension, gameTime) {
   return gameTime - suspension.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
 }
-function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGameTime11()) {
-  const territoryMemory = getTerritoryMemoryRecord5();
+function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGameTime12()) {
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return false;
   }
@@ -11195,8 +11589,8 @@ function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, actio
     (intent) => isTerritorySuppressionFresh2(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
-function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime11()) {
-  const territoryMemory = getTerritoryMemoryRecord5();
+function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime12()) {
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return false;
   }
@@ -11224,14 +11618,14 @@ function isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colony
 function selectVisibleTerritoryControllerIntent(creep) {
   var _a, _b, _c;
   const roomName = (_a = creep.room) == null ? void 0 : _a.name;
-  if (!isNonEmptyString9(roomName) || isVisibleRoomUnsafe(creep.room)) {
+  if (!isNonEmptyString10(roomName) || isVisibleRoomUnsafe(creep.room)) {
     return null;
   }
   const assignmentIntent = normalizeCreepTerritoryIntent(creep, roomName);
   if (assignmentIntent && isCreepVisibleTerritoryIntentActionable(creep, assignmentIntent)) {
     return assignmentIntent;
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   const colony = (_b = creep.memory) == null ? void 0 : _b.colony;
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents).filter((intent) => isActiveVisibleControllerIntentForCreep(intent, roomName, colony)).sort(compareVisibleControllerIntents);
   return (_c = intents.find((intent) => isCreepVisibleTerritoryIntentActionable(creep, intent))) != null ? _c : null;
@@ -11239,7 +11633,7 @@ function selectVisibleTerritoryControllerIntent(creep) {
 function normalizeCreepTerritoryIntent(creep, roomName) {
   var _a, _b, _c, _d;
   const assignment = (_a = creep.memory) == null ? void 0 : _a.territory;
-  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction3(assignment.action) || isNonEmptyString9((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
+  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction3(assignment.action) || isNonEmptyString10((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(assignment.followUp);
@@ -11248,13 +11642,13 @@ function normalizeCreepTerritoryIntent(creep, roomName) {
     targetRoom: assignment.targetRoom,
     action: assignment.action,
     status: "active",
-    updatedAt: getGameTime11(),
+    updatedAt: getGameTime12(),
     ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
     ...followUp ? { followUp } : {}
   };
 }
 function isActiveVisibleControllerIntentForCreep(intent, roomName, creepColony) {
-  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction3(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString9(creepColony) || intent.colony === creepColony);
+  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction3(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString10(creepColony) || intent.colony === creepColony);
 }
 function compareVisibleControllerIntents(left, right) {
   return getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) || getIntentActionPriority(left.action) - getIntentActionPriority(right.action) || right.updatedAt - left.updatedAt || left.colony.localeCompare(right.colony);
@@ -11328,12 +11722,12 @@ function getClaimControllerTargetState(controller) {
 }
 function getTerritoryActorUsername(creep, colony) {
   var _a;
-  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString9(colony) ? getVisibleColonyOwnerUsername2(colony) : null;
+  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString10(colony) ? getVisibleColonyOwnerUsername2(colony) : null;
 }
 function getCreepOwnerUsername(creep) {
   var _a;
   const username = (_a = creep == null ? void 0 : creep.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : null;
+  return isNonEmptyString10(username) ? username : null;
 }
 function canUseControllerClaimPart(creep) {
   return getActiveControllerClaimPartCount(creep) > 0;
@@ -11452,8 +11846,8 @@ function isHostileOwnedController(controller) {
   return controller.my !== true;
 }
 function isControllerOwnedByColony2(controller, colonyOwnerUsername) {
-  const ownerUsername = getControllerOwnerUsername4(controller);
-  return controller.my === true || isNonEmptyString9(ownerUsername) && ownerUsername === colonyOwnerUsername;
+  const ownerUsername = getControllerOwnerUsername5(controller);
+  return controller.my === true || isNonEmptyString10(ownerUsername) && ownerUsername === colonyOwnerUsername;
 }
 function getReserveControllerTargetState(controller, colonyOwnerUsername) {
   if (isControllerOwned(controller)) {
@@ -11463,21 +11857,21 @@ function getReserveControllerTargetState(controller, colonyOwnerUsername) {
   if (!reservation) {
     return "available";
   }
-  if (!isNonEmptyString9(reservation.username) || reservation.username !== colonyOwnerUsername) {
+  if (!isNonEmptyString10(reservation.username) || reservation.username !== colonyOwnerUsername) {
     return "unavailable";
   }
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) === null ? "satisfied" : "available";
 }
 function isForeignReservedController(controller, actorUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString9(actorUsername)) {
+  if (isControllerOwned(controller) || !isNonEmptyString10(actorUsername)) {
     return false;
   }
   const reservation = controller.reservation;
-  return isNonEmptyString9(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
+  return isNonEmptyString10(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
 }
 function isOwnReservedController(controller, actorUsername) {
   const reservation = controller.reservation;
-  return isNonEmptyString9(actorUsername) && isNonEmptyString9(reservation == null ? void 0 : reservation.username) && reservation.username === actorUsername;
+  return isNonEmptyString10(actorUsername) && isNonEmptyString10(reservation == null ? void 0 : reservation.username) && reservation.username === actorUsername;
 }
 function updateTerritoryReservationMemory(territoryMemory, colony, roomName, controllerId, gameTime, reservationTicksToEnd) {
   if (reservationTicksToEnd === null) {
@@ -11524,7 +11918,7 @@ function getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? ticksToEnd : null;
 }
 function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString9(colonyOwnerUsername)) {
+  if (isControllerOwned(controller) || !isNonEmptyString10(colonyOwnerUsername)) {
     return null;
   }
   const reservation = controller.reservation;
@@ -11535,12 +11929,12 @@ function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
 }
 function getVisibleColonyOwnerUsername2(colonyName) {
   const controller = getVisibleController2(colonyName);
-  return getControllerOwnerUsername4(controller != null ? controller : void 0);
+  return getControllerOwnerUsername5(controller != null ? controller : void 0);
 }
-function getControllerOwnerUsername4(controller) {
+function getControllerOwnerUsername5(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : null;
+  return isNonEmptyString10(username) ? username : null;
 }
 function getVisibleController2(targetRoom, controllerId) {
   var _a, _b;
@@ -11555,20 +11949,20 @@ function getVisibleController2(targetRoom, controllerId) {
   }
   return null;
 }
-function getGameTime11() {
+function getGameTime12() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
 function getRemoteMiningBootstrapRecords(territoryMemory, colonyName) {
   const records = territoryMemory.postClaimBootstraps;
-  if (!isRecord9(records)) {
+  if (!isRecord10(records)) {
     return [];
   }
   return Object.values(records).filter((record) => isRemoteMiningBootstrapRecord(record, colonyName)).sort(compareRemoteMiningBootstrapRecords);
 }
 function isRemoteMiningBootstrapRecord(record, colonyName) {
-  return isRecord9(record) && record.colony === colonyName && isNonEmptyString9(record.roomName) && record.roomName !== colonyName && isPostClaimRemoteMiningStatus(record.status);
+  return isRecord10(record) && record.colony === colonyName && isNonEmptyString10(record.roomName) && record.roomName !== colonyName && isPostClaimRemoteMiningStatus(record.status);
 }
 function isPostClaimRemoteMiningStatus(status) {
   return status === "detected" || status === "spawnSitePending" || status === "spawnSiteBlocked" || status === "spawningWorkers" || status === "ready";
@@ -11598,7 +11992,7 @@ function isSameRemoteMiningRoomMemory(left, right) {
   return left != null && left.colony === right.colony && left.roomName === right.roomName && left.status === right.status && left.updatedAt === right.updatedAt && isSameRemoteMiningSources(left.sources, right.sources);
 }
 function isSameRemoteMiningSources(left, right) {
-  if (!isRecord9(left)) {
+  if (!isRecord10(left)) {
     return false;
   }
   const leftKeys = Object.keys(left);
@@ -11687,24 +12081,24 @@ function getRemoteMiningStatus(sources) {
   }
   return "containerReady";
 }
-function getWritableTerritoryMemoryRecord4() {
-  const memory = getMemoryRecord();
+function getWritableTerritoryMemoryRecord5() {
+  const memory = getMemoryRecord2();
   if (!memory) {
     return null;
   }
-  if (!isRecord9(memory.territory)) {
+  if (!isRecord10(memory.territory)) {
     memory.territory = {};
   }
   return memory.territory;
 }
-function getTerritoryMemoryRecord5() {
-  const memory = getMemoryRecord();
-  if (!memory || !isRecord9(memory.territory)) {
+function getTerritoryMemoryRecord6() {
+  const memory = getMemoryRecord2();
+  if (!memory || !isRecord10(memory.territory)) {
     return null;
   }
   return memory.territory;
 }
-function getMemoryRecord() {
+function getMemoryRecord2() {
   const memory = globalThis.Memory;
   return memory != null ? memory : null;
 }
@@ -11720,7 +12114,7 @@ function isTerritoryFollowUpSource2(source) {
 function isTerritoryExecutionHintReason(reason) {
   return reason === "controlEvidenceStillMissing" || reason === "followUpTargetStillUnseen" || reason === "visibleControlEvidenceStillActionable";
 }
-function isNonEmptyString9(value) {
+function isNonEmptyString10(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber7(value) {
@@ -11729,7 +12123,7 @@ function isFiniteNumber7(value) {
 function isPositiveFiniteNumber2(value) {
   return isFiniteNumber7(value) && value > 0;
 }
-function isRecord9(value) {
+function isRecord10(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -12009,7 +12403,7 @@ var BEHAVIOR_COUNTER_KEYS = [
   { key: "pathLength" }
 ];
 var TOP_IDLE_WORKER_COUNT = 3;
-function observeCreepBehaviorTick(creep, tick = getGameTime12()) {
+function observeCreepBehaviorTick(creep, tick = getGameTime13()) {
   var _a, _b;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastObservedTick === tick) {
@@ -12029,7 +12423,7 @@ function observeCreepBehaviorTick(creep, tick = getGameTime12()) {
   }
   telemetry.lastObservedTick = tick;
 }
-function recordCreepBehaviorIdle(creep, tick = getGameTime12()) {
+function recordCreepBehaviorIdle(creep, tick = getGameTime13()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastIdleTick === tick) {
@@ -12038,7 +12432,7 @@ function recordCreepBehaviorIdle(creep, tick = getGameTime12()) {
   telemetry.idleTicks = ((_a = telemetry.idleTicks) != null ? _a : 0) + 1;
   telemetry.lastIdleTick = tick;
 }
-function recordCreepBehaviorMove(creep, tick = getGameTime12()) {
+function recordCreepBehaviorMove(creep, tick = getGameTime13()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastMoveTick === tick) {
@@ -12047,7 +12441,7 @@ function recordCreepBehaviorMove(creep, tick = getGameTime12()) {
   telemetry.moveTicks = ((_a = telemetry.moveTicks) != null ? _a : 0) + 1;
   telemetry.lastMoveTick = tick;
 }
-function recordCreepBehaviorWork(creep, tick = getGameTime12()) {
+function recordCreepBehaviorWork(creep, tick = getGameTime13()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastWorkTick === tick) {
@@ -12064,7 +12458,7 @@ function recordCreepBehaviorContainerTransfer(creep) {
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   telemetry.containerTransfers = ((_a = telemetry.containerTransfers) != null ? _a : 0) + 1;
 }
-function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime12()) {
+function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime13()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastSourceContainerWithdrawalTick === tick) {
@@ -12229,7 +12623,7 @@ function getStepDistance(previous, current) {
   }
   return Math.max(Math.abs(current.x - previous.x), Math.abs(current.y - previous.y));
 }
-function getGameTime12() {
+function getGameTime13() {
   const game = globalThis.Game;
   return typeof (game == null ? void 0 : game.time) === "number" ? game.time : 0;
 }
@@ -12279,7 +12673,7 @@ function getRoomEnergySurplusState(room) {
 function refreshRoomEnergySurplusState(room) {
   const state = getRoomEnergySurplusState(room);
   const memory = getEconomyMemory();
-  const updatedAt = getGameTime13();
+  const updatedAt = getGameTime14();
   if (!isPlainObject(memory.energySurplus) || !isPlainObject(memory.energySurplus.rooms)) {
     memory.energySurplus = { updatedAt, rooms: {} };
   }
@@ -12460,7 +12854,7 @@ function getMemory() {
   }
   return global.Memory;
 }
-function getGameTime13() {
+function getGameTime14() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -12481,7 +12875,7 @@ var STORAGE_BALANCE_IMPORT_RATIO = 0.3;
 var STORAGE_BALANCE_REFRESH_INTERVAL = 25;
 function balanceStorage() {
   const memory = getEconomyMemory2();
-  const gameTime = getGameTime14();
+  const gameTime = getGameTime15();
   const existing = memory.storageBalance;
   if (existing && isStorageBalanceFresh(existing, gameTime)) {
     return;
@@ -12490,7 +12884,7 @@ function balanceStorage() {
 }
 function getStorageBalanceState() {
   const memory = getEconomyMemory2();
-  const gameTime = getGameTime14();
+  const gameTime = getGameTime15();
   const existing = memory.storageBalance;
   if (existing && isStorageBalanceFresh(existing, gameTime)) {
     return existing;
@@ -12688,7 +13082,7 @@ function getMemory2() {
   }
   return global.Memory;
 }
-function getGameTime14() {
+function getGameTime15() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -12707,7 +13101,7 @@ var MIN_CARRY_MOVE_PAIRS = 1;
 var CROSS_ROOM_HAULER_REPLACEMENT_TICKS = 100;
 var CROSS_ROOM_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var OK_CODE5 = 0;
-var ERR_NO_PATH_CODE5 = -2;
+var ERR_NO_PATH_CODE6 = -2;
 var ERR_NOT_IN_RANGE_CODE3 = -9;
 function planCrossRoomHauler(getEnergyBudget = getDefaultCrossRoomHaulerEnergyBudget) {
   const transfer = selectCrossRoomEnergyTransfer();
@@ -12740,7 +13134,7 @@ function planCrossRoomHauler(getEnergyBudget = getDefaultCrossRoomHaulerEnergyBu
   return {
     spawn,
     body,
-    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime15()}`,
+    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime16()}`,
     memory: {
       role: CROSS_ROOM_HAULER_ROLE,
       colony: sourceRoom.name,
@@ -13053,7 +13447,7 @@ function findOwnedLogisticsRoute(fromRoom, targetRoom) {
   if (route === getNoPathResultCode5() || !Array.isArray(route)) {
     return null;
   }
-  const rooms = route.map((step) => isRecord10(step) && typeof step.room === "string" ? step.room : null).filter((roomName) => typeof roomName === "string");
+  const rooms = route.map((step) => isRecord11(step) && typeof step.room === "string" ? step.room : null).filter((roomName) => typeof roomName === "string");
   if (rooms.length !== route.length || !rooms.every(isSafeLogisticsTransitRoom)) {
     return null;
   }
@@ -13076,7 +13470,7 @@ function moveTowardRoom(creep, assignment, destinationRoom) {
 function getAssignmentRoute(assignment) {
   const route = findOwnedLogisticsRoute(assignment.homeRoom, assignment.targetRoom);
   if (!route) {
-    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString10) : null;
+    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString11) : null;
   }
   assignment.route = route.rooms;
   return route.rooms;
@@ -13155,20 +13549,20 @@ function findRoomStructures3(room) {
   return Array.isArray(structures) ? structures : [];
 }
 function normalizeCrossRoomHaulerMemory(value) {
-  if (!isRecord10(value)) {
+  if (!isRecord11(value)) {
     return null;
   }
-  if (!isNonEmptyString10(value.homeRoom) || !isNonEmptyString10(value.targetRoom)) {
+  if (!isNonEmptyString11(value.homeRoom) || !isNonEmptyString11(value.targetRoom)) {
     return null;
   }
-  const sourceId = isNonEmptyString10(value.sourceId) ? value.sourceId : null;
+  const sourceId = isNonEmptyString11(value.sourceId) ? value.sourceId : null;
   const state = value.state === "collecting" || value.state === "delivering" || value.state === "returning" || value.state === "unassigned" ? value.state : void 0;
   return {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId,
     ...state ? { state: sourceId ? state : "unassigned" } : sourceId ? {} : { state: "unassigned" },
-    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString10) } : {}
+    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString11) } : {}
   };
 }
 function getMutableCrossRoomHaulerMemory(creep) {
@@ -13213,7 +13607,7 @@ function getVisibleRoom4(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameTime15() {
+function getGameTime16() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -13228,10 +13622,10 @@ function getErrNotInRangeCode() {
 }
 function getNoPathResultCode5() {
   var _a;
-  return (_a = globalThis.ERR_NO_PATH) != null ? _a : ERR_NO_PATH_CODE5;
+  return (_a = globalThis.ERR_NO_PATH) != null ? _a : ERR_NO_PATH_CODE6;
 }
 function getObjectId7(object) {
-  if (!isRecord10(object)) {
+  if (!isRecord11(object)) {
     return "";
   }
   return typeof object.id === "string" ? object.id : typeof object.name === "string" ? object.name : "";
@@ -13245,10 +13639,10 @@ function getGlobalNumber7(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function isRecord10(value) {
+function isRecord11(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString10(value) {
+function isNonEmptyString11(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -13624,12 +14018,12 @@ function recordWorkerTaskBehaviorTrace(creep, selectedTask) {
 function buildWorkerTaskBehaviorState(creep) {
   var _a, _b, _c, _d, _e;
   const room = creep.room;
-  const structures = findRoomObjects12(room, getFindConstant5("FIND_STRUCTURES"));
-  const myStructures = findRoomObjects12(room, getFindConstant5("FIND_MY_STRUCTURES"));
-  const constructionSites = findRoomObjects12(room, getFindConstant5("FIND_CONSTRUCTION_SITES"));
-  const droppedResources = findRoomObjects12(room, getFindConstant5("FIND_DROPPED_RESOURCES"));
-  const sources = findRoomObjects12(room, getFindConstant5("FIND_SOURCES"));
-  const hostileCreeps = findRoomObjects12(room, getFindConstant5("FIND_HOSTILE_CREEPS"));
+  const structures = findRoomObjects13(room, getFindConstant6("FIND_STRUCTURES"));
+  const myStructures = findRoomObjects13(room, getFindConstant6("FIND_MY_STRUCTURES"));
+  const constructionSites = findRoomObjects13(room, getFindConstant6("FIND_CONSTRUCTION_SITES"));
+  const droppedResources = findRoomObjects13(room, getFindConstant6("FIND_DROPPED_RESOURCES"));
+  const sources = findRoomObjects13(room, getFindConstant6("FIND_SOURCES"));
+  const hostileCreeps = findRoomObjects13(room, getFindConstant6("FIND_HOSTILE_CREEPS"));
   const currentTask = (_c = (_b = (_a = creep.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) != null ? _c : "none";
   const carriedEnergy = getUsedEnergy(creep);
   const freeCapacity = getFreeEnergyCapacity4(creep);
@@ -13708,7 +14102,7 @@ function countRepairTargets(structures) {
     return isStructureType(structure, "STRUCTURE_ROAD", "road") || isStructureType(structure, "STRUCTURE_CONTAINER", "container") || isStructureType(structure, "STRUCTURE_RAMPART", "rampart") && structure.my !== false;
   }).length;
 }
-function findRoomObjects12(room, findConstant) {
+function findRoomObjects13(room, findConstant) {
   if (!room || typeof room.find !== "function" || typeof findConstant !== "number") {
     return [];
   }
@@ -13719,7 +14113,7 @@ function findRoomObjects12(room, findConstant) {
     return [];
   }
 }
-function getFindConstant5(name) {
+function getFindConstant6(name) {
   const value = globalThis[name];
   return typeof value === "number" && Number.isFinite(value) ? value : void 0;
 }
@@ -15126,14 +15520,14 @@ function recordInterRoomEnergyHaulAssignment(creep, transfer, ids) {
   };
 }
 function normalizeInterRoomEnergyHaulMemory(value) {
-  if (!isWorkerTaskRecord(value) || !isNonEmptyString11(value.sourceRoom) || !isNonEmptyString11(value.targetRoom)) {
+  if (!isWorkerTaskRecord(value) || !isNonEmptyString12(value.sourceRoom) || !isNonEmptyString12(value.targetRoom)) {
     return null;
   }
   return {
     sourceRoom: value.sourceRoom,
     targetRoom: value.targetRoom,
-    ...isNonEmptyString11(value.sourceId) ? { sourceId: value.sourceId } : {},
-    ...isNonEmptyString11(value.targetId) ? { targetId: value.targetId } : {},
+    ...isNonEmptyString12(value.sourceId) ? { sourceId: value.sourceId } : {},
+    ...isNonEmptyString12(value.targetId) ? { targetId: value.targetId } : {},
     ...typeof value.updatedAt === "number" && Number.isFinite(value.updatedAt) ? { updatedAt: value.updatedAt } : {}
   };
 }
@@ -15147,7 +15541,7 @@ function clearInterRoomEnergyHaulAssignment(creep) {
     delete creep.memory.interRoomEnergyHaul;
   }
 }
-function isNonEmptyString11(value) {
+function isNonEmptyString12(value) {
   return typeof value === "string" && value.length > 0;
 }
 function getVisibleOwnedRoom(roomName) {
@@ -17755,7 +18149,7 @@ function findVisibleAdjacentClaimedRooms(room) {
   }
   const game = globalThis.Game;
   const visibleRooms = game == null ? void 0 : game.rooms;
-  const adjacentRoomNames = getAdjacentRoomNames4(roomName, game == null ? void 0 : game.map);
+  const adjacentRoomNames = getAdjacentRoomNames5(roomName, game == null ? void 0 : game.map);
   if (!visibleRooms || adjacentRoomNames.length === 0) {
     return [];
   }
@@ -17764,7 +18158,7 @@ function findVisibleAdjacentClaimedRooms(room) {
     return ((_a = candidate == null ? void 0 : candidate.controller) == null ? void 0 : _a.my) === true;
   }).sort((left, right) => left.name.localeCompare(right.name));
 }
-function getAdjacentRoomNames4(roomName, gameMap) {
+function getAdjacentRoomNames5(roomName, gameMap) {
   if (typeof (gameMap == null ? void 0 : gameMap.describeExits) !== "function") {
     return [];
   }
@@ -19074,7 +19468,7 @@ function selectRemoteHarvesterAssignment(homeRoom) {
   )) != null ? _a : null;
 }
 function getRemoteSourceAssignments(homeRoom) {
-  if (!isNonEmptyString12(homeRoom)) {
+  if (!isNonEmptyString13(homeRoom)) {
     return [];
   }
   const records = getRemoteBootstrapRecords(homeRoom);
@@ -19200,13 +19594,13 @@ function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
 function getRemoteBootstrapRecords(homeRoom) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord11(records)) {
+  if (!isRecord12(records)) {
     return [];
   }
   return Object.values(records).filter((record) => isRemoteBootstrapRecord(record, homeRoom)).sort(compareRemoteBootstrapRecords);
 }
 function isRemoteBootstrapRecord(record, homeRoom) {
-  return isRecord11(record) && record.colony === homeRoom && isNonEmptyString12(record.roomName) && record.roomName !== homeRoom && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord12(record) && record.colony === homeRoom && isNonEmptyString13(record.roomName) && record.roomName !== homeRoom && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function compareRemoteBootstrapRecords(left, right) {
   return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
@@ -19241,18 +19635,18 @@ function hasHostileSuspendedTerritoryIntent(homeRoom, targetRoom) {
     return false;
   }
   return intents.some(
-    (intent) => isRecord11(intent) && intent.colony === homeRoom && intent.targetRoom === targetRoom && intent.suspended !== void 0 && isRecord11(intent.suspended) && intent.suspended.reason === "hostile_presence"
+    (intent) => isRecord12(intent) && intent.colony === homeRoom && intent.targetRoom === targetRoom && intent.suspended !== void 0 && isRecord12(intent.suspended) && intent.suspended.reason === "hostile_presence"
   );
 }
 function normalizeRemoteHarvesterMemory(value) {
-  if (!isRecord11(value)) {
+  if (!isRecord12(value)) {
     return null;
   }
-  return isNonEmptyString12(value.homeRoom) && isNonEmptyString12(value.targetRoom) && isNonEmptyString12(value.sourceId) && (value.containerId == null || isNonEmptyString12(value.containerId)) ? {
+  return isNonEmptyString13(value.homeRoom) && isNonEmptyString13(value.targetRoom) && isNonEmptyString13(value.sourceId) && (value.containerId == null || isNonEmptyString13(value.containerId)) ? {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId: value.sourceId,
-    ...isNonEmptyString12(value.containerId) ? { containerId: value.containerId } : {}
+    ...isNonEmptyString13(value.containerId) ? { containerId: value.containerId } : {}
   } : null;
 }
 function getAssignedSource2(assignment) {
@@ -19268,7 +19662,7 @@ function getAssignedSource2(assignment) {
   return (_a = room.find(FIND_SOURCES).find((candidate) => String(candidate.id) === String(assignment.sourceId))) != null ? _a : null;
 }
 function getAssignedContainer(assignment) {
-  if (isNonEmptyString12(assignment.containerId)) {
+  if (isNonEmptyString13(assignment.containerId)) {
     const container = getObjectById2(assignment.containerId);
     if (container) {
       return container;
@@ -19313,11 +19707,11 @@ function isRemoteMoveRoom(roomName, assignment) {
 }
 function findCriticalRoadMoveTargets(room) {
   return [
-    ...findRoomObjects13(room, "FIND_STRUCTURES"),
-    ...findRoomObjects13(room, "FIND_CONSTRUCTION_SITES")
+    ...findRoomObjects14(room, "FIND_STRUCTURES"),
+    ...findRoomObjects14(room, "FIND_CONSTRUCTION_SITES")
   ].filter((target) => matchesStructureType13(target.structureType, "STRUCTURE_ROAD", "road"));
 }
-function findRoomObjects13(room, constantName) {
+function findRoomObjects14(room, constantName) {
   const findConstant = globalThis[constantName];
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return [];
@@ -19452,10 +19846,10 @@ function getErrNotInRangeCode2() {
   var _a;
   return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE5;
 }
-function isRecord11(value) {
+function isRecord12(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString12(value) {
+function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -19474,7 +19868,7 @@ function selectRemoteHaulerAssignment(homeRoom) {
   return (_a = getRemoteSourceAssignments(homeRoom).filter(hasRemoteContainerAssignment).filter((assignment) => assignment.containerEnergy > REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD).filter((assignment) => countRemoteHaulersForContainer(assignment) < MAX_REMOTE_HAULERS_PER_CONTAINER).sort(compareRemoteHaulerAssignments)[0]) != null ? _a : null;
 }
 function hasRemoteContainerAssignment(assignment) {
-  return isNonEmptyString13(assignment.containerId);
+  return isNonEmptyString14(assignment.containerId);
 }
 function hasRemoteHaulerDeliveryDemand(homeRoom) {
   const room = getVisibleRoom6(homeRoom);
@@ -19568,10 +19962,10 @@ function canSatisfyRemoteCreepCapacity2(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > REMOTE_CREEP_REPLACEMENT_TICKS;
 }
 function normalizeRemoteHaulerMemory(value) {
-  if (!isRecord12(value)) {
+  if (!isRecord13(value)) {
     return null;
   }
-  return isNonEmptyString13(value.homeRoom) && isNonEmptyString13(value.targetRoom) && isNonEmptyString13(value.sourceId) && isNonEmptyString13(value.containerId) ? {
+  return isNonEmptyString14(value.homeRoom) && isNonEmptyString14(value.targetRoom) && isNonEmptyString14(value.sourceId) && isNonEmptyString14(value.containerId) ? {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId: value.sourceId,
@@ -19698,10 +20092,10 @@ function getErrNotInRangeCode3() {
   var _a;
   return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE6;
 }
-function isRecord12(value) {
+function isRecord13(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString13(value) {
+function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -19829,13 +20223,13 @@ var MOVE_PART_COST = 50;
 var MAX_CREEP_PARTS5 = 50;
 var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
 var MAX_CONTROLLER_LEVEL4 = 8;
-var ERR_NO_PATH_CODE6 = -2;
+var ERR_NO_PATH_CODE7 = -2;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR4 = ">";
 var ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
 function recordPlannedMultiRoomUpgraderSpawn(memory) {
   var _a, _b;
   const sustain = memory.controllerSustain;
-  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString14(sustain.homeRoom) || !isNonEmptyString14(sustain.targetRoom)) {
+  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString15(sustain.homeRoom) || !isNonEmptyString15(sustain.targetRoom)) {
     return;
   }
   const cache = getActiveMultiRoomUpgraderCountCache();
@@ -19922,11 +20316,11 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
 }
 function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgraderCounts, order) {
   var _a;
-  if (!isNonEmptyString14(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
+  if (!isNonEmptyString15(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
     return null;
   }
   const controller = room.controller;
-  if (!controller || !isNonEmptyString14(controller.id)) {
+  if (!controller || !isNonEmptyString15(controller.id)) {
     return null;
   }
   const controllerState = getEligibleControllerState(controller);
@@ -19936,7 +20330,7 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgra
   if (hasVisibleHostiles(room)) {
     return null;
   }
-  const routeDistance = getRouteDistance(homeRoom, room.name);
+  const routeDistance = getRouteDistance2(homeRoom, room.name);
   if (routeDistance === null) {
     return null;
   }
@@ -19992,7 +20386,7 @@ function hasActiveClaimedRoomSpawnConstructionSite(room) {
   if (((_a = room.controller) == null ? void 0 : _a.my) !== true || typeof room.find !== "function") {
     return false;
   }
-  const findConstant = getFindConstant6("FIND_MY_CONSTRUCTION_SITES");
+  const findConstant = getFindConstant7("FIND_MY_CONSTRUCTION_SITES");
   if (findConstant === null) {
     return false;
   }
@@ -20004,7 +20398,7 @@ function hasActiveClaimedRoomSpawnConstructionSite(room) {
   }
 }
 function isActiveSpawnConstructionSite(site) {
-  return isRecord13(site) && matchesStructureType15(site.structureType, "STRUCTURE_SPAWN", "spawn") && hasIncompleteConstructionSiteProgress(site);
+  return isRecord14(site) && matchesStructureType15(site.structureType, "STRUCTURE_SPAWN", "spawn") && hasIncompleteConstructionSiteProgress(site);
 }
 function hasIncompleteConstructionSiteProgress(site) {
   const progress = site.progress;
@@ -20014,7 +20408,7 @@ function hasIncompleteConstructionSiteProgress(site) {
   }
   return progress < progressTotal;
 }
-function getFindConstant6(constantName) {
+function getFindConstant7(constantName) {
   const findConstant = globalThis[constantName];
   return typeof findConstant === "number" ? findConstant : null;
 }
@@ -20066,7 +20460,7 @@ function countActiveMultiRoomUpgradersByHomeRoom(creeps) {
   const countsByHomeRoom = {};
   for (const creep of Object.values(creeps)) {
     const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString14(sustain.homeRoom) || !isNonEmptyString14(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
+    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString15(sustain.homeRoom) || !isNonEmptyString15(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
       continue;
     }
     const countsByTarget = (_b = countsByHomeRoom[sustain.homeRoom]) != null ? _b : {};
@@ -20096,7 +20490,7 @@ function combineNestedCountMaps(countsByHomeRoom) {
 function getActiveMultiRoomUpgraderCountCache() {
   var _a;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  const gameTime = getGameTime16();
+  const gameTime = getGameTime17();
   if ((activeMultiRoomUpgraderCountCache == null ? void 0 : activeMultiRoomUpgraderCountCache.gameTime) !== gameTime || activeMultiRoomUpgraderCountCache.creeps !== creeps) {
     activeMultiRoomUpgraderCountCache = {
       gameTime,
@@ -20129,12 +20523,12 @@ function hasVisibleHostiles(room) {
   const hostileStructuresFind = globalThis.FIND_HOSTILE_STRUCTURES;
   return typeof hostileCreepsFind === "number" && room.find(hostileCreepsFind).length > 0 || typeof hostileStructuresFind === "number" && room.find(hostileStructuresFind).length > 0;
 }
-function getRouteDistance(fromRoom, targetRoom) {
+function getRouteDistance2(fromRoom, targetRoom) {
   var _a, _b;
   if (fromRoom === targetRoom) {
     return 0;
   }
-  const gameTime = getGameTime16();
+  const gameTime = getGameTime17();
   const cache = getTerritoryRouteDistanceCache3(gameTime);
   const cacheKey = getTerritoryRouteDistanceCacheKey3(fromRoom, targetRoom);
   const cachedRouteDistance = (_a = cache == null ? void 0 : cache.distances) == null ? void 0 : _a[cacheKey];
@@ -20165,13 +20559,13 @@ function getTerritoryRouteDistanceCache3(gameTime) {
   if (!memory) {
     return void 0;
   }
-  if (!isRecord13(memory.territory)) {
+  if (!isRecord14(memory.territory)) {
     memory.territory = {};
   }
-  if (!isRecord13(memory.territory.routeDistances)) {
+  if (!isRecord14(memory.territory.routeDistances)) {
     memory.territory.routeDistances = {};
   }
-  if (!isRecord13(memory.territory.routeDistancesUpdatedAt)) {
+  if (!isRecord14(memory.territory.routeDistancesUpdatedAt)) {
     memory.territory.routeDistancesUpdatedAt = {};
   }
   const distances = memory.territory.routeDistances;
@@ -20219,24 +20613,24 @@ function isAdjacentRoom(fromRoom, targetRoom) {
     return false;
   }
   const exits = gameMap.describeExits(fromRoom);
-  if (!isRecord13(exits)) {
+  if (!isRecord14(exits)) {
     return false;
   }
   return Object.values(exits).some((roomName) => roomName === targetRoom);
 }
 function getNoPathResultCode6() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE6;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE7;
 }
-function getGameTime16() {
+function getGameTime17() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isRecord13(value) {
+function isRecord14(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString14(value) {
+function isNonEmptyString15(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -20268,7 +20662,7 @@ function buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTim
   var _a;
   const roomName = colony.room.name;
   const controller = colony.room.controller;
-  if ((controller == null ? void 0 : controller.my) !== true || !isNonEmptyString15(controller.id)) {
+  if ((controller == null ? void 0 : controller.my) !== true || !isNonEmptyString16(controller.id)) {
     return {
       roomName,
       updatedAt: gameTime,
@@ -20397,7 +20791,7 @@ function getControllerProgressRatioField(controller) {
 function getControllerTicksToDowngradeField(controller) {
   return typeof controller.ticksToDowngrade === "number" && Number.isFinite(controller.ticksToDowngrade) ? { ticksToDowngrade: controller.ticksToDowngrade } : {};
 }
-function isNonEmptyString15(value) {
+function isNonEmptyString16(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -20463,9 +20857,9 @@ function orderColoniesForSpawnPlanning(colonies, roleCountsByRoom) {
 function getSpawnEnergyForecast(colony) {
   const balance = getStorageBalanceMemory();
   const transfers = Array.isArray(balance == null ? void 0 : balance.transfers) ? balance.transfers : [];
-  const incomingEnergy = transfers.filter((transfer) => transfer.targetRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger4(transfer.amount), 0);
-  const outgoingEnergy = transfers.filter((transfer) => transfer.sourceRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger4(transfer.amount), 0);
-  const energyAvailable = normalizeNonNegativeInteger4(colony.energyAvailable);
+  const incomingEnergy = transfers.filter((transfer) => transfer.targetRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger5(transfer.amount), 0);
+  const outgoingEnergy = transfers.filter((transfer) => transfer.sourceRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger5(transfer.amount), 0);
+  const energyAvailable = normalizeNonNegativeInteger5(colony.energyAvailable);
   return {
     roomName: colony.room.name,
     energyAvailable,
@@ -20497,8 +20891,8 @@ function getRoomCreepBudget(colony, roleCounts) {
   return {
     roomName: colony.room.name,
     controllerLevel: getControllerLevel2(colony.room.controller),
-    energyAvailable: normalizeNonNegativeInteger4(colony.energyAvailable),
-    energyCapacityAvailable: normalizeNonNegativeInteger4(colony.energyCapacityAvailable),
+    energyAvailable: normalizeNonNegativeInteger5(colony.energyAvailable),
+    energyCapacityAvailable: normalizeNonNegativeInteger5(colony.energyCapacityAvailable),
     effectiveEnergyAvailable: forecast.effectiveEnergyAvailable,
     energyGate: getSpawnPlanningEnergyGate(forecast.effectiveEnergyAvailable, colony.energyCapacityAvailable),
     ownedSpawnCount: colony.spawns.length,
@@ -20688,7 +21082,7 @@ function selectPostClaimControllerSustainPlan(colony) {
 function getPostClaimControllerSustainRecords(colonyName) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord14(records)) {
+  if (!isRecord15(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -20696,7 +21090,7 @@ function getPostClaimControllerSustainRecords(colonyName) {
   ).sort(comparePostClaimControllerSustainRecords);
 }
 function isPostClaimControllerSustainRecord(record, colonyName) {
-  return isRecord14(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString16(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord15(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString17(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function comparePostClaimControllerSustainRecords(left, right) {
   const leftHasSpawn = hasOperationalSpawnInRoom(left.roomName);
@@ -21090,7 +21484,7 @@ function hasVisibleForeignReservedTerritoryTarget(colony) {
   if (!Array.isArray(targets)) {
     return false;
   }
-  const colonyOwnerUsername = getControllerOwnerUsername5(colony.room.controller);
+  const colonyOwnerUsername = getControllerOwnerUsername6(colony.room.controller);
   return targets.some((target) => {
     if (typeof target !== "object" || target === null) {
       return false;
@@ -21114,7 +21508,7 @@ function isForeignReservedController2(controller, colonyOwnerUsername) {
   const reservationUsername = (_a = controller == null ? void 0 : controller.reservation) == null ? void 0 : _a.username;
   return (controller == null ? void 0 : controller.my) !== true && typeof reservationUsername === "string" && reservationUsername.length > 0 && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername5(controller) {
+function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return typeof username === "string" && username.length > 0 ? username : void 0;
@@ -21171,7 +21565,7 @@ function appendSpawnNameSuffix(baseName, options) {
   return options.nameSuffix ? `${baseName}-${options.nameSuffix}` : baseName;
 }
 function isWorkerOnlyFollowUpPass(options) {
-  return options.workersOnly === true && isNonEmptyString16(options.nameSuffix);
+  return options.workersOnly === true && isNonEmptyString17(options.nameSuffix);
 }
 function selectWorkerBody(colony, roleCounts) {
   if (shouldUseSourceHarvesterBody(colony, roleCounts)) {
@@ -21240,10 +21634,10 @@ function getWorkerDynamicBodyDemand(colony, roleCounts) {
 }
 function getSpawnEnergyBudget(colony) {
   var _a;
-  return normalizeNonNegativeInteger4((_a = colony.spawnEnergyBudget) != null ? _a : colony.energyAvailable);
+  return normalizeNonNegativeInteger5((_a = colony.spawnEnergyBudget) != null ? _a : colony.energyAvailable);
 }
 function generateHarvesterBody(availableEnergy, sourceDistance) {
-  const energyBudget = normalizeNonNegativeInteger4(availableEnergy);
+  const energyBudget = normalizeNonNegativeInteger5(availableEnergy);
   const workParts = selectHarvesterWorkParts(energyBudget);
   if (workParts <= 0) {
     return [];
@@ -21276,7 +21670,7 @@ function buildHarvesterBody(workParts, carryParts) {
   ];
 }
 function getHarvesterCarryTarget(workParts, sourceDistance) {
-  const roundTripTicks = Math.max(1, normalizeNonNegativeInteger4(sourceDistance) * 2);
+  const roundTripTicks = Math.max(1, normalizeNonNegativeInteger5(sourceDistance) * 2);
   const harvestedEnergyBetweenTrips = workParts * HARVEST_POWER_PER_WORK_PART * roundTripTicks;
   return Math.max(1, Math.ceil(harvestedEnergyBetweenTrips / CARRY_CAPACITY_PER_PART2));
 }
@@ -21314,7 +21708,7 @@ function getApproximateRange(left, right) {
   }
   return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
-function normalizeNonNegativeInteger4(value) {
+function normalizeNonNegativeInteger5(value) {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 function canAffordBody(body, energyAvailable) {
@@ -21413,8 +21807,8 @@ function getRoomSpawnPriorityRank(priority) {
   }
 }
 function getSpawnPlanningEnergyGate(energyAvailable, energyCapacityAvailable) {
-  const energy = normalizeNonNegativeInteger4(energyAvailable);
-  const capacity = normalizeNonNegativeInteger4(energyCapacityAvailable);
+  const energy = normalizeNonNegativeInteger5(energyAvailable);
+  const capacity = normalizeNonNegativeInteger5(energyCapacityAvailable);
   if (energy < MINIMUM_EMERGENCY_WORKER_BODY_COST) {
     return "critical";
   }
@@ -21445,10 +21839,10 @@ function getStorageBalanceMemory() {
   var _a, _b;
   return (_b = (_a = globalThis.Memory) == null ? void 0 : _a.economy) == null ? void 0 : _b.storageBalance;
 }
-function isRecord14(value) {
+function isRecord15(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString16(value) {
+function isNonEmptyString17(value) {
   return typeof value === "string" && value.length > 0;
 }
 function getGlobalNumber8(name) {
@@ -21465,14 +21859,14 @@ var ROOM_EDGE_MAX6 = 47;
 var DEFAULT_TERRAIN_WALL_MASK9 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
-  if (!isNonEmptyString17(input.colony) || !isNonEmptyString17(input.roomName)) {
+  if (!isNonEmptyString18(input.colony) || !isNonEmptyString18(input.roomName)) {
     return;
   }
   const bootstraps = getWritablePostClaimBootstrapRecords();
   if (!bootstraps) {
     return;
   }
-  const gameTime = getGameTime17();
+  const gameTime = getGameTime18();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
   bootstraps[input.roomName] = {
@@ -21609,7 +22003,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   return { active: true, spawnConstructionPending: true };
 }
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
-  if (!isNonEmptyString17(roomName)) {
+  if (!isNonEmptyString18(roomName)) {
     return;
   }
   const record = getPostClaimBootstrapRecord(roomName);
@@ -21618,7 +22012,7 @@ function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, res
   }
   updatePostClaimBootstrapRecord(roomName, {
     status: "spawningWorkers",
-    updatedAt: getGameTime17()
+    updatedAt: getGameTime18()
   });
   telemetryEvents.push({
     type: "postClaimBootstrap",
@@ -21661,7 +22055,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
     const spawnSite = toSpawnSiteMemory(existingSpawnSite);
     updatePostClaimBootstrapRecord(roomName, {
       status: "spawnSitePending",
-      updatedAt: getGameTime17(),
+      updatedAt: getGameTime18(),
       workerTarget,
       spawnSite,
       lastResult: OK_CODE9
@@ -21685,7 +22079,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
   const nextStatus = sitePlan.result === OK_CODE9 ? "spawnSitePending" : "spawnSiteBlocked";
   updatePostClaimBootstrapRecord(roomName, {
     status: nextStatus,
-    updatedAt: getGameTime17(),
+    updatedAt: getGameTime18(),
     workerTarget,
     ...sitePlan.position ? { spawnSite: sitePlan.position } : {},
     lastResult: sitePlan.result
@@ -21921,14 +22315,14 @@ function findSources3(room) {
   return room.find(findConstant);
 }
 function getRoomObjectPosition4(object) {
-  if (!isRecord15(object)) {
+  if (!isRecord16(object)) {
     return null;
   }
   if (isFiniteNumber8(object.x) && isFiniteNumber8(object.y)) {
     return { x: object.x, y: object.y };
   }
   const pos = object.pos;
-  if (isRecord15(pos) && isFiniteNumber8(pos.x) && isFiniteNumber8(pos.y)) {
+  if (isRecord16(pos) && isFiniteNumber8(pos.x) && isFiniteNumber8(pos.y)) {
     return { x: pos.x, y: pos.y };
   }
   return null;
@@ -21975,7 +22369,7 @@ function getWritablePostClaimBootstrapRecords() {
   return memory.territory.postClaimBootstraps;
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
-  return isRecord15(value) && value.roomName === expectedRoomName && isNonEmptyString17(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber8(value.claimedAt) && isFiniteNumber8(value.updatedAt);
+  return isRecord16(value) && value.roomName === expectedRoomName && isNonEmptyString18(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber8(value.claimedAt) && isFiniteNumber8(value.updatedAt);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
@@ -22030,15 +22424,15 @@ function getGlobalString2(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getGameTime17() {
+function getGameTime18() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord15(value) {
+function isRecord16(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString17(value) {
+function isNonEmptyString18(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber8(value) {
@@ -22160,8 +22554,8 @@ function getRemoteSourceContainerScans(creeps) {
 }
 function createSourceContainerPlannerLookups3(room) {
   const terrain = getRoomTerrain10(room);
-  const structures = findRoomObjects14(room, "FIND_STRUCTURES");
-  const constructionSites = findRoomObjects14(room, "FIND_CONSTRUCTION_SITES");
+  const structures = findRoomObjects15(room, "FIND_STRUCTURES");
+  const constructionSites = findRoomObjects15(room, "FIND_CONSTRUCTION_SITES");
   if (!terrain || structures === null || constructionSites === null || typeof room.createConstructionSite !== "function") {
     return null;
   }
@@ -22251,7 +22645,7 @@ function compareRoomSourceContainerScans(left, right) {
 }
 function getRoomSources2(room) {
   var _a;
-  return (_a = findRoomObjects14(room, "FIND_SOURCES")) != null ? _a : [];
+  return (_a = findRoomObjects15(room, "FIND_SOURCES")) != null ? _a : [];
 }
 function getVisibleSourceById(room, sourceId) {
   var _a;
@@ -22262,7 +22656,7 @@ function getVisibleSourceById(room, sourceId) {
   }
   return (_a = getRoomSources2(room).find((source) => String(source.id) === String(sourceId))) != null ? _a : null;
 }
-function findRoomObjects14(room, constantName) {
+function findRoomObjects15(room, constantName) {
   const findConstant = getGlobalNumber10(constantName);
   const find = room.find;
   if (findConstant === null || typeof find !== "function") {
@@ -22374,7 +22768,7 @@ function normalizeRemoteHarvesterMemory2(creep) {
     return null;
   }
   const assignment = creep.memory.remoteHarvester;
-  if (!isRecord16(assignment) || typeof assignment.homeRoom !== "string" || assignment.homeRoom.length === 0 || typeof assignment.targetRoom !== "string" || assignment.targetRoom.length === 0 || assignment.homeRoom === assignment.targetRoom || typeof assignment.sourceId !== "string" || assignment.sourceId.length === 0) {
+  if (!isRecord17(assignment) || typeof assignment.homeRoom !== "string" || assignment.homeRoom.length === 0 || typeof assignment.targetRoom !== "string" || assignment.targetRoom.length === 0 || assignment.homeRoom === assignment.targetRoom || typeof assignment.sourceId !== "string" || assignment.sourceId.length === 0) {
     return null;
   }
   return assignment;
@@ -22399,7 +22793,7 @@ function hasDroppedEnergyDecayingAtSource(room, source) {
   if (!sourcePosition) {
     return false;
   }
-  const droppedResources = (_a = findRoomObjects14(room, "FIND_DROPPED_RESOURCES")) != null ? _a : [];
+  const droppedResources = (_a = findRoomObjects15(room, "FIND_DROPPED_RESOURCES")) != null ? _a : [];
   return droppedResources.some((resource) => {
     const resourcePosition = getRoomObjectPosition2(resource);
     return resourcePosition !== null && isDroppedEnergy2(resource) && isSameRoomPosition5(resourcePosition, room.name) && getRangeBetweenPositions4(sourcePosition, resourcePosition) <= 1;
@@ -22426,7 +22820,7 @@ function getEnergyResource11() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
-function isRecord16(value) {
+function isRecord17(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -22454,7 +22848,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return void 0;
   }
-  const tick = getGameTime18();
+  const tick = getGameTime19();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -22551,7 +22945,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime18());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime19());
   }
   return {
     roomName: colony.room.name,
@@ -22561,11 +22955,11 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime18()),
+    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime19()),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime18()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime18()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime18()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime19()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime19()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime19()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -22585,7 +22979,7 @@ function buildPostClaimBootstrapSummary(roomName) {
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime18());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime19());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -22732,7 +23126,7 @@ function isRecentWorkerTaskBehaviorSample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskBehaviorSample(value) {
-  return isRecord17(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord17(value.state) && isRecord17(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+  return isRecord18(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord18(value.state) && isRecord18(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
 }
 function isRecentWorkerTaskPolicyShadow(value, tick) {
   if (!isWorkerTaskPolicyShadow(value)) {
@@ -22741,15 +23135,15 @@ function isRecentWorkerTaskPolicyShadow(value, tick) {
   return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskPolicyShadow(value) {
-  return isRecord17(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
+  return isRecord18(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function shouldBuildStructureSnapshot(tick) {
   return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
 }
 function summarizeStructures(colony, colonyWorkers) {
   var _a, _b;
-  const roomStructures = (_a = findRoomObjects15(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const constructionSites = (_b = findRoomObjects15(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
+  const roomStructures = (_a = findRoomObjects16(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const constructionSites = (_b = findRoomObjects16(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
   const roadCount = countStructuresByType2(roomStructures, "STRUCTURE_ROAD", "road");
   const pendingRoadSiteCount = countConstructionSitesByType(constructionSites, "STRUCTURE_ROAD", "road");
   return {
@@ -22769,7 +23163,7 @@ function countConstructionSitesByType(constructionSites, globalName, fallback) {
   return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
 }
 function countOwnedRamparts(structures) {
-  return structures.filter((structure) => isRecord17(structure) && isObservedOwnedRampart(structure)).length;
+  return structures.filter((structure) => isRecord18(structure) && isObservedOwnedRampart(structure)).length;
 }
 function summarizeContainers(structures) {
   return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
@@ -22806,7 +23200,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   return [...repairCounts.entries()].sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId)).map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
 }
 function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
-  const structureRecord = isRecord17(structure) ? structure : {};
+  const structureRecord = isRecord18(structure) ? structure : {};
   const structureType = typeof structureRecord.structureType === "string" ? structureRecord.structureType : void 0;
   const hits = getFiniteNumber(structureRecord.hits);
   const hitsMax = getFiniteNumber(structureRecord.hitsMax);
@@ -22819,7 +23213,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord17(structure) && matchesStructureType17(structure.structureType, globalName, fallback);
+  return isRecord18(structure) && matchesStructureType17(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -23007,7 +23401,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord17(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord18(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio5(numerator, denominator) {
   if (denominator <= 0) {
@@ -23022,7 +23416,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord17(value)) {
+  if (!isRecord18(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -23063,7 +23457,7 @@ function isRecentSpawnCriticalRefillSample(sample, tick) {
   return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
 }
 function isSpawnCriticalRefillSample(value) {
-  return isRecord17(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
+  return isRecord18(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;
@@ -23090,11 +23484,11 @@ function buildControllerSummary(room) {
 }
 function summarizeResources(colony, colonyWorkers, events) {
   var _a, _b, _c, _d, _e;
-  const roomStructures = (_a = findRoomObjects15(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const roomStructures = (_a = findRoomObjects16(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
   const ownedEnergyStructures = findOwnedEnergyStoreStructures(colony.room);
-  const roomCreeps = (_b = findRoomObjects15(colony.room, "FIND_MY_CREEPS")) != null ? _b : [];
-  const constructionSites = (_c = findRoomObjects15(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _c : [];
-  const droppedResources = (_d = findRoomObjects15(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _d : [];
+  const roomCreeps = (_b = findRoomObjects16(colony.room, "FIND_MY_CREEPS")) != null ? _b : [];
+  const constructionSites = (_c = findRoomObjects16(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _c : [];
+  const droppedResources = (_d = findRoomObjects16(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _d : [];
   const sourceContainerCoverage = summarizeSourceContainerCoverage(colony.room);
   return {
     storedEnergy: sumEnergyInStores(ownedEnergyStructures),
@@ -23110,10 +23504,10 @@ function summarizeResources(colony, colonyWorkers, events) {
 }
 function findOwnedEnergyStoreStructures(room) {
   var _a;
-  return ((_a = findRoomObjects15(room, "FIND_MY_STRUCTURES")) != null ? _a : []).filter(isOwnedEnergyStoreStructure);
+  return ((_a = findRoomObjects16(room, "FIND_MY_STRUCTURES")) != null ? _a : []).filter(isOwnedEnergyStoreStructure);
 }
 function isOwnedEnergyStoreStructure(structure) {
-  if (!isRecord17(structure)) {
+  if (!isRecord18(structure)) {
     return false;
   }
   return matchesStructureType17(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType17(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType17(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType17(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType17(structure.structureType, "STRUCTURE_LINK", "link") || matchesStructureType17(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
@@ -23195,7 +23589,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord17(constructionSite)) {
+  if (!isRecord18(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -23209,7 +23603,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord17(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord18(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -23240,8 +23634,8 @@ function buildControllerProgressRemaining(room) {
 }
 function summarizeCombat(room, events) {
   var _a, _b;
-  const hostileCreeps = (_a = findRoomObjects15(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
-  const hostileStructures = (_b = findRoomObjects15(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
+  const hostileCreeps = (_a = findRoomObjects16(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
+  const hostileStructures = (_b = findRoomObjects16(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
   return {
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -23431,10 +23825,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord17(entry) || typeof entry.event !== "number") {
+    if (!isRecord18(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord17(entry.data) ? entry.data : {};
+    const data = isRecord18(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -23486,7 +23880,7 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
 }
 function getSpawnExtensionEnergyStructureIds(room) {
   var _a, _b;
-  const structures = (_b = (_a = findRoomObjects15(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects15(room, "FIND_STRUCTURES")) != null ? _b : [];
+  const structures = (_b = (_a = findRoomObjects16(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects16(room, "FIND_STRUCTURES")) != null ? _b : [];
   const ids = /* @__PURE__ */ new Set();
   for (const structure of structures) {
     if (!isSpawnExtensionEnergyStructure2(structure)) {
@@ -23500,7 +23894,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord17(structure) && (matchesStructureType17(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType17(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord18(structure) && (matchesStructureType17(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType17(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -23509,9 +23903,9 @@ function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
 function getObjectId10(value) {
-  return isRecord17(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+  return isRecord18(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
-function findRoomObjects15(room, constantName) {
+function findRoomObjects16(room, constantName) {
   const findConstant = getGlobalNumber11(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
@@ -23540,7 +23934,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord17(object) || !isRecord17(object.store)) {
+  if (!isRecord18(object) || !isRecord18(object.store)) {
     return 0;
   }
   const storedEnergy = object.store[getEnergyResource12()];
@@ -23555,7 +23949,7 @@ function getEnergyInStore(object) {
   return 0;
 }
 function getEnergyCapacityInStore(object) {
-  if (!isRecord17(object) || !isRecord17(object.store)) {
+  if (!isRecord18(object) || !isRecord18(object.store)) {
     return 0;
   }
   const getCapacity = object.store.getCapacity;
@@ -23576,7 +23970,7 @@ function getEnergyCapacityInStore(object) {
 function sumDroppedEnergy2(droppedResources) {
   const energyResource = getEnergyResource12();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord17(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord18(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -23605,7 +23999,7 @@ function getEnergyResource12() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord17(value) {
+function isRecord18(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -23623,7 +24017,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime18() {
+function getGameTime19() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -24136,10 +24530,10 @@ var MINERAL_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var ERR_NOT_IN_RANGE_CODE7 = -9;
 function planMineralHarvesterSpawn(colony, creeps, gameTime, options = {}) {
   var _a, _b, _c, _d, _e;
-  const energyAvailable = normalizeNonNegativeInteger5(
+  const energyAvailable = normalizeNonNegativeInteger6(
     (_b = (_a = options.energyAvailable) != null ? _a : colony.energyAvailable) != null ? _b : colony.room.energyAvailable
   );
-  const energyCapacity = normalizeNonNegativeInteger5(
+  const energyCapacity = normalizeNonNegativeInteger6(
     (_c = colony.energyCapacityAvailable) != null ? _c : colony.room.energyCapacityAvailable
   );
   if (!shouldAllowMineralHarvesting(energyAvailable, energyCapacity)) {
@@ -24154,7 +24548,7 @@ function planMineralHarvesterSpawn(colony, creeps, gameTime, options = {}) {
     return null;
   }
   const body = buildMineralHarvesterBody(
-    normalizeNonNegativeInteger5((_d = options.bodyEnergyBudget) != null ? _d : energyAvailable),
+    normalizeNonNegativeInteger6((_d = options.bodyEnergyBudget) != null ? _d : energyAvailable),
     (_e = colony.room.controller) == null ? void 0 : _e.level
   );
   if (body.length === 0) {
@@ -24197,14 +24591,14 @@ function selectMineralHarvestAssignment(room, creeps = Object.values(((_b) => (_
   };
 }
 function shouldAllowMineralHarvesting(energyAvailable, energyCapacity) {
-  const capacity = normalizeNonNegativeInteger5(energyCapacity);
+  const capacity = normalizeNonNegativeInteger6(energyCapacity);
   if (capacity <= 0) {
     return false;
   }
-  return normalizeNonNegativeInteger5(energyAvailable) >= capacity * MINERAL_HARVESTING_MIN_ENERGY_RATIO;
+  return normalizeNonNegativeInteger6(energyAvailable) >= capacity * MINERAL_HARVESTING_MIN_ENERGY_RATIO;
 }
 function buildMineralHarvesterBody(energyAvailable, controllerLevel) {
-  const energyBudget = normalizeNonNegativeInteger5(energyAvailable);
+  const energyBudget = normalizeNonNegativeInteger6(energyAvailable);
   const maxWorkParts = typeof controllerLevel === "number" && controllerLevel >= 6 ? 3 : 2;
   for (let workParts = maxWorkParts; workParts >= 1; workParts -= 1) {
     const body = buildMineralHarvesterBodyWithWorkParts(workParts);
@@ -24263,22 +24657,22 @@ function selectAvailableSpawn(spawns, usedSpawns) {
 }
 function selectExtractor(room) {
   var _a;
-  const ownedStructures = findRoomObjects16(room, "FIND_MY_STRUCTURES");
+  const ownedStructures = findRoomObjects17(room, "FIND_MY_STRUCTURES");
   const extractor = ownedStructures.find(isExtractorStructure);
   if (extractor) {
     return extractor;
   }
-  return (_a = findRoomObjects16(room, "FIND_STRUCTURES").find(isExtractorStructure)) != null ? _a : null;
+  return (_a = findRoomObjects17(room, "FIND_STRUCTURES").find(isExtractorStructure)) != null ? _a : null;
 }
 function selectAvailableMineral(room) {
   var _a;
-  return (_a = findRoomObjects16(room, "FIND_MINERALS").find(isMineralAvailable)) != null ? _a : null;
+  return (_a = findRoomObjects17(room, "FIND_MINERALS").find(isMineralAvailable)) != null ? _a : null;
 }
 function isExtractorStructure(structure) {
   return matchesStructureType19(structure.structureType, "STRUCTURE_EXTRACTOR", "extractor");
 }
 function isMineralAvailable(mineral) {
-  return normalizeNonNegativeInteger5(mineral.mineralAmount) > 0;
+  return normalizeNonNegativeInteger6(mineral.mineralAmount) > 0;
 }
 function getMineralResourceType(mineral) {
   const mineralType = mineral.mineralType;
@@ -24313,10 +24707,10 @@ function getMutableMineralHarvesterMemory(creep) {
   return memory;
 }
 function normalizeMineralHarvesterMemory(value) {
-  if (!isRecord18(value) || !isNonEmptyString18(value.homeRoom) || !isNonEmptyString18(value.mineralId)) {
+  if (!isRecord19(value) || !isNonEmptyString19(value.homeRoom) || !isNonEmptyString19(value.mineralId)) {
     return null;
   }
-  const targetId = isNonEmptyString18(value.targetId) ? value.targetId : void 0;
+  const targetId = isNonEmptyString19(value.targetId) ? value.targetId : void 0;
   if (!targetId) {
     return null;
   }
@@ -24324,12 +24718,12 @@ function normalizeMineralHarvesterMemory(value) {
     homeRoom: value.homeRoom,
     mineralId: value.mineralId,
     targetId,
-    ...isNonEmptyString18(value.mineralType) ? { mineralType: value.mineralType } : {}
+    ...isNonEmptyString19(value.mineralType) ? { mineralType: value.mineralType } : {}
   };
 }
 function getAssignedMineral(assignment, room) {
   var _a, _b;
-  return (_b = (_a = getObjectById4(assignment.mineralId)) != null ? _a : findRoomObjects16(room, "FIND_MINERALS").find((mineral) => mineral.id === assignment.mineralId)) != null ? _b : null;
+  return (_b = (_a = getObjectById4(assignment.mineralId)) != null ? _a : findRoomObjects17(room, "FIND_MINERALS").find((mineral) => mineral.id === assignment.mineralId)) != null ? _b : null;
 }
 function deliverMineral(creep, assignment, resourceType) {
   var _a;
@@ -24408,7 +24802,7 @@ function getVisibleRoom9(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function findRoomObjects16(room, constantName) {
+function findRoomObjects17(room, constantName) {
   const findConstant = globalThis[constantName];
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return [];
@@ -24441,13 +24835,13 @@ function getBodyCost3(body) {
 function getObjectId12(object) {
   return typeof object.id === "string" ? object.id : "";
 }
-function normalizeNonNegativeInteger5(value) {
+function normalizeNonNegativeInteger6(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
-function isRecord18(value) {
+function isRecord19(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString18(value) {
+function isNonEmptyString19(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -24526,7 +24920,7 @@ function reserveRoomForPlannedClaim(creep) {
     controllerId: controller.id,
     ...assignment.followUp ? { followUp: assignment.followUp } : {}
   };
-  creep.memory.territory = (_b = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, getGameTime19())) != null ? _b : reserveAssignment;
+  creep.memory.territory = (_b = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, getGameTime20())) != null ? _b : reserveAssignment;
   const result = creep.reserveController(controller);
   if (result === ERR_NOT_IN_RANGE_CODE8) {
     if (typeof creep.moveTo === "function") {
@@ -24556,7 +24950,7 @@ function reserveRoomForPlannedClaim(creep) {
   };
 }
 function isPlannedClaimAssignment(assignment) {
-  return isNonEmptyString19(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "claim";
+  return isNonEmptyString20(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "claim";
 }
 function selectClaimReservationController(creep, assignment) {
   var _a, _b, _c, _d, _e;
@@ -24584,27 +24978,27 @@ function countVisibleOwnedRooms2(colony) {
   if (!rooms) {
     return 0;
   }
-  const colonyOwnerUsername = getControllerOwnerUsername6(
-    isNonEmptyString19(colony) ? (_b = rooms[colony]) == null ? void 0 : _b.controller : void 0
+  const colonyOwnerUsername = getControllerOwnerUsername7(
+    isNonEmptyString20(colony) ? (_b = rooms[colony]) == null ? void 0 : _b.controller : void 0
   );
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_c = room == null ? void 0 : room.controller) == null ? void 0 : _c.my) === true && (!colonyOwnerUsername || getControllerOwnerUsername6(room.controller) === colonyOwnerUsername)) {
+    if (((_c = room == null ? void 0 : room.controller) == null ? void 0 : _c.my) === true && (!colonyOwnerUsername || getControllerOwnerUsername7(room.controller) === colonyOwnerUsername)) {
       ownedRoomCount += 1;
     }
   }
   return ownedRoomCount;
 }
 function canReserveControllerForColony(controller, creep) {
-  const reservationUsername = getControllerReservationUsername4(controller);
+  const reservationUsername = getControllerReservationUsername5(controller);
   if (!reservationUsername) {
     return true;
   }
   const actorUsername = getActorUsername(creep);
-  return isNonEmptyString19(actorUsername) && reservationUsername === actorUsername;
+  return isNonEmptyString20(actorUsername) && reservationUsername === actorUsername;
 }
 function isControllerOwned2(controller) {
-  return controller.my === true || isNonEmptyString19(getControllerOwnerUsername6(controller));
+  return controller.my === true || isNonEmptyString20(getControllerOwnerUsername7(controller));
 }
 function getActiveClaimPartCount(creep) {
   var _a;
@@ -24621,33 +25015,33 @@ function getActiveClaimPartCount(creep) {
 function getActorUsername(creep) {
   var _a, _b, _c;
   const creepOwner = (_a = creep.owner) == null ? void 0 : _a.username;
-  if (isNonEmptyString19(creepOwner)) {
+  if (isNonEmptyString20(creepOwner)) {
     return creepOwner;
   }
   const colony = creep.memory.colony;
-  const room = isNonEmptyString19(colony) ? (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[colony] : void 0;
-  return getControllerOwnerUsername6(room == null ? void 0 : room.controller);
+  const room = isNonEmptyString20(colony) ? (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[colony] : void 0;
+  return getControllerOwnerUsername7(room == null ? void 0 : room.controller);
 }
-function getControllerOwnerUsername6(controller) {
+function getControllerOwnerUsername7(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString19(username) ? username : void 0;
+  return isNonEmptyString20(username) ? username : void 0;
 }
-function getControllerReservationUsername4(controller) {
+function getControllerReservationUsername5(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString19(username) ? username : void 0;
+  return isNonEmptyString20(username) ? username : void 0;
 }
 function getClaimBodyPartConstant() {
   var _a;
   return (_a = globalThis.CLAIM) != null ? _a : "claim";
 }
-function getGameTime19() {
+function getGameTime20() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString19(value) {
+function isNonEmptyString20(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -24656,7 +25050,7 @@ var AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR = "autonomousExpansionClaim";
 var EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS = 1500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE = 500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_RCL = 2;
-var EXIT_DIRECTION_ORDER4 = ["1", "3", "5", "7"];
+var EXIT_DIRECTION_ORDER5 = ["1", "3", "5", "7"];
 var OK_CODE11 = 0;
 var ERR_NOT_IN_RANGE_CODE9 = -9;
 var ERR_INVALID_TARGET_CODE4 = -7;
@@ -24697,7 +25091,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   if (!isClaimExecutionAssignment(assignment)) {
     return false;
   }
-  const gameTime = getGameTime20();
+  const gameTime = getGameTime21();
   const recommendedClaim = getRecommendedExpansionClaimExecutionGate(creep.memory.colony, assignment);
   if (!recommendedClaim) {
     return false;
@@ -24868,7 +25262,7 @@ function isAutonomousExpansionClaimGclInsufficient() {
 function getAutonomousExpansionClaimTickContext(gameTime) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
-  const territoryMemory = getTerritoryMemoryRecord6();
+  const territoryMemory = getTerritoryMemoryRecord7();
   const rawIntents = territoryMemory == null ? void 0 : territoryMemory.intents;
   if (autonomousExpansionClaimTickContext && autonomousExpansionClaimTickContext.gameTime === gameTime && autonomousExpansionClaimTickContext.gameMap === gameMap) {
     if (autonomousExpansionClaimTickContext.territoryMemory !== territoryMemory || autonomousExpansionClaimTickContext.rawIntents !== rawIntents) {
@@ -24968,7 +25362,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   if (controller && isControllerOwned3(controller)) {
     return { ...visibleControllerEvaluation, reason: "controllerOwned" };
   }
-  const colonyOwnerUsername = getControllerOwnerUsername7(colony.room.controller);
+  const colonyOwnerUsername = getControllerOwnerUsername8(colony.room.controller);
   if (controller && isControllerReserved(controller, colonyOwnerUsername)) {
     return { ...visibleControllerEvaluation, reason: "controllerReserved" };
   }
@@ -24984,7 +25378,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   const scoutValidation = validateTerritoryScoutIntelForClaim({
     colony: colonyName,
     targetRoom: candidate.roomName,
-    colonyOwnerUsername: getControllerOwnerUsername7(colony.room.controller),
+    colonyOwnerUsername: getControllerOwnerUsername8(colony.room.controller),
     gameTime
   });
   const scoutControllerId = getScoutValidationControllerId(scoutValidation);
@@ -25064,15 +25458,15 @@ function getScoutValidationClaimSkipReason(validation) {
 function buildAutonomousExpansionScoringInput(colony, report, context) {
   var _a, _b;
   const colonyName = colony.room.name;
-  const colonyOwnerUsername = getControllerOwnerUsername7(colony.room.controller);
-  const ownedRoomNames = getVisibleOwnedRoomNames4(colonyName, colonyOwnerUsername);
+  const colonyOwnerUsername = getControllerOwnerUsername8(colony.room.controller);
+  const ownedRoomNames = getVisibleOwnedRoomNames5(colonyName, colonyOwnerUsername);
   const adjacentRoomNamesByOwnedRoom = getAdjacentRoomNamesByOwnedRoom2(ownedRoomNames, context);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, colonyOwnerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString20(room.mineralType));
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString21(room.mineralType));
   const seenRooms = /* @__PURE__ */ new Set();
   const candidates = [];
   report.candidates.forEach((candidate, order) => {
-    if (!isNonEmptyString20(candidate.roomName) || seenRooms.has(candidate.roomName)) {
+    if (!isNonEmptyString21(candidate.roomName) || seenRooms.has(candidate.roomName)) {
       return;
     }
     seenRooms.add(candidate.roomName);
@@ -25133,12 +25527,12 @@ function summarizeScoutedExpansionMineral(mineral) {
 }
 function summarizeExpansionController2(controller) {
   var _a, _b;
-  const ownerUsername = getControllerOwnerUsername7(controller);
+  const ownerUsername = getControllerOwnerUsername8(controller);
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
   return {
     ...typeof controller.my === "boolean" ? { my: controller.my } : {},
     ...ownerUsername ? { ownerUsername } : {},
-    ...isNonEmptyString20(reservationUsername) ? { reservationUsername } : {},
+    ...isNonEmptyString21(reservationUsername) ? { reservationUsername } : {},
     ...typeof ((_b = controller.reservation) == null ? void 0 : _b.ticksToEnd) === "number" ? { reservationTicksToEnd: controller.reservation.ticksToEnd } : {}
   };
 }
@@ -25151,7 +25545,7 @@ function compareAutonomousExpansionClaimCandidates(left, right) {
 function compareOptionalNumbers5(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
-function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
+function getVisibleOwnedRoomNames5(colonyName, ownerUsername) {
   var _a, _b;
   const ownedRoomNames = /* @__PURE__ */ new Set([colonyName]);
   const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
@@ -25159,7 +25553,7 @@ function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString20(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString21(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -25177,7 +25571,7 @@ function getCachedAdjacentRoomNames(roomName, context) {
   if (cachedAdjacentRoomNames) {
     return cachedAdjacentRoomNames;
   }
-  const adjacentRoomNames = new Set(getAdjacentRoomNames5(roomName, context.gameMap));
+  const adjacentRoomNames = new Set(getAdjacentRoomNames6(roomName, context.gameMap));
   context.adjacentRoomNamesByOwnedRoom.set(roomName, adjacentRoomNames);
   return adjacentRoomNames;
 }
@@ -25193,26 +25587,26 @@ function getOwnedAdjacency(roomName, adjacentRoomNamesByOwnedRoom) {
   }
   return { adjacentToOwnedRoom: false };
 }
-function getAdjacentRoomNames5(roomName, gameMap = ((_a) => (_a = globalThis.Game) == null ? void 0 : _a.map)()) {
+function getAdjacentRoomNames6(roomName, gameMap = ((_a) => (_a = globalThis.Game) == null ? void 0 : _a.map)()) {
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord19(exits)) {
+  if (!isRecord20(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER4.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER5.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString20(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString21(exitRoom) ? [exitRoom] : [];
   });
 }
 function countActivePostClaimBootstraps2() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord19(records)) {
+  if (!isRecord20(records)) {
     return 0;
   }
-  return Object.values(records).filter((record) => isRecord19(record) && record.status !== "ready").length;
+  return Object.values(records).filter((record) => isRecord20(record) && record.status !== "ready").length;
 }
 function hasSufficientAutonomousExpansionClaimRcl(colony) {
   var _a, _b;
@@ -25243,7 +25637,7 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime, con
   if (!evaluation.targetRoom) {
     return;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
@@ -25260,13 +25654,13 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime, con
   };
   pruneOccupationRecommendationTargets(territoryMemory, colony);
   pruneAutonomousExpansionClaimTargets(colony, territoryMemory, target, context);
-  upsertTerritoryTarget2(territoryMemory, target);
+  upsertTerritoryTarget3(territoryMemory, target);
   const intents = getTerritoryIntentsForAutonomousExpansionClaim(territoryMemory, context);
   territoryMemory.intents = intents;
   const existingIntent = intents.find(
     (intent) => intent.colony === colony && intent.targetRoom === target.roomName && intent.action === "claim" && intent.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR
   );
-  upsertTerritoryIntent4(intents, {
+  upsertTerritoryIntent5(intents, {
     colony,
     targetRoom: target.roomName,
     action: "claim",
@@ -25277,18 +25671,18 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime, con
   });
   syncAutonomousExpansionClaimIntentContext(context, territoryMemory, intents);
 }
-function upsertTerritoryTarget2(territoryMemory, target) {
+function upsertTerritoryTarget3(territoryMemory, target) {
   if (!Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = [];
   }
   const existingTarget = territoryMemory.targets.find(
-    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord19(rawTarget) && rawTarget.createdBy === target.createdBy
+    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord20(rawTarget) && rawTarget.createdBy === target.createdBy
   );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord19(existingTarget)) {
+  if (isRecord20(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -25297,7 +25691,7 @@ function upsertTerritoryTarget2(territoryMemory, target) {
     }
   }
 }
-function upsertTerritoryIntent4(intents, nextIntent) {
+function upsertTerritoryIntent5(intents, nextIntent) {
   const existingIndex = intents.findIndex(
     (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action && intent.createdBy === nextIntent.createdBy
   );
@@ -25307,7 +25701,7 @@ function upsertTerritoryIntent4(intents, nextIntent) {
   }
   intents.push(nextIntent);
 }
-function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerritoryMemoryRecord6(), activeTarget, context) {
+function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerritoryMemoryRecord7(), activeTarget, context) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return;
   }
@@ -25319,7 +25713,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord19(target) && isNonEmptyString20(target.roomName) && target.action === "claim") {
+    if (isRecord20(target) && isNonEmptyString21(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -25338,7 +25732,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord19(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord20(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime, intents) {
@@ -25406,10 +25800,10 @@ function isClaimExecutionAssignment(assignment) {
 }
 function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   var _a;
-  if (!isNonEmptyString20(colony)) {
+  if (!isNonEmptyString21(colony)) {
     return null;
   }
-  const territoryMemory = getTerritoryMemoryRecord6();
+  const territoryMemory = getTerritoryMemoryRecord7();
   if (!territoryMemory) {
     return null;
   }
@@ -25559,7 +25953,7 @@ function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryE
     status: "claimed",
     controllerId: controller.id,
     creepName: creep.name,
-    updatedAt: getGameTime20()
+    updatedAt: getGameTime21()
   });
 }
 function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason, options) {
@@ -25575,7 +25969,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     reason
   });
   if (options.suppressIntent) {
-    suppressRecommendedClaimIntent(colony, assignment, getGameTime20(), options.controllerId, reason);
+    suppressRecommendedClaimIntent(colony, assignment, getGameTime21(), options.controllerId, reason);
   }
   recordColonyExpansionClaimVerification({
     colony,
@@ -25585,7 +25979,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     creepName: creep.name,
     result,
     reason,
-    updatedAt: getGameTime20()
+    updatedAt: getGameTime21()
   });
 }
 function recordRecommendedClaimRetry(creep, assignment, result, reason, options = {}) {
@@ -25600,11 +25994,11 @@ function recordRecommendedClaimRetry(creep, assignment, result, reason, options 
     result,
     reason
   });
-  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime20(), options);
+  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime21(), options);
 }
 function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, options) {
   var _a, _b;
-  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
@@ -25627,7 +26021,7 @@ function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, opti
   }
 }
 function suppressRecommendedClaimIntent(colony, assignment, gameTime, controllerId, reason) {
-  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
@@ -25650,7 +26044,7 @@ function suppressRecommendedClaimIntent(colony, assignment, gameTime, controller
   }
 }
 function completeRecommendedClaimIntent(colony, targetRoom, controllerId) {
-  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
@@ -25671,13 +26065,13 @@ function hasRecommendedClaimTarget(territoryMemory, colony, targetRoom) {
   return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom)) : false;
 }
 function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
-  return isRecord19(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
+  return isRecord20(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
 }
 function recordColonyExpansionClaimVerification(input) {
   var _a;
   const colonyRoom = getVisibleRoom10(input.colony);
   const selection = (_a = colonyRoom == null ? void 0 : colonyRoom.memory) == null ? void 0 : _a.cachedExpansionSelection;
-  if (!isRecord19(selection) || selection.targetRoom !== input.targetRoom) {
+  if (!isRecord20(selection) || selection.targetRoom !== input.targetRoom) {
     return;
   }
   selection.claimExecution = {
@@ -25711,15 +26105,15 @@ function getClaimColony(creep, controller) {
   return (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller == null ? void 0 : controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown";
 }
 function isForeignOwnedController(controller) {
-  return controller.my !== true && isNonEmptyString20(getControllerOwnerUsername7(controller));
+  return controller.my !== true && isNonEmptyString21(getControllerOwnerUsername8(controller));
 }
 function isForeignReservedController3(controller, colony) {
   var _a, _b;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  if (!isNonEmptyString20(reservationUsername)) {
+  if (!isNonEmptyString21(reservationUsername)) {
     return false;
   }
-  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom10(colony != null ? colony : "")) == null ? void 0 : _b.controller);
+  return reservationUsername !== getControllerOwnerUsername8((_b = getVisibleRoom10(colony != null ? colony : "")) == null ? void 0 : _b.controller);
 }
 function getKnownActiveClaimPartCount(creep) {
   var _a;
@@ -25746,10 +26140,10 @@ function isTerritoryAutomationSource3(source) {
   return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord19(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord20(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isSameTarget2(left, right) {
-  return isRecord19(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord20(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
@@ -25758,16 +26152,16 @@ function getVisibleRoom10(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameTime20() {
+function getGameTime21() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function getTerritoryMemoryRecord6() {
+function getTerritoryMemoryRecord7() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
-function getWritableTerritoryMemoryRecord5() {
+function getWritableTerritoryMemoryRecord6() {
   const memory = globalThis.Memory;
   if (!memory) {
     return null;
@@ -25792,22 +26186,22 @@ function isControllerOwned3(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString20(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString21(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername7(controller) {
+function getControllerOwnerUsername8(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString20(username) ? username : void 0;
+  return isNonEmptyString21(username) ? username : void 0;
 }
-function isRecord19(value) {
+function isRecord20(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString20(value) {
+function isNonEmptyString21(value) {
   return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/claimScoring.ts
-var EXIT_DIRECTION_ORDER5 = ["1", "3", "5", "7"];
+var EXIT_DIRECTION_ORDER6 = ["1", "3", "5", "7"];
 var TERRAIN_SCAN_MIN4 = 2;
 var TERRAIN_SCAN_MAX4 = 47;
 var DEFAULT_TERRAIN_WALL_MASK12 = 1;
@@ -25881,7 +26275,7 @@ function scoreClaimTarget(roomName, homeRoom) {
 }
 function selectBestClaimTarget(homeRoom) {
   var _a, _b;
-  const adjacentRooms = getAdjacentRoomNames6(homeRoom.name);
+  const adjacentRooms = getAdjacentRoomNames7(homeRoom.name);
   const candidates = adjacentRooms.map((roomName) => scoreClaimTarget(roomName, homeRoom)).filter((candidate) => candidate.sources > 0 && candidate.score > 0 && !hasUnclaimableController(candidate));
   candidates.sort(compareClaimScores);
   return (_b = (_a = candidates[0]) == null ? void 0 : _a.roomName) != null ? _b : null;
@@ -25904,14 +26298,14 @@ function getScoutIntel(homeRoomName, roomName) {
 }
 function countSources(room, scoutIntel) {
   if (room) {
-    return findRoomObjects17(room, "FIND_SOURCES").length;
+    return findRoomObjects18(room, "FIND_SOURCES").length;
   }
   return typeof (scoutIntel == null ? void 0 : scoutIntel.sourceCount) === "number" ? scoutIntel.sourceCount : 0;
 }
 function countHostiles(room, scoutIntel) {
   var _a, _b, _c;
   if (room) {
-    return findRoomObjects17(room, "FIND_HOSTILE_CREEPS").length + findRoomObjects17(room, "FIND_HOSTILE_STRUCTURES").length;
+    return findRoomObjects18(room, "FIND_HOSTILE_CREEPS").length + findRoomObjects18(room, "FIND_HOSTILE_STRUCTURES").length;
   }
   return ((_a = scoutIntel == null ? void 0 : scoutIntel.hostileCreepCount) != null ? _a : 0) + ((_b = scoutIntel == null ? void 0 : scoutIntel.hostileStructureCount) != null ? _b : 0) + ((_c = scoutIntel == null ? void 0 : scoutIntel.hostileSpawnCount) != null ? _c : 0);
 }
@@ -25922,7 +26316,7 @@ function scoreControllerDistance(room, details) {
     details.push("controller distance unknown");
     return 0;
   }
-  const ranges = findRoomObjects17(room, "FIND_SOURCES").map((source) => getRange2(controllerPos, source.pos)).filter((range) => typeof range === "number" && Number.isFinite(range));
+  const ranges = findRoomObjects18(room, "FIND_SOURCES").map((source) => getRange2(controllerPos, source.pos)).filter((range) => typeof range === "number" && Number.isFinite(range));
   if (ranges.length === 0) {
     details.push("controller distance unknown");
     return 0;
@@ -25966,20 +26360,20 @@ function getControllerStatus2(room, scoutIntel) {
     if (!controller) {
       return "missing";
     }
-    if (controller.my === true || isNonEmptyString21((_a = controller.owner) == null ? void 0 : _a.username)) {
+    if (controller.my === true || isNonEmptyString22((_a = controller.owner) == null ? void 0 : _a.username)) {
       return "owned";
     }
-    if (isNonEmptyString21((_b = controller.reservation) == null ? void 0 : _b.username)) {
+    if (isNonEmptyString22((_b = controller.reservation) == null ? void 0 : _b.username)) {
       return "reserved";
     }
     return "neutral";
   }
   if (scoutIntel == null ? void 0 : scoutIntel.controller) {
     const controller = scoutIntel.controller;
-    if (controller.my === true || isNonEmptyString21(controller.ownerUsername)) {
+    if (controller.my === true || isNonEmptyString22(controller.ownerUsername)) {
       return "owned";
     }
-    if (isNonEmptyString21(controller.reservationUsername)) {
+    if (isNonEmptyString22(controller.reservationUsername)) {
       return "reserved";
     }
     return "neutral";
@@ -26010,19 +26404,19 @@ function getRoomDistance(homeRoomName, roomName) {
   }
   return NO_ROUTE_DISTANCE;
 }
-function getAdjacentRoomNames6(roomName) {
+function getAdjacentRoomNames7(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord20(exits)) {
+  if (!isRecord21(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER5.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER6.flatMap((direction) => {
     const adjacentRoom = exits[direction];
-    return isNonEmptyString21(adjacentRoom) ? [adjacentRoom] : [];
+    return isNonEmptyString22(adjacentRoom) ? [adjacentRoom] : [];
   });
 }
 function getRoomTerrain12(roomName) {
@@ -26033,7 +26427,7 @@ function getRoomTerrain12(roomName) {
   }
   return gameMap.getRoomTerrain(roomName);
 }
-function findRoomObjects17(room, constantName) {
+function findRoomObjects18(room, constantName) {
   const findConstant = getGlobalNumber12(constantName);
   if (!room || typeof room.find !== "function" || typeof findConstant !== "number") {
     return [];
@@ -26056,10 +26450,10 @@ function getGlobalNumber12(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function isRecord20(value) {
+function isRecord21(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString21(value) {
+function isNonEmptyString22(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -26068,8 +26462,8 @@ var ADJACENT_ROOM_RESERVATION_TARGET_CREATOR = "adjacentRoomReservation";
 var MIN_ADJACENT_ROOM_RESERVATION_SCORE = 500;
 var ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS_PER_CLAIM_PART = 600;
 var MAX_ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS = 1e3;
-var EXIT_DIRECTION_ORDER6 = ["1", "3", "5", "7"];
-function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime21(), options = {}) {
+var EXIT_DIRECTION_ORDER7 = ["1", "3", "5", "7"];
+function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime22(), options = {}) {
   const evaluation = selectAdjacentRoomReservationPlan(colony, options);
   if (evaluation.status === "planned" && evaluation.targetRoom) {
     persistAdjacentRoomReservationIntent(colony.room.name, evaluation, gameTime);
@@ -26085,7 +26479,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
   if (!claimBlocker && options.reserveWhenClaimAllowed !== true) {
     return { status: "skipped", colony: colonyName, reason: "claimAllowed" };
   }
-  if (hasBlockingTerritoryPlan(colonyName)) {
+  if (hasBlockingTerritoryPlan2(colonyName)) {
     return {
       status: "skipped",
       colony: colonyName,
@@ -26103,9 +26497,9 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
     };
   }
   const renewalThresholdTicks = getAdjacentRoomReservationRenewalThreshold(claimPartCount);
-  const ownerUsername = getControllerOwnerUsername8(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername9(colony.room.controller);
   const expansionPriorities = getPersistedExpansionCandidatePriorities(colonyName);
-  const candidates = getAdjacentRoomNames7(colonyName).flatMap(
+  const candidates = getAdjacentRoomNames8(colonyName).flatMap(
     (roomName, order) => buildReservationCandidate(
       colony.room,
       roomName,
@@ -26145,7 +26539,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
   };
 }
 function clearAdjacentRoomReservationIntent(colony) {
-  const territoryMemory = getTerritoryMemoryRecord7();
+  const territoryMemory = getTerritoryMemoryRecord8();
   if (!territoryMemory) {
     return;
   }
@@ -26260,9 +26654,9 @@ function getAdjacentRoomClaimBlocker(colony) {
   if (typeof controllerLevel !== "number" || controllerLevel < 2) {
     return "controllerLevelLow";
   }
-  const ownerUsername = getControllerOwnerUsername8(controller);
+  const ownerUsername = getControllerOwnerUsername9(controller);
   const ownedRoomCount = countVisibleOwnedRooms3(colony.room.name, ownerUsername);
-  const gclLevel = getGclLevel3();
+  const gclLevel = getGclLevel4();
   if (typeof gclLevel === "number" && ownedRoomCount >= gclLevel) {
     return "gclInsufficient";
   }
@@ -26291,11 +26685,11 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString22(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString23(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString22(controller.reservationUsername)) {
-    if (isNonEmptyString22(ownerUsername) && controller.reservationUsername === ownerUsername) {
+  if (isNonEmptyString23(controller.reservationUsername)) {
+    if (isNonEmptyString23(ownerUsername) && controller.reservationUsername === ownerUsername) {
       return {
         kind: "ownReserved",
         ...controller.id ? { controllerId: controller.id } : {},
@@ -26309,12 +26703,12 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
 function getVisibleControllerReservationState(controller, ownerUsername) {
   var _a;
   const controllerId = controller.id;
-  if (controller.my === true || isNonEmptyString22((_a = controller.owner) == null ? void 0 : _a.username)) {
+  if (controller.my === true || isNonEmptyString23((_a = controller.owner) == null ? void 0 : _a.username)) {
     return { kind: "owned", controllerId };
   }
   const reservation = controller.reservation;
-  if (isNonEmptyString22(reservation == null ? void 0 : reservation.username)) {
-    if (isNonEmptyString22(ownerUsername) && reservation.username === ownerUsername) {
+  if (isNonEmptyString23(reservation == null ? void 0 : reservation.username)) {
+    if (isNonEmptyString23(ownerUsername) && reservation.username === ownerUsername) {
       return {
         kind: "ownReserved",
         controllerId,
@@ -26335,13 +26729,13 @@ function hasHostilePresence2(colonyName, roomName) {
   return ((_a = scoutIntel == null ? void 0 : scoutIntel.hostileCreepCount) != null ? _a : 0) + ((_b = scoutIntel == null ? void 0 : scoutIntel.hostileStructureCount) != null ? _b : 0) + ((_c = scoutIntel == null ? void 0 : scoutIntel.hostileSpawnCount) != null ? _c : 0) > 0;
 }
 function countVisibleHostiles(room) {
-  return countVisibleRoomObjects2(room, getFindConstant7("FIND_HOSTILE_CREEPS")) + countVisibleRoomObjects2(room, getFindConstant7("FIND_HOSTILE_STRUCTURES"));
+  return countVisibleRoomObjects2(room, getFindConstant8("FIND_HOSTILE_CREEPS")) + countVisibleRoomObjects2(room, getFindConstant8("FIND_HOSTILE_STRUCTURES"));
 }
 function persistAdjacentRoomReservationIntent(colony, evaluation, gameTime) {
   if (!evaluation.targetRoom) {
     return;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord6();
+  const territoryMemory = getWritableTerritoryMemoryRecord7();
   if (!territoryMemory) {
     return;
   }
@@ -26404,7 +26798,7 @@ function upsertAdjacentRoomReservationTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord21(existingTarget)) {
+  if (isRecord22(existingTarget)) {
     existingTarget.createdBy = ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -26424,8 +26818,8 @@ function upsertAdjacentRoomReservationIntent(intents, nextIntent) {
   }
   intents.push(nextIntent);
 }
-function hasBlockingTerritoryPlan(colony) {
-  const territoryMemory = getTerritoryMemoryRecord7();
+function hasBlockingTerritoryPlan2(colony) {
+  const territoryMemory = getTerritoryMemoryRecord8();
   if (!territoryMemory) {
     return false;
   }
@@ -26437,38 +26831,38 @@ function hasBlockingTerritoryPlan(colony) {
   );
 }
 function isBlockingTerritoryTarget(target, colony) {
-  return isRecord21(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
+  return isRecord22(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
 }
 function isAdjacentRoomReservationTarget(target, colony) {
-  return isRecord21(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
+  return isRecord22(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
 }
 function isSameTarget3(left, right) {
-  return isRecord21(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord22(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
-function getAdjacentRoomNames7(roomName) {
+function getAdjacentRoomNames8(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord21(exits)) {
+  if (!isRecord22(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER6.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER7.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString22(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString23(exitRoom) ? [exitRoom] : [];
   });
 }
 function getPersistedExpansionCandidatePriorities(colony) {
   var _a;
-  const rawCandidates = (_a = getTerritoryMemoryRecord7()) == null ? void 0 : _a.expansionCandidates;
+  const rawCandidates = (_a = getTerritoryMemoryRecord8()) == null ? void 0 : _a.expansionCandidates;
   if (!Array.isArray(rawCandidates)) {
     return /* @__PURE__ */ new Map();
   }
   const priorities = /* @__PURE__ */ new Map();
   for (const [index, rawCandidate] of rawCandidates.entries()) {
-    if (!isRecord21(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString22(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
+    if (!isRecord22(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString23(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
       continue;
     }
     priorities.set(rawCandidate.roomName, {
@@ -26486,13 +26880,13 @@ function countVisibleOwnedRooms3(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString22(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString23(room.name) && (!ownerUsername || getControllerOwnerUsername9(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
   return Math.max(1, ownedRoomCount || (((_d = (_c = rooms[colonyName]) == null ? void 0 : _c.controller) == null ? void 0 : _d.my) === true ? 1 : 0));
 }
-function getGclLevel3() {
+function getGclLevel4() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   if (typeof level !== "number" || !Number.isFinite(level) || level <= 0) {
@@ -26515,14 +26909,14 @@ function countVisibleRoomObjects2(room, findConstant) {
   const result = room.find(findConstant);
   return Array.isArray(result) ? result.length : 0;
 }
-function getFindConstant7(name) {
+function getFindConstant8(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getControllerOwnerUsername8(controller) {
+function getControllerOwnerUsername9(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString22(username) ? username : void 0;
+  return isNonEmptyString23(username) ? username : void 0;
 }
 function compareOptionalNumbers6(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
@@ -26539,11 +26933,11 @@ function compareOptionalNumbersDescending2(left, right) {
   }
   return right - left;
 }
-function getTerritoryMemoryRecord7() {
+function getTerritoryMemoryRecord8() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
-function getWritableTerritoryMemoryRecord6() {
+function getWritableTerritoryMemoryRecord7() {
   const root = globalThis;
   if (!root.Memory) {
     root.Memory = {};
@@ -26553,23 +26947,23 @@ function getWritableTerritoryMemoryRecord6() {
   }
   return root.Memory.territory;
 }
-function getGameTime21() {
+function getGameTime22() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString22(value) {
+function isNonEmptyString23(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord21(value) {
+function isRecord22(value) {
   return typeof value === "object" && value !== null;
 }
 
 // src/territory/colonyExpansionPlanner.ts
 var COLONY_EXPANSION_CLAIM_TARGET_CREATOR = "colonyExpansion";
 var MIN_COLONY_EXPANSION_CLAIM_SCORE = MIN_ADJACENT_ROOM_RESERVATION_SCORE;
-var EXIT_DIRECTION_ORDER7 = ["1", "3", "5", "7"];
-function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime22()) {
+var EXIT_DIRECTION_ORDER8 = ["1", "3", "5", "7"];
+function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime23()) {
   const colonyName = colony.room.name;
   if (assessment.territoryReady !== true) {
     const reservation2 = refreshAdjacentRoomReservationIntent(colony, gameTime, {
@@ -26643,17 +27037,17 @@ function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime
   };
 }
 function clearColonyExpansionClaimIntent(colony) {
-  const territoryMemory = getTerritoryMemoryRecord8();
+  const territoryMemory = getTerritoryMemoryRecord9();
   if (!territoryMemory) {
     return;
   }
   pruneColonyExpansionClaimTargets(colony, territoryMemory);
 }
 function selectColonyExpansionCandidate(colony) {
-  const ownerUsername = getControllerOwnerUsername9(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername10(colony.room.controller);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString23(room.mineralType));
-  const candidates = getAdjacentRoomNames8(colony.room.name).flatMap((roomName, order) => {
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString24(room.mineralType));
+  const candidates = getAdjacentRoomNames9(colony.room.name).flatMap((roomName, order) => {
     const room = getVisibleRoom13(roomName);
     if (!room && !getScoutIntel3(colony.room.name, roomName)) {
       return [];
@@ -26786,12 +27180,12 @@ function isColonyReadyToClaimMatureReservation(colony, controllerState) {
   if (hasActivePostClaimBootstrap2(colony.room.name)) {
     return false;
   }
-  const ownerUsername = getControllerOwnerUsername9(controller);
+  const ownerUsername = getControllerOwnerUsername10(controller);
   const ownedRoomCount = countVisibleOwnedRooms4(colony.room.name, ownerUsername);
   if (ownedRoomCount >= maxRoomsForRcl(controllerLevel)) {
     return false;
   }
-  const gclLevel = getGclLevel4();
+  const gclLevel = getGclLevel5();
   return typeof gclLevel !== "number" || ownedRoomCount < gclLevel;
 }
 function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) {
@@ -26803,11 +27197,11 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
       return { kind: "missing" };
     }
     const controllerId = controller2.id;
-    if (controller2.my === true || isNonEmptyString23((_a = controller2.owner) == null ? void 0 : _a.username)) {
+    if (controller2.my === true || isNonEmptyString24((_a = controller2.owner) == null ? void 0 : _a.username)) {
       return { kind: "owned", controllerId };
     }
     const reservationUsername = (_b = controller2.reservation) == null ? void 0 : _b.username;
-    if (isNonEmptyString23(reservationUsername)) {
+    if (isNonEmptyString24(reservationUsername)) {
       return reservationUsername === ownerUsername ? {
         kind: "ownReserved",
         controllerId,
@@ -26824,10 +27218,10 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString23(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString24(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString23(controller.reservationUsername)) {
+  if (isNonEmptyString24(controller.reservationUsername)) {
     return controller.reservationUsername === ownerUsername ? {
       kind: "ownReserved",
       ...controller.id ? { controllerId: controller.id } : {},
@@ -26837,12 +27231,12 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   return { kind: "neutral", ...controller.id ? { controllerId: controller.id } : {} };
 }
 function hasBlockingClaimIntent(colony, targetRoom) {
-  const territoryMemory = getTerritoryMemoryRecord8();
+  const territoryMemory = getTerritoryMemoryRecord9();
   if (!territoryMemory) {
     return false;
   }
   if (Array.isArray(territoryMemory.targets) && territoryMemory.targets.some(
-    (target) => isRecord22(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
+    (target) => isRecord23(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
   )) {
     return true;
   }
@@ -26851,7 +27245,7 @@ function hasBlockingClaimIntent(colony, targetRoom) {
   );
 }
 function persistColonyExpansionClaimIntent(colony, candidate, gameTime) {
-  const territoryMemory = getWritableTerritoryMemoryRecord7();
+  const territoryMemory = getWritableTerritoryMemoryRecord8();
   if (!territoryMemory) {
     return;
   }
@@ -26865,10 +27259,10 @@ function persistColonyExpansionClaimIntent(colony, candidate, gameTime) {
   };
   pruneAdjacentReservationForTarget(colony, candidate.roomName, territoryMemory);
   pruneColonyExpansionClaimTargets(colony, territoryMemory, target);
-  upsertTerritoryTarget3(territoryMemory, target);
+  upsertTerritoryTarget4(territoryMemory, target);
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
-  upsertTerritoryIntent5(intents, {
+  upsertTerritoryIntent6(intents, {
     colony,
     targetRoom: candidate.roomName,
     action: "claim",
@@ -26888,13 +27282,13 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
   const removedRooms = /* @__PURE__ */ new Set();
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter((target) => {
-      if (!isRecord22(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
+      if (!isRecord23(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
         return true;
       }
       if (activeTarget && isSameTarget4(target, activeTarget)) {
         return true;
       }
-      if (isNonEmptyString23(target.roomName)) {
+      if (isNonEmptyString24(target.roomName)) {
         removedRooms.add(target.roomName);
       }
       return false;
@@ -26911,7 +27305,7 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
 function pruneAdjacentReservationForTarget(colony, targetRoom, territoryMemory) {
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter(
-      (target) => !(isRecord22(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
+      (target) => !(isRecord23(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
     );
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
@@ -26919,7 +27313,7 @@ function pruneAdjacentReservationForTarget(colony, targetRoom, territoryMemory) 
   );
   territoryMemory.intents = intents;
 }
-function upsertTerritoryTarget3(territoryMemory, target) {
+function upsertTerritoryTarget4(territoryMemory, target) {
   if (!Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = [];
   }
@@ -26928,7 +27322,7 @@ function upsertTerritoryTarget3(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord22(existingTarget)) {
+  if (isRecord23(existingTarget)) {
     existingTarget.createdBy = COLONY_EXPANSION_CLAIM_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.postClaimBootstrapReserveEnergy) {
@@ -26943,7 +27337,7 @@ function upsertTerritoryTarget3(territoryMemory, target) {
     }
   }
 }
-function upsertTerritoryIntent5(intents, nextIntent) {
+function upsertTerritoryIntent6(intents, nextIntent) {
   const existingIndex = intents.findIndex(
     (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action && intent.createdBy === nextIntent.createdBy
   );
@@ -26954,21 +27348,21 @@ function upsertTerritoryIntent5(intents, nextIntent) {
   intents.push(nextIntent);
 }
 function isSameTarget4(left, right) {
-  return isRecord22(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord23(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
-function getAdjacentRoomNames8(roomName) {
+function getAdjacentRoomNames9(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord22(exits)) {
+  if (!isRecord23(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER7.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER8.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString23(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString24(exitRoom) ? [exitRoom] : [];
   });
 }
 function getVisibleRoom13(roomName) {
@@ -26987,37 +27381,37 @@ function countVisibleOwnedRooms4(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString23(room.name) && (!ownerUsername || getControllerOwnerUsername9(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString24(room.name) && (!ownerUsername || getControllerOwnerUsername10(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
   return Math.max(1, ownedRoomCount || (((_d = (_c = rooms[colonyName]) == null ? void 0 : _c.controller) == null ? void 0 : _d.my) === true ? 1 : 0));
 }
-function getGclLevel4() {
+function getGclLevel5() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
 }
 function hasActivePostClaimBootstrap2(colonyName) {
   var _a;
-  const records = (_a = getTerritoryMemoryRecord8()) == null ? void 0 : _a.postClaimBootstraps;
-  if (!isRecord22(records)) {
+  const records = (_a = getTerritoryMemoryRecord9()) == null ? void 0 : _a.postClaimBootstraps;
+  if (!isRecord23(records)) {
     return false;
   }
   return Object.values(records).some(
-    (record) => isRecord22(record) && record.colony === colonyName && record.status !== "ready"
+    (record) => isRecord23(record) && record.colony === colonyName && record.status !== "ready"
   );
 }
-function getControllerOwnerUsername9(controller) {
+function getControllerOwnerUsername10(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString23(username) ? username : void 0;
+  return isNonEmptyString24(username) ? username : void 0;
 }
-function getTerritoryMemoryRecord8() {
+function getTerritoryMemoryRecord9() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
-function getWritableTerritoryMemoryRecord7() {
+function getWritableTerritoryMemoryRecord8() {
   const memory = globalThis.Memory;
   if (!memory) {
     return null;
@@ -27027,15 +27421,15 @@ function getWritableTerritoryMemoryRecord7() {
   }
   return memory.territory;
 }
-function getGameTime22() {
+function getGameTime23() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord22(value) {
+function isRecord23(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString23(value) {
+function isNonEmptyString24(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -27060,11 +27454,11 @@ function refreshClaimedRoomBootstrapperOwnership() {
     if (newlyClaimed) {
       detectedRoomNames.push(room.name);
     }
-    const claimedAt = newlyClaimed ? getGameTime23() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
+    const claimedAt = newlyClaimed ? getGameTime24() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
     memory.rooms[room.name] = {
       roomName: room.name,
       owned,
-      updatedAt: getGameTime23(),
+      updatedAt: getGameTime24(),
       ...claimedAt !== void 0 ? { claimedAt } : {},
       ...newlyClaimed ? {} : (previous == null ? void 0 : previous.completedAt) !== void 0 ? { completedAt: previous.completedAt } : {}
     };
@@ -27087,14 +27481,14 @@ function getWritableBootstrapperMemory() {
 function getActivePostClaimBootstrapRecord(roomName) {
   var _a, _b, _c;
   const record = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps) == null ? void 0 : _c[roomName];
-  return isRecord23(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
+  return isRecord24(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
 }
-function getGameTime23() {
+function getGameTime24() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord23(value) {
+function isRecord24(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -27136,7 +27530,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   if (assignment.action === "scout") {
-    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime24(), creep.name, telemetryEvents);
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime25(), creep.name, telemetryEvents);
     completeTerritoryAssignment(creep);
     return;
   }
@@ -27218,7 +27612,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime24();
+  const gameTime = getGameTime25();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -27238,7 +27632,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime24());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime25());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -27318,7 +27712,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime24() {
+function getGameTime25() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -27490,11 +27884,11 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
       return creep.memory.colony === room.name || ((_a2 = creep.room) == null ? void 0 : _a2.name) === room.name;
     }
   );
-  const hostileCreeps = findRoomObjects18(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects18(room, "FIND_HOSTILE_STRUCTURES");
-  const ownedStructures = findRoomObjects18(room, "FIND_MY_STRUCTURES");
-  const constructionSites = findRoomObjects18(room, "FIND_MY_CONSTRUCTION_SITES");
-  const sources = findRoomObjects18(room, "FIND_SOURCES");
+  const hostileCreeps = findRoomObjects19(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects19(room, "FIND_HOSTILE_STRUCTURES");
+  const ownedStructures = findRoomObjects19(room, "FIND_MY_STRUCTURES");
+  const constructionSites = findRoomObjects19(room, "FIND_MY_CONSTRUCTION_SITES");
+  const sources = findRoomObjects19(room, "FIND_SOURCES");
   return {
     roomName: room.name,
     controllerLevel: (_a = room.controller) == null ? void 0 : _a.level,
@@ -27585,7 +27979,7 @@ function buildMemoryTerritoryState(roomName) {
   const expansionCandidates = [];
   if (Array.isArray(targets)) {
     for (const target of targets) {
-      if (!isRecord24(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+      if (!isRecord25(target) || target.colony !== roomName || typeof target.roomName !== "string") {
         continue;
       }
       const action = normalizeTerritoryAction(target.action);
@@ -27647,12 +28041,12 @@ function countVisibleOwnedRooms5() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord24(structure) && matchesStructureType20(structure.structureType, globalName, fallback)
+    (structure) => isRecord25(structure) && matchesStructureType20(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
   return structures.reduce((total, structure) => {
-    if (!isRecord24(structure)) {
+    if (!isRecord25(structure)) {
       return total;
     }
     const hits = finiteNumberOrNull(structure.hits);
@@ -27668,7 +28062,7 @@ function getStoredEnergy14(room) {
   return getEnergyInStore2(storage);
 }
 function getEnergyInStore2(object) {
-  if (!isRecord24(object) || !isRecord24(object.store)) {
+  if (!isRecord25(object) || !isRecord25(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -27679,7 +28073,7 @@ function getEnergyInStore2(object) {
   }
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
-function findRoomObjects18(room, constantName) {
+function findRoomObjects19(room, constantName) {
   const findConstant = getGlobalNumber13(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
@@ -27720,7 +28114,7 @@ function finiteNumberOrZero(value) {
 function finiteNumberOrNull(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function isRecord24(value) {
+function isRecord25(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -28030,17 +28424,17 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber9(refreshedAt) || !isRecord25(rawSelection) || !isNonEmptyString24(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber9(refreshedAt) || !isRecord26(rawSelection) || !isNonEmptyString25(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord25(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord26(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString24(rawSelection.targetRoom)) {
+    if (!isNonEmptyString25(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -28077,7 +28471,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord25(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord26(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -28089,7 +28483,7 @@ function getNextExpansionSelectionCacheStateKey(colony) {
     colony.room.name,
     colony.energyCapacityAvailable,
     controllerLevel,
-    (_a = getGclLevel5()) != null ? _a : "unknown",
+    (_a = getGclLevel6()) != null ? _a : "unknown",
     countVisibleOwnedRooms6(),
     downgradeState,
     countActivePostClaimBootstraps3(),
@@ -28107,7 +28501,7 @@ function countVisibleOwnedRooms6() {
     return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
   }).length;
 }
-function getGclLevel5() {
+function getGclLevel6() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
@@ -28115,37 +28509,37 @@ function getGclLevel5() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord25(records)) {
+  if (!isRecord26(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord25(record) && record.status !== "ready"
+    (record) => isRecord26(record) && record.status !== "ready"
   ).length;
 }
 function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel;
-  if (!isRecord25(records)) {
+  if (!isRecord26(records)) {
     return 0;
   }
   let latestUpdatedAt = 0;
   for (const record of Object.values(records)) {
-    if (isRecord25(record) && record.colony === colony && isFiniteNumber9(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
+    if (isRecord26(record) && record.colony === colony && isFiniteNumber9(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
       latestUpdatedAt = record.updatedAt;
     }
   }
   return latestUpdatedAt;
 }
-function isRecord25(value) {
+function isRecord26(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString24(value) {
+function isNonEmptyString25(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber9(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function normalizeNonNegativeInteger6(value) {
+function normalizeNonNegativeInteger7(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 function planCoordinatedSpawn(colony, roleCounts, gameTime, options, colonies, creeps, usedSpawnsByRoom, reservedSpawnEnergyByRoom, plannedRoleCountsByRoom, survivalAssessment) {
@@ -28194,8 +28588,8 @@ function createSpawnPlanningColony(colony, sourceColony, energyAvailable, usedSp
   return {
     ...colony,
     energyAvailable,
-    energyCapacityAvailable: normalizeNonNegativeInteger6(sourceColony.energyCapacityAvailable),
-    spawnEnergyBudget: normalizeNonNegativeInteger6(energyAvailable),
+    energyCapacityAvailable: normalizeNonNegativeInteger7(sourceColony.energyCapacityAvailable),
+    spawnEnergyBudget: normalizeNonNegativeInteger7(energyAvailable),
     spawns: sourceColony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
   };
 }
@@ -28244,7 +28638,7 @@ function canUseCrossRoomSpawnSource(sourceColony, creeps, usedSpawnsByRoom, rese
   return survival.mode === "TERRITORY_READY" && !survival.controllerDowngradeGuard && !survival.hostilePresence;
 }
 function compareCoordinatedSpawnSources(left, right, reservedSpawnEnergyByRoom) {
-  return getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger6(right.energyCapacityAvailable) - normalizeNonNegativeInteger6(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
+  return getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger7(right.energyCapacityAvailable) - normalizeNonNegativeInteger7(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
 }
 function getUnusedSpawnCount(colony, usedSpawnsByRoom) {
   var _a;
@@ -28252,7 +28646,7 @@ function getUnusedSpawnCount(colony, usedSpawnsByRoom) {
   return colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn)).length;
 }
 function hasFullSpawnEnergyAfterReservations(colony, reservedSpawnEnergyByRoom) {
-  const energyCapacity = normalizeNonNegativeInteger6(colony.energyCapacityAvailable);
+  const energyCapacity = normalizeNonNegativeInteger7(colony.energyCapacityAvailable);
   return energyCapacity > 0 && getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) >= energyCapacity;
 }
 function getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) {
@@ -28262,7 +28656,7 @@ function getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) {
   }
   return Math.max(
     0,
-    normalizeNonNegativeInteger6(colony.energyAvailable) - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0)
+    normalizeNonNegativeInteger7(colony.energyAvailable) - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0)
   );
 }
 function refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom) {
@@ -28518,7 +28912,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime25())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime26())
     );
   }
 };
@@ -28590,7 +28984,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime25() {
+function getGameTime26() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -29420,10 +29814,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord26(rawReplay)) {
+  if (!isRecord27(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString25(rawReplay.replayId) || !isNonEmptyString25(rawReplay.room) || !isFiniteNumber10(rawReplay.startTick) || !isFiniteNumber10(rawReplay.endTick) || !isFiniteNumber10(rawReplay.finalScore) || !isRecord26(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString26(rawReplay.replayId) || !isNonEmptyString26(rawReplay.room) || !isFiniteNumber10(rawReplay.startTick) || !isFiniteNumber10(rawReplay.endTick) || !isFiniteNumber10(rawReplay.finalScore) || !isRecord27(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -29448,10 +29842,10 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord26(value) {
+function isRecord27(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString25(value) {
+function isNonEmptyString26(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber10(value) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8325,8 +8325,10 @@ function refreshExpansionPlannerIntent(colony, gameTime = getGameTime11()) {
     };
   }
   const candidates = buildRuntimeExpansionPlannerCandidates(colony);
-  const candidate = candidates[0];
-  const action = candidate ? selectExpansionIntentAction(colony) : null;
+  const selectedAction = candidates.length > 0 ? selectExpansionIntentAction(colony) : null;
+  const preferredUpgradeCandidates = selectedAction === "claim" && potentialReservationUpgradeRooms.size > 0 ? candidates.filter((candidate2) => potentialReservationUpgradeRooms.has(candidate2.roomName)) : [];
+  const candidate = preferredUpgradeCandidates.length > 0 ? preferredUpgradeCandidates[0] : candidates[0];
+  const action = candidate ? selectedAction : null;
   const reservationUpgrade = candidate && action ? getExpansionReservationUpgradeContext(candidate, action) : null;
   if (territoryMemory && hasBlockingTerritoryPlan(territoryMemory, colonyName, reservationUpgrade)) {
     return {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2871,7 +2871,7 @@ function hasRemoteTerritoryReference(value, roomName, roomKey) {
     if (!isRecord2(entry)) {
       return false;
     }
-    return entry[roomKey] === roomName && isNonEmptyString3(entry.colony) && entry.colony !== roomName && isTerritoryControlAction(entry.action) && entry.status !== "suppressed" && entry.enabled !== false;
+    return entry[roomKey] === roomName && isNonEmptyString3(entry.colony) && entry.colony !== roomName && isTerritoryControlAction(entry.action) && (entry.status === void 0 || entry.status === "planned" || entry.status === "active") && entry.enabled !== false;
   });
 }
 function isSelfReservedRoom(room) {
@@ -5216,7 +5216,7 @@ function isTerritoryIntentAction(action) {
   return action === "claim" || action === "reserve" || action === "scout";
 }
 function isTerritoryIntentStatus(status) {
-  return status === "planned" || status === "active" || status === "suppressed";
+  return status === "planned" || status === "active" || status === "suppressed" || status === "inactive" || status === "completed";
 }
 function isTerritoryIntentSuppressionReason(reason) {
   return reason === "deadZoneTarget" || reason === "deadZoneRoute";
@@ -5225,7 +5225,7 @@ function isTerritoryFollowUpSource(source) {
   return source === "satisfiedClaimAdjacent" || source === "satisfiedReserveAdjacent" || source === "activeReserveAdjacent";
 }
 function isTerritoryAutomationSource(source) {
-  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
+  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "expansionPlanner" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function isFiniteNumber4(value) {
   return typeof value === "number" && Number.isFinite(value);
@@ -8236,6 +8236,671 @@ function getOkCode4() {
   return (_a = globalThis.OK) != null ? _a : 0;
 }
 
+// src/territory/expansionPlanner.ts
+var EXPANSION_PLANNER_MIN_SOURCE_COUNT = 2;
+var EXPANSION_PLANNER_MAX_ROUTE_DISTANCE = 2;
+var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
+var ERR_NO_PATH_CODE4 = -2;
+var SOURCE_SCORE_WEIGHT = 1e3;
+var DISTANCE_SCORE_WEIGHT = 100;
+var EXPANSION_PLANNER_TARGET_CREATOR = "expansionPlanner";
+function evaluateExpansionRoomSuitability(room) {
+  var _a;
+  const ownerUsername = getControllerOwnerUsername4(room.controller);
+  const reservationUsername = getControllerReservationUsername3(room.controller);
+  return evaluateExpansionSuitability({
+    sourceCount: findRoomObjects12(room, getFindConstant4("FIND_SOURCES")).length,
+    hostileCreepCount: findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_CREEPS")).length,
+    hostileStructureCount: findRoomObjects12(
+      room,
+      getFindConstant4("FIND_HOSTILE_STRUCTURES")
+    ).length,
+    ...((_a = room.controller) == null ? void 0 : _a.id) ? { controllerId: room.controller.id } : {},
+    ...ownerUsername ? { ownerUsername } : {},
+    ...reservationUsername ? { reservationUsername } : {},
+    hasController: room.controller !== void 0
+  });
+}
+function buildRuntimeExpansionPlannerCandidates(colony) {
+  const colonyName = colony.room.name;
+  const rooms = getGameRooms3();
+  if (!rooms) {
+    return [];
+  }
+  const ownerUsername = getControllerOwnerUsername4(colony.room.controller);
+  const ownedRoomNames = getVisibleOwnedRoomNames3(colonyName, ownerUsername);
+  const candidates = [];
+  const seenRooms = /* @__PURE__ */ new Set();
+  let order = 0;
+  for (const ownedRoomName of ownedRoomNames) {
+    for (const adjacentRoomName of getAdjacentRoomNames3(ownedRoomName)) {
+      if (seenRooms.has(adjacentRoomName) || ownedRoomNames.has(adjacentRoomName)) {
+        continue;
+      }
+      seenRooms.add(adjacentRoomName);
+      const room = rooms[adjacentRoomName];
+      if (!room) {
+        continue;
+      }
+      candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, 1, order));
+      order += 1;
+    }
+  }
+  for (const room of Object.values(rooms)) {
+    if (!room || !isNonEmptyString9(room.name) || room.name === colonyName || ownedRoomNames.has(room.name) || seenRooms.has(room.name)) {
+      continue;
+    }
+    const distance = getNearestOwnedRoomDistance2(ownedRoomNames, room.name);
+    if (distance === null || distance > EXPANSION_PLANNER_MAX_ROUTE_DISTANCE) {
+      continue;
+    }
+    seenRooms.add(room.name);
+    candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, distance, order));
+    order += 1;
+  }
+  return candidates.filter((candidate) => candidate.suitable).sort(compareExpansionPlannerCandidates);
+}
+function refreshExpansionPlannerIntent(colony, gameTime = getGameTime11()) {
+  const colonyName = colony.room.name;
+  if (!getMemoryRecord()) {
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "memoryUnavailable",
+      candidates: []
+    };
+  }
+  const territoryMemory = getTerritoryMemoryRecord5();
+  if (territoryMemory) {
+    refreshTerminalExpansionPlans(territoryMemory, colonyName, gameTime);
+  }
+  const potentialReservationUpgradeRooms = territoryMemory ? getPotentialExpansionReservationUpgradeRooms(territoryMemory, colonyName) : /* @__PURE__ */ new Set();
+  if (potentialReservationUpgradeRooms === null) {
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "existingTerritoryPlan",
+      candidates: []
+    };
+  }
+  const candidates = buildRuntimeExpansionPlannerCandidates(colony);
+  const candidate = candidates[0];
+  const action = candidate ? selectExpansionIntentAction(colony) : null;
+  const reservationUpgrade = candidate && action ? getExpansionReservationUpgradeContext(candidate, action) : null;
+  if (territoryMemory && hasBlockingTerritoryPlan(territoryMemory, colonyName, reservationUpgrade)) {
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "existingTerritoryPlan",
+      candidates: []
+    };
+  }
+  if (!candidate || !action) {
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "noCandidate",
+      candidates
+    };
+  }
+  const intent = createExpansionIntent(candidate, action, gameTime);
+  if (!intent) {
+    return {
+      status: "skipped",
+      colony: colonyName,
+      reason: "memoryUnavailable",
+      candidates
+    };
+  }
+  return {
+    status: "planned",
+    colony: colonyName,
+    candidates,
+    targetRoom: intent.targetRoom,
+    action: intent.action,
+    score: intent.score,
+    ...intent.controllerId ? { controllerId: intent.controllerId } : {}
+  };
+}
+function createExpansionIntent(candidate, action, gameTime = getGameTime11()) {
+  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  if (!territoryMemory) {
+    return null;
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIntent = findExpansionIntent(intents, candidate.colony, candidate.roomName, action);
+  const existingTarget = findExpansionTarget(territoryMemory, candidate.colony, candidate.roomName, action);
+  const terminalStatus = getCandidateTerminalExpansionStatus(candidate, action, existingIntent);
+  if (terminalStatus && (existingIntent || existingTarget)) {
+    persistTerminalExpansionPlan(
+      territoryMemory,
+      intents,
+      {
+        colony: candidate.colony,
+        roomName: candidate.roomName,
+        action,
+        createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+        ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
+      },
+      terminalStatus,
+      gameTime
+    );
+    return null;
+  }
+  if (!candidate.suitable) {
+    return null;
+  }
+  if (action === "claim") {
+    removeSupersededExpansionReservationPlan(territoryMemory, intents, candidate.colony, candidate.roomName);
+  }
+  const target = {
+    colony: candidate.colony,
+    roomName: candidate.roomName,
+    action,
+    createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+    ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
+  };
+  upsertTerritoryTarget2(territoryMemory, target);
+  upsertTerritoryIntent3(intents, {
+    colony: candidate.colony,
+    targetRoom: candidate.roomName,
+    action,
+    status: (existingIntent == null ? void 0 : existingIntent.status) === "active" ? "active" : "planned",
+    updatedAt: gameTime,
+    createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+    ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
+  });
+  return {
+    colony: candidate.colony,
+    targetRoom: candidate.roomName,
+    action,
+    score: candidate.score,
+    ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
+  };
+}
+function evaluateExpansionSuitability({
+  sourceCount,
+  hostileCreepCount,
+  hostileStructureCount,
+  controllerId,
+  ownerUsername,
+  reservationUsername,
+  hasController
+}) {
+  const normalizedSourceCount = normalizeNonNegativeInteger4(sourceCount);
+  const normalizedHostileCreepCount = normalizeNonNegativeInteger4(hostileCreepCount);
+  const normalizedHostileStructureCount = normalizeNonNegativeInteger4(hostileStructureCount);
+  const reasons = [];
+  if (normalizedSourceCount < EXPANSION_PLANNER_MIN_SOURCE_COUNT) {
+    reasons.push("sourceCountBelowMinimum");
+  }
+  if (normalizedHostileCreepCount > 0 || normalizedHostileStructureCount > 0) {
+    reasons.push("hostilePresence");
+  }
+  if (!hasController) {
+    reasons.push("controllerMissing");
+  } else if (isNonEmptyString9(ownerUsername)) {
+    reasons.push("controllerOwned");
+  } else if (isNonEmptyString9(reservationUsername)) {
+    reasons.push("controllerReserved");
+  }
+  return {
+    suitable: reasons.length === 0,
+    sourceCount: normalizedSourceCount,
+    hostileCreepCount: normalizedHostileCreepCount,
+    hostileStructureCount: normalizedHostileStructureCount,
+    reasons,
+    ...controllerId ? { controllerId } : {},
+    ...ownerUsername ? { ownerUsername } : {},
+    ...reservationUsername ? { reservationUsername } : {}
+  };
+}
+function toRuntimeExpansionPlannerCandidate(colony, room, distance, order) {
+  const suitability = evaluateExpansionRoomSuitability(room);
+  const normalizedDistance = Math.max(1, normalizeNonNegativeInteger4(distance));
+  return {
+    colony,
+    roomName: room.name,
+    distance: normalizedDistance,
+    order,
+    score: scoreExpansionPlannerCandidate(suitability.sourceCount, normalizedDistance),
+    ...suitability
+  };
+}
+function compareExpansionPlannerCandidates(left, right) {
+  return right.sourceCount - left.sourceCount || left.distance - right.distance || right.score - left.score || left.order - right.order || left.roomName.localeCompare(right.roomName);
+}
+function scoreExpansionPlannerCandidate(sourceCount, distance) {
+  return sourceCount * SOURCE_SCORE_WEIGHT - distance * DISTANCE_SCORE_WEIGHT;
+}
+function selectExpansionIntentAction(colony) {
+  var _a;
+  const gclLevel = getGclLevel2();
+  if (gclLevel === null) {
+    return "reserve";
+  }
+  const ownerUsername = getControllerOwnerUsername4(colony.room.controller);
+  const ownedRoomCount = getVisibleOwnedRoomNames3(colony.room.name, ownerUsername).size;
+  if (ownedRoomCount >= gclLevel) {
+    return "reserve";
+  }
+  if (ownedRoomCount >= maxRoomsForRcl((_a = colony.room.controller) == null ? void 0 : _a.level)) {
+    return "reserve";
+  }
+  return "claim";
+}
+function refreshTerminalExpansionPlans(territoryMemory, colony, gameTime) {
+  var _a, _b;
+  const ownerUsername = getVisibleColonyOwnerUsername2(colony);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  const refreshedPlans = /* @__PURE__ */ new Set();
+  let changed = false;
+  for (const rawTarget of Array.isArray(territoryMemory.targets) ? territoryMemory.targets : []) {
+    const target = normalizeTerritoryTarget2(rawTarget);
+    if (!target || target.colony !== colony || target.roomName === colony || target.enabled === false || target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || !isExpansionControlAction(target.action)) {
+      continue;
+    }
+    const existingIntent = findExpansionIntent(intents, target.colony, target.roomName, target.action);
+    const terminalStatus = (_a = getTerminalIntentStatus(existingIntent)) != null ? _a : getVisibleExpansionTargetTerminalStatus(target, ownerUsername);
+    if (!terminalStatus) {
+      continue;
+    }
+    persistTerminalExpansionPlan(territoryMemory, intents, target, terminalStatus, gameTime);
+    refreshedPlans.add(getExpansionPlanKey(target.colony, target.roomName, target.action));
+    changed = true;
+  }
+  for (const intent of intents) {
+    if (intent.colony !== colony || intent.targetRoom === colony || !isExpansionControlAction(intent.action) || intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR) {
+      continue;
+    }
+    const planKey = getExpansionPlanKey(intent.colony, intent.targetRoom, intent.action);
+    if (refreshedPlans.has(planKey)) {
+      continue;
+    }
+    const target = {
+      colony: intent.colony,
+      roomName: intent.targetRoom,
+      action: intent.action,
+      createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+      ...intent.controllerId ? { controllerId: intent.controllerId } : {}
+    };
+    const terminalStatus = (_b = getTerminalIntentStatus(intent)) != null ? _b : getVisibleExpansionTargetTerminalStatus(target, ownerUsername);
+    if (!terminalStatus) {
+      continue;
+    }
+    persistTerminalExpansionPlan(territoryMemory, intents, target, terminalStatus, gameTime);
+    changed = true;
+  }
+  if (changed) {
+    territoryMemory.intents = intents;
+  }
+}
+function getPotentialExpansionReservationUpgradeRooms(territoryMemory, colony) {
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  const roomNames = /* @__PURE__ */ new Set();
+  for (const intent of intents) {
+    if (intent.colony !== colony || intent.targetRoom === colony || intent.action !== "claim" && intent.action !== "reserve" && intent.action !== "scout" || intent.status !== "planned" && intent.status !== "active") {
+      continue;
+    }
+    if (isPotentialExpansionReservationUpgradeIntent(intent)) {
+      roomNames.add(intent.targetRoom);
+      continue;
+    }
+    return null;
+  }
+  for (const rawTarget of Array.isArray(territoryMemory.targets) ? territoryMemory.targets : []) {
+    const target = normalizeTerritoryTarget2(rawTarget);
+    if (!target || target.colony !== colony || target.roomName === colony || target.enabled === false || !isExpansionControlAction(target.action)) {
+      continue;
+    }
+    if (isPotentialExpansionReservationUpgradeTarget(target, intents)) {
+      roomNames.add(target.roomName);
+      continue;
+    }
+    if (isBlockingExpansionTarget(rawTarget, colony, intents, null)) {
+      return null;
+    }
+  }
+  return roomNames;
+}
+function hasBlockingTerritoryPlan(territoryMemory, colony, reservationUpgrade) {
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  if (intents.some(
+    (intent) => intent.colony === colony && intent.targetRoom !== colony && (intent.action === "claim" || intent.action === "reserve" || intent.action === "scout") && (intent.status === "planned" || intent.status === "active") && !isUpgradeableExpansionReservationIntent(intent, reservationUpgrade)
+  )) {
+    return true;
+  }
+  return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some((target) => isBlockingExpansionTarget(target, colony, intents, reservationUpgrade)) : false;
+}
+function persistTerminalExpansionPlan(territoryMemory, intents, target, status, gameTime) {
+  if (findExpansionTarget(territoryMemory, target.colony, target.roomName, target.action)) {
+    upsertTerritoryTarget2(territoryMemory, { ...target, enabled: false });
+  }
+  upsertTerritoryIntent3(intents, {
+    colony: target.colony,
+    targetRoom: target.roomName,
+    action: target.action,
+    status,
+    updatedAt: gameTime,
+    createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+    ...target.controllerId ? { controllerId: target.controllerId } : {}
+  });
+}
+function upsertTerritoryTarget2(territoryMemory, target) {
+  if (!Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = [];
+  }
+  const existingTarget = territoryMemory.targets.find(
+    (candidate) => isRecord9(candidate) && candidate.colony === target.colony && candidate.roomName === target.roomName && candidate.action === target.action && candidate.createdBy === target.createdBy
+  );
+  if (!existingTarget) {
+    territoryMemory.targets.push(target);
+    return;
+  }
+  existingTarget.enabled = target.enabled;
+  existingTarget.createdBy = target.createdBy;
+  if (target.controllerId) {
+    existingTarget.controllerId = target.controllerId;
+  } else {
+    delete existingTarget.controllerId;
+  }
+}
+function upsertTerritoryIntent3(intents, nextIntent) {
+  const existingIndex = intents.findIndex(
+    (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action && intent.createdBy === nextIntent.createdBy
+  );
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+  intents.push(nextIntent);
+}
+function findExpansionIntent(intents, colony, targetRoom, action) {
+  return intents.find(
+    (intent) => intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action && intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR
+  );
+}
+function findExpansionTarget(territoryMemory, colony, roomName, action) {
+  var _a;
+  if (!Array.isArray(territoryMemory.targets)) {
+    return null;
+  }
+  return (_a = territoryMemory.targets.map(normalizeTerritoryTarget2).find(
+    (target) => target !== null && target.colony === colony && target.roomName === roomName && target.action === action && target.createdBy === EXPANSION_PLANNER_TARGET_CREATOR
+  )) != null ? _a : null;
+}
+function isBlockingExpansionTarget(rawTarget, colony, intents, reservationUpgrade) {
+  if (!isRecord9(rawTarget)) {
+    return false;
+  }
+  const target = normalizeTerritoryTarget2(rawTarget);
+  if (!target || target.colony !== colony || target.roomName === colony || target.enabled === false || !isExpansionControlAction(target.action)) {
+    return false;
+  }
+  if (isUpgradeableExpansionReservationTarget(target, reservationUpgrade)) {
+    return false;
+  }
+  if (target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR) {
+    return true;
+  }
+  const matchingIntent = findExpansionIntent(intents, target.colony, target.roomName, target.action);
+  return getTerminalIntentStatus(matchingIntent) === null;
+}
+function getExpansionReservationUpgradeContext(candidate, action) {
+  return candidate.suitable && action === "claim" ? { colony: candidate.colony, targetRoom: candidate.roomName, action } : null;
+}
+function isUpgradeableExpansionReservationIntent(intent, reservationUpgrade) {
+  return reservationUpgrade !== null && reservationUpgrade.action === "claim" && intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && intent.colony === reservationUpgrade.colony && intent.targetRoom === reservationUpgrade.targetRoom && intent.action === "reserve";
+}
+function isPotentialExpansionReservationUpgradeIntent(intent) {
+  return intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && intent.action === "reserve";
+}
+function isUpgradeableExpansionReservationTarget(target, reservationUpgrade) {
+  return reservationUpgrade !== null && reservationUpgrade.action === "claim" && target.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && target.colony === reservationUpgrade.colony && target.roomName === reservationUpgrade.targetRoom && target.action === "reserve";
+}
+function isPotentialExpansionReservationUpgradeTarget(target, intents) {
+  if (target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || target.action !== "reserve") {
+    return false;
+  }
+  const matchingIntent = findExpansionIntent(intents, target.colony, target.roomName, target.action);
+  return getTerminalIntentStatus(matchingIntent) === null;
+}
+function removeSupersededExpansionReservationPlan(territoryMemory, intents, colony, roomName) {
+  if (Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = territoryMemory.targets.filter((rawTarget) => {
+      const target = normalizeTerritoryTarget2(rawTarget);
+      return !((target == null ? void 0 : target.createdBy) === EXPANSION_PLANNER_TARGET_CREATOR && target.colony === colony && target.roomName === roomName && target.action === "reserve");
+    });
+  }
+  for (let index = intents.length - 1; index >= 0; index -= 1) {
+    const intent = intents[index];
+    if (intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && intent.colony === colony && intent.targetRoom === roomName && intent.action === "reserve") {
+      intents.splice(index, 1);
+    }
+  }
+}
+function getExpansionPlanKey(colony, targetRoom, action) {
+  return `${colony}:${targetRoom}:${action}`;
+}
+function getCandidateTerminalExpansionStatus(candidate, action, existingIntent) {
+  if (candidate.suitable) {
+    return null;
+  }
+  const terminalStatus = getTerminalIntentStatus(existingIntent);
+  if (terminalStatus) {
+    return terminalStatus;
+  }
+  const ownerUsername = getVisibleColonyOwnerUsername2(candidate.colony);
+  if (action === "claim" && candidate.ownerUsername && candidate.ownerUsername === ownerUsername) {
+    return "completed";
+  }
+  if (action === "reserve" && candidate.reservationUsername && candidate.reservationUsername === ownerUsername) {
+    return "completed";
+  }
+  return "inactive";
+}
+function getTerminalIntentStatus(intent) {
+  return (intent == null ? void 0 : intent.status) === "completed" || (intent == null ? void 0 : intent.status) === "inactive" ? intent.status : null;
+}
+function getVisibleExpansionTargetTerminalStatus(target, ownerUsername) {
+  var _a;
+  const room = (_a = getGameRooms3()) == null ? void 0 : _a[target.roomName];
+  if (!room) {
+    return null;
+  }
+  if (findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_CREEPS")).length > 0 || findRoomObjects12(room, getFindConstant4("FIND_HOSTILE_STRUCTURES")).length > 0) {
+    return "inactive";
+  }
+  const controller = room.controller;
+  if (!controller) {
+    return "inactive";
+  }
+  if (target.action === "claim") {
+    if (isControllerOwnedByUsername(controller, ownerUsername)) {
+      return "completed";
+    }
+    return isControllerOwned(controller) ? "inactive" : null;
+  }
+  if (isControllerOwnedByUsername(controller, ownerUsername)) {
+    return "completed";
+  }
+  if (isControllerOwned(controller)) {
+    return "inactive";
+  }
+  const reservationUsername = getControllerReservationUsername3(controller);
+  if (!reservationUsername) {
+    return null;
+  }
+  return reservationUsername === ownerUsername ? "completed" : "inactive";
+}
+function normalizeTerritoryTarget2(rawTarget) {
+  if (!isRecord9(rawTarget)) {
+    return null;
+  }
+  if (!isNonEmptyString9(rawTarget.colony) || !isNonEmptyString9(rawTarget.roomName) || !isExpansionControlAction(rawTarget.action)) {
+    return null;
+  }
+  return {
+    colony: rawTarget.colony,
+    roomName: rawTarget.roomName,
+    action: rawTarget.action,
+    ...typeof rawTarget.controllerId === "string" ? { controllerId: rawTarget.controllerId } : {},
+    ...rawTarget.enabled === false ? { enabled: false } : {},
+    ...isTerritoryAutomationSource2(rawTarget.createdBy) ? { createdBy: rawTarget.createdBy } : {}
+  };
+}
+function isExpansionControlAction(action) {
+  return action === "claim" || action === "reserve";
+}
+function isTerritoryAutomationSource2(source) {
+  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "expansionPlanner" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
+}
+function getNearestOwnedRoomDistance2(ownedRoomNames, roomName) {
+  let nearestDistance = null;
+  for (const ownedRoomName of ownedRoomNames) {
+    const distance = getRouteDistance(ownedRoomName, roomName);
+    if (distance === null) {
+      continue;
+    }
+    if (nearestDistance === null || distance < nearestDistance) {
+      nearestDistance = distance;
+    }
+  }
+  return nearestDistance;
+}
+function getRouteDistance(fromRoom, targetRoom) {
+  var _a, _b, _c;
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+  if (getAdjacentRoomNames3(fromRoom).includes(targetRoom)) {
+    return 1;
+  }
+  const route = (_c = (_b = (_a = globalThis.Game) == null ? void 0 : _a.map) == null ? void 0 : _b.findRoute) == null ? void 0 : _c.call(_b, fromRoom, targetRoom);
+  if (Array.isArray(route)) {
+    return route.length;
+  }
+  return route === ERR_NO_PATH_CODE4 ? null : null;
+}
+function getAdjacentRoomNames3(roomName) {
+  var _a, _b;
+  const describeExits = (_b = (_a = globalThis.Game) == null ? void 0 : _a.map) == null ? void 0 : _b.describeExits;
+  if (typeof describeExits !== "function") {
+    return [];
+  }
+  const exits = describeExits(roomName);
+  if (!isRecord9(exits)) {
+    return [];
+  }
+  const orderedRooms = EXIT_DIRECTION_ORDER3.flatMap((direction) => {
+    const adjacentRoom = exits[direction];
+    return isNonEmptyString9(adjacentRoom) ? [adjacentRoom] : [];
+  });
+  const remainingRooms = Object.entries(exits).filter(([direction, adjacentRoom]) => !EXIT_DIRECTION_ORDER3.includes(direction) && isNonEmptyString9(adjacentRoom)).map(([, adjacentRoom]) => adjacentRoom).sort();
+  return [...orderedRooms, ...remainingRooms];
+}
+function getVisibleOwnedRoomNames3(colonyName, ownerUsername) {
+  var _a;
+  const rooms = getGameRooms3();
+  const roomNames = /* @__PURE__ */ new Set([colonyName]);
+  if (!rooms) {
+    return roomNames;
+  }
+  for (const room of Object.values(rooms)) {
+    if (!room || !isNonEmptyString9(room.name) || ((_a = room.controller) == null ? void 0 : _a.my) !== true) {
+      continue;
+    }
+    const roomOwnerUsername = getControllerOwnerUsername4(room.controller);
+    if (!ownerUsername || !roomOwnerUsername || ownerUsername === roomOwnerUsername) {
+      roomNames.add(room.name);
+    }
+  }
+  return roomNames;
+}
+function getControllerOwnerUsername4(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
+  if (isNonEmptyString9(username)) {
+    return username;
+  }
+  return (controller == null ? void 0 : controller.my) === true ? "me" : void 0;
+}
+function getVisibleColonyOwnerUsername2(colony) {
+  var _a, _b;
+  return getControllerOwnerUsername4((_b = (_a = getGameRooms3()) == null ? void 0 : _a[colony]) == null ? void 0 : _b.controller);
+}
+function getControllerReservationUsername3(controller) {
+  var _a;
+  const username = (_a = controller == null ? void 0 : controller.reservation) == null ? void 0 : _a.username;
+  return isNonEmptyString9(username) ? username : void 0;
+}
+function isControllerOwnedByUsername(controller, ownerUsername) {
+  const controllerOwnerUsername = getControllerOwnerUsername4(controller);
+  return (controller == null ? void 0 : controller.my) === true || isNonEmptyString9(ownerUsername) && isNonEmptyString9(controllerOwnerUsername) && controllerOwnerUsername === ownerUsername;
+}
+function isControllerOwned(controller) {
+  return (controller == null ? void 0 : controller.my) === true || (controller == null ? void 0 : controller.owner) != null;
+}
+function findRoomObjects12(room, findConstant) {
+  if (typeof findConstant !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function getFindConstant4(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : void 0;
+}
+function getGclLevel2() {
+  var _a, _b;
+  const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
+  return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
+}
+function getGameTime11() {
+  var _a;
+  const time = (_a = globalThis.Game) == null ? void 0 : _a.time;
+  return typeof time === "number" && Number.isFinite(time) ? time : 0;
+}
+function getGameRooms3() {
+  var _a;
+  return (_a = globalThis.Game) == null ? void 0 : _a.rooms;
+}
+function getWritableTerritoryMemoryRecord4() {
+  const memory = getMemoryRecord();
+  if (!memory) {
+    return null;
+  }
+  if (!isRecord9(memory.territory)) {
+    memory.territory = {};
+  }
+  return memory.territory;
+}
+function getTerritoryMemoryRecord5() {
+  const memory = getMemoryRecord();
+  if (!memory || !isRecord9(memory.territory)) {
+    return null;
+  }
+  return memory.territory;
+}
+function getMemoryRecord() {
+  return globalThis.Memory;
+}
+function normalizeNonNegativeInteger4(value) {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+function isNonEmptyString9(value) {
+  return typeof value === "string" && value.length > 0;
+}
+function isRecord9(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/territory/territoryPlanner.ts
 var TERRITORY_CLAIMER_ROLE = "claimer";
 var TERRITORY_SCOUT_ROLE = "scout";
@@ -8257,9 +8922,9 @@ var TERRITORY_FOLLOW_UP_PREPARATION_WORKER_DEMAND = 1;
 var GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS = globalThis.TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS;
 var TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS = typeof GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS === "number" && Number.isFinite(GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS) && GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS > 0 ? Math.floor(GLOBAL_TERRITORY_EXPANSION_CANDIDATE_SCOUT_STALE_TICKS) : 1500;
 var TERRITORY_ADJACENT_CONTROLLER_PROGRESS_WORKER_SURPLUS = 0;
-var EXIT_DIRECTION_ORDER3 = ["1", "3", "5", "7"];
+var EXIT_DIRECTION_ORDER4 = ["1", "3", "5", "7"];
 var MIN_CLAIM_PARTS_FOR_RESERVATION_PROGRESS = 2;
-var ERR_NO_PATH_CODE4 = -2;
+var ERR_NO_PATH_CODE5 = -2;
 var TERRITORY_CANDIDATE_PRIORITY_URGENT_RENEWAL = 0;
 var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_CLAIM = 1;
 var TERRITORY_CANDIDATE_PRIORITY_VISIBLE_RESERVE = 2;
@@ -8307,7 +8972,7 @@ function planTerritoryIntent(colony, roleCounts, workerTarget, gameTime, options
   );
   return plan;
 }
-function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime11()) {
+function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameTime12()) {
   if (!plan || !plan.followUp || !isTerritoryControlAction3(plan.action)) {
     return;
   }
@@ -8315,7 +8980,7 @@ function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameT
   if (!recoveredFollowUpMetadata) {
     return;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
@@ -8339,7 +9004,7 @@ function recordRecoveredTerritoryFollowUpRetryCooldown(plan, gameTime = getGameT
   removeTerritoryFollowUpDemand(territoryMemory, plan.colony, plan.targetRoom, plan.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, plan.colony, plan.targetRoom, plan.action);
 }
-function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime11()) {
+function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGameTime12()) {
   if (isKnownDeadZoneRoom(plan.targetRoom)) {
     return false;
   }
@@ -8356,7 +9021,7 @@ function shouldSpawnTerritoryControllerCreep(plan, roleCounts, gameTime = getGam
     plan.targetRoom,
     plan.action,
     plan.controllerId,
-    getVisibleColonyOwnerUsername2(plan.colony)
+    getVisibleColonyOwnerUsername3(plan.colony)
   )) {
     return false;
   }
@@ -8371,7 +9036,7 @@ function requiresTerritoryControllerPressure(plan) {
     plan.targetRoom,
     plan.action,
     plan.controllerId,
-    getVisibleColonyOwnerUsername2(plan.colony)
+    getVisibleColonyOwnerUsername3(plan.colony)
   ));
 }
 function isTerritoryIntentPlanSpawnCapable(plan) {
@@ -8389,7 +9054,7 @@ function isTerritoryIntentPlanSpawnCapable(plan) {
   const energyCapacityAvailable = (_b = getVisibleRoom3(plan.colony)) == null ? void 0 : _b.energyCapacityAvailable;
   return typeof energyCapacityAvailable !== "number" || energyCapacityAvailable >= TERRITORY_CONTROLLER_PRESSURE_BODY_COST;
 }
-function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime11()) {
+function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTime12()) {
   var _a;
   if (!plan || !isTerritoryControlAction3(plan.action)) {
     return 0;
@@ -8404,18 +9069,18 @@ function getTerritoryFollowUpPreparationWorkerDemand(plan, gameTime = getGameTim
     plan.targetRoom,
     plan.action,
     plan.controllerId,
-    getVisibleColonyOwnerUsername2(plan.colony)
+    getVisibleColonyOwnerUsername3(plan.colony)
   )) {
     return 0;
   }
   const demand = getCurrentTerritoryFollowUpDemand(plan, gameTime);
   return (_a = demand == null ? void 0 : demand.workerCount) != null ? _a : 0;
 }
-function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime11()) {
-  if (!isNonEmptyString9(colony)) {
+function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameTime12()) {
+  if (!isNonEmptyString10(colony)) {
     return false;
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return false;
   }
@@ -8423,11 +9088,11 @@ function hasActiveTerritoryFollowUpPreparationDemand(colony, gameTime = getGameT
     (demand) => demand.updatedAt === gameTime && demand.colony === colony && demand.workerCount > 0
   );
 }
-function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime11()) {
-  if (!isNonEmptyString9(colony)) {
+function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGameTime12()) {
+  if (!isNonEmptyString10(colony)) {
     return false;
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return false;
   }
@@ -8436,12 +9101,12 @@ function hasPendingTerritoryFollowUpIntent(colony, roleCounts, gameTime = getGam
       intent.targetRoom,
       intent.action,
       intent.controllerId,
-      getVisibleColonyOwnerUsername2(intent.colony)
+      getVisibleColonyOwnerUsername3(intent.colony)
     ) && (intent.status === "planned" || isRecoveredTerritoryFollowUpIntent(intent, gameTime) || intent.status === "active" && getTerritoryCreepCountForTarget(roleCounts, intent.targetRoom, intent.action) === 0)
   );
 }
 function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return [];
   }
@@ -8449,17 +9114,17 @@ function getActiveTerritoryFollowUpExecutionHints(colony = void 0) {
   return getBoundedActiveTerritoryFollowUpExecutionHints(
     normalizeTerritoryFollowUpExecutionHints(territoryMemory.executionHints),
     intents
-  ).filter((hint) => !isNonEmptyString9(colony) || hint.colony === colony);
+  ).filter((hint) => !isNonEmptyString10(colony) || hint.colony === colony);
 }
 function getTerritoryIntentProgressSummaries(colony, roleCounts) {
-  if (!isNonEmptyString9(colony)) {
+  if (!isNonEmptyString10(colony)) {
     return [];
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return [];
   }
-  const gameTime = getGameTime11();
+  const gameTime = getGameTime12();
   return normalizeTerritoryIntents(territoryMemory.intents).filter(
     (intent) => isTerritoryIntentProgressVisibleForColony(intent, colony, gameTime)
   ).map((intent) => {
@@ -8479,12 +9144,12 @@ function getTerritoryIntentProgressSummaries(colony, roleCounts) {
     };
   }).sort(compareTerritoryIntentProgressSummaries);
 }
-function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime11()) {
+function getSuspendedTerritoryIntentCountsByRoom(colony, gameTime = getGameTime12()) {
   var _a;
-  if (!isNonEmptyString9(colony)) {
+  if (!isNonEmptyString10(colony)) {
     return {};
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return {};
   }
@@ -8537,7 +9202,7 @@ function canCreepReserveTerritoryController(creep, controller, colony) {
   if (activeClaimParts <= 0) {
     return false;
   }
-  if (isControllerOwned(controller)) {
+  if (isControllerOwned2(controller)) {
     return false;
   }
   const reservation = controller.reservation;
@@ -8545,7 +9210,7 @@ function canCreepReserveTerritoryController(creep, controller, colony) {
     return true;
   }
   const actorUsername = getTerritoryActorUsername(creep, colony);
-  if (!isNonEmptyString9(actorUsername) || !isNonEmptyString9(reservation.username) || reservation.username !== actorUsername || typeof reservation.ticksToEnd !== "number") {
+  if (!isNonEmptyString10(actorUsername) || !isNonEmptyString10(reservation.username) || reservation.username !== actorUsername || typeof reservation.ticksToEnd !== "number") {
     return false;
   }
   const reservationTicksToEnd = reservation.ticksToEnd;
@@ -8577,7 +9242,7 @@ function selectUrgentVisibleReservationRenewalTask(creep) {
   return { type: "reserve", targetId: controller.id };
 }
 function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
-  if (!isNonEmptyString9(assignment.targetRoom)) {
+  if (!isNonEmptyString10(assignment.targetRoom)) {
     return false;
   }
   if (isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
@@ -8589,7 +9254,7 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   if (!isTerritoryControlAction3(assignment.action)) {
     return false;
   }
-  if (isNonEmptyString9(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
+  if (isNonEmptyString10(colony) && isTerritoryIntentSuppressed(colony, assignment.targetRoom, assignment.action)) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
@@ -8608,14 +9273,14 @@ function isVisibleTerritoryAssignmentSafe(assignment, colony, creep) {
   return targetState === "available" || assignment.action === "reserve" && targetState === "satisfied";
 }
 function isVisibleTerritoryAssignmentComplete(assignment, creep) {
-  if (assignment.action !== "claim" || !isNonEmptyString9(assignment.targetRoom)) {
+  if (assignment.action !== "claim" || !isNonEmptyString10(assignment.targetRoom)) {
     return false;
   }
   const controller = selectVisibleTerritoryAssignmentController(assignment, creep);
   return (controller == null ? void 0 : controller.my) === true && !shouldSignOccupiedController(controller);
 }
 function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, creep) {
-  if (assignment.action !== "claim" || !isNonEmptyString9(assignment.targetRoom)) {
+  if (assignment.action !== "claim" || !isNonEmptyString10(assignment.targetRoom)) {
     return false;
   }
   if (!isVisibleRoomUnsafeForTerritoryControllerWork(assignment.targetRoom)) {
@@ -8625,10 +9290,10 @@ function isVisibleTerritoryAssignmentAwaitingUnsafeSigningRetry(assignment, cree
   return (controller == null ? void 0 : controller.my) === true && shouldSignOccupiedController(controller);
 }
 function suppressTerritoryIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString9(colony) || !isNonEmptyString9(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
+  if (!isNonEmptyString10(colony) || !isNonEmptyString10(assignment.targetRoom) || !isTerritoryIntentAction2(assignment.action)) {
     return;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
@@ -8652,7 +9317,7 @@ function suppressTerritoryIntent(colony, assignment, gameTime) {
     ...requiresControllerPressure ? { requiresControllerPressure: true } : {},
     ...followUp ? { followUp } : {}
   };
-  upsertTerritoryIntent3(intents, suppressedIntent);
+  upsertTerritoryIntent4(intents, suppressedIntent);
   removeTerritoryFollowUpDemand(territoryMemory, colony, assignment.targetRoom, assignment.action);
   removeTerritoryFollowUpExecutionHint(territoryMemory, colony, assignment.targetRoom, assignment.action);
 }
@@ -8678,10 +9343,10 @@ function suppressSameRoomClaimTerritoryIntents(territoryMemory, intents, colony,
   setTerritoryIntents(territoryMemory, intents);
 }
 function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
-  if (!isNonEmptyString9(colony) || !isNonEmptyString9(assignment.targetRoom) || assignment.action !== "reserve" || isTerritoryIntentSuppressed(colony, assignment.targetRoom, "reserve", gameTime)) {
+  if (!isNonEmptyString10(colony) || !isNonEmptyString10(assignment.targetRoom) || assignment.action !== "reserve" || isTerritoryIntentSuppressed(colony, assignment.targetRoom, "reserve", gameTime)) {
     return null;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return null;
   }
@@ -8716,7 +9381,7 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
     action: "reserve",
     ...assignment.controllerId ? { controllerId: assignment.controllerId } : {}
   });
-  upsertTerritoryIntent3(intents, {
+  upsertTerritoryIntent4(intents, {
     colony: plan.colony,
     targetRoom: plan.targetRoom,
     action: plan.action,
@@ -8732,23 +9397,23 @@ function recordTerritoryReserveFallbackIntent(colony, assignment, gameTime) {
   return reserveAssignment;
 }
 function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation, gameTime) {
-  if (evaluation.status !== "skipped" || evaluation.reason !== "gclInsufficient" && evaluation.reason !== "controllerCooldown" || !isNonEmptyString9(colony) || !isNonEmptyString9(evaluation.targetRoom) || isTerritoryIntentSuppressed(colony, evaluation.targetRoom, "reserve", gameTime)) {
+  if (evaluation.status !== "skipped" || evaluation.reason !== "gclInsufficient" && evaluation.reason !== "controllerCooldown" || !isNonEmptyString10(colony) || !isNonEmptyString10(evaluation.targetRoom) || isTerritoryIntentSuppressed(colony, evaluation.targetRoom, "reserve", gameTime)) {
     return null;
   }
   const targetRoom = evaluation.targetRoom;
-  if (!isNonEmptyString9(targetRoom)) {
+  if (!isNonEmptyString10(targetRoom)) {
     return null;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return null;
   }
-  const colonyOwnerUsername = getVisibleColonyOwnerUsername2(colony);
-  if (!isNonEmptyString9(colonyOwnerUsername)) {
+  const colonyOwnerUsername = getVisibleColonyOwnerUsername3(colony);
+  if (!isNonEmptyString10(colonyOwnerUsername)) {
     return null;
   }
   const controller = getVisibleController2(targetRoom, evaluation.controllerId);
-  if (!controller || isControllerOwned(controller) || isForeignReservedController(controller, colonyOwnerUsername)) {
+  if (!controller || isControllerOwned2(controller) || isForeignReservedController(controller, colonyOwnerUsername)) {
     return null;
   }
   if (isOwnReservedController(controller, colonyOwnerUsername)) {
@@ -8775,9 +9440,9 @@ function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation,
     gameTime
   );
 }
-function refreshRemoteMiningSetup(colony, gameTime = getGameTime11()) {
+function refreshRemoteMiningSetup(colony, gameTime = getGameTime12()) {
   var _a, _b, _c, _d;
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
@@ -8788,7 +9453,7 @@ function refreshRemoteMiningSetup(colony, gameTime = getGameTime11()) {
     return;
   }
   let remoteMining;
-  if (isRecord9(storedRemoteMining) && !Array.isArray(storedRemoteMining)) {
+  if (isRecord10(storedRemoteMining) && !Array.isArray(storedRemoteMining)) {
     remoteMining = storedRemoteMining;
   } else {
     remoteMining = {};
@@ -8897,8 +9562,11 @@ function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
 function selectTerritoryTarget(colony, roleCounts, workerTarget, gameTime, options = {}) {
   var _a, _b, _c;
   const colonyName = colony.room.name;
-  const colonyOwnerUsername = getControllerOwnerUsername4(colony.room.controller);
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const colonyOwnerUsername = getControllerOwnerUsername5(colony.room.controller);
+  if (options.controllerPressureOnly !== true && options.followUpOnly !== true) {
+    refreshExpansionPlannerIntent(colony, gameTime);
+  }
+  const territoryMemory = getTerritoryMemoryRecord6();
   let intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents);
   const refreshedExpiredClaims = refreshExpiredPostClaimClaimIntents(
     territoryMemory,
@@ -9212,7 +9880,7 @@ function getConfiguredTerritoryCandidates(colony, colonyName, colonyOwnerUsernam
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName) {
       return [];
     }
@@ -9298,7 +9966,7 @@ function getConfiguredTerritoryCandidates(colony, colonyName, colonyOwnerUsernam
   });
 }
 function getConfiguredTerritoryCandidateAction(target, colony, colonyOwnerUsername, territoryMemory, gameTime) {
-  if (target.action !== "reserve" || !isNonEmptyString9(colonyOwnerUsername)) {
+  if (target.action !== "reserve" || !isNonEmptyString10(colonyOwnerUsername)) {
     return target.action;
   }
   if (target.createdBy === "adjacentRoomReservation") {
@@ -9321,7 +9989,7 @@ function shouldAutoClaimAdjacentReservationTarget(target, colony, colonyOwnerUse
     return false;
   }
   const controller = getVisibleController2(target.roomName, target.controllerId);
-  if (!controller || isControllerOwned(controller)) {
+  if (!controller || isControllerOwned2(controller)) {
     return false;
   }
   return isTerritoryAutoClaimReservationMature(
@@ -9346,38 +10014,38 @@ function isColonyReadyForAdjacentReservationAutoClaim(colony) {
   if (hasActivePostClaimBootstrap(colony.room.name)) {
     return false;
   }
-  const ownedRoomCount = getVisibleOwnedRoomNames3(colony.room.name).length;
+  const ownedRoomCount = getVisibleOwnedRoomNames4(colony.room.name).length;
   if (ownedRoomCount >= maxRoomsForRcl(controllerLevel)) {
     return false;
   }
-  const gclLevel = getGclLevel2();
+  const gclLevel = getGclLevel3();
   return typeof gclLevel !== "number" || ownedRoomCount < gclLevel;
 }
 function hasActivePostClaimBootstrap(colonyName) {
   var _a;
-  const records = (_a = getTerritoryMemoryRecord5()) == null ? void 0 : _a.postClaimBootstraps;
-  if (!isRecord9(records)) {
+  const records = (_a = getTerritoryMemoryRecord6()) == null ? void 0 : _a.postClaimBootstraps;
+  if (!isRecord10(records)) {
     return false;
   }
   return Object.values(records).some(
-    (record) => isRecord9(record) && record.colony === colonyName && record.status !== "ready"
+    (record) => isRecord10(record) && record.colony === colonyName && record.status !== "ready"
   );
 }
 function refreshExpiredPostClaimClaimIntents(territoryMemory, intents, colonyName, gameTime) {
-  if (!territoryMemory || !isRecord9(territoryMemory.postClaimBootstraps)) {
+  if (!territoryMemory || !isRecord10(territoryMemory.postClaimBootstraps)) {
     return { intents, changed: false };
   }
   let changed = false;
   const nextIntents = intents;
   for (const record of getExpiredPostClaimClaimRefreshRecords(territoryMemory, colonyName)) {
     const controller = getVisibleController2(record.roomName, record.controllerId);
-    if (!controller || controller.my === true || isControllerOwned(controller)) {
+    if (!controller || controller.my === true || isControllerOwned2(controller)) {
       continue;
     }
     if (isSuppressedTerritoryIntentForAction(nextIntents, colonyName, record.roomName, "claim", gameTime) || isTerritoryIntentSuspendedForAction(nextIntents, colonyName, record.roomName, "claim", gameTime)) {
       continue;
     }
-    const controllerId = isNonEmptyString9(controller.id) ? controller.id : record.controllerId;
+    const controllerId = isNonEmptyString10(controller.id) ? controller.id : record.controllerId;
     const claimTarget = {
       colony: colonyName,
       roomName: record.roomName,
@@ -9386,7 +10054,7 @@ function refreshExpiredPostClaimClaimIntents(territoryMemory, intents, colonyNam
     };
     appendTerritoryTargetIfMissing(territoryMemory, claimTarget);
     territoryMemory.intents = nextIntents;
-    upsertTerritoryIntent3(nextIntents, {
+    upsertTerritoryIntent4(nextIntents, {
       colony: colonyName,
       targetRoom: record.roomName,
       action: "claim",
@@ -9400,7 +10068,7 @@ function refreshExpiredPostClaimClaimIntents(territoryMemory, intents, colonyNam
 }
 function getExpiredPostClaimClaimRefreshRecords(territoryMemory, colonyName) {
   const records = territoryMemory.postClaimBootstraps;
-  if (!isRecord9(records)) {
+  if (!isRecord10(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -9408,12 +10076,12 @@ function getExpiredPostClaimClaimRefreshRecords(territoryMemory, colonyName) {
   ).sort(comparePostClaimClaimRefreshRecords);
 }
 function isPostClaimClaimRefreshRecord(record, colonyName) {
-  return isRecord9(record) && record.colony === colonyName && isNonEmptyString9(record.roomName) && record.roomName !== colonyName && isFiniteNumber7(record.claimedAt) && isFiniteNumber7(record.updatedAt) && isPostClaimRemoteMiningStatus(record.status);
+  return isRecord10(record) && record.colony === colonyName && isNonEmptyString10(record.roomName) && record.roomName !== colonyName && isFiniteNumber7(record.claimedAt) && isFiniteNumber7(record.updatedAt) && isPostClaimRemoteMiningStatus(record.status);
 }
 function comparePostClaimClaimRefreshRecords(left, right) {
   return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
 }
-function getGclLevel2() {
+function getGclLevel3() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
@@ -9464,7 +10132,7 @@ function hasBlockingConfiguredTerritoryTargetForColony(colony, territoryMemory, 
     return false;
   }
   return territoryMemory.targets.some((rawTarget) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.colony !== colonyName) {
       return false;
     }
@@ -9512,7 +10180,7 @@ function refreshTerritoryReservationMemory(territoryMemory, colonyName, colonyOw
   const activeConfiguredReserveKeys = /* @__PURE__ */ new Set();
   let changed = hasMalformedTerritoryReservationMemory(territoryMemory.reservations, reservations);
   for (const rawTarget of territoryMemory.targets) {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName) {
       continue;
     }
@@ -9571,7 +10239,7 @@ function getStoredTerritoryReservation(territoryMemory, target) {
     return null;
   }
   const reservation = normalizeTerritoryReservation(
-    isRecord9(territoryMemory.reservations) ? territoryMemory.reservations[getTerritoryReservationMemoryKey(target.colony, target.roomName)] : void 0
+    isRecord10(territoryMemory.reservations) ? territoryMemory.reservations[getTerritoryReservationMemoryKey(target.colony, target.roomName)] : void 0
   );
   if (!reservation || reservation.colony !== target.colony || reservation.roomName !== target.roomName || target.controllerId !== void 0 && reservation.controllerId !== void 0 && reservation.controllerId !== target.controllerId) {
     return null;
@@ -9583,7 +10251,7 @@ function getTerritoryReservationPreRenewScoutLeadTicks(colonyName, targetRoom, r
   return TERRITORY_RESERVATION_RENEWAL_TICKS + (typeof routeDistance === "number" ? routeDistance * TERRITORY_RESERVATION_PRE_RENEW_SCOUT_ROUTE_TICKS * 2 : 0);
 }
 function normalizeTerritoryReservations(rawReservations) {
-  if (!isRecord9(rawReservations)) {
+  if (!isRecord10(rawReservations)) {
     return {};
   }
   const reservations = {};
@@ -9596,10 +10264,10 @@ function normalizeTerritoryReservations(rawReservations) {
   return reservations;
 }
 function normalizeTerritoryReservation(rawReservation) {
-  if (!isRecord9(rawReservation)) {
+  if (!isRecord10(rawReservation)) {
     return null;
   }
-  if (!isNonEmptyString9(rawReservation.colony) || !isNonEmptyString9(rawReservation.roomName) || !isFiniteNumber7(rawReservation.ticksToEnd) || !isFiniteNumber7(rawReservation.updatedAt)) {
+  if (!isNonEmptyString10(rawReservation.colony) || !isNonEmptyString10(rawReservation.roomName) || !isFiniteNumber7(rawReservation.ticksToEnd) || !isFiniteNumber7(rawReservation.updatedAt)) {
     return null;
   }
   return {
@@ -9611,7 +10279,7 @@ function normalizeTerritoryReservation(rawReservation) {
   };
 }
 function hasMalformedTerritoryReservationMemory(rawReservations, reservations) {
-  return isRecord9(rawReservations) && Object.keys(rawReservations).length !== Object.keys(reservations).length;
+  return isRecord10(rawReservations) && Object.keys(rawReservations).length !== Object.keys(reservations).length;
 }
 function getTerritoryReservationMemoryKey(colonyName, roomName) {
   return `${colonyName}${TERRITORY_ROUTE_DISTANCE_SEPARATOR3}${roomName}`;
@@ -9636,7 +10304,7 @@ function suppressDeadZoneTerritoryTargets(territoryMemory, intents, colonyName, 
   let nextIntents = intents;
   let changed = false;
   for (const rawTarget of territoryMemory.targets) {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.roomName === colonyName) {
       continue;
     }
@@ -9655,7 +10323,7 @@ function suppressDeadZoneTerritoryTargets(territoryMemory, intents, colonyName, 
       continue;
     }
     territoryMemory.intents = nextIntents;
-    upsertTerritoryIntent3(nextIntents, {
+    upsertTerritoryIntent4(nextIntents, {
       colony: target.colony,
       targetRoom: target.roomName,
       action: target.action,
@@ -9726,7 +10394,7 @@ function isClaimTargetDeferredBySameRoomReserveLane(target, intents, roleCounts,
 }
 function getAdjacentReserveCandidates(colonyName, originRoomName, colonyOwnerUsername, territoryMemory, intents, gameTime, includeScoutCandidates, source, orderOffset, routeDistanceLookupContext) {
   const adjacentRooms = sortAdjacentRoomsByPersistedExpansionScore(
-    getAdjacentRoomNames3(originRoomName),
+    getAdjacentRoomNames4(originRoomName),
     colonyName,
     territoryMemory
   );
@@ -9796,10 +10464,10 @@ function getPersistedExpansionCandidateRanks(colonyName, territoryMemory) {
   }
   const ranks = /* @__PURE__ */ new Map();
   for (const [index, rawCandidate] of territoryMemory.expansionCandidates.entries()) {
-    if (!isRecord9(rawCandidate)) {
+    if (!isRecord10(rawCandidate)) {
       continue;
     }
-    if (rawCandidate.colony !== colonyName || !isNonEmptyString9(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || !isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction) || ranks.has(rawCandidate.roomName)) {
+    if (rawCandidate.colony !== colonyName || !isNonEmptyString10(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || !isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction) || ranks.has(rawCandidate.roomName)) {
       continue;
     }
     ranks.set(
@@ -9885,7 +10553,7 @@ function getSatisfiedClaimAdjacentReserveCandidates(colonyName, colonyOwnerUsern
       gameTime,
       includeScoutCandidates,
       "satisfiedClaimAdjacent",
-      (order + 1) * EXIT_DIRECTION_ORDER3.length,
+      (order + 1) * EXIT_DIRECTION_ORDER4.length,
       routeDistanceLookupContext
     )
   );
@@ -9909,7 +10577,7 @@ function getSatisfiedReserveAdjacentReserveCandidates(colonyName, colonyOwnerUse
       gameTime,
       includeScoutCandidates,
       "satisfiedReserveAdjacent",
-      (order + 1) * EXIT_DIRECTION_ORDER3.length,
+      (order + 1) * EXIT_DIRECTION_ORDER4.length,
       routeDistanceLookupContext
     )
   );
@@ -9933,7 +10601,7 @@ function getActiveReserveAdjacentReserveCandidates(colonyName, colonyOwnerUserna
       gameTime,
       includeScoutCandidates,
       "activeReserveAdjacent",
-      (order + 1) * EXIT_DIRECTION_ORDER3.length,
+      (order + 1) * EXIT_DIRECTION_ORDER4.length,
       routeDistanceLookupContext
     )
   );
@@ -9943,7 +10611,7 @@ function getActiveCoveredConfiguredReserveTargets(colonyName, colonyOwnerUsernam
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.action !== "reserve" || target.roomName === colonyName || isKnownDeadZoneRoom(target.roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || !isVisibleRoomKnown(target.roomName) || getTerritoryCreepCountForTarget(roleCounts, target.roomName, target.action) <= 0 || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "available") {
       return [];
     }
@@ -9966,7 +10634,7 @@ function getSatisfiedConfiguredTargets(colonyName, colonyOwnerUsername, territor
     return [];
   }
   return territoryMemory.targets.flatMap((rawTarget, order) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if (!target || target.enabled === false || target.colony !== colonyName || target.action !== action || target.roomName === colonyName || isKnownDeadZoneRoom(target.roomName) || isTerritoryTargetSuppressed(target, intents, gameTime) || isTerritoryIntentSuspendedForAction(intents, target.colony, target.roomName, target.action, gameTime) || hasKnownNoRoute(colonyName, target.roomName, routeDistanceLookupContext) || getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) !== "satisfied") {
       return [];
     }
@@ -10010,7 +10678,7 @@ function getInferredTerritoryRouteDistance(source) {
 }
 function applyOccupationRecommendationScores(colony, roleCounts, workerTarget, candidates, gameTime) {
   var _a;
-  const colonyOwnerUsername = (_a = getControllerOwnerUsername4(colony.room.controller)) != null ? _a : void 0;
+  const colonyOwnerUsername = (_a = getControllerOwnerUsername5(colony.room.controller)) != null ? _a : void 0;
   const adjacentControllerProgressReady = isTerritoryHomeReadyForAdjacentControllerProgress(
     colony,
     roleCounts,
@@ -10140,7 +10808,7 @@ function buildOccupationRecommendationCandidate(candidate, gameTime) {
   const scoutIntel = room || shouldRefreshExpansionCandidateScoutIntel(
     candidate.target.colony,
     candidate.target.roomName,
-    getTerritoryMemoryRecord5(),
+    getTerritoryMemoryRecord6(),
     gameTime
   ) ? null : getFreshTerritoryScoutIntel(candidate.target.colony, candidate.target.roomName, gameTime);
   return {
@@ -10171,7 +10839,7 @@ function hasPersistedAdjacentExpansionCandidate(colonyName, roomName, territoryM
     return false;
   }
   return territoryMemory.expansionCandidates.some((rawCandidate) => {
-    if (!isRecord9(rawCandidate)) {
+    if (!isRecord10(rawCandidate)) {
       return false;
     }
     return rawCandidate.colony === colonyName && rawCandidate.roomName === roomName && rawCandidate.adjacentToOwnedRoom === true && rawCandidate.evidenceStatus !== "unavailable" && isExpansionCandidateRecommendedAction(rawCandidate.recommendedAction);
@@ -10194,11 +10862,11 @@ function buildVisibleOccupationRecommendationEvidence(room, controllerId) {
   const controller = getVisibleController2(room.name, controllerId);
   return {
     ...controller ? { controller: summarizeOccupationController(controller) } : {},
-    sourceCount: countVisibleRoomObjects(room, getFindConstant4("FIND_SOURCES")),
+    sourceCount: countVisibleRoomObjects(room, getFindConstant5("FIND_SOURCES")),
     hostileCreepCount: findVisibleHostileCreeps(room).length,
     hostileStructureCount: findVisibleHostileStructures(room).length,
-    constructionSiteCount: countVisibleRoomObjects(room, getFindConstant4("FIND_MY_CONSTRUCTION_SITES")),
-    ownedStructureCount: countVisibleRoomObjects(room, getFindConstant4("FIND_MY_STRUCTURES"))
+    constructionSiteCount: countVisibleRoomObjects(room, getFindConstant5("FIND_MY_CONSTRUCTION_SITES")),
+    ownedStructureCount: countVisibleRoomObjects(room, getFindConstant5("FIND_MY_STRUCTURES"))
   };
 }
 function buildScoutedOccupationRecommendationEvidence(intel) {
@@ -10224,8 +10892,8 @@ function summarizeScoutOccupationController(controller) {
   };
 }
 function summarizeOccupationController(controller) {
-  const ownerUsername = getControllerOwnerUsername4(controller);
-  const reservationUsername = getControllerReservationUsername3(controller);
+  const ownerUsername = getControllerOwnerUsername5(controller);
+  const reservationUsername = getControllerReservationUsername4(controller);
   const reservationTicksToEnd = getControllerReservationTicksToEnd3(controller);
   return {
     ...controller.my === true ? { my: true } : {},
@@ -10234,10 +10902,10 @@ function summarizeOccupationController(controller) {
     ...typeof reservationTicksToEnd === "number" ? { reservationTicksToEnd } : {}
   };
 }
-function getControllerReservationUsername3(controller) {
+function getControllerReservationUsername4(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : void 0;
+  return isNonEmptyString10(username) ? username : void 0;
 }
 function getControllerReservationTicksToEnd3(controller) {
   var _a;
@@ -10254,13 +10922,13 @@ function getOccupationIntentActionableTicks(selection, colonyOwnerUsername) {
     return void 0;
   }
   if (selection.intentAction === "reserve") {
-    if (isControllerOwned(controller)) {
+    if (isControllerOwned2(controller)) {
       return void 0;
     }
     const ownReservationTicksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
     return (_a = ownReservationTicksToEnd != null ? ownReservationTicksToEnd : getControllerReservationTicksToEnd3(controller)) != null ? _a : 0;
   }
-  if (isControllerOwned(controller)) {
+  if (isControllerOwned2(controller)) {
     return typeof controller.ticksToDowngrade === "number" ? controller.ticksToDowngrade : void 0;
   }
   return (_b = getControllerReservationTicksToEnd3(controller)) != null ? _b : 0;
@@ -10284,7 +10952,7 @@ function countVisibleRoomObjects(room, findConstant) {
     return 0;
   }
 }
-function getFindConstant4(name) {
+function getFindConstant5(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -10390,7 +11058,7 @@ function getTerritoryCandidateSourcePriority(source) {
 }
 function buildTerritoryFollowUp(source, originRoom) {
   const originAction = getTerritoryFollowUpOriginAction2(source);
-  if (originAction === null || !isTerritoryFollowUpSource2(source) || !isNonEmptyString9(originRoom)) {
+  if (originAction === null || !isTerritoryFollowUpSource2(source) || !isNonEmptyString10(originRoom)) {
     return {};
   }
   return {
@@ -10418,7 +11086,7 @@ function hasKnownNoRoute(fromRoom, targetRoom, routeDistanceLookupContext) {
 }
 function getNearestOwnedRoomRouteDistance(colonyName, targetRoom, fallbackRouteDistance, routeDistanceLookupContext) {
   let nearestDistance = fallbackRouteDistance;
-  for (const ownedRoomName of getVisibleOwnedRoomNames3(colonyName)) {
+  for (const ownedRoomName of getVisibleOwnedRoomNames4(colonyName)) {
     const routeDistance = ownedRoomName === colonyName ? fallbackRouteDistance : getKnownRouteLength2(ownedRoomName, targetRoom, routeDistanceLookupContext);
     if (typeof routeDistance !== "number") {
       continue;
@@ -10427,7 +11095,7 @@ function getNearestOwnedRoomRouteDistance(colonyName, targetRoom, fallbackRouteD
   }
   return nearestDistance;
 }
-function getVisibleOwnedRoomNames3(fallbackRoomName) {
+function getVisibleOwnedRoomNames4(fallbackRoomName) {
   var _a, _b;
   const roomNames = /* @__PURE__ */ new Set([fallbackRoomName]);
   const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
@@ -10435,7 +11103,7 @@ function getVisibleOwnedRoomNames3(fallbackRoomName) {
     return Array.from(roomNames);
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString9(room.name)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString10(room.name)) {
       roomNames.add(room.name);
     }
   }
@@ -10476,11 +11144,11 @@ function getKnownRouteLength2(fromRoom, targetRoom, routeDistanceLookupContext) 
   return route.length;
 }
 function getTerritoryRouteDistanceCache2() {
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return void 0;
   }
-  if (!isRecord9(territoryMemory.routeDistances)) {
+  if (!isRecord10(territoryMemory.routeDistances)) {
     territoryMemory.routeDistances = {};
   }
   return territoryMemory.routeDistances;
@@ -10490,7 +11158,7 @@ function getTerritoryRouteDistanceCacheKey2(fromRoom, targetRoom) {
 }
 function getNoPathResultCode4() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE4;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE5;
 }
 function getAdjacentReserveCandidateState(targetRoom, colonyOwnerUsername) {
   if (isVisibleRoomUnsafeForTerritoryControllerWork(targetRoom)) {
@@ -10512,7 +11180,7 @@ function getConfiguredTargetRoomsForColony(territoryMemory, colonyName) {
   }
   return new Set(
     territoryMemory.targets.flatMap((rawTarget) => {
-      const target = normalizeTerritoryTarget2(rawTarget);
+      const target = normalizeTerritoryTarget3(rawTarget);
       return (target == null ? void 0 : target.colony) === colonyName ? [target.roomName] : [];
     })
   );
@@ -10525,36 +11193,36 @@ function appendTerritoryTarget(territoryMemory, target) {
 }
 function appendTerritoryTargetIfMissing(territoryMemory, target) {
   if (Array.isArray(territoryMemory.targets) && territoryMemory.targets.some((rawTarget) => {
-    const existingTarget = normalizeTerritoryTarget2(rawTarget);
+    const existingTarget = normalizeTerritoryTarget3(rawTarget);
     return (existingTarget == null ? void 0 : existingTarget.colony) === target.colony && existingTarget.roomName === target.roomName && existingTarget.action === target.action;
   })) {
     return;
   }
   appendTerritoryTarget(territoryMemory, target);
 }
-function getAdjacentRoomNames3(roomName) {
+function getAdjacentRoomNames4(roomName) {
   const game = globalThis.Game;
   const gameMap = game == null ? void 0 : game.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord9(exits)) {
+  if (!isRecord10(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER3.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER4.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString9(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString10(exitRoom) ? [exitRoom] : [];
   });
 }
 function isRoomAdjacentToColony(colonyName, targetRoom) {
-  return getAdjacentRoomNames3(colonyName).includes(targetRoom);
+  return getAdjacentRoomNames4(colonyName).includes(targetRoom);
 }
-function normalizeTerritoryTarget2(rawTarget) {
-  if (!isRecord9(rawTarget)) {
+function normalizeTerritoryTarget3(rawTarget) {
+  if (!isRecord10(rawTarget)) {
     return null;
   }
-  if (!isNonEmptyString9(rawTarget.colony) || !isNonEmptyString9(rawTarget.roomName) || !isTerritoryControlAction3(rawTarget.action)) {
+  if (!isNonEmptyString10(rawTarget.colony) || !isNonEmptyString10(rawTarget.roomName) || !isTerritoryControlAction3(rawTarget.action)) {
     return null;
   }
   return {
@@ -10563,15 +11231,15 @@ function normalizeTerritoryTarget2(rawTarget) {
     action: rawTarget.action,
     ...typeof rawTarget.controllerId === "string" ? { controllerId: rawTarget.controllerId } : {},
     ...rawTarget.enabled === false ? { enabled: false } : {},
-    ...isTerritoryAutomationSource2(rawTarget.createdBy) ? { createdBy: rawTarget.createdBy } : {},
+    ...isTerritoryAutomationSource3(rawTarget.createdBy) ? { createdBy: rawTarget.createdBy } : {},
     ...isPositiveFiniteNumber2(rawTarget.postClaimBootstrapReserveEnergy) ? { postClaimBootstrapReserveEnergy: Math.floor(rawTarget.postClaimBootstrapReserveEnergy) } : {}
   };
 }
-function isTerritoryAutomationSource2(source) {
-  return source === OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
+function isTerritoryAutomationSource3(source) {
+  return source === OCCUPATION_RECOMMENDATION_TARGET_CREATOR2 || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "expansionPlanner" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function recordTerritoryIntent(plan, status, gameTime, seededTarget = null, routeDistanceLookupContext = createRouteDistanceLookupContext()) {
-  const territoryMemory = getWritableTerritoryMemoryRecord4();
+  const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
@@ -10592,11 +11260,11 @@ function recordTerritoryIntent(plan, status, gameTime, seededTarget = null, rout
     ...plan.followUp ? { followUp: plan.followUp } : {},
     ...plan.postClaimBootstrapReserveEnergy ? { postClaimBootstrapReserveEnergy: plan.postClaimBootstrapReserveEnergy } : {}
   };
-  upsertTerritoryIntent3(intents, nextIntent);
+  upsertTerritoryIntent4(intents, nextIntent);
   recordTerritoryFollowUpDemand(territoryMemory, plan, gameTime);
   recordTerritoryFollowUpExecutionHint(territoryMemory, plan, gameTime, routeDistanceLookupContext);
 }
-function upsertTerritoryIntent3(intents, nextIntent) {
+function upsertTerritoryIntent4(intents, nextIntent) {
   var _a, _b;
   const existingIndex = findTerritoryIntentIndex(intents, nextIntent);
   if (existingIndex >= 0) {
@@ -10648,7 +11316,7 @@ function shouldRecordTerritoryIntentControllerPressure(nextIntent, controllerId,
     nextIntent.targetRoom,
     nextIntent.action,
     controllerId,
-    getVisibleColonyOwnerUsername2(nextIntent.colony)
+    getVisibleColonyOwnerUsername3(nextIntent.colony)
   ) || existingIntent !== void 0 && shouldPreservePersistedTerritoryIntentPressureRequirement2(existingIntent, controllerId);
 }
 function refreshHostileTerritoryIntentSuspensions(territoryMemory, intents, colonyName, gameTime) {
@@ -10713,7 +11381,7 @@ function sanitizeSatisfiedClaimReserveHandoffs(territoryMemory, intents, colonyN
     return { intents, changed: false };
   }
   const nextTargets = territoryMemory.targets.filter((rawTarget) => {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     return !((target == null ? void 0 : target.colony) === colonyName && target.action === "reserve" && satisfiedClaimRooms.has(target.roomName));
   });
   const nextIntents = intents.filter(
@@ -10734,7 +11402,7 @@ function sanitizeSatisfiedClaimReserveHandoffs(territoryMemory, intents, colonyN
 function getSatisfiedConfiguredClaimRoomNames(rawTargets, colonyName, colonyOwnerUsername) {
   const satisfiedClaimRooms = /* @__PURE__ */ new Set();
   for (const rawTarget of rawTargets) {
-    const target = normalizeTerritoryTarget2(rawTarget);
+    const target = normalizeTerritoryTarget3(rawTarget);
     if ((target == null ? void 0 : target.colony) === colonyName && target.action === "claim" && getVisibleTerritoryTargetState(target.roomName, target.action, target.controllerId, colonyOwnerUsername) === "satisfied") {
       satisfiedClaimRooms.add(target.roomName);
     }
@@ -10917,7 +11585,7 @@ function removeTerritoryFollowUpDemand(territoryMemory, colony, targetRoom, acti
 }
 function getCurrentTerritoryFollowUpDemand(plan, gameTime) {
   var _a;
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return null;
   }
@@ -10981,7 +11649,7 @@ function isTerritoryFollowUpExecutionHintStillActive(hint, intents, routeDistanc
     matchingIntent.targetRoom,
     matchingIntent.action,
     matchingIntent.controllerId,
-    getVisibleColonyOwnerUsername2(matchingIntent.colony)
+    getVisibleColonyOwnerUsername3(matchingIntent.colony)
   );
   return currentReason === hint.reason;
 }
@@ -10998,7 +11666,7 @@ function hasActiveTerritoryFollowUpIntentForColony(intents, colony) {
   return intents.some((intent) => intent.colony === colony && isActiveTerritoryFollowUpIntent(intent));
 }
 function isActiveTerritoryFollowUpIntent(intent) {
-  return (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0 && !isTerritoryIntentSuspensionActive(intent, getGameTime11());
+  return (intent.status === "planned" || intent.status === "active") && intent.followUp !== void 0 && !isTerritoryIntentSuspensionActive(intent, getGameTime12());
 }
 function buildTerritoryFollowUpExecutionHint(plan, gameTime) {
   if (!plan.followUp) {
@@ -11008,7 +11676,7 @@ function buildTerritoryFollowUpExecutionHint(plan, gameTime) {
     plan.targetRoom,
     plan.action,
     plan.controllerId,
-    getVisibleColonyOwnerUsername2(plan.colony)
+    getVisibleColonyOwnerUsername3(plan.colony)
   );
   if (reason === null) {
     return null;
@@ -11067,10 +11735,10 @@ function normalizeTerritoryFollowUpExecutionHints(rawHints) {
   }) : [];
 }
 function normalizeTerritoryFollowUpExecutionHint(rawHint) {
-  if (!isRecord9(rawHint)) {
+  if (!isRecord10(rawHint)) {
     return null;
   }
-  if (rawHint.type !== "activeFollowUpExecution" || !isNonEmptyString9(rawHint.colony) || !isNonEmptyString9(rawHint.targetRoom) || !isTerritoryIntentAction2(rawHint.action) || !isTerritoryExecutionHintReason(rawHint.reason) || typeof rawHint.updatedAt !== "number") {
+  if (rawHint.type !== "activeFollowUpExecution" || !isNonEmptyString10(rawHint.colony) || !isNonEmptyString10(rawHint.targetRoom) || !isTerritoryIntentAction2(rawHint.action) || !isTerritoryExecutionHintReason(rawHint.reason) || typeof rawHint.updatedAt !== "number") {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(rawHint.followUp);
@@ -11098,10 +11766,10 @@ function normalizeTerritoryFollowUpDemands(rawDemands) {
   }) : [];
 }
 function normalizeTerritoryFollowUpDemand(rawDemand) {
-  if (!isRecord9(rawDemand)) {
+  if (!isRecord10(rawDemand)) {
     return null;
   }
-  if (rawDemand.type !== "followUpPreparation" || !isNonEmptyString9(rawDemand.colony) || !isNonEmptyString9(rawDemand.targetRoom) || !isTerritoryControlAction3(rawDemand.action) || typeof rawDemand.updatedAt !== "number") {
+  if (rawDemand.type !== "followUpPreparation" || !isNonEmptyString10(rawDemand.colony) || !isNonEmptyString10(rawDemand.targetRoom) || !isTerritoryControlAction3(rawDemand.action) || typeof rawDemand.updatedAt !== "number") {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(rawDemand.followUp);
@@ -11152,8 +11820,8 @@ function withoutTerritoryIntentSuspension(intent) {
 function isHostileTerritoryIntentSuspensionCoolingDown(suspension, gameTime) {
   return gameTime - suspension.updatedAt <= TERRITORY_HOSTILE_INTENT_SUSPENSION_TICKS;
 }
-function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGameTime11()) {
-  const territoryMemory = getTerritoryMemoryRecord5();
+function isTerritoryIntentSuspended(colony, targetRoom, action, gameTime = getGameTime12()) {
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return false;
   }
@@ -11195,8 +11863,8 @@ function isSuppressedTerritoryIntentForAction(intents, colony, targetRoom, actio
     (intent) => isTerritorySuppressionFresh2(intent, gameTime) && intent.colony === colony && intent.targetRoom === targetRoom && intent.action === action
   );
 }
-function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime11()) {
-  const territoryMemory = getTerritoryMemoryRecord5();
+function isTerritoryIntentSuppressed(colony, targetRoom, action, gameTime = getGameTime12()) {
+  const territoryMemory = getTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return false;
   }
@@ -11224,14 +11892,14 @@ function isRecoveredTerritoryFollowUpAttemptCoolingDownForAction(intents, colony
 function selectVisibleTerritoryControllerIntent(creep) {
   var _a, _b, _c;
   const roomName = (_a = creep.room) == null ? void 0 : _a.name;
-  if (!isNonEmptyString9(roomName) || isVisibleRoomUnsafe(creep.room)) {
+  if (!isNonEmptyString10(roomName) || isVisibleRoomUnsafe(creep.room)) {
     return null;
   }
   const assignmentIntent = normalizeCreepTerritoryIntent(creep, roomName);
   if (assignmentIntent && isCreepVisibleTerritoryIntentActionable(creep, assignmentIntent)) {
     return assignmentIntent;
   }
-  const territoryMemory = getTerritoryMemoryRecord5();
+  const territoryMemory = getTerritoryMemoryRecord6();
   const colony = (_b = creep.memory) == null ? void 0 : _b.colony;
   const intents = normalizeTerritoryIntents(territoryMemory == null ? void 0 : territoryMemory.intents).filter((intent) => isActiveVisibleControllerIntentForCreep(intent, roomName, colony)).sort(compareVisibleControllerIntents);
   return (_c = intents.find((intent) => isCreepVisibleTerritoryIntentActionable(creep, intent))) != null ? _c : null;
@@ -11239,7 +11907,7 @@ function selectVisibleTerritoryControllerIntent(creep) {
 function normalizeCreepTerritoryIntent(creep, roomName) {
   var _a, _b, _c, _d;
   const assignment = (_a = creep.memory) == null ? void 0 : _a.territory;
-  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction3(assignment.action) || isNonEmptyString9((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
+  if (!assignment || assignment.targetRoom !== roomName || !isTerritoryControlAction3(assignment.action) || isNonEmptyString10((_b = creep.memory) == null ? void 0 : _b.colony) && isTerritoryIntentSuppressed(creep.memory.colony, assignment.targetRoom, assignment.action)) {
     return null;
   }
   const followUp = normalizeTerritoryFollowUp(assignment.followUp);
@@ -11248,13 +11916,13 @@ function normalizeCreepTerritoryIntent(creep, roomName) {
     targetRoom: assignment.targetRoom,
     action: assignment.action,
     status: "active",
-    updatedAt: getGameTime11(),
+    updatedAt: getGameTime12(),
     ...assignment.controllerId ? { controllerId: assignment.controllerId } : {},
     ...followUp ? { followUp } : {}
   };
 }
 function isActiveVisibleControllerIntentForCreep(intent, roomName, creepColony) {
-  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction3(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString9(creepColony) || intent.colony === creepColony);
+  return intent.targetRoom === roomName && intent.targetRoom !== intent.colony && isTerritoryControlAction3(intent.action) && (intent.status === "planned" || intent.status === "active") && (!isNonEmptyString10(creepColony) || intent.colony === creepColony);
 }
 function compareVisibleControllerIntents(left, right) {
   return getIntentStatusPriority(left.status) - getIntentStatusPriority(right.status) || getIntentActionPriority(left.action) - getIntentActionPriority(right.action) || right.updatedAt - left.updatedAt || left.colony.localeCompare(right.colony);
@@ -11324,16 +11992,16 @@ function getTerritoryControllerTargetState(controller, action, colonyOwnerUserna
   return getClaimControllerTargetState(controller);
 }
 function getClaimControllerTargetState(controller) {
-  return isControllerOwned(controller) ? "unavailable" : "available";
+  return isControllerOwned2(controller) ? "unavailable" : "available";
 }
 function getTerritoryActorUsername(creep, colony) {
   var _a;
-  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString9(colony) ? getVisibleColonyOwnerUsername2(colony) : null;
+  return (_a = getCreepOwnerUsername(creep)) != null ? _a : isNonEmptyString10(colony) ? getVisibleColonyOwnerUsername3(colony) : null;
 }
 function getCreepOwnerUsername(creep) {
   var _a;
   const username = (_a = creep == null ? void 0 : creep.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : null;
+  return isNonEmptyString10(username) ? username : null;
 }
 function canUseControllerClaimPart(creep) {
   return getActiveControllerClaimPartCount(creep) > 0;
@@ -11442,7 +12110,7 @@ function isVisibleRoomMissingController(targetRoom) {
   const room = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[targetRoom];
   return room != null && room.controller == null;
 }
-function isControllerOwned(controller) {
+function isControllerOwned2(controller) {
   return controller.owner != null || controller.my === true;
 }
 function isHostileOwnedController(controller) {
@@ -11452,32 +12120,32 @@ function isHostileOwnedController(controller) {
   return controller.my !== true;
 }
 function isControllerOwnedByColony2(controller, colonyOwnerUsername) {
-  const ownerUsername = getControllerOwnerUsername4(controller);
-  return controller.my === true || isNonEmptyString9(ownerUsername) && ownerUsername === colonyOwnerUsername;
+  const ownerUsername = getControllerOwnerUsername5(controller);
+  return controller.my === true || isNonEmptyString10(ownerUsername) && ownerUsername === colonyOwnerUsername;
 }
 function getReserveControllerTargetState(controller, colonyOwnerUsername) {
-  if (isControllerOwned(controller)) {
+  if (isControllerOwned2(controller)) {
     return "unavailable";
   }
   const reservation = controller.reservation;
   if (!reservation) {
     return "available";
   }
-  if (!isNonEmptyString9(reservation.username) || reservation.username !== colonyOwnerUsername) {
+  if (!isNonEmptyString10(reservation.username) || reservation.username !== colonyOwnerUsername) {
     return "unavailable";
   }
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) === null ? "satisfied" : "available";
 }
 function isForeignReservedController(controller, actorUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString9(actorUsername)) {
+  if (isControllerOwned2(controller) || !isNonEmptyString10(actorUsername)) {
     return false;
   }
   const reservation = controller.reservation;
-  return isNonEmptyString9(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
+  return isNonEmptyString10(reservation == null ? void 0 : reservation.username) && reservation.username !== actorUsername;
 }
 function isOwnReservedController(controller, actorUsername) {
   const reservation = controller.reservation;
-  return isNonEmptyString9(actorUsername) && isNonEmptyString9(reservation == null ? void 0 : reservation.username) && reservation.username === actorUsername;
+  return isNonEmptyString10(actorUsername) && isNonEmptyString10(reservation == null ? void 0 : reservation.username) && reservation.username === actorUsername;
 }
 function updateTerritoryReservationMemory(territoryMemory, colony, roomName, controllerId, gameTime, reservationTicksToEnd) {
   if (reservationTicksToEnd === null) {
@@ -11502,7 +12170,7 @@ function getConfiguredReserveRenewalTicksToEnd(target, colonyOwnerUsername) {
     return null;
   }
   const controller = getVisibleController2(target.roomName, target.controllerId);
-  if (!controller || isControllerOwned(controller)) {
+  if (!controller || isControllerOwned2(controller)) {
     return null;
   }
   return getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername);
@@ -11512,10 +12180,10 @@ function shouldSpawnEmergencyReservationRenewal(plan, activeCoverageCount) {
     return false;
   }
   const controller = getVisibleController2(plan.targetRoom, plan.controllerId);
-  if (!controller || isControllerOwned(controller)) {
+  if (!controller || isControllerOwned2(controller)) {
     return false;
   }
-  const colonyOwnerUsername = getVisibleColonyOwnerUsername2(plan.colony);
+  const colonyOwnerUsername = getVisibleColonyOwnerUsername3(plan.colony);
   const ticksToEnd = getOwnReservationTicksToEnd(controller, colonyOwnerUsername);
   return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_EMERGENCY_RENEWAL_TICKS;
 }
@@ -11524,7 +12192,7 @@ function getUrgentOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   return ticksToEnd !== null && ticksToEnd <= TERRITORY_RESERVATION_RENEWAL_TICKS ? ticksToEnd : null;
 }
 function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
-  if (isControllerOwned(controller) || !isNonEmptyString9(colonyOwnerUsername)) {
+  if (isControllerOwned2(controller) || !isNonEmptyString10(colonyOwnerUsername)) {
     return null;
   }
   const reservation = controller.reservation;
@@ -11533,14 +12201,14 @@ function getOwnReservationTicksToEnd(controller, colonyOwnerUsername) {
   }
   return reservation.ticksToEnd;
 }
-function getVisibleColonyOwnerUsername2(colonyName) {
+function getVisibleColonyOwnerUsername3(colonyName) {
   const controller = getVisibleController2(colonyName);
-  return getControllerOwnerUsername4(controller != null ? controller : void 0);
+  return getControllerOwnerUsername5(controller != null ? controller : void 0);
 }
-function getControllerOwnerUsername4(controller) {
+function getControllerOwnerUsername5(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString9(username) ? username : null;
+  return isNonEmptyString10(username) ? username : null;
 }
 function getVisibleController2(targetRoom, controllerId) {
   var _a, _b;
@@ -11555,20 +12223,20 @@ function getVisibleController2(targetRoom, controllerId) {
   }
   return null;
 }
-function getGameTime11() {
+function getGameTime12() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
 function getRemoteMiningBootstrapRecords(territoryMemory, colonyName) {
   const records = territoryMemory.postClaimBootstraps;
-  if (!isRecord9(records)) {
+  if (!isRecord10(records)) {
     return [];
   }
   return Object.values(records).filter((record) => isRemoteMiningBootstrapRecord(record, colonyName)).sort(compareRemoteMiningBootstrapRecords);
 }
 function isRemoteMiningBootstrapRecord(record, colonyName) {
-  return isRecord9(record) && record.colony === colonyName && isNonEmptyString9(record.roomName) && record.roomName !== colonyName && isPostClaimRemoteMiningStatus(record.status);
+  return isRecord10(record) && record.colony === colonyName && isNonEmptyString10(record.roomName) && record.roomName !== colonyName && isPostClaimRemoteMiningStatus(record.status);
 }
 function isPostClaimRemoteMiningStatus(status) {
   return status === "detected" || status === "spawnSitePending" || status === "spawnSiteBlocked" || status === "spawningWorkers" || status === "ready";
@@ -11598,7 +12266,7 @@ function isSameRemoteMiningRoomMemory(left, right) {
   return left != null && left.colony === right.colony && left.roomName === right.roomName && left.status === right.status && left.updatedAt === right.updatedAt && isSameRemoteMiningSources(left.sources, right.sources);
 }
 function isSameRemoteMiningSources(left, right) {
-  if (!isRecord9(left)) {
+  if (!isRecord10(left)) {
     return false;
   }
   const leftKeys = Object.keys(left);
@@ -11687,24 +12355,24 @@ function getRemoteMiningStatus(sources) {
   }
   return "containerReady";
 }
-function getWritableTerritoryMemoryRecord4() {
-  const memory = getMemoryRecord();
+function getWritableTerritoryMemoryRecord5() {
+  const memory = getMemoryRecord2();
   if (!memory) {
     return null;
   }
-  if (!isRecord9(memory.territory)) {
+  if (!isRecord10(memory.territory)) {
     memory.territory = {};
   }
   return memory.territory;
 }
-function getTerritoryMemoryRecord5() {
-  const memory = getMemoryRecord();
-  if (!memory || !isRecord9(memory.territory)) {
+function getTerritoryMemoryRecord6() {
+  const memory = getMemoryRecord2();
+  if (!memory || !isRecord10(memory.territory)) {
     return null;
   }
   return memory.territory;
 }
-function getMemoryRecord() {
+function getMemoryRecord2() {
   const memory = globalThis.Memory;
   return memory != null ? memory : null;
 }
@@ -11720,7 +12388,7 @@ function isTerritoryFollowUpSource2(source) {
 function isTerritoryExecutionHintReason(reason) {
   return reason === "controlEvidenceStillMissing" || reason === "followUpTargetStillUnseen" || reason === "visibleControlEvidenceStillActionable";
 }
-function isNonEmptyString9(value) {
+function isNonEmptyString10(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber7(value) {
@@ -11729,7 +12397,7 @@ function isFiniteNumber7(value) {
 function isPositiveFiniteNumber2(value) {
   return isFiniteNumber7(value) && value > 0;
 }
-function isRecord9(value) {
+function isRecord10(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -12009,7 +12677,7 @@ var BEHAVIOR_COUNTER_KEYS = [
   { key: "pathLength" }
 ];
 var TOP_IDLE_WORKER_COUNT = 3;
-function observeCreepBehaviorTick(creep, tick = getGameTime12()) {
+function observeCreepBehaviorTick(creep, tick = getGameTime13()) {
   var _a, _b;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastObservedTick === tick) {
@@ -12029,7 +12697,7 @@ function observeCreepBehaviorTick(creep, tick = getGameTime12()) {
   }
   telemetry.lastObservedTick = tick;
 }
-function recordCreepBehaviorIdle(creep, tick = getGameTime12()) {
+function recordCreepBehaviorIdle(creep, tick = getGameTime13()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastIdleTick === tick) {
@@ -12038,7 +12706,7 @@ function recordCreepBehaviorIdle(creep, tick = getGameTime12()) {
   telemetry.idleTicks = ((_a = telemetry.idleTicks) != null ? _a : 0) + 1;
   telemetry.lastIdleTick = tick;
 }
-function recordCreepBehaviorMove(creep, tick = getGameTime12()) {
+function recordCreepBehaviorMove(creep, tick = getGameTime13()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastMoveTick === tick) {
@@ -12047,7 +12715,7 @@ function recordCreepBehaviorMove(creep, tick = getGameTime12()) {
   telemetry.moveTicks = ((_a = telemetry.moveTicks) != null ? _a : 0) + 1;
   telemetry.lastMoveTick = tick;
 }
-function recordCreepBehaviorWork(creep, tick = getGameTime12()) {
+function recordCreepBehaviorWork(creep, tick = getGameTime13()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastWorkTick === tick) {
@@ -12064,7 +12732,7 @@ function recordCreepBehaviorContainerTransfer(creep) {
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   telemetry.containerTransfers = ((_a = telemetry.containerTransfers) != null ? _a : 0) + 1;
 }
-function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime12()) {
+function recordCreepBehaviorSourceContainerWithdrawal(creep, tick = getGameTime13()) {
   var _a;
   const telemetry = ensureCreepBehaviorTelemetry(creep);
   if (telemetry.lastSourceContainerWithdrawalTick === tick) {
@@ -12229,7 +12897,7 @@ function getStepDistance(previous, current) {
   }
   return Math.max(Math.abs(current.x - previous.x), Math.abs(current.y - previous.y));
 }
-function getGameTime12() {
+function getGameTime13() {
   const game = globalThis.Game;
   return typeof (game == null ? void 0 : game.time) === "number" ? game.time : 0;
 }
@@ -12279,7 +12947,7 @@ function getRoomEnergySurplusState(room) {
 function refreshRoomEnergySurplusState(room) {
   const state = getRoomEnergySurplusState(room);
   const memory = getEconomyMemory();
-  const updatedAt = getGameTime13();
+  const updatedAt = getGameTime14();
   if (!isPlainObject(memory.energySurplus) || !isPlainObject(memory.energySurplus.rooms)) {
     memory.energySurplus = { updatedAt, rooms: {} };
   }
@@ -12460,7 +13128,7 @@ function getMemory() {
   }
   return global.Memory;
 }
-function getGameTime13() {
+function getGameTime14() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -12481,7 +13149,7 @@ var STORAGE_BALANCE_IMPORT_RATIO = 0.3;
 var STORAGE_BALANCE_REFRESH_INTERVAL = 25;
 function balanceStorage() {
   const memory = getEconomyMemory2();
-  const gameTime = getGameTime14();
+  const gameTime = getGameTime15();
   const existing = memory.storageBalance;
   if (existing && isStorageBalanceFresh(existing, gameTime)) {
     return;
@@ -12490,7 +13158,7 @@ function balanceStorage() {
 }
 function getStorageBalanceState() {
   const memory = getEconomyMemory2();
-  const gameTime = getGameTime14();
+  const gameTime = getGameTime15();
   const existing = memory.storageBalance;
   if (existing && isStorageBalanceFresh(existing, gameTime)) {
     return existing;
@@ -12688,7 +13356,7 @@ function getMemory2() {
   }
   return global.Memory;
 }
-function getGameTime14() {
+function getGameTime15() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -12707,7 +13375,7 @@ var MIN_CARRY_MOVE_PAIRS = 1;
 var CROSS_ROOM_HAULER_REPLACEMENT_TICKS = 100;
 var CROSS_ROOM_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var OK_CODE5 = 0;
-var ERR_NO_PATH_CODE5 = -2;
+var ERR_NO_PATH_CODE6 = -2;
 var ERR_NOT_IN_RANGE_CODE3 = -9;
 function planCrossRoomHauler(getEnergyBudget = getDefaultCrossRoomHaulerEnergyBudget) {
   const transfer = selectCrossRoomEnergyTransfer();
@@ -12740,7 +13408,7 @@ function planCrossRoomHauler(getEnergyBudget = getDefaultCrossRoomHaulerEnergyBu
   return {
     spawn,
     body,
-    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime15()}`,
+    name: `crossRoomHauler-${sourceRoom.name}-${targetRoom.name}-${getGameTime16()}`,
     memory: {
       role: CROSS_ROOM_HAULER_ROLE,
       colony: sourceRoom.name,
@@ -13053,7 +13721,7 @@ function findOwnedLogisticsRoute(fromRoom, targetRoom) {
   if (route === getNoPathResultCode5() || !Array.isArray(route)) {
     return null;
   }
-  const rooms = route.map((step) => isRecord10(step) && typeof step.room === "string" ? step.room : null).filter((roomName) => typeof roomName === "string");
+  const rooms = route.map((step) => isRecord11(step) && typeof step.room === "string" ? step.room : null).filter((roomName) => typeof roomName === "string");
   if (rooms.length !== route.length || !rooms.every(isSafeLogisticsTransitRoom)) {
     return null;
   }
@@ -13076,7 +13744,7 @@ function moveTowardRoom(creep, assignment, destinationRoom) {
 function getAssignmentRoute(assignment) {
   const route = findOwnedLogisticsRoute(assignment.homeRoom, assignment.targetRoom);
   if (!route) {
-    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString10) : null;
+    return Array.isArray(assignment.route) ? assignment.route.filter(isNonEmptyString11) : null;
   }
   assignment.route = route.rooms;
   return route.rooms;
@@ -13155,20 +13823,20 @@ function findRoomStructures3(room) {
   return Array.isArray(structures) ? structures : [];
 }
 function normalizeCrossRoomHaulerMemory(value) {
-  if (!isRecord10(value)) {
+  if (!isRecord11(value)) {
     return null;
   }
-  if (!isNonEmptyString10(value.homeRoom) || !isNonEmptyString10(value.targetRoom)) {
+  if (!isNonEmptyString11(value.homeRoom) || !isNonEmptyString11(value.targetRoom)) {
     return null;
   }
-  const sourceId = isNonEmptyString10(value.sourceId) ? value.sourceId : null;
+  const sourceId = isNonEmptyString11(value.sourceId) ? value.sourceId : null;
   const state = value.state === "collecting" || value.state === "delivering" || value.state === "returning" || value.state === "unassigned" ? value.state : void 0;
   return {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId,
     ...state ? { state: sourceId ? state : "unassigned" } : sourceId ? {} : { state: "unassigned" },
-    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString10) } : {}
+    ...Array.isArray(value.route) ? { route: value.route.filter(isNonEmptyString11) } : {}
   };
 }
 function getMutableCrossRoomHaulerMemory(creep) {
@@ -13213,7 +13881,7 @@ function getVisibleRoom4(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameTime15() {
+function getGameTime16() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
@@ -13228,10 +13896,10 @@ function getErrNotInRangeCode() {
 }
 function getNoPathResultCode5() {
   var _a;
-  return (_a = globalThis.ERR_NO_PATH) != null ? _a : ERR_NO_PATH_CODE5;
+  return (_a = globalThis.ERR_NO_PATH) != null ? _a : ERR_NO_PATH_CODE6;
 }
 function getObjectId7(object) {
-  if (!isRecord10(object)) {
+  if (!isRecord11(object)) {
     return "";
   }
   return typeof object.id === "string" ? object.id : typeof object.name === "string" ? object.name : "";
@@ -13245,10 +13913,10 @@ function getGlobalNumber7(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function isRecord10(value) {
+function isRecord11(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString10(value) {
+function isNonEmptyString11(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -13624,12 +14292,12 @@ function recordWorkerTaskBehaviorTrace(creep, selectedTask) {
 function buildWorkerTaskBehaviorState(creep) {
   var _a, _b, _c, _d, _e;
   const room = creep.room;
-  const structures = findRoomObjects12(room, getFindConstant5("FIND_STRUCTURES"));
-  const myStructures = findRoomObjects12(room, getFindConstant5("FIND_MY_STRUCTURES"));
-  const constructionSites = findRoomObjects12(room, getFindConstant5("FIND_CONSTRUCTION_SITES"));
-  const droppedResources = findRoomObjects12(room, getFindConstant5("FIND_DROPPED_RESOURCES"));
-  const sources = findRoomObjects12(room, getFindConstant5("FIND_SOURCES"));
-  const hostileCreeps = findRoomObjects12(room, getFindConstant5("FIND_HOSTILE_CREEPS"));
+  const structures = findRoomObjects13(room, getFindConstant6("FIND_STRUCTURES"));
+  const myStructures = findRoomObjects13(room, getFindConstant6("FIND_MY_STRUCTURES"));
+  const constructionSites = findRoomObjects13(room, getFindConstant6("FIND_CONSTRUCTION_SITES"));
+  const droppedResources = findRoomObjects13(room, getFindConstant6("FIND_DROPPED_RESOURCES"));
+  const sources = findRoomObjects13(room, getFindConstant6("FIND_SOURCES"));
+  const hostileCreeps = findRoomObjects13(room, getFindConstant6("FIND_HOSTILE_CREEPS"));
   const currentTask = (_c = (_b = (_a = creep.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) != null ? _c : "none";
   const carriedEnergy = getUsedEnergy(creep);
   const freeCapacity = getFreeEnergyCapacity4(creep);
@@ -13708,7 +14376,7 @@ function countRepairTargets(structures) {
     return isStructureType(structure, "STRUCTURE_ROAD", "road") || isStructureType(structure, "STRUCTURE_CONTAINER", "container") || isStructureType(structure, "STRUCTURE_RAMPART", "rampart") && structure.my !== false;
   }).length;
 }
-function findRoomObjects12(room, findConstant) {
+function findRoomObjects13(room, findConstant) {
   if (!room || typeof room.find !== "function" || typeof findConstant !== "number") {
     return [];
   }
@@ -13719,7 +14387,7 @@ function findRoomObjects12(room, findConstant) {
     return [];
   }
 }
-function getFindConstant5(name) {
+function getFindConstant6(name) {
   const value = globalThis[name];
   return typeof value === "number" && Number.isFinite(value) ? value : void 0;
 }
@@ -15126,14 +15794,14 @@ function recordInterRoomEnergyHaulAssignment(creep, transfer, ids) {
   };
 }
 function normalizeInterRoomEnergyHaulMemory(value) {
-  if (!isWorkerTaskRecord(value) || !isNonEmptyString11(value.sourceRoom) || !isNonEmptyString11(value.targetRoom)) {
+  if (!isWorkerTaskRecord(value) || !isNonEmptyString12(value.sourceRoom) || !isNonEmptyString12(value.targetRoom)) {
     return null;
   }
   return {
     sourceRoom: value.sourceRoom,
     targetRoom: value.targetRoom,
-    ...isNonEmptyString11(value.sourceId) ? { sourceId: value.sourceId } : {},
-    ...isNonEmptyString11(value.targetId) ? { targetId: value.targetId } : {},
+    ...isNonEmptyString12(value.sourceId) ? { sourceId: value.sourceId } : {},
+    ...isNonEmptyString12(value.targetId) ? { targetId: value.targetId } : {},
     ...typeof value.updatedAt === "number" && Number.isFinite(value.updatedAt) ? { updatedAt: value.updatedAt } : {}
   };
 }
@@ -15147,7 +15815,7 @@ function clearInterRoomEnergyHaulAssignment(creep) {
     delete creep.memory.interRoomEnergyHaul;
   }
 }
-function isNonEmptyString11(value) {
+function isNonEmptyString12(value) {
   return typeof value === "string" && value.length > 0;
 }
 function getVisibleOwnedRoom(roomName) {
@@ -17755,7 +18423,7 @@ function findVisibleAdjacentClaimedRooms(room) {
   }
   const game = globalThis.Game;
   const visibleRooms = game == null ? void 0 : game.rooms;
-  const adjacentRoomNames = getAdjacentRoomNames4(roomName, game == null ? void 0 : game.map);
+  const adjacentRoomNames = getAdjacentRoomNames5(roomName, game == null ? void 0 : game.map);
   if (!visibleRooms || adjacentRoomNames.length === 0) {
     return [];
   }
@@ -17764,7 +18432,7 @@ function findVisibleAdjacentClaimedRooms(room) {
     return ((_a = candidate == null ? void 0 : candidate.controller) == null ? void 0 : _a.my) === true;
   }).sort((left, right) => left.name.localeCompare(right.name));
 }
-function getAdjacentRoomNames4(roomName, gameMap) {
+function getAdjacentRoomNames5(roomName, gameMap) {
   if (typeof (gameMap == null ? void 0 : gameMap.describeExits) !== "function") {
     return [];
   }
@@ -19359,7 +20027,7 @@ function selectRemoteHarvesterAssignment(homeRoom) {
   )) != null ? _a : null;
 }
 function getRemoteSourceAssignments(homeRoom) {
-  if (!isNonEmptyString12(homeRoom)) {
+  if (!isNonEmptyString13(homeRoom)) {
     return [];
   }
   const records = getRemoteBootstrapRecords(homeRoom);
@@ -19485,13 +20153,13 @@ function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
 function getRemoteBootstrapRecords(homeRoom) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord11(records)) {
+  if (!isRecord12(records)) {
     return [];
   }
   return Object.values(records).filter((record) => isRemoteBootstrapRecord(record, homeRoom)).sort(compareRemoteBootstrapRecords);
 }
 function isRemoteBootstrapRecord(record, homeRoom) {
-  return isRecord11(record) && record.colony === homeRoom && isNonEmptyString12(record.roomName) && record.roomName !== homeRoom && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord12(record) && record.colony === homeRoom && isNonEmptyString13(record.roomName) && record.roomName !== homeRoom && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function compareRemoteBootstrapRecords(left, right) {
   return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
@@ -19526,18 +20194,18 @@ function hasHostileSuspendedTerritoryIntent(homeRoom, targetRoom) {
     return false;
   }
   return intents.some(
-    (intent) => isRecord11(intent) && intent.colony === homeRoom && intent.targetRoom === targetRoom && intent.suspended !== void 0 && isRecord11(intent.suspended) && intent.suspended.reason === "hostile_presence"
+    (intent) => isRecord12(intent) && intent.colony === homeRoom && intent.targetRoom === targetRoom && intent.suspended !== void 0 && isRecord12(intent.suspended) && intent.suspended.reason === "hostile_presence"
   );
 }
 function normalizeRemoteHarvesterMemory(value) {
-  if (!isRecord11(value)) {
+  if (!isRecord12(value)) {
     return null;
   }
-  return isNonEmptyString12(value.homeRoom) && isNonEmptyString12(value.targetRoom) && isNonEmptyString12(value.sourceId) && (value.containerId == null || isNonEmptyString12(value.containerId)) ? {
+  return isNonEmptyString13(value.homeRoom) && isNonEmptyString13(value.targetRoom) && isNonEmptyString13(value.sourceId) && (value.containerId == null || isNonEmptyString13(value.containerId)) ? {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId: value.sourceId,
-    ...isNonEmptyString12(value.containerId) ? { containerId: value.containerId } : {}
+    ...isNonEmptyString13(value.containerId) ? { containerId: value.containerId } : {}
   } : null;
 }
 function getAssignedSource2(assignment) {
@@ -19553,7 +20221,7 @@ function getAssignedSource2(assignment) {
   return (_a = room.find(FIND_SOURCES).find((candidate) => String(candidate.id) === String(assignment.sourceId))) != null ? _a : null;
 }
 function getAssignedContainer(assignment) {
-  if (isNonEmptyString12(assignment.containerId)) {
+  if (isNonEmptyString13(assignment.containerId)) {
     const container = getObjectById2(assignment.containerId);
     if (container) {
       return container;
@@ -19598,11 +20266,11 @@ function isRemoteMoveRoom(roomName, assignment) {
 }
 function findCriticalRoadMoveTargets(room) {
   return [
-    ...findRoomObjects13(room, "FIND_STRUCTURES"),
-    ...findRoomObjects13(room, "FIND_CONSTRUCTION_SITES")
+    ...findRoomObjects14(room, "FIND_STRUCTURES"),
+    ...findRoomObjects14(room, "FIND_CONSTRUCTION_SITES")
   ].filter((target) => matchesStructureType14(target.structureType, "STRUCTURE_ROAD", "road"));
 }
-function findRoomObjects13(room, constantName) {
+function findRoomObjects14(room, constantName) {
   const findConstant = globalThis[constantName];
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return [];
@@ -19737,10 +20405,10 @@ function getErrNotInRangeCode2() {
   var _a;
   return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE5;
 }
-function isRecord11(value) {
+function isRecord12(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString12(value) {
+function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -19759,7 +20427,7 @@ function selectRemoteHaulerAssignment(homeRoom) {
   return (_a = getRemoteSourceAssignments(homeRoom).filter(hasRemoteContainerAssignment).filter((assignment) => assignment.containerEnergy > REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD).filter((assignment) => countRemoteHaulersForContainer(assignment) < MAX_REMOTE_HAULERS_PER_CONTAINER).sort(compareRemoteHaulerAssignments)[0]) != null ? _a : null;
 }
 function hasRemoteContainerAssignment(assignment) {
-  return isNonEmptyString13(assignment.containerId);
+  return isNonEmptyString14(assignment.containerId);
 }
 function hasRemoteHaulerDeliveryDemand(homeRoom) {
   const room = getVisibleRoom6(homeRoom);
@@ -19853,10 +20521,10 @@ function canSatisfyRemoteCreepCapacity2(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > REMOTE_CREEP_REPLACEMENT_TICKS;
 }
 function normalizeRemoteHaulerMemory(value) {
-  if (!isRecord12(value)) {
+  if (!isRecord13(value)) {
     return null;
   }
-  return isNonEmptyString13(value.homeRoom) && isNonEmptyString13(value.targetRoom) && isNonEmptyString13(value.sourceId) && isNonEmptyString13(value.containerId) ? {
+  return isNonEmptyString14(value.homeRoom) && isNonEmptyString14(value.targetRoom) && isNonEmptyString14(value.sourceId) && isNonEmptyString14(value.containerId) ? {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId: value.sourceId,
@@ -19983,10 +20651,10 @@ function getErrNotInRangeCode3() {
   var _a;
   return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE6;
 }
-function isRecord12(value) {
+function isRecord13(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString13(value) {
+function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -20114,13 +20782,13 @@ var MOVE_PART_COST = 50;
 var MAX_CREEP_PARTS5 = 50;
 var MAX_REMOTE_UPGRADER_PATTERN_COUNT = 4;
 var MAX_CONTROLLER_LEVEL4 = 8;
-var ERR_NO_PATH_CODE6 = -2;
+var ERR_NO_PATH_CODE7 = -2;
 var TERRITORY_ROUTE_DISTANCE_SEPARATOR4 = ">";
 var ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
 function recordPlannedMultiRoomUpgraderSpawn(memory) {
   var _a, _b;
   const sustain = memory.controllerSustain;
-  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString14(sustain.homeRoom) || !isNonEmptyString14(sustain.targetRoom)) {
+  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString15(sustain.homeRoom) || !isNonEmptyString15(sustain.targetRoom)) {
     return;
   }
   const cache = getActiveMultiRoomUpgraderCountCache();
@@ -20207,11 +20875,11 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
 }
 function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgraderCounts, order) {
   var _a;
-  if (!isNonEmptyString14(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
+  if (!isNonEmptyString15(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
     return null;
   }
   const controller = room.controller;
-  if (!controller || !isNonEmptyString14(controller.id)) {
+  if (!controller || !isNonEmptyString15(controller.id)) {
     return null;
   }
   const controllerState = getEligibleControllerState(controller);
@@ -20221,7 +20889,7 @@ function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgra
   if (hasVisibleHostiles(room)) {
     return null;
   }
-  const routeDistance = getRouteDistance(homeRoom, room.name);
+  const routeDistance = getRouteDistance2(homeRoom, room.name);
   if (routeDistance === null) {
     return null;
   }
@@ -20277,7 +20945,7 @@ function hasActiveClaimedRoomSpawnConstructionSite(room) {
   if (((_a = room.controller) == null ? void 0 : _a.my) !== true || typeof room.find !== "function") {
     return false;
   }
-  const findConstant = getFindConstant6("FIND_MY_CONSTRUCTION_SITES");
+  const findConstant = getFindConstant7("FIND_MY_CONSTRUCTION_SITES");
   if (findConstant === null) {
     return false;
   }
@@ -20289,7 +20957,7 @@ function hasActiveClaimedRoomSpawnConstructionSite(room) {
   }
 }
 function isActiveSpawnConstructionSite(site) {
-  return isRecord13(site) && matchesStructureType16(site.structureType, "STRUCTURE_SPAWN", "spawn") && hasIncompleteConstructionSiteProgress(site);
+  return isRecord14(site) && matchesStructureType16(site.structureType, "STRUCTURE_SPAWN", "spawn") && hasIncompleteConstructionSiteProgress(site);
 }
 function hasIncompleteConstructionSiteProgress(site) {
   const progress = site.progress;
@@ -20299,7 +20967,7 @@ function hasIncompleteConstructionSiteProgress(site) {
   }
   return progress < progressTotal;
 }
-function getFindConstant6(constantName) {
+function getFindConstant7(constantName) {
   const findConstant = globalThis[constantName];
   return typeof findConstant === "number" ? findConstant : null;
 }
@@ -20351,7 +21019,7 @@ function countActiveMultiRoomUpgradersByHomeRoom(creeps) {
   const countsByHomeRoom = {};
   for (const creep of Object.values(creeps)) {
     const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString14(sustain.homeRoom) || !isNonEmptyString14(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
+    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString15(sustain.homeRoom) || !isNonEmptyString15(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
       continue;
     }
     const countsByTarget = (_b = countsByHomeRoom[sustain.homeRoom]) != null ? _b : {};
@@ -20381,7 +21049,7 @@ function combineNestedCountMaps(countsByHomeRoom) {
 function getActiveMultiRoomUpgraderCountCache() {
   var _a;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  const gameTime = getGameTime16();
+  const gameTime = getGameTime17();
   if ((activeMultiRoomUpgraderCountCache == null ? void 0 : activeMultiRoomUpgraderCountCache.gameTime) !== gameTime || activeMultiRoomUpgraderCountCache.creeps !== creeps) {
     activeMultiRoomUpgraderCountCache = {
       gameTime,
@@ -20414,12 +21082,12 @@ function hasVisibleHostiles(room) {
   const hostileStructuresFind = globalThis.FIND_HOSTILE_STRUCTURES;
   return typeof hostileCreepsFind === "number" && room.find(hostileCreepsFind).length > 0 || typeof hostileStructuresFind === "number" && room.find(hostileStructuresFind).length > 0;
 }
-function getRouteDistance(fromRoom, targetRoom) {
+function getRouteDistance2(fromRoom, targetRoom) {
   var _a, _b;
   if (fromRoom === targetRoom) {
     return 0;
   }
-  const gameTime = getGameTime16();
+  const gameTime = getGameTime17();
   const cache = getTerritoryRouteDistanceCache3(gameTime);
   const cacheKey = getTerritoryRouteDistanceCacheKey3(fromRoom, targetRoom);
   const cachedRouteDistance = (_a = cache == null ? void 0 : cache.distances) == null ? void 0 : _a[cacheKey];
@@ -20450,13 +21118,13 @@ function getTerritoryRouteDistanceCache3(gameTime) {
   if (!memory) {
     return void 0;
   }
-  if (!isRecord13(memory.territory)) {
+  if (!isRecord14(memory.territory)) {
     memory.territory = {};
   }
-  if (!isRecord13(memory.territory.routeDistances)) {
+  if (!isRecord14(memory.territory.routeDistances)) {
     memory.territory.routeDistances = {};
   }
-  if (!isRecord13(memory.territory.routeDistancesUpdatedAt)) {
+  if (!isRecord14(memory.territory.routeDistancesUpdatedAt)) {
     memory.territory.routeDistancesUpdatedAt = {};
   }
   const distances = memory.territory.routeDistances;
@@ -20504,24 +21172,24 @@ function isAdjacentRoom(fromRoom, targetRoom) {
     return false;
   }
   const exits = gameMap.describeExits(fromRoom);
-  if (!isRecord13(exits)) {
+  if (!isRecord14(exits)) {
     return false;
   }
   return Object.values(exits).some((roomName) => roomName === targetRoom);
 }
 function getNoPathResultCode6() {
   const noPathCode = globalThis.ERR_NO_PATH;
-  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE6;
+  return typeof noPathCode === "number" ? noPathCode : ERR_NO_PATH_CODE7;
 }
-function getGameTime16() {
+function getGameTime17() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isRecord13(value) {
+function isRecord14(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString14(value) {
+function isNonEmptyString15(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -20553,7 +21221,7 @@ function buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTim
   var _a;
   const roomName = colony.room.name;
   const controller = colony.room.controller;
-  if ((controller == null ? void 0 : controller.my) !== true || !isNonEmptyString15(controller.id)) {
+  if ((controller == null ? void 0 : controller.my) !== true || !isNonEmptyString16(controller.id)) {
     return {
       roomName,
       updatedAt: gameTime,
@@ -20682,7 +21350,7 @@ function getControllerProgressRatioField(controller) {
 function getControllerTicksToDowngradeField(controller) {
   return typeof controller.ticksToDowngrade === "number" && Number.isFinite(controller.ticksToDowngrade) ? { ticksToDowngrade: controller.ticksToDowngrade } : {};
 }
-function isNonEmptyString15(value) {
+function isNonEmptyString16(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -20748,9 +21416,9 @@ function orderColoniesForSpawnPlanning(colonies, roleCountsByRoom) {
 function getSpawnEnergyForecast(colony) {
   const balance = getStorageBalanceMemory();
   const transfers = Array.isArray(balance == null ? void 0 : balance.transfers) ? balance.transfers : [];
-  const incomingEnergy = transfers.filter((transfer) => transfer.targetRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger4(transfer.amount), 0);
-  const outgoingEnergy = transfers.filter((transfer) => transfer.sourceRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger4(transfer.amount), 0);
-  const energyAvailable = normalizeNonNegativeInteger4(colony.energyAvailable);
+  const incomingEnergy = transfers.filter((transfer) => transfer.targetRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger5(transfer.amount), 0);
+  const outgoingEnergy = transfers.filter((transfer) => transfer.sourceRoom === colony.room.name).reduce((total, transfer) => total + normalizeNonNegativeInteger5(transfer.amount), 0);
+  const energyAvailable = normalizeNonNegativeInteger5(colony.energyAvailable);
   return {
     roomName: colony.room.name,
     energyAvailable,
@@ -20782,8 +21450,8 @@ function getRoomCreepBudget(colony, roleCounts) {
   return {
     roomName: colony.room.name,
     controllerLevel: getControllerLevel2(colony.room.controller),
-    energyAvailable: normalizeNonNegativeInteger4(colony.energyAvailable),
-    energyCapacityAvailable: normalizeNonNegativeInteger4(colony.energyCapacityAvailable),
+    energyAvailable: normalizeNonNegativeInteger5(colony.energyAvailable),
+    energyCapacityAvailable: normalizeNonNegativeInteger5(colony.energyCapacityAvailable),
     effectiveEnergyAvailable: forecast.effectiveEnergyAvailable,
     energyGate: getSpawnPlanningEnergyGate(forecast.effectiveEnergyAvailable, colony.energyCapacityAvailable),
     ownedSpawnCount: colony.spawns.length,
@@ -20973,7 +21641,7 @@ function selectPostClaimControllerSustainPlan(colony) {
 function getPostClaimControllerSustainRecords(colonyName) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord14(records)) {
+  if (!isRecord15(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -20981,7 +21649,7 @@ function getPostClaimControllerSustainRecords(colonyName) {
   ).sort(comparePostClaimControllerSustainRecords);
 }
 function isPostClaimControllerSustainRecord(record, colonyName) {
-  return isRecord14(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString16(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord15(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString17(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function comparePostClaimControllerSustainRecords(left, right) {
   const leftHasSpawn = hasOperationalSpawnInRoom(left.roomName);
@@ -21375,7 +22043,7 @@ function hasVisibleForeignReservedTerritoryTarget(colony) {
   if (!Array.isArray(targets)) {
     return false;
   }
-  const colonyOwnerUsername = getControllerOwnerUsername5(colony.room.controller);
+  const colonyOwnerUsername = getControllerOwnerUsername6(colony.room.controller);
   return targets.some((target) => {
     if (typeof target !== "object" || target === null) {
       return false;
@@ -21399,7 +22067,7 @@ function isForeignReservedController2(controller, colonyOwnerUsername) {
   const reservationUsername = (_a = controller == null ? void 0 : controller.reservation) == null ? void 0 : _a.username;
   return (controller == null ? void 0 : controller.my) !== true && typeof reservationUsername === "string" && reservationUsername.length > 0 && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername5(controller) {
+function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return typeof username === "string" && username.length > 0 ? username : void 0;
@@ -21456,7 +22124,7 @@ function appendSpawnNameSuffix(baseName, options) {
   return options.nameSuffix ? `${baseName}-${options.nameSuffix}` : baseName;
 }
 function isWorkerOnlyFollowUpPass(options) {
-  return options.workersOnly === true && isNonEmptyString16(options.nameSuffix);
+  return options.workersOnly === true && isNonEmptyString17(options.nameSuffix);
 }
 function selectWorkerBody(colony, roleCounts) {
   if (shouldUseSourceHarvesterBody(colony, roleCounts)) {
@@ -21525,10 +22193,10 @@ function getWorkerDynamicBodyDemand(colony, roleCounts) {
 }
 function getSpawnEnergyBudget(colony) {
   var _a;
-  return normalizeNonNegativeInteger4((_a = colony.spawnEnergyBudget) != null ? _a : colony.energyAvailable);
+  return normalizeNonNegativeInteger5((_a = colony.spawnEnergyBudget) != null ? _a : colony.energyAvailable);
 }
 function generateHarvesterBody(availableEnergy, sourceDistance) {
-  const energyBudget = normalizeNonNegativeInteger4(availableEnergy);
+  const energyBudget = normalizeNonNegativeInteger5(availableEnergy);
   const workParts = selectHarvesterWorkParts(energyBudget);
   if (workParts <= 0) {
     return [];
@@ -21561,7 +22229,7 @@ function buildHarvesterBody(workParts, carryParts) {
   ];
 }
 function getHarvesterCarryTarget(workParts, sourceDistance) {
-  const roundTripTicks = Math.max(1, normalizeNonNegativeInteger4(sourceDistance) * 2);
+  const roundTripTicks = Math.max(1, normalizeNonNegativeInteger5(sourceDistance) * 2);
   const harvestedEnergyBetweenTrips = workParts * HARVEST_POWER_PER_WORK_PART * roundTripTicks;
   return Math.max(1, Math.ceil(harvestedEnergyBetweenTrips / CARRY_CAPACITY_PER_PART2));
 }
@@ -21599,7 +22267,7 @@ function getApproximateRange(left, right) {
   }
   return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
-function normalizeNonNegativeInteger4(value) {
+function normalizeNonNegativeInteger5(value) {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 function canAffordBody(body, energyAvailable) {
@@ -21698,8 +22366,8 @@ function getRoomSpawnPriorityRank(priority) {
   }
 }
 function getSpawnPlanningEnergyGate(energyAvailable, energyCapacityAvailable) {
-  const energy = normalizeNonNegativeInteger4(energyAvailable);
-  const capacity = normalizeNonNegativeInteger4(energyCapacityAvailable);
+  const energy = normalizeNonNegativeInteger5(energyAvailable);
+  const capacity = normalizeNonNegativeInteger5(energyCapacityAvailable);
   if (energy < MINIMUM_EMERGENCY_WORKER_BODY_COST) {
     return "critical";
   }
@@ -21730,10 +22398,10 @@ function getStorageBalanceMemory() {
   var _a, _b;
   return (_b = (_a = globalThis.Memory) == null ? void 0 : _a.economy) == null ? void 0 : _b.storageBalance;
 }
-function isRecord14(value) {
+function isRecord15(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString16(value) {
+function isNonEmptyString17(value) {
   return typeof value === "string" && value.length > 0;
 }
 function getGlobalNumber8(name) {
@@ -21750,14 +22418,14 @@ var ROOM_EDGE_MAX6 = 47;
 var DEFAULT_TERRAIN_WALL_MASK9 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
-  if (!isNonEmptyString17(input.colony) || !isNonEmptyString17(input.roomName)) {
+  if (!isNonEmptyString18(input.colony) || !isNonEmptyString18(input.roomName)) {
     return;
   }
   const bootstraps = getWritablePostClaimBootstrapRecords();
   if (!bootstraps) {
     return;
   }
-  const gameTime = getGameTime17();
+  const gameTime = getGameTime18();
   const existing = getPostClaimBootstrapRecord(input.roomName);
   const claimedAt = (existing == null ? void 0 : existing.status) === "ready" ? gameTime : (_a = existing == null ? void 0 : existing.claimedAt) != null ? _a : gameTime;
   bootstraps[input.roomName] = {
@@ -21894,7 +22562,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   return { active: true, spawnConstructionPending: true };
 }
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
-  if (!isNonEmptyString17(roomName)) {
+  if (!isNonEmptyString18(roomName)) {
     return;
   }
   const record = getPostClaimBootstrapRecord(roomName);
@@ -21903,7 +22571,7 @@ function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, res
   }
   updatePostClaimBootstrapRecord(roomName, {
     status: "spawningWorkers",
-    updatedAt: getGameTime17()
+    updatedAt: getGameTime18()
   });
   telemetryEvents.push({
     type: "postClaimBootstrap",
@@ -21946,7 +22614,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
     const spawnSite = toSpawnSiteMemory(existingSpawnSite);
     updatePostClaimBootstrapRecord(roomName, {
       status: "spawnSitePending",
-      updatedAt: getGameTime17(),
+      updatedAt: getGameTime18(),
       workerTarget,
       spawnSite,
       lastResult: OK_CODE9
@@ -21970,7 +22638,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
   const nextStatus = sitePlan.result === OK_CODE9 ? "spawnSitePending" : "spawnSiteBlocked";
   updatePostClaimBootstrapRecord(roomName, {
     status: nextStatus,
-    updatedAt: getGameTime17(),
+    updatedAt: getGameTime18(),
     workerTarget,
     ...sitePlan.position ? { spawnSite: sitePlan.position } : {},
     lastResult: sitePlan.result
@@ -22206,14 +22874,14 @@ function findSources3(room) {
   return room.find(findConstant);
 }
 function getRoomObjectPosition4(object) {
-  if (!isRecord15(object)) {
+  if (!isRecord16(object)) {
     return null;
   }
   if (isFiniteNumber8(object.x) && isFiniteNumber8(object.y)) {
     return { x: object.x, y: object.y };
   }
   const pos = object.pos;
-  if (isRecord15(pos) && isFiniteNumber8(pos.x) && isFiniteNumber8(pos.y)) {
+  if (isRecord16(pos) && isFiniteNumber8(pos.x) && isFiniteNumber8(pos.y)) {
     return { x: pos.x, y: pos.y };
   }
   return null;
@@ -22260,7 +22928,7 @@ function getWritablePostClaimBootstrapRecords() {
   return memory.territory.postClaimBootstraps;
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
-  return isRecord15(value) && value.roomName === expectedRoomName && isNonEmptyString17(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber8(value.claimedAt) && isFiniteNumber8(value.updatedAt);
+  return isRecord16(value) && value.roomName === expectedRoomName && isNonEmptyString18(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber8(value.claimedAt) && isFiniteNumber8(value.updatedAt);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
@@ -22315,15 +22983,15 @@ function getGlobalString2(name) {
   const value = globalThis[name];
   return typeof value === "string" ? value : null;
 }
-function getGameTime17() {
+function getGameTime18() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord15(value) {
+function isRecord16(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString17(value) {
+function isNonEmptyString18(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber8(value) {
@@ -22445,8 +23113,8 @@ function getRemoteSourceContainerScans(creeps) {
 }
 function createSourceContainerPlannerLookups3(room) {
   const terrain = getRoomTerrain10(room);
-  const structures = findRoomObjects14(room, "FIND_STRUCTURES");
-  const constructionSites = findRoomObjects14(room, "FIND_CONSTRUCTION_SITES");
+  const structures = findRoomObjects15(room, "FIND_STRUCTURES");
+  const constructionSites = findRoomObjects15(room, "FIND_CONSTRUCTION_SITES");
   if (!terrain || structures === null || constructionSites === null || typeof room.createConstructionSite !== "function") {
     return null;
   }
@@ -22536,7 +23204,7 @@ function compareRoomSourceContainerScans(left, right) {
 }
 function getRoomSources2(room) {
   var _a;
-  return (_a = findRoomObjects14(room, "FIND_SOURCES")) != null ? _a : [];
+  return (_a = findRoomObjects15(room, "FIND_SOURCES")) != null ? _a : [];
 }
 function getVisibleSourceById(room, sourceId) {
   var _a;
@@ -22547,7 +23215,7 @@ function getVisibleSourceById(room, sourceId) {
   }
   return (_a = getRoomSources2(room).find((source) => String(source.id) === String(sourceId))) != null ? _a : null;
 }
-function findRoomObjects14(room, constantName) {
+function findRoomObjects15(room, constantName) {
   const findConstant = getGlobalNumber10(constantName);
   const find = room.find;
   if (findConstant === null || typeof find !== "function") {
@@ -22659,7 +23327,7 @@ function normalizeRemoteHarvesterMemory2(creep) {
     return null;
   }
   const assignment = creep.memory.remoteHarvester;
-  if (!isRecord16(assignment) || typeof assignment.homeRoom !== "string" || assignment.homeRoom.length === 0 || typeof assignment.targetRoom !== "string" || assignment.targetRoom.length === 0 || assignment.homeRoom === assignment.targetRoom || typeof assignment.sourceId !== "string" || assignment.sourceId.length === 0) {
+  if (!isRecord17(assignment) || typeof assignment.homeRoom !== "string" || assignment.homeRoom.length === 0 || typeof assignment.targetRoom !== "string" || assignment.targetRoom.length === 0 || assignment.homeRoom === assignment.targetRoom || typeof assignment.sourceId !== "string" || assignment.sourceId.length === 0) {
     return null;
   }
   return assignment;
@@ -22684,7 +23352,7 @@ function hasDroppedEnergyDecayingAtSource(room, source) {
   if (!sourcePosition) {
     return false;
   }
-  const droppedResources = (_a = findRoomObjects14(room, "FIND_DROPPED_RESOURCES")) != null ? _a : [];
+  const droppedResources = (_a = findRoomObjects15(room, "FIND_DROPPED_RESOURCES")) != null ? _a : [];
   return droppedResources.some((resource) => {
     const resourcePosition = getRoomObjectPosition2(resource);
     return resourcePosition !== null && isDroppedEnergy2(resource) && isSameRoomPosition5(resourcePosition, room.name) && getRangeBetweenPositions4(sourcePosition, resourcePosition) <= 1;
@@ -22711,7 +23379,7 @@ function getEnergyResource11() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
-function isRecord16(value) {
+function isRecord17(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -22739,7 +23407,7 @@ function emitRuntimeSummary(colonies, creeps, events = [], options = {}) {
   if (colonies.length === 0 && events.length === 0) {
     return void 0;
   }
-  const tick = getGameTime18();
+  const tick = getGameTime19();
   resetCachedRefillTelemetryIfTickRewound(tick);
   const emitsSummary = shouldEmitRuntimeSummary(tick, events);
   const creepsByColony = groupCreepsByColony(creeps);
@@ -22836,7 +23504,7 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
   const territoryRecommendation = buildRuntimeOccupationRecommendationReport(colony, colonyWorkers);
   const territoryExpansion = buildRuntimeExpansionCandidateReport(colony);
   if (persistOccupationRecommendations) {
-    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime18());
+    persistOccupationRecommendationFollowUpIntent(territoryRecommendation, getGameTime19());
   }
   return {
     roomName: colony.room.name,
@@ -22846,11 +23514,11 @@ function summarizeRoom(colony, colonyCreeps, persistOccupationRecommendations, e
     workerCount: colonyWorkers.length,
     spawnStatus: colony.spawns.map(summarizeSpawn),
     taskCounts: countWorkerTasks(colonyWorkers),
-    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime18()),
+    ...summarizeRuntimeBehavior(colonyWorkers, colonyCreeps, getGameTime19()),
     ...includeStructureSnapshot ? { structures: summarizeStructures(colony, colonyWorkers) } : {},
-    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime18()),
-    ...summarizeRefillTelemetry(colonyWorkers, getGameTime18()),
-    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime18()),
+    ...summarizeWorkerEfficiency(colonyWorkers, getGameTime19()),
+    ...summarizeRefillTelemetry(colonyWorkers, getGameTime19()),
+    ...summarizeSpawnCriticalRefill(colonyWorkers, getGameTime19()),
     ...buildControllerSummary(colony.room),
     resources: summarizeResources(colony, colonyWorkers, eventMetrics.resources),
     combat: summarizeCombat(colony.room, eventMetrics.combat),
@@ -22870,7 +23538,7 @@ function buildPostClaimBootstrapSummary(roomName) {
 }
 function buildTerritoryIntentSummary(colonyName, roleCounts) {
   const territoryIntents = getTerritoryIntentProgressSummaries(colonyName, roleCounts);
-  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime18());
+  const suspendedTerritoryIntentCounts = getSuspendedTerritoryIntentCountsByRoom(colonyName, getGameTime19());
   const hasSuspendedTerritoryIntents = Object.keys(suspendedTerritoryIntentCounts).length > 0;
   if (territoryIntents.length === 0 && !hasSuspendedTerritoryIntents) {
     return {};
@@ -23017,7 +23685,7 @@ function isRecentWorkerTaskBehaviorSample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskBehaviorSample(value) {
-  return isRecord17(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord17(value.state) && isRecord17(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+  return isRecord18(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord18(value.state) && isRecord18(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
 }
 function isRecentWorkerTaskPolicyShadow(value, tick) {
   if (!isWorkerTaskPolicyShadow(value)) {
@@ -23026,15 +23694,15 @@ function isRecentWorkerTaskPolicyShadow(value, tick) {
   return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskPolicyShadow(value) {
-  return isRecord17(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
+  return isRecord18(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function shouldBuildStructureSnapshot(tick) {
   return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
 }
 function summarizeStructures(colony, colonyWorkers) {
   var _a, _b;
-  const roomStructures = (_a = findRoomObjects15(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
-  const constructionSites = (_b = findRoomObjects15(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
+  const roomStructures = (_a = findRoomObjects16(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const constructionSites = (_b = findRoomObjects16(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _b : [];
   const roadCount = countStructuresByType2(roomStructures, "STRUCTURE_ROAD", "road");
   const pendingRoadSiteCount = countConstructionSitesByType(constructionSites, "STRUCTURE_ROAD", "road");
   return {
@@ -23054,7 +23722,7 @@ function countConstructionSitesByType(constructionSites, globalName, fallback) {
   return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
 }
 function countOwnedRamparts(structures) {
-  return structures.filter((structure) => isRecord17(structure) && isObservedOwnedRampart(structure)).length;
+  return structures.filter((structure) => isRecord18(structure) && isObservedOwnedRampart(structure)).length;
 }
 function summarizeContainers(structures) {
   return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
@@ -23091,7 +23759,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   return [...repairCounts.entries()].sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId)).map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
 }
 function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
-  const structureRecord = isRecord17(structure) ? structure : {};
+  const structureRecord = isRecord18(structure) ? structure : {};
   const structureType = typeof structureRecord.structureType === "string" ? structureRecord.structureType : void 0;
   const hits = getFiniteNumber(structureRecord.hits);
   const hitsMax = getFiniteNumber(structureRecord.hitsMax);
@@ -23104,7 +23772,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord17(structure) && matchesStructureType18(structure.structureType, globalName, fallback);
+  return isRecord18(structure) && matchesStructureType18(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -23292,7 +23960,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord17(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord18(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio5(numerator, denominator) {
   if (denominator <= 0) {
@@ -23307,7 +23975,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord17(value)) {
+  if (!isRecord18(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -23348,7 +24016,7 @@ function isRecentSpawnCriticalRefillSample(sample, tick) {
   return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
 }
 function isSpawnCriticalRefillSample(value) {
-  return isRecord17(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
+  return isRecord18(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;
@@ -23375,11 +24043,11 @@ function buildControllerSummary(room) {
 }
 function summarizeResources(colony, colonyWorkers, events) {
   var _a, _b, _c, _d, _e;
-  const roomStructures = (_a = findRoomObjects15(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
+  const roomStructures = (_a = findRoomObjects16(colony.room, "FIND_STRUCTURES")) != null ? _a : colony.spawns;
   const ownedEnergyStructures = findOwnedEnergyStoreStructures(colony.room);
-  const roomCreeps = (_b = findRoomObjects15(colony.room, "FIND_MY_CREEPS")) != null ? _b : [];
-  const constructionSites = (_c = findRoomObjects15(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _c : [];
-  const droppedResources = (_d = findRoomObjects15(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _d : [];
+  const roomCreeps = (_b = findRoomObjects16(colony.room, "FIND_MY_CREEPS")) != null ? _b : [];
+  const constructionSites = (_c = findRoomObjects16(colony.room, "FIND_MY_CONSTRUCTION_SITES")) != null ? _c : [];
+  const droppedResources = (_d = findRoomObjects16(colony.room, "FIND_DROPPED_RESOURCES")) != null ? _d : [];
   const sourceContainerCoverage = summarizeSourceContainerCoverage(colony.room);
   return {
     storedEnergy: sumEnergyInStores(ownedEnergyStructures),
@@ -23395,10 +24063,10 @@ function summarizeResources(colony, colonyWorkers, events) {
 }
 function findOwnedEnergyStoreStructures(room) {
   var _a;
-  return ((_a = findRoomObjects15(room, "FIND_MY_STRUCTURES")) != null ? _a : []).filter(isOwnedEnergyStoreStructure);
+  return ((_a = findRoomObjects16(room, "FIND_MY_STRUCTURES")) != null ? _a : []).filter(isOwnedEnergyStoreStructure);
 }
 function isOwnedEnergyStoreStructure(structure) {
-  if (!isRecord17(structure)) {
+  if (!isRecord18(structure)) {
     return false;
   }
   return matchesStructureType18(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType18(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType18(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType18(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType18(structure.structureType, "STRUCTURE_LINK", "link") || matchesStructureType18(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
@@ -23480,7 +24148,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord17(constructionSite)) {
+  if (!isRecord18(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -23494,7 +24162,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord17(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord18(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -23525,8 +24193,8 @@ function buildControllerProgressRemaining(room) {
 }
 function summarizeCombat(room, events) {
   var _a, _b;
-  const hostileCreeps = (_a = findRoomObjects15(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
-  const hostileStructures = (_b = findRoomObjects15(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
+  const hostileCreeps = (_a = findRoomObjects16(room, "FIND_HOSTILE_CREEPS")) != null ? _a : [];
+  const hostileStructures = (_b = findRoomObjects16(room, "FIND_HOSTILE_STRUCTURES")) != null ? _b : [];
   return {
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -23716,10 +24384,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord17(entry) || typeof entry.event !== "number") {
+    if (!isRecord18(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord17(entry.data) ? entry.data : {};
+    const data = isRecord18(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -23771,7 +24439,7 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
 }
 function getSpawnExtensionEnergyStructureIds(room) {
   var _a, _b;
-  const structures = (_b = (_a = findRoomObjects15(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects15(room, "FIND_STRUCTURES")) != null ? _b : [];
+  const structures = (_b = (_a = findRoomObjects16(room, "FIND_MY_STRUCTURES")) != null ? _a : findRoomObjects16(room, "FIND_STRUCTURES")) != null ? _b : [];
   const ids = /* @__PURE__ */ new Set();
   for (const structure of structures) {
     if (!isSpawnExtensionEnergyStructure2(structure)) {
@@ -23785,7 +24453,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord17(structure) && (matchesStructureType18(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType18(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord18(structure) && (matchesStructureType18(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType18(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -23794,9 +24462,9 @@ function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
 function getObjectId10(value) {
-  return isRecord17(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+  return isRecord18(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
-function findRoomObjects15(room, constantName) {
+function findRoomObjects16(room, constantName) {
   const findConstant = getGlobalNumber11(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
@@ -23825,7 +24493,7 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord17(object) || !isRecord17(object.store)) {
+  if (!isRecord18(object) || !isRecord18(object.store)) {
     return 0;
   }
   const storedEnergy = object.store[getEnergyResource12()];
@@ -23840,7 +24508,7 @@ function getEnergyInStore(object) {
   return 0;
 }
 function getEnergyCapacityInStore(object) {
-  if (!isRecord17(object) || !isRecord17(object.store)) {
+  if (!isRecord18(object) || !isRecord18(object.store)) {
     return 0;
   }
   const getCapacity = object.store.getCapacity;
@@ -23861,7 +24529,7 @@ function getEnergyCapacityInStore(object) {
 function sumDroppedEnergy2(droppedResources) {
   const energyResource = getEnergyResource12();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord17(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord18(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
@@ -23890,7 +24558,7 @@ function getEnergyResource12() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord17(value) {
+function isRecord18(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -23908,7 +24576,7 @@ function buildCpuSummary() {
   }
   return Object.keys(summary).length > 0 ? { cpu: summary } : {};
 }
-function getGameTime18() {
+function getGameTime19() {
   return typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -24421,10 +25089,10 @@ var MINERAL_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var ERR_NOT_IN_RANGE_CODE7 = -9;
 function planMineralHarvesterSpawn(colony, creeps, gameTime, options = {}) {
   var _a, _b, _c, _d, _e;
-  const energyAvailable = normalizeNonNegativeInteger5(
+  const energyAvailable = normalizeNonNegativeInteger6(
     (_b = (_a = options.energyAvailable) != null ? _a : colony.energyAvailable) != null ? _b : colony.room.energyAvailable
   );
-  const energyCapacity = normalizeNonNegativeInteger5(
+  const energyCapacity = normalizeNonNegativeInteger6(
     (_c = colony.energyCapacityAvailable) != null ? _c : colony.room.energyCapacityAvailable
   );
   if (!shouldAllowMineralHarvesting(energyAvailable, energyCapacity)) {
@@ -24439,7 +25107,7 @@ function planMineralHarvesterSpawn(colony, creeps, gameTime, options = {}) {
     return null;
   }
   const body = buildMineralHarvesterBody(
-    normalizeNonNegativeInteger5((_d = options.bodyEnergyBudget) != null ? _d : energyAvailable),
+    normalizeNonNegativeInteger6((_d = options.bodyEnergyBudget) != null ? _d : energyAvailable),
     (_e = colony.room.controller) == null ? void 0 : _e.level
   );
   if (body.length === 0) {
@@ -24482,14 +25150,14 @@ function selectMineralHarvestAssignment(room, creeps = Object.values(((_b) => (_
   };
 }
 function shouldAllowMineralHarvesting(energyAvailable, energyCapacity) {
-  const capacity = normalizeNonNegativeInteger5(energyCapacity);
+  const capacity = normalizeNonNegativeInteger6(energyCapacity);
   if (capacity <= 0) {
     return false;
   }
-  return normalizeNonNegativeInteger5(energyAvailable) >= capacity * MINERAL_HARVESTING_MIN_ENERGY_RATIO;
+  return normalizeNonNegativeInteger6(energyAvailable) >= capacity * MINERAL_HARVESTING_MIN_ENERGY_RATIO;
 }
 function buildMineralHarvesterBody(energyAvailable, controllerLevel) {
-  const energyBudget = normalizeNonNegativeInteger5(energyAvailable);
+  const energyBudget = normalizeNonNegativeInteger6(energyAvailable);
   const maxWorkParts = typeof controllerLevel === "number" && controllerLevel >= 6 ? 3 : 2;
   for (let workParts = maxWorkParts; workParts >= 1; workParts -= 1) {
     const body = buildMineralHarvesterBodyWithWorkParts(workParts);
@@ -24548,22 +25216,22 @@ function selectAvailableSpawn(spawns, usedSpawns) {
 }
 function selectExtractor(room) {
   var _a;
-  const ownedStructures = findRoomObjects16(room, "FIND_MY_STRUCTURES");
+  const ownedStructures = findRoomObjects17(room, "FIND_MY_STRUCTURES");
   const extractor = ownedStructures.find(isExtractorStructure);
   if (extractor) {
     return extractor;
   }
-  return (_a = findRoomObjects16(room, "FIND_STRUCTURES").find(isExtractorStructure)) != null ? _a : null;
+  return (_a = findRoomObjects17(room, "FIND_STRUCTURES").find(isExtractorStructure)) != null ? _a : null;
 }
 function selectAvailableMineral(room) {
   var _a;
-  return (_a = findRoomObjects16(room, "FIND_MINERALS").find(isMineralAvailable)) != null ? _a : null;
+  return (_a = findRoomObjects17(room, "FIND_MINERALS").find(isMineralAvailable)) != null ? _a : null;
 }
 function isExtractorStructure(structure) {
   return matchesStructureType20(structure.structureType, "STRUCTURE_EXTRACTOR", "extractor");
 }
 function isMineralAvailable(mineral) {
-  return normalizeNonNegativeInteger5(mineral.mineralAmount) > 0;
+  return normalizeNonNegativeInteger6(mineral.mineralAmount) > 0;
 }
 function getMineralResourceType(mineral) {
   const mineralType = mineral.mineralType;
@@ -24598,10 +25266,10 @@ function getMutableMineralHarvesterMemory(creep) {
   return memory;
 }
 function normalizeMineralHarvesterMemory(value) {
-  if (!isRecord18(value) || !isNonEmptyString18(value.homeRoom) || !isNonEmptyString18(value.mineralId)) {
+  if (!isRecord19(value) || !isNonEmptyString19(value.homeRoom) || !isNonEmptyString19(value.mineralId)) {
     return null;
   }
-  const targetId = isNonEmptyString18(value.targetId) ? value.targetId : void 0;
+  const targetId = isNonEmptyString19(value.targetId) ? value.targetId : void 0;
   if (!targetId) {
     return null;
   }
@@ -24609,12 +25277,12 @@ function normalizeMineralHarvesterMemory(value) {
     homeRoom: value.homeRoom,
     mineralId: value.mineralId,
     targetId,
-    ...isNonEmptyString18(value.mineralType) ? { mineralType: value.mineralType } : {}
+    ...isNonEmptyString19(value.mineralType) ? { mineralType: value.mineralType } : {}
   };
 }
 function getAssignedMineral(assignment, room) {
   var _a, _b;
-  return (_b = (_a = getObjectById4(assignment.mineralId)) != null ? _a : findRoomObjects16(room, "FIND_MINERALS").find((mineral) => mineral.id === assignment.mineralId)) != null ? _b : null;
+  return (_b = (_a = getObjectById4(assignment.mineralId)) != null ? _a : findRoomObjects17(room, "FIND_MINERALS").find((mineral) => mineral.id === assignment.mineralId)) != null ? _b : null;
 }
 function deliverMineral(creep, assignment, resourceType) {
   var _a;
@@ -24693,7 +25361,7 @@ function getVisibleRoom9(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function findRoomObjects16(room, constantName) {
+function findRoomObjects17(room, constantName) {
   const findConstant = globalThis[constantName];
   if (typeof findConstant !== "number" || typeof room.find !== "function") {
     return [];
@@ -24726,13 +25394,13 @@ function getBodyCost3(body) {
 function getObjectId12(object) {
   return typeof object.id === "string" ? object.id : "";
 }
-function normalizeNonNegativeInteger5(value) {
+function normalizeNonNegativeInteger6(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
-function isRecord18(value) {
+function isRecord19(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString18(value) {
+function isNonEmptyString19(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -24773,7 +25441,7 @@ function reserveRoomForPlannedClaim(creep) {
       targetRoom: assignment.targetRoom
     };
   }
-  if (isControllerOwned2(controller)) {
+  if (isControllerOwned3(controller)) {
     return {
       status: "skipped",
       reason: "controllerOwned",
@@ -24811,7 +25479,7 @@ function reserveRoomForPlannedClaim(creep) {
     controllerId: controller.id,
     ...assignment.followUp ? { followUp: assignment.followUp } : {}
   };
-  creep.memory.territory = (_b = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, getGameTime19())) != null ? _b : reserveAssignment;
+  creep.memory.territory = (_b = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, getGameTime20())) != null ? _b : reserveAssignment;
   const result = creep.reserveController(controller);
   if (result === ERR_NOT_IN_RANGE_CODE8) {
     if (typeof creep.moveTo === "function") {
@@ -24841,7 +25509,7 @@ function reserveRoomForPlannedClaim(creep) {
   };
 }
 function isPlannedClaimAssignment(assignment) {
-  return isNonEmptyString19(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "claim";
+  return isNonEmptyString20(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "claim";
 }
 function selectClaimReservationController(creep, assignment) {
   var _a, _b, _c, _d, _e;
@@ -24869,27 +25537,27 @@ function countVisibleOwnedRooms2(colony) {
   if (!rooms) {
     return 0;
   }
-  const colonyOwnerUsername = getControllerOwnerUsername6(
-    isNonEmptyString19(colony) ? (_b = rooms[colony]) == null ? void 0 : _b.controller : void 0
+  const colonyOwnerUsername = getControllerOwnerUsername7(
+    isNonEmptyString20(colony) ? (_b = rooms[colony]) == null ? void 0 : _b.controller : void 0
   );
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_c = room == null ? void 0 : room.controller) == null ? void 0 : _c.my) === true && (!colonyOwnerUsername || getControllerOwnerUsername6(room.controller) === colonyOwnerUsername)) {
+    if (((_c = room == null ? void 0 : room.controller) == null ? void 0 : _c.my) === true && (!colonyOwnerUsername || getControllerOwnerUsername7(room.controller) === colonyOwnerUsername)) {
       ownedRoomCount += 1;
     }
   }
   return ownedRoomCount;
 }
 function canReserveControllerForColony(controller, creep) {
-  const reservationUsername = getControllerReservationUsername4(controller);
+  const reservationUsername = getControllerReservationUsername5(controller);
   if (!reservationUsername) {
     return true;
   }
   const actorUsername = getActorUsername(creep);
-  return isNonEmptyString19(actorUsername) && reservationUsername === actorUsername;
+  return isNonEmptyString20(actorUsername) && reservationUsername === actorUsername;
 }
-function isControllerOwned2(controller) {
-  return controller.my === true || isNonEmptyString19(getControllerOwnerUsername6(controller));
+function isControllerOwned3(controller) {
+  return controller.my === true || isNonEmptyString20(getControllerOwnerUsername7(controller));
 }
 function getActiveClaimPartCount(creep) {
   var _a;
@@ -24906,33 +25574,33 @@ function getActiveClaimPartCount(creep) {
 function getActorUsername(creep) {
   var _a, _b, _c;
   const creepOwner = (_a = creep.owner) == null ? void 0 : _a.username;
-  if (isNonEmptyString19(creepOwner)) {
+  if (isNonEmptyString20(creepOwner)) {
     return creepOwner;
   }
   const colony = creep.memory.colony;
-  const room = isNonEmptyString19(colony) ? (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[colony] : void 0;
-  return getControllerOwnerUsername6(room == null ? void 0 : room.controller);
+  const room = isNonEmptyString20(colony) ? (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[colony] : void 0;
+  return getControllerOwnerUsername7(room == null ? void 0 : room.controller);
 }
-function getControllerOwnerUsername6(controller) {
+function getControllerOwnerUsername7(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString19(username) ? username : void 0;
+  return isNonEmptyString20(username) ? username : void 0;
 }
-function getControllerReservationUsername4(controller) {
+function getControllerReservationUsername5(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString19(username) ? username : void 0;
+  return isNonEmptyString20(username) ? username : void 0;
 }
 function getClaimBodyPartConstant() {
   var _a;
   return (_a = globalThis.CLAIM) != null ? _a : "claim";
 }
-function getGameTime19() {
+function getGameTime20() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString19(value) {
+function isNonEmptyString20(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -24941,7 +25609,7 @@ var AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR = "autonomousExpansionClaim";
 var EXPANSION_CLAIM_EXECUTION_TIMEOUT_TICKS = 1500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE = 500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_RCL = 2;
-var EXIT_DIRECTION_ORDER4 = ["1", "3", "5", "7"];
+var EXIT_DIRECTION_ORDER5 = ["1", "3", "5", "7"];
 var OK_CODE11 = 0;
 var ERR_NOT_IN_RANGE_CODE9 = -9;
 var ERR_INVALID_TARGET_CODE4 = -7;
@@ -24982,7 +25650,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   if (!isClaimExecutionAssignment(assignment)) {
     return false;
   }
-  const gameTime = getGameTime20();
+  const gameTime = getGameTime21();
   const recommendedClaim = getRecommendedExpansionClaimExecutionGate(creep.memory.colony, assignment);
   if (!recommendedClaim) {
     return false;
@@ -25153,7 +25821,7 @@ function isAutonomousExpansionClaimGclInsufficient() {
 function getAutonomousExpansionClaimTickContext(gameTime) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
-  const territoryMemory = getTerritoryMemoryRecord6();
+  const territoryMemory = getTerritoryMemoryRecord7();
   const rawIntents = territoryMemory == null ? void 0 : territoryMemory.intents;
   if (autonomousExpansionClaimTickContext && autonomousExpansionClaimTickContext.gameTime === gameTime && autonomousExpansionClaimTickContext.gameMap === gameMap) {
     if (autonomousExpansionClaimTickContext.territoryMemory !== territoryMemory || autonomousExpansionClaimTickContext.rawIntents !== rawIntents) {
@@ -25250,10 +25918,10 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   if (room && !controller) {
     return { ...visibleControllerEvaluation, reason: "controllerMissing" };
   }
-  if (controller && isControllerOwned3(controller)) {
+  if (controller && isControllerOwned4(controller)) {
     return { ...visibleControllerEvaluation, reason: "controllerOwned" };
   }
-  const colonyOwnerUsername = getControllerOwnerUsername7(colony.room.controller);
+  const colonyOwnerUsername = getControllerOwnerUsername8(colony.room.controller);
   if (controller && isControllerReserved(controller, colonyOwnerUsername)) {
     return { ...visibleControllerEvaluation, reason: "controllerReserved" };
   }
@@ -25269,7 +25937,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   const scoutValidation = validateTerritoryScoutIntelForClaim({
     colony: colonyName,
     targetRoom: candidate.roomName,
-    colonyOwnerUsername: getControllerOwnerUsername7(colony.room.controller),
+    colonyOwnerUsername: getControllerOwnerUsername8(colony.room.controller),
     gameTime
   });
   const scoutControllerId = getScoutValidationControllerId(scoutValidation);
@@ -25349,15 +26017,15 @@ function getScoutValidationClaimSkipReason(validation) {
 function buildAutonomousExpansionScoringInput(colony, report, context) {
   var _a, _b;
   const colonyName = colony.room.name;
-  const colonyOwnerUsername = getControllerOwnerUsername7(colony.room.controller);
-  const ownedRoomNames = getVisibleOwnedRoomNames4(colonyName, colonyOwnerUsername);
+  const colonyOwnerUsername = getControllerOwnerUsername8(colony.room.controller);
+  const ownedRoomNames = getVisibleOwnedRoomNames5(colonyName, colonyOwnerUsername);
   const adjacentRoomNamesByOwnedRoom = getAdjacentRoomNamesByOwnedRoom2(ownedRoomNames, context);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, colonyOwnerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString20(room.mineralType));
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString21(room.mineralType));
   const seenRooms = /* @__PURE__ */ new Set();
   const candidates = [];
   report.candidates.forEach((candidate, order) => {
-    if (!isNonEmptyString20(candidate.roomName) || seenRooms.has(candidate.roomName)) {
+    if (!isNonEmptyString21(candidate.roomName) || seenRooms.has(candidate.roomName)) {
       return;
     }
     seenRooms.add(candidate.roomName);
@@ -25418,12 +26086,12 @@ function summarizeScoutedExpansionMineral(mineral) {
 }
 function summarizeExpansionController2(controller) {
   var _a, _b;
-  const ownerUsername = getControllerOwnerUsername7(controller);
+  const ownerUsername = getControllerOwnerUsername8(controller);
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
   return {
     ...typeof controller.my === "boolean" ? { my: controller.my } : {},
     ...ownerUsername ? { ownerUsername } : {},
-    ...isNonEmptyString20(reservationUsername) ? { reservationUsername } : {},
+    ...isNonEmptyString21(reservationUsername) ? { reservationUsername } : {},
     ...typeof ((_b = controller.reservation) == null ? void 0 : _b.ticksToEnd) === "number" ? { reservationTicksToEnd: controller.reservation.ticksToEnd } : {}
   };
 }
@@ -25436,7 +26104,7 @@ function compareAutonomousExpansionClaimCandidates(left, right) {
 function compareOptionalNumbers5(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
-function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
+function getVisibleOwnedRoomNames5(colonyName, ownerUsername) {
   var _a, _b;
   const ownedRoomNames = /* @__PURE__ */ new Set([colonyName]);
   const rooms = (_a = globalThis.Game) == null ? void 0 : _a.rooms;
@@ -25444,7 +26112,7 @@ function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString20(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString21(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -25462,7 +26130,7 @@ function getCachedAdjacentRoomNames(roomName, context) {
   if (cachedAdjacentRoomNames) {
     return cachedAdjacentRoomNames;
   }
-  const adjacentRoomNames = new Set(getAdjacentRoomNames5(roomName, context.gameMap));
+  const adjacentRoomNames = new Set(getAdjacentRoomNames6(roomName, context.gameMap));
   context.adjacentRoomNamesByOwnedRoom.set(roomName, adjacentRoomNames);
   return adjacentRoomNames;
 }
@@ -25478,26 +26146,26 @@ function getOwnedAdjacency(roomName, adjacentRoomNamesByOwnedRoom) {
   }
   return { adjacentToOwnedRoom: false };
 }
-function getAdjacentRoomNames5(roomName, gameMap = ((_a) => (_a = globalThis.Game) == null ? void 0 : _a.map)()) {
+function getAdjacentRoomNames6(roomName, gameMap = ((_a) => (_a = globalThis.Game) == null ? void 0 : _a.map)()) {
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord19(exits)) {
+  if (!isRecord20(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER4.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER5.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString20(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString21(exitRoom) ? [exitRoom] : [];
   });
 }
 function countActivePostClaimBootstraps2() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord19(records)) {
+  if (!isRecord20(records)) {
     return 0;
   }
-  return Object.values(records).filter((record) => isRecord19(record) && record.status !== "ready").length;
+  return Object.values(records).filter((record) => isRecord20(record) && record.status !== "ready").length;
 }
 function hasSufficientAutonomousExpansionClaimRcl(colony) {
   var _a, _b;
@@ -25528,7 +26196,7 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime, con
   if (!evaluation.targetRoom) {
     return;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
@@ -25545,13 +26213,13 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime, con
   };
   pruneOccupationRecommendationTargets(territoryMemory, colony);
   pruneAutonomousExpansionClaimTargets(colony, territoryMemory, target, context);
-  upsertTerritoryTarget2(territoryMemory, target);
+  upsertTerritoryTarget3(territoryMemory, target);
   const intents = getTerritoryIntentsForAutonomousExpansionClaim(territoryMemory, context);
   territoryMemory.intents = intents;
   const existingIntent = intents.find(
     (intent) => intent.colony === colony && intent.targetRoom === target.roomName && intent.action === "claim" && intent.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR
   );
-  upsertTerritoryIntent4(intents, {
+  upsertTerritoryIntent5(intents, {
     colony,
     targetRoom: target.roomName,
     action: "claim",
@@ -25562,18 +26230,18 @@ function persistAutonomousExpansionClaimIntent(colony, evaluation, gameTime, con
   });
   syncAutonomousExpansionClaimIntentContext(context, territoryMemory, intents);
 }
-function upsertTerritoryTarget2(territoryMemory, target) {
+function upsertTerritoryTarget3(territoryMemory, target) {
   if (!Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = [];
   }
   const existingTarget = territoryMemory.targets.find(
-    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord19(rawTarget) && rawTarget.createdBy === target.createdBy
+    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord20(rawTarget) && rawTarget.createdBy === target.createdBy
   );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord19(existingTarget)) {
+  if (isRecord20(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -25582,7 +26250,7 @@ function upsertTerritoryTarget2(territoryMemory, target) {
     }
   }
 }
-function upsertTerritoryIntent4(intents, nextIntent) {
+function upsertTerritoryIntent5(intents, nextIntent) {
   const existingIndex = intents.findIndex(
     (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action && intent.createdBy === nextIntent.createdBy
   );
@@ -25592,7 +26260,7 @@ function upsertTerritoryIntent4(intents, nextIntent) {
   }
   intents.push(nextIntent);
 }
-function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerritoryMemoryRecord6(), activeTarget, context) {
+function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerritoryMemoryRecord7(), activeTarget, context) {
   if (!territoryMemory || !Array.isArray(territoryMemory.targets)) {
     return;
   }
@@ -25604,7 +26272,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord19(target) && isNonEmptyString20(target.roomName) && target.action === "claim") {
+    if (isRecord20(target) && isNonEmptyString21(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -25623,7 +26291,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord19(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord20(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime, intents) {
@@ -25691,10 +26359,10 @@ function isClaimExecutionAssignment(assignment) {
 }
 function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   var _a;
-  if (!isNonEmptyString20(colony)) {
+  if (!isNonEmptyString21(colony)) {
     return null;
   }
-  const territoryMemory = getTerritoryMemoryRecord6();
+  const territoryMemory = getTerritoryMemoryRecord7();
   if (!territoryMemory) {
     return null;
   }
@@ -25844,7 +26512,7 @@ function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryE
     status: "claimed",
     controllerId: controller.id,
     creepName: creep.name,
-    updatedAt: getGameTime20()
+    updatedAt: getGameTime21()
   });
 }
 function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason, options) {
@@ -25860,7 +26528,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     reason
   });
   if (options.suppressIntent) {
-    suppressRecommendedClaimIntent(colony, assignment, getGameTime20(), options.controllerId, reason);
+    suppressRecommendedClaimIntent(colony, assignment, getGameTime21(), options.controllerId, reason);
   }
   recordColonyExpansionClaimVerification({
     colony,
@@ -25870,7 +26538,7 @@ function recordRecommendedClaimTerminalFailure(creep, assignment, result, reason
     creepName: creep.name,
     result,
     reason,
-    updatedAt: getGameTime20()
+    updatedAt: getGameTime21()
   });
 }
 function recordRecommendedClaimRetry(creep, assignment, result, reason, options = {}) {
@@ -25885,11 +26553,11 @@ function recordRecommendedClaimRetry(creep, assignment, result, reason, options 
     result,
     reason
   });
-  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime20(), options);
+  updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime21(), options);
 }
 function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, options) {
   var _a, _b;
-  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
@@ -25912,7 +26580,7 @@ function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, opti
   }
 }
 function suppressRecommendedClaimIntent(colony, assignment, gameTime, controllerId, reason) {
-  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
@@ -25935,7 +26603,7 @@ function suppressRecommendedClaimIntent(colony, assignment, gameTime, controller
   }
 }
 function completeRecommendedClaimIntent(colony, targetRoom, controllerId) {
-  const territoryMemory = getWritableTerritoryMemoryRecord5();
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
@@ -25956,13 +26624,13 @@ function hasRecommendedClaimTarget(territoryMemory, colony, targetRoom) {
   return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom)) : false;
 }
 function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
-  return isRecord19(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
+  return isRecord20(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource4(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
 }
 function recordColonyExpansionClaimVerification(input) {
   var _a;
   const colonyRoom = getVisibleRoom10(input.colony);
   const selection = (_a = colonyRoom == null ? void 0 : colonyRoom.memory) == null ? void 0 : _a.cachedExpansionSelection;
-  if (!isRecord19(selection) || selection.targetRoom !== input.targetRoom) {
+  if (!isRecord20(selection) || selection.targetRoom !== input.targetRoom) {
     return;
   }
   selection.claimExecution = {
@@ -25996,15 +26664,15 @@ function getClaimColony(creep, controller) {
   return (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller == null ? void 0 : controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown";
 }
 function isForeignOwnedController(controller) {
-  return controller.my !== true && isNonEmptyString20(getControllerOwnerUsername7(controller));
+  return controller.my !== true && isNonEmptyString21(getControllerOwnerUsername8(controller));
 }
 function isForeignReservedController3(controller, colony) {
   var _a, _b;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  if (!isNonEmptyString20(reservationUsername)) {
+  if (!isNonEmptyString21(reservationUsername)) {
     return false;
   }
-  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom10(colony != null ? colony : "")) == null ? void 0 : _b.controller);
+  return reservationUsername !== getControllerOwnerUsername8((_b = getVisibleRoom10(colony != null ? colony : "")) == null ? void 0 : _b.controller);
 }
 function getKnownActiveClaimPartCount(creep) {
   var _a;
@@ -26027,14 +26695,14 @@ function getBodyPartConstant6(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function isTerritoryAutomationSource3(source) {
-  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
+function isTerritoryAutomationSource4(source) {
+  return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "expansionPlanner" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord19(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord20(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isSameTarget2(left, right) {
-  return isRecord19(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord20(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
@@ -26043,16 +26711,16 @@ function getVisibleRoom10(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
-function getGameTime20() {
+function getGameTime21() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function getTerritoryMemoryRecord6() {
+function getTerritoryMemoryRecord7() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
-function getWritableTerritoryMemoryRecord5() {
+function getWritableTerritoryMemoryRecord6() {
   const memory = globalThis.Memory;
   if (!memory) {
     return null;
@@ -26071,28 +26739,28 @@ function findVisibleHostileCreeps2(room) {
 function findVisibleHostileStructures2(room) {
   return typeof FIND_HOSTILE_STRUCTURES === "number" && typeof room.find === "function" ? room.find(FIND_HOSTILE_STRUCTURES) : [];
 }
-function isControllerOwned3(controller) {
+function isControllerOwned4(controller) {
   return controller.my === true || controller.owner != null;
 }
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString20(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString21(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
-function getControllerOwnerUsername7(controller) {
+function getControllerOwnerUsername8(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString20(username) ? username : void 0;
+  return isNonEmptyString21(username) ? username : void 0;
 }
-function isRecord19(value) {
+function isRecord20(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString20(value) {
+function isNonEmptyString21(value) {
   return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/claimScoring.ts
-var EXIT_DIRECTION_ORDER5 = ["1", "3", "5", "7"];
+var EXIT_DIRECTION_ORDER6 = ["1", "3", "5", "7"];
 var TERRAIN_SCAN_MIN4 = 2;
 var TERRAIN_SCAN_MAX4 = 47;
 var DEFAULT_TERRAIN_WALL_MASK12 = 1;
@@ -26166,7 +26834,7 @@ function scoreClaimTarget(roomName, homeRoom) {
 }
 function selectBestClaimTarget(homeRoom) {
   var _a, _b;
-  const adjacentRooms = getAdjacentRoomNames6(homeRoom.name);
+  const adjacentRooms = getAdjacentRoomNames7(homeRoom.name);
   const candidates = adjacentRooms.map((roomName) => scoreClaimTarget(roomName, homeRoom)).filter((candidate) => candidate.sources > 0 && candidate.score > 0 && !hasUnclaimableController(candidate));
   candidates.sort(compareClaimScores);
   return (_b = (_a = candidates[0]) == null ? void 0 : _a.roomName) != null ? _b : null;
@@ -26189,14 +26857,14 @@ function getScoutIntel(homeRoomName, roomName) {
 }
 function countSources(room, scoutIntel) {
   if (room) {
-    return findRoomObjects17(room, "FIND_SOURCES").length;
+    return findRoomObjects18(room, "FIND_SOURCES").length;
   }
   return typeof (scoutIntel == null ? void 0 : scoutIntel.sourceCount) === "number" ? scoutIntel.sourceCount : 0;
 }
 function countHostiles(room, scoutIntel) {
   var _a, _b, _c;
   if (room) {
-    return findRoomObjects17(room, "FIND_HOSTILE_CREEPS").length + findRoomObjects17(room, "FIND_HOSTILE_STRUCTURES").length;
+    return findRoomObjects18(room, "FIND_HOSTILE_CREEPS").length + findRoomObjects18(room, "FIND_HOSTILE_STRUCTURES").length;
   }
   return ((_a = scoutIntel == null ? void 0 : scoutIntel.hostileCreepCount) != null ? _a : 0) + ((_b = scoutIntel == null ? void 0 : scoutIntel.hostileStructureCount) != null ? _b : 0) + ((_c = scoutIntel == null ? void 0 : scoutIntel.hostileSpawnCount) != null ? _c : 0);
 }
@@ -26207,7 +26875,7 @@ function scoreControllerDistance(room, details) {
     details.push("controller distance unknown");
     return 0;
   }
-  const ranges = findRoomObjects17(room, "FIND_SOURCES").map((source) => getRange2(controllerPos, source.pos)).filter((range) => typeof range === "number" && Number.isFinite(range));
+  const ranges = findRoomObjects18(room, "FIND_SOURCES").map((source) => getRange2(controllerPos, source.pos)).filter((range) => typeof range === "number" && Number.isFinite(range));
   if (ranges.length === 0) {
     details.push("controller distance unknown");
     return 0;
@@ -26251,20 +26919,20 @@ function getControllerStatus2(room, scoutIntel) {
     if (!controller) {
       return "missing";
     }
-    if (controller.my === true || isNonEmptyString21((_a = controller.owner) == null ? void 0 : _a.username)) {
+    if (controller.my === true || isNonEmptyString22((_a = controller.owner) == null ? void 0 : _a.username)) {
       return "owned";
     }
-    if (isNonEmptyString21((_b = controller.reservation) == null ? void 0 : _b.username)) {
+    if (isNonEmptyString22((_b = controller.reservation) == null ? void 0 : _b.username)) {
       return "reserved";
     }
     return "neutral";
   }
   if (scoutIntel == null ? void 0 : scoutIntel.controller) {
     const controller = scoutIntel.controller;
-    if (controller.my === true || isNonEmptyString21(controller.ownerUsername)) {
+    if (controller.my === true || isNonEmptyString22(controller.ownerUsername)) {
       return "owned";
     }
-    if (isNonEmptyString21(controller.reservationUsername)) {
+    if (isNonEmptyString22(controller.reservationUsername)) {
       return "reserved";
     }
     return "neutral";
@@ -26295,19 +26963,19 @@ function getRoomDistance(homeRoomName, roomName) {
   }
   return NO_ROUTE_DISTANCE;
 }
-function getAdjacentRoomNames6(roomName) {
+function getAdjacentRoomNames7(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord20(exits)) {
+  if (!isRecord21(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER5.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER6.flatMap((direction) => {
     const adjacentRoom = exits[direction];
-    return isNonEmptyString21(adjacentRoom) ? [adjacentRoom] : [];
+    return isNonEmptyString22(adjacentRoom) ? [adjacentRoom] : [];
   });
 }
 function getRoomTerrain12(roomName) {
@@ -26318,7 +26986,7 @@ function getRoomTerrain12(roomName) {
   }
   return gameMap.getRoomTerrain(roomName);
 }
-function findRoomObjects17(room, constantName) {
+function findRoomObjects18(room, constantName) {
   const findConstant = getGlobalNumber12(constantName);
   if (!room || typeof room.find !== "function" || typeof findConstant !== "number") {
     return [];
@@ -26341,10 +27009,10 @@ function getGlobalNumber12(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function isRecord20(value) {
+function isRecord21(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString21(value) {
+function isNonEmptyString22(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -26353,8 +27021,8 @@ var ADJACENT_ROOM_RESERVATION_TARGET_CREATOR = "adjacentRoomReservation";
 var MIN_ADJACENT_ROOM_RESERVATION_SCORE = 500;
 var ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS_PER_CLAIM_PART = 600;
 var MAX_ADJACENT_ROOM_RESERVATION_RENEWAL_TICKS = 1e3;
-var EXIT_DIRECTION_ORDER6 = ["1", "3", "5", "7"];
-function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime21(), options = {}) {
+var EXIT_DIRECTION_ORDER7 = ["1", "3", "5", "7"];
+function refreshAdjacentRoomReservationIntent(colony, gameTime = getGameTime22(), options = {}) {
   const evaluation = selectAdjacentRoomReservationPlan(colony, options);
   if (evaluation.status === "planned" && evaluation.targetRoom) {
     persistAdjacentRoomReservationIntent(colony.room.name, evaluation, gameTime);
@@ -26370,7 +27038,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
   if (!claimBlocker && options.reserveWhenClaimAllowed !== true) {
     return { status: "skipped", colony: colonyName, reason: "claimAllowed" };
   }
-  if (hasBlockingTerritoryPlan(colonyName)) {
+  if (hasBlockingTerritoryPlan2(colonyName)) {
     return {
       status: "skipped",
       colony: colonyName,
@@ -26388,9 +27056,9 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
     };
   }
   const renewalThresholdTicks = getAdjacentRoomReservationRenewalThreshold(claimPartCount);
-  const ownerUsername = getControllerOwnerUsername8(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername9(colony.room.controller);
   const expansionPriorities = getPersistedExpansionCandidatePriorities(colonyName);
-  const candidates = getAdjacentRoomNames7(colonyName).flatMap(
+  const candidates = getAdjacentRoomNames8(colonyName).flatMap(
     (roomName, order) => buildReservationCandidate(
       colony.room,
       roomName,
@@ -26430,7 +27098,7 @@ function selectAdjacentRoomReservationPlan(colony, options = {}) {
   };
 }
 function clearAdjacentRoomReservationIntent(colony) {
-  const territoryMemory = getTerritoryMemoryRecord7();
+  const territoryMemory = getTerritoryMemoryRecord8();
   if (!territoryMemory) {
     return;
   }
@@ -26545,9 +27213,9 @@ function getAdjacentRoomClaimBlocker(colony) {
   if (typeof controllerLevel !== "number" || controllerLevel < 2) {
     return "controllerLevelLow";
   }
-  const ownerUsername = getControllerOwnerUsername8(controller);
+  const ownerUsername = getControllerOwnerUsername9(controller);
   const ownedRoomCount = countVisibleOwnedRooms3(colony.room.name, ownerUsername);
-  const gclLevel = getGclLevel3();
+  const gclLevel = getGclLevel4();
   if (typeof gclLevel === "number" && ownedRoomCount >= gclLevel) {
     return "gclInsufficient";
   }
@@ -26576,11 +27244,11 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString22(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString23(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString22(controller.reservationUsername)) {
-    if (isNonEmptyString22(ownerUsername) && controller.reservationUsername === ownerUsername) {
+  if (isNonEmptyString23(controller.reservationUsername)) {
+    if (isNonEmptyString23(ownerUsername) && controller.reservationUsername === ownerUsername) {
       return {
         kind: "ownReserved",
         ...controller.id ? { controllerId: controller.id } : {},
@@ -26594,12 +27262,12 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
 function getVisibleControllerReservationState(controller, ownerUsername) {
   var _a;
   const controllerId = controller.id;
-  if (controller.my === true || isNonEmptyString22((_a = controller.owner) == null ? void 0 : _a.username)) {
+  if (controller.my === true || isNonEmptyString23((_a = controller.owner) == null ? void 0 : _a.username)) {
     return { kind: "owned", controllerId };
   }
   const reservation = controller.reservation;
-  if (isNonEmptyString22(reservation == null ? void 0 : reservation.username)) {
-    if (isNonEmptyString22(ownerUsername) && reservation.username === ownerUsername) {
+  if (isNonEmptyString23(reservation == null ? void 0 : reservation.username)) {
+    if (isNonEmptyString23(ownerUsername) && reservation.username === ownerUsername) {
       return {
         kind: "ownReserved",
         controllerId,
@@ -26620,13 +27288,13 @@ function hasHostilePresence2(colonyName, roomName) {
   return ((_a = scoutIntel == null ? void 0 : scoutIntel.hostileCreepCount) != null ? _a : 0) + ((_b = scoutIntel == null ? void 0 : scoutIntel.hostileStructureCount) != null ? _b : 0) + ((_c = scoutIntel == null ? void 0 : scoutIntel.hostileSpawnCount) != null ? _c : 0) > 0;
 }
 function countVisibleHostiles(room) {
-  return countVisibleRoomObjects2(room, getFindConstant7("FIND_HOSTILE_CREEPS")) + countVisibleRoomObjects2(room, getFindConstant7("FIND_HOSTILE_STRUCTURES"));
+  return countVisibleRoomObjects2(room, getFindConstant8("FIND_HOSTILE_CREEPS")) + countVisibleRoomObjects2(room, getFindConstant8("FIND_HOSTILE_STRUCTURES"));
 }
 function persistAdjacentRoomReservationIntent(colony, evaluation, gameTime) {
   if (!evaluation.targetRoom) {
     return;
   }
-  const territoryMemory = getWritableTerritoryMemoryRecord6();
+  const territoryMemory = getWritableTerritoryMemoryRecord7();
   if (!territoryMemory) {
     return;
   }
@@ -26689,7 +27357,7 @@ function upsertAdjacentRoomReservationTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord21(existingTarget)) {
+  if (isRecord22(existingTarget)) {
     existingTarget.createdBy = ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -26709,8 +27377,8 @@ function upsertAdjacentRoomReservationIntent(intents, nextIntent) {
   }
   intents.push(nextIntent);
 }
-function hasBlockingTerritoryPlan(colony) {
-  const territoryMemory = getTerritoryMemoryRecord7();
+function hasBlockingTerritoryPlan2(colony) {
+  const territoryMemory = getTerritoryMemoryRecord8();
   if (!territoryMemory) {
     return false;
   }
@@ -26722,38 +27390,38 @@ function hasBlockingTerritoryPlan(colony) {
   );
 }
 function isBlockingTerritoryTarget(target, colony) {
-  return isRecord21(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
+  return isRecord22(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
 }
 function isAdjacentRoomReservationTarget(target, colony) {
-  return isRecord21(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
+  return isRecord22(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
 }
 function isSameTarget3(left, right) {
-  return isRecord21(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord22(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
-function getAdjacentRoomNames7(roomName) {
+function getAdjacentRoomNames8(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord21(exits)) {
+  if (!isRecord22(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER6.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER7.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString22(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString23(exitRoom) ? [exitRoom] : [];
   });
 }
 function getPersistedExpansionCandidatePriorities(colony) {
   var _a;
-  const rawCandidates = (_a = getTerritoryMemoryRecord7()) == null ? void 0 : _a.expansionCandidates;
+  const rawCandidates = (_a = getTerritoryMemoryRecord8()) == null ? void 0 : _a.expansionCandidates;
   if (!Array.isArray(rawCandidates)) {
     return /* @__PURE__ */ new Map();
   }
   const priorities = /* @__PURE__ */ new Map();
   for (const [index, rawCandidate] of rawCandidates.entries()) {
-    if (!isRecord21(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString22(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
+    if (!isRecord22(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString23(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
       continue;
     }
     priorities.set(rawCandidate.roomName, {
@@ -26771,13 +27439,13 @@ function countVisibleOwnedRooms3(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString22(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString23(room.name) && (!ownerUsername || getControllerOwnerUsername9(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
   return Math.max(1, ownedRoomCount || (((_d = (_c = rooms[colonyName]) == null ? void 0 : _c.controller) == null ? void 0 : _d.my) === true ? 1 : 0));
 }
-function getGclLevel3() {
+function getGclLevel4() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   if (typeof level !== "number" || !Number.isFinite(level) || level <= 0) {
@@ -26800,14 +27468,14 @@ function countVisibleRoomObjects2(room, findConstant) {
   const result = room.find(findConstant);
   return Array.isArray(result) ? result.length : 0;
 }
-function getFindConstant7(name) {
+function getFindConstant8(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function getControllerOwnerUsername8(controller) {
+function getControllerOwnerUsername9(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString22(username) ? username : void 0;
+  return isNonEmptyString23(username) ? username : void 0;
 }
 function compareOptionalNumbers6(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
@@ -26824,11 +27492,11 @@ function compareOptionalNumbersDescending2(left, right) {
   }
   return right - left;
 }
-function getTerritoryMemoryRecord7() {
+function getTerritoryMemoryRecord8() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
-function getWritableTerritoryMemoryRecord6() {
+function getWritableTerritoryMemoryRecord7() {
   const root = globalThis;
   if (!root.Memory) {
     root.Memory = {};
@@ -26838,23 +27506,23 @@ function getWritableTerritoryMemoryRecord6() {
   }
   return root.Memory.territory;
 }
-function getGameTime21() {
+function getGameTime22() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString22(value) {
+function isNonEmptyString23(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord21(value) {
+function isRecord22(value) {
   return typeof value === "object" && value !== null;
 }
 
 // src/territory/colonyExpansionPlanner.ts
 var COLONY_EXPANSION_CLAIM_TARGET_CREATOR = "colonyExpansion";
 var MIN_COLONY_EXPANSION_CLAIM_SCORE = MIN_ADJACENT_ROOM_RESERVATION_SCORE;
-var EXIT_DIRECTION_ORDER7 = ["1", "3", "5", "7"];
-function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime22()) {
+var EXIT_DIRECTION_ORDER8 = ["1", "3", "5", "7"];
+function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime23()) {
   const colonyName = colony.room.name;
   if (assessment.territoryReady !== true) {
     const reservation2 = refreshAdjacentRoomReservationIntent(colony, gameTime, {
@@ -26928,17 +27596,17 @@ function refreshColonyExpansionIntent(colony, assessment, gameTime = getGameTime
   };
 }
 function clearColonyExpansionClaimIntent(colony) {
-  const territoryMemory = getTerritoryMemoryRecord8();
+  const territoryMemory = getTerritoryMemoryRecord9();
   if (!territoryMemory) {
     return;
   }
   pruneColonyExpansionClaimTargets(colony, territoryMemory);
 }
 function selectColonyExpansionCandidate(colony) {
-  const ownerUsername = getControllerOwnerUsername9(colony.room.controller);
+  const ownerUsername = getControllerOwnerUsername10(colony.room.controller);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString23(room.mineralType));
-  const candidates = getAdjacentRoomNames8(colony.room.name).flatMap((roomName, order) => {
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString24(room.mineralType));
+  const candidates = getAdjacentRoomNames9(colony.room.name).flatMap((roomName, order) => {
     const room = getVisibleRoom13(roomName);
     if (!room && !getScoutIntel3(colony.room.name, roomName)) {
       return [];
@@ -27071,12 +27739,12 @@ function isColonyReadyToClaimMatureReservation(colony, controllerState) {
   if (hasActivePostClaimBootstrap2(colony.room.name)) {
     return false;
   }
-  const ownerUsername = getControllerOwnerUsername9(controller);
+  const ownerUsername = getControllerOwnerUsername10(controller);
   const ownedRoomCount = countVisibleOwnedRooms4(colony.room.name, ownerUsername);
   if (ownedRoomCount >= maxRoomsForRcl(controllerLevel)) {
     return false;
   }
-  const gclLevel = getGclLevel4();
+  const gclLevel = getGclLevel5();
   return typeof gclLevel !== "number" || ownedRoomCount < gclLevel;
 }
 function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) {
@@ -27088,11 +27756,11 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
       return { kind: "missing" };
     }
     const controllerId = controller2.id;
-    if (controller2.my === true || isNonEmptyString23((_a = controller2.owner) == null ? void 0 : _a.username)) {
+    if (controller2.my === true || isNonEmptyString24((_a = controller2.owner) == null ? void 0 : _a.username)) {
       return { kind: "owned", controllerId };
     }
     const reservationUsername = (_b = controller2.reservation) == null ? void 0 : _b.username;
-    if (isNonEmptyString23(reservationUsername)) {
+    if (isNonEmptyString24(reservationUsername)) {
       return reservationUsername === ownerUsername ? {
         kind: "ownReserved",
         controllerId,
@@ -27109,10 +27777,10 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString23(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString24(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString23(controller.reservationUsername)) {
+  if (isNonEmptyString24(controller.reservationUsername)) {
     return controller.reservationUsername === ownerUsername ? {
       kind: "ownReserved",
       ...controller.id ? { controllerId: controller.id } : {},
@@ -27122,12 +27790,12 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   return { kind: "neutral", ...controller.id ? { controllerId: controller.id } : {} };
 }
 function hasBlockingClaimIntent(colony, targetRoom) {
-  const territoryMemory = getTerritoryMemoryRecord8();
+  const territoryMemory = getTerritoryMemoryRecord9();
   if (!territoryMemory) {
     return false;
   }
   if (Array.isArray(territoryMemory.targets) && territoryMemory.targets.some(
-    (target) => isRecord22(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
+    (target) => isRecord23(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
   )) {
     return true;
   }
@@ -27136,7 +27804,7 @@ function hasBlockingClaimIntent(colony, targetRoom) {
   );
 }
 function persistColonyExpansionClaimIntent(colony, candidate, gameTime) {
-  const territoryMemory = getWritableTerritoryMemoryRecord7();
+  const territoryMemory = getWritableTerritoryMemoryRecord8();
   if (!territoryMemory) {
     return;
   }
@@ -27150,10 +27818,10 @@ function persistColonyExpansionClaimIntent(colony, candidate, gameTime) {
   };
   pruneAdjacentReservationForTarget(colony, candidate.roomName, territoryMemory);
   pruneColonyExpansionClaimTargets(colony, territoryMemory, target);
-  upsertTerritoryTarget3(territoryMemory, target);
+  upsertTerritoryTarget4(territoryMemory, target);
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
-  upsertTerritoryIntent5(intents, {
+  upsertTerritoryIntent6(intents, {
     colony,
     targetRoom: candidate.roomName,
     action: "claim",
@@ -27173,13 +27841,13 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
   const removedRooms = /* @__PURE__ */ new Set();
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter((target) => {
-      if (!isRecord22(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
+      if (!isRecord23(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
         return true;
       }
       if (activeTarget && isSameTarget4(target, activeTarget)) {
         return true;
       }
-      if (isNonEmptyString23(target.roomName)) {
+      if (isNonEmptyString24(target.roomName)) {
         removedRooms.add(target.roomName);
       }
       return false;
@@ -27196,7 +27864,7 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
 function pruneAdjacentReservationForTarget(colony, targetRoom, territoryMemory) {
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter(
-      (target) => !(isRecord22(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
+      (target) => !(isRecord23(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
     );
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
@@ -27204,7 +27872,7 @@ function pruneAdjacentReservationForTarget(colony, targetRoom, territoryMemory) 
   );
   territoryMemory.intents = intents;
 }
-function upsertTerritoryTarget3(territoryMemory, target) {
+function upsertTerritoryTarget4(territoryMemory, target) {
   if (!Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = [];
   }
@@ -27213,7 +27881,7 @@ function upsertTerritoryTarget3(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord22(existingTarget)) {
+  if (isRecord23(existingTarget)) {
     existingTarget.createdBy = COLONY_EXPANSION_CLAIM_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.postClaimBootstrapReserveEnergy) {
@@ -27228,7 +27896,7 @@ function upsertTerritoryTarget3(territoryMemory, target) {
     }
   }
 }
-function upsertTerritoryIntent5(intents, nextIntent) {
+function upsertTerritoryIntent6(intents, nextIntent) {
   const existingIndex = intents.findIndex(
     (intent) => intent.colony === nextIntent.colony && intent.targetRoom === nextIntent.targetRoom && intent.action === nextIntent.action && intent.createdBy === nextIntent.createdBy
   );
@@ -27239,21 +27907,21 @@ function upsertTerritoryIntent5(intents, nextIntent) {
   intents.push(nextIntent);
 }
 function isSameTarget4(left, right) {
-  return isRecord22(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord23(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
-function getAdjacentRoomNames8(roomName) {
+function getAdjacentRoomNames9(roomName) {
   var _a;
   const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
   if (!gameMap || typeof gameMap.describeExits !== "function") {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord22(exits)) {
+  if (!isRecord23(exits)) {
     return [];
   }
-  return EXIT_DIRECTION_ORDER7.flatMap((direction) => {
+  return EXIT_DIRECTION_ORDER8.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString23(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString24(exitRoom) ? [exitRoom] : [];
   });
 }
 function getVisibleRoom13(roomName) {
@@ -27272,37 +27940,37 @@ function countVisibleOwnedRooms4(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString23(room.name) && (!ownerUsername || getControllerOwnerUsername9(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString24(room.name) && (!ownerUsername || getControllerOwnerUsername10(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
   return Math.max(1, ownedRoomCount || (((_d = (_c = rooms[colonyName]) == null ? void 0 : _c.controller) == null ? void 0 : _d.my) === true ? 1 : 0));
 }
-function getGclLevel4() {
+function getGclLevel5() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
 }
 function hasActivePostClaimBootstrap2(colonyName) {
   var _a;
-  const records = (_a = getTerritoryMemoryRecord8()) == null ? void 0 : _a.postClaimBootstraps;
-  if (!isRecord22(records)) {
+  const records = (_a = getTerritoryMemoryRecord9()) == null ? void 0 : _a.postClaimBootstraps;
+  if (!isRecord23(records)) {
     return false;
   }
   return Object.values(records).some(
-    (record) => isRecord22(record) && record.colony === colonyName && record.status !== "ready"
+    (record) => isRecord23(record) && record.colony === colonyName && record.status !== "ready"
   );
 }
-function getControllerOwnerUsername9(controller) {
+function getControllerOwnerUsername10(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString23(username) ? username : void 0;
+  return isNonEmptyString24(username) ? username : void 0;
 }
-function getTerritoryMemoryRecord8() {
+function getTerritoryMemoryRecord9() {
   var _a;
   return (_a = globalThis.Memory) == null ? void 0 : _a.territory;
 }
-function getWritableTerritoryMemoryRecord7() {
+function getWritableTerritoryMemoryRecord8() {
   const memory = globalThis.Memory;
   if (!memory) {
     return null;
@@ -27312,15 +27980,15 @@ function getWritableTerritoryMemoryRecord7() {
   }
   return memory.territory;
 }
-function getGameTime22() {
+function getGameTime23() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord22(value) {
+function isRecord23(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString23(value) {
+function isNonEmptyString24(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -27345,11 +28013,11 @@ function refreshClaimedRoomBootstrapperOwnership() {
     if (newlyClaimed) {
       detectedRoomNames.push(room.name);
     }
-    const claimedAt = newlyClaimed ? getGameTime23() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
+    const claimedAt = newlyClaimed ? getGameTime24() : (_a = previous == null ? void 0 : previous.claimedAt) != null ? _a : activePostClaimRecord == null ? void 0 : activePostClaimRecord.claimedAt;
     memory.rooms[room.name] = {
       roomName: room.name,
       owned,
-      updatedAt: getGameTime23(),
+      updatedAt: getGameTime24(),
       ...claimedAt !== void 0 ? { claimedAt } : {},
       ...newlyClaimed ? {} : (previous == null ? void 0 : previous.completedAt) !== void 0 ? { completedAt: previous.completedAt } : {}
     };
@@ -27372,14 +28040,14 @@ function getWritableBootstrapperMemory() {
 function getActivePostClaimBootstrapRecord(roomName) {
   var _a, _b, _c;
   const record = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps) == null ? void 0 : _c[roomName];
-  return isRecord23(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
+  return isRecord24(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
 }
-function getGameTime23() {
+function getGameTime24() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord23(value) {
+function isRecord24(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -27421,7 +28089,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
     return;
   }
   if (assignment.action === "scout") {
-    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime24(), creep.name, telemetryEvents);
+    recordVisibleRoomScoutIntel(creep.memory.colony, creep.room, getGameTime25(), creep.name, telemetryEvents);
     completeTerritoryAssignment(creep);
     return;
   }
@@ -27503,7 +28171,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   if (typeof creep.reserveController !== "function" || !canCreepReserveTerritoryController(creep, controller, creep.memory.colony)) {
     return false;
   }
-  const gameTime = getGameTime24();
+  const gameTime = getGameTime25();
   const reserveAssignment = {
     targetRoom: assignment.targetRoom,
     action: "reserve",
@@ -27523,7 +28191,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   return true;
 }
 function suppressTerritoryAssignment(creep, assignment) {
-  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime24());
+  suppressTerritoryIntent(creep.memory.colony, assignment, getGameTime25());
   completeTerritoryAssignment(creep);
 }
 function completeTerritoryAssignment(creep) {
@@ -27603,7 +28271,7 @@ function selectVisibleTargetRoomController(assignment) {
   }
   return (_c = (_b = (_a = game == null ? void 0 : game.rooms) == null ? void 0 : _a[assignment.targetRoom]) == null ? void 0 : _b.controller) != null ? _c : null;
 }
-function getGameTime24() {
+function getGameTime25() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
@@ -27775,11 +28443,11 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
       return creep.memory.colony === room.name || ((_a2 = creep.room) == null ? void 0 : _a2.name) === room.name;
     }
   );
-  const hostileCreeps = findRoomObjects18(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects18(room, "FIND_HOSTILE_STRUCTURES");
-  const ownedStructures = findRoomObjects18(room, "FIND_MY_STRUCTURES");
-  const constructionSites = findRoomObjects18(room, "FIND_MY_CONSTRUCTION_SITES");
-  const sources = findRoomObjects18(room, "FIND_SOURCES");
+  const hostileCreeps = findRoomObjects19(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects19(room, "FIND_HOSTILE_STRUCTURES");
+  const ownedStructures = findRoomObjects19(room, "FIND_MY_STRUCTURES");
+  const constructionSites = findRoomObjects19(room, "FIND_MY_CONSTRUCTION_SITES");
+  const sources = findRoomObjects19(room, "FIND_SOURCES");
   return {
     roomName: room.name,
     controllerLevel: (_a = room.controller) == null ? void 0 : _a.level,
@@ -27870,7 +28538,7 @@ function buildMemoryTerritoryState(roomName) {
   const expansionCandidates = [];
   if (Array.isArray(targets)) {
     for (const target of targets) {
-      if (!isRecord24(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+      if (!isRecord25(target) || target.colony !== roomName || typeof target.roomName !== "string") {
         continue;
       }
       const action = normalizeTerritoryAction(target.action);
@@ -27932,12 +28600,12 @@ function countVisibleOwnedRooms5() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord24(structure) && matchesStructureType21(structure.structureType, globalName, fallback)
+    (structure) => isRecord25(structure) && matchesStructureType21(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
   return structures.reduce((total, structure) => {
-    if (!isRecord24(structure)) {
+    if (!isRecord25(structure)) {
       return total;
     }
     const hits = finiteNumberOrNull(structure.hits);
@@ -27953,7 +28621,7 @@ function getStoredEnergy14(room) {
   return getEnergyInStore2(storage);
 }
 function getEnergyInStore2(object) {
-  if (!isRecord24(object) || !isRecord24(object.store)) {
+  if (!isRecord25(object) || !isRecord25(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -27964,7 +28632,7 @@ function getEnergyInStore2(object) {
   }
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
-function findRoomObjects18(room, constantName) {
+function findRoomObjects19(room, constantName) {
   const findConstant = getGlobalNumber13(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
@@ -28005,7 +28673,7 @@ function finiteNumberOrZero(value) {
 function finiteNumberOrNull(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function isRecord24(value) {
+function isRecord25(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -28315,17 +28983,17 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber9(refreshedAt) || !isRecord25(rawSelection) || !isNonEmptyString24(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber9(refreshedAt) || !isRecord26(rawSelection) || !isNonEmptyString25(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord25(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord26(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString24(rawSelection.targetRoom)) {
+    if (!isNonEmptyString25(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -28362,7 +29030,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord25(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord26(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -28374,7 +29042,7 @@ function getNextExpansionSelectionCacheStateKey(colony) {
     colony.room.name,
     colony.energyCapacityAvailable,
     controllerLevel,
-    (_a = getGclLevel5()) != null ? _a : "unknown",
+    (_a = getGclLevel6()) != null ? _a : "unknown",
     countVisibleOwnedRooms6(),
     downgradeState,
     countActivePostClaimBootstraps3(),
@@ -28392,7 +29060,7 @@ function countVisibleOwnedRooms6() {
     return ((_a2 = room == null ? void 0 : room.controller) == null ? void 0 : _a2.my) === true;
   }).length;
 }
-function getGclLevel5() {
+function getGclLevel6() {
   var _a, _b;
   const level = (_b = (_a = globalThis.Game) == null ? void 0 : _a.gcl) == null ? void 0 : _b.level;
   return typeof level === "number" && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
@@ -28400,37 +29068,37 @@ function getGclLevel5() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord25(records)) {
+  if (!isRecord26(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord25(record) && record.status !== "ready"
+    (record) => isRecord26(record) && record.status !== "ready"
   ).length;
 }
 function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel;
-  if (!isRecord25(records)) {
+  if (!isRecord26(records)) {
     return 0;
   }
   let latestUpdatedAt = 0;
   for (const record of Object.values(records)) {
-    if (isRecord25(record) && record.colony === colony && isFiniteNumber9(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
+    if (isRecord26(record) && record.colony === colony && isFiniteNumber9(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
       latestUpdatedAt = record.updatedAt;
     }
   }
   return latestUpdatedAt;
 }
-function isRecord25(value) {
+function isRecord26(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString24(value) {
+function isNonEmptyString25(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber9(value) {
   return typeof value === "number" && Number.isFinite(value);
 }
-function normalizeNonNegativeInteger6(value) {
+function normalizeNonNegativeInteger7(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 function planCoordinatedSpawn(colony, roleCounts, gameTime, options, colonies, creeps, usedSpawnsByRoom, reservedSpawnEnergyByRoom, plannedRoleCountsByRoom, survivalAssessment) {
@@ -28479,8 +29147,8 @@ function createSpawnPlanningColony(colony, sourceColony, energyAvailable, usedSp
   return {
     ...colony,
     energyAvailable,
-    energyCapacityAvailable: normalizeNonNegativeInteger6(sourceColony.energyCapacityAvailable),
-    spawnEnergyBudget: normalizeNonNegativeInteger6(energyAvailable),
+    energyCapacityAvailable: normalizeNonNegativeInteger7(sourceColony.energyCapacityAvailable),
+    spawnEnergyBudget: normalizeNonNegativeInteger7(energyAvailable),
     spawns: sourceColony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn))
   };
 }
@@ -28529,7 +29197,7 @@ function canUseCrossRoomSpawnSource(sourceColony, creeps, usedSpawnsByRoom, rese
   return survival.mode === "TERRITORY_READY" && !survival.controllerDowngradeGuard && !survival.hostilePresence;
 }
 function compareCoordinatedSpawnSources(left, right, reservedSpawnEnergyByRoom) {
-  return getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger6(right.energyCapacityAvailable) - normalizeNonNegativeInteger6(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
+  return getAvailableSpawnEnergy(right, reservedSpawnEnergyByRoom) - getAvailableSpawnEnergy(left, reservedSpawnEnergyByRoom) || normalizeNonNegativeInteger7(right.energyCapacityAvailable) - normalizeNonNegativeInteger7(left.energyCapacityAvailable) || left.room.name.localeCompare(right.room.name);
 }
 function getUnusedSpawnCount(colony, usedSpawnsByRoom) {
   var _a;
@@ -28537,7 +29205,7 @@ function getUnusedSpawnCount(colony, usedSpawnsByRoom) {
   return colony.spawns.filter((spawn) => !spawn.spawning && !usedSpawns.has(spawn)).length;
 }
 function hasFullSpawnEnergyAfterReservations(colony, reservedSpawnEnergyByRoom) {
-  const energyCapacity = normalizeNonNegativeInteger6(colony.energyCapacityAvailable);
+  const energyCapacity = normalizeNonNegativeInteger7(colony.energyCapacityAvailable);
   return energyCapacity > 0 && getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) >= energyCapacity;
 }
 function getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) {
@@ -28547,7 +29215,7 @@ function getAvailableSpawnEnergy(colony, reservedSpawnEnergyByRoom) {
   }
   return Math.max(
     0,
-    normalizeNonNegativeInteger6(colony.energyAvailable) - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0)
+    normalizeNonNegativeInteger7(colony.energyAvailable) - ((_a = reservedSpawnEnergyByRoom.get(colony.room.name)) != null ? _a : 0)
   );
 }
 function refreshSpawnEnergyBufferStates(colonies, reservedSpawnEnergyByRoom) {
@@ -28803,7 +29471,7 @@ var Kernel = class {
     this.dependencies.cleanupDeadCreepMemory();
     const defenseEvents = this.dependencies.runDefense();
     return this.dependencies.runEconomy(
-      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime25())
+      selectForwardedDefenseEvents(defenseEvents, this.lastForwardedDefenseEventTick, getGameTime26())
     );
   }
 };
@@ -28875,7 +29543,7 @@ function getDefenseEventPriority(event) {
       return 3;
   }
 }
-function getGameTime25() {
+function getGameTime26() {
   return typeof Game !== "undefined" && typeof Game.time === "number" ? Game.time : 0;
 }
 
@@ -29705,10 +30373,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord26(rawReplay)) {
+  if (!isRecord27(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString25(rawReplay.replayId) || !isNonEmptyString25(rawReplay.room) || !isFiniteNumber10(rawReplay.startTick) || !isFiniteNumber10(rawReplay.endTick) || !isFiniteNumber10(rawReplay.finalScore) || !isRecord26(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString26(rawReplay.replayId) || !isNonEmptyString26(rawReplay.room) || !isFiniteNumber10(rawReplay.startTick) || !isFiniteNumber10(rawReplay.endTick) || !isFiniteNumber10(rawReplay.finalScore) || !isRecord27(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -29733,10 +30401,10 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord26(value) {
+function isRecord27(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString25(value) {
+function isNonEmptyString26(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber10(value) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8244,7 +8244,7 @@ var ERR_NO_PATH_CODE4 = -2;
 var SOURCE_SCORE_WEIGHT = 1e3;
 var DISTANCE_SCORE_WEIGHT = 100;
 var EXPANSION_PLANNER_TARGET_CREATOR = "expansionPlanner";
-function evaluateExpansionRoomSuitability(room) {
+function evaluateExpansionRoomSuitability(room, colonyOwnerUsername) {
   var _a;
   const ownerUsername = getControllerOwnerUsername4(room.controller);
   const reservationUsername = getControllerReservationUsername3(room.controller);
@@ -8258,6 +8258,7 @@ function evaluateExpansionRoomSuitability(room) {
     ...((_a = room.controller) == null ? void 0 : _a.id) ? { controllerId: room.controller.id } : {},
     ...ownerUsername ? { ownerUsername } : {},
     ...reservationUsername ? { reservationUsername } : {},
+    ...colonyOwnerUsername ? { colonyOwnerUsername } : {},
     hasController: room.controller !== void 0
   });
 }
@@ -8282,7 +8283,7 @@ function buildRuntimeExpansionPlannerCandidates(colony) {
       if (!room) {
         continue;
       }
-      candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, 1, order));
+      candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, 1, order, ownerUsername));
       order += 1;
     }
   }
@@ -8295,7 +8296,7 @@ function buildRuntimeExpansionPlannerCandidates(colony) {
       continue;
     }
     seenRooms.add(room.name);
-    candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, distance, order));
+    candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, distance, order, ownerUsername));
     order += 1;
   }
   return candidates.filter((candidate) => candidate.suitable).sort(compareExpansionPlannerCandidates);
@@ -8426,6 +8427,7 @@ function evaluateExpansionSuitability({
   controllerId,
   ownerUsername,
   reservationUsername,
+  colonyOwnerUsername,
   hasController
 }) {
   const normalizedSourceCount = normalizeNonNegativeInteger4(sourceCount);
@@ -8442,7 +8444,7 @@ function evaluateExpansionSuitability({
     reasons.push("controllerMissing");
   } else if (isNonEmptyString9(ownerUsername)) {
     reasons.push("controllerOwned");
-  } else if (isNonEmptyString9(reservationUsername)) {
+  } else if (isNonEmptyString9(reservationUsername) && (!isNonEmptyString9(colonyOwnerUsername) || reservationUsername !== colonyOwnerUsername)) {
     reasons.push("controllerReserved");
   }
   return {
@@ -8456,8 +8458,8 @@ function evaluateExpansionSuitability({
     ...reservationUsername ? { reservationUsername } : {}
   };
 }
-function toRuntimeExpansionPlannerCandidate(colony, room, distance, order) {
-  const suitability = evaluateExpansionRoomSuitability(room);
+function toRuntimeExpansionPlannerCandidate(colony, room, distance, order, colonyOwnerUsername) {
+  const suitability = evaluateExpansionRoomSuitability(room, colonyOwnerUsername);
   const normalizedDistance = Math.max(1, normalizeNonNegativeInteger4(distance));
   return {
     colony,

--- a/prod/src/construction/criticalRoads.ts
+++ b/prod/src/construction/criticalRoads.ts
@@ -299,7 +299,7 @@ function hasRemoteTerritoryReference(value: unknown, roomName: string, roomKey: 
       isNonEmptyString(entry.colony) &&
       entry.colony !== roomName &&
       isTerritoryControlAction(entry.action) &&
-      entry.status !== 'suppressed' &&
+      (entry.status === undefined || entry.status === 'planned' || entry.status === 'active') &&
       entry.enabled !== false
     );
   });

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -1460,7 +1460,7 @@ function canAffordBody(body: BodyPartConstant[], energyAvailable: number): boole
   return body.length > 0 && getBodyCost(body) <= energyAvailable;
 }
 
-function buildTerritorySpawnBody(energyAvailable: number, intent: TerritoryIntentPlan): BodyPartConstant[] {
+export function buildTerritorySpawnBody(energyAvailable: number, intent: TerritoryIntentPlan): BodyPartConstant[] {
   if (intent.action === 'scout') {
     return energyAvailable >= TERRITORY_SCOUT_BODY_COST ? [...TERRITORY_SCOUT_BODY] : [];
   }

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -1624,6 +1624,7 @@ function isTerritoryAutomationSource(source: unknown): source is TerritoryAutoma
     source === 'occupationRecommendation' ||
     source === 'autonomousExpansionClaim' ||
     source === 'colonyExpansion' ||
+    source === 'expansionPlanner' ||
     source === 'nextExpansionScoring' ||
     source === 'adjacentRoomReservation'
   );

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -79,7 +79,10 @@ interface ExpansionReservationUpgradeContext {
   action: TerritoryControlAction;
 }
 
-export function evaluateExpansionRoomSuitability(room: Room): ExpansionRoomSuitability {
+export function evaluateExpansionRoomSuitability(
+  room: Room,
+  colonyOwnerUsername?: string
+): ExpansionRoomSuitability {
   const ownerUsername = getControllerOwnerUsername(room.controller);
   const reservationUsername = getControllerReservationUsername(room.controller);
   return evaluateExpansionSuitability({
@@ -92,6 +95,7 @@ export function evaluateExpansionRoomSuitability(room: Room): ExpansionRoomSuita
     ...(room.controller?.id ? { controllerId: room.controller.id } : {}),
     ...(ownerUsername ? { ownerUsername } : {}),
     ...(reservationUsername ? { reservationUsername } : {}),
+    ...(colonyOwnerUsername ? { colonyOwnerUsername } : {}),
     hasController: room.controller !== undefined
   });
 }
@@ -160,7 +164,7 @@ export function buildRuntimeExpansionPlannerCandidates(
         continue;
       }
 
-      candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, 1, order));
+      candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, 1, order, ownerUsername));
       order += 1;
     }
   }
@@ -182,7 +186,7 @@ export function buildRuntimeExpansionPlannerCandidates(
     }
 
     seenRooms.add(room.name);
-    candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, distance, order));
+    candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, distance, order, ownerUsername));
     order += 1;
   }
 
@@ -341,6 +345,7 @@ function evaluateExpansionSuitability({
   controllerId,
   ownerUsername,
   reservationUsername,
+  colonyOwnerUsername,
   hasController
 }: {
   sourceCount: number;
@@ -349,6 +354,7 @@ function evaluateExpansionSuitability({
   controllerId?: Id<StructureController>;
   ownerUsername?: string;
   reservationUsername?: string;
+  colonyOwnerUsername?: string;
   hasController: boolean;
 }): ExpansionRoomSuitability {
   const normalizedSourceCount = normalizeNonNegativeInteger(sourceCount);
@@ -368,7 +374,10 @@ function evaluateExpansionSuitability({
     reasons.push('controllerMissing');
   } else if (isNonEmptyString(ownerUsername)) {
     reasons.push('controllerOwned');
-  } else if (isNonEmptyString(reservationUsername)) {
+  } else if (
+    isNonEmptyString(reservationUsername) &&
+    (!isNonEmptyString(colonyOwnerUsername) || reservationUsername !== colonyOwnerUsername)
+  ) {
     reasons.push('controllerReserved');
   }
 
@@ -388,9 +397,10 @@ function toRuntimeExpansionPlannerCandidate(
   colony: string,
   room: Room,
   distance: number,
-  order: number
+  order: number,
+  colonyOwnerUsername: string | undefined
 ): ExpansionPlannerCandidate {
-  const suitability = evaluateExpansionRoomSuitability(room);
+  const suitability = evaluateExpansionRoomSuitability(room, colonyOwnerUsername);
   const normalizedDistance = Math.max(1, normalizeNonNegativeInteger(distance));
   return {
     colony,

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -9,6 +9,9 @@ const EXIT_DIRECTION_ORDER = ['1', '3', '5', '7'];
 const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const SOURCE_SCORE_WEIGHT = 1_000;
 const DISTANCE_SCORE_WEIGHT = 100;
+const EXPANSION_PLANNER_TARGET_CREATOR: TerritoryAutomationSource = 'expansionPlanner';
+
+type TerminalExpansionIntentStatus = Extract<TerritoryIntentMemory['status'], 'inactive' | 'completed'>;
 
 export type ExpansionRoomUnsuitableReason =
   | 'sourceCountBelowMinimum'
@@ -197,6 +200,10 @@ export function refreshExpansionPlannerIntent(
   }
 
   const territoryMemory = getTerritoryMemoryRecord();
+  if (territoryMemory) {
+    refreshTerminalExpansionPlans(territoryMemory, colonyName, gameTime);
+  }
+
   if (territoryMemory && hasBlockingTerritoryPlan(territoryMemory, colonyName)) {
     return {
       status: 'skipped',
@@ -244,12 +251,34 @@ export function createExpansionIntent(
   action: TerritoryControlAction,
   gameTime = getGameTime()
 ): ExpansionPlannerIntent | null {
-  if (!candidate.suitable) {
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
     return null;
   }
 
-  const territoryMemory = getWritableTerritoryMemoryRecord();
-  if (!territoryMemory) {
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIntent = findExpansionIntent(intents, candidate.colony, candidate.roomName, action);
+  const existingTarget = findExpansionTarget(territoryMemory, candidate.colony, candidate.roomName, action);
+  const terminalStatus = getCandidateTerminalExpansionStatus(candidate, action, existingIntent);
+  if (terminalStatus && (existingIntent || existingTarget)) {
+    persistTerminalExpansionPlan(
+      territoryMemory,
+      intents,
+      {
+        colony: candidate.colony,
+        roomName: candidate.roomName,
+        action,
+        createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+        ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
+      },
+      terminalStatus,
+      gameTime
+    );
+    return null;
+  }
+
+  if (!candidate.suitable) {
     return null;
   }
 
@@ -257,24 +286,18 @@ export function createExpansionIntent(
     colony: candidate.colony,
     roomName: candidate.roomName,
     action,
+    createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
     ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
   };
   upsertTerritoryTarget(territoryMemory, target);
 
-  const intents = normalizeTerritoryIntents(territoryMemory.intents);
-  territoryMemory.intents = intents;
-  const existingIntent = intents.find(
-    (intent) =>
-      intent.colony === candidate.colony &&
-      intent.targetRoom === candidate.roomName &&
-      intent.action === action
-  );
   upsertTerritoryIntent(intents, {
     colony: candidate.colony,
     targetRoom: candidate.roomName,
     action,
     status: existingIntent?.status === 'active' ? 'active' : 'planned',
     updatedAt: gameTime,
+    createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
     ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
   });
 
@@ -391,9 +414,82 @@ function selectExpansionIntentAction(colony: ColonySnapshot): TerritoryControlAc
   return 'claim';
 }
 
+function refreshTerminalExpansionPlans(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  gameTime: number
+): void {
+  const ownerUsername = getVisibleColonyOwnerUsername(colony);
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  const refreshedPlans = new Set<string>();
+  let changed = false;
+
+  for (const rawTarget of Array.isArray(territoryMemory.targets) ? territoryMemory.targets : []) {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (
+      !target ||
+      target.colony !== colony ||
+      target.roomName === colony ||
+      target.enabled === false ||
+      target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR ||
+      !isExpansionControlAction(target.action)
+    ) {
+      continue;
+    }
+
+    const existingIntent = findExpansionIntent(intents, target.colony, target.roomName, target.action);
+    const terminalStatus =
+      getTerminalIntentStatus(existingIntent) ?? getVisibleExpansionTargetTerminalStatus(target, ownerUsername);
+    if (!terminalStatus) {
+      continue;
+    }
+
+    persistTerminalExpansionPlan(territoryMemory, intents, target, terminalStatus, gameTime);
+    refreshedPlans.add(getExpansionPlanKey(target.colony, target.roomName, target.action));
+    changed = true;
+  }
+
+  for (const intent of intents) {
+    if (
+      intent.colony !== colony ||
+      intent.targetRoom === colony ||
+      !isExpansionControlAction(intent.action) ||
+      intent.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR
+    ) {
+      continue;
+    }
+
+    const planKey = getExpansionPlanKey(intent.colony, intent.targetRoom, intent.action);
+    if (refreshedPlans.has(planKey)) {
+      continue;
+    }
+
+    const target: TerritoryTargetMemory = {
+      colony: intent.colony,
+      roomName: intent.targetRoom,
+      action: intent.action,
+      createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+      ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
+    };
+    const terminalStatus =
+      getTerminalIntentStatus(intent) ?? getVisibleExpansionTargetTerminalStatus(target, ownerUsername);
+    if (!terminalStatus) {
+      continue;
+    }
+
+    persistTerminalExpansionPlan(territoryMemory, intents, target, terminalStatus, gameTime);
+    changed = true;
+  }
+
+  if (changed) {
+    territoryMemory.intents = intents;
+  }
+}
+
 function hasBlockingTerritoryPlan(territoryMemory: TerritoryMemory, colony: string): boolean {
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
   if (
-    normalizeTerritoryIntents(territoryMemory.intents).some(
+    intents.some(
       (intent) =>
         intent.colony === colony &&
         intent.targetRoom !== colony &&
@@ -407,13 +503,31 @@ function hasBlockingTerritoryPlan(territoryMemory: TerritoryMemory, colony: stri
   return Array.isArray(territoryMemory.targets)
     ? territoryMemory.targets.some(
         (target) =>
-          isRecord(target) &&
-          target.colony === colony &&
-          target.roomName !== colony &&
-          target.enabled !== false &&
-          (target.action === 'claim' || target.action === 'reserve')
+          isBlockingExpansionTarget(target, colony, intents)
       )
     : false;
+}
+
+function persistTerminalExpansionPlan(
+  territoryMemory: TerritoryMemory,
+  intents: TerritoryIntentMemory[],
+  target: TerritoryTargetMemory,
+  status: TerminalExpansionIntentStatus,
+  gameTime: number
+): void {
+  if (findExpansionTarget(territoryMemory, target.colony, target.roomName, target.action)) {
+    upsertTerritoryTarget(territoryMemory, { ...target, enabled: false });
+  }
+
+  upsertTerritoryIntent(intents, {
+    colony: target.colony,
+    targetRoom: target.roomName,
+    action: target.action,
+    status,
+    updatedAt: gameTime,
+    createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+    ...(target.controllerId ? { controllerId: target.controllerId } : {})
+  });
 }
 
 function upsertTerritoryTarget(territoryMemory: TerritoryMemory, target: TerritoryTargetMemory): void {
@@ -426,7 +540,8 @@ function upsertTerritoryTarget(territoryMemory: TerritoryMemory, target: Territo
       isRecord(candidate) &&
       candidate.colony === target.colony &&
       candidate.roomName === target.roomName &&
-      candidate.action === target.action
+      candidate.action === target.action &&
+      candidate.createdBy === target.createdBy
   );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
@@ -434,6 +549,7 @@ function upsertTerritoryTarget(territoryMemory: TerritoryMemory, target: Territo
   }
 
   existingTarget.enabled = target.enabled;
+  existingTarget.createdBy = target.createdBy;
   if (target.controllerId) {
     existingTarget.controllerId = target.controllerId;
   } else {
@@ -449,7 +565,8 @@ function upsertTerritoryIntent(
     (intent) =>
       intent.colony === nextIntent.colony &&
       intent.targetRoom === nextIntent.targetRoom &&
-      intent.action === nextIntent.action
+      intent.action === nextIntent.action &&
+      intent.createdBy === nextIntent.createdBy
   );
   if (existingIndex >= 0) {
     intents[existingIndex] = nextIntent;
@@ -457,6 +574,194 @@ function upsertTerritoryIntent(
   }
 
   intents.push(nextIntent);
+}
+
+function findExpansionIntent(
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  targetRoom: string,
+  action: TerritoryControlAction
+): TerritoryIntentMemory | undefined {
+  return intents.find(
+    (intent) =>
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      intent.action === action &&
+      intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR
+  );
+}
+
+function findExpansionTarget(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  roomName: string,
+  action: TerritoryControlAction
+): TerritoryTargetMemory | null {
+  if (!Array.isArray(territoryMemory.targets)) {
+    return null;
+  }
+
+  return (
+    territoryMemory.targets
+      .map(normalizeTerritoryTarget)
+      .find(
+        (target): target is TerritoryTargetMemory =>
+          target !== null &&
+          target.colony === colony &&
+          target.roomName === roomName &&
+          target.action === action &&
+          target.createdBy === EXPANSION_PLANNER_TARGET_CREATOR
+      ) ?? null
+  );
+}
+
+function isBlockingExpansionTarget(
+  rawTarget: unknown,
+  colony: string,
+  intents: TerritoryIntentMemory[]
+): boolean {
+  if (!isRecord(rawTarget)) {
+    return false;
+  }
+
+  const target = normalizeTerritoryTarget(rawTarget);
+  if (
+    !target ||
+    target.colony !== colony ||
+    target.roomName === colony ||
+    target.enabled === false ||
+    !isExpansionControlAction(target.action)
+  ) {
+    return false;
+  }
+
+  if (target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR) {
+    return true;
+  }
+
+  const matchingIntent = findExpansionIntent(intents, target.colony, target.roomName, target.action);
+  return getTerminalIntentStatus(matchingIntent) === null;
+}
+
+function getExpansionPlanKey(colony: string, targetRoom: string, action: TerritoryControlAction): string {
+  return `${colony}:${targetRoom}:${action}`;
+}
+
+function getCandidateTerminalExpansionStatus(
+  candidate: ExpansionPlannerCandidate,
+  action: TerritoryControlAction,
+  existingIntent: TerritoryIntentMemory | undefined
+): TerminalExpansionIntentStatus | null {
+  const terminalStatus = getTerminalIntentStatus(existingIntent);
+  if (terminalStatus) {
+    return terminalStatus;
+  }
+
+  if (candidate.suitable) {
+    return null;
+  }
+
+  const ownerUsername = getVisibleColonyOwnerUsername(candidate.colony);
+  if (action === 'claim' && candidate.ownerUsername && candidate.ownerUsername === ownerUsername) {
+    return 'completed';
+  }
+
+  if (action === 'reserve' && candidate.reservationUsername && candidate.reservationUsername === ownerUsername) {
+    return 'completed';
+  }
+
+  return 'inactive';
+}
+
+function getTerminalIntentStatus(
+  intent: TerritoryIntentMemory | undefined
+): TerminalExpansionIntentStatus | null {
+  return intent?.status === 'completed' || intent?.status === 'inactive' ? intent.status : null;
+}
+
+function getVisibleExpansionTargetTerminalStatus(
+  target: TerritoryTargetMemory,
+  ownerUsername: string | undefined
+): TerminalExpansionIntentStatus | null {
+  const room = getGameRooms()?.[target.roomName];
+  if (!room) {
+    return null;
+  }
+
+  if (
+    findRoomObjects<Creep>(room, getFindConstant('FIND_HOSTILE_CREEPS')).length > 0 ||
+    findRoomObjects<AnyStructure>(room, getFindConstant('FIND_HOSTILE_STRUCTURES')).length > 0
+  ) {
+    return 'inactive';
+  }
+
+  const controller = room.controller;
+  if (!controller) {
+    return 'inactive';
+  }
+
+  if (target.action === 'claim') {
+    if (isControllerOwnedByUsername(controller, ownerUsername)) {
+      return 'completed';
+    }
+
+    return isControllerOwned(controller) ? 'inactive' : null;
+  }
+
+  if (isControllerOwnedByUsername(controller, ownerUsername)) {
+    return 'completed';
+  }
+
+  if (isControllerOwned(controller)) {
+    return 'inactive';
+  }
+
+  const reservationUsername = getControllerReservationUsername(controller);
+  if (!reservationUsername) {
+    return null;
+  }
+
+  return reservationUsername === ownerUsername ? 'completed' : 'inactive';
+}
+
+function normalizeTerritoryTarget(rawTarget: unknown): TerritoryTargetMemory | null {
+  if (!isRecord(rawTarget)) {
+    return null;
+  }
+
+  if (
+    !isNonEmptyString(rawTarget.colony) ||
+    !isNonEmptyString(rawTarget.roomName) ||
+    !isExpansionControlAction(rawTarget.action)
+  ) {
+    return null;
+  }
+
+  return {
+    colony: rawTarget.colony,
+    roomName: rawTarget.roomName,
+    action: rawTarget.action,
+    ...(typeof rawTarget.controllerId === 'string'
+      ? { controllerId: rawTarget.controllerId as Id<StructureController> }
+      : {}),
+    ...(rawTarget.enabled === false ? { enabled: false } : {}),
+    ...(isTerritoryAutomationSource(rawTarget.createdBy) ? { createdBy: rawTarget.createdBy } : {})
+  };
+}
+
+function isExpansionControlAction(action: unknown): action is TerritoryControlAction {
+  return action === 'claim' || action === 'reserve';
+}
+
+function isTerritoryAutomationSource(source: unknown): source is TerritoryAutomationSource {
+  return (
+    source === 'occupationRecommendation' ||
+    source === 'autonomousExpansionClaim' ||
+    source === 'colonyExpansion' ||
+    source === 'expansionPlanner' ||
+    source === 'nextExpansionScoring' ||
+    source === 'adjacentRoomReservation'
+  );
 }
 
 function getNearestOwnedRoomDistance(ownedRoomNames: Set<string>, roomName: string): number | null {
@@ -546,10 +851,31 @@ function getControllerOwnerUsername(controller: StructureController | undefined)
   return controller?.my === true ? 'me' : undefined;
 }
 
+function getVisibleColonyOwnerUsername(colony: string): string | undefined {
+  return getControllerOwnerUsername(getGameRooms()?.[colony]?.controller);
+}
+
 function getControllerReservationUsername(controller: StructureController | undefined): string | undefined {
   const username = (controller as (StructureController & { reservation?: { username?: string } }) | undefined)
     ?.reservation?.username;
   return isNonEmptyString(username) ? username : undefined;
+}
+
+function isControllerOwnedByUsername(
+  controller: StructureController | undefined,
+  ownerUsername: string | undefined
+): boolean {
+  const controllerOwnerUsername = getControllerOwnerUsername(controller);
+  return (
+    controller?.my === true ||
+    (isNonEmptyString(ownerUsername) &&
+      isNonEmptyString(controllerOwnerUsername) &&
+      controllerOwnerUsername === ownerUsername)
+  );
+}
+
+function isControllerOwned(controller: StructureController | undefined): boolean {
+  return controller?.my === true || controller?.owner != null;
 }
 
 function findRoomObjects<T>(room: Room, findConstant: number | undefined): T[] {

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -1,0 +1,623 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { maxRoomsForRcl } from './expansionScoring';
+import { normalizeTerritoryIntents } from './territoryMemoryUtils';
+
+export const EXPANSION_PLANNER_MIN_SOURCE_COUNT = 2;
+export const EXPANSION_PLANNER_MAX_ROUTE_DISTANCE = 2;
+
+const EXIT_DIRECTION_ORDER = ['1', '3', '5', '7'];
+const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
+const SOURCE_SCORE_WEIGHT = 1_000;
+const DISTANCE_SCORE_WEIGHT = 100;
+
+export type ExpansionRoomUnsuitableReason =
+  | 'sourceCountBelowMinimum'
+  | 'hostilePresence'
+  | 'controllerMissing'
+  | 'controllerOwned'
+  | 'controllerReserved';
+
+export type ExpansionPlannerSkipReason = 'existingTerritoryPlan' | 'memoryUnavailable' | 'noCandidate';
+
+export interface ExpansionRoomSuitability {
+  suitable: boolean;
+  sourceCount: number;
+  hostileCreepCount: number;
+  hostileStructureCount: number;
+  reasons: ExpansionRoomUnsuitableReason[];
+  controllerId?: Id<StructureController>;
+  ownerUsername?: string;
+  reservationUsername?: string;
+}
+
+export interface ExpansionPlannerCandidateInput {
+  colony: string;
+  roomName: string;
+  distance: number;
+  sourceCount: number;
+  order?: number;
+  hostileCreepCount?: number;
+  hostileStructureCount?: number;
+  controllerId?: Id<StructureController>;
+  ownerUsername?: string;
+  reservationUsername?: string;
+}
+
+export interface ExpansionPlannerCandidate extends ExpansionRoomSuitability {
+  colony: string;
+  roomName: string;
+  distance: number;
+  order: number;
+  score: number;
+}
+
+export interface ExpansionPlannerIntent {
+  colony: string;
+  targetRoom: string;
+  action: TerritoryControlAction;
+  score: number;
+  controllerId?: Id<StructureController>;
+}
+
+export interface ExpansionPlannerEvaluation {
+  status: 'planned' | 'skipped';
+  colony: string;
+  candidates: ExpansionPlannerCandidate[];
+  reason?: ExpansionPlannerSkipReason;
+  targetRoom?: string;
+  action?: TerritoryControlAction;
+  score?: number;
+  controllerId?: Id<StructureController>;
+}
+
+export function evaluateExpansionRoomSuitability(room: Room): ExpansionRoomSuitability {
+  const ownerUsername = getControllerOwnerUsername(room.controller);
+  const reservationUsername = getControllerReservationUsername(room.controller);
+  return evaluateExpansionSuitability({
+    sourceCount: findRoomObjects<Source>(room, getFindConstant('FIND_SOURCES')).length,
+    hostileCreepCount: findRoomObjects<Creep>(room, getFindConstant('FIND_HOSTILE_CREEPS')).length,
+    hostileStructureCount: findRoomObjects<AnyStructure>(
+      room,
+      getFindConstant('FIND_HOSTILE_STRUCTURES')
+    ).length,
+    ...(room.controller?.id ? { controllerId: room.controller.id } : {}),
+    ...(ownerUsername ? { ownerUsername } : {}),
+    ...(reservationUsername ? { reservationUsername } : {}),
+    hasController: room.controller !== undefined
+  });
+}
+
+export function evaluateExpansionCandidate(
+  candidate: ExpansionPlannerCandidateInput
+): ExpansionPlannerCandidate {
+  const suitability = evaluateExpansionSuitability({
+    sourceCount: candidate.sourceCount,
+    hostileCreepCount: candidate.hostileCreepCount ?? 0,
+    hostileStructureCount: candidate.hostileStructureCount ?? 0,
+    ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {}),
+    ...(candidate.ownerUsername ? { ownerUsername: candidate.ownerUsername } : {}),
+    ...(candidate.reservationUsername ? { reservationUsername: candidate.reservationUsername } : {}),
+    hasController:
+      candidate.controllerId !== undefined ||
+      candidate.ownerUsername !== undefined ||
+      candidate.reservationUsername !== undefined
+  });
+  const order = normalizeNonNegativeInteger(candidate.order ?? 0);
+  const distance = Math.max(1, normalizeNonNegativeInteger(candidate.distance));
+
+  return {
+    colony: candidate.colony,
+    roomName: candidate.roomName,
+    distance,
+    order,
+    score: scoreExpansionPlannerCandidate(suitability.sourceCount, distance),
+    ...suitability
+  };
+}
+
+export function prioritizeExpansionCandidates(
+  candidates: ExpansionPlannerCandidateInput[]
+): ExpansionPlannerCandidate[] {
+  return candidates
+    .map(evaluateExpansionCandidate)
+    .filter((candidate) => candidate.suitable)
+    .sort(compareExpansionPlannerCandidates);
+}
+
+export function buildRuntimeExpansionPlannerCandidates(
+  colony: ColonySnapshot
+): ExpansionPlannerCandidate[] {
+  const colonyName = colony.room.name;
+  const rooms = getGameRooms();
+  if (!rooms) {
+    return [];
+  }
+
+  const ownerUsername = getControllerOwnerUsername(colony.room.controller);
+  const ownedRoomNames = getVisibleOwnedRoomNames(colonyName, ownerUsername);
+  const candidates: ExpansionPlannerCandidate[] = [];
+  const seenRooms = new Set<string>();
+  let order = 0;
+
+  for (const ownedRoomName of ownedRoomNames) {
+    for (const adjacentRoomName of getAdjacentRoomNames(ownedRoomName)) {
+      if (seenRooms.has(adjacentRoomName) || ownedRoomNames.has(adjacentRoomName)) {
+        continue;
+      }
+
+      seenRooms.add(adjacentRoomName);
+      const room = rooms[adjacentRoomName];
+      if (!room) {
+        continue;
+      }
+
+      candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, 1, order));
+      order += 1;
+    }
+  }
+
+  for (const room of Object.values(rooms)) {
+    if (
+      !room ||
+      !isNonEmptyString(room.name) ||
+      room.name === colonyName ||
+      ownedRoomNames.has(room.name) ||
+      seenRooms.has(room.name)
+    ) {
+      continue;
+    }
+
+    const distance = getNearestOwnedRoomDistance(ownedRoomNames, room.name);
+    if (distance === null || distance > EXPANSION_PLANNER_MAX_ROUTE_DISTANCE) {
+      continue;
+    }
+
+    seenRooms.add(room.name);
+    candidates.push(toRuntimeExpansionPlannerCandidate(colonyName, room, distance, order));
+    order += 1;
+  }
+
+  return candidates
+    .filter((candidate) => candidate.suitable)
+    .sort(compareExpansionPlannerCandidates);
+}
+
+export function refreshExpansionPlannerIntent(
+  colony: ColonySnapshot,
+  gameTime = getGameTime()
+): ExpansionPlannerEvaluation {
+  const colonyName = colony.room.name;
+  if (!getMemoryRecord()) {
+    return {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'memoryUnavailable',
+      candidates: []
+    };
+  }
+
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (territoryMemory && hasBlockingTerritoryPlan(territoryMemory, colonyName)) {
+    return {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'existingTerritoryPlan',
+      candidates: []
+    };
+  }
+
+  const candidates = buildRuntimeExpansionPlannerCandidates(colony);
+  const candidate = candidates[0];
+  if (!candidate) {
+    return {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'noCandidate',
+      candidates
+    };
+  }
+
+  const action = selectExpansionIntentAction(colony);
+  const intent = createExpansionIntent(candidate, action, gameTime);
+  if (!intent) {
+    return {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'memoryUnavailable',
+      candidates
+    };
+  }
+
+  return {
+    status: 'planned',
+    colony: colonyName,
+    candidates,
+    targetRoom: intent.targetRoom,
+    action: intent.action,
+    score: intent.score,
+    ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
+  };
+}
+
+export function createExpansionIntent(
+  candidate: ExpansionPlannerCandidate,
+  action: TerritoryControlAction,
+  gameTime = getGameTime()
+): ExpansionPlannerIntent | null {
+  if (!candidate.suitable) {
+    return null;
+  }
+
+  const territoryMemory = getWritableTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return null;
+  }
+
+  const target: TerritoryTargetMemory = {
+    colony: candidate.colony,
+    roomName: candidate.roomName,
+    action,
+    ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
+  };
+  upsertTerritoryTarget(territoryMemory, target);
+
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const existingIntent = intents.find(
+    (intent) =>
+      intent.colony === candidate.colony &&
+      intent.targetRoom === candidate.roomName &&
+      intent.action === action
+  );
+  upsertTerritoryIntent(intents, {
+    colony: candidate.colony,
+    targetRoom: candidate.roomName,
+    action,
+    status: existingIntent?.status === 'active' ? 'active' : 'planned',
+    updatedAt: gameTime,
+    ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
+  });
+
+  return {
+    colony: candidate.colony,
+    targetRoom: candidate.roomName,
+    action,
+    score: candidate.score,
+    ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
+  };
+}
+
+function evaluateExpansionSuitability({
+  sourceCount,
+  hostileCreepCount,
+  hostileStructureCount,
+  controllerId,
+  ownerUsername,
+  reservationUsername,
+  hasController
+}: {
+  sourceCount: number;
+  hostileCreepCount: number;
+  hostileStructureCount: number;
+  controllerId?: Id<StructureController>;
+  ownerUsername?: string;
+  reservationUsername?: string;
+  hasController: boolean;
+}): ExpansionRoomSuitability {
+  const normalizedSourceCount = normalizeNonNegativeInteger(sourceCount);
+  const normalizedHostileCreepCount = normalizeNonNegativeInteger(hostileCreepCount);
+  const normalizedHostileStructureCount = normalizeNonNegativeInteger(hostileStructureCount);
+  const reasons: ExpansionRoomUnsuitableReason[] = [];
+
+  if (normalizedSourceCount < EXPANSION_PLANNER_MIN_SOURCE_COUNT) {
+    reasons.push('sourceCountBelowMinimum');
+  }
+
+  if (normalizedHostileCreepCount > 0 || normalizedHostileStructureCount > 0) {
+    reasons.push('hostilePresence');
+  }
+
+  if (!hasController) {
+    reasons.push('controllerMissing');
+  } else if (isNonEmptyString(ownerUsername)) {
+    reasons.push('controllerOwned');
+  } else if (isNonEmptyString(reservationUsername)) {
+    reasons.push('controllerReserved');
+  }
+
+  return {
+    suitable: reasons.length === 0,
+    sourceCount: normalizedSourceCount,
+    hostileCreepCount: normalizedHostileCreepCount,
+    hostileStructureCount: normalizedHostileStructureCount,
+    reasons,
+    ...(controllerId ? { controllerId } : {}),
+    ...(ownerUsername ? { ownerUsername } : {}),
+    ...(reservationUsername ? { reservationUsername } : {})
+  };
+}
+
+function toRuntimeExpansionPlannerCandidate(
+  colony: string,
+  room: Room,
+  distance: number,
+  order: number
+): ExpansionPlannerCandidate {
+  const suitability = evaluateExpansionRoomSuitability(room);
+  const normalizedDistance = Math.max(1, normalizeNonNegativeInteger(distance));
+  return {
+    colony,
+    roomName: room.name,
+    distance: normalizedDistance,
+    order,
+    score: scoreExpansionPlannerCandidate(suitability.sourceCount, normalizedDistance),
+    ...suitability
+  };
+}
+
+function compareExpansionPlannerCandidates(
+  left: ExpansionPlannerCandidate,
+  right: ExpansionPlannerCandidate
+): number {
+  return (
+    right.sourceCount - left.sourceCount ||
+    left.distance - right.distance ||
+    right.score - left.score ||
+    left.order - right.order ||
+    left.roomName.localeCompare(right.roomName)
+  );
+}
+
+function scoreExpansionPlannerCandidate(sourceCount: number, distance: number): number {
+  return sourceCount * SOURCE_SCORE_WEIGHT - distance * DISTANCE_SCORE_WEIGHT;
+}
+
+function selectExpansionIntentAction(colony: ColonySnapshot): TerritoryControlAction {
+  const gclLevel = getGclLevel();
+  if (gclLevel === null) {
+    return 'reserve';
+  }
+
+  const ownerUsername = getControllerOwnerUsername(colony.room.controller);
+  const ownedRoomCount = getVisibleOwnedRoomNames(colony.room.name, ownerUsername).size;
+  if (ownedRoomCount >= gclLevel) {
+    return 'reserve';
+  }
+
+  if (ownedRoomCount >= maxRoomsForRcl(colony.room.controller?.level)) {
+    return 'reserve';
+  }
+
+  return 'claim';
+}
+
+function hasBlockingTerritoryPlan(territoryMemory: TerritoryMemory, colony: string): boolean {
+  if (
+    normalizeTerritoryIntents(territoryMemory.intents).some(
+      (intent) =>
+        intent.colony === colony &&
+        intent.targetRoom !== colony &&
+        (intent.action === 'claim' || intent.action === 'reserve' || intent.action === 'scout') &&
+        (intent.status === 'planned' || intent.status === 'active')
+    )
+  ) {
+    return true;
+  }
+
+  return Array.isArray(territoryMemory.targets)
+    ? territoryMemory.targets.some(
+        (target) =>
+          isRecord(target) &&
+          target.colony === colony &&
+          target.roomName !== colony &&
+          target.enabled !== false &&
+          (target.action === 'claim' || target.action === 'reserve')
+      )
+    : false;
+}
+
+function upsertTerritoryTarget(territoryMemory: TerritoryMemory, target: TerritoryTargetMemory): void {
+  if (!Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = [];
+  }
+
+  const existingTarget = territoryMemory.targets.find(
+    (candidate) =>
+      isRecord(candidate) &&
+      candidate.colony === target.colony &&
+      candidate.roomName === target.roomName &&
+      candidate.action === target.action
+  );
+  if (!existingTarget) {
+    territoryMemory.targets.push(target);
+    return;
+  }
+
+  existingTarget.enabled = target.enabled;
+  if (target.controllerId) {
+    existingTarget.controllerId = target.controllerId;
+  } else {
+    delete existingTarget.controllerId;
+  }
+}
+
+function upsertTerritoryIntent(
+  intents: TerritoryIntentMemory[],
+  nextIntent: TerritoryIntentMemory
+): void {
+  const existingIndex = intents.findIndex(
+    (intent) =>
+      intent.colony === nextIntent.colony &&
+      intent.targetRoom === nextIntent.targetRoom &&
+      intent.action === nextIntent.action
+  );
+  if (existingIndex >= 0) {
+    intents[existingIndex] = nextIntent;
+    return;
+  }
+
+  intents.push(nextIntent);
+}
+
+function getNearestOwnedRoomDistance(ownedRoomNames: Set<string>, roomName: string): number | null {
+  let nearestDistance: number | null = null;
+  for (const ownedRoomName of ownedRoomNames) {
+    const distance = getRouteDistance(ownedRoomName, roomName);
+    if (distance === null) {
+      continue;
+    }
+
+    if (nearestDistance === null || distance < nearestDistance) {
+      nearestDistance = distance;
+    }
+  }
+
+  return nearestDistance;
+}
+
+function getRouteDistance(fromRoom: string, targetRoom: string): number | null {
+  if (fromRoom === targetRoom) {
+    return 0;
+  }
+
+  if (getAdjacentRoomNames(fromRoom).includes(targetRoom)) {
+    return 1;
+  }
+
+  const route = (globalThis as { Game?: Partial<Game> }).Game?.map?.findRoute?.(fromRoom, targetRoom);
+  if (Array.isArray(route)) {
+    return route.length;
+  }
+
+  return route === ERR_NO_PATH_CODE ? null : null;
+}
+
+function getAdjacentRoomNames(roomName: string): string[] {
+  const describeExits = (globalThis as { Game?: Partial<Game> }).Game?.map?.describeExits;
+  if (typeof describeExits !== 'function') {
+    return [];
+  }
+
+  const exits = describeExits(roomName) as Record<string, string> | null;
+  if (!isRecord(exits)) {
+    return [];
+  }
+
+  const orderedRooms = EXIT_DIRECTION_ORDER.flatMap((direction) => {
+    const adjacentRoom = exits[direction];
+    return isNonEmptyString(adjacentRoom) ? [adjacentRoom] : [];
+  });
+  const remainingRooms = Object.entries(exits)
+    .filter(([direction, adjacentRoom]) => !EXIT_DIRECTION_ORDER.includes(direction) && isNonEmptyString(adjacentRoom))
+    .map(([, adjacentRoom]) => adjacentRoom)
+    .sort();
+
+  return [...orderedRooms, ...remainingRooms];
+}
+
+function getVisibleOwnedRoomNames(colonyName: string, ownerUsername: string | undefined): Set<string> {
+  const rooms = getGameRooms();
+  const roomNames = new Set<string>([colonyName]);
+  if (!rooms) {
+    return roomNames;
+  }
+
+  for (const room of Object.values(rooms)) {
+    if (!room || !isNonEmptyString(room.name) || room.controller?.my !== true) {
+      continue;
+    }
+
+    const roomOwnerUsername = getControllerOwnerUsername(room.controller);
+    if (!ownerUsername || !roomOwnerUsername || ownerUsername === roomOwnerUsername) {
+      roomNames.add(room.name);
+    }
+  }
+
+  return roomNames;
+}
+
+function getControllerOwnerUsername(controller: StructureController | undefined): string | undefined {
+  const username = (controller as (StructureController & { owner?: { username?: string } }) | undefined)?.owner
+    ?.username;
+  if (isNonEmptyString(username)) {
+    return username;
+  }
+
+  return controller?.my === true ? 'me' : undefined;
+}
+
+function getControllerReservationUsername(controller: StructureController | undefined): string | undefined {
+  const username = (controller as (StructureController & { reservation?: { username?: string } }) | undefined)
+    ?.reservation?.username;
+  return isNonEmptyString(username) ? username : undefined;
+}
+
+function findRoomObjects<T>(room: Room, findConstant: number | undefined): T[] {
+  if (typeof findConstant !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = room.find(findConstant as FindConstant);
+    return Array.isArray(result) ? (result as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function getFindConstant(name: string): number | undefined {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function getGclLevel(): number | null {
+  const level = (globalThis as { Game?: Partial<Game> & { gcl?: { level?: number } } }).Game?.gcl?.level;
+  return typeof level === 'number' && Number.isFinite(level) && level > 0 ? Math.floor(level) : null;
+}
+
+function getGameTime(): number {
+  const time = (globalThis as { Game?: Partial<Game> }).Game?.time;
+  return typeof time === 'number' && Number.isFinite(time) ? time : 0;
+}
+
+function getGameRooms(): Record<string, Room> | undefined {
+  return (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms as Record<string, Room> | undefined;
+}
+
+function getWritableTerritoryMemoryRecord(): TerritoryMemory | null {
+  const memory = getMemoryRecord();
+  if (!memory) {
+    return null;
+  }
+
+  if (!isRecord(memory.territory)) {
+    memory.territory = {};
+  }
+
+  return memory.territory as TerritoryMemory;
+}
+
+function getTerritoryMemoryRecord(): TerritoryMemory | null {
+  const memory = getMemoryRecord();
+  if (!memory || !isRecord(memory.territory)) {
+    return null;
+  }
+
+  return memory.territory as TerritoryMemory;
+}
+
+function getMemoryRecord(): Partial<Memory> | undefined {
+  return (globalThis as { Memory?: Partial<Memory> }).Memory;
+}
+
+function normalizeNonNegativeInteger(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -227,8 +227,14 @@ export function refreshExpansionPlannerIntent(
   }
 
   const candidates = buildRuntimeExpansionPlannerCandidates(colony);
-  const candidate = candidates[0];
-  const action = candidate ? selectExpansionIntentAction(colony) : null;
+  const selectedAction = candidates.length > 0 ? selectExpansionIntentAction(colony) : null;
+  const preferredUpgradeCandidates =
+    selectedAction === 'claim' && potentialReservationUpgradeRooms.size > 0
+      ? candidates.filter((candidate) => potentialReservationUpgradeRooms.has(candidate.roomName))
+      : [];
+  const candidate =
+    preferredUpgradeCandidates.length > 0 ? preferredUpgradeCandidates[0] : candidates[0];
+  const action = candidate ? selectedAction : null;
   const reservationUpgrade = candidate && action ? getExpansionReservationUpgradeContext(candidate, action) : null;
 
   if (territoryMemory && hasBlockingTerritoryPlan(territoryMemory, colonyName, reservationUpgrade)) {

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -902,7 +902,7 @@ function getVisibleExpansionTargetTerminalStatus(
     return null;
   }
 
-  return reservationUsername === ownerUsername ? 'completed' : 'inactive';
+  return reservationUsername === ownerUsername ? null : 'inactive';
 }
 
 function normalizeTerritoryTarget(rawTarget: unknown): TerritoryTargetMemory | null {

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -73,6 +73,12 @@ export interface ExpansionPlannerEvaluation {
   controllerId?: Id<StructureController>;
 }
 
+interface ExpansionReservationUpgradeContext {
+  colony: string;
+  targetRoom: string;
+  action: TerritoryControlAction;
+}
+
 export function evaluateExpansionRoomSuitability(room: Room): ExpansionRoomSuitability {
   const ownerUsername = getControllerOwnerUsername(room.controller);
   const reservationUsername = getControllerReservationUsername(room.controller);
@@ -204,7 +210,10 @@ export function refreshExpansionPlannerIntent(
     refreshTerminalExpansionPlans(territoryMemory, colonyName, gameTime);
   }
 
-  if (territoryMemory && hasBlockingTerritoryPlan(territoryMemory, colonyName)) {
+  const potentialReservationUpgradeRooms = territoryMemory
+    ? getPotentialExpansionReservationUpgradeRooms(territoryMemory, colonyName)
+    : new Set<string>();
+  if (potentialReservationUpgradeRooms === null) {
     return {
       status: 'skipped',
       colony: colonyName,
@@ -215,7 +224,19 @@ export function refreshExpansionPlannerIntent(
 
   const candidates = buildRuntimeExpansionPlannerCandidates(colony);
   const candidate = candidates[0];
-  if (!candidate) {
+  const action = candidate ? selectExpansionIntentAction(colony) : null;
+  const reservationUpgrade = candidate && action ? getExpansionReservationUpgradeContext(candidate, action) : null;
+
+  if (territoryMemory && hasBlockingTerritoryPlan(territoryMemory, colonyName, reservationUpgrade)) {
+    return {
+      status: 'skipped',
+      colony: colonyName,
+      reason: 'existingTerritoryPlan',
+      candidates: []
+    };
+  }
+
+  if (!candidate || !action) {
     return {
       status: 'skipped',
       colony: colonyName,
@@ -224,7 +245,6 @@ export function refreshExpansionPlannerIntent(
     };
   }
 
-  const action = selectExpansionIntentAction(colony);
   const intent = createExpansionIntent(candidate, action, gameTime);
   if (!intent) {
     return {
@@ -280,6 +300,10 @@ export function createExpansionIntent(
 
   if (!candidate.suitable) {
     return null;
+  }
+
+  if (action === 'claim') {
+    removeSupersededExpansionReservationPlan(territoryMemory, intents, candidate.colony, candidate.roomName);
   }
 
   const target: TerritoryTargetMemory = {
@@ -486,7 +510,61 @@ function refreshTerminalExpansionPlans(
   }
 }
 
-function hasBlockingTerritoryPlan(territoryMemory: TerritoryMemory, colony: string): boolean {
+function getPotentialExpansionReservationUpgradeRooms(
+  territoryMemory: TerritoryMemory,
+  colony: string
+): Set<string> | null {
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  const roomNames = new Set<string>();
+
+  for (const intent of intents) {
+    if (
+      intent.colony !== colony ||
+      intent.targetRoom === colony ||
+      (intent.action !== 'claim' && intent.action !== 'reserve' && intent.action !== 'scout') ||
+      (intent.status !== 'planned' && intent.status !== 'active')
+    ) {
+      continue;
+    }
+
+    if (isPotentialExpansionReservationUpgradeIntent(intent)) {
+      roomNames.add(intent.targetRoom);
+      continue;
+    }
+
+    return null;
+  }
+
+  for (const rawTarget of Array.isArray(territoryMemory.targets) ? territoryMemory.targets : []) {
+    const target = normalizeTerritoryTarget(rawTarget);
+    if (
+      !target ||
+      target.colony !== colony ||
+      target.roomName === colony ||
+      target.enabled === false ||
+      !isExpansionControlAction(target.action)
+    ) {
+      continue;
+    }
+
+    if (isPotentialExpansionReservationUpgradeTarget(target, intents)) {
+      roomNames.add(target.roomName);
+      continue;
+    }
+
+    if (isBlockingExpansionTarget(rawTarget, colony, intents, null)) {
+      return null;
+    }
+  }
+
+  return roomNames;
+}
+
+function hasBlockingTerritoryPlan(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  reservationUpgrade: ExpansionReservationUpgradeContext | null
+): boolean {
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   if (
     intents.some(
@@ -494,17 +572,15 @@ function hasBlockingTerritoryPlan(territoryMemory: TerritoryMemory, colony: stri
         intent.colony === colony &&
         intent.targetRoom !== colony &&
         (intent.action === 'claim' || intent.action === 'reserve' || intent.action === 'scout') &&
-        (intent.status === 'planned' || intent.status === 'active')
+        (intent.status === 'planned' || intent.status === 'active') &&
+        !isUpgradeableExpansionReservationIntent(intent, reservationUpgrade)
     )
   ) {
     return true;
   }
 
   return Array.isArray(territoryMemory.targets)
-    ? territoryMemory.targets.some(
-        (target) =>
-          isBlockingExpansionTarget(target, colony, intents)
-      )
+    ? territoryMemory.targets.some((target) => isBlockingExpansionTarget(target, colony, intents, reservationUpgrade))
     : false;
 }
 
@@ -618,7 +694,8 @@ function findExpansionTarget(
 function isBlockingExpansionTarget(
   rawTarget: unknown,
   colony: string,
-  intents: TerritoryIntentMemory[]
+  intents: TerritoryIntentMemory[],
+  reservationUpgrade: ExpansionReservationUpgradeContext | null
 ): boolean {
   if (!isRecord(rawTarget)) {
     return false;
@@ -635,12 +712,100 @@ function isBlockingExpansionTarget(
     return false;
   }
 
+  if (isUpgradeableExpansionReservationTarget(target, reservationUpgrade)) {
+    return false;
+  }
+
   if (target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR) {
     return true;
   }
 
   const matchingIntent = findExpansionIntent(intents, target.colony, target.roomName, target.action);
   return getTerminalIntentStatus(matchingIntent) === null;
+}
+
+function getExpansionReservationUpgradeContext(
+  candidate: ExpansionPlannerCandidate,
+  action: TerritoryControlAction
+): ExpansionReservationUpgradeContext | null {
+  return candidate.suitable && action === 'claim'
+    ? { colony: candidate.colony, targetRoom: candidate.roomName, action }
+    : null;
+}
+
+function isUpgradeableExpansionReservationIntent(
+  intent: TerritoryIntentMemory,
+  reservationUpgrade: ExpansionReservationUpgradeContext | null
+): boolean {
+  return (
+    reservationUpgrade !== null &&
+    reservationUpgrade.action === 'claim' &&
+    intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR &&
+    intent.colony === reservationUpgrade.colony &&
+    intent.targetRoom === reservationUpgrade.targetRoom &&
+    intent.action === 'reserve'
+  );
+}
+
+function isPotentialExpansionReservationUpgradeIntent(intent: TerritoryIntentMemory): boolean {
+  return intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && intent.action === 'reserve';
+}
+
+function isUpgradeableExpansionReservationTarget(
+  target: TerritoryTargetMemory,
+  reservationUpgrade: ExpansionReservationUpgradeContext | null
+): boolean {
+  return (
+    reservationUpgrade !== null &&
+    reservationUpgrade.action === 'claim' &&
+    target.createdBy === EXPANSION_PLANNER_TARGET_CREATOR &&
+    target.colony === reservationUpgrade.colony &&
+    target.roomName === reservationUpgrade.targetRoom &&
+    target.action === 'reserve'
+  );
+}
+
+function isPotentialExpansionReservationUpgradeTarget(
+  target: TerritoryTargetMemory,
+  intents: TerritoryIntentMemory[]
+): boolean {
+  if (target.createdBy !== EXPANSION_PLANNER_TARGET_CREATOR || target.action !== 'reserve') {
+    return false;
+  }
+
+  const matchingIntent = findExpansionIntent(intents, target.colony, target.roomName, target.action);
+  return getTerminalIntentStatus(matchingIntent) === null;
+}
+
+function removeSupersededExpansionReservationPlan(
+  territoryMemory: TerritoryMemory,
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  roomName: string
+): void {
+  if (Array.isArray(territoryMemory.targets)) {
+    territoryMemory.targets = territoryMemory.targets.filter((rawTarget) => {
+      const target = normalizeTerritoryTarget(rawTarget);
+      return !(
+        target?.createdBy === EXPANSION_PLANNER_TARGET_CREATOR &&
+        target.colony === colony &&
+        target.roomName === roomName &&
+        target.action === 'reserve'
+      );
+    });
+  }
+
+  for (let index = intents.length - 1; index >= 0; index -= 1) {
+    const intent = intents[index];
+    if (
+      intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR &&
+      intent.colony === colony &&
+      intent.targetRoom === roomName &&
+      intent.action === 'reserve'
+    ) {
+      intents.splice(index, 1);
+    }
+  }
 }
 
 function getExpansionPlanKey(colony: string, targetRoom: string, action: TerritoryControlAction): string {
@@ -652,13 +817,13 @@ function getCandidateTerminalExpansionStatus(
   action: TerritoryControlAction,
   existingIntent: TerritoryIntentMemory | undefined
 ): TerminalExpansionIntentStatus | null {
+  if (candidate.suitable) {
+    return null;
+  }
+
   const terminalStatus = getTerminalIntentStatus(existingIntent);
   if (terminalStatus) {
     return terminalStatus;
-  }
-
-  if (candidate.suitable) {
-    return null;
   }
 
   const ownerUsername = getVisibleColonyOwnerUsername(candidate.colony);

--- a/prod/src/territory/territoryMemoryUtils.ts
+++ b/prod/src/territory/territoryMemoryUtils.ts
@@ -94,7 +94,13 @@ function isTerritoryIntentAction(action: unknown): action is TerritoryIntentActi
 }
 
 function isTerritoryIntentStatus(status: unknown): status is TerritoryIntentMemory['status'] {
-  return status === 'planned' || status === 'active' || status === 'suppressed';
+  return (
+    status === 'planned' ||
+    status === 'active' ||
+    status === 'suppressed' ||
+    status === 'inactive' ||
+    status === 'completed'
+  );
 }
 
 function isTerritoryIntentSuppressionReason(reason: unknown): reason is TerritoryIntentSuppressionReason {
@@ -114,6 +120,7 @@ function isTerritoryAutomationSource(source: unknown): source is TerritoryAutoma
     source === 'occupationRecommendation' ||
     source === 'autonomousExpansionClaim' ||
     source === 'colonyExpansion' ||
+    source === 'expansionPlanner' ||
     source === 'nextExpansionScoring' ||
     source === 'adjacentRoomReservation'
   );

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -34,6 +34,7 @@ import {
   findSourceContainerConstructionSite
 } from '../economy/sourceContainers';
 import { getTerritoryScoutIntel } from './scoutIntel';
+import { refreshExpansionPlannerIntent } from './expansionPlanner';
 
 export const TERRITORY_CLAIMER_ROLE = 'claimer';
 export const TERRITORY_SCOUT_ROLE = 'scout';
@@ -1074,6 +1075,10 @@ function selectTerritoryTarget(
 ): SelectedTerritoryTarget | null {
   const colonyName = colony.room.name;
   const colonyOwnerUsername = getControllerOwnerUsername(colony.room.controller);
+  if (options.controllerPressureOnly !== true && options.followUpOnly !== true) {
+    refreshExpansionPlannerIntent(colony, gameTime);
+  }
+
   const territoryMemory = getTerritoryMemoryRecord();
   let intents = normalizeTerritoryIntents(territoryMemory?.intents);
   const refreshedExpiredClaims = refreshExpiredPostClaimClaimIntents(

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -3738,6 +3738,7 @@ function isTerritoryAutomationSource(source: unknown): source is TerritoryAutoma
     source === OCCUPATION_RECOMMENDATION_TARGET_CREATOR ||
     source === 'autonomousExpansionClaim' ||
     source === 'colonyExpansion' ||
+    source === 'expansionPlanner' ||
     source === 'nextExpansionScoring' ||
     source === 'adjacentRoomReservation'
   );

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -301,6 +301,7 @@ declare global {
     | 'occupationRecommendation'
     | 'autonomousExpansionClaim'
     | 'colonyExpansion'
+    | 'expansionPlanner'
     | 'nextExpansionScoring'
     | 'adjacentRoomReservation';
   type TerritoryIntentSuspensionReason = 'hostile_presence';
@@ -403,7 +404,7 @@ declare global {
     colony: string;
     targetRoom: string;
     action: TerritoryIntentAction;
-    status: 'planned' | 'active' | 'suppressed';
+    status: 'planned' | 'active' | 'suppressed' | 'inactive' | 'completed';
     updatedAt: number;
     createdBy?: TerritoryAutomationSource;
     reason?: TerritoryIntentSuppressionReason;

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -146,7 +146,80 @@ describe('expansion planner', () => {
     ]);
   });
 
-  it('does not reactivate completed expansion intents', () => {
+  it('upgrades existing expansion planner reservations to claim targets when claim capacity opens', () => {
+    const controllerId = 'controller-W2N1' as Id<StructureController>;
+    const { colony } = makeColony({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controllerLevel: 3
+    });
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'reserve',
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'reserve',
+          status: 'planned',
+          updatedAt: 90,
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ]
+    };
+    installGame(colony, {
+      gclLevel: 2,
+      exits: { W1N1: { '3': 'W2N1' } },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1')
+      }
+    });
+
+    const plan = planTerritoryIntent(
+      colony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      110
+    );
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      createdBy: 'expansionPlanner',
+      controllerId
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 110,
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+  });
+
+  it('does not reactivate completed expansion intents while the candidate remains unsuitable', () => {
     const controllerId = 'controller-W2N1' as Id<StructureController>;
     Memory.territory = {
       targets: [
@@ -178,7 +251,8 @@ describe('expansion planner', () => {
         roomName: 'W2N1',
         distance: 1,
         sourceCount: 2,
-        controllerId
+        controllerId,
+        ownerUsername: 'me'
       }),
       'claim',
       120
@@ -203,6 +277,73 @@ describe('expansion planner', () => {
         action: 'claim',
         status: 'completed',
         updatedAt: 120,
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+  });
+
+  it('ignores stale terminal intent status when the current candidate is suitable', () => {
+    const controllerId = 'controller-W2N1' as Id<StructureController>;
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'claim',
+          createdBy: 'expansionPlanner',
+          controllerId,
+          enabled: false
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'claim',
+          status: 'inactive',
+          updatedAt: 100,
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ]
+    };
+
+    const intent = createExpansionIntent(
+      evaluateExpansionCandidate({
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        distance: 1,
+        sourceCount: 2,
+        controllerId
+      }),
+      'claim',
+      121
+    );
+
+    const territory = Memory.territory as TerritoryMemory;
+    expect(intent).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      score: 1_900,
+      controllerId
+    });
+    expect(territory.targets?.[0]).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      action: 'claim',
+      createdBy: 'expansionPlanner',
+      controllerId
+    });
+    expect(territory.targets?.[0]?.enabled).toBeUndefined();
+    expect(territory.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 121,
         createdBy: 'expansionPlanner',
         controllerId
       }

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -1,6 +1,7 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import { buildTerritorySpawnBody } from '../src/spawn/spawnPlanner';
 import {
+  buildRuntimeExpansionPlannerCandidates,
   createExpansionIntent,
   evaluateExpansionCandidate,
   evaluateExpansionRoomSuitability,
@@ -179,7 +180,13 @@ describe('expansion planner', () => {
       gclLevel: 2,
       exits: { W1N1: { '3': 'W2N1' } },
       rooms: {
-        W2N1: makeExpansionRoom('W2N1')
+        W2N1: makeExpansionRoom('W2N1', {
+          controller: {
+            id: controllerId,
+            my: false,
+            reservation: { username: 'me', ticksToEnd: 3_000 }
+          } as StructureController
+        })
       }
     });
 
@@ -217,6 +224,33 @@ describe('expansion planner', () => {
         controllerId
       }
     ]);
+  });
+
+  it('filters enemy-reserved runtime rooms from expansion candidates', () => {
+    const { colony } = makeColony({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controllerLevel: 3
+    });
+    installGame(colony, {
+      gclLevel: 2,
+      exits: { W1N1: { '3': 'W2N1' } },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', {
+          controller: {
+            id: 'controller-W2N1' as Id<StructureController>,
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController
+        })
+      }
+    });
+
+    expect(buildRuntimeExpansionPlannerCandidates(colony)).toEqual([]);
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 115)
+    ).toBeNull();
+    expect(Memory.territory).toBeUndefined();
   });
 
   it('does not reactivate completed expansion intents while the candidate remains unsuitable', () => {

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -1,6 +1,8 @@
 import type { ColonySnapshot } from '../src/colony/colonyRegistry';
 import { buildTerritorySpawnBody } from '../src/spawn/spawnPlanner';
 import {
+  createExpansionIntent,
+  evaluateExpansionCandidate,
   evaluateExpansionRoomSuitability,
   prioritizeExpansionCandidates
 } from '../src/territory/expansionPlanner';
@@ -119,6 +121,7 @@ describe('expansion planner', () => {
       colony: 'W1N1',
       targetRoom: 'W2N1',
       action: 'claim',
+      createdBy: 'expansionPlanner',
       controllerId: 'controller-W2N1'
     });
     expect(Memory.territory?.targets).toEqual([
@@ -126,6 +129,7 @@ describe('expansion planner', () => {
         colony: 'W1N1',
         roomName: 'W2N1',
         action: 'claim',
+        createdBy: 'expansionPlanner',
         controllerId: 'controller-W2N1'
       }
     ]);
@@ -136,7 +140,323 @@ describe('expansion planner', () => {
         action: 'claim',
         status: 'planned',
         updatedAt: 100,
+        createdBy: 'expansionPlanner',
         controllerId: 'controller-W2N1'
+      }
+    ]);
+  });
+
+  it('does not reactivate completed expansion intents', () => {
+    const controllerId = 'controller-W2N1' as Id<StructureController>;
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'claim',
+          createdBy: 'expansionPlanner',
+          controllerId,
+          enabled: true
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'claim',
+          status: 'completed',
+          updatedAt: 100,
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ]
+    };
+
+    const intent = createExpansionIntent(
+      evaluateExpansionCandidate({
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        distance: 1,
+        sourceCount: 2,
+        controllerId
+      }),
+      'claim',
+      120
+    );
+
+    const territory = Memory.territory as TerritoryMemory;
+    expect(intent).toBeNull();
+    expect(territory.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId,
+        enabled: false
+      }
+    ]);
+    expect(territory.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'completed',
+        updatedAt: 120,
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+  });
+
+  it('marks stale expansion targets inactive instead of re-enabling them', () => {
+    const controllerId = 'controller-W2N1' as Id<StructureController>;
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'claim',
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'claim',
+          status: 'active',
+          updatedAt: 100,
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ]
+    };
+
+    const intent = createExpansionIntent(
+      evaluateExpansionCandidate({
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        distance: 1,
+        sourceCount: 2,
+        hostileCreepCount: 1,
+        controllerId
+      }),
+      'claim',
+      125
+    );
+
+    const territory = Memory.territory as TerritoryMemory;
+    expect(intent).toBeNull();
+    expect(territory.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId,
+        enabled: false
+      }
+    ]);
+    expect(territory.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'inactive',
+        updatedAt: 125,
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+  });
+
+  it('clears completed expansion targets before planning the next room', () => {
+    const completedControllerId = 'controller-W2N1' as Id<StructureController>;
+    const nextControllerId = 'controller-W3N1' as Id<StructureController>;
+    const { colony } = makeColony({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controllerLevel: 4
+    });
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'claim',
+          createdBy: 'expansionPlanner',
+          controllerId: completedControllerId
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'claim',
+          status: 'active',
+          updatedAt: 99,
+          createdBy: 'expansionPlanner',
+          controllerId: completedControllerId
+        }
+      ]
+    };
+    installGame(colony, {
+      gclLevel: 4,
+      exits: {
+        W1N1: { '3': 'W2N1' },
+        W2N1: { '3': 'W3N1' }
+      },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', {
+          controller: {
+            id: completedControllerId,
+            my: true,
+            owner: { username: 'me' },
+            level: 1
+          } as StructureController
+        }),
+        W3N1: makeExpansionRoom('W3N1')
+      }
+    });
+
+    const plan = planTerritoryIntent(
+      colony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      130
+    );
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      createdBy: 'expansionPlanner',
+      controllerId: nextControllerId
+    });
+    const territory = Memory.territory as TerritoryMemory;
+    expect(territory.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId: completedControllerId,
+        enabled: false
+      },
+      {
+        colony: 'W1N1',
+        roomName: 'W3N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId: nextControllerId
+      }
+    ]);
+    expect(territory.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'completed',
+        updatedAt: 130,
+        createdBy: 'expansionPlanner',
+        controllerId: completedControllerId
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 130,
+        createdBy: 'expansionPlanner',
+        controllerId: nextControllerId
+      }
+    ]);
+  });
+
+  it('clears completed expansion planner intents without targets before planning the next room', () => {
+    const completedControllerId = 'controller-W2N1' as Id<StructureController>;
+    const nextControllerId = 'controller-W3N1' as Id<StructureController>;
+    const { colony } = makeColony({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controllerLevel: 4
+    });
+    Memory.territory = {
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'claim',
+          status: 'active',
+          updatedAt: 99,
+          createdBy: 'expansionPlanner',
+          controllerId: completedControllerId
+        }
+      ]
+    };
+    installGame(colony, {
+      gclLevel: 4,
+      exits: {
+        W1N1: { '3': 'W2N1' },
+        W2N1: { '3': 'W3N1' }
+      },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', {
+          controller: {
+            id: completedControllerId,
+            my: true,
+            owner: { username: 'me' },
+            level: 1
+          } as StructureController
+        }),
+        W3N1: makeExpansionRoom('W3N1')
+      }
+    });
+
+    const plan = planTerritoryIntent(
+      colony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      140
+    );
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W3N1',
+      action: 'claim',
+      createdBy: 'expansionPlanner',
+      controllerId: nextControllerId
+    });
+    const territory = Memory.territory as TerritoryMemory;
+    expect(territory.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W3N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId: nextControllerId
+      }
+    ]);
+    expect(territory.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'completed',
+        updatedAt: 140,
+        createdBy: 'expansionPlanner',
+        controllerId: completedControllerId
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W3N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 140,
+        createdBy: 'expansionPlanner',
+        controllerId: nextControllerId
       }
     ]);
   });
@@ -158,10 +478,12 @@ describe('expansion planner', () => {
 
 function makeColony({
   energyAvailable = 650,
-  energyCapacityAvailable = 650
+  energyCapacityAvailable = 650,
+  controllerLevel = 3
 }: {
   energyAvailable?: number;
   energyCapacityAvailable?: number;
+  controllerLevel?: number;
 } = {}): { colony: ColonySnapshot } {
   const room = {
     name: 'W1N1',
@@ -171,7 +493,7 @@ function makeColony({
       id: 'controller-W1N1' as Id<StructureController>,
       my: true,
       owner: { username: 'me' },
-      level: 3,
+      level: controllerLevel,
       ticksToDowngrade: 10_000
     } as StructureController,
     find: jest.fn((findType: number): unknown[] => {

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -341,6 +341,83 @@ describe('expansion planner', () => {
     expect(Memory.territory).toBeUndefined();
   });
 
+  it('keeps existing reserve targets active when the controller is reserved by us', () => {
+    const controllerId = 'controller-W2N1' as Id<StructureController>;
+    const { colony } = makeColony({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controllerLevel: 3
+    });
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'reserve',
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'reserve',
+          status: 'active',
+          updatedAt: 100,
+          createdBy: 'expansionPlanner',
+          controllerId
+        }
+      ]
+    };
+    installGame(colony, {
+      gclLevel: 1,
+      exits: { W1N1: {} },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', {
+          controller: {
+            id: controllerId,
+            my: false,
+            reservation: { username: 'me', ticksToEnd: 3_000 }
+          } as StructureController
+        })
+      }
+    });
+    (Game.map.findRoute as jest.Mock).mockReturnValue([
+      { exit: 3, room: 'W1N2' },
+      { exit: 3, room: 'W2N2' },
+      { exit: 3, room: 'W2N1' }
+    ]);
+
+    const plan = refreshExpansionPlannerIntent(colony, 116);
+
+    expect(plan).toMatchObject({
+      status: 'skipped',
+      colony: 'W1N1',
+      reason: 'existingTerritoryPlan'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'reserve',
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'reserve',
+        status: 'active',
+        updatedAt: 100,
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+  });
+
   it('does not reactivate completed expansion intents while the candidate remains unsuitable', () => {
     const controllerId = 'controller-W2N1' as Id<StructureController>;
     Memory.territory = {

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -5,7 +5,8 @@ import {
   createExpansionIntent,
   evaluateExpansionCandidate,
   evaluateExpansionRoomSuitability,
-  prioritizeExpansionCandidates
+  prioritizeExpansionCandidates,
+  refreshExpansionPlannerIntent
 } from '../src/territory/expansionPlanner';
 import { planTerritoryIntent, type TerritoryIntentPlan } from '../src/territory/territoryPlanner';
 
@@ -222,6 +223,93 @@ describe('expansion planner', () => {
         updatedAt: 110,
         createdBy: 'expansionPlanner',
         controllerId
+      }
+    ]);
+  });
+
+  it('prefers reserved expansion targets over higher scoring new claim candidates', () => {
+    const reservedControllerId = 'controller-W2N1' as Id<StructureController>;
+    const higherScoringControllerId = 'controller-W3N1' as Id<StructureController>;
+    const { colony } = makeColony({
+      energyAvailable: 1_300,
+      energyCapacityAvailable: 1_300,
+      controllerLevel: 3
+    });
+    Memory.territory = {
+      targets: [
+        {
+          colony: 'W1N1',
+          roomName: 'W2N1',
+          action: 'reserve',
+          createdBy: 'expansionPlanner',
+          controllerId: reservedControllerId
+        }
+      ],
+      intents: [
+        {
+          colony: 'W1N1',
+          targetRoom: 'W2N1',
+          action: 'reserve',
+          status: 'planned',
+          updatedAt: 90,
+          createdBy: 'expansionPlanner',
+          controllerId: reservedControllerId
+        }
+      ]
+    };
+    installGame(colony, {
+      gclLevel: 2,
+      exits: { W1N1: { '1': 'W3N1', '3': 'W2N1' } },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1', {
+          controller: {
+            id: reservedControllerId,
+            my: false
+          } as StructureController
+        }),
+        W3N1: makeExpansionRoom('W3N1', {
+          sourceCount: 3,
+          controller: {
+            id: higherScoringControllerId,
+            my: false
+          } as StructureController
+        })
+      }
+    });
+
+    expect(buildRuntimeExpansionPlannerCandidates(colony).map((candidate) => candidate.roomName)).toEqual([
+      'W3N1',
+      'W2N1'
+    ]);
+
+    const plan = refreshExpansionPlannerIntent(colony, 111);
+
+    expect(plan).toMatchObject({
+      status: 'planned',
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      controllerId: reservedControllerId
+    });
+    expect(plan.candidates.map((candidate) => candidate.roomName)).toEqual(['W3N1', 'W2N1']);
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        controllerId: reservedControllerId
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 111,
+        createdBy: 'expansionPlanner',
+        controllerId: reservedControllerId
       }
     ]);
   });

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -1,0 +1,265 @@
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import { buildTerritorySpawnBody } from '../src/spawn/spawnPlanner';
+import {
+  evaluateExpansionRoomSuitability,
+  prioritizeExpansionCandidates
+} from '../src/territory/expansionPlanner';
+import { planTerritoryIntent, type TerritoryIntentPlan } from '../src/territory/territoryPlanner';
+
+describe('expansion planner', () => {
+  beforeEach(() => {
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 2;
+    (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 3;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+  });
+
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+    delete (globalThis as { Memory?: Partial<Memory> }).Memory;
+  });
+
+  it('evaluates room suitability from source count, hostiles, and controller occupancy', () => {
+    expect(evaluateExpansionRoomSuitability(makeExpansionRoom('W2N1'))).toMatchObject({
+      suitable: true,
+      sourceCount: 2,
+      hostileCreepCount: 0,
+      hostileStructureCount: 0,
+      reasons: []
+    });
+
+    expect(evaluateExpansionRoomSuitability(makeExpansionRoom('W2N1', { sourceCount: 1 })).reasons).toContain(
+      'sourceCountBelowMinimum'
+    );
+    expect(
+      evaluateExpansionRoomSuitability(makeExpansionRoom('W2N1', { hostileCreepCount: 1 })).reasons
+    ).toContain('hostilePresence');
+    expect(
+      evaluateExpansionRoomSuitability(
+        makeExpansionRoom('W2N1', {
+          controller: {
+            id: 'controller-W2N1' as Id<StructureController>,
+            my: false,
+            owner: { username: 'enemy' }
+          } as StructureController
+        })
+      ).reasons
+    ).toContain('controllerOwned');
+    expect(
+      evaluateExpansionRoomSuitability(
+        makeExpansionRoom('W2N1', {
+          controller: {
+            id: 'controller-W2N1' as Id<StructureController>,
+            my: false,
+            reservation: { username: 'enemy', ticksToEnd: 3_000 }
+          } as StructureController
+        })
+      ).reasons
+    ).toContain('controllerReserved');
+  });
+
+  it('prioritizes suitable candidates by source count, distance, and stable order', () => {
+    const orderedCandidates = prioritizeExpansionCandidates([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        distance: 2,
+        sourceCount: 2,
+        controllerId: 'controller-W2N1' as Id<StructureController>,
+        order: 0
+      },
+      {
+        colony: 'W1N1',
+        roomName: 'W1N2',
+        distance: 1,
+        sourceCount: 2,
+        controllerId: 'controller-W1N2' as Id<StructureController>,
+        order: 1
+      },
+      {
+        colony: 'W1N1',
+        roomName: 'W3N1',
+        distance: 1,
+        sourceCount: 1,
+        controllerId: 'controller-W3N1' as Id<StructureController>,
+        order: 2
+      },
+      {
+        colony: 'W1N1',
+        roomName: 'W4N1',
+        distance: 2,
+        sourceCount: 3,
+        controllerId: 'controller-W4N1' as Id<StructureController>,
+        order: 3
+      }
+    ]);
+
+    expect(orderedCandidates.map((candidate) => candidate.roomName)).toEqual(['W4N1', 'W1N2', 'W2N1']);
+  });
+
+  it('creates expansion targets and intents through territory planning', () => {
+    const { colony } = makeColony({ energyAvailable: 1_300, energyCapacityAvailable: 1_300 });
+    installGame(colony, {
+      gclLevel: 2,
+      exits: { W1N1: { '3': 'W2N1' } },
+      rooms: {
+        W2N1: makeExpansionRoom('W2N1')
+      }
+    });
+
+    const plan = planTerritoryIntent(
+      colony,
+      { worker: 3, claimer: 0, claimersByTargetRoom: {} },
+      3,
+      100
+    );
+
+    expect(plan).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      controllerId: 'controller-W2N1'
+    });
+    expect(Memory.territory?.targets).toEqual([
+      {
+        colony: 'W1N1',
+        roomName: 'W2N1',
+        action: 'claim',
+        controllerId: 'controller-W2N1'
+      }
+    ]);
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 100,
+        controllerId: 'controller-W2N1'
+      }
+    ]);
+  });
+
+  it('keeps claimer and reserver body selection distinct for expansion intents', () => {
+    expect(buildTerritorySpawnBody(1_300, makeIntent('claim'))).toEqual([
+      'claim',
+      'move',
+      'work',
+      'carry',
+      'move',
+      'work',
+      'carry',
+      'move'
+    ]);
+    expect(buildTerritorySpawnBody(1_300, makeIntent('reserve'))).toEqual(['claim', 'claim', 'move', 'move']);
+  });
+});
+
+function makeColony({
+  energyAvailable = 650,
+  energyCapacityAvailable = 650
+}: {
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
+} = {}): { colony: ColonySnapshot } {
+  const room = {
+    name: 'W1N1',
+    energyAvailable,
+    energyCapacityAvailable,
+    controller: {
+      id: 'controller-W1N1' as Id<StructureController>,
+      my: true,
+      owner: { username: 'me' },
+      level: 3,
+      ticksToDowngrade: 10_000
+    } as StructureController,
+    find: jest.fn((findType: number): unknown[] => {
+      if (findType === FIND_SOURCES) {
+        return [{ id: 'source-W1N1-0' }];
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+
+  return {
+    colony: {
+      room,
+      spawns: [],
+      energyAvailable,
+      energyCapacityAvailable
+    }
+  };
+}
+
+function makeExpansionRoom(
+  roomName: string,
+  {
+    sourceCount = 2,
+    hostileCreepCount = 0,
+    hostileStructureCount = 0,
+    controller = {
+      id: `controller-${roomName}` as Id<StructureController>,
+      my: false
+    } as StructureController
+  }: {
+    sourceCount?: number;
+    hostileCreepCount?: number;
+    hostileStructureCount?: number;
+    controller?: StructureController;
+  } = {}
+): Room {
+  return {
+    name: roomName,
+    controller,
+    find: jest.fn((findType: number): unknown[] => {
+      switch (findType) {
+        case FIND_SOURCES:
+          return Array.from({ length: sourceCount }, (_value, index) => ({ id: `source-${roomName}-${index}` }));
+        case FIND_HOSTILE_CREEPS:
+          return Array.from({ length: hostileCreepCount }, (_value, index) => ({ id: `hostile-${index}` }));
+        case FIND_HOSTILE_STRUCTURES:
+          return Array.from({ length: hostileStructureCount }, (_value, index) => ({
+            id: `hostile-structure-${index}`
+          }));
+        default:
+          return [];
+      }
+    })
+  } as unknown as Room;
+}
+
+function installGame(
+  colony: ColonySnapshot,
+  {
+    gclLevel,
+    exits,
+    rooms
+  }: {
+    gclLevel: number;
+    exits: Record<string, Record<string, string>>;
+    rooms: Record<string, Room>;
+  }
+): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time: 100,
+    gcl: { level: gclLevel, progress: 0, progressTotal: 0 } as GlobalControlLevel,
+    rooms: {
+      [colony.room.name]: colony.room,
+      ...rooms
+    },
+    map: {
+      describeExits: jest.fn((roomName: string) => exits[roomName] ?? null),
+      findRoute: jest.fn((_fromRoom: string, toRoom: string) => [{ exit: 3, room: toRoom }])
+    } as unknown as GameMap
+  };
+}
+
+function makeIntent(action: TerritoryControlAction): TerritoryIntentPlan {
+  return {
+    colony: 'W1N1',
+    targetRoom: 'W2N1',
+    action
+  };
+}

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1192,14 +1192,16 @@ describe('planTerritoryIntent', () => {
     ).toEqual({
       colony: 'W1N1',
       targetRoom: 'W2N1',
-      action: 'reserve'
+      action: 'reserve',
+      createdBy: 'expansionPlanner'
     });
     expect(describeExits).toHaveBeenCalledWith('W1N1');
     expect(Memory.territory?.targets).toEqual([
       {
         colony: 'W1N1',
         roomName: 'W2N1',
-        action: 'reserve'
+        action: 'reserve',
+        createdBy: 'expansionPlanner'
       }
     ]);
   });


### PR DESCRIPTION
## Summary

Implements a basic room expansion planner that identifies nearby rooms suitable for claiming or reserving based on room scoring, controller presence, and territory intent persistence.

## Changes

- **`prod/src/territory/expansionPlanner.ts`** (new): Core expansion planner module that evaluates nearby rooms for claim/reserve suitability, integrates with territory planner for intent persistence, and produces room-level expansion recommendations.
- **`prod/test/expansionPlanner.test.ts`** (new): Tests covering expansion candidate scoring, controller reservation logic, territory intent integration, and edge cases.
- **`prod/src/spawn/spawnPlanner.ts`**: Minor integration hook for expansion planning.
- **`prod/src/territory/territoryPlanner.ts`**: Integration with expansion planner for territory intent updates.
- **`prod/dist/main.js`**: Regenerated bundle.

## Verification

- TypeScript typecheck: PASS
- Jest test suite: 1326 tests, 64 suites, all PASS
- Build: PASS
- Whitespace check: PASS

## Related

Closes #723
Refs #722 (dynamic body scaling merged separately)
