### PR TITLE
fix(telemetry): guard KPI history DB recovery path (#729)

### DIFF
--- a/scripts/generate-roadmap-page.py
+++ b/scripts/generate-roadmap-page.py
@@ -13,6 +13,7 @@ import re
 import sqlite3
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
@@ -1189,6 +1190,7 @@ def prepare_history_db(db_path: Path) -> tuple[sqlite3.Connection, JsonObject]:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     status: JsonObject
     if is_lfs_pointer(db_path):
+        guard_history_db_recovery_path(db_path)
         db_path.unlink()
         status = {
             "status": "cold-start-lfs-pointer",
@@ -1219,6 +1221,7 @@ def prepare_history_db(db_path: Path) -> tuple[sqlite3.Connection, JsonObject]:
         except Exception:
             pass
         if db_path.exists():
+            guard_history_db_recovery_path(db_path)
             db_path.unlink()
         status = {
             "status": "recreated-invalid-sqlite",
@@ -1231,6 +1234,50 @@ def prepare_history_db(db_path: Path) -> tuple[sqlite3.Connection, JsonObject]:
     conn.execute("PRAGMA foreign_keys=ON")
     ensure_schema(conn)
     return conn, status
+
+
+def guard_history_db_recovery_path(db_path: Path) -> None:
+    expected_name = "roadmap-kpi.sqlite"
+    if has_symlink_component(db_path):
+        raise RuntimeError(
+            f"Refusing to auto-recreate KPI history DB at {db_path}: path has a symlink component; "
+            "the path was not removed."
+        )
+    if db_path.name != expected_name or db_path.parent.name != "docs":
+        raise RuntimeError(
+            f"Refusing to auto-recreate KPI history DB at {db_path}: only docs/{expected_name} "
+            "may be recovered automatically; the path was not removed."
+        )
+
+    resolved_path = db_path.resolve(strict=False)
+    repo_history_db = (Path(__file__).resolve().parents[1] / "docs" / expected_name).resolve(strict=False)
+    if resolved_path == repo_history_db or is_temp_history_db_recovery_path(resolved_path, expected_name):
+        return
+
+    raise RuntimeError(
+        f"Refusing to auto-recreate KPI history DB at {db_path}: path is outside the expected "
+        f"repository docs/{expected_name} or temporary test docs/{expected_name} location; "
+        "the path was not removed."
+    )
+
+
+def has_symlink_component(path: Path) -> bool:
+    check_path = path if path.is_absolute() else Path.cwd() / path
+    current = Path(check_path.anchor)
+    for part in check_path.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            return True
+    return False
+
+
+def is_temp_history_db_recovery_path(path: Path, expected_name: str) -> bool:
+    temp_root = Path(tempfile.gettempdir()).resolve(strict=False)
+    try:
+        relative = path.relative_to(temp_root)
+    except ValueError:
+        return False
+    return len(relative.parts) == 3 and relative.parts[1] == "docs" and relative.parts[2] == expected_name
 
 
 def is_lfs_pointer(path: Path) -> bool:

--- a/scripts/test_generate_roadmap_page.py
+++ b/scripts/test_generate_roadmap_page.py
@@ -115,6 +115,19 @@ def metric_history_point(sampled_at: str, value: int | float = 1) -> dict[str, A
     }
 
 
+def lfs_pointer_text() -> str:
+    return (
+        "\n".join(
+            [
+                "version https://git-lfs.github.com/spec/v1",
+                "oid sha256:" + ("a" * 64),
+                "size 69632",
+            ]
+        )
+        + "\n"
+    )
+
+
 def runtime_summary_line(*, tick: int, level: int = 3, stored_energy: int = 0, hostile_creeps: int = 0) -> str:
     payload = {
         "type": "runtime-summary",
@@ -224,17 +237,7 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             db_path = Path(tmp) / "docs" / "roadmap-kpi.sqlite"
             db_path.parent.mkdir(parents=True, exist_ok=True)
-            db_path.write_text(
-                "\n".join(
-                    [
-                        "version https://git-lfs.github.com/spec/v1",
-                        "oid sha256:" + ("a" * 64),
-                        "size 69632",
-                    ]
-                )
-                + "\n",
-                encoding="utf-8",
-            )
+            db_path.write_text(lfs_pointer_text(), encoding="utf-8")
 
             conn, db_status = roadmap.prepare_history_db(db_path)
             try:
@@ -254,6 +257,47 @@ class GenerateRoadmapPageTest(unittest.TestCase):
         self.assertEqual(territory["history"]["status"], "collecting")
         self.assertTrue(territory["history"]["insufficient"])
         self.assertIn("SQLite history is cold-started", territory["footer"])
+
+    def test_unexpected_lfs_pointer_history_db_path_is_not_deleted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "nested" / "docs" / "roadmap-kpi.sqlite"
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            original = lfs_pointer_text()
+            db_path.write_text(original, encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "Refusing to auto-recreate KPI history DB"):
+                roadmap.prepare_history_db(db_path)
+
+            self.assertEqual(db_path.read_text(encoding="utf-8"), original)
+
+    def test_unexpected_invalid_history_db_path_is_not_deleted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "docs" / "unexpected.sqlite"
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            original = "not a sqlite database\n"
+            db_path.write_text(original, encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "only docs/roadmap-kpi.sqlite"):
+                roadmap.prepare_history_db(db_path)
+
+            self.assertEqual(db_path.read_text(encoding="utf-8"), original)
+
+    def test_symlink_history_db_recovery_path_is_not_deleted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target-lfs-pointer"
+            target.write_text(lfs_pointer_text(), encoding="utf-8")
+            db_path = Path(tmp) / "docs" / "roadmap-kpi.sqlite"
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                db_path.symlink_to(target)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"symlink creation unavailable: {error}")
+
+            with self.assertRaisesRegex(RuntimeError, "symlink component"):
+                roadmap.prepare_history_db(db_path)
+
+            self.assertTrue(db_path.is_symlink())
+            self.assertEqual(target.read_text(encoding="utf-8"), lfs_pointer_text())
 
     def test_runtime_artifact_history_derives_daily_buckets_outside_sqlite(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Guard `prepare_history_db()` recovery deletion so it only auto-recreates the expected KPI history DB target.
- Refuse symlinked, unexpected filename, or unexpected temp/repo locations before any `unlink()`.
- Add regression coverage proving unexpected LFS-pointer/invalid SQLite paths are not deleted.

## Verification
- `git diff --check HEAD^ HEAD`
- `python3 -m py_compile scripts/generate-roadmap-page.py scripts/screeps_runtime_kpi_artifact_bridge.py scripts/screeps_runtime_kpi_reducer.py`
- `python3 scripts/test_generate_roadmap_page.py` — 16 tests OK

Fixes #729
Follow-up for #728 / #609 review thread: https://github.com/lanyusea/screeps/pull/728#discussion_r3198786021
