### PR TITLE
feat(economy): container mining and link network energy distribution

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1859,32 +1859,38 @@ var WORKER_REPLACEMENT_TICKS_TO_LIVE = 100;
 function countCreepsByRole(creeps, colonyName) {
   const counts = creeps.reduce(
     (counts2, creep) => {
-      var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k;
+      var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m;
       if (isColonyWorker(creep, colonyName)) {
         counts2.worker += 1;
         if (canSatisfyRoleCapacity(creep)) {
           counts2.workerCapacity = ((_a = counts2.workerCapacity) != null ? _a : 0) + 1;
         }
       }
+      if (isColonySourceHarvester(creep, colonyName)) {
+        counts2.sourceHarvester = ((_b = counts2.sourceHarvester) != null ? _b : 0) + 1;
+        if (canSatisfyRoleCapacity(creep)) {
+          counts2.workerCapacity = ((_c = counts2.workerCapacity) != null ? _c : 0) + 1;
+        }
+      }
       if (canSatisfyDefenderCapacity(creep, colonyName)) {
-        counts2.defender = ((_b = counts2.defender) != null ? _b : 0) + 1;
+        counts2.defender = ((_d = counts2.defender) != null ? _d : 0) + 1;
       }
       if (isColonyClaimer(creep, colonyName) && canSatisfyTerritoryControllerCapacity(creep)) {
-        counts2.claimer = ((_c = counts2.claimer) != null ? _c : 0) + 1;
-        const targetRoom = (_d = creep.memory.territory) == null ? void 0 : _d.targetRoom;
+        counts2.claimer = ((_e = counts2.claimer) != null ? _e : 0) + 1;
+        const targetRoom = (_f = creep.memory.territory) == null ? void 0 : _f.targetRoom;
         if (targetRoom) {
-          const claimersByTargetRoom = (_e = counts2.claimersByTargetRoom) != null ? _e : {};
-          claimersByTargetRoom[targetRoom] = ((_f = claimersByTargetRoom[targetRoom]) != null ? _f : 0) + 1;
+          const claimersByTargetRoom = (_g = counts2.claimersByTargetRoom) != null ? _g : {};
+          claimersByTargetRoom[targetRoom] = ((_h = claimersByTargetRoom[targetRoom]) != null ? _h : 0) + 1;
           counts2.claimersByTargetRoom = claimersByTargetRoom;
-          incrementTargetRoomActionCount(counts2, (_g = creep.memory.territory) == null ? void 0 : _g.action, targetRoom);
+          incrementTargetRoomActionCount(counts2, (_i = creep.memory.territory) == null ? void 0 : _i.action, targetRoom);
         }
       }
       if (isColonyScout(creep, colonyName) && canSatisfyRoleCapacity(creep)) {
-        counts2.scout = ((_h = counts2.scout) != null ? _h : 0) + 1;
-        const targetRoom = (_i = creep.memory.territory) == null ? void 0 : _i.targetRoom;
+        counts2.scout = ((_j = counts2.scout) != null ? _j : 0) + 1;
+        const targetRoom = (_k = creep.memory.territory) == null ? void 0 : _k.targetRoom;
         if (targetRoom) {
-          const scoutsByTargetRoom = (_j = counts2.scoutsByTargetRoom) != null ? _j : {};
-          scoutsByTargetRoom[targetRoom] = ((_k = scoutsByTargetRoom[targetRoom]) != null ? _k : 0) + 1;
+          const scoutsByTargetRoom = (_l = counts2.scoutsByTargetRoom) != null ? _l : {};
+          scoutsByTargetRoom[targetRoom] = ((_m = scoutsByTargetRoom[targetRoom]) != null ? _m : 0) + 1;
           counts2.scoutsByTargetRoom = scoutsByTargetRoom;
         }
       }
@@ -1914,6 +1920,9 @@ function incrementTargetRoomActionCount(counts, action, targetRoom) {
 }
 function isColonyWorker(creep, colonyName) {
   return creep.memory.colony === colonyName && creep.memory.role === "worker";
+}
+function isColonySourceHarvester(creep, colonyName) {
+  return creep.memory.colony === colonyName && creep.memory.role === "sourceHarvester";
 }
 function isColonyClaimer(creep, colonyName) {
   return creep.memory.colony === colonyName && creep.memory.role === "claimer";
@@ -2464,8 +2473,8 @@ function getRoomName(room) {
   return typeof room.name === "string" && room.name.length > 0 ? room.name : null;
 }
 function getColonyCreepTotal(roleCounts) {
-  var _a, _b, _c;
-  return normalizeNonNegativeInteger3(roleCounts.worker) + normalizeNonNegativeInteger3((_a = roleCounts.defender) != null ? _a : 0) + normalizeNonNegativeInteger3((_b = roleCounts.claimer) != null ? _b : 0) + normalizeNonNegativeInteger3((_c = roleCounts.scout) != null ? _c : 0);
+  var _a, _b, _c, _d;
+  return normalizeNonNegativeInteger3(roleCounts.worker) + normalizeNonNegativeInteger3((_a = roleCounts.sourceHarvester) != null ? _a : 0) + normalizeNonNegativeInteger3((_b = roleCounts.defender) != null ? _b : 0) + normalizeNonNegativeInteger3((_c = roleCounts.claimer) != null ? _c : 0) + normalizeNonNegativeInteger3((_d = roleCounts.scout) != null ? _d : 0);
 }
 function getPersistedColonyStageMode(colony) {
   var _a, _b;
@@ -7936,9 +7945,9 @@ function getVisibleController(targetRoom, controllerId) {
   if (roomController) {
     return roomController;
   }
-  const getObjectById5 = game == null ? void 0 : game.getObjectById;
-  if (controllerId && typeof getObjectById5 === "function") {
-    return getObjectById5.call(game, controllerId);
+  const getObjectById6 = game == null ? void 0 : game.getObjectById;
+  if (controllerId && typeof getObjectById6 === "function") {
+    return getObjectById6.call(game, controllerId);
   }
   return null;
 }
@@ -11308,11 +11317,11 @@ function selectCreepRoomController(creep, controllerId) {
     return roomController;
   }
   const game = globalThis.Game;
-  const getObjectById5 = game == null ? void 0 : game.getObjectById;
-  if (typeof getObjectById5 !== "function") {
+  const getObjectById6 = game == null ? void 0 : game.getObjectById;
+  if (typeof getObjectById6 !== "function") {
     return null;
   }
-  return getObjectById5.call(game, controllerId);
+  return getObjectById6.call(game, controllerId);
 }
 function getTerritoryControllerTargetState(controller, action, colonyOwnerUsername) {
   if (action === "reserve") {
@@ -11549,9 +11558,9 @@ function getVisibleController2(targetRoom, controllerId) {
   if (roomController) {
     return roomController;
   }
-  const getObjectById5 = game == null ? void 0 : game.getObjectById;
-  if (controllerId && typeof getObjectById5 === "function") {
-    return getObjectById5.call(game, controllerId);
+  const getObjectById6 = game == null ? void 0 : game.getObjectById;
+  if (controllerId && typeof getObjectById6 === "function") {
+    return getObjectById6.call(game, controllerId);
   }
   return null;
 }
@@ -13206,8 +13215,8 @@ function getFreeEnergyCapacity2(target) {
 }
 function getObjectById(id) {
   var _a;
-  const getObjectById5 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  return typeof getObjectById5 === "function" ? getObjectById5(String(id)) : null;
+  const getObjectById6 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById6 === "function" ? getObjectById6(String(id)) : null;
 }
 function getVisibleRoom4(roomName) {
   var _a, _b;
@@ -13255,6 +13264,7 @@ function isNonEmptyString10(value) {
 // src/economy/linkManager.ts
 var SOURCE_LINK_RANGE = 2;
 var CONTROLLER_LINK_RANGE = 3;
+var SPAWN_LINK_RANGE = 2;
 var STORAGE_LINK_RANGE = 2;
 var STORAGE_LINK_ROUTING_TARGET_RATIO = 0.3;
 var OK_CODE6 = 0;
@@ -13270,6 +13280,15 @@ function transferEnergy(room) {
     transferSourceLinksToDestination(
       sortSourceLinksByDistanceToDestination(network.sourceLinks, network.controllerLink),
       { link: network.controllerLink, role: "controller" },
+      projectedState,
+      spentSourceIds,
+      results
+    );
+  }
+  if (shouldSpawnLinkReceiveEnergy(room, network.spawnLink, projectedState)) {
+    transferSourceLinksToDestination(
+      sortSourceLinksByDistanceToDestination(network.sourceLinks, network.spawnLink),
+      { link: network.spawnLink, role: "spawn" },
       projectedState,
       spentSourceIds,
       results
@@ -13292,13 +13311,15 @@ function classifyLinks(room) {
   const controllerLink = selectControllerLink(room, links);
   const storage = (_a = room.storage) != null ? _a : findStorage(room);
   const storageLink = selectStorageLink(room, links, controllerLink, storage);
+  const spawnLink = selectSpawnLink(room, links, controllerLink, storageLink);
   const destinationIds = new Set(
-    [controllerLink, storageLink].filter((link) => link !== null).map((link) => getObjectId8(link))
+    [controllerLink, spawnLink, storageLink].filter((link) => link !== null).map((link) => getObjectId8(link))
   );
   return {
     links,
     sourceLinks: selectSourceLinks(room, links, destinationIds),
     controllerLink,
+    spawnLink,
     storageLink,
     storage
   };
@@ -13368,6 +13389,18 @@ function shouldControllerLinkReceiveEnergy(room, controllerLink, projectedState)
   }
   return ((_b = projectedState.freeCapacityById.get(getObjectId8(controllerLink))) != null ? _b : 0) > 0;
 }
+function shouldSpawnLinkReceiveEnergy(room, spawnLink, projectedState) {
+  var _a;
+  if (!spawnLink) {
+    return false;
+  }
+  if (((_a = projectedState.freeCapacityById.get(getObjectId8(spawnLink))) != null ? _a : 0) <= 0) {
+    return false;
+  }
+  const energyAvailable = getKnownRoomEnergyAvailable(room);
+  const energyCapacityAvailable = getKnownRoomEnergyCapacityAvailable(room);
+  return energyAvailable === null || energyCapacityAvailable === null || energyCapacityAvailable <= 0 || energyAvailable < energyCapacityAvailable;
+}
 function shouldStorageLinkReceiveSurplus(network, projectedState) {
   var _a;
   if (!network.storageLink || getObjectId8(network.storageLink) === getObjectId8(network.controllerLink)) {
@@ -13397,6 +13430,15 @@ function createSourceLinkRoutingReserve(room, network, projectedState) {
     reserveSourceLinksForDestination(
       sortSourceLinksByDistanceToDestination(network.sourceLinks, network.controllerLink),
       network.controllerLink,
+      projectedState,
+      spentSourceIds,
+      reserveById
+    );
+  }
+  if (shouldSpawnLinkReceiveEnergy(room, network.spawnLink, projectedState)) {
+    reserveSourceLinksForDestination(
+      sortSourceLinksByDistanceToDestination(network.sourceLinks, network.spawnLink),
+      network.spawnLink,
       projectedState,
       spentSourceIds,
       reserveById
@@ -13498,6 +13540,31 @@ function selectStorageLink(room, links, controllerLink, storage) {
     STORAGE_LINK_RANGE
   );
 }
+function selectSpawnLink(room, links, controllerLink, storageLink) {
+  var _a;
+  const excludedIds = new Set(
+    [controllerLink, storageLink].map((link) => getObjectId8(link)).filter((id) => id.length > 0)
+  );
+  const sourceLinkCandidateIds = new Set(selectSourceLinks(room, links, /* @__PURE__ */ new Set()).map((link) => getObjectId8(link)));
+  const spawns = findRoomSpawns(room);
+  if (spawns.length === 0) {
+    return null;
+  }
+  return (_a = spawns.flatMap((spawn) => {
+    const link = selectClosestLink(
+      links.filter((candidate) => {
+        const candidateId = getObjectId8(candidate);
+        return !excludedIds.has(candidateId) && !sourceLinkCandidateIds.has(candidateId);
+      }),
+      spawn,
+      room.name,
+      SPAWN_LINK_RANGE
+    );
+    return link ? [link] : [];
+  }).sort(
+    (left, right) => compareClosestSpawnRange(room, left, right) || getObjectId8(left).localeCompare(getObjectId8(right))
+  )[0]) != null ? _a : null;
+}
 function selectClosestLink(links, target, roomName, range) {
   var _a;
   const targetPosition = getRoomObjectPosition2(target);
@@ -13537,12 +13604,43 @@ function findStorage(room) {
     (structure) => matchesStructureType11(structure.structureType, "STRUCTURE_STORAGE", "storage")
   )[0]) != null ? _a : null;
 }
+function findRoomSpawns(room) {
+  var _a;
+  const ownedStructureSpawns = findOwnedStructures5(room).filter(
+    (structure) => matchesStructureType11(structure.structureType, "STRUCTURE_SPAWN", "spawn")
+  );
+  const gameSpawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
+  const visibleSpawns = gameSpawns ? Object.values(gameSpawns).filter((spawn) => {
+    var _a2;
+    return ((_a2 = spawn == null ? void 0 : spawn.room) == null ? void 0 : _a2.name) === room.name;
+  }) : [];
+  const spawnsById = /* @__PURE__ */ new Map();
+  for (const spawn of [...ownedStructureSpawns, ...visibleSpawns]) {
+    const id = getObjectId8(spawn);
+    if (id.length > 0) {
+      spawnsById.set(id, spawn);
+    }
+  }
+  return [...spawnsById.values()].sort(compareObjectIds4);
+}
 function findSources2(room) {
   if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
     return [];
   }
   const result = room.find(FIND_SOURCES);
   return Array.isArray(result) ? result : [];
+}
+function compareClosestSpawnRange(room, left, right) {
+  const spawns = findRoomSpawns(room);
+  if (spawns.length === 0) {
+    return 0;
+  }
+  return Math.min(...spawns.map((spawn) => getRangeBetweenRoomObjects(left, spawn, room.name))) - Math.min(...spawns.map((spawn) => getRangeBetweenRoomObjects(right, spawn, room.name)));
+}
+function getRangeBetweenRoomObjects(left, right, roomName) {
+  const leftPosition = getRoomObjectPosition2(left);
+  const rightPosition = getRoomObjectPosition2(right);
+  return leftPosition !== null && rightPosition !== null && isSameRoomPosition5(leftPosition, roomName) && isSameRoomPosition5(rightPosition, roomName) ? getRangeBetweenPositions4(leftPosition, rightPosition) : Number.POSITIVE_INFINITY;
 }
 function getStoredEnergy7(structure) {
   var _a;
@@ -13556,6 +13654,14 @@ function getFreeEnergyCapacity3(structure) {
 function getLinkCooldown(link) {
   return typeof link.cooldown === "number" && Number.isFinite(link.cooldown) ? link.cooldown : 0;
 }
+function getKnownRoomEnergyAvailable(room) {
+  const energyAvailable = room.energyAvailable;
+  return typeof energyAvailable === "number" && Number.isFinite(energyAvailable) ? Math.max(0, energyAvailable) : null;
+}
+function getKnownRoomEnergyCapacityAvailable(room) {
+  const energyCapacityAvailable = room.energyCapacityAvailable;
+  return typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable) ? Math.max(0, energyCapacityAvailable) : null;
+}
 function getEnergyResource8() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
@@ -13567,13 +13673,285 @@ function getObjectId8(object) {
   if (typeof object !== "object" || object === null) {
     return "";
   }
-  const id = object.id;
-  return typeof id === "string" ? id : "";
+  const candidate = object;
+  if (typeof candidate.id === "string") {
+    return candidate.id;
+  }
+  return typeof candidate.name === "string" ? candidate.name : "";
 }
 function matchesStructureType11(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+
+// src/creeps/sourceHarvester.ts
+var SOURCE_HARVESTER_ROLE = "sourceHarvester";
+var ERR_FULL_CODE2 = -8;
+var ERR_NOT_ENOUGH_RESOURCES_CODE = -6;
+var ERR_NOT_IN_RANGE_CODE4 = -9;
+var SOURCE_LINK_DEPOSIT_RANGE = 1;
+function selectSourceHarvesterAssignment(room) {
+  var _a;
+  return (_a = getSourceHarvesterAssignments(room).find(
+    (assignment) => countAssignedSourceHarvesters(assignment) < 1
+  )) != null ? _a : null;
+}
+function getSourceHarvesterAssignments(room) {
+  if (typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
+    return [];
+  }
+  return room.find(FIND_SOURCES).flatMap((source) => {
+    const container = findSourceContainer(room, source);
+    return container ? [
+      {
+        roomName: room.name,
+        sourceId: source.id,
+        containerId: container.id
+      }
+    ] : [];
+  }).sort(compareAssignments);
+}
+function runSourceHarvester(creep) {
+  var _a, _b, _c, _d;
+  const assignment = normalizeSourceHarvesterMemory((_a = creep.memory) == null ? void 0 : _a.sourceHarvester);
+  if (!assignment) {
+    return;
+  }
+  creep.memory.task = {
+    type: "harvest",
+    targetId: assignment.sourceId,
+    sourceContainerAssigned: true
+  };
+  if (((_b = creep.room) == null ? void 0 : _b.name) !== assignment.roomName) {
+    moveTowardRoom2(creep, assignment.roomName);
+    return;
+  }
+  const source = getAssignedSource2(assignment);
+  if (!source) {
+    moveTowardRoom2(creep, assignment.roomName);
+    return;
+  }
+  const container = (_c = getAssignedContainer(assignment)) != null ? _c : findSourceContainer(creep.room, source);
+  if (!container) {
+    runMobileFallback(creep, source);
+    return;
+  }
+  if (!isInRangeTo(creep, container, 0)) {
+    moveTo2(creep, container);
+    return;
+  }
+  if (isSourceDepleted(source)) {
+    if (getCarriedEnergy2(creep) > 0) {
+      transferHarvestedEnergy(creep, source, container);
+    }
+    return;
+  }
+  if (getFreeEnergyCapacity4(creep) <= 0 && getCarriedEnergy2(creep) > 0) {
+    transferHarvestedEnergy(creep, source, container);
+    return;
+  }
+  const result = (_d = creep.harvest) == null ? void 0 : _d.call(creep, source);
+  if ((result === getErrFullCode() || result === getErrNotEnoughResourcesCode()) && getCarriedEnergy2(creep) > 0) {
+    transferHarvestedEnergy(creep, source, container);
+  }
+}
+function runMobileFallback(creep, source) {
+  var _a, _b;
+  if (getCarriedEnergy2(creep) > 0 && getFreeEnergyCapacity4(creep) <= 0) {
+    const sink = selectMobileFallbackEnergySink(creep);
+    if (sink) {
+      const result = (_a = creep.transfer) == null ? void 0 : _a.call(creep, sink, getEnergyResource9());
+      if (result === getErrNotInRangeCode2()) {
+        moveTo2(creep, sink);
+      }
+      return;
+    }
+  }
+  if (!isInRangeTo(creep, source, 1)) {
+    moveTo2(creep, source);
+    return;
+  }
+  (_b = creep.harvest) == null ? void 0 : _b.call(creep, source);
+}
+function transferHarvestedEnergy(creep, source, container) {
+  var _a;
+  const link = selectSourceLinkDeposit(creep.room, source, container);
+  const target = link != null ? link : container;
+  const result = (_a = creep.transfer) == null ? void 0 : _a.call(creep, target, getEnergyResource9());
+  if (result === getErrNotInRangeCode2()) {
+    moveTo2(creep, target);
+  }
+  return result;
+}
+function selectSourceLinkDeposit(room, source, container) {
+  var _a;
+  return (_a = classifyLinks(room).sourceLinks.filter((link) => getFreeEnergyCapacity4(link) > 0).filter((link) => isNearRoomObject3(source, link, 2)).filter((link) => isNearRoomObject3(container, link, SOURCE_LINK_DEPOSIT_RANGE)).sort((left, right) => compareSourceLinkDeposits(container, left, right))[0]) != null ? _a : null;
+}
+function compareSourceLinkDeposits(container, left, right) {
+  const containerPosition = getRoomObjectPosition2(container);
+  const leftPosition = getRoomObjectPosition2(left);
+  const rightPosition = getRoomObjectPosition2(right);
+  return (containerPosition && leftPosition ? getRangeBetweenPositions4(containerPosition, leftPosition) : 99) - (containerPosition && rightPosition ? getRangeBetweenPositions4(containerPosition, rightPosition) : 99) || String(left.id).localeCompare(String(right.id));
+}
+function selectMobileFallbackEnergySink(creep) {
+  var _a, _b;
+  if (typeof FIND_MY_STRUCTURES !== "number" || typeof ((_a = creep.room) == null ? void 0 : _a.find) !== "function") {
+    return null;
+  }
+  const sinks = creep.room.find(FIND_MY_STRUCTURES).filter((structure) => isMobileFallbackEnergySink(structure)).sort((left, right) => compareRangeToCreep(creep, left, right) || String(left.id).localeCompare(String(right.id)));
+  return (_b = sinks[0]) != null ? _b : null;
+}
+function isMobileFallbackEnergySink(structure) {
+  const structureType = structure.structureType;
+  return (matchesStructureType12(structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType12(structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType12(structureType, "STRUCTURE_TOWER", "tower")) && getFreeEnergyCapacity4(structure) > 0;
+}
+function countAssignedSourceHarvesters(assignment) {
+  return getGameCreeps().filter((creep) => isAssignedToSourceHarvesterSlot(creep, assignment)).length;
+}
+function isAssignedToSourceHarvesterSlot(creep, assignment) {
+  var _a, _b, _c, _d, _e, _f;
+  if (!canSatisfySourceHarvesterCapacity(creep)) {
+    return false;
+  }
+  if (((_a = creep.memory) == null ? void 0 : _a.role) === SOURCE_HARVESTER_ROLE && ((_b = creep.memory.sourceHarvester) == null ? void 0 : _b.roomName) === assignment.roomName && String((_c = creep.memory.sourceHarvester) == null ? void 0 : _c.sourceId) === String(assignment.sourceId)) {
+    return true;
+  }
+  const task = (_d = creep.memory) == null ? void 0 : _d.task;
+  return ((_e = creep.memory) == null ? void 0 : _e.role) === "worker" && ((_f = creep.room) == null ? void 0 : _f.name) === assignment.roomName && (task == null ? void 0 : task.type) === "harvest" && task.sourceContainerAssigned === true && String(task.targetId) === String(assignment.sourceId);
+}
+function canSatisfySourceHarvesterCapacity(creep) {
+  return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
+}
+function getAssignedSource2(assignment) {
+  var _a;
+  const source = getObjectById2(assignment.sourceId);
+  if (source) {
+    return source;
+  }
+  const room = getVisibleRoom5(assignment.roomName);
+  if (!room || typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
+    return null;
+  }
+  return (_a = room.find(FIND_SOURCES).find((candidate) => String(candidate.id) === String(assignment.sourceId))) != null ? _a : null;
+}
+function getAssignedContainer(assignment) {
+  const container = getObjectById2(assignment.containerId);
+  return container != null ? container : null;
+}
+function normalizeSourceHarvesterMemory(value) {
+  if (!isRecord11(value)) {
+    return null;
+  }
+  return isNonEmptyString11(value.roomName) && isNonEmptyString11(value.sourceId) && isNonEmptyString11(value.containerId) ? {
+    roomName: value.roomName,
+    sourceId: value.sourceId,
+    containerId: value.containerId
+  } : null;
+}
+function moveTowardRoom2(creep, roomName) {
+  var _a;
+  const visibleController = (_a = getVisibleRoom5(roomName)) == null ? void 0 : _a.controller;
+  if (visibleController) {
+    moveTo2(creep, visibleController);
+    return;
+  }
+  const RoomPositionCtor = globalThis.RoomPosition;
+  if (typeof RoomPositionCtor === "function") {
+    moveTo2(creep, new RoomPositionCtor(25, 25, roomName));
+  }
+}
+function moveTo2(creep, target) {
+  var _a;
+  (_a = creep.moveTo) == null ? void 0 : _a.call(creep, target);
+}
+function isInRangeTo(creep, target, range) {
+  var _a, _b;
+  const actualRange = (_b = (_a = creep.pos) == null ? void 0 : _a.getRangeTo) == null ? void 0 : _b.call(_a, target);
+  return typeof actualRange !== "number" || actualRange <= range;
+}
+function isNearRoomObject3(left, right, range) {
+  const leftPosition = getRoomObjectPosition2(left);
+  const rightPosition = getRoomObjectPosition2(right);
+  return leftPosition !== null && rightPosition !== null && (typeof leftPosition.roomName !== "string" || typeof rightPosition.roomName !== "string" || leftPosition.roomName === rightPosition.roomName) && getRangeBetweenPositions4(leftPosition, rightPosition) <= range;
+}
+function compareRangeToCreep(creep, left, right) {
+  var _a;
+  const getRangeTo = (_a = creep.pos) == null ? void 0 : _a.getRangeTo;
+  if (typeof getRangeTo !== "function") {
+    return 0;
+  }
+  return normalizeRange(getRangeTo.call(creep.pos, left)) - normalizeRange(getRangeTo.call(creep.pos, right));
+}
+function normalizeRange(range) {
+  return typeof range === "number" && Number.isFinite(range) ? range : Number.POSITIVE_INFINITY;
+}
+function isSourceDepleted(source) {
+  return typeof source.energy === "number" && source.energy <= 0;
+}
+function getCarriedEnergy2(creep) {
+  return getStoredEnergy8(creep);
+}
+function getStoredEnergy8(target) {
+  var _a, _b;
+  const usedCapacity = (_b = (_a = target == null ? void 0 : target.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, getEnergyResource9());
+  return typeof usedCapacity === "number" && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
+}
+function getFreeEnergyCapacity4(target) {
+  var _a, _b;
+  const freeCapacity = (_b = (_a = target == null ? void 0 : target.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource9());
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+function getEnergyResource9() {
+  var _a;
+  return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
+}
+function getErrFullCode() {
+  var _a;
+  return (_a = globalThis.ERR_FULL) != null ? _a : ERR_FULL_CODE2;
+}
+function getErrNotEnoughResourcesCode() {
+  var _a;
+  return (_a = globalThis.ERR_NOT_ENOUGH_RESOURCES) != null ? _a : ERR_NOT_ENOUGH_RESOURCES_CODE;
+}
+function getErrNotInRangeCode2() {
+  var _a;
+  return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE4;
+}
+function getObjectById2(id) {
+  var _a;
+  const getObjectById6 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  if (typeof getObjectById6 !== "function") {
+    return null;
+  }
+  try {
+    return getObjectById6(id);
+  } catch {
+    return null;
+  }
+}
+function getVisibleRoom5(roomName) {
+  var _a, _b;
+  return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+}
+function getGameCreeps() {
+  var _a;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  return creeps ? Object.values(creeps).filter((creep) => creep !== void 0) : [];
+}
+function compareAssignments(left, right) {
+  return left.roomName.localeCompare(right.roomName) || String(left.sourceId).localeCompare(String(right.sourceId));
+}
+function matchesStructureType12(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
+}
+function isRecord11(value) {
+  return typeof value === "object" && value !== null;
+}
+function isNonEmptyString11(value) {
+  return typeof value === "string" && value.length > 0;
 }
 
 // src/rl/workerTaskBehavior.ts
@@ -13632,10 +14010,10 @@ function buildWorkerTaskBehaviorState(creep) {
   const hostileCreeps = findRoomObjects12(room, getFindConstant5("FIND_HOSTILE_CREEPS"));
   const currentTask = (_c = (_b = (_a = creep.memory) == null ? void 0 : _a.task) == null ? void 0 : _b.type) != null ? _c : "none";
   const carriedEnergy = getUsedEnergy(creep);
-  const freeCapacity = getFreeEnergyCapacity4(creep);
+  const freeCapacity = getFreeEnergyCapacity5(creep);
   const energyCapacity = Math.max(0, carriedEnergy + freeCapacity);
   const controller = room == null ? void 0 : room.controller;
-  const nearbyStructures = structures.filter((structure) => getRangeBetweenRoomObjects(creep, structure) <= NEARBY_STRUCTURE_RANGE);
+  const nearbyStructures = structures.filter((structure) => getRangeBetweenRoomObjects2(creep, structure) <= NEARBY_STRUCTURE_RANGE);
   const nearbyRoadCount = nearbyStructures.filter((structure) => isStructureType(structure, "STRUCTURE_ROAD", "road")).length;
   const nearbyContainerCount = nearbyStructures.filter(
     (structure) => isStructureType(structure, "STRUCTURE_CONTAINER", "container")
@@ -13728,7 +14106,7 @@ function getUsedEnergy(target) {
   const value = (_b = (_a = target.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, getEnergyResourceConstant());
   return Math.max(0, (_c = finiteNumber(value)) != null ? _c : 0);
 }
-function getFreeEnergyCapacity4(target) {
+function getFreeEnergyCapacity5(target) {
   var _a, _b, _c;
   const value = (_b = (_a = target.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResourceConstant());
   return Math.max(0, (_c = finiteNumber(value)) != null ? _c : 0);
@@ -13750,7 +14128,7 @@ function isStructureType(structure, globalName, fallback) {
   const globalValue = globalThis[globalName];
   return structure.structureType === globalValue || structure.structureType === fallback;
 }
-function getRangeBetweenRoomObjects(left, right) {
+function getRangeBetweenRoomObjects2(left, right) {
   var _a, _b;
   const range = (_b = (_a = left.pos) == null ? void 0 : _a.getRangeTo) == null ? void 0 : _b.call(_a, right);
   if (typeof range === "number" && Number.isFinite(range)) {
@@ -13985,7 +14363,7 @@ function selectHeuristicWorkerTask(creep) {
       return interRoomRecallTask;
     }
     let hasPriorityEnergySink = false;
-    if (getFreeEnergyCapacity5(creep) > 0) {
+    if (getFreeEnergyCapacity6(creep) > 0) {
       const spawnRecoveryEnergySink = selectFillableEnergySink(creep);
       if (spawnRecoveryEnergySink) {
         hasPriorityEnergySink = true;
@@ -14064,7 +14442,7 @@ function selectHeuristicWorkerTask(creep) {
     if (source) {
       return { type: "harvest", targetId: source.id };
     }
-    if (getFreeEnergyCapacity5(creep) > 0) {
+    if (getFreeEnergyCapacity6(creep) > 0) {
       return selectWorkerLinkEnergyFallbackTask(creep);
     }
     return null;
@@ -14342,7 +14720,7 @@ function selectUpgraderBoostUpgradeTask(creep, controller, carriedEnergy) {
   return { type: "upgrade", targetId: controller.id };
 }
 function selectUpgraderBoostEnergyAcquisitionTask(creep, controller) {
-  if (!isUpgraderBoostActive(creep, controller) || !hasLowEnergyForUpgraderBoost(creep) || getFreeEnergyCapacity5(creep) <= 0) {
+  if (!isUpgraderBoostActive(creep, controller) || !hasLowEnergyForUpgraderBoost(creep) || getFreeEnergyCapacity6(creep) <= 0) {
     return null;
   }
   const context = {
@@ -14357,7 +14735,7 @@ function selectUpgraderBoostEnergyAcquisitionTask(creep, controller) {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy8(source),
+      getStoredEnergy9(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -14388,12 +14766,12 @@ function isControllerNearLevelUp(controller) {
 }
 function hasLowEnergyForUpgraderBoost(creep) {
   const carriedEnergy = getUsedEnergy2(creep);
-  const freeCapacity = getFreeEnergyCapacity5(creep);
+  const freeCapacity = getFreeEnergyCapacity6(creep);
   const capacity = getEnergyCapacity3(creep, carriedEnergy, freeCapacity);
   return capacity > 0 && carriedEnergy < capacity * UPGRADER_BOOST_LOW_ENERGY_RATIO;
 }
 function isUpgraderBoostStoredEnergySource(source) {
-  return matchesStructureType12(source.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType12(source.structureType, "STRUCTURE_STORAGE", "storage");
+  return matchesStructureType13(source.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType13(source.structureType, "STRUCTURE_STORAGE", "storage");
 }
 function selectFirstEnergySinkByStableId(energySinks) {
   var _a;
@@ -14471,7 +14849,7 @@ function hasEmergencySpawnExtensionRefillDemand(creep) {
 }
 function getLowLoadWorkerEnergyContext(creep) {
   const carriedEnergy = getUsedEnergy2(creep);
-  const freeCapacity = getFreeEnergyCapacity5(creep);
+  const freeCapacity = getFreeEnergyCapacity6(creep);
   if (carriedEnergy <= 0 || freeCapacity <= 0) {
     return null;
   }
@@ -14570,7 +14948,7 @@ function recordLowLoadReturnTelemetry(creep, task, reason) {
   };
 }
 function isFillableEnergySink(structure) {
-  return (matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType12(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType12(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
+  return (matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType13(structure.structureType, "STRUCTURE_TOWER", "tower")) && "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
 function selectFillableEnergySink(creep) {
   var _a;
@@ -14593,7 +14971,7 @@ function selectSpawnOrExtensionEnergySink(creep) {
   return unreservedEnergySink != null ? unreservedEnergySink : selectCloserReservedEnergySinkFallback(energySinks, creep, loadedWorkers, reservedEnergyDeliveries);
 }
 function selectStorageToSpawnExtensionRefillAcquisitionTask(creep) {
-  if (!isSpawnExtensionThroughputBottlenecked(creep.room) || getFreeEnergyCapacity5(creep) <= 0) {
+  if (!isSpawnExtensionThroughputBottlenecked(creep.room) || getFreeEnergyCapacity6(creep) <= 0) {
     return null;
   }
   const storage = selectStorageForSpawnExtensionRefill(creep);
@@ -14601,7 +14979,7 @@ function selectStorageToSpawnExtensionRefillAcquisitionTask(creep) {
     return null;
   }
   const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
-  const storageEnergy = getStoredEnergy8(storage);
+  const storageEnergy = getStoredEnergy9(storage);
   const reservedEnergy = getReservedWorkerEnergyAcquisitionAmount(storage, reservationContext);
   const projectedStorageEnergy = Math.max(0, storageEnergy - reservedEnergy);
   const plannedWithdrawal = Math.min(projectedStorageEnergy, creep.store.getFreeCapacity(RESOURCE_ENERGY));
@@ -14640,7 +15018,7 @@ function selectStorageForSpawnExtensionRefill(creep) {
     (structure) => isSafeStoredEnergySource(structure, context) && structure.structureType === "storage" && getStorageEnergyAvailableForWithdrawal(
       creep.room,
       structure,
-      getStoredEnergy8(structure),
+      getStoredEnergy9(structure),
       SPAWN_EXTENSION_REFILL_STORAGE_WITHDRAWAL_OPTIONS
     ) > 0
   );
@@ -14672,7 +15050,7 @@ function compareSpawnExtensionRecoveryEnergySinks(left, right, creep, reservedEn
   const carriedEnergy = getUsedEnergy2(creep);
   const leftDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(left, reservedEnergyDeliveries);
   const rightDeliveryCapacity = getUnreservedEnergySinkDeliveryCapacity(right, reservedEnergyDeliveries);
-  return compareCriticalSpawnPriority(left, right) || compareLowEnergySpawnPriority(left, right) || compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareAssignedTransferTarget(left, right, assignedTransferTargetId) || compareOptionalRanges(getRangeBetweenRoomObjects2(creep, left), getRangeBetweenRoomObjects2(creep, right)) || compareEnergySinkId(left, right);
+  return compareCriticalSpawnPriority(left, right) || compareLowEnergySpawnPriority(left, right) || compareAcceptedDeliveryEnergy(leftDeliveryCapacity, rightDeliveryCapacity, carriedEnergy) || compareAssignedTransferTarget(left, right, assignedTransferTargetId) || compareOptionalRanges(getRangeBetweenRoomObjects3(creep, left), getRangeBetweenRoomObjects3(creep, right)) || compareEnergySinkId(left, right);
 }
 function compareCriticalSpawnPriority(left, right) {
   if (isSpawnEnergySink(left) && isSpawnEnergySink(right)) {
@@ -14694,7 +15072,7 @@ function compareLowEnergySpawnPriority(left, right) {
   return leftLowEnergySpawn ? -1 : 1;
 }
 function isLowEnergySpawn(structure) {
-  return isSpawnEnergySink(structure) && getStoredEnergy8(structure) < getSpawnEnergyCapacity();
+  return isSpawnEnergySink(structure) && getStoredEnergy9(structure) < getSpawnEnergyCapacity();
 }
 function isCriticalSpawnEnergySink(structure) {
   const storedEnergy = getKnownStoredEnergy2(structure);
@@ -14773,7 +15151,7 @@ function selectInterRoomEnergyHaulingTask(creep, carriedEnergy) {
 }
 function selectInterRoomCollectionTask(creep, transfer) {
   var _a;
-  if (getFreeEnergyCapacity5(creep) <= 0) {
+  if (getFreeEnergyCapacity6(creep) <= 0) {
     return null;
   }
   const source = selectInterRoomEnergySource(transfer.sourceRoom, (_a = creep.memory.interRoomEnergyHaul) == null ? void 0 : _a.sourceId);
@@ -14824,7 +15202,7 @@ function selectNewInterRoomEnergyTransfer(creep, carriedEnergy) {
   if (!colonyName || !isWorkerInColonyRoom(creep)) {
     return null;
   }
-  const minimumRemainingEnergy = Math.max(1, carriedEnergy || getFreeEnergyCapacity5(creep));
+  const minimumRemainingEnergy = Math.max(1, carriedEnergy || getFreeEnergyCapacity6(creep));
   return (_a = getStorageBalanceState().transfers.filter((transfer) => isWorkerAllowedForInterRoomTransfer(creep, transfer)).filter((transfer) => transfer.amount > 0).filter(isCachedLiveTransferCandidate).filter((transfer) => getRemainingInterRoomHaulEnergy(transfer, creep) >= minimumRemainingEnergy).sort(compareInterRoomEnergyTransfersForWorker)[0]) != null ? _a : null;
 }
 function isCachedLiveTransferCandidate(transfer) {
@@ -14886,7 +15264,7 @@ function getInterRoomHaulReservationCache() {
     reservedEnergyByTransferKey: /* @__PURE__ */ new Map(),
     tick: gameTick
   };
-  for (const creep of getGameCreeps()) {
+  for (const creep of getGameCreeps2()) {
     setCachedInterRoomHaulReservation(
       interRoomHaulReservationCache,
       creep,
@@ -14992,7 +15370,7 @@ function getDedicatedCrossRoomHaulReservation(creep) {
     return null;
   }
   return {
-    energy: Math.max(getUsedEnergy2(creep), getFreeEnergyCapacity5(creep)),
+    energy: Math.max(getUsedEnergy2(creep), getFreeEnergyCapacity6(creep)),
     transferKey: getInterRoomTransferKey(assignment.homeRoom, assignment.targetRoom)
   };
 }
@@ -15016,7 +15394,7 @@ function selectInterRoomEnergySource(roomName, preferredSourceId) {
   if (!room) {
     return null;
   }
-  const sources = findInterRoomEnergyStores(room).filter((source) => getStoredEnergy8(source) > 0);
+  const sources = findInterRoomEnergyStores(room).filter((source) => getStoredEnergy9(source) > 0);
   const preferredSource = sources.find((source) => String(source.id) === String(preferredSourceId));
   if (preferredSource) {
     return preferredSource;
@@ -15049,7 +15427,7 @@ function selectInterRoomForeignRoomReturnTask(creep, carriedEnergy) {
 }
 function selectInterRoomHomeEnergyAcquisitionTask(creep) {
   const colonyRoom = getCreepColonyRoom(creep);
-  if (!colonyRoom || getFreeEnergyCapacity5(creep) <= 0) {
+  if (!colonyRoom || getFreeEnergyCapacity6(creep) <= 0) {
     return null;
   }
   const source = selectInterRoomEnergySource(colonyRoom.name);
@@ -15089,7 +15467,7 @@ function findInterRoomEnergyStores(room) {
   });
 }
 function compareInterRoomEnergySources(left, right) {
-  return getStoredEnergy8(right) - getStoredEnergy8(left) || getInterRoomEnergyStorePriority(right) - getInterRoomEnergyStorePriority(left) || String(left.id).localeCompare(String(right.id));
+  return getStoredEnergy9(right) - getStoredEnergy9(left) || getInterRoomEnergyStorePriority(right) - getInterRoomEnergyStorePriority(left) || String(left.id).localeCompare(String(right.id));
 }
 function compareInterRoomEnergyTargets(left, right) {
   return getInterRoomEnergyStorePriority(right) - getInterRoomEnergyStorePriority(left) || getFreeStoredEnergyCapacity(right) - getFreeStoredEnergyCapacity(left) || String(left.id).localeCompare(String(right.id));
@@ -15098,19 +15476,19 @@ function compareInterRoomRecallEnergySinks(left, right) {
   return getInterRoomRecallSinkPriority(right) - getInterRoomRecallSinkPriority(left) || String(left.id).localeCompare(String(right.id));
 }
 function getInterRoomEnergyStorePriority(store) {
-  return matchesStructureType12(store.structureType, "STRUCTURE_STORAGE", "storage") ? 2 : 1;
+  return matchesStructureType13(store.structureType, "STRUCTURE_STORAGE", "storage") ? 2 : 1;
 }
 function getInterRoomRecallSinkPriority(sink) {
-  if (matchesStructureType12(sink.structureType, "STRUCTURE_SPAWN", "spawn")) {
+  if (matchesStructureType13(sink.structureType, "STRUCTURE_SPAWN", "spawn")) {
     return 5;
   }
-  if (matchesStructureType12(sink.structureType, "STRUCTURE_EXTENSION", "extension")) {
+  if (matchesStructureType13(sink.structureType, "STRUCTURE_EXTENSION", "extension")) {
     return 4;
   }
-  if (matchesStructureType12(sink.structureType, "STRUCTURE_TOWER", "tower")) {
+  if (matchesStructureType13(sink.structureType, "STRUCTURE_TOWER", "tower")) {
     return 3;
   }
-  if (matchesStructureType12(sink.structureType, "STRUCTURE_STORAGE", "storage")) {
+  if (matchesStructureType13(sink.structureType, "STRUCTURE_STORAGE", "storage")) {
     return 2;
   }
   return 1;
@@ -15126,14 +15504,14 @@ function recordInterRoomEnergyHaulAssignment(creep, transfer, ids) {
   };
 }
 function normalizeInterRoomEnergyHaulMemory(value) {
-  if (!isWorkerTaskRecord(value) || !isNonEmptyString11(value.sourceRoom) || !isNonEmptyString11(value.targetRoom)) {
+  if (!isWorkerTaskRecord(value) || !isNonEmptyString12(value.sourceRoom) || !isNonEmptyString12(value.targetRoom)) {
     return null;
   }
   return {
     sourceRoom: value.sourceRoom,
     targetRoom: value.targetRoom,
-    ...isNonEmptyString11(value.sourceId) ? { sourceId: value.sourceId } : {},
-    ...isNonEmptyString11(value.targetId) ? { targetId: value.targetId } : {},
+    ...isNonEmptyString12(value.sourceId) ? { sourceId: value.sourceId } : {},
+    ...isNonEmptyString12(value.targetId) ? { targetId: value.targetId } : {},
     ...typeof value.updatedAt === "number" && Number.isFinite(value.updatedAt) ? { updatedAt: value.updatedAt } : {}
   };
 }
@@ -15147,7 +15525,7 @@ function clearInterRoomEnergyHaulAssignment(creep) {
     delete creep.memory.interRoomEnergyHaul;
   }
 }
-function isNonEmptyString11(value) {
+function isNonEmptyString12(value) {
   return typeof value === "string" && value.length > 0;
 }
 function getVisibleOwnedRoom(roomName) {
@@ -15167,7 +15545,7 @@ function selectCloserReservedEnergySinkFallback(energySinks, creep, loadedWorker
   );
 }
 function isCloserThanReservedEnergyDelivery(creep, energySink, loadedWorkers) {
-  const creepRange = getRangeBetweenRoomObjects2(creep, energySink);
+  const creepRange = getRangeBetweenRoomObjects3(creep, energySink);
   if (creepRange === null) {
     return false;
   }
@@ -15178,7 +15556,7 @@ function isCloserThanReservedEnergyDelivery(creep, energySink, loadedWorkers) {
       continue;
     }
     hasReservedDelivery = true;
-    const workerRange = getRangeBetweenRoomObjects2(worker, energySink);
+    const workerRange = getRangeBetweenRoomObjects3(worker, energySink);
     if (workerRange === null) {
       continue;
     }
@@ -15265,10 +15643,10 @@ function isRemoteHaulerStoredEnergySink(structure) {
   return "store" in structure && getFreeStoredEnergyCapacity(structure) > 0;
 }
 function isRemoteHaulerStorageSink(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_STORAGE", "storage") && isRemoteHaulerStoredEnergySink(structure);
+  return matchesStructureType13(structure.structureType, "STRUCTURE_STORAGE", "storage") && isRemoteHaulerStoredEnergySink(structure);
 }
 function isRemoteHaulerTerminalSink(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_TERMINAL", "terminal") && isRemoteHaulerStoredEnergySink(structure);
+  return matchesStructureType13(structure.structureType, "STRUCTURE_TERMINAL", "terminal") && isRemoteHaulerStoredEnergySink(structure);
 }
 function selectFirstRemoteHaulerStorageSinkByStableId(storageSinks) {
   var _a;
@@ -15279,14 +15657,14 @@ function selectFirstRemoteHaulerTerminalSinkByStableId(terminalSinks) {
   return (_a = [...terminalSinks].sort((left, right) => String(left.id).localeCompare(String(right.id)))[0]) != null ? _a : null;
 }
 function isSpawnExtensionEnergyStructure(structure) {
-  return (matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType12(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;
+  return (matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && "store" in structure;
 }
 function isSpawnEnergySink(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isNearTermSpawningSpawn(structure) {
   var _a;
-  if (!matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn")) {
+  if (!matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn")) {
     return false;
   }
   const remainingTime = (_a = structure.spawning) == null ? void 0 : _a.remainingTime;
@@ -15296,13 +15674,13 @@ function isSpawnOrExtensionEnergySink(structure) {
   return isSpawnEnergySink(structure) || isExtensionEnergySink(structure);
 }
 function isExtensionEnergySink(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension");
 }
 function isTowerEnergySink(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_TOWER", "tower");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_TOWER", "tower");
 }
 function isPriorityTowerEnergySink(structure) {
-  return isTowerEnergySink(structure) && getStoredEnergy8(structure) < TOWER_REFILL_ENERGY_FLOOR;
+  return isTowerEnergySink(structure) && getStoredEnergy9(structure) < TOWER_REFILL_ENERGY_FLOOR;
 }
 function selectClosestEnergySink(energySinks, creep) {
   var _a;
@@ -15401,7 +15779,7 @@ function findConstructionPriorityProtectedRampartAnchors(room) {
     anchors.push(room.controller.pos);
   }
   for (const structure of findConstructionPriorityOwnedStructures(room)) {
-    if (matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn") && structure.pos && isPositionInRoom(structure.pos, room.name)) {
+    if (matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") && structure.pos && isPositionInRoom(structure.pos, room.name)) {
       anchors.push(structure.pos);
     }
   }
@@ -15466,7 +15844,7 @@ function getRoomOwnedCreeps(room) {
       return roomCreeps;
     }
   }
-  return getGameCreeps().filter((worker) => isSameRoomWorker(worker, room));
+  return getGameCreeps2().filter((worker) => isSameRoomWorker(worker, room));
 }
 function isWorkerAssignedToConstructionSite(worker, site) {
   var _a;
@@ -15485,7 +15863,7 @@ function selectFinishPriorityConstructionSite(creep, constructionSites, construc
   )[0];
 }
 function compareConstructionSiteCandidates(creep, left, right, constructionReservationContext, priorityContext) {
-  return getConstructionSiteImpactPriority(right, priorityContext) - getConstructionSiteImpactPriority(left, priorityContext) || compareConstructionSiteFinishPriority(creep, left, right, constructionReservationContext) || compareConstructionSiteReasonableRange(creep, left, right) || compareOptionalRanges(getRangeBetweenRoomObjects2(creep, left), getRangeBetweenRoomObjects2(creep, right)) || compareConstructionSiteId(left, right);
+  return getConstructionSiteImpactPriority(right, priorityContext) - getConstructionSiteImpactPriority(left, priorityContext) || compareConstructionSiteFinishPriority(creep, left, right, constructionReservationContext) || compareConstructionSiteReasonableRange(creep, left, right) || compareOptionalRanges(getRangeBetweenRoomObjects3(creep, left), getRangeBetweenRoomObjects3(creep, right)) || compareConstructionSiteId(left, right);
 }
 function compareConstructionSiteReasonableRange(creep, left, right) {
   const leftInRange = isConstructionSiteWithinReasonableRange(
@@ -15504,7 +15882,7 @@ function compareConstructionSiteReasonableRange(creep, left, right) {
   return leftInRange ? -1 : 1;
 }
 function isConstructionSiteWithinReasonableRange(creep, site, rangeLimit) {
-  const range = getRangeBetweenRoomObjects2(creep, site);
+  const range = getRangeBetweenRoomObjects3(creep, site);
   return range === null || range <= rangeLimit;
 }
 function selectTopImpactConstructionSiteCandidates(candidates, priorityContext) {
@@ -15613,7 +15991,7 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
   if (criticalSpawnRepairTarget) {
     return { type: "repair", targetId: criticalSpawnRepairTarget.id };
   }
-  const controllerRange = getRangeBetweenRoomObjects2(creep, controller);
+  const controllerRange = getRangeBetweenRoomObjects3(creep, controller);
   if (controllerRange === null) {
     return null;
   }
@@ -15646,7 +16024,7 @@ function selectNearbyProductiveEnergySinkTask(creep, constructionSites, controll
   return candidates.sort(compareProductiveEnergySinkCandidates)[0].task;
 }
 function createProductiveEnergySinkCandidate(creep, target, task, taskPriority, canCompleteConstruction = false) {
-  const range = getRangeBetweenRoomObjects2(creep, target);
+  const range = getRangeBetweenRoomObjects3(creep, target);
   if (range === null) {
     return null;
   }
@@ -15754,7 +16132,7 @@ function shouldPreBufferEnergyForConstructionSite(creep, site) {
   if (!canSpendCreepEnergyOnConstruction(creep)) {
     return false;
   }
-  const range = getRangeBetweenRoomObjects2(creep, site);
+  const range = getRangeBetweenRoomObjects3(creep, site);
   return range === null || range > CONSTRUCTION_PREBUFFER_SITE_RANGE;
 }
 function selectConstructionEnergyPreBufferSink(creep, site) {
@@ -15765,7 +16143,7 @@ function selectConstructionEnergyPreBufferSink(creep, site) {
   return sinks.sort((left, right) => compareConstructionPreBufferSinks(creep, site, left, right))[0];
 }
 function compareConstructionPreBufferSinks(creep, site, left, right) {
-  return compareOptionalRanges(getRangeBetweenRoomObjects2(site, left), getRangeBetweenRoomObjects2(site, right)) || compareOptionalRanges(getRangeBetweenRoomObjects2(creep, left), getRangeBetweenRoomObjects2(creep, right)) || getFreeStoredEnergyCapacity(right) - getFreeStoredEnergyCapacity(left) || String(left.id).localeCompare(String(right.id));
+  return compareOptionalRanges(getRangeBetweenRoomObjects3(site, left), getRangeBetweenRoomObjects3(site, right)) || compareOptionalRanges(getRangeBetweenRoomObjects3(creep, left), getRangeBetweenRoomObjects3(creep, right)) || getFreeStoredEnergyCapacity(right) - getFreeStoredEnergyCapacity(left) || String(left.id).localeCompare(String(right.id));
 }
 function isConstructionPreBufferSink(structure) {
   if (!("store" in structure) || getFreeStoredEnergyCapacity(structure) < CONSTRUCTION_PREBUFFER_MIN_FREE_CAPACITY) {
@@ -15777,13 +16155,13 @@ function isConstructionPreBufferSink(structure) {
   return isStorageEnergyBuffer(structure) && isOwnedRoomStructure(structure);
 }
 function isConstructionPreBufferSource(creep, site, structure) {
-  return (isExtensionEnergyBuffer(structure) || isStorageEnergyBuffer(structure)) && isOwnedRoomStructure(structure) && isConstructionSiteNearSource(site, structure, CONSTRUCTION_PREBUFFER_SITE_RANGE) && getStoredEnergy8(structure) >= CONSTRUCTION_PREBUFFER_MIN_STORED_ENERGY;
+  return (isExtensionEnergyBuffer(structure) || isStorageEnergyBuffer(structure)) && isOwnedRoomStructure(structure) && isConstructionSiteNearSource(site, structure, CONSTRUCTION_PREBUFFER_SITE_RANGE) && getStoredEnergy9(structure) >= CONSTRUCTION_PREBUFFER_MIN_STORED_ENERGY;
 }
 function isExtensionEnergyBuffer(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension");
 }
 function isStorageEnergyBuffer(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_STORAGE", "storage");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_STORAGE", "storage");
 }
 function isOwnedRoomStructure(structure) {
   const ownership = structure.my;
@@ -15826,24 +16204,24 @@ function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstruction
   return criticalRoadConstructionSite ? { type: "build", targetId: criticalRoadConstructionSite.id } : null;
 }
 function isSpawnConstructionSite(site) {
-  return matchesStructureType12(site.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType13(site.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isExtensionConstructionSite(site) {
-  return matchesStructureType12(site.structureType, "STRUCTURE_EXTENSION", "extension");
+  return matchesStructureType13(site.structureType, "STRUCTURE_EXTENSION", "extension");
 }
 function isContainerConstructionSite3(site) {
-  return matchesStructureType12(site.structureType, "STRUCTURE_CONTAINER", "container");
+  return matchesStructureType13(site.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isRoadConstructionSite2(site) {
-  return matchesStructureType12(site.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType13(site.structureType, "STRUCTURE_ROAD", "road");
 }
 function isRampartConstructionSite(site) {
-  return matchesStructureType12(site.structureType, "STRUCTURE_RAMPART", "rampart");
+  return matchesStructureType13(site.structureType, "STRUCTURE_RAMPART", "rampart");
 }
 function isHighImpactConstructionSite(site, priorityContext) {
   return isContainerConstructionSite3(site) || getConstructionSiteImpactPriority(site, priorityContext != null ? priorityContext : {}) >= CONSTRUCTION_SITE_IMPACT_PRIORITY.criticalRoad;
 }
-function matchesStructureType12(actual, globalName, fallback) {
+function matchesStructureType13(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -15874,7 +16252,7 @@ function scoreStoredEnergySources(creep, sources) {
   }
   return sources.map((source) => {
     var _a, _b;
-    const energy = getStoredEnergy8(source);
+    const energy = getStoredEnergy9(source);
     const range = Math.max(0, (_b = (_a = position.getRangeTo) == null ? void 0 : _a.call(position, source)) != null ? _b : 0);
     return {
       energy,
@@ -15891,16 +16269,16 @@ function isSafeStoredEnergySource(structure, context) {
   return isStoredWorkerEnergySource(structure, context.room) && hasWithdrawableStoredEnergy(structure, context) && isFriendlyStoredEnergySource(structure, context);
 }
 function isStoredWorkerEnergySource(structure, room) {
-  if (matchesStructureType12(structure.structureType, "STRUCTURE_LINK", "link")) {
+  if (matchesStructureType13(structure.structureType, "STRUCTURE_LINK", "link")) {
     return isSourceLink(room, structure);
   }
-  return matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType12(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType12(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType12(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType13(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType13(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function hasWithdrawableStoredEnergy(structure, context) {
   if (isSpawnEnergySource(structure)) {
     return getSpawnEnergyAvailableForWithdrawal(context.room, structure) > 0;
   }
-  return getStoredEnergy8(structure) > 0;
+  return getStoredEnergy9(structure) > 0;
 }
 function isFriendlyStoredEnergySource(structure, context) {
   var _a;
@@ -15911,7 +16289,7 @@ function isFriendlyStoredEnergySource(structure, context) {
   if (((_a = context.room.controller) == null ? void 0 : _a.my) === true) {
     return true;
   }
-  return matchesStructureType12(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
+  return matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container") && isRoomSafeForUnownedContainerWithdrawal(context);
 }
 function isRoomSafeForUnownedContainerWithdrawal(context) {
   var _a;
@@ -15967,7 +16345,7 @@ function findBuilderEnergyAcquisitionCandidates(creep, constructionSite) {
     const candidate = createUnreservedBuilderStoredEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy8(source),
+      getStoredEnergy9(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -16020,8 +16398,8 @@ function createUnreservedBuilderStoredEnergyAcquisitionCandidate(creep, source, 
   return candidate ? toBuilderEnergyAcquisitionCandidate(candidate) : null;
 }
 function createBuilderEnergyAcquisitionCandidate(creep, source, energy, task) {
-  const range = getRangeBetweenRoomObjects2(creep, source);
-  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity5(creep));
+  const range = getRangeBetweenRoomObjects3(creep, source);
+  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity6(creep));
   return {
     energy,
     priority: isExtensionEnergyBuffer(source) ? 1 : getWorkerEnergyAcquisitionPriority(creep, source, energy, range),
@@ -16037,10 +16415,10 @@ function isBuilderConstructionPreBufferExtension(creep, constructionSite, struct
 function isConstructionPreBufferExtensionSource(creep, structure) {
   var _a;
   const memory = (_a = creep.memory) == null ? void 0 : _a.constructionPreBuffer;
-  return (memory == null ? void 0 : memory.bufferId) === String(structure.id) && isOwnedRoomStructure(structure) && getStoredEnergy8(structure) >= CONSTRUCTION_PREBUFFER_MIN_STORED_ENERGY;
+  return (memory == null ? void 0 : memory.bufferId) === String(structure.id) && isOwnedRoomStructure(structure) && getStoredEnergy9(structure) >= CONSTRUCTION_PREBUFFER_MIN_STORED_ENERGY;
 }
 function isConstructionSiteNearSource(constructionSite, source, rangeLimit) {
-  const rangeToSite = getRangeBetweenRoomObjects2(constructionSite, source);
+  const rangeToSite = getRangeBetweenRoomObjects3(constructionSite, source);
   return rangeToSite !== null && rangeToSite <= rangeLimit;
 }
 function compareBuilderEnergyAcquisitionCandidates(left, right) {
@@ -16096,7 +16474,7 @@ function createCompetitiveHarvestEnergyAcquisitionCandidate(creep, source) {
   if (energy <= 0) {
     return null;
   }
-  const score = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity5(creep));
+  const score = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity6(creep));
   return {
     energy,
     priority: getWorkerEnergyAcquisitionPriority(creep, source, energy, range),
@@ -16256,7 +16634,7 @@ function findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationCo
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy8(source),
+      getStoredEnergy9(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -16271,7 +16649,7 @@ function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationC
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy8(source),
+      getStoredEnergy9(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -16319,7 +16697,7 @@ function findLowLoadHarvestEnergyAcquisitionCandidates(creep) {
     return [];
   }
   const source = selectHarvestSource(creep);
-  if (!source || isSourceDepleted(source)) {
+  if (!source || isSourceDepleted2(source)) {
     return [];
   }
   return [
@@ -16332,7 +16710,7 @@ function findLowLoadHarvestEnergyAcquisitionCandidates(creep) {
   ];
 }
 function getHarvestCandidateEnergy(creep, source) {
-  return typeof source.energy === "number" && Number.isFinite(source.energy) ? source.energy : getFreeEnergyCapacity5(creep);
+  return typeof source.energy === "number" && Number.isFinite(source.energy) ? source.energy : getFreeEnergyCapacity6(creep);
 }
 function createLowLoadWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
@@ -16410,7 +16788,7 @@ function findWorkerEnergyAcquisitionCandidates(creep, options = {}) {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy8(source),
+      getStoredEnergy9(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -16423,7 +16801,7 @@ function findWorkerEnergyAcquisitionCandidates(creep, options = {}) {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       source,
-      getStoredEnergy8(source),
+      getStoredEnergy9(source),
       {
         type: "withdraw",
         targetId: source.id
@@ -16497,7 +16875,7 @@ function findNearestNearbyWorkerLinkRefillCandidate(creep, reservationContext = 
 }
 function hasLowEnergyForNearbyLinkRefill(creep) {
   const carriedEnergy = getUsedEnergy2(creep);
-  const freeCapacity = getFreeEnergyCapacity5(creep);
+  const freeCapacity = getFreeEnergyCapacity6(creep);
   const capacity = getEnergyCapacity3(creep, carriedEnergy, freeCapacity);
   return freeCapacity > 0 && capacity > 0 && carriedEnergy < capacity * MINIMUM_USEFUL_LOAD_RATIO;
 }
@@ -16506,7 +16884,7 @@ function findOwnedWorkerEnergyLinks(room) {
     return [];
   }
   const structures = room.find(FIND_MY_STRUCTURES, {
-    filter: (structure) => isLinkEnergySource(structure) && getStoredEnergy8(structure) > 0
+    filter: (structure) => isLinkEnergySource(structure) && getStoredEnergy9(structure) > 0
   });
   return Array.isArray(structures) ? structures : [];
 }
@@ -16518,10 +16896,19 @@ function findOwnedSourceWorkerEnergyLinks(room, network) {
   return selectOwnedSourceWorkerEnergyLinks(network != null ? network : classifyLinks(room), workerLinkIds);
 }
 function selectOwnedSourceWorkerEnergyLinks(network, workerLinkIds) {
-  return network.sourceLinks.filter((link) => workerLinkIds.has(String(link.id)));
+  const linksById = /* @__PURE__ */ new Map();
+  for (const link of network.sourceLinks) {
+    if (workerLinkIds.has(String(link.id))) {
+      linksById.set(String(link.id), link);
+    }
+  }
+  if (network.spawnLink && workerLinkIds.has(String(network.spawnLink.id))) {
+    linksById.set(String(network.spawnLink.id), network.spawnLink);
+  }
+  return [...linksById.values()].sort((left, right) => String(left.id).localeCompare(String(right.id)));
 }
 function getMinimumWorkerLinkWithdrawalEnergy(creep) {
-  return Math.max(1, getFreeEnergyCapacity5(creep));
+  return Math.max(1, getFreeEnergyCapacity6(creep));
 }
 function getWorkerLinkEnergyAvailable(room, link, network) {
   return getSourceLinkWorkerEnergyAvailable(room, link, network);
@@ -16599,7 +16986,7 @@ function createUnreservedWorkerEnergyAcquisitionCandidate(creep, source, energy,
 }
 function createWorkerEnergyAcquisitionCandidate(creep, source, energy, task) {
   const range = getRangeToWorkerEnergyAcquisitionSource(creep, source);
-  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity5(creep));
+  const energyScore = scoreWorkerEnergyAcquisitionAmount(energy, getFreeEnergyCapacity6(creep));
   return {
     energy,
     priority: getWorkerEnergyAcquisitionPriority(creep, source, energy, range),
@@ -16632,7 +17019,7 @@ function isStorageEnergySource(source) {
 }
 function isLinkEnergySource(source) {
   const structureType = source == null ? void 0 : source.structureType;
-  return matchesStructureType12(typeof structureType === "string" ? structureType : void 0, "STRUCTURE_LINK", "link");
+  return matchesStructureType13(typeof structureType === "string" ? structureType : void 0, "STRUCTURE_LINK", "link");
 }
 function isPreferredNearbyWorkerEnergySource(source) {
   return isContainerEnergySource(source) || isStorageEnergySource(source) || isWorkerDroppedEnergySource(source) || "ticksToDecay" in source;
@@ -16648,7 +17035,7 @@ function isDurableStoredEnergySource(source) {
 }
 function isStructureEnergySourceType(source, globalName, fallback) {
   const structureType = source.structureType;
-  return matchesStructureType12(typeof structureType === "string" ? structureType : void 0, globalName, fallback);
+  return matchesStructureType13(typeof structureType === "string" ? structureType : void 0, globalName, fallback);
 }
 function scoreWorkerEnergyAcquisitionAmount(energy, freeCapacity) {
   if (freeCapacity <= 0) {
@@ -16666,7 +17053,7 @@ function createWorkerEnergyAcquisitionReservationContext(creep) {
 function getReservedWorkerEnergyAcquisitionsBySourceId(creep) {
   var _a, _b;
   const reservedEnergyBySourceId = /* @__PURE__ */ new Map();
-  for (const worker of getGameCreeps()) {
+  for (const worker of getGameCreeps2()) {
     if (isSameCreep(worker, creep) || !isSameRoomWorker(worker, creep.room)) {
       continue;
     }
@@ -16674,7 +17061,7 @@ function getReservedWorkerEnergyAcquisitionsBySourceId(creep) {
     if (!isWorkerEnergyAcquisitionReservationTask(task)) {
       continue;
     }
-    const freeCapacity = getFreeEnergyCapacity5(worker);
+    const freeCapacity = getFreeEnergyCapacity6(worker);
     if (freeCapacity <= 0) {
       continue;
     }
@@ -16694,7 +17081,7 @@ function getUnreservedWorkerEnergyAcquisitionAmount(source, energy, reservationC
   if (!creep || !isStorageEnergySource(source)) {
     return projectedEnergy;
   }
-  const plannedWithdrawal = Math.min(projectedEnergy, getFreeEnergyCapacity5(creep));
+  const plannedWithdrawal = Math.min(projectedEnergy, getFreeEnergyCapacity6(creep));
   if (plannedWithdrawal <= 0 || plannedWithdrawal > getStorageEnergyAvailableForWithdrawal(creep.room, source, projectedEnergy) || !withdrawFromStorage(creep.room, plannedWithdrawal, source, projectedEnergy)) {
     return 0;
   }
@@ -16708,7 +17095,7 @@ function createSpawnRecoveryEnergyAcquisitionCandidate(candidate, energySink) {
   if (candidate.range === null) {
     return null;
   }
-  const sourceToSinkRange = getRangeBetweenRoomObjects2(candidate.source, energySink);
+  const sourceToSinkRange = getRangeBetweenRoomObjects3(candidate.source, energySink);
   if (sourceToSinkRange === null) {
     return null;
   }
@@ -16745,7 +17132,7 @@ function estimateHarvestTicks(creep, energySink) {
   return Math.ceil(energyNeeded / Math.max(HARVEST_ENERGY_PER_WORK_PART, workParts * HARVEST_ENERGY_PER_WORK_PART));
 }
 function getSpawnRecoveryHarvestEnergyTarget(creep, energySink) {
-  return Math.max(1, Math.min(getFreeEnergyCapacity5(creep), getFreeStoredEnergyCapacity(energySink)));
+  return Math.max(1, Math.min(getFreeEnergyCapacity6(creep), getFreeStoredEnergyCapacity(energySink)));
 }
 function estimateHarvestSourceAvailabilityDelay(source) {
   if (typeof source.energy !== "number") {
@@ -16785,7 +17172,7 @@ function getBodyPartConstant3(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function getRangeBetweenRoomObjects2(left, right) {
+function getRangeBetweenRoomObjects3(left, right) {
   const position = left.pos;
   if (typeof (position == null ? void 0 : position.getRangeTo) !== "function") {
     return null;
@@ -16809,7 +17196,7 @@ function isReachable(creep, target) {
   if (typeof (position == null ? void 0 : position.findPathTo) !== "function") {
     return true;
   }
-  const range = getRangeBetweenRoomObjects2(creep, target);
+  const range = getRangeBetweenRoomObjects3(creep, target);
   if (range !== null && range <= 1) {
     return true;
   }
@@ -16885,7 +17272,7 @@ function findRuins(room) {
   return room.find(FIND_RUINS);
 }
 function hasSalvageableEnergy(source) {
-  return getStoredEnergy8(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
+  return getStoredEnergy9(source) >= MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT;
 }
 function getCreepOwnerUsername2(creep) {
   var _a;
@@ -16988,7 +17375,7 @@ function isSafeRepairTarget(structure) {
   if (isRoadOrContainerRepairTarget(structure)) {
     return true;
   }
-  return matchesStructureType12(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
+  return matchesStructureType13(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure);
 }
 function isThreatenedBarrierRepairTarget(structure) {
   return isBarrierRepairTarget(structure) && !isWorkerRepairTargetComplete(structure);
@@ -17010,16 +17397,16 @@ function isRoadOrContainerRepairTarget(structure) {
   return isRoadRepairTarget(structure) || isContainerRepairTarget(structure);
 }
 function isBarrierRepairTarget(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) || isWallRepairTarget(structure);
+  return matchesStructureType13(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) || isWallRepairTarget(structure);
 }
 function isRoadRepairTarget(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_ROAD", "road");
 }
 function isContainerRepairTarget(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_CONTAINER", "container");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isWallRepairTarget(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_WALL", "constructedWall");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_WALL", "constructedWall");
 }
 function isCriticalOwnedSpawnRepairTarget(structure) {
   return isOwnedSpawnRepairTarget(structure) && !isWorkerRepairTargetComplete(structure) && getHitsRatio(structure) <= CRITICAL_SPAWN_REPAIR_HITS_RATIO;
@@ -17028,7 +17415,7 @@ function isOwnedSpawnRepairTarget(structure) {
   return isSpawnRepairTarget(structure) && structure.my === true;
 }
 function isSpawnRepairTarget(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_SPAWN", "spawn");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn");
 }
 function isWorkerRepairTargetComplete(structure) {
   return structure.hits >= getWorkerRepairHitsCeiling(structure);
@@ -17040,7 +17427,7 @@ function getWorkerRepairHitsCeiling(structure) {
   return structure.hitsMax;
 }
 function isWorkerBarrierRepairStructure(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) || matchesStructureType12(structure.structureType, "STRUCTURE_WALL", "constructedWall");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_RAMPART", "rampart") && isOwnedRampart(structure) || matchesStructureType13(structure.structureType, "STRUCTURE_WALL", "constructedWall");
 }
 function isOwnedRampart(structure) {
   return structure.my === true;
@@ -17052,10 +17439,10 @@ function getRepairPriority(structure) {
   if (isCriticalOwnedSpawnRepairTarget(structure)) {
     return 0;
   }
-  if (matchesStructureType12(structure.structureType, "STRUCTURE_ROAD", "road")) {
+  if (matchesStructureType13(structure.structureType, "STRUCTURE_ROAD", "road")) {
     return 1;
   }
-  if (matchesStructureType12(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container")) {
     return 2;
   }
   if (isSpawnRepairTarget(structure)) {
@@ -17106,7 +17493,7 @@ function createNearTermSpawnExtensionRefillReserveContext(room) {
     room,
     spawnExtensionEnergyStructures
   );
-  const sortedLoadedWorkers = refillReserve > 0 ? dedupeCreepsByStableKey(getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, room))).sort(
+  const sortedLoadedWorkers = refillReserve > 0 ? dedupeCreepsByStableKey(getGameCreeps2().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, room))).sort(
     (left, right) => compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
   ) : [];
   return {
@@ -17175,7 +17562,7 @@ function dedupeCreepsByStableKey(creeps) {
 function getClosestNearTermRefillRange(creep, spawnExtensionEnergyStructures) {
   let closestRange = null;
   for (const structure of spawnExtensionEnergyStructures) {
-    const range = getRangeBetweenRoomObjects2(creep, structure);
+    const range = getRangeBetweenRoomObjects3(creep, structure);
     if (range === null) {
       continue;
     }
@@ -17316,7 +17703,7 @@ function selectSource2ControllerLaneHarvestSource(creep) {
     return null;
   }
   const topology = getSource2ControllerLaneTopology(creep.room, controller);
-  if (!topology || isSourceDepleted(topology.source) || hasOtherSource2ControllerLaneWorker(creep, topology)) {
+  if (!topology || isSourceDepleted2(topology.source) || hasOtherSource2ControllerLaneWorker(creep, topology)) {
     return null;
   }
   return topology.source;
@@ -17347,11 +17734,11 @@ function isHomeRoomName(room, controller) {
   const controllerRoomName = getPositionRoomName(controller);
   return roomName === null || controllerRoomName === null || roomName === controllerRoomName;
 }
-function isSourceDepleted(source) {
+function isSourceDepleted2(source) {
   return typeof source.energy === "number" && source.energy <= 0;
 }
 function hasOtherSource2ControllerLaneWorker(creep, topology) {
-  return getGameCreeps().some(
+  return getGameCreeps2().some(
     (candidate) => !isSameCreep(candidate, creep) && isSameRoomWorker(candidate, creep.room) && isSource2ControllerLaneTask(candidate, topology)
   );
 }
@@ -17370,7 +17757,7 @@ function getRangeBetweenRoomObjectPositions(left, right) {
   if (!leftPosition || !rightPosition || !isSameRoomPosition6(leftPosition, rightPosition)) {
     return null;
   }
-  const rangeFromApi = getRangeBetweenRoomObjects2(left, right);
+  const rangeFromApi = getRangeBetweenRoomObjects3(left, right);
   if (rangeFromApi !== null) {
     return rangeFromApi;
   }
@@ -17484,7 +17871,7 @@ function isActiveTerritoryPressureIntent(intent, colonyName) {
   return intent.colony === colonyName && intent.targetRoom !== colonyName && (intent.status === "planned" || intent.status === "active") && (intent.action === "claim" || intent.action === "reserve" || intent.action === "scout");
 }
 function getSameRoomLoadedWorkers(creep) {
-  return getSameRoomLoadedWorkersFromCandidates(creep, getGameCreeps());
+  return getSameRoomLoadedWorkersFromCandidates(creep, getGameCreeps2());
 }
 function getSameRoomLoadedWorkersForRefillReservations(creep) {
   return getSameRoomLoadedWorkersFromCandidates(creep, getRoomOwnedCreeps(creep.room));
@@ -17508,12 +17895,12 @@ function isInRoom(creep, room) {
   return creep.room === room;
 }
 function getUsedEnergy2(creep) {
-  return getStoredEnergy8(creep);
+  return getStoredEnergy9(creep);
 }
-function getFreeEnergyCapacity5(creep) {
+function getFreeEnergyCapacity6(creep) {
   return getFreeStoredEnergyCapacity(creep);
 }
-function getStoredEnergy8(object) {
+function getStoredEnergy9(object) {
   var _a;
   return (_a = getKnownStoredEnergy2(object)) != null ? _a : 0;
 }
@@ -17542,7 +17929,7 @@ function getFreeStoredEnergyCapacity(object) {
   const freeCapacity = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
   return typeof freeCapacity === "number" ? freeCapacity : 0;
 }
-function getEnergyCapacity3(creep, carriedEnergy = getUsedEnergy2(creep), freeCapacity = getFreeEnergyCapacity5(creep)) {
+function getEnergyCapacity3(creep, carriedEnergy = getUsedEnergy2(creep), freeCapacity = getFreeEnergyCapacity6(creep)) {
   var _a;
   const store = getStore(creep);
   const capacity = (_a = store == null ? void 0 : store.getCapacity) == null ? void 0 : _a.call(store, getWorkerEnergyResource());
@@ -17654,7 +18041,7 @@ function findSourceContainerWithdrawCandidates(creep) {
     const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
       creep,
       sourceContainer,
-      getStoredEnergy8(sourceContainer),
+      getStoredEnergy9(sourceContainer),
       {
         type: "withdraw",
         targetId: sourceContainer.id
@@ -17706,7 +18093,7 @@ function selectSourceContainerHarvestSource(creep) {
 }
 function hasNonEmptyVisibleSourceContainer(creep, source) {
   const sourceContainer = findVisibleSourceContainer(creep, source);
-  return sourceContainer !== null && getStoredEnergy8(sourceContainer) > 0;
+  return sourceContainer !== null && getStoredEnergy9(sourceContainer) > 0;
 }
 function hasVisiblePositionedContainer(room) {
   if (typeof FIND_STRUCTURES !== "number" || typeof room.find !== "function") {
@@ -17714,7 +18101,7 @@ function hasVisiblePositionedContainer(room) {
   }
   return room.find(FIND_STRUCTURES).some((structure) => {
     const position = getRoomObjectPosition3(structure);
-    return position !== null && matchesStructureType12(structure.structureType, "STRUCTURE_CONTAINER", "container");
+    return position !== null && matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container");
   });
 }
 function findVisibleHarvestSources(creep) {
@@ -18036,7 +18423,7 @@ function estimateRoadAwareTravelCostBetweenRoomObjects(origin, target, targetRan
       return null;
     }
   }
-  const range = getRangeBetweenRoomObjects2(origin, target);
+  const range = getRangeBetweenRoomObjects3(origin, target);
   if (range !== null) {
     return Math.max(0, range - Math.max(0, targetRange - 1));
   }
@@ -18103,16 +18490,16 @@ function createRoadAwareRoomCallback(allowedRoomNames) {
   };
 }
 function isRoadStructure2(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_ROAD", "road");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_ROAD", "road");
 }
 function isBlockingRoadAwareStructure(structure) {
   return !isRoadStructure2(structure) && !isContainerStructure2(structure) && !isWalkableRampartStructure(structure);
 }
 function isContainerStructure2(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_CONTAINER", "container");
+  return matchesStructureType13(structure.structureType, "STRUCTURE_CONTAINER", "container");
 }
 function isWalkableRampartStructure(structure) {
-  return matchesStructureType12(structure.structureType, "STRUCTURE_RAMPART", "rampart") && (structure.my === true || structure.isPublic === true);
+  return matchesStructureType13(structure.structureType, "STRUCTURE_RAMPART", "rampart") && (structure.my === true || structure.isPublic === true);
 }
 function selectViableHarvestSources(sources, harvestEnergyTarget) {
   const sourcesWithEnergy = sources.filter(hasHarvestableEnergy);
@@ -18136,27 +18523,29 @@ function getHarvestSourceAvailableEnergy(source) {
   return getHarvestSourceEnergyCapacity(source);
 }
 function getHarvestEnergyTarget(creep) {
-  return Math.max(1, getFreeEnergyCapacity5(creep));
+  return Math.max(1, getFreeEnergyCapacity6(creep));
 }
 function getWorkerHarvestLoads(sources) {
-  var _a, _b, _c;
+  var _a, _b, _c, _d, _e, _f;
   const assignmentLoads = /* @__PURE__ */ new Map();
   for (const source of sources) {
     assignmentLoads.set(source.id, createEmptyHarvestSourceAssignmentLoad());
   }
   const sourceIds = new Set(sources.map((source) => source.id));
-  for (const assignedCreep of getGameCreeps()) {
+  for (const assignedCreep of getGameCreeps2()) {
     const task = (_a = assignedCreep.memory) == null ? void 0 : _a.task;
     const targetId = typeof (task == null ? void 0 : task.targetId) === "string" ? task.targetId : void 0;
-    if (((_b = assignedCreep.memory) == null ? void 0 : _b.role) !== "worker" || (task == null ? void 0 : task.type) !== "harvest" || !targetId || !sourceIds.has(targetId)) {
+    const sourceHarvesterTargetId = ((_b = assignedCreep.memory) == null ? void 0 : _b.role) === SOURCE_HARVESTER_ROLE && typeof ((_c = assignedCreep.memory.sourceHarvester) == null ? void 0 : _c.sourceId) === "string" ? assignedCreep.memory.sourceHarvester.sourceId : void 0;
+    const assignedSourceId = ((_d = assignedCreep.memory) == null ? void 0 : _d.role) === "worker" && (task == null ? void 0 : task.type) === "harvest" && targetId && sourceIds.has(targetId) ? targetId : sourceHarvesterTargetId;
+    if (!assignedSourceId || !sourceIds.has(assignedSourceId)) {
       continue;
     }
-    const sourceId = targetId;
-    const currentLoad = (_c = assignmentLoads.get(sourceId)) != null ? _c : createEmptyHarvestSourceAssignmentLoad();
+    const sourceId = assignedSourceId;
+    const currentLoad = (_e = assignmentLoads.get(sourceId)) != null ? _e : createEmptyHarvestSourceAssignmentLoad();
     assignmentLoads.set(sourceId, {
       assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts(assignedCreep),
       assignmentCount: currentLoad.assignmentCount + 1,
-      hasContainerAssignment: currentLoad.hasContainerAssignment || isSourceContainerHarvestAssignment(task)
+      hasContainerAssignment: currentLoad.hasContainerAssignment || ((_f = assignedCreep.memory) == null ? void 0 : _f.role) === SOURCE_HARVESTER_ROLE || isSourceContainerHarvestAssignment(task)
     });
   }
   return assignmentLoads;
@@ -18164,7 +18553,7 @@ function getWorkerHarvestLoads(sources) {
 function isSourceContainerHarvestAssignment(task) {
   return (task == null ? void 0 : task.type) === "harvest" && task.sourceContainerAssigned === true;
 }
-function getGameCreeps() {
+function getGameCreeps2() {
   const game = getGameReference();
   const creeps = game == null ? void 0 : game.creeps;
   const gameTick = getGameTick3();
@@ -18216,7 +18605,7 @@ function selectEnergyDropoffOptimization(context, config = {}) {
 }
 function isDurableEnergyDropoff(target) {
   const structureType = target == null ? void 0 : target.structureType;
-  return matchesStructureType13(structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType13(structureType, "STRUCTURE_TERMINAL", "terminal");
+  return matchesStructureType14(structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType14(structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function findRoomConstructionSites(room) {
   if (typeof FIND_CONSTRUCTION_SITES !== "number") {
@@ -18277,7 +18666,7 @@ function createControllerCandidate(context, config) {
   );
 }
 function createCandidate(context, target, task, priority, config) {
-  const directRange = getRangeBetweenRoomObjects3(context.origin, target);
+  const directRange = getRangeBetweenRoomObjects4(context.origin, target);
   if (directRange === null) {
     return null;
   }
@@ -18298,16 +18687,16 @@ function isEfficientReturnPathTarget(directRange, returnPathDetour, context, con
   if (returnPathDetour !== null) {
     return returnPathDetour <= config.maxReturnPathDetour;
   }
-  const dropoffRange = getRangeBetweenRoomObjects3(context.origin, context.dropoff);
+  const dropoffRange = getRangeBetweenRoomObjects4(context.origin, context.dropoff);
   if (dropoffRange !== null && directRange > dropoffRange + config.maxUnknownPathExtraRangeBeyondDropoff) {
     return false;
   }
   return directRange <= config.maxUnknownPathDirectRange;
 }
 function getReturnPathDetour(origin, target, dropoff) {
-  const originToTarget = getRangeBetweenRoomObjects3(origin, target);
-  const targetToDropoff = getRangeBetweenRoomObjects3(target, dropoff);
-  const originToDropoff = getRangeBetweenRoomObjects3(origin, dropoff);
+  const originToTarget = getRangeBetweenRoomObjects4(origin, target);
+  const targetToDropoff = getRangeBetweenRoomObjects4(target, dropoff);
+  const originToDropoff = getRangeBetweenRoomObjects4(origin, dropoff);
   if (originToTarget === null || targetToDropoff === null || originToDropoff === null) {
     return null;
   }
@@ -18339,19 +18728,19 @@ function canReceiveControllerUpgradeEnergy(controller, config) {
   return (controller == null ? void 0 : controller.my) === true && typeof controller.level === "number" && Number.isFinite(controller.level) && controller.level < config.maxControllerLevel;
 }
 function isRefillStructure(structure, config) {
-  return (isPrimaryRefillStructure(structure) || isTowerRefillStructure(structure)) && getFreeEnergyCapacity6(structure) >= config.minRefillFreeCapacity;
+  return (isPrimaryRefillStructure(structure) || isTowerRefillStructure(structure)) && getFreeEnergyCapacity7(structure) >= config.minRefillFreeCapacity;
 }
 function isPrimaryRefillStructure(structure) {
   return isExtensionRefillStructure(structure) || isSpawnRefillStructure(structure);
 }
 function isExtensionRefillStructure(structure) {
-  return matchesStructureType13(structure.structureType, "STRUCTURE_EXTENSION", "extension") && "store" in structure;
+  return matchesStructureType14(structure.structureType, "STRUCTURE_EXTENSION", "extension") && "store" in structure;
 }
 function isSpawnRefillStructure(structure) {
-  return matchesStructureType13(structure.structureType, "STRUCTURE_SPAWN", "spawn") && "store" in structure;
+  return matchesStructureType14(structure.structureType, "STRUCTURE_SPAWN", "spawn") && "store" in structure;
 }
 function isTowerRefillStructure(structure) {
-  return matchesStructureType13(structure.structureType, "STRUCTURE_TOWER", "tower") && "store" in structure;
+  return matchesStructureType14(structure.structureType, "STRUCTURE_TOWER", "tower") && "store" in structure;
 }
 function getConstructionRemainingProgress(site) {
   const progress = site.progress;
@@ -18361,12 +18750,12 @@ function getConstructionRemainingProgress(site) {
   }
   return Math.max(0, progressTotal - progress);
 }
-function getFreeEnergyCapacity6(target) {
+function getFreeEnergyCapacity7(target) {
   var _a, _b;
   const freeCapacity = (_b = (_a = target == null ? void 0 : target.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY);
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
 }
-function getRangeBetweenRoomObjects3(left, right) {
+function getRangeBetweenRoomObjects4(left, right) {
   var _a, _b, _c, _d;
   const directRange = (_b = (_a = left.pos) == null ? void 0 : _a.getRangeTo) == null ? void 0 : _b.call(_a, right);
   if (typeof directRange === "number" && Number.isFinite(directRange)) {
@@ -18388,7 +18777,7 @@ function getStableId(object) {
   const id = object.id;
   return typeof id === "string" ? id : "";
 }
-function matchesStructureType13(actual, globalName, fallback) {
+function matchesStructureType14(actual, globalName, fallback) {
   var _a;
   if (typeof actual !== "string") {
     return false;
@@ -18403,10 +18792,10 @@ var WORKER_NULL_LOOP_TICK_WINDOW = 10;
 var WORKER_STANDBY_IDLE_TIMEOUT_TICKS = 8;
 var WORKER_NULL_LOOP_FALLBACK_ATTEMPTS = 2;
 var OK_CODE7 = 0;
-var ERR_NOT_ENOUGH_RESOURCES_CODE = -6;
+var ERR_NOT_ENOUGH_RESOURCES_CODE2 = -6;
 var ERR_INVALID_TARGET_CODE = -7;
-var ERR_FULL_CODE2 = -8;
-var ERR_NOT_IN_RANGE_CODE4 = -9;
+var ERR_FULL_CODE3 = -8;
+var ERR_NOT_IN_RANGE_CODE5 = -9;
 var MIN_HAULER_DROPPED_ENERGY = 25;
 function runWorker(creep) {
   if (runControllerSustainMovement(creep)) {
@@ -18508,9 +18897,9 @@ function runControllerSustainMovement(creep) {
   }
   const roomName = (_a = creep.room) == null ? void 0 : _a.name;
   if (roomName === sustain.targetRoom) {
-    if (sustain.role === "hauler" && getCarriedEnergy2(creep) <= 0) {
+    if (sustain.role === "hauler" && getCarriedEnergy3(creep) <= 0) {
       clearAssignedTask(creep);
-      moveTowardRoom2(creep, sustain.homeRoom);
+      moveTowardRoom3(creep, sustain.homeRoom);
       return true;
     }
     return false;
@@ -18525,7 +18914,7 @@ function runControllerSustainMovement(creep) {
     }
   }
   clearAssignedTask(creep);
-  moveTowardRoom2(creep, selectControllerSustainDestinationRoom(creep, sustain, roomName));
+  moveTowardRoom3(creep, selectControllerSustainDestinationRoom(creep, sustain, roomName));
   return true;
 }
 function shouldControllerSustainHaulerLoadAtHome(creep, sustain, roomName) {
@@ -18535,7 +18924,7 @@ function selectControllerSustainDestinationRoom(creep, sustain, roomName) {
   if (sustain.role !== "hauler") {
     return sustain.targetRoom;
   }
-  if (getCarriedEnergy2(creep) > 0) {
+  if (getCarriedEnergy3(creep) > 0) {
     return sustain.targetRoom;
   }
   return roomName === sustain.homeRoom ? sustain.targetRoom : sustain.homeRoom;
@@ -18550,7 +18939,7 @@ function runSpawnSupportMovement(creep) {
     return false;
   }
   clearAssignedTask(creep);
-  moveTowardRoom2(creep, support.targetRoom);
+  moveTowardRoom3(creep, support.targetRoom);
   return true;
 }
 function isSpawnSupportMemory(value) {
@@ -18561,7 +18950,7 @@ function clearAssignedTask(creep) {
   delete creep.memory.task;
   clearEnergyDropoffOptimizationMemory(creep);
 }
-function moveTowardRoom2(creep, roomName) {
+function moveTowardRoom3(creep, roomName) {
   if (typeof creep.moveTo !== "function") {
     return;
   }
@@ -18593,7 +18982,7 @@ function selectControllerSustainStoredEnergyTask(creep) {
   return source ? { type: "withdraw", targetId: source.id } : null;
 }
 function compareControllerSustainStoredEnergySources(creep, left, right) {
-  return getStoredEnergy9(right) - getStoredEnergy9(left) || compareRoomObjectsByRangeAndId(creep, left, right);
+  return getStoredEnergy10(right) - getStoredEnergy10(left) || compareRoomObjectsByRangeAndId(creep, left, right);
 }
 function selectControllerSustainDroppedEnergyTask(creep) {
   var _a;
@@ -18614,7 +19003,7 @@ function selectControllerSustainHarvestTask(creep) {
 function isControllerSustainStoredEnergySource(structure) {
   const structureType = structure.structureType;
   const ownedState = structure.my;
-  return (structureType === STRUCTURE_CONTAINER || ownedState !== false) && (structureType === STRUCTURE_CONTAINER || structureType === STRUCTURE_STORAGE || structureType === STRUCTURE_TERMINAL) && getStoredEnergy9(structure) > 0;
+  return (structureType === STRUCTURE_CONTAINER || ownedState !== false) && (structureType === STRUCTURE_CONTAINER || structureType === STRUCTURE_STORAGE || structureType === STRUCTURE_TERMINAL) && getStoredEnergy10(structure) > 0;
 }
 function compareRoomObjectsByRangeAndId(creep, left, right) {
   return getRangeToRoomObject(creep, left) - getRangeToRoomObject(creep, right) || getStableId2(left).localeCompare(getStableId2(right));
@@ -18628,13 +19017,13 @@ function getStableId2(object) {
   const id = object.id;
   return typeof id === "string" ? id : "";
 }
-function getStoredEnergy9(target) {
+function getStoredEnergy10(target) {
   var _a, _b;
   const storedEnergy = (_b = (_a = target.store) == null ? void 0 : _a.getUsedCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY);
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
-function getCarriedEnergy2(creep) {
-  return getStoredEnergy9(creep);
+function getCarriedEnergy3(creep) {
+  return getStoredEnergy10(creep);
 }
 function optimizeAssignedEnergyDropoffTask(creep) {
   const task = creep.memory.task;
@@ -18750,19 +19139,19 @@ function executeAssignedTask(creep, selectedTask, immediateReselectExecutions = 
     }
     return;
   }
-  if (execution.result === ERR_NOT_IN_RANGE_CODE4) {
+  if (execution.result === ERR_NOT_IN_RANGE_CODE5) {
     creep.moveTo(target);
     recordCreepBehaviorMove(creep);
   }
 }
 function shouldImmediatelyReselectAfterTaskResult(task, result) {
   if (task.type === "transfer") {
-    return result === ERR_FULL_CODE2;
+    return result === ERR_FULL_CODE3;
   }
   return isEnergyAcquisitionTask(task) && isUnavailableEnergyAcquisitionResult(result);
 }
 function isUnavailableEnergyAcquisitionResult(result) {
-  return result === ERR_NOT_ENOUGH_RESOURCES_CODE || result === ERR_INVALID_TARGET_CODE;
+  return result === ERR_NOT_ENOUGH_RESOURCES_CODE2 || result === ERR_INVALID_TARGET_CODE;
 }
 function assignSelectedTask(creep, selectedTask, previousTask) {
   if (!selectedTask || previousTask && isSameTask(previousTask, selectedTask)) {
@@ -18881,7 +19270,7 @@ function shouldPreemptTaskForUpgraderBoost(creep, task, selectedTask) {
   if (!isUpgraderBoostActive(creep, (_a = creep.room) == null ? void 0 : _a.controller)) {
     return false;
   }
-  return getCarriedEnergy2(creep) > 0;
+  return getCarriedEnergy3(creep) > 0;
 }
 function shouldPreemptEnergyAcquisitionTaskForNearbyEnergyChoice(creep, task, selectedTask) {
   var _a;
@@ -19037,8 +19426,8 @@ function isUrgentEnergySpendingTask(task) {
 }
 function getTaskTarget(task) {
   const game = globalThis.Game;
-  const getObjectById5 = game == null ? void 0 : game.getObjectById;
-  return typeof getObjectById5 === "function" ? getObjectById5(String(task.targetId)) : null;
+  const getObjectById6 = game == null ? void 0 : game.getObjectById;
+  return typeof getObjectById6 === "function" ? getObjectById6(String(task.targetId)) : null;
 }
 function isCapacityEnablingConstructionSite(target) {
   const structureType = target == null ? void 0 : target.structureType;
@@ -19162,7 +19551,7 @@ function executeTask(creep, task, target) {
       const requestedAmount = getFreeTransferEnergyCapacity(creep);
       const safeAmount = getSpawnEnergyWithdrawalAmount(creep.room, withdrawTarget, requestedAmount);
       if (safeAmount <= 0) {
-        return { result: ERR_NOT_ENOUGH_RESOURCES_CODE };
+        return { result: ERR_NOT_ENOUGH_RESOURCES_CODE2 };
       }
       const result = creep.withdraw(withdrawTarget, RESOURCE_ENERGY, safeAmount);
       return toTaskExecutionResult(result, "work", {
@@ -19175,8 +19564,8 @@ function executeTask(creep, task, target) {
         containerTransfer: isContainerStructure3(target)
       });
     case "build":
-      if (!checkEnergyBufferForSpending(creep.room, getCarriedEnergy2(creep))) {
-        return { result: ERR_NOT_ENOUGH_RESOURCES_CODE };
+      if (!checkEnergyBufferForSpending(creep.room, getCarriedEnergy3(creep))) {
+        return { result: ERR_NOT_ENOUGH_RESOURCES_CODE2 };
       }
       return toTaskExecutionResult(creep.build(target), "work");
     case "repair":
@@ -19211,10 +19600,10 @@ function executeHarvestTask(creep, source) {
     return transferDedicatedHarvestEnergy(creep, sourceContainer);
   }
   const result = creep.harvest(source);
-  if ((result === ERR_FULL_CODE2 || result === ERR_NOT_ENOUGH_RESOURCES_CODE) && getUsedTransferEnergy(creep) > 0) {
+  if ((result === ERR_FULL_CODE3 || result === ERR_NOT_ENOUGH_RESOURCES_CODE2) && getUsedTransferEnergy(creep) > 0) {
     return transferDedicatedHarvestEnergy(creep, sourceContainer);
   }
-  return toTaskExecutionResult(result === ERR_NOT_ENOUGH_RESOURCES_CODE ? OK_CODE7 : result, "work", {
+  return toTaskExecutionResult(result === ERR_NOT_ENOUGH_RESOURCES_CODE2 ? OK_CODE7 : result, "work", {
     ...result === OK_CODE7 ? { energyAcquisitionMethod: "harvested" } : {}
   });
 }
@@ -19223,7 +19612,7 @@ function transferDedicatedHarvestEnergy(creep, sourceContainer) {
     return { result: OK_CODE7 };
   }
   const result = creep.transfer(sourceContainer, RESOURCE_ENERGY);
-  if (result === ERR_NOT_IN_RANGE_CODE4) {
+  if (result === ERR_NOT_IN_RANGE_CODE5) {
     creep.moveTo(sourceContainer);
     return { result: OK_CODE7, action: "move" };
   }
@@ -19246,7 +19635,7 @@ function recordTaskBehavior(creep, task, execution) {
     recordCreepBehaviorMove(creep);
   } else if (execution.action === "work") {
     recordCreepBehaviorWork(creep);
-  } else if (execution.result !== ERR_NOT_IN_RANGE_CODE4) {
+  } else if (execution.result !== ERR_NOT_IN_RANGE_CODE5) {
     recordCreepBehaviorIdle(creep);
   }
   if (execution.containerTransfer) {
@@ -19347,9 +19736,9 @@ var REMOTE_HARVESTER_ROLE = "remoteHarvester";
 var REMOTE_CREEP_REPLACEMENT_TICKS = 100;
 var MAX_REMOTE_HARVESTERS_PER_SOURCE = 1;
 var REMOTE_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
-var ERR_FULL_CODE3 = -8;
-var ERR_NOT_ENOUGH_RESOURCES_CODE2 = -6;
-var ERR_NOT_IN_RANGE_CODE5 = -9;
+var ERR_FULL_CODE4 = -8;
+var ERR_NOT_ENOUGH_RESOURCES_CODE3 = -6;
+var ERR_NOT_IN_RANGE_CODE6 = -9;
 var DEFAULT_REMOTE_ROOM_DISTANCE = 1;
 var CRITICAL_ROAD_MOVE_COST = 1;
 function selectRemoteHarvesterAssignment(homeRoom) {
@@ -19359,7 +19748,7 @@ function selectRemoteHarvesterAssignment(homeRoom) {
   )) != null ? _a : null;
 }
 function getRemoteSourceAssignments(homeRoom) {
-  if (!isNonEmptyString12(homeRoom)) {
+  if (!isNonEmptyString13(homeRoom)) {
     return [];
   }
   const records = getRemoteBootstrapRecords(homeRoom);
@@ -19368,7 +19757,7 @@ function getRemoteSourceAssignments(homeRoom) {
     if (record.roomName === homeRoom || !isAdjacentRoomOrUnknown(homeRoom, record.roomName) || isRemoteOperationSuspended(homeRoom, record.roomName)) {
       continue;
     }
-    const room = getVisibleRoom5(record.roomName);
+    const room = getVisibleRoom6(record.roomName);
     if (!isUsableRemoteRoom(room)) {
       continue;
     }
@@ -19393,74 +19782,74 @@ function runRemoteHarvester(creep) {
   }
   if (shouldRetreatFromRemote(creep, assignment)) {
     delete creep.memory.task;
-    moveTowardRoom3(creep, assignment.homeRoom, void 0, assignment);
+    moveTowardRoom4(creep, assignment.homeRoom, void 0, assignment);
     return;
   }
   if (((_b = creep.room) == null ? void 0 : _b.name) !== assignment.targetRoom) {
     delete creep.memory.task;
-    moveTowardRoom3(
+    moveTowardRoom4(
       creep,
       assignment.targetRoom,
-      (_c = getAssignedContainer(assignment)) != null ? _c : getAssignedSource2(assignment),
+      (_c = getAssignedContainer2(assignment)) != null ? _c : getAssignedSource3(assignment),
       assignment
     );
     return;
   }
-  const source = getAssignedSource2(assignment);
-  const container = getAssignedContainer(assignment);
+  const source = getAssignedSource3(assignment);
+  const container = getAssignedContainer2(assignment);
   if (!container) {
     delete creep.memory.task;
-    if (getCarriedEnergy3(creep) > 0) {
-      (_d = creep.drop) == null ? void 0 : _d.call(creep, getEnergyResource9());
+    if (getCarriedEnergy4(creep) > 0) {
+      (_d = creep.drop) == null ? void 0 : _d.call(creep, getEnergyResource10());
       return;
     }
   }
   if (!source) {
     if (container) {
-      moveTo2(creep, container, assignment);
+      moveTo3(creep, container, assignment);
     }
     return;
   }
-  if (!isInRangeTo(creep, source, 1)) {
-    moveTo2(creep, container != null ? container : source, assignment);
+  if (!isInRangeTo2(creep, source, 1)) {
+    moveTo3(creep, container != null ? container : source, assignment);
     return;
   }
-  if (isSourceDepleted2(source)) {
-    if (container && getCarriedEnergy3(creep) > 0) {
+  if (isSourceDepleted3(source)) {
+    if (container && getCarriedEnergy4(creep) > 0) {
       transferToContainer(creep, container, assignment);
     }
     return;
   }
-  if (container && getFreeEnergyCapacity7(creep) <= 0 && getCarriedEnergy3(creep) > 0) {
+  if (container && getFreeEnergyCapacity8(creep) <= 0 && getCarriedEnergy4(creep) > 0) {
     transferToContainer(creep, container, assignment);
     return;
   }
   const result = (_e = creep.harvest) == null ? void 0 : _e.call(creep, source);
-  if (container && (result === getErrFullCode() || result === getErrNotEnoughResourcesCode()) && getCarriedEnergy3(creep) > 0) {
+  if (container && (result === getErrFullCode2() || result === getErrNotEnoughResourcesCode2()) && getCarriedEnergy4(creep) > 0) {
     transferToContainer(creep, container, assignment);
   }
 }
-function moveTowardRoom3(creep, roomName, target, assignment) {
+function moveTowardRoom4(creep, roomName, target, assignment) {
   var _a;
   if (target) {
-    moveTo2(creep, target, assignment);
+    moveTo3(creep, target, assignment);
     return;
   }
-  const visibleController = (_a = getVisibleRoom5(roomName)) == null ? void 0 : _a.controller;
+  const visibleController = (_a = getVisibleRoom6(roomName)) == null ? void 0 : _a.controller;
   if (visibleController) {
-    moveTo2(creep, visibleController, assignment);
+    moveTo3(creep, visibleController, assignment);
     return;
   }
   const RoomPositionCtor = globalThis.RoomPosition;
   if (typeof RoomPositionCtor === "function") {
-    moveTo2(creep, new RoomPositionCtor(25, 25, roomName), assignment);
+    moveTo3(creep, new RoomPositionCtor(25, 25, roomName), assignment);
   }
 }
 function shouldRetreatFromRemote(creep, assignment) {
   if (isRemoteOperationSuspended(assignment.homeRoom, assignment.targetRoom)) {
     return true;
   }
-  const targetRoom = getVisibleRoom5(assignment.targetRoom);
+  const targetRoom = getVisibleRoom6(assignment.targetRoom);
   if (isForeignOwnedRemoteController(targetRoom == null ? void 0 : targetRoom.controller)) {
     return true;
   }
@@ -19477,7 +19866,7 @@ function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
       targetRoom: room.name,
       sourceId: source.id,
       ...container ? { containerId: container.id } : {},
-      containerEnergy: container ? getStoredEnergy10(container) : 0,
+      containerEnergy: container ? getStoredEnergy11(container) : 0,
       routeDistance: estimateRemoteRoomDistance(homeRoom, room.name)
     };
   });
@@ -19485,13 +19874,13 @@ function getRemoteSourceAssignmentsInRoom(homeRoom, room) {
 function getRemoteBootstrapRecords(homeRoom) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord11(records)) {
+  if (!isRecord12(records)) {
     return [];
   }
   return Object.values(records).filter((record) => isRemoteBootstrapRecord(record, homeRoom)).sort(compareRemoteBootstrapRecords);
 }
 function isRemoteBootstrapRecord(record, homeRoom) {
-  return isRecord11(record) && record.colony === homeRoom && isNonEmptyString12(record.roomName) && record.roomName !== homeRoom && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord12(record) && record.colony === homeRoom && isNonEmptyString13(record.roomName) && record.roomName !== homeRoom && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function compareRemoteBootstrapRecords(left, right) {
   return left.claimedAt - right.claimedAt || left.roomName.localeCompare(right.roomName);
@@ -19526,51 +19915,51 @@ function hasHostileSuspendedTerritoryIntent(homeRoom, targetRoom) {
     return false;
   }
   return intents.some(
-    (intent) => isRecord11(intent) && intent.colony === homeRoom && intent.targetRoom === targetRoom && intent.suspended !== void 0 && isRecord11(intent.suspended) && intent.suspended.reason === "hostile_presence"
+    (intent) => isRecord12(intent) && intent.colony === homeRoom && intent.targetRoom === targetRoom && intent.suspended !== void 0 && isRecord12(intent.suspended) && intent.suspended.reason === "hostile_presence"
   );
 }
 function normalizeRemoteHarvesterMemory(value) {
-  if (!isRecord11(value)) {
+  if (!isRecord12(value)) {
     return null;
   }
-  return isNonEmptyString12(value.homeRoom) && isNonEmptyString12(value.targetRoom) && isNonEmptyString12(value.sourceId) && (value.containerId == null || isNonEmptyString12(value.containerId)) ? {
+  return isNonEmptyString13(value.homeRoom) && isNonEmptyString13(value.targetRoom) && isNonEmptyString13(value.sourceId) && (value.containerId == null || isNonEmptyString13(value.containerId)) ? {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId: value.sourceId,
-    ...isNonEmptyString12(value.containerId) ? { containerId: value.containerId } : {}
+    ...isNonEmptyString13(value.containerId) ? { containerId: value.containerId } : {}
   } : null;
 }
-function getAssignedSource2(assignment) {
+function getAssignedSource3(assignment) {
   var _a;
-  const source = getObjectById2(assignment.sourceId);
+  const source = getObjectById3(assignment.sourceId);
   if (source) {
     return source;
   }
-  const room = getVisibleRoom5(assignment.targetRoom);
+  const room = getVisibleRoom6(assignment.targetRoom);
   if (!room || typeof FIND_SOURCES !== "number" || typeof room.find !== "function") {
     return null;
   }
   return (_a = room.find(FIND_SOURCES).find((candidate) => String(candidate.id) === String(assignment.sourceId))) != null ? _a : null;
 }
-function getAssignedContainer(assignment) {
-  if (isNonEmptyString12(assignment.containerId)) {
-    const container = getObjectById2(assignment.containerId);
+function getAssignedContainer2(assignment) {
+  if (isNonEmptyString13(assignment.containerId)) {
+    const container = getObjectById3(assignment.containerId);
     if (container) {
       return container;
     }
   }
-  const source = getAssignedSource2(assignment);
-  const room = getVisibleRoom5(assignment.targetRoom);
+  const source = getAssignedSource3(assignment);
+  const room = getVisibleRoom6(assignment.targetRoom);
   return source && room ? findSourceContainer(room, source) : null;
 }
 function transferToContainer(creep, container, assignment) {
   var _a;
-  const result = (_a = creep.transfer) == null ? void 0 : _a.call(creep, container, getEnergyResource9());
-  if (result === getErrNotInRangeCode2()) {
-    moveTo2(creep, container, assignment);
+  const result = (_a = creep.transfer) == null ? void 0 : _a.call(creep, container, getEnergyResource10());
+  if (result === getErrNotInRangeCode3()) {
+    moveTo3(creep, container, assignment);
   }
 }
-function moveTo2(creep, target, assignment) {
+function moveTo3(creep, target, assignment) {
   var _a;
   (_a = creep.moveTo) == null ? void 0 : _a.call(creep, target, getRemoteMoveOpts(assignment));
 }
@@ -19580,7 +19969,7 @@ function getRemoteMoveOpts(assignment) {
 }
 function buildCriticalRoadMoveCostCallback(assignment) {
   return (roomName, costMatrix) => {
-    const room = getVisibleRoom5(roomName);
+    const room = getVisibleRoom6(roomName);
     if (!room || !isRemoteMoveRoom(roomName, assignment)) {
       return costMatrix;
     }
@@ -19600,7 +19989,7 @@ function findCriticalRoadMoveTargets(room) {
   return [
     ...findRoomObjects13(room, "FIND_STRUCTURES"),
     ...findRoomObjects13(room, "FIND_CONSTRUCTION_SITES")
-  ].filter((target) => matchesStructureType14(target.structureType, "STRUCTURE_ROAD", "road"));
+  ].filter((target) => matchesStructureType15(target.structureType, "STRUCTURE_ROAD", "road"));
 }
 function findRoomObjects13(room, constantName) {
   const findConstant = globalThis[constantName];
@@ -19614,47 +20003,47 @@ function findRoomObjects13(room, constantName) {
     return [];
   }
 }
-function matchesStructureType14(actual, globalName, fallback) {
+function matchesStructureType15(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
-function isInRangeTo(creep, target, range) {
+function isInRangeTo2(creep, target, range) {
   var _a, _b;
   const actualRange = (_b = (_a = creep.pos) == null ? void 0 : _a.getRangeTo) == null ? void 0 : _b.call(_a, target);
   return typeof actualRange !== "number" || actualRange <= range;
 }
-function isSourceDepleted2(source) {
+function isSourceDepleted3(source) {
   return typeof source.energy === "number" && source.energy <= 0;
 }
-function getCarriedEnergy3(creep) {
-  return getStoredEnergy10(creep);
+function getCarriedEnergy4(creep) {
+  return getStoredEnergy11(creep);
 }
-function getFreeEnergyCapacity7(creep) {
+function getFreeEnergyCapacity8(creep) {
   var _a, _b;
-  const freeCapacity = (_b = (_a = creep.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource9());
+  const freeCapacity = (_b = (_a = creep.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, getEnergyResource10());
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
 }
-function getStoredEnergy10(target) {
+function getStoredEnergy11(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource9());
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource10());
   if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
     return Math.max(0, usedCapacity);
   }
-  const storedEnergy = store == null ? void 0 : store[getEnergyResource9()];
+  const storedEnergy = store == null ? void 0 : store[getEnergyResource10()];
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
-function getEnergyResource9() {
+function getEnergyResource10() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
-function getObjectById2(id) {
+function getObjectById3(id) {
   var _a;
-  const getObjectById5 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  return typeof getObjectById5 === "function" ? getObjectById5(String(id)) : null;
+  const getObjectById6 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById6 === "function" ? getObjectById6(String(id)) : null;
 }
-function getVisibleRoom5(roomName) {
+function getVisibleRoom6(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -19666,7 +20055,7 @@ function getRemoteOperationCreeps(homeRoom, targetRoom) {
   const seen = /* @__PURE__ */ new Set();
   const creeps = [];
   for (const roomName of [homeRoom, targetRoom]) {
-    const room = getVisibleRoom5(roomName);
+    const room = getVisibleRoom6(roomName);
     const roomCreeps = typeof (room == null ? void 0 : room.find) === "function" ? room.find(findMyCreeps3) : void 0;
     if (!Array.isArray(roomCreeps)) {
       continue;
@@ -19725,22 +20114,22 @@ function isVisibleRemoteThreatened(room, targetRoom) {
   const hostiles = room.find(FIND_HOSTILE_CREEPS);
   return Array.isArray(hostiles) && hostiles.length > 0;
 }
-function getErrFullCode() {
+function getErrFullCode2() {
   var _a;
-  return (_a = globalThis.ERR_FULL) != null ? _a : ERR_FULL_CODE3;
+  return (_a = globalThis.ERR_FULL) != null ? _a : ERR_FULL_CODE4;
 }
-function getErrNotEnoughResourcesCode() {
+function getErrNotEnoughResourcesCode2() {
   var _a;
-  return (_a = globalThis.ERR_NOT_ENOUGH_RESOURCES) != null ? _a : ERR_NOT_ENOUGH_RESOURCES_CODE2;
+  return (_a = globalThis.ERR_NOT_ENOUGH_RESOURCES) != null ? _a : ERR_NOT_ENOUGH_RESOURCES_CODE3;
 }
-function getErrNotInRangeCode2() {
+function getErrNotInRangeCode3() {
   var _a;
-  return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE5;
+  return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE6;
 }
-function isRecord11(value) {
+function isRecord12(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString12(value) {
+function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -19750,7 +20139,7 @@ var REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD = 500;
 var MAX_REMOTE_HAULERS_PER_CONTAINER = 1;
 var HAULER_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
 var OK_CODE8 = 0;
-var ERR_NOT_IN_RANGE_CODE6 = -9;
+var ERR_NOT_IN_RANGE_CODE7 = -9;
 function selectRemoteHaulerAssignment(homeRoom) {
   var _a;
   if (!hasRemoteHaulerDeliveryDemand(homeRoom)) {
@@ -19759,10 +20148,10 @@ function selectRemoteHaulerAssignment(homeRoom) {
   return (_a = getRemoteSourceAssignments(homeRoom).filter(hasRemoteContainerAssignment).filter((assignment) => assignment.containerEnergy > REMOTE_HAULER_DISPATCH_ENERGY_THRESHOLD).filter((assignment) => countRemoteHaulersForContainer(assignment) < MAX_REMOTE_HAULERS_PER_CONTAINER).sort(compareRemoteHaulerAssignments)[0]) != null ? _a : null;
 }
 function hasRemoteContainerAssignment(assignment) {
-  return isNonEmptyString13(assignment.containerId);
+  return isNonEmptyString14(assignment.containerId);
 }
 function hasRemoteHaulerDeliveryDemand(homeRoom) {
-  const room = getVisibleRoom6(homeRoom);
+  const room = getVisibleRoom7(homeRoom);
   return room !== void 0 && selectRemoteHaulerDeliveryTask(room) !== null;
 }
 function runHauler(creep) {
@@ -19773,14 +20162,14 @@ function runHauler(creep) {
   }
   if (shouldRetreatFromRemote(creep, assignment)) {
     delete creep.memory.task;
-    if (getCarriedEnergy4(creep) > 0 && ((_b = creep.room) == null ? void 0 : _b.name) === assignment.homeRoom) {
+    if (getCarriedEnergy5(creep) > 0 && ((_b = creep.room) == null ? void 0 : _b.name) === assignment.homeRoom) {
       deliverEnergy2(creep, assignment);
-    } else if (((_c = creep.room) == null ? void 0 : _c.name) !== assignment.homeRoom || getCarriedEnergy4(creep) > 0) {
-      moveTowardRoom3(creep, assignment.homeRoom);
+    } else if (((_c = creep.room) == null ? void 0 : _c.name) !== assignment.homeRoom || getCarriedEnergy5(creep) > 0) {
+      moveTowardRoom4(creep, assignment.homeRoom);
     }
     return;
   }
-  if (getCarriedEnergy4(creep) > 0) {
+  if (getCarriedEnergy5(creep) > 0) {
     deliverEnergy2(creep, assignment);
     return;
   }
@@ -19788,17 +20177,17 @@ function runHauler(creep) {
 }
 function collectRemoteEnergy(creep, assignment) {
   var _a, _b;
-  const assignedContainer = getAssignedContainer2(assignment);
+  const assignedContainer = getAssignedContainer3(assignment);
   if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.targetRoom) {
     delete creep.memory.task;
-    moveTowardRoom3(creep, assignment.targetRoom, assignedContainer);
+    moveTowardRoom4(creep, assignment.targetRoom, assignedContainer);
     return;
   }
   const source = selectRemoteHaulerEnergySource(creep, assignedContainer);
   if (!source) {
     delete creep.memory.task;
     if (assignedContainer) {
-      moveTo3(creep, assignedContainer);
+      moveTo4(creep, assignedContainer);
     }
     return;
   }
@@ -19807,19 +20196,19 @@ function collectRemoteEnergy(creep, assignment) {
     targetId: source.id
   };
   creep.memory.task = task;
-  const result = (_b = creep.withdraw) == null ? void 0 : _b.call(creep, source, getEnergyResource10());
+  const result = (_b = creep.withdraw) == null ? void 0 : _b.call(creep, source, getEnergyResource11());
   if (result === OK_CODE8) {
     recordCreepBehaviorEnergyAcquisition(creep, "withdrawn");
   }
-  if (result === getErrNotInRangeCode3()) {
-    moveTo3(creep, source);
+  if (result === getErrNotInRangeCode4()) {
+    moveTo4(creep, source);
   }
 }
 function deliverEnergy2(creep, assignment) {
   var _a, _b;
   if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
     delete creep.memory.task;
-    moveTowardRoom3(creep, assignment.homeRoom);
+    moveTowardRoom4(creep, assignment.homeRoom);
     return;
   }
   const task = selectRemoteHaulerDeliveryTask(creep.room);
@@ -19828,14 +20217,14 @@ function deliverEnergy2(creep, assignment) {
     return;
   }
   creep.memory.task = task;
-  const target = getObjectById3(task.targetId);
+  const target = getObjectById4(task.targetId);
   if (!target) {
     delete creep.memory.task;
     return;
   }
-  const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, target, getEnergyResource10());
-  if (result === getErrNotInRangeCode3()) {
-    moveTo3(creep, target);
+  const result = (_b = creep.transfer) == null ? void 0 : _b.call(creep, target, getEnergyResource11());
+  if (result === getErrNotInRangeCode4()) {
+    moveTo4(creep, target);
   }
 }
 function compareRemoteHaulerAssignments(left, right) {
@@ -19853,25 +20242,25 @@ function canSatisfyRemoteCreepCapacity2(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > REMOTE_CREEP_REPLACEMENT_TICKS;
 }
 function normalizeRemoteHaulerMemory(value) {
-  if (!isRecord12(value)) {
+  if (!isRecord13(value)) {
     return null;
   }
-  return isNonEmptyString13(value.homeRoom) && isNonEmptyString13(value.targetRoom) && isNonEmptyString13(value.sourceId) && isNonEmptyString13(value.containerId) ? {
+  return isNonEmptyString14(value.homeRoom) && isNonEmptyString14(value.targetRoom) && isNonEmptyString14(value.sourceId) && isNonEmptyString14(value.containerId) ? {
     homeRoom: value.homeRoom,
     targetRoom: value.targetRoom,
     sourceId: value.sourceId,
     containerId: value.containerId
   } : null;
 }
-function getAssignedContainer2(assignment) {
-  return getObjectById3(assignment.containerId);
+function getAssignedContainer3(assignment) {
+  return getObjectById4(assignment.containerId);
 }
 function selectRemoteHaulerEnergySource(creep, assignedContainer) {
   var _a;
   const seenSourceIds = /* @__PURE__ */ new Set();
   const sources = [];
   for (const source of [assignedContainer, ...findVisibleRemoteHaulerEnergySources(creep.room)]) {
-    if (!source || getStoredEnergy11(source) <= 0) {
+    if (!source || getStoredEnergy12(source) <= 0) {
       continue;
     }
     const sourceId = getObjectId9(source);
@@ -19892,47 +20281,47 @@ function findVisibleRemoteHaulerEnergySources(room) {
 }
 function isRemoteHaulerEnergySource(structure) {
   const structureType = structure.structureType;
-  if (matchesStructureType15(structureType, "STRUCTURE_CONTAINER", "container")) {
+  if (matchesStructureType16(structureType, "STRUCTURE_CONTAINER", "container")) {
     return true;
   }
-  if (matchesStructureType15(structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType15(structureType, "STRUCTURE_TERMINAL", "terminal")) {
+  if (matchesStructureType16(structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType16(structureType, "STRUCTURE_TERMINAL", "terminal")) {
     return structure.my !== false;
   }
   return false;
 }
 function compareRemoteHaulerEnergySources(creep, left, right) {
-  return getStoredEnergy11(right) - getStoredEnergy11(left) || getRangeToRoomObject2(creep, left) - getRangeToRoomObject2(creep, right) || getObjectId9(left).localeCompare(getObjectId9(right));
+  return getStoredEnergy12(right) - getStoredEnergy12(left) || getRangeToRoomObject2(creep, left) - getRangeToRoomObject2(creep, right) || getObjectId9(left).localeCompare(getObjectId9(right));
 }
 function getRangeToRoomObject2(creep, target) {
   var _a, _b;
   const range = (_b = (_a = creep.pos) == null ? void 0 : _a.getRangeTo) == null ? void 0 : _b.call(_a, target);
   return typeof range === "number" && Number.isFinite(range) ? Math.max(0, range) : Number.MAX_SAFE_INTEGER;
 }
-function moveTo3(creep, target) {
+function moveTo4(creep, target) {
   var _a;
   (_a = creep.moveTo) == null ? void 0 : _a.call(creep, target, HAULER_MOVE_OPTS);
 }
-function getCarriedEnergy4(creep) {
-  return getStoredEnergy11(creep);
+function getCarriedEnergy5(creep) {
+  return getStoredEnergy12(creep);
 }
-function getStoredEnergy11(target) {
+function getStoredEnergy12(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource10());
+  const usedCapacity = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource11());
   if (typeof usedCapacity === "number" && Number.isFinite(usedCapacity)) {
     return Math.max(0, usedCapacity);
   }
-  const storedEnergy = store == null ? void 0 : store[getEnergyResource10()];
+  const storedEnergy = store == null ? void 0 : store[getEnergyResource11()];
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
-function getEnergyResource10() {
+function getEnergyResource11() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
-function getObjectById3(id) {
+function getObjectById4(id) {
   var _a;
-  const getObjectById5 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  return typeof getObjectById5 === "function" ? getObjectById5(String(id)) : null;
+  const getObjectById6 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById6 === "function" ? getObjectById6(String(id)) : null;
 }
 function getRemoteOperationCreeps2(homeRoom, targetRoom) {
   const findMyCreeps3 = globalThis.FIND_MY_CREEPS;
@@ -19942,7 +20331,7 @@ function getRemoteOperationCreeps2(homeRoom, targetRoom) {
   const seen = /* @__PURE__ */ new Set();
   const creeps = [];
   for (const roomName of [homeRoom, targetRoom]) {
-    const room = getVisibleRoom6(roomName);
+    const room = getVisibleRoom7(roomName);
     const roomCreeps = typeof (room == null ? void 0 : room.find) === "function" ? room.find(findMyCreeps3) : void 0;
     if (!Array.isArray(roomCreeps)) {
       continue;
@@ -19958,7 +20347,7 @@ function getRemoteOperationCreeps2(homeRoom, targetRoom) {
   }
   return creeps;
 }
-function getVisibleRoom6(roomName) {
+function getVisibleRoom7(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -19974,19 +20363,19 @@ function getObjectId9(object) {
   const name = object == null ? void 0 : object.name;
   return typeof name === "string" ? name : "";
 }
-function matchesStructureType15(actual, globalName, fallback) {
+function matchesStructureType16(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
-function getErrNotInRangeCode3() {
+function getErrNotInRangeCode4() {
   var _a;
-  return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE6;
+  return (_a = globalThis.ERR_NOT_IN_RANGE) != null ? _a : ERR_NOT_IN_RANGE_CODE7;
 }
-function isRecord12(value) {
+function isRecord13(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString13(value) {
+function isNonEmptyString14(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -20120,7 +20509,7 @@ var ROUTE_DISTANCE_CACHE_TTL_TICKS = 300;
 function recordPlannedMultiRoomUpgraderSpawn(memory) {
   var _a, _b;
   const sustain = memory.controllerSustain;
-  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString14(sustain.homeRoom) || !isNonEmptyString14(sustain.targetRoom)) {
+  if (memory.role !== "worker" || (sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString15(sustain.homeRoom) || !isNonEmptyString15(sustain.targetRoom)) {
     return;
   }
   const cache = getActiveMultiRoomUpgraderCountCache();
@@ -20207,11 +20596,11 @@ function getVisibleMultiRoomUpgradeCandidates(colony, config) {
 }
 function getVisibleMultiRoomUpgradeCandidate(homeRoom, room, config, activeUpgraderCounts, order) {
   var _a;
-  if (!isNonEmptyString14(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
+  if (!isNonEmptyString15(room.name) || room.name === homeRoom || isKnownDeadZoneRoom(room.name)) {
     return null;
   }
   const controller = room.controller;
-  if (!controller || !isNonEmptyString14(controller.id)) {
+  if (!controller || !isNonEmptyString15(controller.id)) {
     return null;
   }
   const controllerState = getEligibleControllerState(controller);
@@ -20250,7 +20639,7 @@ function hasPrimaryRoomStorageSurplus(colony, storageEnergyThresholdRatio) {
   if (!storage) {
     return false;
   }
-  const storedEnergy = getStoredEnergy12(storage);
+  const storedEnergy = getStoredEnergy13(storage);
   const storageCapacity = getStorageEnergyCapacity(storage);
   return storageCapacity > 0 && storedEnergy > storageCapacity * storageEnergyThresholdRatio;
 }
@@ -20289,7 +20678,7 @@ function hasActiveClaimedRoomSpawnConstructionSite(room) {
   }
 }
 function isActiveSpawnConstructionSite(site) {
-  return isRecord13(site) && matchesStructureType16(site.structureType, "STRUCTURE_SPAWN", "spawn") && hasIncompleteConstructionSiteProgress(site);
+  return isRecord14(site) && matchesStructureType17(site.structureType, "STRUCTURE_SPAWN", "spawn") && hasIncompleteConstructionSiteProgress(site);
 }
 function hasIncompleteConstructionSiteProgress(site) {
   const progress = site.progress;
@@ -20303,7 +20692,7 @@ function getFindConstant6(constantName) {
   const findConstant = globalThis[constantName];
   return typeof findConstant === "number" ? findConstant : null;
 }
-function matchesStructureType16(actual, globalName, fallback) {
+function matchesStructureType17(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return typeof actual === "string" && actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -20351,7 +20740,7 @@ function countActiveMultiRoomUpgradersByHomeRoom(creeps) {
   const countsByHomeRoom = {};
   for (const creep of Object.values(creeps)) {
     const sustain = (_a = creep.memory) == null ? void 0 : _a.controllerSustain;
-    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString14(sustain.homeRoom) || !isNonEmptyString14(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
+    if ((sustain == null ? void 0 : sustain.role) !== "upgrader" || !isNonEmptyString15(sustain.homeRoom) || !isNonEmptyString15(sustain.targetRoom) || !isActiveMultiRoomUpgrader(creep)) {
       continue;
     }
     const countsByTarget = (_b = countsByHomeRoom[sustain.homeRoom]) != null ? _b : {};
@@ -20401,7 +20790,7 @@ function getControllerLevel(controller) {
 function getControllerTicksToDowngradePlanField(controller) {
   return typeof controller.ticksToDowngrade === "number" && Number.isFinite(controller.ticksToDowngrade) ? { controllerTicksToDowngrade: Math.max(0, Math.floor(controller.ticksToDowngrade)) } : {};
 }
-function getStoredEnergy12(storage) {
+function getStoredEnergy13(storage) {
   const storedEnergy = storage.store.getUsedCapacity(RESOURCE_ENERGY);
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
@@ -20450,13 +20839,13 @@ function getTerritoryRouteDistanceCache3(gameTime) {
   if (!memory) {
     return void 0;
   }
-  if (!isRecord13(memory.territory)) {
+  if (!isRecord14(memory.territory)) {
     memory.territory = {};
   }
-  if (!isRecord13(memory.territory.routeDistances)) {
+  if (!isRecord14(memory.territory.routeDistances)) {
     memory.territory.routeDistances = {};
   }
-  if (!isRecord13(memory.territory.routeDistancesUpdatedAt)) {
+  if (!isRecord14(memory.territory.routeDistancesUpdatedAt)) {
     memory.territory.routeDistancesUpdatedAt = {};
   }
   const distances = memory.territory.routeDistances;
@@ -20504,7 +20893,7 @@ function isAdjacentRoom(fromRoom, targetRoom) {
     return false;
   }
   const exits = gameMap.describeExits(fromRoom);
-  if (!isRecord13(exits)) {
+  if (!isRecord14(exits)) {
     return false;
   }
   return Object.values(exits).some((roomName) => roomName === targetRoom);
@@ -20518,10 +20907,10 @@ function getGameTime16() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isRecord13(value) {
+function isRecord14(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString14(value) {
+function isNonEmptyString15(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -20553,7 +20942,7 @@ function buildControllerManagementPlan(colony, roleCounts, workerTarget, gameTim
   var _a;
   const roomName = colony.room.name;
   const controller = colony.room.controller;
-  if ((controller == null ? void 0 : controller.my) !== true || !isNonEmptyString15(controller.id)) {
+  if ((controller == null ? void 0 : controller.my) !== true || !isNonEmptyString16(controller.id)) {
     return {
       roomName,
       updatedAt: gameTime,
@@ -20682,7 +21071,7 @@ function getControllerProgressRatioField(controller) {
 function getControllerTicksToDowngradeField(controller) {
   return typeof controller.ticksToDowngrade === "number" && Number.isFinite(controller.ticksToDowngrade) ? { ticksToDowngrade: controller.ticksToDowngrade } : {};
 }
-function isNonEmptyString15(value) {
+function isNonEmptyString16(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -20709,6 +21098,7 @@ var POST_CLAIM_SUSTAIN_MIN_HAULER_ENERGY = 200;
 var MINIMUM_EMERGENCY_WORKER_BODY_COST = getBodyCost(EMERGENCY_BOOTSTRAP_WORKER_BODY);
 var SPAWN_PRIORITY_TIERS = [
   "emergencyBootstrap",
+  "localSourceMining",
   "localRefillSurvival",
   "controllerDowngradeGuard",
   "defense",
@@ -20798,6 +21188,8 @@ function planSpawnForPriorityTier(tier, context) {
   switch (tier) {
     case "emergencyBootstrap":
       return planEmergencyBootstrapSpawn(context);
+    case "localSourceMining":
+      return planLocalSourceMiningSpawn(context);
     case "localRefillSurvival":
       return planLocalSurvivalSpawn(context);
     case "controllerDowngradeGuard":
@@ -20834,6 +21226,42 @@ function planLocalSurvivalSpawn(context) {
     return null;
   }
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
+}
+function planLocalSourceMiningSpawn(context) {
+  var _a, _b;
+  if (context.options.workersOnly || context.survival.hostilePresence || context.survival.controllerDowngradeGuard || ((_a = context.colony.room.controller) == null ? void 0 : _a.my) !== true || ((_b = context.colony.room.controller.level) != null ? _b : 0) < 2 || context.workerCapacity < LOCAL_SUPPORT_WORKER_FLOOR) {
+    return null;
+  }
+  const assignment = selectSourceHarvesterAssignment(context.colony.room);
+  if (!assignment) {
+    return null;
+  }
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+  const body = selectDynamicBodyForColony(
+    context.colony,
+    SOURCE_HARVESTER_ROLE,
+    context.workerCapacity < context.workerTarget ? "recovery" : "surplus",
+    buildRemoteHarvesterBody
+  );
+  if (body.length === 0) {
+    return null;
+  }
+  return {
+    spawn,
+    body,
+    name: appendSpawnNameSuffix(
+      `${SOURCE_HARVESTER_ROLE}-${context.colony.room.name}-${assignment.sourceId}-${context.gameTime}`,
+      context.options
+    ),
+    memory: {
+      role: SOURCE_HARVESTER_ROLE,
+      colony: context.colony.room.name,
+      sourceHarvester: assignment
+    }
+  };
 }
 function planControllerDowngradeGuardSpawn(context) {
   if (!context.survival.controllerDowngradeGuard || context.workerCapacity > context.workerTarget || context.colony.energyAvailable < BOOTSTRAP_MIN_SPAWN_ENERGY || !hasControllerDowngradeGuardSpawnCapacity(context)) {
@@ -20946,7 +21374,7 @@ function selectPostClaimControllerSustainPlan(colony) {
   var _a;
   const records = getPostClaimControllerSustainRecords(colony.room.name);
   for (const record of records) {
-    const targetRoom = getVisibleRoom7(record.roomName);
+    const targetRoom = getVisibleRoom8(record.roomName);
     if (((_a = targetRoom == null ? void 0 : targetRoom.controller) == null ? void 0 : _a.my) !== true) {
       continue;
     }
@@ -20973,7 +21401,7 @@ function selectPostClaimControllerSustainPlan(colony) {
 function getPostClaimControllerSustainRecords(colonyName) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord14(records)) {
+  if (!isRecord15(records)) {
     return [];
   }
   return Object.values(records).filter(
@@ -20981,7 +21409,7 @@ function getPostClaimControllerSustainRecords(colonyName) {
   ).sort(comparePostClaimControllerSustainRecords);
 }
 function isPostClaimControllerSustainRecord(record, colonyName) {
-  return isRecord14(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString16(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
+  return isRecord15(record) && record.colony === colonyName && record.roomName !== colonyName && isNonEmptyString17(record.roomName) && (record.status === "detected" || record.status === "spawnSitePending" || record.status === "spawnSiteBlocked" || record.status === "spawningWorkers" || record.status === "ready");
 }
 function comparePostClaimControllerSustainRecords(left, right) {
   const leftHasSpawn = hasOperationalSpawnInRoom(left.roomName);
@@ -20993,7 +21421,7 @@ function comparePostClaimControllerSustainRecords(left, right) {
 }
 function getVisibleControllerLevel(roomName) {
   var _a, _b;
-  const level = (_b = (_a = getVisibleRoom7(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
+  const level = (_b = (_a = getVisibleRoom8(roomName)) == null ? void 0 : _a.controller) == null ? void 0 : _b.level;
   return typeof level === "number" ? level : MAX_CONTROLLER_LEVEL5 + 1;
 }
 function hasOperationalSpawnInRoom(roomName) {
@@ -21129,7 +21557,7 @@ function planPostClaimControllerDefenseSpawn(context) {
 function selectPostClaimControllerDefensePlan(colony) {
   var _a;
   for (const record of getPostClaimControllerSustainRecords(colony.room.name)) {
-    const targetRoom = getVisibleRoom7(record.roomName);
+    const targetRoom = getVisibleRoom8(record.roomName);
     const controllerUnderAttack = hasControllerAttackPressure(targetRoom == null ? void 0 : targetRoom.controller);
     if (((_a = targetRoom == null ? void 0 : targetRoom.controller) == null ? void 0 : _a.my) !== true || !controllerUnderAttack) {
       continue;
@@ -21456,7 +21884,7 @@ function appendSpawnNameSuffix(baseName, options) {
   return options.nameSuffix ? `${baseName}-${options.nameSuffix}` : baseName;
 }
 function isWorkerOnlyFollowUpPass(options) {
-  return options.workersOnly === true && isNonEmptyString16(options.nameSuffix);
+  return options.workersOnly === true && isNonEmptyString17(options.nameSuffix);
 }
 function selectWorkerBody(colony, roleCounts) {
   if (shouldUseSourceHarvesterBody(colony, roleCounts)) {
@@ -21626,7 +22054,7 @@ function buildTerritorySpawnBody(energyAvailable, intent) {
 function hasPostClaimBootstrapReserve(intent) {
   return intent.action === "claim" && typeof intent.postClaimBootstrapReserveEnergy === "number" && intent.postClaimBootstrapReserveEnergy > 0;
 }
-function getVisibleRoom7(roomName) {
+function getVisibleRoom8(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -21730,10 +22158,10 @@ function getStorageBalanceMemory() {
   var _a, _b;
   return (_b = (_a = globalThis.Memory) == null ? void 0 : _a.economy) == null ? void 0 : _b.storageBalance;
 }
-function isRecord14(value) {
+function isRecord15(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString16(value) {
+function isNonEmptyString17(value) {
   return typeof value === "string" && value.length > 0;
 }
 function getGlobalNumber8(name) {
@@ -21750,7 +22178,7 @@ var ROOM_EDGE_MAX6 = 47;
 var DEFAULT_TERRAIN_WALL_MASK9 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
-  if (!isNonEmptyString17(input.colony) || !isNonEmptyString17(input.roomName)) {
+  if (!isNonEmptyString18(input.colony) || !isNonEmptyString18(input.roomName)) {
     return;
   }
   const bootstraps = getWritablePostClaimBootstrapRecords();
@@ -21894,7 +22322,7 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   return { active: true, spawnConstructionPending: true };
 }
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
-  if (!isNonEmptyString17(roomName)) {
+  if (!isNonEmptyString18(roomName)) {
     return;
   }
   const record = getPostClaimBootstrapRecord(roomName);
@@ -22194,7 +22622,7 @@ function findExistingSpawnConstructionSite(room) {
     return null;
   }
   const sites = room.find(findConstant, {
-    filter: (site) => matchesStructureType17(site.structureType, "STRUCTURE_SPAWN", "spawn")
+    filter: (site) => matchesStructureType18(site.structureType, "STRUCTURE_SPAWN", "spawn")
   });
   return (_a = sites[0]) != null ? _a : null;
 }
@@ -22206,14 +22634,14 @@ function findSources3(room) {
   return room.find(findConstant);
 }
 function getRoomObjectPosition4(object) {
-  if (!isRecord15(object)) {
+  if (!isRecord16(object)) {
     return null;
   }
   if (isFiniteNumber8(object.x) && isFiniteNumber8(object.y)) {
     return { x: object.x, y: object.y };
   }
   const pos = object.pos;
-  if (isRecord15(pos) && isFiniteNumber8(pos.x) && isFiniteNumber8(pos.y)) {
+  if (isRecord16(pos) && isFiniteNumber8(pos.x) && isFiniteNumber8(pos.y)) {
     return { x: pos.x, y: pos.y };
   }
   return null;
@@ -22260,7 +22688,7 @@ function getWritablePostClaimBootstrapRecords() {
   return memory.territory.postClaimBootstraps;
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
-  return isRecord15(value) && value.roomName === expectedRoomName && isNonEmptyString17(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber8(value.claimedAt) && isFiniteNumber8(value.updatedAt);
+  return isRecord16(value) && value.roomName === expectedRoomName && isNonEmptyString18(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber8(value.claimedAt) && isFiniteNumber8(value.updatedAt);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
@@ -22299,7 +22727,7 @@ function getRoomTerrain9(roomName) {
 function getTerrainWallMask7() {
   return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK9;
 }
-function matchesStructureType17(actual, globalName, fallback) {
+function matchesStructureType18(actual, globalName, fallback) {
   return actual === getStructureConstant2(globalName, fallback);
 }
 function getStructureConstant2(globalName, fallback) {
@@ -22320,10 +22748,10 @@ function getGameTime17() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord15(value) {
+function isRecord16(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString17(value) {
+function isNonEmptyString18(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber8(value) {
@@ -22336,7 +22764,7 @@ var ROOM_EDGE_MAX7 = 48;
 var DEFAULT_TERRAIN_WALL_MASK10 = 1;
 var ERR_INVALID_TARGET_CODE3 = -7;
 var REMOTE_HARVESTER_ROLE2 = "remoteHarvester";
-function ensureRemoteSourceContainersForAssignedHarvesters(creeps = getGameCreeps2()) {
+function ensureRemoteSourceContainersForAssignedHarvesters(creeps = getGameCreeps3()) {
   const roomResults = getRemoteSourceContainerScans(creeps).map(planSourceContainersForRoom);
   return buildSourceContainerPlannerResult(roomResults);
 }
@@ -22414,7 +22842,7 @@ function getRemoteSourceContainerScans(creeps) {
     if (!assignment) {
       continue;
     }
-    const room = getVisibleRoom8(assignment.targetRoom);
+    const room = getVisibleRoom9(assignment.targetRoom);
     if (!room || !isBuildableRemoteRoom(room)) {
       continue;
     }
@@ -22427,7 +22855,7 @@ function getRemoteSourceContainerScans(creeps) {
     sourcesByRoom.set(room.name, sources);
   }
   return [...sourcesByRoom.entries()].map(([roomName, sourcesById]) => {
-    const room = getVisibleRoom8(roomName);
+    const room = getVisibleRoom9(roomName);
     if (!room) {
       return null;
     }
@@ -22500,7 +22928,7 @@ function getSourceContainerCandidatePositions(room, source, lookups, anchor) {
   return getAdjacentBuildPositions2(sourcePosition, room.name).filter((position) => canPlaceSourceContainer3(lookups, position)).sort((left, right) => compareSourceContainerPositions3(left, right, anchor));
 }
 function hasSourceContainerCoverage2(room, source, lookups) {
-  return findSourceContainer(room, source) !== null || findSourceContainerConstructionSite(room, source) !== null || lookups.pendingContainerPositions.some((position) => isNearRoomObject3(source, position));
+  return findSourceContainer(room, source) !== null || findSourceContainerConstructionSite(room, source) !== null || lookups.pendingContainerPositions.some((position) => isNearRoomObject4(source, position));
 }
 function getAdjacentBuildPositions2(sourcePosition, roomName) {
   const positions = [];
@@ -22565,7 +22993,7 @@ function selectSourceContainerAnchor(room) {
   const primarySpawnPosition = primarySpawn ? getRoomObjectPosition2(primarySpawn) : null;
   return primarySpawnPosition != null ? primarySpawnPosition : room.controller ? getRoomObjectPosition2(room.controller) : null;
 }
-function isNearRoomObject3(object, position) {
+function isNearRoomObject4(object, position) {
   const objectPosition = getRoomObjectPosition2(object);
   if (!objectPosition) {
     return false;
@@ -22590,7 +23018,7 @@ function getOwnedRoomControllerLevel(room) {
   const level = ((_a = room.controller) == null ? void 0 : _a.my) === true ? room.controller.level : 0;
   return typeof level === "number" && Number.isFinite(level) ? Math.max(0, Math.floor(level)) : 0;
 }
-function getVisibleRoom8(roomName) {
+function getVisibleRoom9(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -22599,19 +23027,19 @@ function getVisibleSpawns() {
   const spawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
   return spawns ? Object.values(spawns).filter((spawn) => spawn !== void 0) : [];
 }
-function getGameCreeps2() {
+function getGameCreeps3() {
   var _a;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
   return creeps ? Object.values(creeps).filter((creep) => creep !== void 0) : [];
 }
 function getGameSourceById(id) {
   var _a;
-  const getObjectById5 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  if (typeof getObjectById5 !== "function") {
+  const getObjectById6 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  if (typeof getObjectById6 !== "function") {
     return null;
   }
   try {
-    return getObjectById5(id);
+    return getObjectById6(id);
   } catch {
     return null;
   }
@@ -22659,7 +23087,7 @@ function normalizeRemoteHarvesterMemory2(creep) {
     return null;
   }
   const assignment = creep.memory.remoteHarvester;
-  if (!isRecord16(assignment) || typeof assignment.homeRoom !== "string" || assignment.homeRoom.length === 0 || typeof assignment.targetRoom !== "string" || assignment.targetRoom.length === 0 || assignment.homeRoom === assignment.targetRoom || typeof assignment.sourceId !== "string" || assignment.sourceId.length === 0) {
+  if (!isRecord17(assignment) || typeof assignment.homeRoom !== "string" || assignment.homeRoom.length === 0 || typeof assignment.targetRoom !== "string" || assignment.targetRoom.length === 0 || assignment.homeRoom === assignment.targetRoom || typeof assignment.sourceId !== "string" || assignment.sourceId.length === 0) {
     return null;
   }
   return assignment;
@@ -22676,7 +23104,7 @@ function isAssignedRemoteHarvesterLosingEnergyToDecay(creep, room, source) {
   if (((_a = creep.room) == null ? void 0 : _a.name) !== room.name) {
     return false;
   }
-  return getUsedEnergy3(creep) > 0 || getFreeEnergyCapacity8(creep) === 0;
+  return getUsedEnergy3(creep) > 0 || getFreeEnergyCapacity9(creep) === 0;
 }
 function hasDroppedEnergyDecayingAtSource(room, source) {
   var _a;
@@ -22693,25 +23121,25 @@ function hasDroppedEnergyDecayingAtSource(room, source) {
 function isDroppedEnergy2(resource) {
   const amount = resource.amount;
   const ticksToDecay = resource.ticksToDecay;
-  return resource.resourceType === getEnergyResource11() && typeof amount === "number" && Number.isFinite(amount) && amount > 0 && (typeof ticksToDecay !== "number" || ticksToDecay > 0);
+  return resource.resourceType === getEnergyResource12() && typeof amount === "number" && Number.isFinite(amount) && amount > 0 && (typeof ticksToDecay !== "number" || ticksToDecay > 0);
 }
 function getUsedEnergy3(creep) {
   var _a;
   const store = creep.store;
-  const used = (_a = store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource11());
+  const used = (_a = store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource12());
   return typeof used === "number" && Number.isFinite(used) ? Math.max(0, used) : 0;
 }
-function getFreeEnergyCapacity8(creep) {
+function getFreeEnergyCapacity9(creep) {
   var _a;
   const store = creep.store;
-  const free = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource11());
+  const free = (_a = store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource12());
   return typeof free === "number" && Number.isFinite(free) ? Math.max(0, free) : null;
 }
-function getEnergyResource11() {
+function getEnergyResource12() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
-function isRecord16(value) {
+function isRecord17(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -23017,7 +23445,7 @@ function isRecentWorkerTaskBehaviorSample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskBehaviorSample(value) {
-  return isRecord17(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord17(value.state) && isRecord17(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
+  return isRecord18(value) && value.type === "workerTaskBehavior" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && isRecord18(value.state) && isRecord18(value.action) && isWorkerTaskBehaviorActionType(value.action.type) && typeof value.action.targetId === "string";
 }
 function isRecentWorkerTaskPolicyShadow(value, tick) {
   if (!isWorkerTaskPolicyShadow(value)) {
@@ -23026,7 +23454,7 @@ function isRecentWorkerTaskPolicyShadow(value, tick) {
   return tick <= 0 || value.tick <= tick && value.tick > tick - WORKER_BEHAVIOR_SAMPLE_TTL;
 }
 function isWorkerTaskPolicyShadow(value) {
-  return isRecord17(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
+  return isRecord18(value) && value.type === "workerTaskPolicyShadow" && value.schemaVersion === 1 && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.policyId === "string" && value.liveEffect === false && typeof value.matched === "boolean";
 }
 function shouldBuildStructureSnapshot(tick) {
   return tick > 0 && tick % RUNTIME_SUMMARY_INTERVAL === 0;
@@ -23054,7 +23482,7 @@ function countConstructionSitesByType(constructionSites, globalName, fallback) {
   return constructionSites.filter((site) => isStructureOfType(site, globalName, fallback)).length;
 }
 function countOwnedRamparts(structures) {
-  return structures.filter((structure) => isRecord17(structure) && isObservedOwnedRampart(structure)).length;
+  return structures.filter((structure) => isRecord18(structure) && isObservedOwnedRampart(structure)).length;
 }
 function summarizeContainers(structures) {
   return structures.filter((structure) => isStructureOfType(structure, "STRUCTURE_CONTAINER", "container")).map(toRuntimeContainerSnapshot).filter((summary) => summary !== null).sort((left, right) => left.id.localeCompare(right.id));
@@ -23091,7 +23519,7 @@ function summarizeRepairTargetDistribution(colonyWorkers, roomStructures) {
   return [...repairCounts.entries()].sort(([leftTargetId], [rightTargetId]) => leftTargetId.localeCompare(rightTargetId)).map(([targetId, repairCount]) => toRuntimeRepairTargetSnapshot(targetId, repairCount, structuresById.get(targetId)));
 }
 function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
-  const structureRecord = isRecord17(structure) ? structure : {};
+  const structureRecord = isRecord18(structure) ? structure : {};
   const structureType = typeof structureRecord.structureType === "string" ? structureRecord.structureType : void 0;
   const hits = getFiniteNumber(structureRecord.hits);
   const hitsMax = getFiniteNumber(structureRecord.hitsMax);
@@ -23104,7 +23532,7 @@ function toRuntimeRepairTargetSnapshot(targetId, repairCount, structure) {
   };
 }
 function isStructureOfType(structure, globalName, fallback) {
-  return isRecord17(structure) && matchesStructureType18(structure.structureType, globalName, fallback);
+  return isRecord18(structure) && matchesStructureType19(structure.structureType, globalName, fallback);
 }
 function calculateRoadCoverageRatio(roadCount, pendingRoadSiteCount) {
   const totalKnownRoadWork = roadCount + pendingRoadSiteCount;
@@ -23292,7 +23720,7 @@ function isRecentRefillDeliverySample(sample, tick) {
   return isRefillDeliverySample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - REFILL_DELIVERY_SAMPLE_TTL);
 }
 function isRefillDeliverySample(value) {
-  return isRecord17(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
+  return isRecord18(value) && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.deliveryTicks === "number" && Number.isFinite(value.deliveryTicks) && typeof value.activeTicks === "number" && Number.isFinite(value.activeTicks) && typeof value.idleOrOtherTaskTicks === "number" && Number.isFinite(value.idleOrOtherTaskTicks) && typeof value.energyDelivered === "number" && Number.isFinite(value.energyDelivered);
 }
 function roundRatio5(numerator, denominator) {
   if (denominator <= 0) {
@@ -23307,7 +23735,7 @@ function isRecentWorkerEfficiencySample(sample, tick) {
   return sample.tick <= tick && sample.tick > tick - WORKER_EFFICIENCY_SAMPLE_TTL;
 }
 function isWorkerEfficiencySample(value) {
-  if (!isRecord17(value)) {
+  if (!isRecord18(value)) {
     return false;
   }
   return (value.type === "lowLoadReturn" || value.type === "nearbyEnergyChoice") && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && isWorkerEfficiencyTaskType(value.selectedTask) && typeof value.targetId === "string";
@@ -23348,7 +23776,7 @@ function isRecentSpawnCriticalRefillSample(sample, tick) {
   return isSpawnCriticalRefillSample(sample) && (tick <= 0 || sample.tick <= tick && sample.tick > tick - SPAWN_CRITICAL_REFILL_SAMPLE_TTL);
 }
 function isSpawnCriticalRefillSample(value) {
-  return isRecord17(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
+  return isRecord18(value) && value.type === "spawnCriticalRefill" && typeof value.tick === "number" && Number.isFinite(value.tick) && typeof value.targetId === "string" && typeof value.carriedEnergy === "number" && Number.isFinite(value.carriedEnergy) && typeof value.spawnEnergy === "number" && Number.isFinite(value.spawnEnergy) && typeof value.freeCapacity === "number" && Number.isFinite(value.freeCapacity) && typeof value.threshold === "number" && Number.isFinite(value.threshold);
 }
 function getCreepName2(creep) {
   const name = creep.name;
@@ -23398,10 +23826,10 @@ function findOwnedEnergyStoreStructures(room) {
   return ((_a = findRoomObjects15(room, "FIND_MY_STRUCTURES")) != null ? _a : []).filter(isOwnedEnergyStoreStructure);
 }
 function isOwnedEnergyStoreStructure(structure) {
-  if (!isRecord17(structure)) {
+  if (!isRecord18(structure)) {
     return false;
   }
-  return matchesStructureType18(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType18(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType18(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType18(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType18(structure.structureType, "STRUCTURE_LINK", "link") || matchesStructureType18(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
+  return matchesStructureType19(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType19(structure.structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType19(structure.structureType, "STRUCTURE_STORAGE", "storage") || matchesStructureType19(structure.structureType, "STRUCTURE_CONTAINER", "container") || matchesStructureType19(structure.structureType, "STRUCTURE_LINK", "link") || matchesStructureType19(structure.structureType, "STRUCTURE_TERMINAL", "terminal");
 }
 function summarizeEnergySurplus(room, colonyWorkers) {
   const state = getRoomEnergySurplusState(room);
@@ -23480,7 +23908,7 @@ function sumPendingBuildProgress(constructionSites) {
   return constructionSites.reduce((total, constructionSite) => total + getPendingBuildProgress(constructionSite), 0);
 }
 function getPendingBuildProgress(constructionSite) {
-  if (!isRecord17(constructionSite)) {
+  if (!isRecord18(constructionSite)) {
     return 0;
   }
   const progress = getFiniteNumber(constructionSite.progress);
@@ -23494,7 +23922,7 @@ function sumRepairBacklogHits(roomStructures) {
   return roomStructures.reduce((total, structure) => total + getRepairBacklogHits(structure), 0);
 }
 function getRepairBacklogHits(structure) {
-  if (!isRecord17(structure) || !isObservableRepairBacklogStructure(structure)) {
+  if (!isRecord18(structure) || !isObservableRepairBacklogStructure(structure)) {
     return 0;
   }
   const hits = getFiniteNumber(structure.hits);
@@ -23506,10 +23934,10 @@ function getRepairBacklogHits(structure) {
   return Math.max(0, Math.ceil(repairCeiling - hits));
 }
 function isObservableRepairBacklogStructure(structure) {
-  return matchesStructureType18(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType18(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
+  return matchesStructureType19(structure.structureType, "STRUCTURE_ROAD", "road") || matchesStructureType19(structure.structureType, "STRUCTURE_CONTAINER", "container") || isObservedOwnedRampart(structure);
 }
 function isObservedOwnedRampart(structure) {
-  return matchesStructureType18(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
+  return matchesStructureType19(structure.structureType, "STRUCTURE_RAMPART", "rampart") && structure.my === true;
 }
 function buildControllerProgressRemaining(room) {
   const controller = room.controller;
@@ -23716,10 +24144,10 @@ function summarizeRoomEventMetrics(room, refillTargetIds = getSpawnExtensionEner
   let hasResourceEvents = false;
   let hasCombatEvents = false;
   for (const entry of eventLog) {
-    if (!isRecord17(entry) || typeof entry.event !== "number") {
+    if (!isRecord18(entry) || typeof entry.event !== "number") {
       continue;
     }
-    const data = isRecord17(entry.data) ? entry.data : {};
+    const data = isRecord18(entry.data) ? entry.data : {};
     if (entry.event === harvestEvent && isEnergyEventData(data)) {
       resourceEvents.harvestedEnergy += getNumericEventData(data, "amount");
       hasResourceEvents = true;
@@ -23785,7 +24213,7 @@ function getSpawnExtensionEnergyStructureIds(room) {
   return ids;
 }
 function isSpawnExtensionEnergyStructure2(structure) {
-  return isRecord17(structure) && (matchesStructureType18(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType18(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
+  return isRecord18(structure) && (matchesStructureType19(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType19(structure.structureType, "STRUCTURE_EXTENSION", "extension"));
 }
 function getEventTargetId(data) {
   return typeof data.targetId === "string" && data.targetId.length > 0 ? data.targetId : null;
@@ -23794,7 +24222,7 @@ function buildEventObjectId(entry) {
   return typeof entry.objectId === "string" && entry.objectId.length > 0 ? { objectId: entry.objectId } : {};
 }
 function getObjectId10(value) {
-  return isRecord17(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
+  return isRecord18(value) && typeof value.id === "string" && value.id.length > 0 ? value.id : null;
 }
 function findRoomObjects15(room, constantName) {
   const findConstant = getGlobalNumber11(constantName);
@@ -23815,7 +24243,7 @@ function getRoomEventLog(room) {
     return void 0;
   }
   try {
-    const eventLog = getEventLog.call(room, getEnergyResource12());
+    const eventLog = getEventLog.call(room, getEnergyResource13());
     return Array.isArray(eventLog) ? eventLog : void 0;
   } catch {
     return void 0;
@@ -23825,32 +24253,32 @@ function sumEnergyInStores(objects) {
   return objects.reduce((total, object) => total + getEnergyInStore(object), 0);
 }
 function getEnergyInStore(object) {
-  if (!isRecord17(object) || !isRecord17(object.store)) {
+  if (!isRecord18(object) || !isRecord18(object.store)) {
     return 0;
   }
-  const storedEnergy = object.store[getEnergyResource12()];
+  const storedEnergy = object.store[getEnergyResource13()];
   if (typeof storedEnergy === "number") {
     return storedEnergy;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
   if (typeof getUsedCapacity === "function") {
-    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource12());
+    const usedCapacity = getUsedCapacity.call(object.store, getEnergyResource13());
     return typeof usedCapacity === "number" ? usedCapacity : 0;
   }
   return 0;
 }
 function getEnergyCapacityInStore(object) {
-  if (!isRecord17(object) || !isRecord17(object.store)) {
+  if (!isRecord18(object) || !isRecord18(object.store)) {
     return 0;
   }
   const getCapacity = object.store.getCapacity;
   if (typeof getCapacity === "function") {
-    const capacity2 = getCapacity.call(object.store, getEnergyResource12());
+    const capacity2 = getCapacity.call(object.store, getEnergyResource13());
     return typeof capacity2 === "number" && Number.isFinite(capacity2) ? Math.max(0, capacity2) : 0;
   }
   const getFreeCapacity = object.store.getFreeCapacity;
   if (typeof getFreeCapacity === "function") {
-    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource12());
+    const freeCapacity = getFreeCapacity.call(object.store, getEnergyResource13());
     if (typeof freeCapacity === "number" && Number.isFinite(freeCapacity)) {
       return Math.max(0, getEnergyInStore(object) + freeCapacity);
     }
@@ -23859,16 +24287,16 @@ function getEnergyCapacityInStore(object) {
   return typeof capacity === "number" && Number.isFinite(capacity) ? Math.max(0, capacity) : 0;
 }
 function sumDroppedEnergy2(droppedResources) {
-  const energyResource = getEnergyResource12();
+  const energyResource = getEnergyResource13();
   return droppedResources.reduce((total, droppedResource) => {
-    if (!isRecord17(droppedResource) || droppedResource.resourceType !== energyResource) {
+    if (!isRecord18(droppedResource) || droppedResource.resourceType !== energyResource) {
       return total;
     }
     return total + (typeof droppedResource.amount === "number" ? droppedResource.amount : 0);
   }, 0);
 }
 function isEnergyEventData(data) {
-  return data.resourceType === void 0 || data.resourceType === getEnergyResource12();
+  return data.resourceType === void 0 || data.resourceType === getEnergyResource13();
 }
 function getNumericEventData(data, key) {
   const value = data[key];
@@ -23878,7 +24306,7 @@ function getGlobalNumber11(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function matchesStructureType18(value, globalName, fallback) {
+function matchesStructureType19(value, globalName, fallback) {
   var _a;
   const expectedValue = (_a = globalThis[globalName]) != null ? _a : fallback;
   return value === expectedValue;
@@ -23886,11 +24314,11 @@ function matchesStructureType18(value, globalName, fallback) {
 function getFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function getEnergyResource12() {
+function getEnergyResource13() {
   const value = globalThis.RESOURCE_ENERGY;
   return typeof value === "string" ? value : "energy";
 }
-function isRecord17(value) {
+function isRecord18(value) {
   return typeof value === "object" && value !== null;
 }
 function buildCpuSummary() {
@@ -23937,7 +24365,7 @@ function recordSourceWorkloads(room, creeps, tick) {
     )
   };
 }
-function buildSourceWorkloadRecords(room, sources = findSources4(room), creeps = getGameCreeps3()) {
+function buildSourceWorkloadRecords(room, sources = findSources4(room), creeps = getGameCreeps4()) {
   const roomName = getRoomName5(room);
   const assignmentLoads = getSourceAssignmentLoads(roomName, sources, creeps);
   return sources.filter((source) => hasSourcePositionInRoom(source, room)).sort((left, right) => String(left.id).localeCompare(String(right.id))).map((source) => {
@@ -23965,7 +24393,7 @@ function buildSourceWorkloadRecords(room, sources = findSources4(room), creeps =
   });
 }
 function getSourceAssignmentLoads(roomName, sources, creeps) {
-  var _a, _b, _c, _d;
+  var _a, _b, _c, _d, _e, _f;
   const assignmentLoads = /* @__PURE__ */ new Map();
   for (const source of sources) {
     assignmentLoads.set(String(source.id), createEmptySourceAssignmentLoad());
@@ -23977,11 +24405,13 @@ function getSourceAssignmentLoads(roomName, sources, creeps) {
   for (const creep of creeps) {
     const task = (_a = creep.memory) == null ? void 0 : _a.task;
     const targetId = typeof (task == null ? void 0 : task.targetId) === "string" ? task.targetId : void 0;
-    if (((_b = creep.memory) == null ? void 0 : _b.role) !== "worker" || ((_c = creep.room) == null ? void 0 : _c.name) !== roomName || (task == null ? void 0 : task.type) !== "harvest" || !targetId || !sourceIds.has(targetId)) {
+    const sourceHarvesterTargetId = ((_b = creep.memory) == null ? void 0 : _b.role) === SOURCE_HARVESTER_ROLE && ((_c = creep.memory.sourceHarvester) == null ? void 0 : _c.roomName) === roomName && typeof creep.memory.sourceHarvester.sourceId === "string" ? creep.memory.sourceHarvester.sourceId : void 0;
+    const assignedSourceId = ((_d = creep.memory) == null ? void 0 : _d.role) === "worker" && ((_e = creep.room) == null ? void 0 : _e.name) === roomName && (task == null ? void 0 : task.type) === "harvest" && targetId && sourceIds.has(targetId) ? targetId : sourceHarvesterTargetId;
+    if (!assignedSourceId || !sourceIds.has(assignedSourceId)) {
       continue;
     }
-    const currentLoad = (_d = assignmentLoads.get(targetId)) != null ? _d : createEmptySourceAssignmentLoad();
-    assignmentLoads.set(targetId, {
+    const currentLoad = (_f = assignmentLoads.get(assignedSourceId)) != null ? _f : createEmptySourceAssignmentLoad();
+    assignmentLoads.set(assignedSourceId, {
       assignedHarvesters: currentLoad.assignedHarvesters + 1,
       assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts2(creep)
     });
@@ -24074,7 +24504,7 @@ function getBodyPartConstant5(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function getGameCreeps3() {
+function getGameCreeps4() {
   var _a;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
   return creeps ? Object.values(creeps) : [];
@@ -24091,7 +24521,7 @@ function manageStorage(room) {
     return { assignedTasks: 0, linkTransfers: [] };
   }
   const linkTransfers = transferStorageLinkEnergy(room);
-  const storageEnergy = getStoredEnergy13(storage);
+  const storageEnergy = getStoredEnergy14(storage);
   if (storageEnergy <= 0) {
     return { assignedTasks: 0, linkTransfers };
   }
@@ -24112,8 +24542,8 @@ function transferStorageLinkEnergy(room) {
   if (getLinkCooldown2(storageLink) > 0) {
     return [];
   }
-  const storedEnergy = getStoredEnergy13(storageLink);
-  const destinationFreeCapacity = getFreeEnergyCapacity9(controllerLink);
+  const storedEnergy = getStoredEnergy14(storageLink);
+  const destinationFreeCapacity = getFreeEnergyCapacity10(controllerLink);
   const amount = Math.min(storedEnergy, destinationFreeCapacity);
   if (amount <= 0) {
     return [];
@@ -24143,13 +24573,13 @@ function buildEnergyDemandState(room) {
 }
 function findSpawnExtensionRefillTargets(room) {
   const structures = findOwnedStructures6(room).filter(
-    (structure) => (matchesStructureType19(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType19(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity9(structure) > 0
+    (structure) => (matchesStructureType20(structure.structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType20(structure.structureType, "STRUCTURE_EXTENSION", "extension")) && getFreeEnergyCapacity10(structure) > 0
   );
   if (!isRoomSpawnExtensionEnergyLow(room, structures)) {
     return [];
   }
   return structures.map((target) => ({
-    freeCapacity: getFreeEnergyCapacity9(target),
+    freeCapacity: getFreeEnergyCapacity10(target),
     id: getObjectId11(target),
     priority: 3,
     target
@@ -24157,9 +24587,9 @@ function findSpawnExtensionRefillTargets(room) {
 }
 function findTowerRefillTargets(room) {
   return findOwnedStructures6(room).filter(
-    (structure) => matchesStructureType19(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy13(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity9(structure) > 0
+    (structure) => matchesStructureType20(structure.structureType, "STRUCTURE_TOWER", "tower") && getStoredEnergy14(structure) < TOWER_REFILL_THRESHOLD && getFreeEnergyCapacity10(structure) > 0
   ).map((target) => ({
-    freeCapacity: getFreeEnergyCapacity9(target),
+    freeCapacity: getFreeEnergyCapacity10(target),
     id: getObjectId11(target),
     priority: 2,
     target
@@ -24170,12 +24600,12 @@ function findStorageLinkRefillTargets(room) {
   if (!controllerLink || !storageLink || getObjectId11(controllerLink) === getObjectId11(storageLink)) {
     return [];
   }
-  if (getFreeEnergyCapacity9(controllerLink) <= 0 || getFreeEnergyCapacity9(storageLink) <= 0) {
+  if (getFreeEnergyCapacity10(controllerLink) <= 0 || getFreeEnergyCapacity10(storageLink) <= 0) {
     return [];
   }
   return [
     {
-      freeCapacity: getFreeEnergyCapacity9(storageLink),
+      freeCapacity: getFreeEnergyCapacity10(storageLink),
       id: getObjectId11(storageLink),
       priority: 1,
       target: storageLink
@@ -24191,7 +24621,7 @@ function isRoomSpawnExtensionEnergyLow(room, structures) {
   if (typeof energyAvailable === "number" && Number.isFinite(energyAvailable) && typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable)) {
     return energyAvailable < energyCapacityAvailable;
   }
-  return structures.some((structure) => getFreeEnergyCapacity9(structure) > 0);
+  return structures.some((structure) => getFreeEnergyCapacity10(structure) > 0);
 }
 function findStorageManagementWorkers(room, storage, demandState) {
   const storageId = getObjectId11(storage);
@@ -24209,12 +24639,12 @@ function reserveExistingAssignments(workers, storage, demandState, storageEnergy
       if (typeof remainingCapacity === "number") {
         demandState.remainingCapacityById.set(
           targetId,
-          Math.max(0, remainingCapacity - getCarriedEnergy5(worker))
+          Math.max(0, remainingCapacity - getCarriedEnergy6(worker))
         );
       }
     }
     if ((task == null ? void 0 : task.type) === "withdraw" && String(task.targetId) === storageId) {
-      projectedStorageEnergy -= getFreeEnergyCapacity9(worker);
+      projectedStorageEnergy -= getFreeEnergyCapacity10(worker);
     }
   }
   return Math.max(0, projectedStorageEnergy);
@@ -24222,7 +24652,7 @@ function reserveExistingAssignments(workers, storage, demandState, storageEnergy
 function assignLoadedWorkers(workers, demandState) {
   let assignedTasks = 0;
   for (const worker of workers) {
-    const carriedEnergy = getCarriedEnergy5(worker);
+    const carriedEnergy = getCarriedEnergy6(worker);
     if (carriedEnergy <= 0) {
       continue;
     }
@@ -24245,13 +24675,13 @@ function assignStorageWithdrawals(room, workers, storage, demandState, initialPr
   let assignedTasks = 0;
   let projectedStorageEnergy = initialProjectedStorageEnergy;
   for (const worker of workers) {
-    if (!hasRemainingDemand(demandState) || getCarriedEnergy5(worker) > 0) {
+    if (!hasRemainingDemand(demandState) || getCarriedEnergy6(worker) > 0) {
       continue;
     }
     if (((_a = worker.memory.task) == null ? void 0 : _a.type) === "withdraw" && String(worker.memory.task.targetId) === String(storage.id)) {
       continue;
     }
-    const freeCapacity = getFreeEnergyCapacity9(worker);
+    const freeCapacity = getFreeEnergyCapacity10(worker);
     const withdrawableStorageEnergy = getStorageEnergyAvailableForWithdrawal(room, storage, projectedStorageEnergy);
     const plannedWithdrawal = Math.min(freeCapacity, projectedStorageEnergy);
     if (plannedWithdrawal <= 0 || plannedWithdrawal > withdrawableStorageEnergy || !withdrawFromStorage(room, plannedWithdrawal, storage, projectedStorageEnergy)) {
@@ -24336,9 +24766,9 @@ function compareOptionalRange(worker, left, right) {
   }
   const leftRange = getRangeTo.call(worker.pos, left);
   const rightRange = getRangeTo.call(worker.pos, right);
-  return normalizeRange(leftRange) - normalizeRange(rightRange);
+  return normalizeRange2(leftRange) - normalizeRange2(rightRange);
 }
-function normalizeRange(range) {
+function normalizeRange2(range) {
   return typeof range === "number" && Number.isFinite(range) ? range : Number.POSITIVE_INFINITY;
 }
 function compareWorkers(left, right) {
@@ -24358,7 +24788,7 @@ function getRoomStorage3(room) {
     return room.storage;
   }
   return (_a = findOwnedStructures6(room).filter(
-    (structure) => matchesStructureType19(structure.structureType, "STRUCTURE_STORAGE", "storage")
+    (structure) => matchesStructureType20(structure.structureType, "STRUCTURE_STORAGE", "storage")
   )[0]) != null ? _a : null;
 }
 function findOwnedStructures6(room) {
@@ -24375,25 +24805,25 @@ function findMyCreeps2(room) {
   const result = room.find(FIND_MY_CREEPS);
   return Array.isArray(result) ? result : [];
 }
-function getStoredEnergy13(target) {
+function getStoredEnergy14(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const storedEnergy = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource13());
+  const storedEnergy = (_a = store == null ? void 0 : store.getUsedCapacity) == null ? void 0 : _a.call(store, getEnergyResource14());
   return typeof storedEnergy === "number" && Number.isFinite(storedEnergy) ? Math.max(0, storedEnergy) : 0;
 }
-function getFreeEnergyCapacity9(target) {
+function getFreeEnergyCapacity10(target) {
   var _a;
   const store = target == null ? void 0 : target.store;
-  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource13());
+  const freeCapacity = (_a = store == null ? void 0 : store.getFreeCapacity) == null ? void 0 : _a.call(store, getEnergyResource14());
   return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
 }
-function getCarriedEnergy5(creep) {
-  return getStoredEnergy13(creep);
+function getCarriedEnergy6(creep) {
+  return getStoredEnergy14(creep);
 }
 function getLinkCooldown2(link) {
   return typeof link.cooldown === "number" && Number.isFinite(link.cooldown) ? link.cooldown : 0;
 }
-function getEnergyResource13() {
+function getEnergyResource14() {
   var _a;
   return (_a = globalThis.RESOURCE_ENERGY) != null ? _a : "energy";
 }
@@ -24407,7 +24837,7 @@ function getObjectId11(object) {
   }
   return typeof candidate.name === "string" ? candidate.name : "";
 }
-function matchesStructureType19(actual, globalName, fallback) {
+function matchesStructureType20(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -24418,7 +24848,7 @@ var MINERAL_HARVESTER_ROLE = "mineralHarvester";
 var MINERAL_HARVESTER_REPLACEMENT_TICKS = 100;
 var MINERAL_HARVESTING_MIN_ENERGY_RATIO = 0.3;
 var MINERAL_MOVE_OPTS = { reusePath: 20, ignoreRoads: false };
-var ERR_NOT_IN_RANGE_CODE7 = -9;
+var ERR_NOT_IN_RANGE_CODE8 = -9;
 function planMineralHarvesterSpawn(colony, creeps, gameTime, options = {}) {
   var _a, _b, _c, _d, _e;
   const energyAvailable = normalizeNonNegativeInteger5(
@@ -24508,7 +24938,7 @@ function runMineralHarvester(creep) {
   }
   if (((_a = creep.room) == null ? void 0 : _a.name) !== assignment.homeRoom) {
     delete creep.memory.task;
-    moveTowardRoom4(creep, assignment.homeRoom);
+    moveTowardRoom5(creep, assignment.homeRoom);
     return;
   }
   const carriedResourceType = selectCarriedResourceType(creep, assignment.mineralType);
@@ -24526,8 +24956,8 @@ function runMineralHarvester(creep) {
   }
   delete creep.memory.task;
   const result = (_b = creep.harvest) == null ? void 0 : _b.call(creep, mineral);
-  if (result === ERR_NOT_IN_RANGE_CODE7) {
-    moveTo4(creep, mineral);
+  if (result === ERR_NOT_IN_RANGE_CODE8) {
+    moveTo5(creep, mineral);
   }
 }
 function buildMineralHarvesterBodyWithWorkParts(workParts) {
@@ -24560,7 +24990,7 @@ function selectAvailableMineral(room) {
   return (_a = findRoomObjects16(room, "FIND_MINERALS").find(isMineralAvailable)) != null ? _a : null;
 }
 function isExtractorStructure(structure) {
-  return matchesStructureType20(structure.structureType, "STRUCTURE_EXTRACTOR", "extractor");
+  return matchesStructureType21(structure.structureType, "STRUCTURE_EXTRACTOR", "extractor");
 }
 function isMineralAvailable(mineral) {
   return normalizeNonNegativeInteger5(mineral.mineralAmount) > 0;
@@ -24586,7 +25016,7 @@ function compareMineralDeliveryTargets(left, right) {
   return getDeliveryPriority2(right) - getDeliveryPriority2(left) || getObjectId12(left).localeCompare(getObjectId12(right));
 }
 function getDeliveryPriority2(target) {
-  return matchesStructureType20(target.structureType, "STRUCTURE_TERMINAL", "terminal") ? 2 : 1;
+  return matchesStructureType21(target.structureType, "STRUCTURE_TERMINAL", "terminal") ? 2 : 1;
 }
 function getMutableMineralHarvesterMemory(creep) {
   var _a;
@@ -24598,10 +25028,10 @@ function getMutableMineralHarvesterMemory(creep) {
   return memory;
 }
 function normalizeMineralHarvesterMemory(value) {
-  if (!isRecord18(value) || !isNonEmptyString18(value.homeRoom) || !isNonEmptyString18(value.mineralId)) {
+  if (!isRecord19(value) || !isNonEmptyString19(value.homeRoom) || !isNonEmptyString19(value.mineralId)) {
     return null;
   }
-  const targetId = isNonEmptyString18(value.targetId) ? value.targetId : void 0;
+  const targetId = isNonEmptyString19(value.targetId) ? value.targetId : void 0;
   if (!targetId) {
     return null;
   }
@@ -24609,12 +25039,12 @@ function normalizeMineralHarvesterMemory(value) {
     homeRoom: value.homeRoom,
     mineralId: value.mineralId,
     targetId,
-    ...isNonEmptyString18(value.mineralType) ? { mineralType: value.mineralType } : {}
+    ...isNonEmptyString19(value.mineralType) ? { mineralType: value.mineralType } : {}
   };
 }
 function getAssignedMineral(assignment, room) {
   var _a, _b;
-  return (_b = (_a = getObjectById4(assignment.mineralId)) != null ? _a : findRoomObjects16(room, "FIND_MINERALS").find((mineral) => mineral.id === assignment.mineralId)) != null ? _b : null;
+  return (_b = (_a = getObjectById5(assignment.mineralId)) != null ? _a : findRoomObjects16(room, "FIND_MINERALS").find((mineral) => mineral.id === assignment.mineralId)) != null ? _b : null;
 }
 function deliverMineral(creep, assignment, resourceType) {
   var _a;
@@ -24626,12 +25056,12 @@ function deliverMineral(creep, assignment, resourceType) {
   assignment.targetId = target.id;
   creep.memory.task = { type: "transfer", targetId: assignment.targetId };
   const result = (_a = creep.transfer) == null ? void 0 : _a.call(creep, target, resourceType);
-  if (result === ERR_NOT_IN_RANGE_CODE7) {
-    moveTo4(creep, target);
+  if (result === ERR_NOT_IN_RANGE_CODE8) {
+    moveTo5(creep, target);
   }
 }
 function selectDeliveryTargetForAssignment(room, assignment, resourceType) {
-  const assignedTarget = getObjectById4(assignment.targetId);
+  const assignedTarget = getObjectById5(assignment.targetId);
   if (assignedTarget && getStoreFreeCapacity(assignedTarget.store, resourceType) > 0) {
     return assignedTarget;
   }
@@ -24652,19 +25082,19 @@ function selectCarriedResourceType(creep, preferredResourceType) {
   const totalUsedCapacity = getStoreUsedCapacity(creep.store);
   return totalUsedCapacity > 0 && preferredResourceType ? preferredResourceType : null;
 }
-function moveTowardRoom4(creep, roomName) {
+function moveTowardRoom5(creep, roomName) {
   var _a;
-  const visibleController = (_a = getVisibleRoom9(roomName)) == null ? void 0 : _a.controller;
+  const visibleController = (_a = getVisibleRoom10(roomName)) == null ? void 0 : _a.controller;
   if (visibleController) {
-    moveTo4(creep, visibleController);
+    moveTo5(creep, visibleController);
     return;
   }
   const RoomPositionCtor = globalThis.RoomPosition;
   if (typeof RoomPositionCtor === "function") {
-    moveTo4(creep, new RoomPositionCtor(25, 25, roomName));
+    moveTo5(creep, new RoomPositionCtor(25, 25, roomName));
   }
 }
-function moveTo4(creep, target) {
+function moveTo5(creep, target) {
   var _a;
   (_a = creep.moveTo) == null ? void 0 : _a.call(creep, target, MINERAL_MOVE_OPTS);
 }
@@ -24684,12 +25114,12 @@ function getStoreUsedCapacity(store, resourceType) {
   const usedCapacity = getUsedCapacity.call(store, resourceType);
   return typeof usedCapacity === "number" && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
 }
-function getObjectById4(id) {
+function getObjectById5(id) {
   var _a;
-  const getObjectById5 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
-  return typeof getObjectById5 === "function" ? getObjectById5(String(id)) : null;
+  const getObjectById6 = (_a = globalThis.Game) == null ? void 0 : _a.getObjectById;
+  return typeof getObjectById6 === "function" ? getObjectById6(String(id)) : null;
 }
-function getVisibleRoom9(roomName) {
+function getVisibleRoom10(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -24705,7 +25135,7 @@ function findRoomObjects16(room, constantName) {
     return [];
   }
 }
-function matchesStructureType20(actual, globalName, fallback) {
+function matchesStructureType21(actual, globalName, fallback) {
   var _a;
   const constants = globalThis;
   return actual === ((_a = constants[globalName]) != null ? _a : fallback);
@@ -24729,16 +25159,16 @@ function getObjectId12(object) {
 function normalizeNonNegativeInteger5(value) {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
-function isRecord18(value) {
+function isRecord19(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString18(value) {
+function isNonEmptyString19(value) {
   return typeof value === "string" && value.length > 0;
 }
 
 // src/territory/roomReservation.ts
 var OK_CODE10 = 0;
-var ERR_NOT_IN_RANGE_CODE8 = -9;
+var ERR_NOT_IN_RANGE_CODE9 = -9;
 function runPlannedClaimReservation(creep) {
   const result = reserveRoomForPlannedClaim(creep);
   return result.status === "reserved" || result.status === "moving" || result.status === "blocked";
@@ -24813,7 +25243,7 @@ function reserveRoomForPlannedClaim(creep) {
   };
   creep.memory.territory = (_b = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, getGameTime19())) != null ? _b : reserveAssignment;
   const result = creep.reserveController(controller);
-  if (result === ERR_NOT_IN_RANGE_CODE8) {
+  if (result === ERR_NOT_IN_RANGE_CODE9) {
     if (typeof creep.moveTo === "function") {
       creep.moveTo(controller);
     }
@@ -24841,7 +25271,7 @@ function reserveRoomForPlannedClaim(creep) {
   };
 }
 function isPlannedClaimAssignment(assignment) {
-  return isNonEmptyString19(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "claim";
+  return isNonEmptyString20(assignment == null ? void 0 : assignment.targetRoom) && assignment.action === "claim";
 }
 function selectClaimReservationController(creep, assignment) {
   var _a, _b, _c, _d, _e;
@@ -24870,7 +25300,7 @@ function countVisibleOwnedRooms2(colony) {
     return 0;
   }
   const colonyOwnerUsername = getControllerOwnerUsername6(
-    isNonEmptyString19(colony) ? (_b = rooms[colony]) == null ? void 0 : _b.controller : void 0
+    isNonEmptyString20(colony) ? (_b = rooms[colony]) == null ? void 0 : _b.controller : void 0
   );
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
@@ -24886,10 +25316,10 @@ function canReserveControllerForColony(controller, creep) {
     return true;
   }
   const actorUsername = getActorUsername(creep);
-  return isNonEmptyString19(actorUsername) && reservationUsername === actorUsername;
+  return isNonEmptyString20(actorUsername) && reservationUsername === actorUsername;
 }
 function isControllerOwned2(controller) {
-  return controller.my === true || isNonEmptyString19(getControllerOwnerUsername6(controller));
+  return controller.my === true || isNonEmptyString20(getControllerOwnerUsername6(controller));
 }
 function getActiveClaimPartCount(creep) {
   var _a;
@@ -24906,22 +25336,22 @@ function getActiveClaimPartCount(creep) {
 function getActorUsername(creep) {
   var _a, _b, _c;
   const creepOwner = (_a = creep.owner) == null ? void 0 : _a.username;
-  if (isNonEmptyString19(creepOwner)) {
+  if (isNonEmptyString20(creepOwner)) {
     return creepOwner;
   }
   const colony = creep.memory.colony;
-  const room = isNonEmptyString19(colony) ? (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[colony] : void 0;
+  const room = isNonEmptyString20(colony) ? (_c = (_b = globalThis.Game) == null ? void 0 : _b.rooms) == null ? void 0 : _c[colony] : void 0;
   return getControllerOwnerUsername6(room == null ? void 0 : room.controller);
 }
 function getControllerOwnerUsername6(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString19(username) ? username : void 0;
+  return isNonEmptyString20(username) ? username : void 0;
 }
 function getControllerReservationUsername4(controller) {
   var _a;
   const username = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString19(username) ? username : void 0;
+  return isNonEmptyString20(username) ? username : void 0;
 }
 function getClaimBodyPartConstant() {
   var _a;
@@ -24932,7 +25362,7 @@ function getGameTime19() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString19(value) {
+function isNonEmptyString20(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -24943,7 +25373,7 @@ var MIN_AUTONOMOUS_EXPANSION_CLAIM_SCORE = 500;
 var MIN_AUTONOMOUS_EXPANSION_CLAIM_RCL = 2;
 var EXIT_DIRECTION_ORDER4 = ["1", "3", "5", "7"];
 var OK_CODE11 = 0;
-var ERR_NOT_IN_RANGE_CODE9 = -9;
+var ERR_NOT_IN_RANGE_CODE10 = -9;
 var ERR_INVALID_TARGET_CODE4 = -7;
 var ERR_NO_BODYPART_CODE = -12;
 var ERR_GCL_NOT_ENOUGH_CODE = -15;
@@ -25076,7 +25506,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
     completeClaimAssignment(creep);
     return true;
   }
-  if (result === ERR_NOT_IN_RANGE_CODE9) {
+  if (result === ERR_NOT_IN_RANGE_CODE10) {
     moveTowardController(creep, controller);
     return true;
   }
@@ -25234,7 +25664,7 @@ function evaluateAutonomousExpansionClaim(colony, report, gameTime, context, tel
   if (!hasSufficientAutonomousExpansionClaimRcl(colony)) {
     return { ...baseEvaluation, reason: "controllerLevelLow" };
   }
-  const room = getVisibleRoom10(candidate.roomName);
+  const room = getVisibleRoom11(candidate.roomName);
   const controller = room == null ? void 0 : room.controller;
   if (room) {
     recordVisibleRoomScoutIntel(colonyName, room, gameTime, void 0, telemetryEvents);
@@ -25353,11 +25783,11 @@ function buildAutonomousExpansionScoringInput(colony, report, context) {
   const ownedRoomNames = getVisibleOwnedRoomNames4(colonyName, colonyOwnerUsername);
   const adjacentRoomNamesByOwnedRoom = getAdjacentRoomNamesByOwnedRoom2(ownedRoomNames, context);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, colonyOwnerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString20(room.mineralType));
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString21(room.mineralType));
   const seenRooms = /* @__PURE__ */ new Set();
   const candidates = [];
   report.candidates.forEach((candidate, order) => {
-    if (!isNonEmptyString20(candidate.roomName) || seenRooms.has(candidate.roomName)) {
+    if (!isNonEmptyString21(candidate.roomName) || seenRooms.has(candidate.roomName)) {
       return;
     }
     seenRooms.add(candidate.roomName);
@@ -25385,7 +25815,7 @@ function buildAutonomousExpansionScoringInput(colony, report, context) {
 }
 function toExpansionCandidateInput(candidate, order, colonyName, includeMineralSynergyEvidence, adjacency) {
   var _a;
-  const room = getVisibleRoom10(candidate.roomName);
+  const room = getVisibleRoom11(candidate.roomName);
   const controller = room == null ? void 0 : room.controller;
   const controllerId = typeof (controller == null ? void 0 : controller.id) === "string" ? controller.id : candidate.controllerId;
   const hostileCreepCount = typeof candidate.hostileCreepCount === "number" ? candidate.hostileCreepCount : room ? findVisibleHostileCreeps2(room).length : void 0;
@@ -25423,7 +25853,7 @@ function summarizeExpansionController2(controller) {
   return {
     ...typeof controller.my === "boolean" ? { my: controller.my } : {},
     ...ownerUsername ? { ownerUsername } : {},
-    ...isNonEmptyString20(reservationUsername) ? { reservationUsername } : {},
+    ...isNonEmptyString21(reservationUsername) ? { reservationUsername } : {},
     ...typeof ((_b = controller.reservation) == null ? void 0 : _b.ticksToEnd) === "number" ? { reservationTicksToEnd: controller.reservation.ticksToEnd } : {}
   };
 }
@@ -25444,7 +25874,7 @@ function getVisibleOwnedRoomNames4(colonyName, ownerUsername) {
     return ownedRoomNames;
   }
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString20(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString21(room.name) && (!ownerUsername || getControllerOwnerUsername7(room.controller) === ownerUsername)) {
       ownedRoomNames.add(room.name);
     }
   }
@@ -25483,21 +25913,21 @@ function getAdjacentRoomNames5(roomName, gameMap = ((_a) => (_a = globalThis.Gam
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord19(exits)) {
+  if (!isRecord20(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER4.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString20(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString21(exitRoom) ? [exitRoom] : [];
   });
 }
 function countActivePostClaimBootstraps2() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord19(records)) {
+  if (!isRecord20(records)) {
     return 0;
   }
-  return Object.values(records).filter((record) => isRecord19(record) && record.status !== "ready").length;
+  return Object.values(records).filter((record) => isRecord20(record) && record.status !== "ready").length;
 }
 function hasSufficientAutonomousExpansionClaimRcl(colony) {
   var _a, _b;
@@ -25567,13 +25997,13 @@ function upsertTerritoryTarget2(territoryMemory, target) {
     territoryMemory.targets = [];
   }
   const existingTarget = territoryMemory.targets.find(
-    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord19(rawTarget) && rawTarget.createdBy === target.createdBy
+    (rawTarget) => isSameTarget2(rawTarget, target) && isRecord20(rawTarget) && rawTarget.createdBy === target.createdBy
   );
   if (!existingTarget) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord19(existingTarget)) {
+  if (isRecord20(existingTarget)) {
     existingTarget.action = target.action;
     existingTarget.createdBy = target.createdBy;
     existingTarget.enabled = target.enabled;
@@ -25604,7 +26034,7 @@ function pruneAutonomousExpansionClaimTargets(colony, territoryMemory = getTerri
     if (activeTarget && isSameTarget2(target, activeTarget)) {
       return true;
     }
-    if (isRecord19(target) && isNonEmptyString20(target.roomName) && target.action === "claim") {
+    if (isRecord20(target) && isNonEmptyString21(target.roomName) && target.action === "claim") {
       removedTargetKeys.add(getTargetKey2(target.roomName, "claim"));
     }
     return false;
@@ -25623,7 +26053,7 @@ function pruneOccupationRecommendationTargets(territoryMemory, colony) {
     return;
   }
   territoryMemory.targets = territoryMemory.targets.filter(
-    (target) => !(isRecord19(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
+    (target) => !(isRecord20(target) && target.colony === colony && target.createdBy === "occupationRecommendation")
   );
 }
 function isAutonomousClaimSuppressed(colony, targetRoom, gameTime, intents) {
@@ -25670,7 +26100,7 @@ function getClaimResultReason(result) {
   switch (result) {
     case OK_CODE11:
       return null;
-    case ERR_NOT_IN_RANGE_CODE9:
+    case ERR_NOT_IN_RANGE_CODE10:
       return "notInRange";
     case ERR_INVALID_TARGET_CODE4:
       return "invalidTarget";
@@ -25691,7 +26121,7 @@ function isClaimExecutionAssignment(assignment) {
 }
 function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   var _a;
-  if (!isNonEmptyString20(colony)) {
+  if (!isNonEmptyString21(colony)) {
     return null;
   }
   const territoryMemory = getTerritoryMemoryRecord6();
@@ -25732,7 +26162,7 @@ function isTerritoryIntentSuspensionActive2(intent, gameTime) {
   return isHostileTerritoryIntentSuspensionCoolingDown2(intent.suspended, gameTime);
 }
 function getVisibleHostileCreepCount2(targetRoom) {
-  const room = getVisibleRoom10(targetRoom);
+  const room = getVisibleRoom11(targetRoom);
   return room ? findVisibleHostileCreeps2(room).length : null;
 }
 function isHostileTerritoryIntentSuspensionCoolingDown2(suspension, gameTime) {
@@ -25749,7 +26179,7 @@ function selectClaimTargetController(creep, assignment) {
       }
     }
   }
-  return (_d = (_c = (_a = creep.room) == null ? void 0 : _a.controller) != null ? _c : (_b = getVisibleRoom10(assignment.targetRoom)) == null ? void 0 : _b.controller) != null ? _d : null;
+  return (_d = (_c = (_a = creep.room) == null ? void 0 : _a.controller) != null ? _c : (_b = getVisibleRoom11(assignment.targetRoom)) == null ? void 0 : _b.controller) != null ? _d : null;
 }
 function moveTowardClaimTarget(creep, assignment) {
   const visibleController = selectVisibleClaimTargetController(assignment);
@@ -25810,7 +26240,7 @@ function tryPressureForeignClaimBlocker(creep, assignment, controller, telemetry
     return false;
   }
   const result = creep.attackController(controller);
-  if (result === ERR_NOT_IN_RANGE_CODE9) {
+  if (result === ERR_NOT_IN_RANGE_CODE10) {
     moveTowardController(creep, controller);
     return true;
   }
@@ -25956,13 +26386,13 @@ function hasRecommendedClaimTarget(territoryMemory, colony, targetRoom) {
   return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom)) : false;
 }
 function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
-  return isRecord19(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
+  return isRecord20(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource3(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
 }
 function recordColonyExpansionClaimVerification(input) {
   var _a;
-  const colonyRoom = getVisibleRoom10(input.colony);
+  const colonyRoom = getVisibleRoom11(input.colony);
   const selection = (_a = colonyRoom == null ? void 0 : colonyRoom.memory) == null ? void 0 : _a.cachedExpansionSelection;
-  if (!isRecord19(selection) || selection.targetRoom !== input.targetRoom) {
+  if (!isRecord20(selection) || selection.targetRoom !== input.targetRoom) {
     return;
   }
   selection.claimExecution = {
@@ -25985,7 +26415,7 @@ function getVisibleClaimedRoom(targetRoom, controller) {
   if (((_a = controllerRoom == null ? void 0 : controllerRoom.controller) == null ? void 0 : _a.my) === true) {
     return controllerRoom;
   }
-  const gameRoom = getVisibleRoom10(targetRoom);
+  const gameRoom = getVisibleRoom11(targetRoom);
   return ((_b = gameRoom == null ? void 0 : gameRoom.controller) == null ? void 0 : _b.my) === true ? gameRoom : null;
 }
 function completeClaimAssignment(creep) {
@@ -25996,15 +26426,15 @@ function getClaimColony(creep, controller) {
   return (_e = (_d = (_b = creep.memory.colony) != null ? _b : (_a = creep.room) == null ? void 0 : _a.name) != null ? _d : (_c = controller == null ? void 0 : controller.room) == null ? void 0 : _c.name) != null ? _e : "unknown";
 }
 function isForeignOwnedController(controller) {
-  return controller.my !== true && isNonEmptyString20(getControllerOwnerUsername7(controller));
+  return controller.my !== true && isNonEmptyString21(getControllerOwnerUsername7(controller));
 }
 function isForeignReservedController3(controller, colony) {
   var _a, _b;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  if (!isNonEmptyString20(reservationUsername)) {
+  if (!isNonEmptyString21(reservationUsername)) {
     return false;
   }
-  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom10(colony != null ? colony : "")) == null ? void 0 : _b.controller);
+  return reservationUsername !== getControllerOwnerUsername7((_b = getVisibleRoom11(colony != null ? colony : "")) == null ? void 0 : _b.controller);
 }
 function getKnownActiveClaimPartCount(creep) {
   var _a;
@@ -26031,15 +26461,15 @@ function isTerritoryAutomationSource3(source) {
   return source === "occupationRecommendation" || source === "autonomousExpansionClaim" || source === "colonyExpansion" || source === "nextExpansionScoring" || source === "adjacentRoomReservation";
 }
 function isAutonomousExpansionClaimTarget(target, colony) {
-  return isRecord19(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
+  return isRecord20(target) && target.colony === colony && target.action === "claim" && target.createdBy === AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR;
 }
 function isSameTarget2(left, right) {
-  return isRecord19(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord20(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getTargetKey2(roomName, action) {
   return `${roomName}:${action}`;
 }
-function getVisibleRoom10(roomName) {
+function getVisibleRoom11(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -26077,17 +26507,17 @@ function isControllerOwned3(controller) {
 function isControllerReserved(controller, colonyOwnerUsername) {
   var _a;
   const reservationUsername = (_a = controller.reservation) == null ? void 0 : _a.username;
-  return isNonEmptyString20(reservationUsername) && reservationUsername !== colonyOwnerUsername;
+  return isNonEmptyString21(reservationUsername) && reservationUsername !== colonyOwnerUsername;
 }
 function getControllerOwnerUsername7(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString20(username) ? username : void 0;
+  return isNonEmptyString21(username) ? username : void 0;
 }
-function isRecord19(value) {
+function isRecord20(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString20(value) {
+function isNonEmptyString21(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -26107,7 +26537,7 @@ var DISTANCE_PENALTY = 55;
 var NO_ROUTE_DISTANCE = 99;
 function scoreClaimTarget(roomName, homeRoom) {
   const details = [];
-  const room = getVisibleRoom11(roomName);
+  const room = getVisibleRoom12(roomName);
   const scoutIntel = getScoutIntel(homeRoom.name, roomName);
   const sources = countSources(room, scoutIntel);
   const distance = getRoomDistance(homeRoom.name, roomName);
@@ -26179,7 +26609,7 @@ function hasUnclaimableController(score) {
     (detail) => detail === "controller already claimed" || detail === "controller already reserved" || detail === "controller missing"
   );
 }
-function getVisibleRoom11(roomName) {
+function getVisibleRoom12(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -26251,20 +26681,20 @@ function getControllerStatus2(room, scoutIntel) {
     if (!controller) {
       return "missing";
     }
-    if (controller.my === true || isNonEmptyString21((_a = controller.owner) == null ? void 0 : _a.username)) {
+    if (controller.my === true || isNonEmptyString22((_a = controller.owner) == null ? void 0 : _a.username)) {
       return "owned";
     }
-    if (isNonEmptyString21((_b = controller.reservation) == null ? void 0 : _b.username)) {
+    if (isNonEmptyString22((_b = controller.reservation) == null ? void 0 : _b.username)) {
       return "reserved";
     }
     return "neutral";
   }
   if (scoutIntel == null ? void 0 : scoutIntel.controller) {
     const controller = scoutIntel.controller;
-    if (controller.my === true || isNonEmptyString21(controller.ownerUsername)) {
+    if (controller.my === true || isNonEmptyString22(controller.ownerUsername)) {
       return "owned";
     }
-    if (isNonEmptyString21(controller.reservationUsername)) {
+    if (isNonEmptyString22(controller.reservationUsername)) {
       return "reserved";
     }
     return "neutral";
@@ -26302,12 +26732,12 @@ function getAdjacentRoomNames6(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord20(exits)) {
+  if (!isRecord21(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER5.flatMap((direction) => {
     const adjacentRoom = exits[direction];
-    return isNonEmptyString21(adjacentRoom) ? [adjacentRoom] : [];
+    return isNonEmptyString22(adjacentRoom) ? [adjacentRoom] : [];
   });
 }
 function getRoomTerrain12(roomName) {
@@ -26341,10 +26771,10 @@ function getGlobalNumber12(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
-function isRecord20(value) {
+function isRecord21(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString21(value) {
+function isNonEmptyString22(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -26560,7 +26990,7 @@ function getReservationClaimPartCount(energyCapacityAvailable) {
   return buildTerritoryReserverBody(energyCapacityAvailable).filter((part) => part === "claim").length;
 }
 function getReservationControllerState(colonyName, roomName, ownerUsername) {
-  const room = getVisibleRoom12(roomName);
+  const room = getVisibleRoom13(roomName);
   if (room) {
     const controller2 = room.controller;
     if (!controller2) {
@@ -26576,11 +27006,11 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString22(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString23(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString22(controller.reservationUsername)) {
-    if (isNonEmptyString22(ownerUsername) && controller.reservationUsername === ownerUsername) {
+  if (isNonEmptyString23(controller.reservationUsername)) {
+    if (isNonEmptyString23(ownerUsername) && controller.reservationUsername === ownerUsername) {
       return {
         kind: "ownReserved",
         ...controller.id ? { controllerId: controller.id } : {},
@@ -26594,12 +27024,12 @@ function getReservationControllerState(colonyName, roomName, ownerUsername) {
 function getVisibleControllerReservationState(controller, ownerUsername) {
   var _a;
   const controllerId = controller.id;
-  if (controller.my === true || isNonEmptyString22((_a = controller.owner) == null ? void 0 : _a.username)) {
+  if (controller.my === true || isNonEmptyString23((_a = controller.owner) == null ? void 0 : _a.username)) {
     return { kind: "owned", controllerId };
   }
   const reservation = controller.reservation;
-  if (isNonEmptyString22(reservation == null ? void 0 : reservation.username)) {
-    if (isNonEmptyString22(ownerUsername) && reservation.username === ownerUsername) {
+  if (isNonEmptyString23(reservation == null ? void 0 : reservation.username)) {
+    if (isNonEmptyString23(ownerUsername) && reservation.username === ownerUsername) {
       return {
         kind: "ownReserved",
         controllerId,
@@ -26612,7 +27042,7 @@ function getVisibleControllerReservationState(controller, ownerUsername) {
 }
 function hasHostilePresence2(colonyName, roomName) {
   var _a, _b, _c;
-  const room = getVisibleRoom12(roomName);
+  const room = getVisibleRoom13(roomName);
   if (room) {
     return countVisibleHostiles(room) > 0;
   }
@@ -26689,7 +27119,7 @@ function upsertAdjacentRoomReservationTarget(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord21(existingTarget)) {
+  if (isRecord22(existingTarget)) {
     existingTarget.createdBy = ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.controllerId) {
@@ -26722,13 +27152,13 @@ function hasBlockingTerritoryPlan(colony) {
   );
 }
 function isBlockingTerritoryTarget(target, colony) {
-  return isRecord21(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
+  return isRecord22(target) && target.colony === colony && target.enabled !== false && target.createdBy !== ADJACENT_ROOM_RESERVATION_TARGET_CREATOR && (target.action === "claim" || target.action === "reserve");
 }
 function isAdjacentRoomReservationTarget(target, colony) {
-  return isRecord21(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
+  return isRecord22(target) && target.colony === colony && target.action === "reserve" && target.createdBy === ADJACENT_ROOM_RESERVATION_TARGET_CREATOR;
 }
 function isSameTarget3(left, right) {
-  return isRecord21(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord22(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getAdjacentRoomNames7(roomName) {
   var _a;
@@ -26737,12 +27167,12 @@ function getAdjacentRoomNames7(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord21(exits)) {
+  if (!isRecord22(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER6.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString22(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString23(exitRoom) ? [exitRoom] : [];
   });
 }
 function getPersistedExpansionCandidatePriorities(colony) {
@@ -26753,7 +27183,7 @@ function getPersistedExpansionCandidatePriorities(colony) {
   }
   const priorities = /* @__PURE__ */ new Map();
   for (const [index, rawCandidate] of rawCandidates.entries()) {
-    if (!isRecord21(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString22(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
+    if (!isRecord22(rawCandidate) || rawCandidate.colony !== colony || !isNonEmptyString23(rawCandidate.roomName) || rawCandidate.evidenceStatus === "unavailable" || priorities.has(rawCandidate.roomName)) {
       continue;
     }
     priorities.set(rawCandidate.roomName, {
@@ -26771,7 +27201,7 @@ function countVisibleOwnedRooms3(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString22(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString23(room.name) && (!ownerUsername || getControllerOwnerUsername8(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
@@ -26789,7 +27219,7 @@ function getScoutIntel2(colonyName, roomName) {
   var _a, _b, _c;
   return (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel) == null ? void 0 : _c[`${colonyName}>${roomName}`];
 }
-function getVisibleRoom12(roomName) {
+function getVisibleRoom13(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -26807,7 +27237,7 @@ function getFindConstant7(name) {
 function getControllerOwnerUsername8(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString22(username) ? username : void 0;
+  return isNonEmptyString23(username) ? username : void 0;
 }
 function compareOptionalNumbers6(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
@@ -26843,10 +27273,10 @@ function getGameTime21() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" ? gameTime : 0;
 }
-function isNonEmptyString22(value) {
+function isNonEmptyString23(value) {
   return typeof value === "string" && value.length > 0;
 }
-function isRecord21(value) {
+function isRecord22(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -26937,9 +27367,9 @@ function clearColonyExpansionClaimIntent(colony) {
 function selectColonyExpansionCandidate(colony) {
   const ownerUsername = getControllerOwnerUsername9(colony.room.controller);
   const claimedRooms = buildRuntimeClaimedRoomSynergyEvidence(colony.room, ownerUsername);
-  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString23(room.mineralType));
+  const includeMineralSynergyEvidence = claimedRooms.some((room) => isNonEmptyString24(room.mineralType));
   const candidates = getAdjacentRoomNames8(colony.room.name).flatMap((roomName, order) => {
-    const room = getVisibleRoom13(roomName);
+    const room = getVisibleRoom14(roomName);
     if (!room && !getScoutIntel3(colony.room.name, roomName)) {
       return [];
     }
@@ -27028,7 +27458,7 @@ function applyColonyExpansionRankingScores(colony, ownerUsername, claimedRooms, 
   }
 }
 function toColonyExpansionCandidateInput(colonyName, roomName, order, claimScore, controllerState, ownerUsername, includeMineralSynergyEvidence) {
-  const room = getVisibleRoom13(roomName);
+  const room = getVisibleRoom14(roomName);
   const mineral = includeMineralSynergyEvidence && room ? buildVisibleExpansionMineralEvidence(room) : void 0;
   return {
     roomName,
@@ -27081,18 +27511,18 @@ function isColonyReadyToClaimMatureReservation(colony, controllerState) {
 }
 function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) {
   var _a, _b, _c;
-  const room = getVisibleRoom13(roomName);
+  const room = getVisibleRoom14(roomName);
   if (room) {
     const controller2 = room.controller;
     if (!controller2) {
       return { kind: "missing" };
     }
     const controllerId = controller2.id;
-    if (controller2.my === true || isNonEmptyString23((_a = controller2.owner) == null ? void 0 : _a.username)) {
+    if (controller2.my === true || isNonEmptyString24((_a = controller2.owner) == null ? void 0 : _a.username)) {
       return { kind: "owned", controllerId };
     }
     const reservationUsername = (_b = controller2.reservation) == null ? void 0 : _b.username;
-    if (isNonEmptyString23(reservationUsername)) {
+    if (isNonEmptyString24(reservationUsername)) {
       return reservationUsername === ownerUsername ? {
         kind: "ownReserved",
         controllerId,
@@ -27109,10 +27539,10 @@ function getColonyExpansionControllerState(colonyName, roomName, ownerUsername) 
   if (!controller) {
     return { kind: "missing" };
   }
-  if (controller.my === true || isNonEmptyString23(controller.ownerUsername)) {
+  if (controller.my === true || isNonEmptyString24(controller.ownerUsername)) {
     return { kind: "owned", ...controller.id ? { controllerId: controller.id } : {} };
   }
-  if (isNonEmptyString23(controller.reservationUsername)) {
+  if (isNonEmptyString24(controller.reservationUsername)) {
     return controller.reservationUsername === ownerUsername ? {
       kind: "ownReserved",
       ...controller.id ? { controllerId: controller.id } : {},
@@ -27127,7 +27557,7 @@ function hasBlockingClaimIntent(colony, targetRoom) {
     return false;
   }
   if (Array.isArray(territoryMemory.targets) && territoryMemory.targets.some(
-    (target) => isRecord22(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
+    (target) => isRecord23(target) && target.colony === colony && target.action === "claim" && target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR
   )) {
     return true;
   }
@@ -27173,13 +27603,13 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
   const removedRooms = /* @__PURE__ */ new Set();
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter((target) => {
-      if (!isRecord22(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
+      if (!isRecord23(target) || target.colony !== colony || target.action !== "claim" || target.createdBy !== COLONY_EXPANSION_CLAIM_TARGET_CREATOR) {
         return true;
       }
       if (activeTarget && isSameTarget4(target, activeTarget)) {
         return true;
       }
-      if (isNonEmptyString23(target.roomName)) {
+      if (isNonEmptyString24(target.roomName)) {
         removedRooms.add(target.roomName);
       }
       return false;
@@ -27196,7 +27626,7 @@ function pruneColonyExpansionClaimTargets(colony, territoryMemory, activeTarget)
 function pruneAdjacentReservationForTarget(colony, targetRoom, territoryMemory) {
   if (Array.isArray(territoryMemory.targets)) {
     territoryMemory.targets = territoryMemory.targets.filter(
-      (target) => !(isRecord22(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
+      (target) => !(isRecord23(target) && target.colony === colony && target.roomName === targetRoom && target.action === "reserve" && target.createdBy === "adjacentRoomReservation")
     );
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
@@ -27213,7 +27643,7 @@ function upsertTerritoryTarget3(territoryMemory, target) {
     territoryMemory.targets.push(target);
     return;
   }
-  if (isRecord22(existingTarget)) {
+  if (isRecord23(existingTarget)) {
     existingTarget.createdBy = COLONY_EXPANSION_CLAIM_TARGET_CREATOR;
     existingTarget.enabled = target.enabled;
     if (target.postClaimBootstrapReserveEnergy) {
@@ -27239,7 +27669,7 @@ function upsertTerritoryIntent5(intents, nextIntent) {
   intents.push(nextIntent);
 }
 function isSameTarget4(left, right) {
-  return isRecord22(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
+  return isRecord23(left) && left.colony === right.colony && left.roomName === right.roomName && left.action === right.action;
 }
 function getAdjacentRoomNames8(roomName) {
   var _a;
@@ -27248,15 +27678,15 @@ function getAdjacentRoomNames8(roomName) {
     return [];
   }
   const exits = gameMap.describeExits(roomName);
-  if (!isRecord22(exits)) {
+  if (!isRecord23(exits)) {
     return [];
   }
   return EXIT_DIRECTION_ORDER7.flatMap((direction) => {
     const exitRoom = exits[direction];
-    return isNonEmptyString23(exitRoom) ? [exitRoom] : [];
+    return isNonEmptyString24(exitRoom) ? [exitRoom] : [];
   });
 }
-function getVisibleRoom13(roomName) {
+function getVisibleRoom14(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
 }
@@ -27272,7 +27702,7 @@ function countVisibleOwnedRooms4(colonyName, ownerUsername) {
   }
   let ownedRoomCount = 0;
   for (const room of Object.values(rooms)) {
-    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString23(room.name) && (!ownerUsername || getControllerOwnerUsername9(room.controller) === ownerUsername)) {
+    if (((_b = room == null ? void 0 : room.controller) == null ? void 0 : _b.my) === true && isNonEmptyString24(room.name) && (!ownerUsername || getControllerOwnerUsername9(room.controller) === ownerUsername)) {
       ownedRoomCount += 1;
     }
   }
@@ -27286,17 +27716,17 @@ function getGclLevel4() {
 function hasActivePostClaimBootstrap2(colonyName) {
   var _a;
   const records = (_a = getTerritoryMemoryRecord8()) == null ? void 0 : _a.postClaimBootstraps;
-  if (!isRecord22(records)) {
+  if (!isRecord23(records)) {
     return false;
   }
   return Object.values(records).some(
-    (record) => isRecord22(record) && record.colony === colonyName && record.status !== "ready"
+    (record) => isRecord23(record) && record.colony === colonyName && record.status !== "ready"
   );
 }
 function getControllerOwnerUsername9(controller) {
   var _a;
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
-  return isNonEmptyString23(username) ? username : void 0;
+  return isNonEmptyString24(username) ? username : void 0;
 }
 function getTerritoryMemoryRecord8() {
   var _a;
@@ -27317,10 +27747,10 @@ function getGameTime22() {
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord22(value) {
+function isRecord23(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString23(value) {
+function isNonEmptyString24(value) {
   return typeof value === "string" && value.length > 0;
 }
 
@@ -27372,19 +27802,19 @@ function getWritableBootstrapperMemory() {
 function getActivePostClaimBootstrapRecord(roomName) {
   var _a, _b, _c;
   const record = (_c = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps) == null ? void 0 : _c[roomName];
-  return isRecord23(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
+  return isRecord24(record) && record.roomName === roomName && record.status !== "ready" ? record : null;
 }
 function getGameTime23() {
   var _a;
   const gameTime = (_a = globalThis.Game) == null ? void 0 : _a.time;
   return typeof gameTime === "number" && Number.isFinite(gameTime) ? gameTime : 0;
 }
-function isRecord23(value) {
+function isRecord24(value) {
   return typeof value === "object" && value !== null;
 }
 
 // src/territory/territoryRunner.ts
-var ERR_NOT_IN_RANGE_CODE10 = -9;
+var ERR_NOT_IN_RANGE_CODE11 = -9;
 var ERR_INVALID_TARGET_CODE5 = -7;
 var ERR_NO_BODYPART_CODE2 = -12;
 var ERR_GCL_NOT_ENOUGH_CODE2 = -15;
@@ -27448,7 +27878,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   }
   if (isTerritoryControlAction4(assignment.action) && typeof creep.attackController === "function" && canCreepPressureTerritoryController(creep, controller, creep.memory.colony)) {
     const pressureResult = executeControllerAction(creep, controller, "attackController");
-    if (pressureResult === ERR_NOT_IN_RANGE_CODE10 && typeof creep.moveTo === "function") {
+    if (pressureResult === ERR_NOT_IN_RANGE_CODE11 && typeof creep.moveTo === "function") {
       creep.moveTo(controller);
       return;
     }
@@ -27474,7 +27904,7 @@ function runTerritoryControllerCreep(creep, telemetryEvents = []) {
   if (assignment.action === "claim" && result === OK_CODE12) {
     recordPostClaimBootstrapIfOwned(creep, assignment, controller, telemetryEvents);
   }
-  if (result === ERR_NOT_IN_RANGE_CODE10 && typeof creep.moveTo === "function") {
+  if (result === ERR_NOT_IN_RANGE_CODE11 && typeof creep.moveTo === "function") {
     creep.moveTo(controller);
     return;
   }
@@ -27513,7 +27943,7 @@ function tryFallbackClaimAssignmentToReserve(creep, assignment, controller) {
   suppressTerritoryIntent(creep.memory.colony, assignment, gameTime);
   creep.memory.territory = (_a = recordTerritoryReserveFallbackIntent(creep.memory.colony, reserveAssignment, gameTime)) != null ? _a : reserveAssignment;
   const reserveResult = executeControllerAction(creep, controller, "reserveController");
-  if (reserveResult === ERR_NOT_IN_RANGE_CODE10 && typeof creep.moveTo === "function") {
+  if (reserveResult === ERR_NOT_IN_RANGE_CODE11 && typeof creep.moveTo === "function") {
     creep.moveTo(controller);
     return true;
   }
@@ -27557,9 +27987,9 @@ function selectTargetController(creep, assignment) {
   var _a, _b;
   if (assignment.controllerId) {
     const game = globalThis.Game;
-    const getObjectById5 = game == null ? void 0 : game.getObjectById;
-    if (typeof getObjectById5 === "function") {
-      const controller = getObjectById5.call(game, assignment.controllerId);
+    const getObjectById6 = game == null ? void 0 : game.getObjectById;
+    if (typeof getObjectById6 === "function") {
+      const controller = getObjectById6.call(game, assignment.controllerId);
       if (controller) {
         return controller;
       }
@@ -27787,7 +28217,7 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
     workerCount: colonyCreeps.filter((creep) => creep.memory.role === "worker").length,
     energyAvailable: colony.energyAvailable,
     energyCapacity: colony.energyCapacityAvailable,
-    storedEnergy: getStoredEnergy14(room),
+    storedEnergy: getStoredEnergy15(room),
     sourceCount: sources.length,
     hostileCreepCount: hostileCreeps.length,
     hostileStructureCount: hostileStructures.length,
@@ -27870,7 +28300,7 @@ function buildMemoryTerritoryState(roomName) {
   const expansionCandidates = [];
   if (Array.isArray(targets)) {
     for (const target of targets) {
-      if (!isRecord24(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+      if (!isRecord25(target) || target.colony !== roomName || typeof target.roomName !== "string") {
         continue;
       }
       const action = normalizeTerritoryAction(target.action);
@@ -27932,12 +28362,12 @@ function countVisibleOwnedRooms5() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord24(structure) && matchesStructureType21(structure.structureType, globalName, fallback)
+    (structure) => isRecord25(structure) && matchesStructureType22(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
   return structures.reduce((total, structure) => {
-    if (!isRecord24(structure)) {
+    if (!isRecord25(structure)) {
       return total;
     }
     const hits = finiteNumberOrNull(structure.hits);
@@ -27948,12 +28378,12 @@ function estimateRepairBacklogHits(structures) {
     return total + (hitsMax - hits);
   }, 0);
 }
-function getStoredEnergy14(room) {
+function getStoredEnergy15(room) {
   const storage = room.storage;
   return getEnergyInStore2(storage);
 }
 function getEnergyInStore2(object) {
-  if (!isRecord24(object) || !isRecord24(object.store)) {
+  if (!isRecord25(object) || !isRecord25(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -27977,7 +28407,7 @@ function findRoomObjects18(room, constantName) {
     return [];
   }
 }
-function matchesStructureType21(value, globalName, fallback) {
+function matchesStructureType22(value, globalName, fallback) {
   const globalValue = globalThis[globalName];
   return value === globalValue || value === fallback;
 }
@@ -28005,7 +28435,7 @@ function finiteNumberOrZero(value) {
 function finiteNumberOrNull(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function isRecord24(value) {
+function isRecord25(value) {
   return typeof value === "object" && value !== null;
 }
 
@@ -28116,6 +28546,8 @@ function runEconomy(preludeTelemetryEvents = []) {
   for (const creep of creeps) {
     if (creep.memory.role === "worker") {
       runWorker(creep);
+    } else if (creep.memory.role === SOURCE_HARVESTER_ROLE) {
+      runSourceHarvester(creep);
     } else if (creep.memory.role === REMOTE_HARVESTER_ROLE) {
       runRemoteHarvester(creep);
     } else if (creep.memory.role === HAULER_ROLE) {
@@ -28315,17 +28747,17 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber9(refreshedAt) || !isRecord25(rawSelection) || !isNonEmptyString24(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber9(refreshedAt) || !isRecord26(rawSelection) || !isNonEmptyString25(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord25(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord26(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
-    if (!isNonEmptyString24(rawSelection.targetRoom)) {
+    if (!isNonEmptyString25(rawSelection.targetRoom)) {
       return null;
     }
     return {
@@ -28362,7 +28794,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord25(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord26(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -28400,31 +28832,31 @@ function getGclLevel5() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord25(records)) {
+  if (!isRecord26(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord25(record) && record.status !== "ready"
+    (record) => isRecord26(record) && record.status !== "ready"
   ).length;
 }
 function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel;
-  if (!isRecord25(records)) {
+  if (!isRecord26(records)) {
     return 0;
   }
   let latestUpdatedAt = 0;
   for (const record of Object.values(records)) {
-    if (isRecord25(record) && record.colony === colony && isFiniteNumber9(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
+    if (isRecord26(record) && record.colony === colony && isFiniteNumber9(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
       latestUpdatedAt = record.updatedAt;
     }
   }
   return latestUpdatedAt;
 }
-function isRecord25(value) {
+function isRecord26(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString24(value) {
+function isNonEmptyString25(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber9(value) {
@@ -29705,10 +30137,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord26(rawReplay)) {
+  if (!isRecord27(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString25(rawReplay.replayId) || !isNonEmptyString25(rawReplay.room) || !isFiniteNumber10(rawReplay.startTick) || !isFiniteNumber10(rawReplay.endTick) || !isFiniteNumber10(rawReplay.finalScore) || !isRecord26(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString26(rawReplay.replayId) || !isNonEmptyString26(rawReplay.room) || !isFiniteNumber10(rawReplay.startTick) || !isFiniteNumber10(rawReplay.endTick) || !isFiniteNumber10(rawReplay.finalScore) || !isRecord27(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -29733,10 +30165,10 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord26(value) {
+function isRecord27(value) {
   return typeof value === "object" && value !== null;
 }
-function isNonEmptyString25(value) {
+function isNonEmptyString26(value) {
   return typeof value === "string" && value.length > 0;
 }
 function isFiniteNumber10(value) {

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -14363,10 +14363,12 @@ var ERR_FULL_CODE2 = -8;
 var ERR_NOT_ENOUGH_RESOURCES_CODE = -6;
 var ERR_NOT_IN_RANGE_CODE4 = -9;
 var SOURCE_LINK_DEPOSIT_RANGE = 1;
+var sourceHarvesterAssignmentCountCache = null;
 function selectSourceHarvesterAssignment(room) {
   var _a;
+  const assignmentCounts = getSourceHarvesterAssignmentCounts();
   return (_a = getSourceHarvesterAssignments(room).find(
-    (assignment) => countAssignedSourceHarvesters(assignment) < 1
+    (assignment) => countAssignedSourceHarvesters(assignment, assignmentCounts) < 1
   )) != null ? _a : null;
 }
 function getSourceHarvesterAssignments(room) {
@@ -14478,19 +14480,56 @@ function isMobileFallbackEnergySink(structure) {
   const structureType = structure.structureType;
   return (matchesStructureType12(structureType, "STRUCTURE_SPAWN", "spawn") || matchesStructureType12(structureType, "STRUCTURE_EXTENSION", "extension") || matchesStructureType12(structureType, "STRUCTURE_TOWER", "tower")) && getFreeEnergyCapacity4(structure) > 0;
 }
-function countAssignedSourceHarvesters(assignment) {
-  return getGameCreeps().filter((creep) => isAssignedToSourceHarvesterSlot(creep, assignment)).length;
+function countAssignedSourceHarvesters(assignment, assignmentCounts) {
+  var _a;
+  return (_a = assignmentCounts.get(getSourceHarvesterAssignmentKey(assignment.roomName, assignment.sourceId))) != null ? _a : 0;
 }
-function isAssignedToSourceHarvesterSlot(creep, assignment) {
-  var _a, _b, _c, _d, _e, _f;
+function getSourceHarvesterAssignmentCounts() {
+  var _a;
+  const game = globalThis.Game;
+  const creeps = game == null ? void 0 : game.creeps;
+  if (!creeps) {
+    return /* @__PURE__ */ new Map();
+  }
+  const gameTime = getCacheableGameTime(game);
+  if (gameTime !== null && (sourceHarvesterAssignmentCountCache == null ? void 0 : sourceHarvesterAssignmentCountCache.gameTime) === gameTime && sourceHarvesterAssignmentCountCache.creeps === creeps) {
+    return sourceHarvesterAssignmentCountCache.counts;
+  }
+  const counts = /* @__PURE__ */ new Map();
+  for (const creep of Object.values(creeps)) {
+    const assignmentKey = getAssignedSourceHarvesterSlotKey(creep);
+    if (!assignmentKey) {
+      continue;
+    }
+    counts.set(assignmentKey, ((_a = counts.get(assignmentKey)) != null ? _a : 0) + 1);
+  }
+  if (gameTime !== null) {
+    sourceHarvesterAssignmentCountCache = { gameTime, creeps, counts };
+  }
+  return counts;
+}
+function getAssignedSourceHarvesterSlotKey(creep) {
+  var _a, _b, _c, _d, _e;
   if (!canSatisfySourceHarvesterCapacity(creep)) {
-    return false;
+    return null;
   }
-  if (((_a = creep.memory) == null ? void 0 : _a.role) === SOURCE_HARVESTER_ROLE && ((_b = creep.memory.sourceHarvester) == null ? void 0 : _b.roomName) === assignment.roomName && String((_c = creep.memory.sourceHarvester) == null ? void 0 : _c.sourceId) === String(assignment.sourceId)) {
-    return true;
+  if (((_a = creep.memory) == null ? void 0 : _a.role) === SOURCE_HARVESTER_ROLE && typeof ((_b = creep.memory.sourceHarvester) == null ? void 0 : _b.roomName) === "string" && creep.memory.sourceHarvester.sourceId !== void 0) {
+    return getSourceHarvesterAssignmentKey(
+      creep.memory.sourceHarvester.roomName,
+      creep.memory.sourceHarvester.sourceId
+    );
   }
-  const task = (_d = creep.memory) == null ? void 0 : _d.task;
-  return ((_e = creep.memory) == null ? void 0 : _e.role) === "worker" && ((_f = creep.room) == null ? void 0 : _f.name) === assignment.roomName && (task == null ? void 0 : task.type) === "harvest" && task.sourceContainerAssigned === true && String(task.targetId) === String(assignment.sourceId);
+  const task = (_c = creep.memory) == null ? void 0 : _c.task;
+  if (((_d = creep.memory) == null ? void 0 : _d.role) === "worker" && typeof ((_e = creep.room) == null ? void 0 : _e.name) === "string" && (task == null ? void 0 : task.type) === "harvest" && task.sourceContainerAssigned === true && task.targetId !== void 0) {
+    return getSourceHarvesterAssignmentKey(creep.room.name, task.targetId);
+  }
+  return null;
+}
+function getSourceHarvesterAssignmentKey(roomName, sourceId) {
+  return `${roomName}\0${String(sourceId)}`;
+}
+function getCacheableGameTime(game) {
+  return typeof game.time === "number" && Number.isFinite(game.time) ? game.time : null;
 }
 function canSatisfySourceHarvesterCapacity(creep) {
   return creep.ticksToLive === void 0 || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
@@ -14605,11 +14644,6 @@ function getObjectById2(id) {
 function getVisibleRoom5(roomName) {
   var _a, _b;
   return (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
-}
-function getGameCreeps() {
-  var _a;
-  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  return creeps ? Object.values(creeps).filter((creep) => creep !== void 0) : [];
 }
 function compareAssignments(left, right) {
   return left.roomName.localeCompare(right.roomName) || String(left.sourceId).localeCompare(String(right.sourceId));
@@ -15936,7 +15970,7 @@ function getInterRoomHaulReservationCache() {
     reservedEnergyByTransferKey: /* @__PURE__ */ new Map(),
     tick: gameTick
   };
-  for (const creep of getGameCreeps2()) {
+  for (const creep of getGameCreeps()) {
     setCachedInterRoomHaulReservation(
       interRoomHaulReservationCache,
       creep,
@@ -16516,7 +16550,7 @@ function getRoomOwnedCreeps(room) {
       return roomCreeps;
     }
   }
-  return getGameCreeps2().filter((worker) => isSameRoomWorker(worker, room));
+  return getGameCreeps().filter((worker) => isSameRoomWorker(worker, room));
 }
 function isWorkerAssignedToConstructionSite(worker, site) {
   var _a;
@@ -17725,7 +17759,7 @@ function createWorkerEnergyAcquisitionReservationContext(creep) {
 function getReservedWorkerEnergyAcquisitionsBySourceId(creep) {
   var _a, _b;
   const reservedEnergyBySourceId = /* @__PURE__ */ new Map();
-  for (const worker of getGameCreeps2()) {
+  for (const worker of getGameCreeps()) {
     if (isSameCreep(worker, creep) || !isSameRoomWorker(worker, creep.room)) {
       continue;
     }
@@ -18165,7 +18199,7 @@ function createNearTermSpawnExtensionRefillReserveContext(room) {
     room,
     spawnExtensionEnergyStructures
   );
-  const sortedLoadedWorkers = refillReserve > 0 ? dedupeCreepsByStableKey(getGameCreeps2().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, room))).sort(
+  const sortedLoadedWorkers = refillReserve > 0 ? dedupeCreepsByStableKey(getGameCreeps().filter((candidate) => isSameRoomWorkerWithEnergy(candidate, room))).sort(
     (left, right) => compareNearTermRefillReserveWorkers(left, right, spawnExtensionEnergyStructures)
   ) : [];
   return {
@@ -18410,7 +18444,7 @@ function isSourceDepleted2(source) {
   return typeof source.energy === "number" && source.energy <= 0;
 }
 function hasOtherSource2ControllerLaneWorker(creep, topology) {
-  return getGameCreeps2().some(
+  return getGameCreeps().some(
     (candidate) => !isSameCreep(candidate, creep) && isSameRoomWorker(candidate, creep.room) && isSource2ControllerLaneTask(candidate, topology)
   );
 }
@@ -18543,7 +18577,7 @@ function isActiveTerritoryPressureIntent(intent, colonyName) {
   return intent.colony === colonyName && intent.targetRoom !== colonyName && (intent.status === "planned" || intent.status === "active") && (intent.action === "claim" || intent.action === "reserve" || intent.action === "scout");
 }
 function getSameRoomLoadedWorkers(creep) {
-  return getSameRoomLoadedWorkersFromCandidates(creep, getGameCreeps2());
+  return getSameRoomLoadedWorkersFromCandidates(creep, getGameCreeps());
 }
 function getSameRoomLoadedWorkersForRefillReservations(creep) {
   return getSameRoomLoadedWorkersFromCandidates(creep, getRoomOwnedCreeps(creep.room));
@@ -19204,7 +19238,7 @@ function getWorkerHarvestLoads(sources) {
     assignmentLoads.set(source.id, createEmptyHarvestSourceAssignmentLoad());
   }
   const sourceIds = new Set(sources.map((source) => source.id));
-  for (const assignedCreep of getGameCreeps2()) {
+  for (const assignedCreep of getGameCreeps()) {
     const task = (_a = assignedCreep.memory) == null ? void 0 : _a.task;
     const targetId = typeof (task == null ? void 0 : task.targetId) === "string" ? task.targetId : void 0;
     const sourceHarvesterTargetId = ((_b = assignedCreep.memory) == null ? void 0 : _b.role) === SOURCE_HARVESTER_ROLE && typeof ((_c = assignedCreep.memory.sourceHarvester) == null ? void 0 : _c.sourceId) === "string" ? assignedCreep.memory.sourceHarvester.sourceId : void 0;
@@ -19225,7 +19259,7 @@ function getWorkerHarvestLoads(sources) {
 function isSourceContainerHarvestAssignment(task) {
   return (task == null ? void 0 : task.type) === "harvest" && task.sourceContainerAssigned === true;
 }
-function getGameCreeps2() {
+function getGameCreeps() {
   const game = getGameReference();
   const creeps = game == null ? void 0 : game.creeps;
   const gameTick = getGameTick3();
@@ -21901,7 +21935,7 @@ function planLocalSurvivalSpawn(context) {
 }
 function planLocalSourceMiningSpawn(context) {
   var _a, _b;
-  if (context.options.workersOnly || context.survival.hostilePresence || context.survival.controllerDowngradeGuard || ((_a = context.colony.room.controller) == null ? void 0 : _a.my) !== true || ((_b = context.colony.room.controller.level) != null ? _b : 0) < 2 || context.workerCapacity < LOCAL_SUPPORT_WORKER_FLOOR) {
+  if (context.options.workersOnly || context.survival.hostilePresence || context.survival.controllerDowngradeGuard || ((_a = context.colony.room.controller) == null ? void 0 : _a.my) !== true || ((_b = context.colony.room.controller.level) != null ? _b : 0) < 2 || context.roleCounts.worker < LOCAL_SUPPORT_WORKER_FLOOR) {
     return null;
   }
   const assignment = selectSourceHarvesterAssignment(context.colony.room);
@@ -22674,7 +22708,7 @@ function getHarvesterBodyPartCount(workParts, carryParts) {
 function shouldUseSourceHarvesterBody(colony, roleCounts) {
   const sourceAwareWorkerTarget = getSourceAwareWorkerTarget(colony.room);
   const workerCapacity = getWorkerCapacity(roleCounts);
-  return sourceAwareWorkerTarget > LOCAL_SUPPORT_WORKER_FLOOR && workerCapacity >= LOCAL_SUPPORT_WORKER_FLOOR && workerCapacity < sourceAwareWorkerTarget;
+  return sourceAwareWorkerTarget > LOCAL_SUPPORT_WORKER_FLOOR && roleCounts.worker >= LOCAL_SUPPORT_WORKER_FLOOR && workerCapacity < sourceAwareWorkerTarget;
 }
 function getSourceAwareWorkerTarget(room) {
   return getSourceCount(room) * 2;
@@ -23436,7 +23470,7 @@ var ROOM_EDGE_MAX7 = 48;
 var DEFAULT_TERRAIN_WALL_MASK10 = 1;
 var ERR_INVALID_TARGET_CODE3 = -7;
 var REMOTE_HARVESTER_ROLE2 = "remoteHarvester";
-function ensureRemoteSourceContainersForAssignedHarvesters(creeps = getGameCreeps3()) {
+function ensureRemoteSourceContainersForAssignedHarvesters(creeps = getGameCreeps2()) {
   const roomResults = getRemoteSourceContainerScans(creeps).map(planSourceContainersForRoom);
   return buildSourceContainerPlannerResult(roomResults);
 }
@@ -23699,7 +23733,7 @@ function getVisibleSpawns() {
   const spawns = (_a = globalThis.Game) == null ? void 0 : _a.spawns;
   return spawns ? Object.values(spawns).filter((spawn) => spawn !== void 0) : [];
 }
-function getGameCreeps3() {
+function getGameCreeps2() {
   var _a;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
   return creeps ? Object.values(creeps).filter((creep) => creep !== void 0) : [];
@@ -25037,7 +25071,7 @@ function recordSourceWorkloads(room, creeps, tick) {
     )
   };
 }
-function buildSourceWorkloadRecords(room, sources = findSources4(room), creeps = getGameCreeps4()) {
+function buildSourceWorkloadRecords(room, sources = findSources4(room), creeps = getGameCreeps3()) {
   const roomName = getRoomName5(room);
   const assignmentLoads = getSourceAssignmentLoads(roomName, sources, creeps);
   return sources.filter((source) => hasSourcePositionInRoom(source, room)).sort((left, right) => String(left.id).localeCompare(String(right.id))).map((source) => {
@@ -25176,7 +25210,7 @@ function getBodyPartConstant5(globalName, fallback) {
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
 }
-function getGameCreeps4() {
+function getGameCreeps3() {
   var _a;
   const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
   return creeps ? Object.values(creeps) : [];

--- a/prod/src/colony/colonyStage.ts
+++ b/prod/src/colony/colonyStage.ts
@@ -486,6 +486,7 @@ function getRoomName(room: Room): string | null {
 
 function getColonyCreepTotal(roleCounts: RoleCounts): number {
   return normalizeNonNegativeInteger(roleCounts.worker) +
+    normalizeNonNegativeInteger(roleCounts.sourceHarvester ?? 0) +
     normalizeNonNegativeInteger(roleCounts.defender ?? 0) +
     normalizeNonNegativeInteger(roleCounts.claimer ?? 0) +
     normalizeNonNegativeInteger(roleCounts.scout ?? 0);

--- a/prod/src/creeps/roleCounts.ts
+++ b/prod/src/creeps/roleCounts.ts
@@ -1,6 +1,7 @@
 export interface RoleCounts {
   worker: number;
   workerCapacity?: number;
+  sourceHarvester?: number;
   defender?: number;
   claimer?: number;
   claimersByTargetRoom?: Record<string, number>;
@@ -19,6 +20,12 @@ export function countCreepsByRole(creeps: Creep[], colonyName: string): RoleCoun
     (counts, creep) => {
       if (isColonyWorker(creep, colonyName)) {
         counts.worker += 1;
+        if (canSatisfyRoleCapacity(creep)) {
+          counts.workerCapacity = (counts.workerCapacity ?? 0) + 1;
+        }
+      }
+      if (isColonySourceHarvester(creep, colonyName)) {
+        counts.sourceHarvester = (counts.sourceHarvester ?? 0) + 1;
         if (canSatisfyRoleCapacity(creep)) {
           counts.workerCapacity = (counts.workerCapacity ?? 0) + 1;
         }
@@ -79,6 +86,10 @@ function incrementTargetRoomActionCount(
 
 function isColonyWorker(creep: Creep, colonyName: string): boolean {
   return creep.memory.colony === colonyName && creep.memory.role === 'worker';
+}
+
+function isColonySourceHarvester(creep: Creep, colonyName: string): boolean {
+  return creep.memory.colony === colonyName && creep.memory.role === 'sourceHarvester';
 }
 
 function isColonyClaimer(creep: Creep, colonyName: string): boolean {

--- a/prod/src/creeps/sourceHarvester.ts
+++ b/prod/src/creeps/sourceHarvester.ts
@@ -1,0 +1,388 @@
+import { classifyLinks } from '../economy/linkManager';
+import { findSourceContainer, getRangeBetweenPositions, getRoomObjectPosition } from '../economy/sourceContainers';
+import { buildRemoteHarvesterBody } from '../spawn/bodyBuilder';
+import { WORKER_REPLACEMENT_TICKS_TO_LIVE } from './roleCounts';
+
+export const SOURCE_HARVESTER_ROLE = 'sourceHarvester';
+
+const ERR_FULL_CODE = -8 as ScreepsReturnCode;
+const ERR_NOT_ENOUGH_RESOURCES_CODE = -6 as ScreepsReturnCode;
+const ERR_NOT_IN_RANGE_CODE = -9 as ScreepsReturnCode;
+const SOURCE_LINK_DEPOSIT_RANGE = 1;
+
+type MobileFallbackEnergySink = StructureSpawn | StructureExtension | StructureTower;
+
+export interface SourceHarvesterAssignment {
+  roomName: string;
+  sourceId: Id<Source>;
+  containerId: Id<StructureContainer>;
+}
+
+export { buildRemoteHarvesterBody as buildSourceHarvesterBody };
+
+export function selectSourceHarvesterAssignment(room: Room): SourceHarvesterAssignment | null {
+  return (
+    getSourceHarvesterAssignments(room).find(
+      (assignment) => countAssignedSourceHarvesters(assignment) < 1
+    ) ?? null
+  );
+}
+
+export function getSourceHarvesterAssignments(room: Room): SourceHarvesterAssignment[] {
+  if (typeof FIND_SOURCES !== 'number' || typeof room.find !== 'function') {
+    return [];
+  }
+
+  return (room.find(FIND_SOURCES) as Source[])
+    .flatMap((source) => {
+      const container = findSourceContainer(room, source);
+      return container
+        ? [
+            {
+              roomName: room.name,
+              sourceId: source.id,
+              containerId: container.id
+            }
+          ]
+        : [];
+    })
+    .sort(compareAssignments);
+}
+
+export function runSourceHarvester(creep: Creep): void {
+  const assignment = normalizeSourceHarvesterMemory(creep.memory?.sourceHarvester);
+  if (!assignment) {
+    return;
+  }
+
+  creep.memory.task = {
+    type: 'harvest',
+    targetId: assignment.sourceId,
+    sourceContainerAssigned: true
+  };
+
+  if (creep.room?.name !== assignment.roomName) {
+    moveTowardRoom(creep, assignment.roomName);
+    return;
+  }
+
+  const source = getAssignedSource(assignment);
+  if (!source) {
+    moveTowardRoom(creep, assignment.roomName);
+    return;
+  }
+
+  const container = getAssignedContainer(assignment) ?? findSourceContainer(creep.room, source);
+  if (!container) {
+    runMobileFallback(creep, source);
+    return;
+  }
+
+  if (!isInRangeTo(creep, container, 0)) {
+    moveTo(creep, container);
+    return;
+  }
+
+  if (isSourceDepleted(source)) {
+    if (getCarriedEnergy(creep) > 0) {
+      transferHarvestedEnergy(creep, source, container);
+    }
+    return;
+  }
+
+  if (getFreeEnergyCapacity(creep) <= 0 && getCarriedEnergy(creep) > 0) {
+    transferHarvestedEnergy(creep, source, container);
+    return;
+  }
+
+  const result = creep.harvest?.(source);
+  if (
+    (result === getErrFullCode() || result === getErrNotEnoughResourcesCode()) &&
+    getCarriedEnergy(creep) > 0
+  ) {
+    transferHarvestedEnergy(creep, source, container);
+  }
+}
+
+function runMobileFallback(creep: Creep, source: Source): void {
+  if (getCarriedEnergy(creep) > 0 && getFreeEnergyCapacity(creep) <= 0) {
+    const sink = selectMobileFallbackEnergySink(creep);
+    if (sink) {
+      const result = creep.transfer?.(sink, getEnergyResource());
+      if (result === getErrNotInRangeCode()) {
+        moveTo(creep, sink);
+      }
+      return;
+    }
+  }
+
+  if (!isInRangeTo(creep, source, 1)) {
+    moveTo(creep, source);
+    return;
+  }
+
+  creep.harvest?.(source);
+}
+
+function transferHarvestedEnergy(
+  creep: Creep,
+  source: Source,
+  container: StructureContainer
+): ScreepsReturnCode | undefined {
+  const link = selectSourceLinkDeposit(creep.room, source, container);
+  const target = link ?? container;
+  const result = creep.transfer?.(target, getEnergyResource());
+  if (result === getErrNotInRangeCode()) {
+    moveTo(creep, target);
+  }
+  return result;
+}
+
+function selectSourceLinkDeposit(
+  room: Room,
+  source: Source,
+  container: StructureContainer
+): StructureLink | null {
+  return (
+    classifyLinks(room).sourceLinks
+      .filter((link) => getFreeEnergyCapacity(link) > 0)
+      .filter((link) => isNearRoomObject(source, link, 2))
+      .filter((link) => isNearRoomObject(container, link, SOURCE_LINK_DEPOSIT_RANGE))
+      .sort((left, right) => compareSourceLinkDeposits(container, left, right))[0] ?? null
+  );
+}
+
+function compareSourceLinkDeposits(
+  container: StructureContainer,
+  left: StructureLink,
+  right: StructureLink
+): number {
+  const containerPosition = getRoomObjectPosition(container);
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return (
+    (containerPosition && leftPosition ? getRangeBetweenPositions(containerPosition, leftPosition) : 99) -
+      (containerPosition && rightPosition ? getRangeBetweenPositions(containerPosition, rightPosition) : 99) ||
+    String(left.id).localeCompare(String(right.id))
+  );
+}
+
+function selectMobileFallbackEnergySink(creep: Creep): AnyStoreStructure | null {
+  if (typeof FIND_MY_STRUCTURES !== 'number' || typeof creep.room?.find !== 'function') {
+    return null;
+  }
+
+  const sinks = (creep.room.find(FIND_MY_STRUCTURES) as AnyOwnedStructure[])
+    .filter((structure): structure is MobileFallbackEnergySink => isMobileFallbackEnergySink(structure))
+    .sort((left, right) => compareRangeToCreep(creep, left, right) || String(left.id).localeCompare(String(right.id)));
+  return sinks[0] ?? null;
+}
+
+function isMobileFallbackEnergySink(structure: AnyOwnedStructure): structure is MobileFallbackEnergySink {
+  const structureType = structure.structureType;
+  return (
+    (matchesStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+      matchesStructureType(structureType, 'STRUCTURE_EXTENSION', 'extension') ||
+      matchesStructureType(structureType, 'STRUCTURE_TOWER', 'tower')) &&
+    getFreeEnergyCapacity(structure) > 0
+  );
+}
+
+function countAssignedSourceHarvesters(assignment: SourceHarvesterAssignment): number {
+  return getGameCreeps().filter((creep) => isAssignedToSourceHarvesterSlot(creep, assignment)).length;
+}
+
+function isAssignedToSourceHarvesterSlot(creep: Creep, assignment: SourceHarvesterAssignment): boolean {
+  if (!canSatisfySourceHarvesterCapacity(creep)) {
+    return false;
+  }
+
+  if (
+    creep.memory?.role === SOURCE_HARVESTER_ROLE &&
+    creep.memory.sourceHarvester?.roomName === assignment.roomName &&
+    String(creep.memory.sourceHarvester?.sourceId) === String(assignment.sourceId)
+  ) {
+    return true;
+  }
+
+  const task = creep.memory?.task as Partial<CreepTaskMemory> | undefined;
+  return (
+    creep.memory?.role === 'worker' &&
+    creep.room?.name === assignment.roomName &&
+    task?.type === 'harvest' &&
+    task.sourceContainerAssigned === true &&
+    String(task.targetId) === String(assignment.sourceId)
+  );
+}
+
+function canSatisfySourceHarvesterCapacity(creep: Creep): boolean {
+  return creep.ticksToLive === undefined || creep.ticksToLive > WORKER_REPLACEMENT_TICKS_TO_LIVE;
+}
+
+function getAssignedSource(assignment: SourceHarvesterAssignment): Source | null {
+  const source = getObjectById<Source>(assignment.sourceId);
+  if (source) {
+    return source;
+  }
+
+  const room = getVisibleRoom(assignment.roomName);
+  if (!room || typeof FIND_SOURCES !== 'number' || typeof room.find !== 'function') {
+    return null;
+  }
+
+  return (
+    (room.find(FIND_SOURCES) as Source[]).find((candidate) => String(candidate.id) === String(assignment.sourceId)) ??
+    null
+  );
+}
+
+function getAssignedContainer(assignment: SourceHarvesterAssignment): StructureContainer | null {
+  const container = getObjectById<StructureContainer>(assignment.containerId);
+  return container ?? null;
+}
+
+function normalizeSourceHarvesterMemory(value: unknown): SourceHarvesterAssignment | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return isNonEmptyString(value.roomName) &&
+    isNonEmptyString(value.sourceId) &&
+    isNonEmptyString(value.containerId)
+    ? {
+        roomName: value.roomName,
+        sourceId: value.sourceId as Id<Source>,
+        containerId: value.containerId as Id<StructureContainer>
+      }
+    : null;
+}
+
+function moveTowardRoom(creep: Creep, roomName: string): void {
+  const visibleController = getVisibleRoom(roomName)?.controller;
+  if (visibleController) {
+    moveTo(creep, visibleController);
+    return;
+  }
+
+  const RoomPositionCtor = (globalThis as { RoomPosition?: new (x: number, y: number, roomName: string) => RoomPosition })
+    .RoomPosition;
+  if (typeof RoomPositionCtor === 'function') {
+    moveTo(creep, new RoomPositionCtor(25, 25, roomName));
+  }
+}
+
+function moveTo(creep: Creep, target: RoomObject | RoomPosition): void {
+  creep.moveTo?.(target);
+}
+
+function isInRangeTo(creep: Creep, target: RoomObject, range: number): boolean {
+  const actualRange = creep.pos?.getRangeTo?.(target);
+  return typeof actualRange !== 'number' || actualRange <= range;
+}
+
+function isNearRoomObject(left: RoomObject, right: RoomObject, range: number): boolean {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return (
+    leftPosition !== null &&
+    rightPosition !== null &&
+    (typeof leftPosition.roomName !== 'string' ||
+      typeof rightPosition.roomName !== 'string' ||
+      leftPosition.roomName === rightPosition.roomName) &&
+    getRangeBetweenPositions(leftPosition, rightPosition) <= range
+  );
+}
+
+function compareRangeToCreep(creep: Creep, left: RoomObject, right: RoomObject): number {
+  const getRangeTo = creep.pos?.getRangeTo;
+  if (typeof getRangeTo !== 'function') {
+    return 0;
+  }
+
+  return normalizeRange(getRangeTo.call(creep.pos, left)) - normalizeRange(getRangeTo.call(creep.pos, right));
+}
+
+function normalizeRange(range: unknown): number {
+  return typeof range === 'number' && Number.isFinite(range) ? range : Number.POSITIVE_INFINITY;
+}
+
+function isSourceDepleted(source: Source): boolean {
+  return typeof source.energy === 'number' && source.energy <= 0;
+}
+
+function getCarriedEnergy(creep: Creep): number {
+  return getStoredEnergy(creep);
+}
+
+function getStoredEnergy(target: unknown): number {
+  const usedCapacity = (target as { store?: { getUsedCapacity?: (resource?: ResourceConstant) => number | null } } | null)
+    ?.store?.getUsedCapacity?.(getEnergyResource());
+  return typeof usedCapacity === 'number' && Number.isFinite(usedCapacity) ? Math.max(0, usedCapacity) : 0;
+}
+
+function getFreeEnergyCapacity(target: unknown): number {
+  const freeCapacity = (target as { store?: { getFreeCapacity?: (resource?: ResourceConstant) => number | null } } | null)
+    ?.store?.getFreeCapacity?.(getEnergyResource());
+  return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+
+function getEnergyResource(): ResourceConstant {
+  return ((globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
+}
+
+function getErrFullCode(): ScreepsReturnCode {
+  return ((globalThis as { ERR_FULL?: ScreepsReturnCode }).ERR_FULL ?? ERR_FULL_CODE) as ScreepsReturnCode;
+}
+
+function getErrNotEnoughResourcesCode(): ScreepsReturnCode {
+  return ((globalThis as { ERR_NOT_ENOUGH_RESOURCES?: ScreepsReturnCode }).ERR_NOT_ENOUGH_RESOURCES ??
+    ERR_NOT_ENOUGH_RESOURCES_CODE) as ScreepsReturnCode;
+}
+
+function getErrNotInRangeCode(): ScreepsReturnCode {
+  return ((globalThis as { ERR_NOT_IN_RANGE?: ScreepsReturnCode }).ERR_NOT_IN_RANGE ??
+    ERR_NOT_IN_RANGE_CODE) as ScreepsReturnCode;
+}
+
+function getObjectById<T>(id: string): T | null {
+  const getObjectById = (globalThis as { Game?: Partial<Game> }).Game?.getObjectById;
+  if (typeof getObjectById !== 'function') {
+    return null;
+  }
+
+  try {
+    return getObjectById(id) as T | null;
+  } catch {
+    return null;
+  }
+}
+
+function getVisibleRoom(roomName: string): Room | undefined {
+  return (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName];
+}
+
+function getGameCreeps(): Creep[] {
+  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
+  return creeps ? Object.values(creeps).filter((creep): creep is Creep => creep !== undefined) : [];
+}
+
+function compareAssignments(left: SourceHarvesterAssignment, right: SourceHarvesterAssignment): number {
+  return left.roomName.localeCompare(right.roomName) || String(left.sourceId).localeCompare(String(right.sourceId));
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: 'STRUCTURE_EXTENSION' | 'STRUCTURE_SPAWN' | 'STRUCTURE_TOWER',
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<Record<typeof globalName, string>>;
+  return actual === (constants[globalName] ?? fallback);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/prod/src/creeps/sourceHarvester.ts
+++ b/prod/src/creeps/sourceHarvester.ts
@@ -12,18 +12,27 @@ const SOURCE_LINK_DEPOSIT_RANGE = 1;
 
 type MobileFallbackEnergySink = StructureSpawn | StructureExtension | StructureTower;
 
+interface SourceHarvesterAssignmentCountCache {
+  gameTime: number;
+  creeps: Game['creeps'];
+  counts: Map<string, number>;
+}
+
 export interface SourceHarvesterAssignment {
   roomName: string;
   sourceId: Id<Source>;
   containerId: Id<StructureContainer>;
 }
 
+let sourceHarvesterAssignmentCountCache: SourceHarvesterAssignmentCountCache | null = null;
+
 export { buildRemoteHarvesterBody as buildSourceHarvesterBody };
 
 export function selectSourceHarvesterAssignment(room: Room): SourceHarvesterAssignment | null {
+  const assignmentCounts = getSourceHarvesterAssignmentCounts();
   return (
     getSourceHarvesterAssignments(room).find(
-      (assignment) => countAssignedSourceHarvesters(assignment) < 1
+      (assignment) => countAssignedSourceHarvesters(assignment, assignmentCounts) < 1
     ) ?? null
   );
 }
@@ -188,31 +197,82 @@ function isMobileFallbackEnergySink(structure: AnyOwnedStructure): structure is 
   );
 }
 
-function countAssignedSourceHarvesters(assignment: SourceHarvesterAssignment): number {
-  return getGameCreeps().filter((creep) => isAssignedToSourceHarvesterSlot(creep, assignment)).length;
+function countAssignedSourceHarvesters(
+  assignment: SourceHarvesterAssignment,
+  assignmentCounts: ReadonlyMap<string, number>
+): number {
+  return assignmentCounts.get(getSourceHarvesterAssignmentKey(assignment.roomName, assignment.sourceId)) ?? 0;
 }
 
-function isAssignedToSourceHarvesterSlot(creep: Creep, assignment: SourceHarvesterAssignment): boolean {
+function getSourceHarvesterAssignmentCounts(): Map<string, number> {
+  const game = (globalThis as { Game?: Partial<Pick<Game, 'creeps' | 'time'>> }).Game;
+  const creeps = game?.creeps;
+  if (!creeps) {
+    return new Map();
+  }
+
+  const gameTime = getCacheableGameTime(game);
+  if (
+    gameTime !== null &&
+    sourceHarvesterAssignmentCountCache?.gameTime === gameTime &&
+    sourceHarvesterAssignmentCountCache.creeps === creeps
+  ) {
+    return sourceHarvesterAssignmentCountCache.counts;
+  }
+
+  const counts = new Map<string, number>();
+  for (const creep of Object.values(creeps)) {
+    const assignmentKey = getAssignedSourceHarvesterSlotKey(creep);
+    if (!assignmentKey) {
+      continue;
+    }
+
+    counts.set(assignmentKey, (counts.get(assignmentKey) ?? 0) + 1);
+  }
+
+  if (gameTime !== null) {
+    sourceHarvesterAssignmentCountCache = { gameTime, creeps, counts };
+  }
+
+  return counts;
+}
+
+function getAssignedSourceHarvesterSlotKey(creep: Creep): string | null {
   if (!canSatisfySourceHarvesterCapacity(creep)) {
-    return false;
+    return null;
   }
 
   if (
     creep.memory?.role === SOURCE_HARVESTER_ROLE &&
-    creep.memory.sourceHarvester?.roomName === assignment.roomName &&
-    String(creep.memory.sourceHarvester?.sourceId) === String(assignment.sourceId)
+    typeof creep.memory.sourceHarvester?.roomName === 'string' &&
+    creep.memory.sourceHarvester.sourceId !== undefined
   ) {
-    return true;
+    return getSourceHarvesterAssignmentKey(
+      creep.memory.sourceHarvester.roomName,
+      creep.memory.sourceHarvester.sourceId
+    );
   }
 
   const task = creep.memory?.task as Partial<CreepTaskMemory> | undefined;
-  return (
+  if (
     creep.memory?.role === 'worker' &&
-    creep.room?.name === assignment.roomName &&
+    typeof creep.room?.name === 'string' &&
     task?.type === 'harvest' &&
     task.sourceContainerAssigned === true &&
-    String(task.targetId) === String(assignment.sourceId)
-  );
+    task.targetId !== undefined
+  ) {
+    return getSourceHarvesterAssignmentKey(creep.room.name, task.targetId);
+  }
+
+  return null;
+}
+
+function getSourceHarvesterAssignmentKey(roomName: string, sourceId: unknown): string {
+  return `${roomName}\0${String(sourceId)}`;
+}
+
+function getCacheableGameTime(game: Partial<Pick<Game, 'time'>>): number | null {
+  return typeof game.time === 'number' && Number.isFinite(game.time) ? game.time : null;
 }
 
 function canSatisfySourceHarvesterCapacity(creep: Creep): boolean {
@@ -359,11 +419,6 @@ function getObjectById<T>(id: string): T | null {
 
 function getVisibleRoom(roomName: string): Room | undefined {
   return (globalThis as { Game?: Partial<Pick<Game, 'rooms'>> }).Game?.rooms?.[roomName];
-}
-
-function getGameCreeps(): Creep[] {
-  const creeps = (globalThis as { Game?: Partial<Pick<Game, 'creeps'>> }).Game?.creeps;
-  return creeps ? Object.values(creeps).filter((creep): creep is Creep => creep !== undefined) : [];
 }
 
 function compareAssignments(left: SourceHarvesterAssignment, right: SourceHarvesterAssignment): number {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -9,6 +9,7 @@ import {
 import { planConstructionForColony } from '../construction/planner';
 import { countCreepsByRole, getWorkerCapacity, type RoleCounts } from '../creeps/roleCounts';
 import { runWorker } from '../creeps/workerRunner';
+import { SOURCE_HARVESTER_ROLE, runSourceHarvester } from '../creeps/sourceHarvester';
 import { HAULER_ROLE, runHauler } from '../creeps/hauler';
 import { REMOTE_HARVESTER_ROLE, runRemoteHarvester } from '../creeps/remoteHarvester';
 import { getBodyCost, TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS } from '../spawn/bodyBuilder';
@@ -249,6 +250,8 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   for (const creep of creeps) {
     if (creep.memory.role === 'worker') {
       runWorker(creep);
+    } else if (creep.memory.role === SOURCE_HARVESTER_ROLE) {
+      runSourceHarvester(creep);
     } else if (creep.memory.role === REMOTE_HARVESTER_ROLE) {
       runRemoteHarvester(creep);
     } else if (creep.memory.role === HAULER_ROLE) {

--- a/prod/src/economy/linkManager.ts
+++ b/prod/src/economy/linkManager.ts
@@ -4,20 +4,22 @@ import {
   isSameRoomPosition
 } from './sourceContainers';
 
-type LinkStructureConstantGlobal = 'STRUCTURE_LINK' | 'STRUCTURE_STORAGE';
+type LinkStructureConstantGlobal = 'STRUCTURE_LINK' | 'STRUCTURE_SPAWN' | 'STRUCTURE_STORAGE';
 
 export const SOURCE_LINK_RANGE = 2;
 export const CONTROLLER_LINK_RANGE = 3;
+export const SPAWN_LINK_RANGE = 2;
 export const STORAGE_LINK_RANGE = 2;
 export const STORAGE_LINK_ROUTING_TARGET_RATIO = 0.3;
 const OK_CODE = 0 as ScreepsReturnCode;
 
-export type LinkDestinationRole = 'controller' | 'storage';
+export type LinkDestinationRole = 'controller' | 'spawn' | 'storage';
 
 export interface LinkNetwork {
   links: StructureLink[];
   sourceLinks: StructureLink[];
   controllerLink: StructureLink | null;
+  spawnLink: StructureLink | null;
   storageLink: StructureLink | null;
   storage: StructureStorage | null;
 }
@@ -55,6 +57,16 @@ export function transferEnergy(room: Room): LinkTransferResult[] {
     );
   }
 
+  if (shouldSpawnLinkReceiveEnergy(room, network.spawnLink, projectedState)) {
+    transferSourceLinksToDestination(
+      sortSourceLinksByDistanceToDestination(network.sourceLinks, network.spawnLink),
+      { link: network.spawnLink, role: 'spawn' },
+      projectedState,
+      spentSourceIds,
+      results
+    );
+  }
+
   if (shouldStorageLinkReceiveSurplus(network, projectedState)) {
     transferSourceLinksToDestination(
       sortSourceLinksBySurplusPriority(network.sourceLinks, network.storageLink, projectedState),
@@ -73,8 +85,9 @@ export function classifyLinks(room: Room): LinkNetwork {
   const controllerLink = selectControllerLink(room, links);
   const storage = room.storage ?? findStorage(room);
   const storageLink = selectStorageLink(room, links, controllerLink, storage);
+  const spawnLink = selectSpawnLink(room, links, controllerLink, storageLink);
   const destinationIds = new Set(
-    [controllerLink, storageLink]
+    [controllerLink, spawnLink, storageLink]
       .filter((link): link is StructureLink => link !== null)
       .map((link) => getObjectId(link))
   );
@@ -83,6 +96,7 @@ export function classifyLinks(room: Room): LinkNetwork {
     links,
     sourceLinks: selectSourceLinks(room, links, destinationIds),
     controllerLink,
+    spawnLink,
     storageLink,
     storage
   };
@@ -172,6 +186,29 @@ function shouldControllerLinkReceiveEnergy(
   return (projectedState.freeCapacityById.get(getObjectId(controllerLink)) ?? 0) > 0;
 }
 
+function shouldSpawnLinkReceiveEnergy(
+  room: Room,
+  spawnLink: StructureLink | null,
+  projectedState: ProjectedLinkState
+): spawnLink is StructureLink {
+  if (!spawnLink) {
+    return false;
+  }
+
+  if ((projectedState.freeCapacityById.get(getObjectId(spawnLink)) ?? 0) <= 0) {
+    return false;
+  }
+
+  const energyAvailable = getKnownRoomEnergyAvailable(room);
+  const energyCapacityAvailable = getKnownRoomEnergyCapacityAvailable(room);
+  return (
+    energyAvailable === null ||
+    energyCapacityAvailable === null ||
+    energyCapacityAvailable <= 0 ||
+    energyAvailable < energyCapacityAvailable
+  );
+}
+
 function shouldStorageLinkReceiveSurplus(
   network: LinkNetwork,
   projectedState: ProjectedLinkState
@@ -217,6 +254,16 @@ function createSourceLinkRoutingReserve(
     reserveSourceLinksForDestination(
       sortSourceLinksByDistanceToDestination(network.sourceLinks, network.controllerLink),
       network.controllerLink,
+      projectedState,
+      spentSourceIds,
+      reserveById
+    );
+  }
+
+  if (shouldSpawnLinkReceiveEnergy(room, network.spawnLink, projectedState)) {
+    reserveSourceLinksForDestination(
+      sortSourceLinksByDistanceToDestination(network.sourceLinks, network.spawnLink),
+      network.spawnLink,
       projectedState,
       spentSourceIds,
       reserveById
@@ -365,6 +412,43 @@ function selectStorageLink(
   );
 }
 
+function selectSpawnLink(
+  room: Room,
+  links: StructureLink[],
+  controllerLink: StructureLink | null,
+  storageLink: StructureLink | null
+): StructureLink | null {
+  const excludedIds = new Set(
+    [controllerLink, storageLink].map((link) => getObjectId(link)).filter((id) => id.length > 0)
+  );
+  const sourceLinkCandidateIds = new Set(selectSourceLinks(room, links, new Set()).map((link) => getObjectId(link)));
+  const spawns = findRoomSpawns(room);
+  if (spawns.length === 0) {
+    return null;
+  }
+
+  return (
+    spawns
+      .flatMap((spawn) => {
+        const link = selectClosestLink(
+          links.filter((candidate) => {
+            const candidateId = getObjectId(candidate);
+            return !excludedIds.has(candidateId) && !sourceLinkCandidateIds.has(candidateId);
+          }),
+          spawn,
+          room.name,
+          SPAWN_LINK_RANGE
+        );
+        return link ? [link] : [];
+      })
+      .sort(
+        (left, right) =>
+          compareClosestSpawnRange(room, left, right) ||
+          getObjectId(left).localeCompare(getObjectId(right))
+      )[0] ?? null
+  );
+}
+
 function selectClosestLink(
   links: StructureLink[],
   target: RoomObject,
@@ -434,6 +518,24 @@ function findStorage(room: Room): StructureStorage | null {
   );
 }
 
+function findRoomSpawns(room: Room): StructureSpawn[] {
+  const ownedStructureSpawns = findOwnedStructures(room).filter((structure): structure is StructureSpawn =>
+    matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn')
+  );
+  const gameSpawns = (globalThis as { Game?: Partial<Pick<Game, 'spawns'>> }).Game?.spawns;
+  const visibleSpawns = gameSpawns
+    ? Object.values(gameSpawns).filter((spawn): spawn is StructureSpawn => spawn?.room?.name === room.name)
+    : [];
+  const spawnsById = new Map<string, StructureSpawn>();
+  for (const spawn of [...ownedStructureSpawns, ...visibleSpawns]) {
+    const id = getObjectId(spawn);
+    if (id.length > 0) {
+      spawnsById.set(id, spawn);
+    }
+  }
+  return [...spawnsById.values()].sort(compareObjectIds);
+}
+
 function findSources(room: Room): Source[] {
   if (typeof FIND_SOURCES !== 'number' || typeof room.find !== 'function') {
     return [];
@@ -441,6 +543,29 @@ function findSources(room: Room): Source[] {
 
   const result = room.find(FIND_SOURCES);
   return Array.isArray(result) ? result : [];
+}
+
+function compareClosestSpawnRange(room: Room, left: StructureLink, right: StructureLink): number {
+  const spawns = findRoomSpawns(room);
+  if (spawns.length === 0) {
+    return 0;
+  }
+
+  return (
+    Math.min(...spawns.map((spawn) => getRangeBetweenRoomObjects(left, spawn, room.name))) -
+    Math.min(...spawns.map((spawn) => getRangeBetweenRoomObjects(right, spawn, room.name)))
+  );
+}
+
+function getRangeBetweenRoomObjects(left: RoomObject, right: RoomObject, roomName: string): number {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  return leftPosition !== null &&
+    rightPosition !== null &&
+    isSameRoomPosition(leftPosition, roomName) &&
+    isSameRoomPosition(rightPosition, roomName)
+    ? getRangeBetweenPositions(leftPosition, rightPosition)
+    : Number.POSITIVE_INFINITY;
 }
 
 function getStoredEnergy(structure: StructureLink): number {
@@ -456,6 +581,18 @@ function getLinkCooldown(link: StructureLink): number {
   return typeof link.cooldown === 'number' && Number.isFinite(link.cooldown) ? link.cooldown : 0;
 }
 
+function getKnownRoomEnergyAvailable(room: Room): number | null {
+  const energyAvailable = room.energyAvailable;
+  return typeof energyAvailable === 'number' && Number.isFinite(energyAvailable) ? Math.max(0, energyAvailable) : null;
+}
+
+function getKnownRoomEnergyCapacityAvailable(room: Room): number | null {
+  const energyCapacityAvailable = room.energyCapacityAvailable;
+  return typeof energyCapacityAvailable === 'number' && Number.isFinite(energyCapacityAvailable)
+    ? Math.max(0, energyCapacityAvailable)
+    : null;
+}
+
 function getEnergyResource(): ResourceConstant {
   return ((globalThis as { RESOURCE_ENERGY?: ResourceConstant }).RESOURCE_ENERGY ?? 'energy') as ResourceConstant;
 }
@@ -469,8 +606,12 @@ function getObjectId(object: unknown): string {
     return '';
   }
 
-  const id = (object as { id?: unknown }).id;
-  return typeof id === 'string' ? id : '';
+  const candidate = object as { id?: unknown; name?: unknown };
+  if (typeof candidate.id === 'string') {
+    return candidate.id;
+  }
+
+  return typeof candidate.name === 'string' ? candidate.name : '';
 }
 
 function matchesStructureType(

--- a/prod/src/economy/sourceWorkload.ts
+++ b/prod/src/economy/sourceWorkload.ts
@@ -3,6 +3,7 @@ import {
   getRoomObjectPosition,
   isSameRoomPosition
 } from './sourceContainers';
+import { SOURCE_HARVESTER_ROLE } from '../creeps/sourceHarvester';
 
 const HARVEST_ENERGY_PER_WORK_PART = 2;
 const DEFAULT_SOURCE_ENERGY_CAPACITY = 3_000;
@@ -104,18 +105,26 @@ function getSourceAssignmentLoads(
   for (const creep of creeps) {
     const task = creep.memory?.task as Partial<CreepTaskMemory> | undefined;
     const targetId = typeof task?.targetId === 'string' ? task.targetId : undefined;
-    if (
-      creep.memory?.role !== 'worker' ||
-      creep.room?.name !== roomName ||
-      task?.type !== 'harvest' ||
-      !targetId ||
-      !sourceIds.has(targetId)
-    ) {
+    const sourceHarvesterTargetId =
+      creep.memory?.role === SOURCE_HARVESTER_ROLE &&
+      creep.memory.sourceHarvester?.roomName === roomName &&
+      typeof creep.memory.sourceHarvester.sourceId === 'string'
+        ? creep.memory.sourceHarvester.sourceId
+        : undefined;
+    const assignedSourceId =
+      creep.memory?.role === 'worker' &&
+      creep.room?.name === roomName &&
+      task?.type === 'harvest' &&
+      targetId &&
+      sourceIds.has(targetId)
+        ? targetId
+        : sourceHarvesterTargetId;
+    if (!assignedSourceId || !sourceIds.has(assignedSourceId)) {
       continue;
     }
 
-    const currentLoad = assignmentLoads.get(targetId) ?? createEmptySourceAssignmentLoad();
-    assignmentLoads.set(targetId, {
+    const currentLoad = assignmentLoads.get(assignedSourceId) ?? createEmptySourceAssignmentLoad();
+    assignmentLoads.set(assignedSourceId, {
       assignedHarvesters: currentLoad.assignedHarvesters + 1,
       assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts(creep)
     });

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -348,7 +348,7 @@ function planLocalSourceMiningSpawn(context: SpawnPlanningContext): SpawnRequest
     context.survival.controllerDowngradeGuard ||
     context.colony.room.controller?.my !== true ||
     (context.colony.room.controller.level ?? 0) < 2 ||
-    context.workerCapacity < LOCAL_SUPPORT_WORKER_FLOOR
+    context.roleCounts.worker < LOCAL_SUPPORT_WORKER_FLOOR
   ) {
     return null;
   }
@@ -1470,7 +1470,7 @@ function shouldUseSourceHarvesterBody(colony: ColonySnapshot, roleCounts: RoleCo
   const workerCapacity = getWorkerCapacity(roleCounts);
   return (
     sourceAwareWorkerTarget > LOCAL_SUPPORT_WORKER_FLOOR &&
-    workerCapacity >= LOCAL_SUPPORT_WORKER_FLOOR &&
+    roleCounts.worker >= LOCAL_SUPPORT_WORKER_FLOOR &&
     workerCapacity < sourceAwareWorkerTarget
   );
 }

--- a/prod/src/spawn/spawnPlanner.ts
+++ b/prod/src/spawn/spawnPlanner.ts
@@ -15,6 +15,11 @@ import {
   selectRemoteHarvesterAssignment
 } from '../creeps/remoteHarvester';
 import {
+  buildSourceHarvesterBody,
+  selectSourceHarvesterAssignment,
+  SOURCE_HARVESTER_ROLE
+} from '../creeps/sourceHarvester';
+import {
   HAULER_ROLE,
   selectRemoteHaulerAssignment
 } from '../creeps/hauler';
@@ -64,6 +69,7 @@ import { isLiveTransferCandidate } from '../economy/crossRoomHauler';
 
 type SpawnPriorityTier =
   | 'emergencyBootstrap'
+  | 'localSourceMining'
   | 'defense'
   | 'localRefillSurvival'
   | 'controllerDowngradeGuard'
@@ -161,6 +167,7 @@ const POST_CLAIM_SUSTAIN_MIN_HAULER_ENERGY = 200;
 const MINIMUM_EMERGENCY_WORKER_BODY_COST = getBodyCost(EMERGENCY_BOOTSTRAP_WORKER_BODY);
 const SPAWN_PRIORITY_TIERS: SpawnPriorityTier[] = [
   'emergencyBootstrap',
+  'localSourceMining',
   'localRefillSurvival',
   'controllerDowngradeGuard',
   'defense',
@@ -282,6 +289,8 @@ function planSpawnForPriorityTier(
   switch (tier) {
     case 'emergencyBootstrap':
       return planEmergencyBootstrapSpawn(context);
+    case 'localSourceMining':
+      return planLocalSourceMiningSpawn(context);
     case 'localRefillSurvival':
       return planLocalSurvivalSpawn(context);
     case 'controllerDowngradeGuard':
@@ -330,6 +339,53 @@ function planLocalSurvivalSpawn(context: SpawnPlanningContext): SpawnRequest | n
   }
 
   return planWorkerSpawn(context.colony, context.roleCounts, context.gameTime, context.options);
+}
+
+function planLocalSourceMiningSpawn(context: SpawnPlanningContext): SpawnRequest | null {
+  if (
+    context.options.workersOnly ||
+    context.survival.hostilePresence ||
+    context.survival.controllerDowngradeGuard ||
+    context.colony.room.controller?.my !== true ||
+    (context.colony.room.controller.level ?? 0) < 2 ||
+    context.workerCapacity < LOCAL_SUPPORT_WORKER_FLOOR
+  ) {
+    return null;
+  }
+
+  const assignment = selectSourceHarvesterAssignment(context.colony.room);
+  if (!assignment) {
+    return null;
+  }
+
+  const spawn = context.colony.spawns.find((candidate) => !candidate.spawning);
+  if (!spawn) {
+    return null;
+  }
+
+  const body = selectDynamicBodyForColony(
+    context.colony,
+    SOURCE_HARVESTER_ROLE,
+    context.workerCapacity < context.workerTarget ? 'recovery' : 'surplus',
+    buildSourceHarvesterBody
+  );
+  if (body.length === 0) {
+    return null;
+  }
+
+  return {
+    spawn,
+    body,
+    name: appendSpawnNameSuffix(
+      `${SOURCE_HARVESTER_ROLE}-${context.colony.room.name}-${assignment.sourceId}-${context.gameTime}`,
+      context.options
+    ),
+    memory: {
+      role: SOURCE_HARVESTER_ROLE,
+      colony: context.colony.room.name,
+      sourceHarvester: assignment
+    }
+  };
 }
 
 function planControllerDowngradeGuardSpawn(context: SpawnPlanningContext): SpawnRequest | null {

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -47,6 +47,7 @@ import {
   type LinkNetwork,
   SOURCE_LINK_RANGE
 } from '../economy/linkManager';
+import { SOURCE_HARVESTER_ROLE } from '../creeps/sourceHarvester';
 import { recordWorkerTaskBehaviorTrace } from '../rl/workerTaskBehavior';
 import { selectWorkerTaskWithBcFallback } from '../rl/workerTaskPolicy';
 
@@ -4187,7 +4188,18 @@ function findOwnedSourceWorkerEnergyLinks(room: Room, network?: LinkNetwork): St
 }
 
 function selectOwnedSourceWorkerEnergyLinks(network: LinkNetwork, workerLinkIds: Set<string>): StructureLink[] {
-  return network.sourceLinks.filter((link) => workerLinkIds.has(String(link.id)));
+  const linksById = new Map<string, StructureLink>();
+  for (const link of network.sourceLinks) {
+    if (workerLinkIds.has(String(link.id))) {
+      linksById.set(String(link.id), link);
+    }
+  }
+
+  if (network.spawnLink && workerLinkIds.has(String(network.spawnLink.id))) {
+    linksById.set(String(network.spawnLink.id), network.spawnLink);
+  }
+
+  return [...linksById.values()].sort((left, right) => String(left.id).localeCompare(String(right.id)));
 }
 
 function getMinimumWorkerLinkWithdrawalEnergy(creep: Creep): number {
@@ -6604,21 +6616,31 @@ function getWorkerHarvestLoads(sources: Source[]): Map<Id<Source>, HarvestSource
     const task = assignedCreep.memory?.task as Partial<CreepTaskMemory> | undefined;
     const targetId = typeof task?.targetId === 'string' ? task.targetId : undefined;
 
-    if (
-      assignedCreep.memory?.role !== 'worker' ||
-      task?.type !== 'harvest' ||
-      !targetId ||
-      !sourceIds.has(targetId)
-    ) {
+    const sourceHarvesterTargetId =
+      assignedCreep.memory?.role === SOURCE_HARVESTER_ROLE &&
+      typeof assignedCreep.memory.sourceHarvester?.sourceId === 'string'
+        ? assignedCreep.memory.sourceHarvester.sourceId
+        : undefined;
+    const assignedSourceId =
+      assignedCreep.memory?.role === 'worker' &&
+      task?.type === 'harvest' &&
+      targetId &&
+      sourceIds.has(targetId)
+        ? targetId
+        : sourceHarvesterTargetId;
+    if (!assignedSourceId || !sourceIds.has(assignedSourceId)) {
       continue;
     }
 
-    const sourceId = targetId as Id<Source>;
+    const sourceId = assignedSourceId as Id<Source>;
     const currentLoad = assignmentLoads.get(sourceId) ?? createEmptyHarvestSourceAssignmentLoad();
     assignmentLoads.set(sourceId, {
       assignedWorkParts: currentLoad.assignedWorkParts + getActiveWorkParts(assignedCreep),
       assignmentCount: currentLoad.assignmentCount + 1,
-      hasContainerAssignment: currentLoad.hasContainerAssignment || isSourceContainerHarvestAssignment(task)
+      hasContainerAssignment:
+        currentLoad.hasContainerAssignment ||
+        assignedCreep.memory?.role === SOURCE_HARVESTER_ROLE ||
+        isSourceContainerHarvestAssignment(task)
     });
   }
 

--- a/prod/src/types.d.ts
+++ b/prod/src/types.d.ts
@@ -42,6 +42,7 @@ declare global {
     territory?: CreepTerritoryMemory;
     controllerSustain?: CreepControllerSustainMemory;
     controllerUpgrade?: CreepControllerUpgradeMemory;
+    sourceHarvester?: CreepSourceHarvesterMemory;
     remoteHarvester?: CreepRemoteHarvesterMemory;
     remoteHauler?: CreepRemoteHaulerMemory;
     workerEfficiency?: WorkerEfficiencySampleMemory;
@@ -148,6 +149,12 @@ declare global {
     controllerId: Id<StructureController>;
     priority: ControllerUpgradePriority;
     assignedAt?: number;
+  }
+
+  interface CreepSourceHarvesterMemory {
+    roomName: string;
+    sourceId: Id<Source>;
+    containerId: Id<StructureContainer>;
   }
 
   interface CreepRemoteHarvesterMemory {

--- a/prod/test/linkManager.test.ts
+++ b/prod/test/linkManager.test.ts
@@ -15,6 +15,7 @@ describe('linkManager', () => {
       FIND_SOURCES: 2,
       RESOURCE_ENERGY: 'energy',
       STRUCTURE_LINK: 'link',
+      STRUCTURE_SPAWN: 'spawn',
       STRUCTURE_STORAGE: 'storage'
     });
   });
@@ -87,6 +88,50 @@ describe('linkManager', () => {
       }
     ]);
     expect(sourceLink.transferEnergy).toHaveBeenCalledWith(storageLink, 200);
+  });
+
+  it('routes source link energy to a spawn-side link when spawn extensions need refill', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 400, 400);
+    const controllerLink = makeLink('controller-link', 25, 23, 800, 0);
+    const spawnLink = makeLink('spawn-link', 6, 5, 0, 800);
+    const spawn = makeSpawn('spawn1', 5, 5);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      energyAvailable: 300,
+      energyCapacityAvailable: 800,
+      links: [sourceLink, controllerLink, spawnLink],
+      sources: [makeSource('source1', 10, 10)],
+      spawns: [spawn]
+    });
+
+    expect(transferEnergy(room)).toEqual([
+      {
+        amount: 400,
+        destinationId: 'spawn-link',
+        destinationRole: 'spawn',
+        result: OK_CODE,
+        sourceId: 'source-link'
+      }
+    ]);
+    expect(sourceLink.transferEnergy).toHaveBeenCalledWith(spawnLink, 400);
+  });
+
+  it('does not route source link energy to a spawn-side link when room energy is full', () => {
+    const sourceLink = makeLink('source-link', 11, 10, 400, 400);
+    const controllerLink = makeLink('controller-link', 25, 23, 800, 0);
+    const spawnLink = makeLink('spawn-link', 6, 5, 0, 800);
+    const spawn = makeSpawn('spawn1', 5, 5);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      energyAvailable: 800,
+      energyCapacityAvailable: 800,
+      links: [sourceLink, controllerLink, spawnLink],
+      sources: [makeSource('source1', 10, 10)],
+      spawns: [spawn]
+    });
+
+    expect(transferEnergy(room)).toEqual([]);
+    expect(sourceLink.transferEnergy).not.toHaveBeenCalled();
   });
 
   it('respects source cooldown and empty or full link edge cases', () => {
@@ -256,19 +301,27 @@ describe('linkManager', () => {
 
 function makeRoom({
   controller = makeController(25, 25),
+  energyAvailable,
+  energyCapacityAvailable,
   links = [],
   sources = [],
+  spawns = [],
   storage
 }: {
   controller?: StructureController;
+  energyAvailable?: number;
+  energyCapacityAvailable?: number;
   links?: TestStructureLink[];
   sources?: Source[];
+  spawns?: StructureSpawn[];
   storage?: StructureStorage;
 }): Room {
-  const structures = storage ? [...links, storage] : links;
+  const structures = storage ? [...links, storage, ...spawns] : [...links, ...spawns];
   return {
     name: 'W1N1',
     controller,
+    ...(typeof energyAvailable === 'number' ? { energyAvailable } : {}),
+    ...(typeof energyCapacityAvailable === 'number' ? { energyCapacityAvailable } : {}),
     ...(storage ? { storage } : {}),
     find: jest.fn((type: number) => {
       if (type === FIND_MY_STRUCTURES) {
@@ -331,6 +384,15 @@ function makeSource(id: string, x: number, y: number): Source {
 
 function makeController(x: number, y: number): StructureController {
   return { id: 'controller1', my: true, pos: makeRoomPosition(x, y) } as unknown as StructureController;
+}
+
+function makeSpawn(id: string, x: number, y: number): StructureSpawn {
+  return {
+    id,
+    name: id,
+    structureType: 'spawn',
+    pos: makeRoomPosition(x, y)
+  } as unknown as StructureSpawn;
 }
 
 function makeRoomPosition(x: number, y: number): RoomPosition {

--- a/prod/test/roleCounts.test.ts
+++ b/prod/test/roleCounts.test.ts
@@ -128,6 +128,45 @@ describe('countCreepsByRole', () => {
     });
   });
 
+  it('counts local source harvesters as replacement-aware colony energy capacity', () => {
+    const worker = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1
+    } as Creep;
+    const sourceHarvester = {
+      memory: {
+        role: 'sourceHarvester',
+        colony: 'W1N1',
+        sourceHarvester: {
+          roomName: 'W1N1',
+          sourceId: 'source1' as Id<Source>,
+          containerId: 'container1' as Id<StructureContainer>
+        }
+      },
+      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE + 1
+    } as Creep;
+    const expiringSourceHarvester = {
+      memory: {
+        role: 'sourceHarvester',
+        colony: 'W1N1',
+        sourceHarvester: {
+          roomName: 'W1N1',
+          sourceId: 'source2' as Id<Source>,
+          containerId: 'container2' as Id<StructureContainer>
+        }
+      },
+      ticksToLive: WORKER_REPLACEMENT_TICKS_TO_LIVE
+    } as Creep;
+
+    expect(countCreepsByRole([worker, sourceHarvester, expiringSourceHarvester], 'W1N1')).toEqual({
+      worker: 1,
+      workerCapacity: 2,
+      sourceHarvester: 2,
+      claimer: 0,
+      claimersByTargetRoom: {}
+    });
+  });
+
   it('excludes colony claimers at replacement age from territory capacity', () => {
     const healthyClaimer = {
       memory: { role: 'claimer', colony: 'W1N1', territory: { targetRoom: 'W2N1', action: 'claim' } },

--- a/prod/test/sourceHarvester.test.ts
+++ b/prod/test/sourceHarvester.test.ts
@@ -40,6 +40,39 @@ describe('sourceHarvester', () => {
     });
   });
 
+  it('skips source assignments already held by active source harvesters', () => {
+    const firstSource = makeSource('source1', 10, 10);
+    const secondSource = makeSource('source2', 20, 20);
+    const firstContainer = makeContainer('container1', 10, 11);
+    const secondContainer = makeContainer('container2', 20, 21);
+    const room = makeRoom({
+      sources: [firstSource, secondSource],
+      structures: [firstContainer, secondContainer]
+    });
+    (globalThis as { Game?: Partial<Game> }).Game = {
+      time: 101,
+      creeps: {
+        Harvester1: {
+          memory: {
+            role: 'sourceHarvester',
+            colony: 'W1N1',
+            sourceHarvester: {
+              roomName: 'W1N1',
+              sourceId: 'source1' as Id<Source>,
+              containerId: 'container1' as Id<StructureContainer>
+            }
+          }
+        } as Creep
+      }
+    };
+
+    expect(selectSourceHarvesterAssignment(room)).toEqual({
+      roomName: 'W1N1',
+      sourceId: 'source2',
+      containerId: 'container2'
+    });
+  });
+
   it('moves onto the assigned container before harvesting', () => {
     const source = makeSource('source1', 10, 10);
     const container = makeContainer('container1', 10, 11);

--- a/prod/test/sourceHarvester.test.ts
+++ b/prod/test/sourceHarvester.test.ts
@@ -1,0 +1,234 @@
+import {
+  runSourceHarvester,
+  selectSourceHarvesterAssignment
+} from '../src/creeps/sourceHarvester';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+describe('sourceHarvester', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, {
+      FIND_MY_STRUCTURES: 1,
+      FIND_SOURCES: 2,
+      FIND_STRUCTURES: 3,
+      RESOURCE_ENERGY: 'energy',
+      STRUCTURE_CONTAINER: 'container',
+      STRUCTURE_EXTENSION: 'extension',
+      STRUCTURE_LINK: 'link',
+      STRUCTURE_SPAWN: 'spawn',
+      STRUCTURE_TOWER: 'tower'
+    });
+  });
+
+  afterEach(() => {
+    delete (globalThis as { Game?: Partial<Game> }).Game;
+  });
+
+  it('selects only sources with built source-adjacent containers', () => {
+    const sourceWithContainer = makeSource('source1', 10, 10);
+    const sourceWithoutContainer = makeSource('source2', 20, 20);
+    const container = makeContainer('container1', 10, 11);
+    const room = makeRoom({
+      sources: [sourceWithoutContainer, sourceWithContainer],
+      structures: [container]
+    });
+
+    expect(selectSourceHarvesterAssignment(room)).toEqual({
+      roomName: 'W1N1',
+      sourceId: 'source1',
+      containerId: 'container1'
+    });
+  });
+
+  it('moves onto the assigned container before harvesting', () => {
+    const source = makeSource('source1', 10, 10);
+    const container = makeContainer('container1', 10, 11);
+    const room = makeRoom({ sources: [source], structures: [container] });
+    const creep = makeSourceHarvester(room, {
+      usedEnergy: 0,
+      freeEnergy: 50,
+      ranges: { source1: 1, container1: 1 }
+    });
+    installGame(room, { source, container });
+
+    runSourceHarvester(creep);
+
+    expect(creep.moveTo).toHaveBeenCalledWith(container);
+    expect(creep.harvest).not.toHaveBeenCalled();
+  });
+
+  it('transfers full carried energy into an adjacent source link before the container', () => {
+    const source = makeSource('source1', 10, 10);
+    const container = makeContainer('container1', 10, 11);
+    const link = makeLink('link-source', 10, 12, 0, 800);
+    const controllerLink = makeLink('link-controller', 25, 24, 0, 800);
+    const room = makeRoom({
+      controller: makeController(25, 25),
+      sources: [source],
+      structures: [container],
+      myStructures: [link, controllerLink]
+    });
+    const creep = makeSourceHarvester(room, {
+      usedEnergy: 50,
+      freeEnergy: 0,
+      ranges: { source1: 1, container1: 0, 'link-source': 1 }
+    });
+    installGame(room, { source, container, link });
+
+    runSourceHarvester(creep);
+
+    expect(creep.transfer).toHaveBeenCalledWith(link, RESOURCE_ENERGY);
+    expect(creep.harvest).not.toHaveBeenCalled();
+  });
+
+  it('falls back to mobile source harvesting when the container is destroyed', () => {
+    const source = makeSource('source1', 10, 10);
+    const room = makeRoom({ sources: [source], structures: [] });
+    const creep = makeSourceHarvester(room, {
+      usedEnergy: 0,
+      freeEnergy: 50,
+      ranges: { source1: 1 }
+    });
+    installGame(room, { source });
+
+    runSourceHarvester(creep);
+
+    expect(creep.harvest).toHaveBeenCalledWith(source);
+    expect(creep.moveTo).not.toHaveBeenCalled();
+  });
+});
+
+function makeSourceHarvester(
+  room: Room,
+  {
+    usedEnergy,
+    freeEnergy,
+    ranges
+  }: {
+    usedEnergy: number;
+    freeEnergy: number;
+    ranges: Record<string, number>;
+  }
+): Creep {
+  return {
+    memory: {
+      role: 'sourceHarvester',
+      colony: 'W1N1',
+      sourceHarvester: {
+        roomName: 'W1N1',
+        sourceId: 'source1' as Id<Source>,
+        containerId: 'container1' as Id<StructureContainer>
+      }
+    },
+    room,
+    pos: {
+      getRangeTo: jest.fn((target: { id?: string }) => ranges[String(target.id)] ?? 99)
+    } as unknown as RoomPosition,
+    store: {
+      getUsedCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? usedEnergy : 0)),
+      getFreeCapacity: jest.fn((resource: ResourceConstant) => (resource === RESOURCE_ENERGY ? freeEnergy : 0))
+    },
+    harvest: jest.fn().mockReturnValue(OK_CODE),
+    transfer: jest.fn().mockReturnValue(OK_CODE),
+    moveTo: jest.fn()
+  } as unknown as Creep;
+}
+
+function installGame(
+  room: Room,
+  objects: {
+    source?: Source;
+    container?: StructureContainer;
+    link?: StructureLink;
+  }
+): void {
+  (globalThis as { Game?: Partial<Game> }).Game = {
+    rooms: { W1N1: room },
+    creeps: {},
+    getObjectById: jest.fn((id: string) => {
+      if (id === objects.source?.id) {
+        return objects.source;
+      }
+
+      if (id === objects.container?.id) {
+        return objects.container;
+      }
+
+      if (id === objects.link?.id) {
+        return objects.link;
+      }
+
+      return null;
+    })
+  };
+}
+
+function makeRoom({
+  controller = makeController(25, 25),
+  sources = [],
+  structures = [],
+  myStructures = []
+}: {
+  controller?: StructureController;
+  sources?: Source[];
+  structures?: AnyStructure[];
+  myStructures?: AnyOwnedStructure[];
+} = {}): Room {
+  return {
+    name: 'W1N1',
+    controller,
+    find: jest.fn((type: number) => {
+      if (type === FIND_SOURCES) {
+        return sources;
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return structures;
+      }
+
+      if (type === FIND_MY_STRUCTURES) {
+        return myStructures;
+      }
+
+      return [];
+    })
+  } as unknown as Room;
+}
+
+function makeSource(id: string, x: number, y: number): Source {
+  return { id, energy: 300, pos: makeRoomPosition(x, y) } as unknown as Source;
+}
+
+function makeContainer(id: string, x: number, y: number): StructureContainer {
+  return {
+    id,
+    structureType: 'container',
+    pos: makeRoomPosition(x, y),
+    store: {
+      getFreeCapacity: jest.fn().mockReturnValue(2_000),
+      getUsedCapacity: jest.fn().mockReturnValue(0)
+    }
+  } as unknown as StructureContainer;
+}
+
+function makeLink(id: string, x: number, y: number, energy: number, freeCapacity: number): StructureLink {
+  return {
+    id,
+    cooldown: 0,
+    my: true,
+    structureType: 'link',
+    pos: makeRoomPosition(x, y),
+    store: {
+      getFreeCapacity: jest.fn().mockReturnValue(freeCapacity),
+      getUsedCapacity: jest.fn().mockReturnValue(energy)
+    }
+  } as unknown as StructureLink;
+}
+
+function makeController(x: number, y: number): StructureController {
+  return { id: 'controller1', my: true, pos: makeRoomPosition(x, y) } as unknown as StructureController;
+}
+
+function makeRoomPosition(x: number, y: number): RoomPosition {
+  return { x, y, roomName: 'W1N1' } as RoomPosition;
+}

--- a/prod/test/sourceWorkload.test.ts
+++ b/prod/test/sourceWorkload.test.ts
@@ -24,6 +24,7 @@ describe('source workload tracking', () => {
       makeWorker(room, 'source1', 2),
       makeWorker(room, 'source1', 1),
       makeWorker(room, 'source2', 1),
+      makeSourceHarvester(room, 'source2', 5),
       makeWorker({ name: 'W2N2' } as Room, 'source1', 5),
       { memory: { role: 'miner', task: { type: 'harvest', targetId: 'source1' } }, room } as unknown as Creep
     ];
@@ -46,11 +47,11 @@ describe('source workload tracking', () => {
       },
       {
         sourceId: 'source2',
-        assignedHarvesters: 1,
-        assignedWorkParts: 1,
+        assignedHarvesters: 2,
+        assignedWorkParts: 6,
         openPositions: 8,
         harvestWorkCapacity: 5,
-        harvestEnergyPerTick: 2,
+        harvestEnergyPerTick: 12,
         regenEnergyPerTick: 10,
         sourceEnergyCapacity: 3_000,
         sourceEnergyRegenTicks: 300,
@@ -102,6 +103,22 @@ function makeRoom(sources: Source[], structures: AnyStructure[]): Room {
 function makeWorker(room: Room, sourceId: string, workParts: number): Creep {
   return {
     memory: { role: 'worker', task: { type: 'harvest', targetId: sourceId as Id<Source> } },
+    room,
+    getActiveBodyparts: jest.fn().mockReturnValue(workParts)
+  } as unknown as Creep;
+}
+
+function makeSourceHarvester(room: Room, sourceId: string, workParts: number): Creep {
+  return {
+    memory: {
+      role: 'sourceHarvester',
+      colony: room.name,
+      sourceHarvester: {
+        roomName: room.name,
+        sourceId: sourceId as Id<Source>,
+        containerId: `${sourceId}-container` as Id<StructureContainer>
+      }
+    },
     room,
     getActiveBodyparts: jest.fn().mockReturnValue(workParts)
   } as unknown as Creep;

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -514,6 +514,23 @@ describe('planSpawn', () => {
     });
   });
 
+  it('keeps the local source mining support floor tied to actual workers', () => {
+    const sourcePosition = makeRoomPosition(10, 10, 'W1N30');
+    const container = makeRemoteContainer('container0', 0, 10, 11, 'W1N30') as unknown as AnyStructure;
+    const { colony } = makeColony({
+      roomName: 'W1N30',
+      sourceCount: 1,
+      sourcePositions: [sourcePosition],
+      structures: [container],
+      energyAvailable: 600,
+      energyCapacityAvailable: 600,
+      spawnEnergyBudget: 600,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 2, sourceHarvester: 1, workerCapacity: 3 }, 163)).toBeNull();
+  });
+
   it('keeps mobile worker harvesting as the fallback when a local source container is missing', () => {
     const { colony } = makeColony({
       roomName: 'W1N29',
@@ -3871,6 +3888,22 @@ describe('planSpawn', () => {
       body: ['work', 'work', 'carry', 'move', 'move', 'move'],
       name: 'worker-W1N7-137',
       memory: { role: 'worker', colony: 'W1N7' }
+    });
+  });
+
+  it('uses a general worker body below the actual worker support floor', () => {
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N8',
+      sourceCount: 2,
+      energyAvailable: 400,
+      energyCapacityAvailable: 600
+    });
+
+    expect(planSpawn(colony, { worker: 2, sourceHarvester: 1, workerCapacity: 3 }, 139)).toEqual({
+      spawn,
+      body: ['work', 'carry', 'move', 'work', 'carry', 'move'],
+      name: 'worker-W1N8-139',
+      memory: { role: 'worker', colony: 'W1N8' }
     });
   });
 

--- a/prod/test/spawnPlanner.test.ts
+++ b/prod/test/spawnPlanner.test.ts
@@ -64,6 +64,7 @@ describe('planSpawn', () => {
     spawnEnergyBudget = energyAvailable,
     omitSpawnEnergyBudget = false,
     sourcePositions,
+    structures = [],
     ownedStructures = []
   }: {
     sourceCount?: number;
@@ -80,6 +81,7 @@ describe('planSpawn', () => {
     spawnEnergyBudget?: number;
     omitSpawnEnergyBudget?: boolean;
     sourcePositions?: RoomPosition[];
+    structures?: AnyStructure[];
     ownedStructures?: AnyOwnedStructure[];
   } = {}): { colony: ColonySnapshot; spawn: StructureSpawn; find: jest.Mock<unknown[], [number]> } {
     const sources = Array.from(
@@ -109,6 +111,10 @@ describe('planSpawn', () => {
 
       if (type === FIND_MY_STRUCTURES) {
         return ownedStructures;
+      }
+
+      if (type === FIND_STRUCTURES) {
+        return structures;
       }
 
       const hostileCreepsFind = (globalThis as Record<string, unknown>).FIND_HOSTILE_CREEPS;
@@ -476,6 +482,50 @@ describe('planSpawn', () => {
       name: 'worker-W2N27-160',
       memory: { role: 'worker', colony: 'W2N27' }
     });
+  });
+
+  it('plans a stationary source harvester for a built local source container', () => {
+    const sourcePosition = makeRoomPosition(10, 10, 'W1N28');
+    const container = makeRemoteContainer('container0', 0, 10, 11, 'W1N28') as unknown as AnyStructure;
+    const { colony, spawn } = makeColony({
+      roomName: 'W1N28',
+      sourceCount: 1,
+      sourcePositions: [sourcePosition],
+      structures: [container],
+      energyAvailable: 600,
+      energyCapacityAvailable: 600,
+      spawnEnergyBudget: 600,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 161)).toEqual({
+      spawn,
+      body: ['work', 'work', 'work', 'work', 'work', 'carry', 'move'],
+      name: 'sourceHarvester-W1N28-source0-161',
+      memory: {
+        role: 'sourceHarvester',
+        colony: 'W1N28',
+        sourceHarvester: {
+          roomName: 'W1N28',
+          sourceId: 'source0',
+          containerId: 'container0'
+        }
+      }
+    });
+  });
+
+  it('keeps mobile worker harvesting as the fallback when a local source container is missing', () => {
+    const { colony } = makeColony({
+      roomName: 'W1N29',
+      sourceCount: 1,
+      sourcePositions: [makeRoomPosition(10, 10, 'W1N29')],
+      energyAvailable: 600,
+      energyCapacityAvailable: 600,
+      spawnEnergyBudget: 600,
+      controller: makeSafeOwnedController()
+    });
+
+    expect(planSpawn(colony, { worker: 3 }, 162)).toBeNull();
   });
 
   it('uses the RCL4 medium worker profile when full capacity is affordable', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -3441,6 +3441,32 @@ describe('selectWorkerTask', () => {
     expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'link-source' });
   });
 
+  it('withdraws from a spawn-side link for local spawn recovery', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300, {
+      pos: makeRoomPosition(5, 5)
+    });
+    const spawnLink = makeStoredEnergyLink('link-spawn', 6, 5, 200);
+    const room = makeWorkerTaskRoom({
+      energyAvailable: 300,
+      energyCapacityAvailable: 800,
+      myStructures: [spawn as unknown as AnyOwnedStructure, spawnLink as unknown as AnyOwnedStructure],
+      structures: [spawn as unknown as AnyStructure, spawnLink as unknown as AnyStructure]
+    });
+    const creep = {
+      memory: { role: 'worker', colony: 'W1N1' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(0),
+        getFreeCapacity: jest.fn().mockReturnValue(50)
+      },
+      pos: {
+        getRangeTo: jest.fn((target: { id?: string }) => (target.id === 'link-spawn' ? 1 : 2))
+      },
+      room
+    } as unknown as Creep;
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'link-spawn' });
+  });
+
   it('does not withdraw source-link energy reserved for controller link routing', () => {
     const emptySource = makeSource('source-empty', 10, 10, 0);
     const distantContainer = makeStoredEnergyStructure('container-distant', 'container' as StructureConstant, 200);


### PR DESCRIPTION
## Summary
Implement container-based source mining with link network energy distribution.

## Changes
- Add `sourceHarvester` creep role that mines from sources with containers
- Add link manager logic for source-to-spawn/controller link energy transfer
- Update spawn planner to allocate dedicated harvester creeps
- Update role counts, worker tasks, and economy loop for container mining
- Fall back to mobile harvesters when containers not yet built

## Verification
- Typecheck: PASS
- Test suite: 1342 tests, all passing
- Build: PASS
- Whitespace check: PASS

Refs #731
