### PR TITLE
feat(territory): implement room claiming execution from expansion planner (#736)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2348,7 +2348,7 @@ function recordClaimedRoomBootstrapStage(roomName, tick = getGameTime6()) {
   if (!room) {
     return null;
   }
-  const roleCounts = countVisibleColonyRoles(roomName);
+  const roleCounts = countVisibleColonyRoles(room, roomName);
   const workerCapacity = getWorkerCapacity(roleCounts);
   const assessment = assessColonyStage({
     roomName,
@@ -2556,31 +2556,40 @@ function getRoomEnergyCapacityAvailable(room) {
   const energyCapacityAvailable = room.energyCapacityAvailable;
   return typeof energyCapacityAvailable === "number" ? energyCapacityAvailable : 0;
 }
-function countVisibleColonyRoles(roomName) {
-  var _a, _b, _c, _d, _e, _f;
-  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
-  if (!creeps) {
-    return { worker: 0 };
-  }
+function countVisibleColonyRoles(room, roomName) {
+  var _a, _b, _c, _d, _e;
   const roleCounts = { worker: 0 };
-  for (const creep of Object.values(creeps)) {
-    if (((_b = creep == null ? void 0 : creep.memory) == null ? void 0 : _b.colony) !== roomName) {
+  for (const creep of findVisibleColonyCreeps(room, roomName)) {
+    if (((_a = creep == null ? void 0 : creep.memory) == null ? void 0 : _a.colony) !== roomName) {
       continue;
     }
     const role = creep.memory.role;
     if (role === "worker") {
       roleCounts.worker = normalizeNonNegativeInteger3(roleCounts.worker) + 1;
     } else if (role === "sourceHarvester") {
-      roleCounts.sourceHarvester = normalizeNonNegativeInteger3((_c = roleCounts.sourceHarvester) != null ? _c : 0) + 1;
+      roleCounts.sourceHarvester = normalizeNonNegativeInteger3((_b = roleCounts.sourceHarvester) != null ? _b : 0) + 1;
     } else if (role === "defender") {
-      roleCounts.defender = normalizeNonNegativeInteger3((_d = roleCounts.defender) != null ? _d : 0) + 1;
+      roleCounts.defender = normalizeNonNegativeInteger3((_c = roleCounts.defender) != null ? _c : 0) + 1;
     } else if (role === "claimer") {
-      roleCounts.claimer = normalizeNonNegativeInteger3((_e = roleCounts.claimer) != null ? _e : 0) + 1;
+      roleCounts.claimer = normalizeNonNegativeInteger3((_d = roleCounts.claimer) != null ? _d : 0) + 1;
     } else if (role === "scout") {
-      roleCounts.scout = normalizeNonNegativeInteger3((_f = roleCounts.scout) != null ? _f : 0) + 1;
+      roleCounts.scout = normalizeNonNegativeInteger3((_e = roleCounts.scout) != null ? _e : 0) + 1;
     }
   }
   return roleCounts;
+}
+function findVisibleColonyCreeps(room, roomName) {
+  if (typeof room.find !== "function") {
+    return [];
+  }
+  const findConstant = getGlobalNumber3("FIND_MY_CREEPS");
+  if (findConstant === void 0) {
+    return [];
+  }
+  return room.find(findConstant).filter((creep) => {
+    var _a;
+    return ((_a = creep.memory) == null ? void 0 : _a.colony) === roomName;
+  });
 }
 function isColonyStage(value) {
   return value === "BOOTSTRAP" || value === "LOCAL_STABLE" || value === "TERRITORY_READY" || value === "DEFENSE";
@@ -27127,9 +27136,7 @@ function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   if (!territoryMemory) {
     return null;
   }
-  const targetSource = getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom);
-  const expansionPlannerRecommendation = getMatchingExpansionPlannerClaimRecommendation(colony, assignment);
-  const source = targetSource != null ? targetSource : expansionPlannerRecommendation == null ? void 0 : expansionPlannerRecommendation.createdBy;
+  const source = getRecommendedClaimExecutionSource(territoryMemory, colony, assignment);
   const allowUnscopedIntent = source !== void 0;
   const intent = (_a = normalizeTerritoryIntents(territoryMemory.intents).find(
     (candidate) => isMatchingRecommendedClaimIntent(
@@ -27328,15 +27335,15 @@ function recordRecommendedClaimRetry(creep, assignment, result, reason, options 
   updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime22(), options);
 }
 function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, options) {
-  var _a, _b, _c, _d, _e, _f;
+  var _a, _b, _c, _d;
   const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
-  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
-  const fallbackSource = (_b = getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom)) != null ? _b : (_a = getMatchingExpansionPlannerClaimRecommendation(colony, assignment)) == null ? void 0 : _a.createdBy;
+  const fallbackSource = getRecommendedClaimExecutionSource(territoryMemory, colony, assignment);
+  const allowUnscopedIntent = fallbackSource !== void 0;
   let matchedIntent = false;
   for (let i = 0; i < intents.length; i += 1) {
     const intent = intents[i];
@@ -27349,11 +27356,11 @@ function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, opti
       status: options.releaseAssignment ? "planned" : "active",
       updatedAt: gameTime,
       lastAttemptAt: gameTime,
-      ...((_c = options.controllerId) != null ? _c : assignment.controllerId) ? { controllerId: (_d = options.controllerId) != null ? _d : assignment.controllerId } : {},
+      ...((_a = options.controllerId) != null ? _a : assignment.controllerId) ? { controllerId: (_b = options.controllerId) != null ? _b : assignment.controllerId } : {},
       ...options.requiresControllerPressure || intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
     };
   }
-  if (!matchedIntent && fallbackSource) {
+  if (!matchedIntent && fallbackSource && !hasIdenticalClaimIntentSource(intents, colony, assignment.targetRoom, fallbackSource)) {
     intents.push({
       colony,
       targetRoom: assignment.targetRoom,
@@ -27362,21 +27369,20 @@ function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, opti
       updatedAt: gameTime,
       lastAttemptAt: gameTime,
       createdBy: fallbackSource,
-      ...((_e = options.controllerId) != null ? _e : assignment.controllerId) ? { controllerId: (_f = options.controllerId) != null ? _f : assignment.controllerId } : {},
+      ...((_c = options.controllerId) != null ? _c : assignment.controllerId) ? { controllerId: (_d = options.controllerId) != null ? _d : assignment.controllerId } : {},
       ...options.requiresControllerPressure ? { requiresControllerPressure: true } : {}
     });
   }
 }
 function suppressRecommendedClaimIntent(colony, assignment, gameTime, controllerId, reason) {
-  var _a, _b;
   const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
     return;
   }
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
-  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
-  const fallbackSource = (_b = getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom)) != null ? _b : (_a = getMatchingExpansionPlannerClaimRecommendation(colony, assignment)) == null ? void 0 : _a.createdBy;
+  const fallbackSource = getRecommendedClaimExecutionSource(territoryMemory, colony, assignment);
+  const allowUnscopedIntent = fallbackSource !== void 0;
   let matchedIntent = false;
   for (let i = 0; i < intents.length; i += 1) {
     const intent = intents[i];
@@ -27393,7 +27399,7 @@ function suppressRecommendedClaimIntent(colony, assignment, gameTime, controller
       ...reason === "controllerReserved" || intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
     };
   }
-  if (!matchedIntent && fallbackSource) {
+  if (!matchedIntent && fallbackSource && !hasIdenticalClaimIntentSource(intents, colony, assignment.targetRoom, fallbackSource)) {
     intents.push({
       colony,
       targetRoom: assignment.targetRoom,
@@ -27412,7 +27418,12 @@ function completeRecommendedClaimIntent(colony, targetRoom, controllerId) {
   if (!territoryMemory) {
     return;
   }
-  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, targetRoom);
+  const source = getRecommendedClaimExecutionSource(territoryMemory, colony, {
+    targetRoom,
+    action: "claim",
+    controllerId
+  });
+  const allowUnscopedIntent = source !== void 0;
   territoryMemory.intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
     (intent) => !isMatchingRecommendedClaimIntent(intent, colony, targetRoom, controllerId, allowUnscopedIntent)
   );
@@ -27425,12 +27436,18 @@ function completeRecommendedClaimIntent(colony, targetRoom, controllerId) {
 function isMatchingRecommendedClaimIntent(intent, colony, targetRoom, controllerId, allowUnscopedIntent = false) {
   return intent.colony === colony && intent.targetRoom === targetRoom && intent.action === "claim" && (intent.createdBy !== void 0 && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(intent.createdBy) || allowUnscopedIntent && intent.createdBy === void 0) && (!controllerId || !intent.controllerId || intent.controllerId === controllerId);
 }
-function hasRecommendedClaimTarget(territoryMemory, colony, targetRoom) {
-  return getRecommendedClaimTargetSource(territoryMemory, colony, targetRoom) !== void 0;
-}
 function getRecommendedClaimTargetSource(territoryMemory, colony, targetRoom) {
   var _a;
   return Array.isArray(territoryMemory.targets) ? (_a = territoryMemory.targets.find((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom))) == null ? void 0 : _a.createdBy : void 0;
+}
+function getRecommendedClaimExecutionSource(territoryMemory, colony, assignment) {
+  var _a, _b;
+  return (_b = getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom)) != null ? _b : (_a = getMatchingExpansionPlannerClaimRecommendation(colony, assignment)) == null ? void 0 : _a.createdBy;
+}
+function hasIdenticalClaimIntentSource(intents, colony, targetRoom, createdBy) {
+  return intents.some(
+    (intent) => intent.colony === colony && intent.targetRoom === targetRoom && intent.action === "claim" && intent.createdBy === createdBy
+  );
 }
 function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
   return isRecord22(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource5(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -2326,6 +2326,9 @@ function recordColonySurvivalAssessment(colonyName, assessment, tick = getGameTi
   }
   stageAssessmentByColony.set(colonyName, { assessment, tick });
 }
+function recordColonyStageAssessment(colonyName, assessment, tick = getGameTime6()) {
+  recordColonySurvivalAssessment(colonyName, assessment, tick);
+}
 function persistColonyStageAssessment(colony, assessment, tick = getGameTime6()) {
   if (tick === null) {
     return;
@@ -2336,6 +2339,33 @@ function persistColonyStageAssessment(colony, assessment, tick = getGameTime6())
     updatedAt: tick,
     ...assessment.suppressionReasons.length > 0 ? { suppressionReasons: assessment.suppressionReasons } : {}
   };
+}
+function recordClaimedRoomBootstrapStage(roomName, tick = getGameTime6()) {
+  if (!isNonEmptyString2(roomName) || tick === null) {
+    return null;
+  }
+  const room = getVisibleOwnedRoom(roomName);
+  if (!room) {
+    return null;
+  }
+  const roleCounts = countVisibleColonyRoles(roomName);
+  const workerCapacity = getWorkerCapacity(roleCounts);
+  const assessment = assessColonyStage({
+    roomName,
+    totalCreeps: getColonyCreepTotal(roleCounts),
+    workerCapacity,
+    workerTarget: Math.max(1, MIN_WORKER_TARGET),
+    energyAvailable: getRoomEnergyAvailable(room),
+    energyCapacityAvailable: getRoomEnergyCapacityAvailable(room),
+    spawnEnergyAvailable: getRoomEnergyAvailable(room),
+    previousMode: getPersistedRoomStageMode(room),
+    controller: getControllerSurvivalState(room.controller),
+    hostileCreepCount: countRoomFind(room, "FIND_HOSTILE_CREEPS"),
+    hostileStructureCount: countRoomFind(room, "FIND_HOSTILE_STRUCTURES")
+  });
+  recordColonyStageAssessment(roomName, assessment, tick);
+  persistRoomColonyStageAssessment(room, assessment, tick);
+  return assessment;
 }
 function getRecordedColonySurvivalAssessment(colonyName, tick = getGameTime6()) {
   if (!isNonEmptyString2(colonyName) || tick === null) {
@@ -2485,6 +2515,11 @@ function getReadableColonyMemory(colony) {
   var _a;
   return (_a = colony.memory) != null ? _a : colony.room.memory;
 }
+function getPersistedRoomStageMode(room) {
+  var _a, _b;
+  const mode = (_b = (_a = room.memory) == null ? void 0 : _a.colonyStage) == null ? void 0 : _b.mode;
+  return isColonyStage(mode) ? mode : void 0;
+}
 function getWritableColonyMemory(colony) {
   var _a, _b;
   const roomWithMemory = colony.room;
@@ -2496,6 +2531,56 @@ function getWritableColonyMemory(colony) {
     roomWithMemory.memory = memory;
   }
   return memory;
+}
+function persistRoomColonyStageAssessment(room, assessment, tick) {
+  var _a;
+  const roomWithMemory = room;
+  const memory = (_a = roomWithMemory.memory) != null ? _a : {};
+  roomWithMemory.memory = memory;
+  memory.colonyStage = {
+    mode: assessment.mode,
+    updatedAt: tick,
+    ...assessment.suppressionReasons.length > 0 ? { suppressionReasons: assessment.suppressionReasons } : {}
+  };
+}
+function getVisibleOwnedRoom(roomName) {
+  var _a, _b, _c;
+  const room = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
+  return ((_c = room == null ? void 0 : room.controller) == null ? void 0 : _c.my) === true ? room : null;
+}
+function getRoomEnergyAvailable(room) {
+  const energyAvailable = room.energyAvailable;
+  return typeof energyAvailable === "number" ? energyAvailable : 0;
+}
+function getRoomEnergyCapacityAvailable(room) {
+  const energyCapacityAvailable = room.energyCapacityAvailable;
+  return typeof energyCapacityAvailable === "number" ? energyCapacityAvailable : 0;
+}
+function countVisibleColonyRoles(roomName) {
+  var _a, _b, _c, _d, _e, _f;
+  const creeps = (_a = globalThis.Game) == null ? void 0 : _a.creeps;
+  if (!creeps) {
+    return { worker: 0 };
+  }
+  const roleCounts = { worker: 0 };
+  for (const creep of Object.values(creeps)) {
+    if (((_b = creep == null ? void 0 : creep.memory) == null ? void 0 : _b.colony) !== roomName) {
+      continue;
+    }
+    const role = creep.memory.role;
+    if (role === "worker") {
+      roleCounts.worker = normalizeNonNegativeInteger3(roleCounts.worker) + 1;
+    } else if (role === "sourceHarvester") {
+      roleCounts.sourceHarvester = normalizeNonNegativeInteger3((_c = roleCounts.sourceHarvester) != null ? _c : 0) + 1;
+    } else if (role === "defender") {
+      roleCounts.defender = normalizeNonNegativeInteger3((_d = roleCounts.defender) != null ? _d : 0) + 1;
+    } else if (role === "claimer") {
+      roleCounts.claimer = normalizeNonNegativeInteger3((_e = roleCounts.claimer) != null ? _e : 0) + 1;
+    } else if (role === "scout") {
+      roleCounts.scout = normalizeNonNegativeInteger3((_f = roleCounts.scout) != null ? _f : 0) + 1;
+    }
+  }
+  return roleCounts;
 }
 function isColonyStage(value) {
   return value === "BOOTSTRAP" || value === "LOCAL_STABLE" || value === "TERRITORY_READY" || value === "DEFENSE";
@@ -4702,7 +4787,7 @@ var STRUCTURE_TYPE_FALLBACKS = {
 function planConstructionForColony(colony, options = {}) {
   const room = colony.room;
   const rcl = getOwnedRoomRcl2(room);
-  const energyAvailable = getRoomEnergyAvailable(colony);
+  const energyAvailable = getRoomEnergyAvailable2(colony);
   const budgetState = {
     energyBudget: Math.floor(energyAvailable * resolveEnergyBudgetRatio(options.energyBudgetRatio)),
     energyReserved: 0
@@ -4921,7 +5006,7 @@ function resolvePositiveInteger(value, fallback) {
   }
   return Math.max(0, Math.floor(value));
 }
-function getRoomEnergyAvailable(colony) {
+function getRoomEnergyAvailable2(colony) {
   const roomEnergy = colony.room.energyAvailable;
   if (typeof roomEnergy === "number" && Number.isFinite(roomEnergy)) {
     return Math.max(0, roomEnergy);
@@ -8374,6 +8459,55 @@ function refreshExpansionPlannerIntent(colony, gameTime = getGameTime11()) {
     ...intent.controllerId ? { controllerId: intent.controllerId } : {}
   };
 }
+function getExpansionPlannerClaimRecommendations(colony) {
+  const territoryMemory = getTerritoryMemoryRecord5();
+  if (!territoryMemory) {
+    return [];
+  }
+  const recommendations = /* @__PURE__ */ new Map();
+  const blockedKeys = /* @__PURE__ */ new Set();
+  for (const intent of normalizeTerritoryIntents(territoryMemory.intents)) {
+    if (!isExpansionPlannerClaimIntentForColony(intent, colony)) {
+      continue;
+    }
+    const key = getExpansionPlanKey(intent.colony, intent.targetRoom, "claim");
+    if (!isRunnableExpansionPlannerClaimStatus(intent.status)) {
+      blockedKeys.add(key);
+      recommendations.delete(key);
+      continue;
+    }
+    recommendations.set(key, {
+      colony: intent.colony,
+      targetRoom: intent.targetRoom,
+      action: "claim",
+      createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+      status: intent.status,
+      updatedAt: intent.updatedAt,
+      ...intent.controllerId ? { controllerId: intent.controllerId } : {}
+    });
+  }
+  if (Array.isArray(territoryMemory.targets)) {
+    for (const rawTarget of territoryMemory.targets) {
+      const target = normalizeTerritoryTarget2(rawTarget);
+      if (!isExpansionPlannerClaimTargetForColony(target, colony)) {
+        continue;
+      }
+      const key = getExpansionPlanKey(target.colony, target.roomName, "claim");
+      if (blockedKeys.has(key) || recommendations.has(key)) {
+        continue;
+      }
+      recommendations.set(key, {
+        colony: target.colony,
+        targetRoom: target.roomName,
+        action: "claim",
+        createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+        status: "planned",
+        ...target.controllerId ? { controllerId: target.controllerId } : {}
+      });
+    }
+  }
+  return Array.from(recommendations.values()).sort(compareExpansionPlannerClaimRecommendations);
+}
 function createExpansionIntent(candidate, action, gameTime = getGameTime11()) {
   const territoryMemory = getWritableTerritoryMemoryRecord4();
   if (!territoryMemory) {
@@ -8696,6 +8830,18 @@ function removeSupersededExpansionReservationPlan(territoryMemory, intents, colo
 function getExpansionPlanKey(colony, targetRoom, action) {
   return `${colony}:${targetRoom}:${action}`;
 }
+function isExpansionPlannerClaimIntentForColony(intent, colony) {
+  return intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && intent.action === "claim" && (!isNonEmptyString9(colony) || intent.colony === colony);
+}
+function isExpansionPlannerClaimTargetForColony(target, colony) {
+  return target !== null && target.createdBy === EXPANSION_PLANNER_TARGET_CREATOR && target.action === "claim" && target.enabled !== false && (!isNonEmptyString9(colony) || target.colony === colony);
+}
+function isRunnableExpansionPlannerClaimStatus(status) {
+  return status === "planned" || status === "active";
+}
+function compareExpansionPlannerClaimRecommendations(left, right) {
+  return left.colony.localeCompare(right.colony) || left.targetRoom.localeCompare(right.targetRoom) || compareOptionalNumbers3(left.updatedAt, right.updatedAt);
+}
 function getCandidateTerminalExpansionStatus(candidate, action, existingIntent) {
   if (candidate.suitable) {
     return null;
@@ -8913,6 +9059,9 @@ function getMemoryRecord() {
 }
 function normalizeNonNegativeInteger4(value) {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+function compareOptionalNumbers3(left, right) {
+  return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 function isNonEmptyString9(value) {
   return typeof value === "string" && value.length > 0;
@@ -10123,6 +10272,7 @@ function getPersistedTerritoryIntentCandidates(colonyName, colonyOwnerUsername, 
       colony: intent.colony,
       roomName: intent.targetRoom,
       action: intent.action,
+      ...intent.createdBy ? { createdBy: intent.createdBy } : {},
       ...intent.controllerId ? { controllerId: intent.controllerId } : {},
       ...intent.postClaimBootstrapReserveEnergy ? { postClaimBootstrapReserveEnergy: intent.postClaimBootstrapReserveEnergy } : {}
     };
@@ -10992,7 +11142,7 @@ function getTerritoryCandidatePriority(selection, renewalTicksToEnd) {
   return selection.target.action === "claim" ? TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_CLAIM : TERRITORY_CANDIDATE_PRIORITY_UNKNOWN_RESERVE;
 }
 function compareTerritoryCandidates(left, right) {
-  return left.priority - right.priority || compareOptionalNumbers3(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || compareSafeAdjacentControllerProgressPreference(left, right) || compareImmediateControllerFollowUpPreference(left, right) || comparePersistedControllerFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers3(left.occupationActionableTicks, right.occupationActionableTicks) || compareRecoveredFollowUpPreference(left, right) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
+  return left.priority - right.priority || compareOptionalNumbers4(left.renewalTicksToEnd, right.renewalTicksToEnd) || compareVisibleAdjacentFollowUpPreference(left, right) || compareSafeAdjacentControllerProgressPreference(left, right) || compareImmediateControllerFollowUpPreference(left, right) || comparePersistedControllerFollowUpPreference(left, right) || getTerritoryCandidateSourcePriority(left.source) - getTerritoryCandidateSourcePriority(right.source) || compareOptionalNumbersDescending(left.recommendationScore, right.recommendationScore) || compareOptionalNumbers4(left.occupationActionableTicks, right.occupationActionableTicks) || compareRecoveredFollowUpPreference(left, right) || left.order - right.order || left.target.roomName.localeCompare(right.target.roomName) || left.intentAction.localeCompare(right.intentAction);
 }
 function compareImmediateControllerFollowUpPreference(left, right) {
   const leftImmediate = left.immediateControllerFollowUp === true;
@@ -11058,7 +11208,7 @@ function isFartherTerritoryCandidate(candidate, other) {
   const otherDistance = (_b = other.routeDistance) != null ? _b : Number.POSITIVE_INFINITY;
   return candidateDistance > otherDistance;
 }
-function compareOptionalNumbers3(left, right) {
+function compareOptionalNumbers4(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 function compareOptionalNumbersDescending(left, right) {
@@ -12521,7 +12671,7 @@ function refreshSpawnEnergyBufferState(room, spawns, gameTime, options = {}) {
   };
   return snapshot;
 }
-function getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy = getRoomEnergyAvailable2(room)) {
+function getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy = getRoomEnergyAvailable3(room)) {
   const thresholdPerSpawn = getSpawnEnergyBufferThreshold(room);
   const spawnCount = getSpawnBufferCount(spawns);
   const threshold = thresholdPerSpawn * spawnCount;
@@ -12542,7 +12692,7 @@ function getSpawnEnergyBufferThreshold(room) {
 function getSpawnEnergyBufferRequirement(room, spawns) {
   return getSpawnEnergyBufferThreshold(room) * getSpawnBufferCount(spawns);
 }
-function getBufferedSpawnEnergyBudget(room, spawns, availableEnergy = getRoomEnergyAvailable2(room)) {
+function getBufferedSpawnEnergyBudget(room, spawns, availableEnergy = getRoomEnergyAvailable3(room)) {
   return Math.max(0, normalizeEnergyAmount2(availableEnergy) - getSpawnEnergyBufferRequirement(room, spawns));
 }
 function isSpawnEnergyBufferViolated(room, spawns, availableEnergy, spendAmount) {
@@ -12623,7 +12773,7 @@ function getRoomRcl2(room) {
   }
   return Math.min(8, Math.max(1, Math.floor(level)));
 }
-function getRoomEnergyAvailable2(room) {
+function getRoomEnergyAvailable3(room) {
   return normalizeEnergyAmount2(room.energyAvailable);
 }
 function getWritableEconomyMemory() {
@@ -15558,13 +15708,13 @@ function estimateNearTermSpawnCompletionRefillReserve(room, spawnExtensionEnergy
   if (!spawnExtensionEnergyStructures.some(isNearTermSpawningSpawn)) {
     return 0;
   }
-  return Math.max(0, (_a = getRoomEnergyCapacityAvailable(room)) != null ? _a : 0);
+  return Math.max(0, (_a = getRoomEnergyCapacityAvailable2(room)) != null ? _a : 0);
 }
 function isTerritoryControlTask(task) {
   return (task == null ? void 0 : task.type) === "claim" || (task == null ? void 0 : task.type) === "reserve";
 }
 function hasEmergencySpawnExtensionRefillDemand(creep) {
-  const energyAvailable = getRoomEnergyAvailable3(creep.room);
+  const energyAvailable = getRoomEnergyAvailable4(creep.room);
   return energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
 }
 function getLowLoadWorkerEnergyContext(creep) {
@@ -15608,7 +15758,7 @@ function applyMinimumUsefulSpawnExtensionDeliveryPolicy(creep, task) {
   return task;
 }
 function hasKnownSpawnExtensionEnergyCapacity(room) {
-  return getRoomEnergyCapacityAvailable(room) !== null;
+  return getRoomEnergyCapacityAvailable2(room) !== null;
 }
 function clearWorkerEfficiencyTelemetry(creep) {
   const memory = creep.memory;
@@ -15720,8 +15870,8 @@ function selectStorageToSpawnExtensionRefillAcquisitionTask(creep) {
   return { type: "withdraw", targetId: storage.id };
 }
 function isSpawnExtensionThroughputBottlenecked(room) {
-  const energyAvailable = getRoomEnergyAvailable3(room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  const energyAvailable = getRoomEnergyAvailable4(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(room);
   if (energyAvailable === null || energyCapacityAvailable === null || energyCapacityAvailable <= 0) {
     return false;
   }
@@ -16110,7 +16260,7 @@ function getInterRoomTransferKey(sourceRoom, targetRoom) {
 }
 function selectInterRoomEnergySource(roomName, preferredSourceId) {
   var _a;
-  const room = getVisibleOwnedRoom(roomName);
+  const room = getVisibleOwnedRoom2(roomName);
   if (!room) {
     return null;
   }
@@ -16123,7 +16273,7 @@ function selectInterRoomEnergySource(roomName, preferredSourceId) {
 }
 function selectInterRoomEnergyTarget(roomName, preferredTargetId) {
   var _a;
-  const room = getVisibleOwnedRoom(roomName);
+  const room = getVisibleOwnedRoom2(roomName);
   if (!room) {
     return null;
   }
@@ -16248,7 +16398,7 @@ function clearInterRoomEnergyHaulAssignment(creep) {
 function isNonEmptyString13(value) {
   return typeof value === "string" && value.length > 0;
 }
-function getVisibleOwnedRoom(roomName) {
+function getVisibleOwnedRoom2(roomName) {
   var _a, _b, _c;
   const room = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
   return ((_c = room == null ? void 0 : room.controller) == null ? void 0 : _c.my) === true ? room : null;
@@ -16888,7 +17038,7 @@ function isOwnedRoomStructure(structure) {
   return ownership === true;
 }
 function shouldPrioritizeExtensionCapacity(room) {
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(room);
   return energyCapacityAvailable === null || energyCapacityAvailable < BASELINE_WORKER_THROUGHPUT_ENERGY_CAPACITY;
 }
 function selectReadyFollowUpProductiveEnergySinkTask(creep, capacityConstructionSite, controller, constructionSites, constructionReservationContext, priorityContext) {
@@ -18344,8 +18494,8 @@ function shouldUseSurplusForControllerProgress(creep, controller) {
   }
   const hasRecoverableEnergySurplus = hasRecoverableSurplusEnergy(creep);
   const upgradePriority = getControllerUpgradePriority(controller, {
-    energyAvailable: (_a = getRoomEnergyAvailable3(creep.room)) != null ? _a : void 0,
-    energyCapacityAvailable: (_b = getRoomEnergyCapacityAvailable(creep.room)) != null ? _b : void 0,
+    energyAvailable: (_a = getRoomEnergyAvailable4(creep.room)) != null ? _a : void 0,
+    energyCapacityAvailable: (_b = getRoomEnergyCapacityAvailable2(creep.room)) != null ? _b : void 0,
     hasEnergySurplus: hasRecoverableEnergySurplus
   });
   if (controller.my === true && controller.level >= 2 && (upgradePriority === "rclProgress" || upgradePriority === "energySurplus")) {
@@ -18533,8 +18683,8 @@ function hasControllerUpgradeEnergySurplus(creep) {
   return hasRecoverableSurplusEnergy(creep) || hasFullRoomEnergyForControllerProgress(creep.room);
 }
 function hasFullRoomEnergyForControllerProgress(room) {
-  const energyAvailable = getRoomEnergyAvailable3(room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  const energyAvailable = getRoomEnergyAvailable4(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(room);
   return energyAvailable !== null && energyCapacityAvailable !== null && energyCapacityAvailable >= TERRITORY_CONTROLLER_BODY_COST && energyAvailable >= energyCapacityAvailable;
 }
 function hasReservedTerritoryFollowUpRefillCapacity(creep) {
@@ -18544,25 +18694,25 @@ function hasReadyTerritoryFollowUpEnergy(creep) {
   if (!hasReservedTerritoryFollowUpRefillCapacity(creep)) {
     return false;
   }
-  const energyAvailable = getRoomEnergyAvailable3(creep.room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(creep.room);
+  const energyAvailable = getRoomEnergyAvailable4(creep.room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(creep.room);
   if (energyAvailable === null || energyCapacityAvailable === null) {
     return false;
   }
   const followUpEnergyTarget = Math.min(TERRITORY_CONTROLLER_BODY_COST, energyCapacityAvailable);
   return energyAvailable >= followUpEnergyTarget;
 }
-function getRoomEnergyAvailable3(room) {
+function getRoomEnergyAvailable4(room) {
   const energyAvailable = room.energyAvailable;
   return typeof energyAvailable === "number" && Number.isFinite(energyAvailable) ? energyAvailable : null;
 }
-function getRoomEnergyCapacityAvailable(room) {
+function getRoomEnergyCapacityAvailable2(room) {
   const energyCapacityAvailable = room.energyCapacityAvailable;
   return typeof energyCapacityAvailable === "number" && Number.isFinite(energyCapacityAvailable) ? energyCapacityAvailable : null;
 }
 function estimateRoomEnergyRefillShortfall(room) {
-  const energyAvailable = getRoomEnergyAvailable3(room);
-  const energyCapacityAvailable = getRoomEnergyCapacityAvailable(room);
+  const energyAvailable = getRoomEnergyAvailable4(room);
+  const energyCapacityAvailable = getRoomEnergyCapacityAvailable2(room);
   if (energyAvailable === null || energyCapacityAvailable === null) {
     return null;
   }
@@ -21443,9 +21593,9 @@ function getBodyPartCost2(part) {
   }
 }
 function compareMultiRoomUpgradeCandidates(left, right) {
-  return compareOptionalNumbers4(left.controllerTicksToDowngrade, right.controllerTicksToDowngrade) || left.controllerLevel - right.controllerLevel || compareOptionalNumbers4(left.routeDistance, right.routeDistance) || left.targetRoom.localeCompare(right.targetRoom) || left.order - right.order;
+  return compareOptionalNumbers5(left.controllerTicksToDowngrade, right.controllerTicksToDowngrade) || left.controllerLevel - right.controllerLevel || compareOptionalNumbers5(left.routeDistance, right.routeDistance) || left.targetRoom.localeCompare(right.targetRoom) || left.order - right.order;
 }
-function compareOptionalNumbers4(left, right) {
+function compareOptionalNumbers5(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 var activeMultiRoomUpgraderCountCache = null;
@@ -23083,7 +23233,7 @@ function getPostClaimBootstrapSummary(roomName) {
 }
 function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
   const record = getPostClaimBootstrapRecord(roomName);
-  const room = getVisibleOwnedRoom2(roomName);
+  const room = getVisibleOwnedRoom3(roomName);
   if (!record || !room || !canAttemptImmediateSpawnSitePlacement(room) || hasOwnedSpawnInRoom(roomName)) {
     return;
   }
@@ -23139,7 +23289,7 @@ function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
     recordSpawnSitePlacedTelemetry(record, sitePlan.position, sitePlan.result, telemetryEvents);
   }
 }
-function getVisibleOwnedRoom2(roomName) {
+function getVisibleOwnedRoom3(roomName) {
   var _a, _b, _c;
   const room = (_b = (_a = globalThis.Game) == null ? void 0 : _a.rooms) == null ? void 0 : _b[roomName];
   return ((_c = room == null ? void 0 : room.controller) == null ? void 0 : _c.my) === true ? room : null;
@@ -23210,8 +23360,8 @@ function planInitialSpawnConstructionSiteWithPlanner(room) {
   const result = planConstructionForColony({
     room,
     spawns: getRoomSpawns2(room.name),
-    energyAvailable: getRoomEnergyAvailable4(room),
-    energyCapacityAvailable: getRoomEnergyCapacityAvailable2(room)
+    energyAvailable: getRoomEnergyAvailable5(room),
+    energyCapacityAvailable: getRoomEnergyCapacityAvailable3(room)
   });
   const spawnPlacement = result.placements.find((placement) => placement.priority === "spawn");
   if (!spawnPlacement) {
@@ -23233,11 +23383,11 @@ function getRoomSpawns2(roomName) {
     return ((_a2 = spawn == null ? void 0 : spawn.room) == null ? void 0 : _a2.name) === roomName;
   });
 }
-function getRoomEnergyAvailable4(room) {
+function getRoomEnergyAvailable5(room) {
   return typeof room.energyAvailable === "number" && Number.isFinite(room.energyAvailable) ? Math.max(0, room.energyAvailable) : 0;
 }
-function getRoomEnergyCapacityAvailable2(room) {
-  return typeof room.energyCapacityAvailable === "number" && Number.isFinite(room.energyCapacityAvailable) ? Math.max(0, room.energyCapacityAvailable) : getRoomEnergyAvailable4(room);
+function getRoomEnergyCapacityAvailable3(room) {
+  return typeof room.energyCapacityAvailable === "number" && Number.isFinite(room.energyCapacityAvailable) ? Math.max(0, room.energyCapacityAvailable) : getRoomEnergyAvailable5(room);
 }
 function findInitialSpawnConstructionPositions(room) {
   const anchor = selectInitialSpawnAnchor2(room);
@@ -26225,7 +26375,8 @@ var ERR_GCL_NOT_ENOUGH_CODE = -15;
 var RECOMMENDED_EXPANSION_CLAIM_SOURCES = /* @__PURE__ */ new Set([
   NEXT_EXPANSION_TARGET_CREATOR,
   AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR,
-  "colonyExpansion"
+  "colonyExpansion",
+  EXPANSION_PLANNER_TARGET_CREATOR
 ]);
 var autonomousExpansionClaimTickContext = null;
 function refreshClaimExecutionTargets(options = {}) {
@@ -26265,7 +26416,7 @@ function runRecommendedExpansionClaimExecutor(creep, telemetryEvents = []) {
   if (!recommendedClaim) {
     return false;
   }
-  if (!isRecommendedClaimIntentRunnable(recommendedClaim.intent, gameTime)) {
+  if (!isRecommendedClaimExecutionGateRunnable(recommendedClaim, gameTime)) {
     completeClaimAssignment(creep);
     return true;
   }
@@ -26709,9 +26860,9 @@ function getRankedAdjacentExpansionCandidates(report) {
   return report.candidates.filter((candidate) => candidate.adjacentToOwnedRoom).slice().sort(compareAutonomousExpansionClaimCandidates);
 }
 function compareAutonomousExpansionClaimCandidates(left, right) {
-  return right.score - left.score || compareOptionalNumbers5(left.nearestOwnedRoomDistance, right.nearestOwnedRoomDistance) || compareOptionalNumbers5(left.routeDistance, right.routeDistance) || left.roomName.localeCompare(right.roomName);
+  return right.score - left.score || compareOptionalNumbers6(left.nearestOwnedRoomDistance, right.nearestOwnedRoomDistance) || compareOptionalNumbers6(left.routeDistance, right.routeDistance) || left.roomName.localeCompare(right.roomName);
 }
-function compareOptionalNumbers5(left, right) {
+function compareOptionalNumbers6(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 function getVisibleOwnedRoomNames5(colonyName, ownerUsername) {
@@ -26976,7 +27127,10 @@ function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
   if (!territoryMemory) {
     return null;
   }
-  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  const targetSource = getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom);
+  const expansionPlannerRecommendation = getMatchingExpansionPlannerClaimRecommendation(colony, assignment);
+  const source = targetSource != null ? targetSource : expansionPlannerRecommendation == null ? void 0 : expansionPlannerRecommendation.createdBy;
+  const allowUnscopedIntent = source !== void 0;
   const intent = (_a = normalizeTerritoryIntents(territoryMemory.intents).find(
     (candidate) => isMatchingRecommendedClaimIntent(
       candidate,
@@ -26987,15 +27141,22 @@ function getRecommendedExpansionClaimExecutionGate(colony, assignment) {
     )
   )) != null ? _a : null;
   if (intent) {
-    return { intent };
+    return {
+      intent,
+      ...intent.createdBy ? { source: intent.createdBy } : source ? { source } : {},
+      targetOnly: false
+    };
   }
-  return allowUnscopedIntent ? { intent: null } : null;
+  return allowUnscopedIntent ? { intent: null, ...source ? { source } : {}, targetOnly: true } : null;
 }
-function isRecommendedClaimIntentRunnable(intent, gameTime) {
-  if (!intent || intent.status !== "planned" && intent.status !== "active") {
+function isRecommendedClaimExecutionGateRunnable(gate, gameTime) {
+  if (!gate.intent) {
+    return gate.targetOnly;
+  }
+  if (gate.intent.status !== "planned" && gate.intent.status !== "active") {
     return false;
   }
-  return !isTerritoryIntentSuspensionActive2(intent, gameTime);
+  return !isTerritoryIntentSuspensionActive2(gate.intent, gameTime);
 }
 function isTerritoryIntentSuspensionActive2(intent, gameTime) {
   if (!intent.suspended) {
@@ -27115,6 +27276,7 @@ function recordRecommendedClaimSuccess(creep, assignment, controller, telemetryE
     },
     telemetryEvents
   );
+  recordClaimedRoomBootstrapStage(targetRoom, getGameTime22());
   completeRecommendedClaimIntent(colony, targetRoom, controller.id);
   recordColonyExpansionClaimVerification({
     colony,
@@ -27166,6 +27328,46 @@ function recordRecommendedClaimRetry(creep, assignment, result, reason, options 
   updateRecommendedClaimIntentForRetry(colony, assignment, getGameTime22(), options);
 }
 function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, options) {
+  var _a, _b, _c, _d, _e, _f;
+  const territoryMemory = getWritableTerritoryMemoryRecord6();
+  if (!territoryMemory) {
+    return;
+  }
+  const intents = normalizeTerritoryIntents(territoryMemory.intents);
+  territoryMemory.intents = intents;
+  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  const fallbackSource = (_b = getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom)) != null ? _b : (_a = getMatchingExpansionPlannerClaimRecommendation(colony, assignment)) == null ? void 0 : _a.createdBy;
+  let matchedIntent = false;
+  for (let i = 0; i < intents.length; i += 1) {
+    const intent = intents[i];
+    if (!isMatchingRecommendedClaimIntent(intent, colony, assignment.targetRoom, void 0, allowUnscopedIntent)) {
+      continue;
+    }
+    matchedIntent = true;
+    intents[i] = {
+      ...intent,
+      status: options.releaseAssignment ? "planned" : "active",
+      updatedAt: gameTime,
+      lastAttemptAt: gameTime,
+      ...((_c = options.controllerId) != null ? _c : assignment.controllerId) ? { controllerId: (_d = options.controllerId) != null ? _d : assignment.controllerId } : {},
+      ...options.requiresControllerPressure || intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
+    };
+  }
+  if (!matchedIntent && fallbackSource) {
+    intents.push({
+      colony,
+      targetRoom: assignment.targetRoom,
+      action: "claim",
+      status: options.releaseAssignment ? "planned" : "active",
+      updatedAt: gameTime,
+      lastAttemptAt: gameTime,
+      createdBy: fallbackSource,
+      ...((_e = options.controllerId) != null ? _e : assignment.controllerId) ? { controllerId: (_f = options.controllerId) != null ? _f : assignment.controllerId } : {},
+      ...options.requiresControllerPressure ? { requiresControllerPressure: true } : {}
+    });
+  }
+}
+function suppressRecommendedClaimIntent(colony, assignment, gameTime, controllerId, reason) {
   var _a, _b;
   const territoryMemory = getWritableTerritoryMemoryRecord6();
   if (!territoryMemory) {
@@ -27174,34 +27376,14 @@ function updateRecommendedClaimIntentForRetry(colony, assignment, gameTime, opti
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  const fallbackSource = (_b = getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom)) != null ? _b : (_a = getMatchingExpansionPlannerClaimRecommendation(colony, assignment)) == null ? void 0 : _a.createdBy;
+  let matchedIntent = false;
   for (let i = 0; i < intents.length; i += 1) {
     const intent = intents[i];
     if (!isMatchingRecommendedClaimIntent(intent, colony, assignment.targetRoom, void 0, allowUnscopedIntent)) {
       continue;
     }
-    intents[i] = {
-      ...intent,
-      status: options.releaseAssignment ? "planned" : "active",
-      updatedAt: gameTime,
-      lastAttemptAt: gameTime,
-      ...((_a = options.controllerId) != null ? _a : assignment.controllerId) ? { controllerId: (_b = options.controllerId) != null ? _b : assignment.controllerId } : {},
-      ...options.requiresControllerPressure || intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
-    };
-  }
-}
-function suppressRecommendedClaimIntent(colony, assignment, gameTime, controllerId, reason) {
-  const territoryMemory = getWritableTerritoryMemoryRecord6();
-  if (!territoryMemory) {
-    return;
-  }
-  const intents = normalizeTerritoryIntents(territoryMemory.intents);
-  territoryMemory.intents = intents;
-  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
-  for (let i = 0; i < intents.length; i += 1) {
-    const intent = intents[i];
-    if (!isMatchingRecommendedClaimIntent(intent, colony, assignment.targetRoom, void 0, allowUnscopedIntent)) {
-      continue;
-    }
+    matchedIntent = true;
     intents[i] = {
       ...intent,
       status: "suppressed",
@@ -27210,6 +27392,19 @@ function suppressRecommendedClaimIntent(colony, assignment, gameTime, controller
       ...(controllerId != null ? controllerId : assignment.controllerId) ? { controllerId: controllerId != null ? controllerId : assignment.controllerId } : {},
       ...reason === "controllerReserved" || intent.requiresControllerPressure ? { requiresControllerPressure: true } : {}
     };
+  }
+  if (!matchedIntent && fallbackSource) {
+    intents.push({
+      colony,
+      targetRoom: assignment.targetRoom,
+      action: "claim",
+      status: "suppressed",
+      updatedAt: gameTime,
+      lastAttemptAt: gameTime,
+      createdBy: fallbackSource,
+      ...(controllerId != null ? controllerId : assignment.controllerId) ? { controllerId: controllerId != null ? controllerId : assignment.controllerId } : {},
+      ...reason === "controllerReserved" ? { requiresControllerPressure: true } : {}
+    });
   }
 }
 function completeRecommendedClaimIntent(colony, targetRoom, controllerId) {
@@ -27231,10 +27426,19 @@ function isMatchingRecommendedClaimIntent(intent, colony, targetRoom, controller
   return intent.colony === colony && intent.targetRoom === targetRoom && intent.action === "claim" && (intent.createdBy !== void 0 && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(intent.createdBy) || allowUnscopedIntent && intent.createdBy === void 0) && (!controllerId || !intent.controllerId || intent.controllerId === controllerId);
 }
 function hasRecommendedClaimTarget(territoryMemory, colony, targetRoom) {
-  return Array.isArray(territoryMemory.targets) ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom)) : false;
+  return getRecommendedClaimTargetSource(territoryMemory, colony, targetRoom) !== void 0;
+}
+function getRecommendedClaimTargetSource(territoryMemory, colony, targetRoom) {
+  var _a;
+  return Array.isArray(territoryMemory.targets) ? (_a = territoryMemory.targets.find((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom))) == null ? void 0 : _a.createdBy : void 0;
 }
 function isMatchingRecommendedClaimTarget(target, colony, targetRoom) {
   return isRecord22(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && isTerritoryAutomationSource5(target.createdBy) && RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy);
+}
+function getMatchingExpansionPlannerClaimRecommendation(colony, assignment) {
+  return getExpansionPlannerClaimRecommendations(colony).find(
+    (recommendation) => recommendation.targetRoom === assignment.targetRoom && (!assignment.controllerId || !recommendation.controllerId || recommendation.controllerId === assignment.controllerId)
+  );
 }
 function recordColonyExpansionClaimVerification(input) {
   var _a;
@@ -27800,12 +28004,12 @@ function compareReservationCandidates(left, right) {
     return kindPriority;
   }
   if (left.selectionKind === "renewal") {
-    return compareOptionalNumbers6(left.controllerState.ticksToEnd, right.controllerState.ticksToEnd) || compareOptionalNumbers6(left.expansionRank, right.expansionRank) || right.effectiveScore - left.effectiveScore || left.order - right.order || left.roomName.localeCompare(right.roomName);
+    return compareOptionalNumbers7(left.controllerState.ticksToEnd, right.controllerState.ticksToEnd) || compareOptionalNumbers7(left.expansionRank, right.expansionRank) || right.effectiveScore - left.effectiveScore || left.order - right.order || left.roomName.localeCompare(right.roomName);
   }
   if (left.selectionKind === "unscouted") {
-    return compareOptionalNumbers6(left.expansionRank, right.expansionRank) || compareOptionalNumbersDescending2(left.expansionScore, right.expansionScore) || left.order - right.order || left.roomName.localeCompare(right.roomName);
+    return compareOptionalNumbers7(left.expansionRank, right.expansionRank) || compareOptionalNumbersDescending2(left.expansionScore, right.expansionScore) || left.order - right.order || left.roomName.localeCompare(right.roomName);
   }
-  return compareOptionalNumbers6(left.expansionRank, right.expansionRank) || compareOptionalNumbersDescending2(left.expansionScore, right.expansionScore) || right.effectiveScore - left.effectiveScore || right.score.sources - left.score.sources || left.score.distance - right.score.distance || left.order - right.order || left.roomName.localeCompare(right.roomName);
+  return compareOptionalNumbers7(left.expansionRank, right.expansionRank) || compareOptionalNumbersDescending2(left.expansionScore, right.expansionScore) || right.effectiveScore - left.effectiveScore || right.score.sources - left.score.sources || left.score.distance - right.score.distance || left.order - right.order || left.roomName.localeCompare(right.roomName);
 }
 function getReservationSelectionKindPriority(candidate) {
   switch (candidate.selectionKind) {
@@ -28087,7 +28291,7 @@ function getControllerOwnerUsername9(controller) {
   const username = (_a = controller == null ? void 0 : controller.owner) == null ? void 0 : _a.username;
   return isNonEmptyString25(username) ? username : void 0;
 }
-function compareOptionalNumbers6(left, right) {
+function compareOptionalNumbers7(left, right) {
   return (left != null ? left : Number.POSITIVE_INFINITY) - (right != null ? right : Number.POSITIVE_INFINITY);
 }
 function compareOptionalNumbersDescending2(left, right) {

--- a/prod/src/colony/colonyStage.ts
+++ b/prod/src/colony/colonyStage.ts
@@ -270,7 +270,7 @@ export function recordClaimedRoomBootstrapStage(
     return null;
   }
 
-  const roleCounts = countVisibleColonyRoles(roomName);
+  const roleCounts = countVisibleColonyRoles(room, roomName);
   const workerCapacity = getWorkerCapacity(roleCounts);
   const assessment = assessColonyStage({
     roomName,
@@ -582,14 +582,9 @@ function getRoomEnergyCapacityAvailable(room: Room): number {
   return typeof energyCapacityAvailable === 'number' ? energyCapacityAvailable : 0;
 }
 
-function countVisibleColonyRoles(roomName: string): RoleCounts {
-  const creeps = (globalThis as { Game?: Partial<Game> }).Game?.creeps;
-  if (!creeps) {
-    return { worker: 0 };
-  }
-
+function countVisibleColonyRoles(room: Room, roomName: string): RoleCounts {
   const roleCounts: RoleCounts = { worker: 0 };
-  for (const creep of Object.values(creeps)) {
+  for (const creep of findVisibleColonyCreeps(room, roomName)) {
     if (creep?.memory?.colony !== roomName) {
       continue;
     }
@@ -609,6 +604,19 @@ function countVisibleColonyRoles(roomName: string): RoleCounts {
   }
 
   return roleCounts;
+}
+
+function findVisibleColonyCreeps(room: Room, roomName: string): Creep[] {
+  if (typeof room.find !== 'function') {
+    return [];
+  }
+
+  const findConstant = getGlobalNumber('FIND_MY_CREEPS');
+  if (findConstant === undefined) {
+    return [];
+  }
+
+  return (room.find(findConstant as FindConstant) as Creep[]).filter((creep) => creep.memory?.colony === roomName);
 }
 
 function isColonyStage(value: unknown): value is ColonyStage {

--- a/prod/src/colony/colonyStage.ts
+++ b/prod/src/colony/colonyStage.ts
@@ -257,6 +257,40 @@ export function persistColonyStageAssessment(
   };
 }
 
+export function recordClaimedRoomBootstrapStage(
+  roomName: string,
+  tick = getGameTime()
+): ColonyStageAssessment | null {
+  if (!isNonEmptyString(roomName) || tick === null) {
+    return null;
+  }
+
+  const room = getVisibleOwnedRoom(roomName);
+  if (!room) {
+    return null;
+  }
+
+  const roleCounts = countVisibleColonyRoles(roomName);
+  const workerCapacity = getWorkerCapacity(roleCounts);
+  const assessment = assessColonyStage({
+    roomName,
+    totalCreeps: getColonyCreepTotal(roleCounts),
+    workerCapacity,
+    workerTarget: Math.max(1, MIN_WORKER_TARGET),
+    energyAvailable: getRoomEnergyAvailable(room),
+    energyCapacityAvailable: getRoomEnergyCapacityAvailable(room),
+    spawnEnergyAvailable: getRoomEnergyAvailable(room),
+    previousMode: getPersistedRoomStageMode(room),
+    controller: getControllerSurvivalState(room.controller),
+    hostileCreepCount: countRoomFind(room, 'FIND_HOSTILE_CREEPS'),
+    hostileStructureCount: countRoomFind(room, 'FIND_HOSTILE_STRUCTURES')
+  });
+
+  recordColonyStageAssessment(roomName, assessment, tick);
+  persistRoomColonyStageAssessment(room, assessment, tick);
+  return assessment;
+}
+
 export function getRecordedColonySurvivalAssessment(
   colonyName: string | null | undefined,
   tick = getGameTime()
@@ -501,6 +535,11 @@ function getReadableColonyMemory(colony: ColonySnapshot): RoomMemory | undefined
   return colony.memory ?? (colony.room as Room & { memory?: RoomMemory }).memory;
 }
 
+function getPersistedRoomStageMode(room: Room): ColonyStage | undefined {
+  const mode = (room as Room & { memory?: RoomMemory }).memory?.colonyStage?.mode;
+  return isColonyStage(mode) ? mode : undefined;
+}
+
 function getWritableColonyMemory(colony: ColonySnapshot): RoomMemory {
   const roomWithMemory = colony.room as Room & { memory?: RoomMemory };
   const memory = colony.memory ?? roomWithMemory.memory ?? {};
@@ -511,6 +550,65 @@ function getWritableColonyMemory(colony: ColonySnapshot): RoomMemory {
     roomWithMemory.memory = memory;
   }
   return memory;
+}
+
+function persistRoomColonyStageAssessment(
+  room: Room,
+  assessment: ColonyStageAssessment,
+  tick: number
+): void {
+  const roomWithMemory = room as Room & { memory?: RoomMemory };
+  const memory = roomWithMemory.memory ?? {};
+  roomWithMemory.memory = memory;
+  memory.colonyStage = {
+    mode: assessment.mode,
+    updatedAt: tick,
+    ...(assessment.suppressionReasons.length > 0 ? { suppressionReasons: assessment.suppressionReasons } : {})
+  };
+}
+
+function getVisibleOwnedRoom(roomName: string): Room | null {
+  const room = (globalThis as { Game?: Partial<Game> }).Game?.rooms?.[roomName];
+  return room?.controller?.my === true ? room : null;
+}
+
+function getRoomEnergyAvailable(room: Room): number {
+  const energyAvailable = (room as Room & { energyAvailable?: number }).energyAvailable;
+  return typeof energyAvailable === 'number' ? energyAvailable : 0;
+}
+
+function getRoomEnergyCapacityAvailable(room: Room): number {
+  const energyCapacityAvailable = (room as Room & { energyCapacityAvailable?: number }).energyCapacityAvailable;
+  return typeof energyCapacityAvailable === 'number' ? energyCapacityAvailable : 0;
+}
+
+function countVisibleColonyRoles(roomName: string): RoleCounts {
+  const creeps = (globalThis as { Game?: Partial<Game> }).Game?.creeps;
+  if (!creeps) {
+    return { worker: 0 };
+  }
+
+  const roleCounts: RoleCounts = { worker: 0 };
+  for (const creep of Object.values(creeps)) {
+    if (creep?.memory?.colony !== roomName) {
+      continue;
+    }
+
+    const role = creep.memory.role;
+    if (role === 'worker') {
+      roleCounts.worker = normalizeNonNegativeInteger(roleCounts.worker) + 1;
+    } else if (role === 'sourceHarvester') {
+      roleCounts.sourceHarvester = normalizeNonNegativeInteger(roleCounts.sourceHarvester ?? 0) + 1;
+    } else if (role === 'defender') {
+      roleCounts.defender = normalizeNonNegativeInteger(roleCounts.defender ?? 0) + 1;
+    } else if (role === 'claimer') {
+      roleCounts.claimer = normalizeNonNegativeInteger(roleCounts.claimer ?? 0) + 1;
+    } else if (role === 'scout') {
+      roleCounts.scout = normalizeNonNegativeInteger(roleCounts.scout ?? 0) + 1;
+    }
+  }
+
+  return roleCounts;
 }
 
 function isColonyStage(value: unknown): value is ColonyStage {

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -1159,9 +1159,7 @@ function getRecommendedExpansionClaimExecutionGate(
     return null;
   }
 
-  const targetSource = getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom);
-  const expansionPlannerRecommendation = getMatchingExpansionPlannerClaimRecommendation(colony, assignment);
-  const source = targetSource ?? expansionPlannerRecommendation?.createdBy;
+  const source = getRecommendedClaimExecutionSource(territoryMemory, colony, assignment);
   const allowUnscopedIntent = source !== undefined;
   const intent =
     normalizeTerritoryIntents(territoryMemory.intents).find((candidate) =>
@@ -1455,10 +1453,8 @@ function updateRecommendedClaimIntentForRetry(
 
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
-  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
-  const fallbackSource =
-    getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom) ??
-    getMatchingExpansionPlannerClaimRecommendation(colony, assignment)?.createdBy;
+  const fallbackSource = getRecommendedClaimExecutionSource(territoryMemory, colony, assignment);
+  const allowUnscopedIntent = fallbackSource !== undefined;
   let matchedIntent = false;
   for (let i = 0; i < intents.length; i += 1) {
     const intent = intents[i];
@@ -1481,7 +1477,11 @@ function updateRecommendedClaimIntentForRetry(
     };
   }
 
-  if (!matchedIntent && fallbackSource) {
+  if (
+    !matchedIntent &&
+    fallbackSource &&
+    !hasIdenticalClaimIntentSource(intents, colony, assignment.targetRoom, fallbackSource)
+  ) {
     intents.push({
       colony,
       targetRoom: assignment.targetRoom,
@@ -1512,10 +1512,8 @@ function suppressRecommendedClaimIntent(
 
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
-  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
-  const fallbackSource =
-    getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom) ??
-    getMatchingExpansionPlannerClaimRecommendation(colony, assignment)?.createdBy;
+  const fallbackSource = getRecommendedClaimExecutionSource(territoryMemory, colony, assignment);
+  const allowUnscopedIntent = fallbackSource !== undefined;
   let matchedIntent = false;
   for (let i = 0; i < intents.length; i += 1) {
     const intent = intents[i];
@@ -1538,7 +1536,11 @@ function suppressRecommendedClaimIntent(
     };
   }
 
-  if (!matchedIntent && fallbackSource) {
+  if (
+    !matchedIntent &&
+    fallbackSource &&
+    !hasIdenticalClaimIntentSource(intents, colony, assignment.targetRoom, fallbackSource)
+  ) {
     intents.push({
       colony,
       targetRoom: assignment.targetRoom,
@@ -1565,7 +1567,12 @@ function completeRecommendedClaimIntent(
     return;
   }
 
-  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, targetRoom);
+  const source = getRecommendedClaimExecutionSource(territoryMemory, colony, {
+    targetRoom,
+    action: 'claim',
+    controllerId
+  });
+  const allowUnscopedIntent = source !== undefined;
   territoryMemory.intents = normalizeTerritoryIntents(territoryMemory.intents).filter(
     (intent) => !isMatchingRecommendedClaimIntent(intent, colony, targetRoom, controllerId, allowUnscopedIntent)
   );
@@ -1594,10 +1601,6 @@ function isMatchingRecommendedClaimIntent(
   );
 }
 
-function hasRecommendedClaimTarget(territoryMemory: TerritoryMemory, colony: string, targetRoom: string): boolean {
-  return getRecommendedClaimTargetSource(territoryMemory, colony, targetRoom) !== undefined;
-}
-
 function getRecommendedClaimTargetSource(
   territoryMemory: TerritoryMemory,
   colony: string,
@@ -1607,6 +1610,32 @@ function getRecommendedClaimTargetSource(
     ? territoryMemory.targets.find((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom))
         ?.createdBy
     : undefined;
+}
+
+function getRecommendedClaimExecutionSource(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  assignment: CreepTerritoryMemory
+): TerritoryAutomationSource | undefined {
+  return (
+    getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom) ??
+    getMatchingExpansionPlannerClaimRecommendation(colony, assignment)?.createdBy
+  );
+}
+
+function hasIdenticalClaimIntentSource(
+  intents: TerritoryIntentMemory[],
+  colony: string,
+  targetRoom: string,
+  createdBy: TerritoryAutomationSource
+): boolean {
+  return intents.some(
+    (intent) =>
+      intent.colony === colony &&
+      intent.targetRoom === targetRoom &&
+      intent.action === 'claim' &&
+      intent.createdBy === createdBy
+  );
 }
 
 function isMatchingRecommendedClaimTarget(target: unknown, colony: string, targetRoom: string): boolean {

--- a/prod/src/territory/claimExecutor.ts
+++ b/prod/src/territory/claimExecutor.ts
@@ -1,4 +1,5 @@
 import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { recordClaimedRoomBootstrapStage } from '../colony/colonyStage';
 import {
   TERRITORY_CONTROLLER_BODY_COST,
   TERRITORY_CONTROLLER_PRESSURE_CLAIM_PARTS
@@ -38,6 +39,11 @@ import {
   type TerritoryExecutionRefreshOptions,
   type TerritoryExecutionRefreshResult
 } from './executionTargets';
+import {
+  EXPANSION_PLANNER_TARGET_CREATOR,
+  getExpansionPlannerClaimRecommendations,
+  type ExpansionPlannerClaimRecommendation
+} from './expansionPlanner';
 
 export const AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR: TerritoryAutomationSource =
   'autonomousExpansionClaim';
@@ -54,7 +60,8 @@ const ERR_GCL_NOT_ENOUGH_CODE = -15 as ScreepsReturnCode;
 const RECOMMENDED_EXPANSION_CLAIM_SOURCES = new Set<TerritoryAutomationSource>([
   NEXT_EXPANSION_TARGET_CREATOR,
   AUTONOMOUS_EXPANSION_CLAIM_TARGET_CREATOR,
-  'colonyExpansion'
+  'colonyExpansion',
+  EXPANSION_PLANNER_TARGET_CREATOR
 ]);
 let autonomousExpansionClaimTickContext: AutonomousExpansionClaimTickContext | null = null;
 
@@ -76,6 +83,11 @@ interface ClaimExecutionAssignment extends CreepTerritoryMemory {
   claimStartedAt?: number;
   lastClaimAttemptAt?: number;
   claimAttemptCount?: number;
+}
+interface RecommendedClaimExecutionGate {
+  intent: TerritoryIntentMemory | null;
+  source?: TerritoryAutomationSource;
+  targetOnly: boolean;
 }
 type RoomPositionConstructor = new (x: number, y: number, roomName: string) => RoomPosition;
 
@@ -148,7 +160,7 @@ export function runRecommendedExpansionClaimExecutor(
     return false;
   }
 
-  if (!isRecommendedClaimIntentRunnable(recommendedClaim.intent, gameTime)) {
+  if (!isRecommendedClaimExecutionGateRunnable(recommendedClaim, gameTime)) {
     completeClaimAssignment(creep);
     return true;
   }
@@ -1137,7 +1149,7 @@ function isClaimExecutionAssignment(assignment: CreepTerritoryMemory | undefined
 function getRecommendedExpansionClaimExecutionGate(
   colony: string | undefined,
   assignment: CreepTerritoryMemory
-): { intent: TerritoryIntentMemory | null } | null {
+): RecommendedClaimExecutionGate | null {
   if (!isNonEmptyString(colony)) {
     return null;
   }
@@ -1147,7 +1159,10 @@ function getRecommendedExpansionClaimExecutionGate(
     return null;
   }
 
-  const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  const targetSource = getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom);
+  const expansionPlannerRecommendation = getMatchingExpansionPlannerClaimRecommendation(colony, assignment);
+  const source = targetSource ?? expansionPlannerRecommendation?.createdBy;
+  const allowUnscopedIntent = source !== undefined;
   const intent =
     normalizeTerritoryIntents(territoryMemory.intents).find((candidate) =>
       isMatchingRecommendedClaimIntent(
@@ -1159,18 +1174,29 @@ function getRecommendedExpansionClaimExecutionGate(
       )
     ) ?? null;
   if (intent) {
-    return { intent };
+    return {
+      intent,
+      ...(intent.createdBy ? { source: intent.createdBy } : source ? { source } : {}),
+      targetOnly: false
+    };
   }
 
-  return allowUnscopedIntent ? { intent: null } : null;
+  return allowUnscopedIntent ? { intent: null, ...(source ? { source } : {}), targetOnly: true } : null;
 }
 
-function isRecommendedClaimIntentRunnable(intent: TerritoryIntentMemory | null, gameTime: number): boolean {
-  if (!intent || (intent.status !== 'planned' && intent.status !== 'active')) {
+function isRecommendedClaimExecutionGateRunnable(
+  gate: RecommendedClaimExecutionGate,
+  gameTime: number
+): boolean {
+  if (!gate.intent) {
+    return gate.targetOnly;
+  }
+
+  if (gate.intent.status !== 'planned' && gate.intent.status !== 'active') {
     return false;
   }
 
-  return !isTerritoryIntentSuspensionActive(intent, gameTime);
+  return !isTerritoryIntentSuspensionActive(gate.intent, gameTime);
 }
 
 function isTerritoryIntentSuspensionActive(intent: TerritoryIntentMemory, gameTime: number): boolean {
@@ -1333,6 +1359,7 @@ function recordRecommendedClaimSuccess(
     },
     telemetryEvents
   );
+  recordClaimedRoomBootstrapStage(targetRoom, getGameTime());
   completeRecommendedClaimIntent(colony, targetRoom, controller.id);
   recordColonyExpansionClaimVerification({
     colony,
@@ -1429,12 +1456,17 @@ function updateRecommendedClaimIntentForRetry(
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  const fallbackSource =
+    getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom) ??
+    getMatchingExpansionPlannerClaimRecommendation(colony, assignment)?.createdBy;
+  let matchedIntent = false;
   for (let i = 0; i < intents.length; i += 1) {
     const intent = intents[i];
     if (!isMatchingRecommendedClaimIntent(intent, colony, assignment.targetRoom, undefined, allowUnscopedIntent)) {
       continue;
     }
 
+    matchedIntent = true;
     intents[i] = {
       ...intent,
       status: options.releaseAssignment ? 'planned' : 'active',
@@ -1447,6 +1479,22 @@ function updateRecommendedClaimIntentForRetry(
         ? { requiresControllerPressure: true }
         : {})
     };
+  }
+
+  if (!matchedIntent && fallbackSource) {
+    intents.push({
+      colony,
+      targetRoom: assignment.targetRoom,
+      action: 'claim',
+      status: options.releaseAssignment ? 'planned' : 'active',
+      updatedAt: gameTime,
+      lastAttemptAt: gameTime,
+      createdBy: fallbackSource,
+      ...(options.controllerId ?? assignment.controllerId
+        ? { controllerId: (options.controllerId ?? assignment.controllerId) as Id<StructureController> }
+        : {}),
+      ...(options.requiresControllerPressure ? { requiresControllerPressure: true } : {})
+    });
   }
 }
 
@@ -1465,12 +1513,17 @@ function suppressRecommendedClaimIntent(
   const intents = normalizeTerritoryIntents(territoryMemory.intents);
   territoryMemory.intents = intents;
   const allowUnscopedIntent = hasRecommendedClaimTarget(territoryMemory, colony, assignment.targetRoom);
+  const fallbackSource =
+    getRecommendedClaimTargetSource(territoryMemory, colony, assignment.targetRoom) ??
+    getMatchingExpansionPlannerClaimRecommendation(colony, assignment)?.createdBy;
+  let matchedIntent = false;
   for (let i = 0; i < intents.length; i += 1) {
     const intent = intents[i];
     if (!isMatchingRecommendedClaimIntent(intent, colony, assignment.targetRoom, undefined, allowUnscopedIntent)) {
       continue;
     }
 
+    matchedIntent = true;
     intents[i] = {
       ...intent,
       status: 'suppressed',
@@ -1483,6 +1536,22 @@ function suppressRecommendedClaimIntent(
         ? { requiresControllerPressure: true }
         : {})
     };
+  }
+
+  if (!matchedIntent && fallbackSource) {
+    intents.push({
+      colony,
+      targetRoom: assignment.targetRoom,
+      action: 'claim',
+      status: 'suppressed',
+      updatedAt: gameTime,
+      lastAttemptAt: gameTime,
+      createdBy: fallbackSource,
+      ...(controllerId ?? assignment.controllerId
+        ? { controllerId: (controllerId ?? assignment.controllerId) as Id<StructureController> }
+        : {}),
+      ...(reason === 'controllerReserved' ? { requiresControllerPressure: true } : {})
+    });
   }
 }
 
@@ -1526,9 +1595,18 @@ function isMatchingRecommendedClaimIntent(
 }
 
 function hasRecommendedClaimTarget(territoryMemory: TerritoryMemory, colony: string, targetRoom: string): boolean {
+  return getRecommendedClaimTargetSource(territoryMemory, colony, targetRoom) !== undefined;
+}
+
+function getRecommendedClaimTargetSource(
+  territoryMemory: TerritoryMemory,
+  colony: string,
+  targetRoom: string
+): TerritoryAutomationSource | undefined {
   return Array.isArray(territoryMemory.targets)
-    ? territoryMemory.targets.some((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom))
-    : false;
+    ? territoryMemory.targets.find((target) => isMatchingRecommendedClaimTarget(target, colony, targetRoom))
+        ?.createdBy
+    : undefined;
 }
 
 function isMatchingRecommendedClaimTarget(target: unknown, colony: string, targetRoom: string): boolean {
@@ -1539,6 +1617,19 @@ function isMatchingRecommendedClaimTarget(target: unknown, colony: string, targe
     target.action === 'claim' &&
     isTerritoryAutomationSource(target.createdBy) &&
     RECOMMENDED_EXPANSION_CLAIM_SOURCES.has(target.createdBy)
+  );
+}
+
+function getMatchingExpansionPlannerClaimRecommendation(
+  colony: string,
+  assignment: CreepTerritoryMemory
+): ExpansionPlannerClaimRecommendation | undefined {
+  return getExpansionPlannerClaimRecommendations(colony).find(
+    (recommendation) =>
+      recommendation.targetRoom === assignment.targetRoom &&
+      (!assignment.controllerId ||
+        !recommendation.controllerId ||
+        recommendation.controllerId === assignment.controllerId)
   );
 }
 

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -9,7 +9,7 @@ const EXIT_DIRECTION_ORDER = ['1', '3', '5', '7'];
 const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const SOURCE_SCORE_WEIGHT = 1_000;
 const DISTANCE_SCORE_WEIGHT = 100;
-const EXPANSION_PLANNER_TARGET_CREATOR: TerritoryAutomationSource = 'expansionPlanner';
+export const EXPANSION_PLANNER_TARGET_CREATOR = 'expansionPlanner';
 
 type TerminalExpansionIntentStatus = Extract<TerritoryIntentMemory['status'], 'inactive' | 'completed'>;
 
@@ -70,6 +70,16 @@ export interface ExpansionPlannerEvaluation {
   targetRoom?: string;
   action?: TerritoryControlAction;
   score?: number;
+  controllerId?: Id<StructureController>;
+}
+
+export interface ExpansionPlannerClaimRecommendation {
+  colony: string;
+  targetRoom: string;
+  action: 'claim';
+  createdBy: typeof EXPANSION_PLANNER_TARGET_CREATOR;
+  status: Extract<TerritoryIntentMemory['status'], 'planned' | 'active'>;
+  updatedAt?: number;
   controllerId?: Id<StructureController>;
 }
 
@@ -274,6 +284,65 @@ export function refreshExpansionPlannerIntent(
     score: intent.score,
     ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
   };
+}
+
+export function getExpansionPlannerClaimRecommendations(
+  colony?: string
+): ExpansionPlannerClaimRecommendation[] {
+  const territoryMemory = getTerritoryMemoryRecord();
+  if (!territoryMemory) {
+    return [];
+  }
+
+  const recommendations = new Map<string, ExpansionPlannerClaimRecommendation>();
+  const blockedKeys = new Set<string>();
+  for (const intent of normalizeTerritoryIntents(territoryMemory.intents)) {
+    if (!isExpansionPlannerClaimIntentForColony(intent, colony)) {
+      continue;
+    }
+
+    const key = getExpansionPlanKey(intent.colony, intent.targetRoom, 'claim');
+    if (!isRunnableExpansionPlannerClaimStatus(intent.status)) {
+      blockedKeys.add(key);
+      recommendations.delete(key);
+      continue;
+    }
+
+    recommendations.set(key, {
+      colony: intent.colony,
+      targetRoom: intent.targetRoom,
+      action: 'claim',
+      createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+      status: intent.status,
+      updatedAt: intent.updatedAt,
+      ...(intent.controllerId ? { controllerId: intent.controllerId } : {})
+    });
+  }
+
+  if (Array.isArray(territoryMemory.targets)) {
+    for (const rawTarget of territoryMemory.targets) {
+      const target = normalizeTerritoryTarget(rawTarget);
+      if (!isExpansionPlannerClaimTargetForColony(target, colony)) {
+        continue;
+      }
+
+      const key = getExpansionPlanKey(target.colony, target.roomName, 'claim');
+      if (blockedKeys.has(key) || recommendations.has(key)) {
+        continue;
+      }
+
+      recommendations.set(key, {
+        colony: target.colony,
+        targetRoom: target.roomName,
+        action: 'claim',
+        createdBy: EXPANSION_PLANNER_TARGET_CREATOR,
+        status: 'planned',
+        ...(target.controllerId ? { controllerId: target.controllerId } : {})
+      });
+    }
+  }
+
+  return Array.from(recommendations.values()).sort(compareExpansionPlannerClaimRecommendations);
 }
 
 export function createExpansionIntent(
@@ -828,6 +897,47 @@ function getExpansionPlanKey(colony: string, targetRoom: string, action: Territo
   return `${colony}:${targetRoom}:${action}`;
 }
 
+function isExpansionPlannerClaimIntentForColony(
+  intent: TerritoryIntentMemory,
+  colony: string | undefined
+): boolean {
+  return (
+    intent.createdBy === EXPANSION_PLANNER_TARGET_CREATOR &&
+    intent.action === 'claim' &&
+    (!isNonEmptyString(colony) || intent.colony === colony)
+  );
+}
+
+function isExpansionPlannerClaimTargetForColony(
+  target: TerritoryTargetMemory | null,
+  colony: string | undefined
+): target is TerritoryTargetMemory & { action: 'claim'; createdBy: typeof EXPANSION_PLANNER_TARGET_CREATOR } {
+  return (
+    target !== null &&
+    target.createdBy === EXPANSION_PLANNER_TARGET_CREATOR &&
+    target.action === 'claim' &&
+    target.enabled !== false &&
+    (!isNonEmptyString(colony) || target.colony === colony)
+  );
+}
+
+function isRunnableExpansionPlannerClaimStatus(
+  status: TerritoryIntentMemory['status']
+): status is Extract<TerritoryIntentMemory['status'], 'planned' | 'active'> {
+  return status === 'planned' || status === 'active';
+}
+
+function compareExpansionPlannerClaimRecommendations(
+  left: ExpansionPlannerClaimRecommendation,
+  right: ExpansionPlannerClaimRecommendation
+): number {
+  return (
+    left.colony.localeCompare(right.colony) ||
+    left.targetRoom.localeCompare(right.targetRoom) ||
+    compareOptionalNumbers(left.updatedAt, right.updatedAt)
+  );
+}
+
 function getCandidateTerminalExpansionStatus(
   candidate: ExpansionPlannerCandidate,
   action: TerritoryControlAction,
@@ -1128,6 +1238,10 @@ function getMemoryRecord(): Partial<Memory> | undefined {
 
 function normalizeNonNegativeInteger(value: number): number {
   return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function compareOptionalNumbers(left: number | undefined, right: number | undefined): number {
+  return (left ?? Number.POSITIVE_INFINITY) - (right ?? Number.POSITIVE_INFINITY);
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -1874,6 +1874,7 @@ function getPersistedTerritoryIntentCandidates(
       colony: intent.colony,
       roomName: intent.targetRoom,
       action: intent.action,
+      ...(intent.createdBy ? { createdBy: intent.createdBy } : {}),
       ...(intent.controllerId ? { controllerId: intent.controllerId } : {}),
       ...(intent.postClaimBootstrapReserveEnergy
         ? { postClaimBootstrapReserveEnergy: intent.postClaimBootstrapReserveEnergy }

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -248,6 +248,12 @@ describe('autonomous expansion claim executor', () => {
       W1N1: makeColony().room,
       W2N1: targetRoom
     };
+    Object.defineProperty(Game, 'creeps', {
+      configurable: true,
+      get: () => {
+        throw new Error('claim success stage refresh should not scan Game.creeps');
+      }
+    });
     (Game as unknown as { getObjectById: jest.Mock }).getObjectById = jest.fn((id: Id<StructureController>) =>
       id === controllerId ? controller : null
     );
@@ -312,6 +318,185 @@ describe('autonomous expansion claim executor', () => {
       controllerId,
       workerTarget: 2
     });
+  });
+
+  it('clears legacy unscoped planner claim intents after claim success', () => {
+    const controllerId = 'controller2' as Id<StructureController>;
+    (Game as { time: number }).time = 2_230;
+    const targetRoom = makeTargetRoom('W2N1', { controllerId });
+    (targetRoom as Room & { memory?: RoomMemory }).memory = {};
+    const controller = targetRoom.controller as StructureController & { my: boolean; room: Room };
+    controller.room = targetRoom;
+    (Game.rooms as Record<string, Room>) = {
+      W1N1: makeColony().room,
+      W2N1: targetRoom
+    };
+    (Game as unknown as { getObjectById: jest.Mock }).getObjectById = jest.fn((id: Id<StructureController>) =>
+      id === controllerId ? controller : null
+    );
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 2_229,
+            controllerId
+          },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 2_229,
+            createdBy: 'expansionPlanner',
+            controllerId
+          }
+        ]
+      }
+    };
+    const creep = makeRecommendedClaimCreep({
+      controllerId,
+      room: targetRoom
+    });
+    creep.claimController.mockImplementation(() => {
+      controller.my = true;
+      return 0 as ScreepsReturnCode;
+    });
+
+    expect(runRecommendedExpansionClaimExecutor(creep)).toBe(true);
+
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(Memory.territory?.intents).toEqual([]);
+  });
+
+  it('retries legacy unscoped planner claim intents without duplicating the planner intent', () => {
+    const controllerId = 'controller2' as Id<StructureController>;
+    (Game as { time: number }).time = 2_240;
+    const targetRoom = makeTargetRoom('W2N1', { controllerId });
+    (Game.rooms as Record<string, Room>) = {
+      W1N1: makeColony().room,
+      W2N1: targetRoom
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 2_239,
+            controllerId
+          },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 2_239,
+            createdBy: 'expansionPlanner',
+            controllerId
+          }
+        ]
+      }
+    };
+    const creep = makeRecommendedClaimCreep({
+      controllerId,
+      room: targetRoom
+    }) as MockClaimCreep & { getActiveBodyparts: jest.Mock };
+    creep.getActiveBodyparts = jest.fn().mockReturnValue(0);
+
+    expect(runRecommendedExpansionClaimExecutor(creep)).toBe(true);
+
+    expect(creep.claimController).not.toHaveBeenCalled();
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 2_240,
+        lastAttemptAt: 2_240,
+        controllerId
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 2_240,
+        createdBy: 'expansionPlanner',
+        lastAttemptAt: 2_240,
+        controllerId
+      }
+    ]);
+  });
+
+  it('suppresses legacy unscoped planner claim intents without duplicating the planner intent', () => {
+    const controllerId = 'controller2' as Id<StructureController>;
+    (Game as { time: number }).time = 2_250;
+    const targetRoom = makeTargetRoom('W2N1', { controllerId });
+    (Game.rooms as Record<string, Room>) = {
+      W1N1: makeColony().room,
+      W2N1: targetRoom
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 2_249,
+            controllerId
+          },
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 2_249,
+            createdBy: 'expansionPlanner',
+            controllerId
+          }
+        ]
+      }
+    };
+    const creep = makeRecommendedClaimCreep({
+      controllerId,
+      room: targetRoom
+    });
+    creep.claimController.mockReturnValue(-15 as ScreepsReturnCode);
+
+    expect(runRecommendedExpansionClaimExecutor(creep)).toBe(true);
+
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 2_250,
+        lastAttemptAt: 2_250,
+        controllerId
+      },
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'suppressed',
+        updatedAt: 2_250,
+        createdBy: 'expansionPlanner',
+        lastAttemptAt: 2_250,
+        controllerId
+      }
+    ]);
   });
 
   it('uses claimed-room resource synergy when ranking autonomous expansion claims', () => {

--- a/prod/test/claimExecutor.test.ts
+++ b/prod/test/claimExecutor.test.ts
@@ -8,6 +8,7 @@ import {
   runRecommendedExpansionClaimExecutor,
   shouldDeferOccupationRecommendationForExpansionClaim
 } from '../src/territory/claimExecutor';
+import { getExpansionPlannerClaimRecommendations } from '../src/territory/expansionPlanner';
 import type {
   OccupationRecommendationReport,
   OccupationRecommendationScore
@@ -193,6 +194,123 @@ describe('autonomous expansion claim executor', () => {
           controllerId: 'controller2'
         }
       }
+    });
+  });
+
+  it('exports expansion planner claim recommendations for execution', () => {
+    const controllerId = 'controller2' as Id<StructureController>;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            action: 'claim',
+            createdBy: 'expansionPlanner',
+            controllerId
+          }
+        ],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 151,
+            createdBy: 'expansionPlanner',
+            controllerId
+          }
+        ]
+      }
+    };
+
+    expect(getExpansionPlannerClaimRecommendations('W1N1')).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        createdBy: 'expansionPlanner',
+        status: 'active',
+        updatedAt: 151,
+        controllerId
+      }
+    ]);
+  });
+
+  it('claims an external expansion planner target and marks the new room for bootstrap', () => {
+    const controllerId = 'controller2' as Id<StructureController>;
+    (Game as { time: number }).time = 2_200;
+    const targetRoom = makeTargetRoom('W2N1', { controllerId });
+    (targetRoom as Room & { memory?: RoomMemory }).memory = {};
+    const controller = targetRoom.controller as StructureController & { my: boolean; room: Room };
+    controller.room = targetRoom;
+    (Game.rooms as Record<string, Room>) = {
+      W1N1: makeColony().room,
+      W2N1: targetRoom
+    };
+    (Game as unknown as { getObjectById: jest.Mock }).getObjectById = jest.fn((id: Id<StructureController>) =>
+      id === controllerId ? controller : null
+    );
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [
+          {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            action: 'claim',
+            createdBy: 'expansionPlanner',
+            controllerId
+          }
+        ],
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'active',
+            updatedAt: 2_199,
+            createdBy: 'expansionPlanner',
+            controllerId
+          }
+        ]
+      }
+    };
+    const events: RuntimeTelemetryEvent[] = [];
+    const creep = makeRecommendedClaimCreep({
+      controllerId,
+      room: targetRoom
+    });
+    creep.claimController.mockImplementation(() => {
+      controller.my = true;
+      return 0 as ScreepsReturnCode;
+    });
+
+    expect(runRecommendedExpansionClaimExecutor(creep, events)).toBe(true);
+
+    expect(creep.claimController).toHaveBeenCalledWith(controller);
+    expect(creep.memory.territory).toBeUndefined();
+    expect(Memory.territory?.targets).toEqual([]);
+    expect(Memory.territory?.intents).toEqual([]);
+    expect(Memory.territory?.postClaimBootstraps?.W2N1).toMatchObject({
+      colony: 'W1N1',
+      roomName: 'W2N1',
+      status: 'detected',
+      claimedAt: 2_200,
+      updatedAt: 2_200,
+      controllerId
+    });
+    expect((targetRoom as Room & { memory: RoomMemory }).memory.colonyStage).toEqual({
+      mode: 'BOOTSTRAP',
+      updatedAt: 2_200,
+      suppressionReasons: ['bootstrapWorkerFloor', 'spawnEnergyCritical']
+    });
+    expect(events).toContainEqual({
+      type: 'postClaimBootstrap',
+      roomName: 'W2N1',
+      colony: 'W1N1',
+      phase: 'detected',
+      controllerId,
+      workerTarget: 2
     });
   });
 

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -1176,6 +1176,55 @@ describe('planTerritoryIntent', () => {
     ]);
   });
 
+  it('plans persisted expansion planner claim recommendations as claim execution work', () => {
+    const colony = makeSafeColony();
+    const controllerId = 'controller2' as Id<StructureController>;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      rooms: {
+        W2N1: makeRecommendationRoom('W2N1', {
+          sourceCount: 2,
+          controller: { id: controllerId, my: false } as StructureController
+        })
+      }
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        intents: [
+          {
+            colony: 'W1N1',
+            targetRoom: 'W2N1',
+            action: 'claim',
+            status: 'planned',
+            updatedAt: 580,
+            createdBy: 'expansionPlanner',
+            controllerId
+          }
+        ]
+      }
+    };
+
+    expect(
+      planTerritoryIntent(colony, { worker: 3, claimer: 0, claimersByTargetRoom: {} }, 3, 581)
+    ).toEqual({
+      colony: 'W1N1',
+      targetRoom: 'W2N1',
+      action: 'claim',
+      createdBy: 'expansionPlanner',
+      controllerId
+    });
+    expect(Memory.territory?.intents).toEqual([
+      {
+        colony: 'W1N1',
+        targetRoom: 'W2N1',
+        action: 'claim',
+        status: 'planned',
+        updatedAt: 581,
+        createdBy: 'expansionPlanner',
+        controllerId
+      }
+    ]);
+  });
+
   it('uses recommendation scoring to seed the strongest sufficient visible reserve candidate', () => {
     const colony = makeSafeColony();
     const describeExits = jest.fn(() => ({ '1': 'W1N2', '3': 'W2N1' }));


### PR DESCRIPTION
Implements room claiming execution from the expansion planner recommendations.

Changes:
- `claimExecutor.ts`: claimer and reserver creep execution from planner output
- `expansionPlanner.ts`: planner integration with claim executor
- `colonyStage.ts`: colony stage transitions for claiming
- Tests: claim executor and territory planner test coverage

Closes #736