### PR TITLE
feat(territory): implement tower construction and active defense in claimed colonies (#745)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -1173,6 +1173,8 @@ var HOSTILES_PER_DEFENDER = 3;
 var MAX_CREEP_PARTS = 50;
 var SAFE_MODE_HOSTILE_COUNT_THRESHOLD = 2;
 var CRITICAL_SPAWN_LOSS_HITS_RATIO = 0.25;
+var TOWER_CONTROLLER_THREAT_RANGE = 3;
+var TOWER_STRUCTURE_THREAT_RANGE = 3;
 function hasDefensePressure(summary) {
   return normalizeNonNegativeInteger(summary.hostileCreepCount) > 0 || normalizeNonNegativeInteger(summary.hostileStructureCount) > 0 || normalizeNonNegativeInteger(summary.damagedCriticalStructureCount) > 0;
 }
@@ -1219,9 +1221,18 @@ function planDefenderSpawn(input) {
     }
   };
 }
-function selectTowerAttackTarget(origin, hostileCreeps, hostileStructures) {
-  var _a;
-  return (_a = selectClosestTarget(origin, hostileCreeps, { sameRoomOnly: true })) != null ? _a : selectClosestTarget(origin, hostileStructures, { sameRoomOnly: true });
+function selectTowerAttackTarget(origin, hostileCreeps, hostileStructures, options = {}) {
+  var _a, _b, _c, _d, _e, _f;
+  const controller = (_b = options.controller) != null ? _b : (_a = origin.room) == null ? void 0 : _a.controller;
+  const protectedStructures = (_c = options.protectedStructures) != null ? _c : [];
+  const sameRoomHostileCreeps = hostileCreeps.filter((hostile) => isTargetInOriginRoom(origin, hostile));
+  return (_f = (_e = (_d = selectClosestTarget(
+    origin,
+    sameRoomHostileCreeps.filter((hostile) => isHostileNearController(hostile, controller))
+  )) != null ? _d : selectClosestTarget(
+    origin,
+    sameRoomHostileCreeps.filter((hostile) => isHostileNearProtectedStructure(hostile, protectedStructures))
+  )) != null ? _e : selectClosestTarget(origin, sameRoomHostileCreeps)) != null ? _f : selectClosestTarget(origin, hostileStructures, { sameRoomOnly: true });
 }
 function selectDefenderAttackTarget(origin, hostileCreeps, hostileStructures) {
   var _a;
@@ -1255,6 +1266,23 @@ function isTargetInOriginRoom(origin, target) {
   }
   return origin.pos.roomName === target.pos.roomName;
 }
+function isHostileNearController(hostile, controller) {
+  if (!(controller == null ? void 0 : controller.pos) || !hostile.pos || hostile.pos.roomName !== controller.pos.roomName) {
+    return false;
+  }
+  return getRangeBetweenPositions(hostile.pos, controller.pos) <= TOWER_CONTROLLER_THREAT_RANGE;
+}
+function isHostileNearProtectedStructure(hostile, structures) {
+  if (!hostile.pos) {
+    return false;
+  }
+  return structures.some(
+    (structure) => {
+      var _a, _b;
+      return ((_a = structure.pos) == null ? void 0 : _a.roomName) === ((_b = hostile.pos) == null ? void 0 : _b.roomName) && getRangeBetweenPositions(hostile.pos, structure.pos) <= TOWER_STRUCTURE_THREAT_RANGE;
+    }
+  );
+}
 function compareRange(origin, left, right) {
   var _a;
   const getRangeTo = (_a = origin.pos) == null ? void 0 : _a.getRangeTo;
@@ -1264,6 +1292,9 @@ function compareRange(origin, left, right) {
   const leftRange = left.pos ? getRangeTo.call(origin.pos, left.pos) : Infinity;
   const rightRange = right.pos ? getRangeTo.call(origin.pos, right.pos) : Infinity;
   return leftRange - rightRange;
+}
+function getRangeBetweenPositions(left, right) {
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
 function compareObjectIds2(left, right) {
   return getObjectId2(left).localeCompare(getObjectId2(right));
@@ -1415,7 +1446,10 @@ function runTowerAttack(tower, context, result, priorityTargetGroups) {
   if (typeof tower.attack !== "function") {
     return false;
   }
-  const target = (_a = selectPriorityTowerAttackTarget(tower, priorityTargetGroups)) != null ? _a : selectTowerAttackTarget(tower, context.hostileCreeps, context.hostileStructures);
+  const target = (_a = selectPriorityTowerAttackTarget(tower, priorityTargetGroups)) != null ? _a : selectTowerAttackTarget(tower, context.hostileCreeps, context.hostileStructures, {
+    controller: context.room.controller,
+    protectedStructures: findOwnedStructures(context.room)
+  });
   if (!target) {
     return false;
   }
@@ -1450,7 +1484,11 @@ function selectPriorityTowerAttackTarget(tower, priorityTargetGroups) {
       group.hostileStructures.filter((structure) => {
         var _a;
         return ((_a = structure.room) == null ? void 0 : _a.name) === tower.room.name;
-      })
+      }),
+      {
+        controller: tower.room.controller,
+        protectedStructures: findOwnedStructures(tower.room)
+      }
     );
     if (target) {
       return target;
@@ -3301,7 +3339,7 @@ function selectSourceControllerRoadRoutes(room) {
   if (!controllerPosition || !isSameRoomPosition2(controllerPosition, room.name)) {
     return [];
   }
-  return getSortedSources(room).filter((source) => getRangeBetweenPositions(source.pos, controllerPosition) <= SOURCE_CONTROLLER_ROAD_MAX_RANGE).map((source) => createRoadRoute(source.pos, { pos: controllerPosition }, 0));
+  return getSortedSources(room).filter((source) => getRangeBetweenPositions2(source.pos, controllerPosition) <= SOURCE_CONTROLLER_ROAD_MAX_RANGE).map((source) => createRoadRoute(source.pos, { pos: controllerPosition }, 0));
 }
 function createRoadRoute(origin, target, priority) {
   return { origin, priority, target };
@@ -3458,7 +3496,7 @@ function isWithinBuildableRoomBounds(position) {
 function isSameRoomPosition2(position, roomName) {
   return !position.roomName || position.roomName === roomName;
 }
-function getRangeBetweenPositions(left, right) {
+function getRangeBetweenPositions2(left, right) {
   return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
 function isTerrainWall2(terrain, position) {
@@ -3961,7 +3999,7 @@ function canPlaceSourceContainer(lookups, position) {
   return isWithinBuildableRoomBounds2(position) && !isTerrainWall3(lookups.terrain, position) && !lookups.blockingPositions.has(getPositionKey3(position));
 }
 function compareSourceContainerPositions(left, right, anchor) {
-  return compareOptionalNumber(getRangeBetweenPositions2(left, anchor), getRangeBetweenPositions2(right, anchor)) || left.y - right.y || left.x - right.x;
+  return compareOptionalNumber(getRangeBetweenPositions3(left, anchor), getRangeBetweenPositions3(right, anchor)) || left.y - right.y || left.x - right.x;
 }
 function selectConstructionAnchor(colony) {
   var _a;
@@ -3970,7 +4008,7 @@ function selectConstructionAnchor(colony) {
 }
 function isNearRoomObject(object, position) {
   const objectPosition = getRoomObjectPosition(object);
-  const range = getRangeBetweenPositions2(objectPosition, position);
+  const range = getRangeBetweenPositions3(objectPosition, position);
   return isSameRoomPosition3(objectPosition, position.roomName) && range !== null && range <= 1;
 }
 function isSourceContainerConstructionSite(site, context) {
@@ -3994,7 +4032,7 @@ function isProtectedRampartConstructionSite(site, context) {
     return false;
   }
   return context.protectedRampartAnchors.some((anchor) => {
-    const range = getRangeBetweenPositions2(sitePosition, anchor);
+    const range = getRangeBetweenPositions3(sitePosition, anchor);
     return range !== null && range <= 2;
   });
 }
@@ -4018,7 +4056,7 @@ function isSameRoomPosition3(position, roomName) {
 function isWithinBuildableRoomBounds2(position) {
   return position.x >= ROOM_EDGE_MIN4 && position.x <= ROOM_EDGE_MAX4 && position.y >= ROOM_EDGE_MIN4 && position.y <= ROOM_EDGE_MAX4;
 }
-function getRangeBetweenPositions2(left, right) {
+function getRangeBetweenPositions3(left, right) {
   if (!left || !right) {
     return null;
   }
@@ -5066,7 +5104,7 @@ function selectInitialSpawnAnchor(room) {
   if (!controllerPosition) {
     return null;
   }
-  const nearestSourcePosition = getSortedSources3(room).map((source) => getAnyObjectPosition(source)).filter((position) => position !== null).sort((left, right) => getRangeBetweenPositions3(controllerPosition, left) - getRangeBetweenPositions3(controllerPosition, right))[0];
+  const nearestSourcePosition = getSortedSources3(room).map((source) => getAnyObjectPosition(source)).filter((position) => position !== null).sort((left, right) => getRangeBetweenPositions4(controllerPosition, left) - getRangeBetweenPositions4(controllerPosition, right))[0];
   if (!nearestSourcePosition) {
     return clampSpawnPosition({ x: controllerPosition.x, y: controllerPosition.y, roomName: room.name });
   }
@@ -5171,7 +5209,7 @@ function getAnyObjectPosition(object) {
 function isSameRoomPosition4(position, roomName) {
   return position !== null && (!position.roomName || position.roomName === roomName);
 }
-function getRangeBetweenPositions3(left, right) {
+function getRangeBetweenPositions4(left, right) {
   return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
 function isTerrainWall4(terrain, position) {
@@ -8111,7 +8149,7 @@ function findSourceContainer(room, source) {
   }
   const containers = room.find(FIND_STRUCTURES).filter((structure) => isContainerStructure(structure)).filter((container) => {
     const containerPosition = getRoomObjectPosition2(container);
-    return containerPosition !== null && isSameRoomPosition5(containerPosition, room.name) && getRangeBetweenPositions4(sourcePosition, containerPosition) <= 1;
+    return containerPosition !== null && isSameRoomPosition5(containerPosition, room.name) && getRangeBetweenPositions5(sourcePosition, containerPosition) <= 1;
   });
   return (_a = containers.sort((left, right) => compareSourceContainers(sourcePosition, left, right))[0]) != null ? _a : null;
 }
@@ -8126,14 +8164,14 @@ function findSourceContainerConstructionSite(room, source) {
   }
   const sites = room.find(FIND_CONSTRUCTION_SITES).filter((site) => isContainerConstructionSite(site)).filter((site) => {
     const sitePosition = getRoomObjectPosition2(site);
-    return sitePosition !== null && isSameRoomPosition5(sitePosition, room.name) && getRangeBetweenPositions4(sourcePosition, sitePosition) <= 1;
+    return sitePosition !== null && isSameRoomPosition5(sitePosition, room.name) && getRangeBetweenPositions5(sourcePosition, sitePosition) <= 1;
   });
   return (_a = sites.sort((left, right) => compareSourceContainerSites(sourcePosition, left, right))[0]) != null ? _a : null;
 }
 function isContainerStructure(structure) {
   return matchesStructureType7(structure.structureType, "STRUCTURE_CONTAINER", "container");
 }
-function getRangeBetweenPositions4(left, right) {
+function getRangeBetweenPositions5(left, right) {
   return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
 function getRoomObjectPosition2(object) {
@@ -8150,16 +8188,16 @@ function compareSourceContainers(sourcePosition, left, right) {
   const leftPosition = getRoomObjectPosition2(left);
   const rightPosition = getRoomObjectPosition2(right);
   return compareNumbers(
-    leftPosition ? getRangeBetweenPositions4(sourcePosition, leftPosition) : Number.POSITIVE_INFINITY,
-    rightPosition ? getRangeBetweenPositions4(sourcePosition, rightPosition) : Number.POSITIVE_INFINITY
+    leftPosition ? getRangeBetweenPositions5(sourcePosition, leftPosition) : Number.POSITIVE_INFINITY,
+    rightPosition ? getRangeBetweenPositions5(sourcePosition, rightPosition) : Number.POSITIVE_INFINITY
   ) || String(left.id).localeCompare(String(right.id));
 }
 function compareSourceContainerSites(sourcePosition, left, right) {
   const leftPosition = getRoomObjectPosition2(left);
   const rightPosition = getRoomObjectPosition2(right);
   return compareNumbers(
-    leftPosition ? getRangeBetweenPositions4(sourcePosition, leftPosition) : Number.POSITIVE_INFINITY,
-    rightPosition ? getRangeBetweenPositions4(sourcePosition, rightPosition) : Number.POSITIVE_INFINITY
+    leftPosition ? getRangeBetweenPositions5(sourcePosition, leftPosition) : Number.POSITIVE_INFINITY,
+    rightPosition ? getRangeBetweenPositions5(sourcePosition, rightPosition) : Number.POSITIVE_INFINITY
   ) || String(left.id).localeCompare(String(right.id));
 }
 function compareNumbers(left, right) {
@@ -8310,8 +8348,8 @@ function canPlaceSourceContainer2(lookups, position) {
 }
 function compareSourceContainerPositions2(left, right, anchor) {
   if (anchor) {
-    const leftRange = getRangeBetweenPositions4(left, anchor);
-    const rightRange = getRangeBetweenPositions4(right, anchor);
+    const leftRange = getRangeBetweenPositions5(left, anchor);
+    const rightRange = getRangeBetweenPositions5(right, anchor);
     if (leftRange !== rightRange) {
       return leftRange - rightRange;
     }
@@ -8347,6 +8385,13 @@ var ERR_NO_PATH_CODE4 = -2;
 var SOURCE_SCORE_WEIGHT = 1e3;
 var DISTANCE_SCORE_WEIGHT = 100;
 var EXPANSION_PLANNER_TARGET_CREATOR = "expansionPlanner";
+var EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS = 6;
+var EXPANSION_TOWER_ROOM_EDGE_MIN = 1;
+var EXPANSION_TOWER_ROOM_EDGE_MAX = 48;
+var EXPANSION_TOWER_CONTROLLER_WEIGHT = 6;
+var EXPANSION_TOWER_SOURCE_WEIGHT = 3;
+var EXPANSION_TOWER_ENTRANCE_WEIGHT = 1;
+var DEFAULT_TERRAIN_WALL_MASK9 = 1;
 function evaluateExpansionRoomSuitability(room, colonyOwnerUsername) {
   var _a;
   const ownerUsername = getControllerOwnerUsername4(room.controller);
@@ -8622,6 +8667,278 @@ function createExpansionIntent(candidate, action, gameTime = getGameTime11()) {
     score: candidate.score,
     ...candidate.controllerId ? { controllerId: candidate.controllerId } : {}
   };
+}
+function planExpansionTowerPlacements(room, options = {}) {
+  if (!isNonEmptyString9(room.name)) {
+    return [];
+  }
+  const lookups = createExpansionTowerPlacementLookups(room);
+  if (lookups.anchors.length === 0) {
+    return [];
+  }
+  const placements = [];
+  for (let y = EXPANSION_TOWER_ROOM_EDGE_MIN; y <= EXPANSION_TOWER_ROOM_EDGE_MAX; y += 1) {
+    for (let x = EXPANSION_TOWER_ROOM_EDGE_MIN; x <= EXPANSION_TOWER_ROOM_EDGE_MAX; x += 1) {
+      const position = { x, y, roomName: room.name };
+      if (!canPlaceExpansionTower(lookups, position)) {
+        continue;
+      }
+      placements.push(scoreExpansionTowerPlacement(position, lookups.anchors, room.name));
+    }
+  }
+  return placements.sort(compareExpansionTowerPlacements).slice(0, getExpansionTowerMaxPlacements(options.maxPlacements));
+}
+function createExpansionTowerPlacementLookups(room) {
+  const blockedPositions = /* @__PURE__ */ new Set();
+  for (const object of [
+    room.controller,
+    ...findRoomObjects12(room, getFindConstant4("FIND_SOURCES")),
+    ...findRoomObjects12(room, getFindConstant4("FIND_STRUCTURES")),
+    ...findRoomObjects12(room, getFindConstant4("FIND_CONSTRUCTION_SITES"))
+  ]) {
+    addExpansionTowerBlockedPosition(blockedPositions, object, room.name);
+  }
+  return {
+    terrain: getExpansionTowerRoomTerrain(room.name),
+    blockedPositions,
+    anchors: buildExpansionTowerAnchors(room)
+  };
+}
+function buildExpansionTowerAnchors(room) {
+  const anchors = [];
+  addExpansionTowerAnchor(
+    anchors,
+    room.controller,
+    "controller",
+    EXPANSION_TOWER_CONTROLLER_WEIGHT,
+    room.name
+  );
+  for (const source of findRoomObjects12(room, getFindConstant4("FIND_SOURCES")).sort(compareExpansionTowerObjectIds)) {
+    addExpansionTowerAnchor(anchors, source, "source", EXPANSION_TOWER_SOURCE_WEIGHT, room.name);
+  }
+  for (const entrancePosition of getExpansionTowerEntranceAnchors(room)) {
+    anchors.push({
+      kind: "entrance",
+      position: entrancePosition,
+      weight: EXPANSION_TOWER_ENTRANCE_WEIGHT
+    });
+  }
+  return anchors;
+}
+function addExpansionTowerAnchor(anchors, object, kind, weight, roomName) {
+  const position = getExpansionTowerObjectPosition(object);
+  if (!isExpansionTowerSameRoomPosition(position, roomName)) {
+    return;
+  }
+  anchors.push({
+    kind,
+    position,
+    weight
+  });
+}
+function getExpansionTowerEntranceAnchors(room) {
+  const exitPositions = findRoomObjects12(room, getFindConstant4("FIND_EXIT")).map(getExpansionTowerObjectPosition).filter(
+    (position) => isExpansionTowerSameRoomPosition(position, room.name)
+  );
+  if (exitPositions.length > 0) {
+    return selectRepresentativeExpansionTowerExits(exitPositions);
+  }
+  return getExpansionTowerFallbackEntranceAnchors(room.name);
+}
+function selectRepresentativeExpansionTowerExits(exitPositions) {
+  const groups = groupExpansionTowerExits(exitPositions);
+  return groups.map((group) => {
+    const sortedPositions = [...group.positions].sort(compareExpansionTowerExitPositions);
+    const middle = sortedPositions[Math.floor(sortedPositions.length / 2)];
+    return {
+      x: middle.x,
+      y: middle.y,
+      roomName: middle.roomName
+    };
+  });
+}
+function groupExpansionTowerExits(exitPositions) {
+  const groups = [];
+  for (const position of [...exitPositions].sort(compareExpansionTowerExitPositions)) {
+    const side = getExpansionTowerExitSide(position);
+    if (!side) {
+      continue;
+    }
+    const previous = groups[groups.length - 1];
+    if (previous && previous.side === side && areContiguousExpansionTowerExits(previous.positions[previous.positions.length - 1], position)) {
+      previous.positions.push(position);
+    } else {
+      groups.push({ side, positions: [position] });
+    }
+  }
+  return groups;
+}
+function getExpansionTowerFallbackEntranceAnchors(roomName) {
+  var _a, _b, _c;
+  const exits = (_c = (_b = (_a = globalThis.Game) == null ? void 0 : _a.map) == null ? void 0 : _b.describeExits) == null ? void 0 : _c.call(_b, roomName);
+  if (!isRecord9(exits)) {
+    return [];
+  }
+  const anchors = [];
+  if (isNonEmptyString9(exits["1"])) {
+    anchors.push({ x: 25, y: 0, roomName });
+  }
+  if (isNonEmptyString9(exits["3"])) {
+    anchors.push({ x: 49, y: 25, roomName });
+  }
+  if (isNonEmptyString9(exits["5"])) {
+    anchors.push({ x: 25, y: 49, roomName });
+  }
+  if (isNonEmptyString9(exits["7"])) {
+    anchors.push({ x: 0, y: 25, roomName });
+  }
+  return anchors;
+}
+function areContiguousExpansionTowerExits(left, right) {
+  if (!left || getExpansionTowerExitSide(left) !== getExpansionTowerExitSide(right)) {
+    return false;
+  }
+  if (left.x === right.x) {
+    return Math.abs(left.y - right.y) <= 1;
+  }
+  if (left.y === right.y) {
+    return Math.abs(left.x - right.x) <= 1;
+  }
+  return false;
+}
+function compareExpansionTowerExitPositions(left, right) {
+  var _a, _b;
+  const leftSide = (_a = getExpansionTowerExitSide(left)) != null ? _a : "";
+  const rightSide = (_b = getExpansionTowerExitSide(right)) != null ? _b : "";
+  return getExpansionTowerExitSideOrder(leftSide) - getExpansionTowerExitSideOrder(rightSide) || left.y - right.y || left.x - right.x;
+}
+function getExpansionTowerExitSide(position) {
+  if (position.y <= 0) {
+    return "top";
+  }
+  if (position.x >= 49) {
+    return "right";
+  }
+  if (position.y >= 49) {
+    return "bottom";
+  }
+  if (position.x <= 0) {
+    return "left";
+  }
+  return null;
+}
+function getExpansionTowerExitSideOrder(side) {
+  switch (side) {
+    case "top":
+      return 0;
+    case "right":
+      return 1;
+    case "bottom":
+      return 2;
+    case "left":
+      return 3;
+    default:
+      return 4;
+  }
+}
+function canPlaceExpansionTower(lookups, position) {
+  return position.x >= EXPANSION_TOWER_ROOM_EDGE_MIN && position.x <= EXPANSION_TOWER_ROOM_EDGE_MAX && position.y >= EXPANSION_TOWER_ROOM_EDGE_MIN && position.y <= EXPANSION_TOWER_ROOM_EDGE_MAX && !lookups.blockedPositions.has(getExpansionTowerPositionKey(position)) && !isExpansionTowerTerrainWall(lookups.terrain, position);
+}
+function scoreExpansionTowerPlacement(position, anchors, roomName) {
+  const controllerRange = getNearestExpansionTowerAnchorRange(position, anchors, "controller");
+  const nearestSourceRange = getNearestExpansionTowerAnchorRange(position, anchors, "source");
+  const nearestEntranceRange = getNearestExpansionTowerAnchorRange(position, anchors, "entrance");
+  return {
+    roomName,
+    x: position.x,
+    y: position.y,
+    score: anchors.reduce(
+      (score, anchor) => score + getExpansionTowerRange(position, anchor.position) * anchor.weight,
+      0
+    ),
+    ...controllerRange !== null ? { controllerRange } : {},
+    ...nearestSourceRange !== null ? { nearestSourceRange } : {},
+    ...nearestEntranceRange !== null ? { nearestEntranceRange } : {}
+  };
+}
+function getNearestExpansionTowerAnchorRange(position, anchors, kind) {
+  let nearestRange = null;
+  for (const anchor of anchors) {
+    if (anchor.kind !== kind) {
+      continue;
+    }
+    const range = getExpansionTowerRange(position, anchor.position);
+    if (nearestRange === null || range < nearestRange) {
+      nearestRange = range;
+    }
+  }
+  return nearestRange;
+}
+function compareExpansionTowerPlacements(left, right) {
+  return left.score - right.score || compareOptionalNumbers3(left.controllerRange, right.controllerRange) || compareOptionalNumbers3(left.nearestSourceRange, right.nearestSourceRange) || compareOptionalNumbers3(left.nearestEntranceRange, right.nearestEntranceRange) || left.y - right.y || left.x - right.x;
+}
+function addExpansionTowerBlockedPosition(blockedPositions, object, roomName) {
+  const position = getExpansionTowerObjectPosition(object);
+  if (isExpansionTowerSameRoomPosition(position, roomName)) {
+    blockedPositions.add(getExpansionTowerPositionKey(position));
+  }
+}
+function getExpansionTowerObjectPosition(object) {
+  if (!isRecord9(object)) {
+    return null;
+  }
+  if (typeof object.x === "number" && Number.isFinite(object.x) && typeof object.y === "number" && Number.isFinite(object.y)) {
+    return {
+      x: object.x,
+      y: object.y,
+      ...typeof object.roomName === "string" ? { roomName: object.roomName } : {}
+    };
+  }
+  const position = object.pos;
+  if (isRecord9(position) && typeof position.x === "number" && Number.isFinite(position.x) && typeof position.y === "number" && Number.isFinite(position.y)) {
+    return {
+      x: position.x,
+      y: position.y,
+      ...typeof position.roomName === "string" ? { roomName: position.roomName } : {}
+    };
+  }
+  return null;
+}
+function isExpansionTowerSameRoomPosition(position, roomName) {
+  return position !== null && (position.roomName === void 0 || position.roomName === roomName);
+}
+function getExpansionTowerRange(left, right) {
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
+}
+function getExpansionTowerPositionKey(position) {
+  return `${position.x},${position.y}`;
+}
+function getExpansionTowerRoomTerrain(roomName) {
+  var _a;
+  const gameMap = (_a = globalThis.Game) == null ? void 0 : _a.map;
+  return typeof (gameMap == null ? void 0 : gameMap.getRoomTerrain) === "function" ? gameMap.getRoomTerrain(roomName) : null;
+}
+function isExpansionTowerTerrainWall(terrain, position) {
+  return terrain !== null && (terrain.get(position.x, position.y) & getExpansionTowerTerrainWallMask()) !== 0;
+}
+function getExpansionTowerTerrainWallMask() {
+  const terrainWallMask = globalThis.TERRAIN_MASK_WALL;
+  return typeof terrainWallMask === "number" ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK9;
+}
+function getExpansionTowerMaxPlacements(maxPlacements) {
+  if (typeof maxPlacements !== "number" || !Number.isFinite(maxPlacements)) {
+    return EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS;
+  }
+  return Math.max(1, Math.floor(maxPlacements));
+}
+function compareExpansionTowerObjectIds(left, right) {
+  return getExpansionTowerObjectId(left).localeCompare(getExpansionTowerObjectId(right));
+}
+function getExpansionTowerObjectId(object) {
+  if (!isRecord9(object)) {
+    return "";
+  }
+  return typeof object.id === "string" ? object.id : "";
 }
 function evaluateExpansionSuitability({
   sourceCount,
@@ -14484,7 +14801,7 @@ function selectClosestLink(links, target, roomName, range) {
 function isNearRoomObject2(left, right, roomName, range) {
   const leftPosition = getRoomObjectPosition2(left);
   const rightPosition = getRoomObjectPosition2(right);
-  return leftPosition !== null && rightPosition !== null && isSameRoomPosition5(leftPosition, roomName) && isSameRoomPosition5(rightPosition, roomName) && getRangeBetweenPositions4(leftPosition, rightPosition) <= range;
+  return leftPosition !== null && rightPosition !== null && isSameRoomPosition5(leftPosition, roomName) && isSameRoomPosition5(rightPosition, roomName) && getRangeBetweenPositions5(leftPosition, rightPosition) <= range;
 }
 function compareRangeToPosition(position, left, right) {
   if (!position) {
@@ -14492,7 +14809,7 @@ function compareRangeToPosition(position, left, right) {
   }
   const leftPosition = getRoomObjectPosition2(left);
   const rightPosition = getRoomObjectPosition2(right);
-  return (leftPosition ? getRangeBetweenPositions4(position, leftPosition) : Number.POSITIVE_INFINITY) - (rightPosition ? getRangeBetweenPositions4(position, rightPosition) : Number.POSITIVE_INFINITY);
+  return (leftPosition ? getRangeBetweenPositions5(position, leftPosition) : Number.POSITIVE_INFINITY) - (rightPosition ? getRangeBetweenPositions5(position, rightPosition) : Number.POSITIVE_INFINITY);
 }
 function findOwnedLinks(room) {
   return findOwnedStructures5(room).filter((structure) => matchesStructureType11(structure.structureType, "STRUCTURE_LINK", "link")).sort(compareObjectIds4);
@@ -14546,7 +14863,7 @@ function compareClosestSpawnRange(room, left, right) {
 function getRangeBetweenRoomObjects(left, right, roomName) {
   const leftPosition = getRoomObjectPosition2(left);
   const rightPosition = getRoomObjectPosition2(right);
-  return leftPosition !== null && rightPosition !== null && isSameRoomPosition5(leftPosition, roomName) && isSameRoomPosition5(rightPosition, roomName) ? getRangeBetweenPositions4(leftPosition, rightPosition) : Number.POSITIVE_INFINITY;
+  return leftPosition !== null && rightPosition !== null && isSameRoomPosition5(leftPosition, roomName) && isSameRoomPosition5(rightPosition, roomName) ? getRangeBetweenPositions5(leftPosition, rightPosition) : Number.POSITIVE_INFINITY;
 }
 function getStoredEnergy7(structure) {
   var _a;
@@ -14700,7 +15017,7 @@ function compareSourceLinkDeposits(container, left, right) {
   const containerPosition = getRoomObjectPosition2(container);
   const leftPosition = getRoomObjectPosition2(left);
   const rightPosition = getRoomObjectPosition2(right);
-  return (containerPosition && leftPosition ? getRangeBetweenPositions4(containerPosition, leftPosition) : 99) - (containerPosition && rightPosition ? getRangeBetweenPositions4(containerPosition, rightPosition) : 99) || String(left.id).localeCompare(String(right.id));
+  return (containerPosition && leftPosition ? getRangeBetweenPositions5(containerPosition, leftPosition) : 99) - (containerPosition && rightPosition ? getRangeBetweenPositions5(containerPosition, rightPosition) : 99) || String(left.id).localeCompare(String(right.id));
 }
 function selectMobileFallbackEnergySink(creep) {
   var _a, _b;
@@ -14818,7 +15135,7 @@ function isInRangeTo(creep, target, range) {
 function isNearRoomObject3(left, right, range) {
   const leftPosition = getRoomObjectPosition2(left);
   const rightPosition = getRoomObjectPosition2(right);
-  return leftPosition !== null && rightPosition !== null && (typeof leftPosition.roomName !== "string" || typeof rightPosition.roomName !== "string" || leftPosition.roomName === rightPosition.roomName) && getRangeBetweenPositions4(leftPosition, rightPosition) <= range;
+  return leftPosition !== null && rightPosition !== null && (typeof leftPosition.roomName !== "string" || typeof rightPosition.roomName !== "string" || leftPosition.roomName === rightPosition.roomName) && getRangeBetweenPositions5(leftPosition, rightPosition) <= range;
 }
 function compareRangeToCreep(creep, left, right) {
   var _a;
@@ -23473,7 +23790,7 @@ var OK_CODE9 = 0;
 var ERR_INVALID_TARGET_CODE2 = -7;
 var ROOM_EDGE_MIN6 = 2;
 var ROOM_EDGE_MAX6 = 47;
-var DEFAULT_TERRAIN_WALL_MASK9 = 1;
+var DEFAULT_TERRAIN_WALL_MASK10 = 1;
 function recordPostClaimBootstrapClaimSuccess(input, telemetryEvents = []) {
   var _a, _b;
   if (!isNonEmptyString19(input.colony) || !isNonEmptyString19(input.roomName)) {
@@ -24023,7 +24340,7 @@ function getRoomTerrain9(roomName) {
   return typeof (gameMap == null ? void 0 : gameMap.getRoomTerrain) === "function" ? gameMap.getRoomTerrain(roomName) : null;
 }
 function getTerrainWallMask7() {
-  return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK9;
+  return typeof TERRAIN_MASK_WALL === "number" ? TERRAIN_MASK_WALL : DEFAULT_TERRAIN_WALL_MASK10;
 }
 function matchesStructureType19(actual, globalName, fallback) {
   return actual === getStructureConstant2(globalName, fallback);
@@ -24059,7 +24376,7 @@ function isFiniteNumber8(value) {
 // src/economy/sourceContainerPlanner.ts
 var ROOM_EDGE_MIN7 = 1;
 var ROOM_EDGE_MAX7 = 48;
-var DEFAULT_TERRAIN_WALL_MASK10 = 1;
+var DEFAULT_TERRAIN_WALL_MASK11 = 1;
 var ERR_INVALID_TARGET_CODE3 = -7;
 var REMOTE_HARVESTER_ROLE2 = "remoteHarvester";
 function ensureRemoteSourceContainersForAssignedHarvesters(creeps = getGameCreeps2()) {
@@ -24249,8 +24566,8 @@ function canPlaceSourceContainer3(lookups, position) {
 }
 function compareSourceContainerPositions3(left, right, anchor) {
   if (anchor) {
-    const leftRange = getRangeBetweenPositions4(left, anchor);
-    const rightRange = getRangeBetweenPositions4(right, anchor);
+    const leftRange = getRangeBetweenPositions5(left, anchor);
+    const rightRange = getRangeBetweenPositions5(right, anchor);
     if (leftRange !== rightRange) {
       return leftRange - rightRange;
     }
@@ -24299,7 +24616,7 @@ function isNearRoomObject4(object, position) {
   if (typeof objectPosition.roomName === "string" && typeof position.roomName === "string" && objectPosition.roomName !== position.roomName) {
     return false;
   }
-  return getRangeBetweenPositions4(objectPosition, position) <= 1;
+  return getRangeBetweenPositions5(objectPosition, position) <= 1;
 }
 function addBlockingPosition2(lookups, position) {
   if (position) {
@@ -24370,7 +24687,7 @@ function getErrInvalidTargetCode() {
 }
 function getTerrainWallMask8() {
   const terrainWallMask = globalThis.TERRAIN_MASK_WALL;
-  return typeof terrainWallMask === "number" ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK10;
+  return typeof terrainWallMask === "number" ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK11;
 }
 function getGlobalNumber10(name) {
   const value = globalThis[name];
@@ -24413,7 +24730,7 @@ function hasDroppedEnergyDecayingAtSource(room, source) {
   const droppedResources = (_a = findRoomObjects15(room, "FIND_DROPPED_RESOURCES")) != null ? _a : [];
   return droppedResources.some((resource) => {
     const resourcePosition = getRoomObjectPosition2(resource);
-    return resourcePosition !== null && isDroppedEnergy2(resource) && isSameRoomPosition5(resourcePosition, room.name) && getRangeBetweenPositions4(sourcePosition, resourcePosition) <= 1;
+    return resourcePosition !== null && isDroppedEnergy2(resource) && isSameRoomPosition5(resourcePosition, room.name) && getRangeBetweenPositions5(sourcePosition, resourcePosition) <= 1;
   });
 }
 function isDroppedEnergy2(resource) {
@@ -25642,7 +25959,7 @@ function getGameTime20() {
 var HARVEST_ENERGY_PER_WORK_PART2 = 2;
 var DEFAULT_SOURCE_ENERGY_CAPACITY2 = 3e3;
 var DEFAULT_SOURCE_ENERGY_REGEN_TICKS2 = 300;
-var DEFAULT_TERRAIN_WALL_MASK11 = 1;
+var DEFAULT_TERRAIN_WALL_MASK12 = 1;
 function recordSourceWorkloads(room, creeps, tick) {
   var _a, _b, _c;
   const memory = globalThis.Memory;
@@ -25766,7 +26083,7 @@ function getRoomTerrain11(roomName) {
 }
 function getTerrainWallMask9() {
   const terrainWallMask = globalThis.TERRAIN_MASK_WALL;
-  return typeof terrainWallMask === "number" ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK11;
+  return typeof terrainWallMask === "number" ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK12;
 }
 function getSourceEnergyCapacity(source) {
   const sourceEnergyCapacity = source.energyCapacity;
@@ -28013,7 +28330,7 @@ function isNonEmptyString23(value) {
 var EXIT_DIRECTION_ORDER6 = ["1", "3", "5", "7"];
 var TERRAIN_SCAN_MIN4 = 2;
 var TERRAIN_SCAN_MAX4 = 47;
-var DEFAULT_TERRAIN_WALL_MASK12 = 1;
+var DEFAULT_TERRAIN_WALL_MASK13 = 1;
 var DEFAULT_TERRAIN_SWAMP_MASK4 = 2;
 var SOURCE_SCORE = 150;
 var DUAL_SOURCE_BONUS2 = 260;
@@ -28141,7 +28458,7 @@ function scoreTerrain(roomName, details) {
     details.push("terrain unknown");
     return 0;
   }
-  const wallMask = (_a = getGlobalNumber12("TERRAIN_MASK_WALL")) != null ? _a : DEFAULT_TERRAIN_WALL_MASK12;
+  const wallMask = (_a = getGlobalNumber12("TERRAIN_MASK_WALL")) != null ? _a : DEFAULT_TERRAIN_WALL_MASK13;
   const swampMask = (_b = getGlobalNumber12("TERRAIN_MASK_SWAMP")) != null ? _b : DEFAULT_TERRAIN_SWAMP_MASK4;
   let total = 0;
   let walls = 0;
@@ -30196,6 +30513,150 @@ function refreshReserveExecutionTargets(options = {}) {
   return refreshTerritoryExecutionTargets("reserve", options);
 }
 
+// src/territory/towerConstructionExecutor.ts
+var EXPANSION_TOWER_CONSTRUCTION_MIN_RCL = 3;
+var EXPANSION_TOWER_CONSTRUCTION_MIN_ENERGY = 1;
+var OK_CODE14 = 0;
+var ERR_FULL_CODE5 = -8;
+var ERR_RCL_NOT_ENOUGH_CODE2 = -14;
+var FALLBACK_TOWER_LIMITS_BY_RCL = [0, 0, 0, 1, 1, 2, 2, 3, 6];
+function runTowerConstructionExecutorForColony(colony, options = {}) {
+  var _a;
+  const room = colony.room;
+  if (options.requireExpansionMemory === true && !isExpansionControlledRoom(room.name)) {
+    return { roomName: room.name, status: "skipped", reason: "notExpansionRoom" };
+  }
+  if (((_a = room.controller) == null ? void 0 : _a.my) !== true) {
+    return { roomName: room.name, status: "skipped", reason: "roomNotClaimed" };
+  }
+  if (!hasTowerConstructionExecutorApis(room)) {
+    return { roomName: room.name, status: "skipped", reason: "apiUnavailable" };
+  }
+  const rcl = getOwnedRoomRcl3(room);
+  if (rcl < EXPANSION_TOWER_CONSTRUCTION_MIN_RCL) {
+    return { roomName: room.name, status: "skipped", reason: "controllerLevelLow" };
+  }
+  const minEnergyAvailable = resolveNonNegativeInteger3(
+    options.minEnergyAvailable,
+    EXPANSION_TOWER_CONSTRUCTION_MIN_ENERGY
+  );
+  if (getColonyEnergyAvailable(colony) < minEnergyAvailable) {
+    return { roomName: room.name, status: "skipped", reason: "energyUnavailable" };
+  }
+  const towerLimit = getTowerLimitForRcl2(rcl);
+  const plannedTowerCount = countExistingAndPendingTowers(room);
+  if (towerLimit <= 0 || plannedTowerCount >= towerLimit) {
+    return { roomName: room.name, status: "skipped", reason: "towerCapacityCovered" };
+  }
+  const structureType = getStructureConstant3("STRUCTURE_TOWER", "tower");
+  const placements = planExpansionTowerPlacements(room, {
+    maxPlacements: options.maxPlacementCandidates
+  });
+  for (const placement of placements) {
+    const result = room.createConstructionSite(placement.x, placement.y, structureType);
+    if (result === OK_CODE14) {
+      return {
+        roomName: room.name,
+        status: "created",
+        result,
+        x: placement.x,
+        y: placement.y
+      };
+    }
+    if (isFatalConstructionSiteResult2(result)) {
+      return { roomName: room.name, status: "skipped", reason: "noPlacement", result };
+    }
+  }
+  return { roomName: room.name, status: "skipped", reason: "noPlacement" };
+}
+function isExpansionControlledRoom(roomName) {
+  var _a, _b, _c, _d;
+  const territoryMemory = (_a = globalThis.Memory) == null ? void 0 : _a.territory;
+  if (!territoryMemory) {
+    return false;
+  }
+  if (isRecord28((_b = territoryMemory.postClaimBootstraps) == null ? void 0 : _b[roomName])) {
+    return true;
+  }
+  const claimedRoomRecord = (_d = (_c = territoryMemory.claimedRoomBootstrapper) == null ? void 0 : _c.rooms) == null ? void 0 : _d[roomName];
+  if ((claimedRoomRecord == null ? void 0 : claimedRoomRecord.claimedAt) !== void 0) {
+    return true;
+  }
+  return hasExpansionControlReference(territoryMemory.targets, roomName, "roomName") || hasExpansionControlReference(territoryMemory.intents, roomName, "targetRoom");
+}
+function hasExpansionControlReference(records, roomName, roomKey) {
+  return Array.isArray(records) ? records.some(
+    (record) => isRecord28(record) && record[roomKey] === roomName && (record.action === "claim" || record.action === "reserve")
+  ) : false;
+}
+function hasTowerConstructionExecutorApis(room) {
+  return typeof room.find === "function" && typeof room.createConstructionSite === "function";
+}
+function getOwnedRoomRcl3(room) {
+  var _a;
+  const level = (_a = room.controller) == null ? void 0 : _a.level;
+  return typeof level === "number" && Number.isFinite(level) ? Math.max(0, Math.floor(level)) : 0;
+}
+function getColonyEnergyAvailable(colony) {
+  return Math.max(
+    0,
+    Math.floor(
+      Number.isFinite(colony.energyAvailable) ? colony.energyAvailable : typeof colony.room.energyAvailable === "number" ? colony.room.energyAvailable : 0
+    )
+  );
+}
+function getTowerLimitForRcl2(rcl) {
+  var _a, _b;
+  const normalizedRcl = Math.max(0, Math.floor(rcl));
+  const structureType = getStructureConstant3("STRUCTURE_TOWER", "tower");
+  const controllerStructures = globalThis.CONTROLLER_STRUCTURES;
+  const configuredLimit = (_a = controllerStructures == null ? void 0 : controllerStructures[structureType]) == null ? void 0 : _a[normalizedRcl];
+  if (typeof configuredLimit === "number" && Number.isFinite(configuredLimit)) {
+    return Math.max(0, Math.floor(configuredLimit));
+  }
+  return (_b = FALLBACK_TOWER_LIMITS_BY_RCL[normalizedRcl]) != null ? _b : 0;
+}
+function countExistingAndPendingTowers(room) {
+  return findRoomObjects19(room, "FIND_MY_STRUCTURES").filter(isTowerLike).length + findRoomObjects19(room, "FIND_MY_CONSTRUCTION_SITES").filter(isTowerLike).length;
+}
+function findRoomObjects19(room, globalName) {
+  const findConstant = getGlobalNumber13(globalName);
+  if (findConstant === null || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function isTowerLike(object) {
+  return object.structureType === getStructureConstant3("STRUCTURE_TOWER", "tower");
+}
+function getStructureConstant3(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function getGlobalNumber13(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : null;
+}
+function getGlobalReturnCode2(name, fallback) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : fallback;
+}
+function isFatalConstructionSiteResult2(result) {
+  return result === getGlobalReturnCode2("ERR_FULL", ERR_FULL_CODE5) || result === getGlobalReturnCode2("ERR_RCL_NOT_ENOUGH", ERR_RCL_NOT_ENOUGH_CODE2);
+}
+function resolveNonNegativeInteger3(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : fallback;
+}
+function isRecord28(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/strategy/strategyRecommender.ts
 var DEFAULT_STRATEGY_RECOMMENDATION_CONFIDENCE_THRESHOLD = 0.7;
 var MAX_RECOMMENDATIONS = 5;
@@ -30324,11 +30785,11 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
       return creep.memory.colony === room.name || ((_a2 = creep.room) == null ? void 0 : _a2.name) === room.name;
     }
   );
-  const hostileCreeps = findRoomObjects19(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects19(room, "FIND_HOSTILE_STRUCTURES");
-  const ownedStructures = findRoomObjects19(room, "FIND_MY_STRUCTURES");
-  const constructionSites = findRoomObjects19(room, "FIND_MY_CONSTRUCTION_SITES");
-  const sources = findRoomObjects19(room, "FIND_SOURCES");
+  const hostileCreeps = findRoomObjects20(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects20(room, "FIND_HOSTILE_STRUCTURES");
+  const ownedStructures = findRoomObjects20(room, "FIND_MY_STRUCTURES");
+  const constructionSites = findRoomObjects20(room, "FIND_MY_CONSTRUCTION_SITES");
+  const sources = findRoomObjects20(room, "FIND_SOURCES");
   return {
     roomName: room.name,
     controllerLevel: (_a = room.controller) == null ? void 0 : _a.level,
@@ -30419,7 +30880,7 @@ function buildMemoryTerritoryState(roomName) {
   const expansionCandidates = [];
   if (Array.isArray(targets)) {
     for (const target of targets) {
-      if (!isRecord28(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+      if (!isRecord29(target) || target.colony !== roomName || typeof target.roomName !== "string") {
         continue;
       }
       const action = normalizeTerritoryAction(target.action);
@@ -30481,12 +30942,12 @@ function countVisibleOwnedRooms5() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord28(structure) && matchesStructureType23(structure.structureType, globalName, fallback)
+    (structure) => isRecord29(structure) && matchesStructureType23(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
   return structures.reduce((total, structure) => {
-    if (!isRecord28(structure)) {
+    if (!isRecord29(structure)) {
       return total;
     }
     const hits = finiteNumberOrNull(structure.hits);
@@ -30502,7 +30963,7 @@ function getStoredEnergy16(room) {
   return getEnergyInStore2(storage);
 }
 function getEnergyInStore2(object) {
-  if (!isRecord28(object) || !isRecord28(object.store)) {
+  if (!isRecord29(object) || !isRecord29(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -30513,8 +30974,8 @@ function getEnergyInStore2(object) {
   }
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
-function findRoomObjects19(room, constantName) {
-  const findConstant = getGlobalNumber13(constantName);
+function findRoomObjects20(room, constantName) {
+  const findConstant = getGlobalNumber14(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return [];
@@ -30534,7 +30995,7 @@ function getResourceEnergy() {
   const value = globalThis.RESOURCE_ENERGY;
   return value != null ? value : "energy";
 }
-function getGlobalNumber13(name) {
+function getGlobalNumber14(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -30554,13 +31015,13 @@ function finiteNumberOrZero(value) {
 function finiteNumberOrNull(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function isRecord28(value) {
+function isRecord29(value) {
   return typeof value === "object" && value !== null;
 }
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
-var OK_CODE14 = 0;
+var OK_CODE15 = 0;
 var BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 var NEXT_EXPANSION_SCORING_REFRESH_INTERVAL = 50;
 var NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS = 5e3;
@@ -30597,6 +31058,7 @@ function runEconomy(preludeTelemetryEvents = []) {
       }
     );
     refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
+    runTowerConstructionExecutorForColony(colony, { requireExpansionMemory: true });
     planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
     if (survivalAssessment.mode === "TERRITORY_READY") {
       refreshRemoteMiningSetup(colony, Game.time);
@@ -30638,7 +31100,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         telemetryEvents,
         coordinatedPlan.spawns
       );
-      if (!outcome || outcome.result !== OK_CODE14) {
+      if (!outcome || outcome.result !== OK_CODE15) {
         break;
       }
       const spawnRoomName = (_b = (_a = outcome.spawn.room) == null ? void 0 : _a.name) != null ? _b : "unknown";
@@ -30750,7 +31212,7 @@ function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom
     telemetryEvents,
     candidateSpawns
   );
-  if (!outcome || outcome.result !== OK_CODE14) {
+  if (!outcome || outcome.result !== OK_CODE15) {
     return;
   }
   recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
@@ -30782,7 +31244,7 @@ function attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSp
     }
     const bodyCost = getBodyCost(spawnRequest.body);
     const outcome = attemptSpawnRequest(spawnRequest, roomName, telemetryEvents, candidateSpawns);
-    if (!outcome || outcome.result !== OK_CODE14) {
+    if (!outcome || outcome.result !== OK_CODE15) {
       continue;
     }
     recordUsedSpawn(usedSpawnsByRoom, roomName, outcome.spawn);
@@ -30870,13 +31332,13 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber10(refreshedAt) || !isRecord29(rawSelection) || !isNonEmptyString28(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber10(refreshedAt) || !isRecord30(rawSelection) || !isNonEmptyString28(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord29(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord30(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
@@ -30917,7 +31379,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord29(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord30(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -30955,28 +31417,28 @@ function getGclLevel6() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord29(records)) {
+  if (!isRecord30(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord29(record) && record.status !== "ready"
+    (record) => isRecord30(record) && record.status !== "ready"
   ).length;
 }
 function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel;
-  if (!isRecord29(records)) {
+  if (!isRecord30(records)) {
     return 0;
   }
   let latestUpdatedAt = 0;
   for (const record of Object.values(records)) {
-    if (isRecord29(record) && record.colony === colony && isFiniteNumber10(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
+    if (isRecord30(record) && record.colony === colony && isFiniteNumber10(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
       latestUpdatedAt = record.updatedAt;
     }
   }
   return latestUpdatedAt;
 }
-function isRecord29(value) {
+function isRecord30(value) {
   return typeof value === "object" && value !== null;
 }
 function isNonEmptyString28(value) {
@@ -32260,10 +32722,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord30(rawReplay)) {
+  if (!isRecord31(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString29(rawReplay.replayId) || !isNonEmptyString29(rawReplay.room) || !isFiniteNumber11(rawReplay.startTick) || !isFiniteNumber11(rawReplay.endTick) || !isFiniteNumber11(rawReplay.finalScore) || !isRecord30(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString29(rawReplay.replayId) || !isNonEmptyString29(rawReplay.room) || !isFiniteNumber11(rawReplay.startTick) || !isFiniteNumber11(rawReplay.endTick) || !isFiniteNumber11(rawReplay.finalScore) || !isRecord31(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -32288,7 +32750,7 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord30(value) {
+function isRecord31(value) {
   return typeof value === "object" && value !== null;
 }
 function isNonEmptyString29(value) {

--- a/prod/src/defense/defensePlanner.ts
+++ b/prod/src/defense/defensePlanner.ts
@@ -7,6 +7,8 @@ const HOSTILES_PER_DEFENDER = 3;
 const MAX_CREEP_PARTS = 50;
 export const SAFE_MODE_HOSTILE_COUNT_THRESHOLD = 2;
 export const CRITICAL_SPAWN_LOSS_HITS_RATIO = 0.25;
+export const TOWER_CONTROLLER_THREAT_RANGE = 3;
+export const TOWER_STRUCTURE_THREAT_RANGE = 3;
 
 export type DefenseTarget = Creep | Structure;
 
@@ -36,6 +38,11 @@ export interface SafeModePlanInput {
   controller?: StructureController;
   hostileCreeps: Creep[];
   ownedSpawns: StructureSpawn[];
+}
+
+export interface TowerAttackTargetOptions {
+  controller?: StructureController;
+  protectedStructures?: Structure[];
 }
 
 export function hasDefensePressure(summary: DefensePressureSummary): boolean {
@@ -100,10 +107,23 @@ export function planDefenderSpawn(input: DefenderSpawnPlanInput): DefenderSpawnP
 export function selectTowerAttackTarget(
   origin: { pos?: RoomPosition },
   hostileCreeps: Creep[],
-  hostileStructures: Structure[]
+  hostileStructures: Structure[],
+  options: TowerAttackTargetOptions = {}
 ): DefenseTarget | null {
+  const controller = options.controller ?? (origin as { room?: Room }).room?.controller;
+  const protectedStructures = options.protectedStructures ?? [];
+  const sameRoomHostileCreeps = hostileCreeps.filter((hostile) => isTargetInOriginRoom(origin, hostile));
+
   return (
-    selectClosestTarget(origin, hostileCreeps, { sameRoomOnly: true }) ??
+    selectClosestTarget(
+      origin,
+      sameRoomHostileCreeps.filter((hostile) => isHostileNearController(hostile, controller))
+    ) ??
+    selectClosestTarget(
+      origin,
+      sameRoomHostileCreeps.filter((hostile) => isHostileNearProtectedStructure(hostile, protectedStructures))
+    ) ??
+    selectClosestTarget(origin, sameRoomHostileCreeps) ??
     selectClosestTarget(origin, hostileStructures, { sameRoomOnly: true })
   );
 }
@@ -170,6 +190,32 @@ function isTargetInOriginRoom(origin: { pos?: RoomPosition }, target: { pos?: Ro
   return origin.pos.roomName === target.pos.roomName;
 }
 
+function isHostileNearController(
+  hostile: { pos?: RoomPosition },
+  controller: StructureController | undefined
+): boolean {
+  if (!controller?.pos || !hostile.pos || hostile.pos.roomName !== controller.pos.roomName) {
+    return false;
+  }
+
+  return getRangeBetweenPositions(hostile.pos, controller.pos) <= TOWER_CONTROLLER_THREAT_RANGE;
+}
+
+function isHostileNearProtectedStructure(
+  hostile: { pos?: RoomPosition },
+  structures: Structure[]
+): boolean {
+  if (!hostile.pos) {
+    return false;
+  }
+
+  return structures.some(
+    (structure) =>
+      structure.pos?.roomName === hostile.pos?.roomName &&
+      getRangeBetweenPositions(hostile.pos as RoomPosition, structure.pos) <= TOWER_STRUCTURE_THREAT_RANGE
+  );
+}
+
 function compareRange(
   origin: { pos?: RoomPosition },
   left: { pos?: RoomPosition },
@@ -183,6 +229,10 @@ function compareRange(
   const leftRange = left.pos ? getRangeTo.call(origin.pos, left.pos) : Infinity;
   const rightRange = right.pos ? getRangeTo.call(origin.pos, right.pos) : Infinity;
   return leftRange - rightRange;
+}
+
+function getRangeBetweenPositions(left: RoomPosition, right: RoomPosition): number {
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
 }
 
 function compareObjectIds(left: unknown, right: unknown): number {

--- a/prod/src/defense/towerManager.ts
+++ b/prod/src/defense/towerManager.ts
@@ -3,6 +3,7 @@ import {
   buildDefenseTelemetryContext,
   compareObjectIds,
   findMyCreeps,
+  findOwnedStructures,
   getEnergyResource,
   getObjectId,
   getOwnedTowers,
@@ -103,7 +104,10 @@ function runTowerAttack(
 
   const target =
     selectPriorityTowerAttackTarget(tower, priorityTargetGroups) ??
-    selectTowerAttackTarget(tower, context.hostileCreeps, context.hostileStructures);
+    selectTowerAttackTarget(tower, context.hostileCreeps, context.hostileStructures, {
+      controller: context.room.controller,
+      protectedStructures: findOwnedStructures(context.room)
+    });
   if (!target) {
     return false;
   }
@@ -139,7 +143,11 @@ function selectPriorityTowerAttackTarget(
     const target = selectTowerAttackTarget(
       tower,
       group.hostileCreeps.filter((creep) => creep.room?.name === tower.room.name),
-      group.hostileStructures.filter((structure) => structure.room?.name === tower.room.name)
+      group.hostileStructures.filter((structure) => structure.room?.name === tower.room.name),
+      {
+        controller: tower.room.controller,
+        protectedStructures: findOwnedStructures(tower.room)
+      }
     );
     if (target) {
       return target;

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -92,6 +92,7 @@ import {
   logBestClaimTarget,
   runTerritoryControllerCreep
 } from '../territory/territoryRunner';
+import { runTowerConstructionExecutorForColony } from '../territory/towerConstructionExecutor';
 import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgrader';
 import { refreshControllerManagement } from '../territory/controllerManager';
 import {
@@ -175,6 +176,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
       }
     );
     refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
+    runTowerConstructionExecutorForColony(colony, { requireExpansionMemory: true });
     planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
     if (survivalAssessment.mode === 'TERRITORY_READY') {
       refreshRemoteMiningSetup(colony, Game.time);

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -10,6 +10,14 @@ const ERR_NO_PATH_CODE = -2 as ScreepsReturnCode;
 const SOURCE_SCORE_WEIGHT = 1_000;
 const DISTANCE_SCORE_WEIGHT = 100;
 export const EXPANSION_PLANNER_TARGET_CREATOR = 'expansionPlanner';
+export const EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS = 6;
+
+const EXPANSION_TOWER_ROOM_EDGE_MIN = 1;
+const EXPANSION_TOWER_ROOM_EDGE_MAX = 48;
+const EXPANSION_TOWER_CONTROLLER_WEIGHT = 6;
+const EXPANSION_TOWER_SOURCE_WEIGHT = 3;
+const EXPANSION_TOWER_ENTRANCE_WEIGHT = 1;
+const DEFAULT_TERRAIN_WALL_MASK = 1;
 
 type TerminalExpansionIntentStatus = Extract<TerritoryIntentMemory['status'], 'inactive' | 'completed'>;
 
@@ -97,6 +105,45 @@ interface ExpansionReservationUpgradeContext {
   colony: string;
   targetRoom: string;
   action: TerritoryControlAction;
+}
+
+export type ExpansionTowerPlacementAnchorKind = 'controller' | 'source' | 'entrance';
+
+export interface ExpansionTowerPlacementOptions {
+  maxPlacements?: number;
+}
+
+export interface ExpansionTowerPlacement {
+  roomName: string;
+  x: number;
+  y: number;
+  score: number;
+  controllerRange?: number;
+  nearestSourceRange?: number;
+  nearestEntranceRange?: number;
+}
+
+interface ExpansionTowerAnchor {
+  kind: ExpansionTowerPlacementAnchorKind;
+  position: RoomPositionLike;
+  weight: number;
+}
+
+interface RoomPositionLike {
+  x: number;
+  y: number;
+  roomName?: string;
+}
+
+interface ExpansionTowerPlacementLookups {
+  terrain: RoomTerrain | null;
+  blockedPositions: Set<string>;
+  anchors: ExpansionTowerAnchor[];
+}
+
+interface ExitGroup {
+  side: 'top' | 'right' | 'bottom' | 'left';
+  positions: RoomPositionLike[];
 }
 
 export function evaluateExpansionRoomSuitability(
@@ -480,6 +527,396 @@ export function createExpansionIntent(
     score: candidate.score,
     ...(candidate.controllerId ? { controllerId: candidate.controllerId } : {})
   };
+}
+
+export function planExpansionTowerPlacements(
+  room: Room,
+  options: ExpansionTowerPlacementOptions = {}
+): ExpansionTowerPlacement[] {
+  if (!isNonEmptyString(room.name)) {
+    return [];
+  }
+
+  const lookups = createExpansionTowerPlacementLookups(room);
+  if (lookups.anchors.length === 0) {
+    return [];
+  }
+
+  const placements: ExpansionTowerPlacement[] = [];
+  for (let y = EXPANSION_TOWER_ROOM_EDGE_MIN; y <= EXPANSION_TOWER_ROOM_EDGE_MAX; y += 1) {
+    for (let x = EXPANSION_TOWER_ROOM_EDGE_MIN; x <= EXPANSION_TOWER_ROOM_EDGE_MAX; x += 1) {
+      const position = { x, y, roomName: room.name };
+      if (!canPlaceExpansionTower(lookups, position)) {
+        continue;
+      }
+
+      placements.push(scoreExpansionTowerPlacement(position, lookups.anchors, room.name));
+    }
+  }
+
+  return placements
+    .sort(compareExpansionTowerPlacements)
+    .slice(0, getExpansionTowerMaxPlacements(options.maxPlacements));
+}
+
+function createExpansionTowerPlacementLookups(room: Room): ExpansionTowerPlacementLookups {
+  const blockedPositions = new Set<string>();
+  for (const object of [
+    room.controller,
+    ...findRoomObjects<Source>(room, getFindConstant('FIND_SOURCES')),
+    ...findRoomObjects<AnyStructure>(room, getFindConstant('FIND_STRUCTURES')),
+    ...findRoomObjects<ConstructionSite>(room, getFindConstant('FIND_CONSTRUCTION_SITES'))
+  ]) {
+    addExpansionTowerBlockedPosition(blockedPositions, object, room.name);
+  }
+
+  return {
+    terrain: getExpansionTowerRoomTerrain(room.name),
+    blockedPositions,
+    anchors: buildExpansionTowerAnchors(room)
+  };
+}
+
+function buildExpansionTowerAnchors(room: Room): ExpansionTowerAnchor[] {
+  const anchors: ExpansionTowerAnchor[] = [];
+  addExpansionTowerAnchor(
+    anchors,
+    room.controller,
+    'controller',
+    EXPANSION_TOWER_CONTROLLER_WEIGHT,
+    room.name
+  );
+
+  for (const source of findRoomObjects<Source>(room, getFindConstant('FIND_SOURCES')).sort(compareExpansionTowerObjectIds)) {
+    addExpansionTowerAnchor(anchors, source, 'source', EXPANSION_TOWER_SOURCE_WEIGHT, room.name);
+  }
+
+  for (const entrancePosition of getExpansionTowerEntranceAnchors(room)) {
+    anchors.push({
+      kind: 'entrance',
+      position: entrancePosition,
+      weight: EXPANSION_TOWER_ENTRANCE_WEIGHT
+    });
+  }
+
+  return anchors;
+}
+
+function addExpansionTowerAnchor(
+  anchors: ExpansionTowerAnchor[],
+  object: unknown,
+  kind: ExpansionTowerPlacementAnchorKind,
+  weight: number,
+  roomName: string
+): void {
+  const position = getExpansionTowerObjectPosition(object);
+  if (!isExpansionTowerSameRoomPosition(position, roomName)) {
+    return;
+  }
+
+  anchors.push({
+    kind,
+    position,
+    weight
+  });
+}
+
+function getExpansionTowerEntranceAnchors(room: Room): RoomPositionLike[] {
+  const exitPositions = findRoomObjects<RoomPosition>(room, getFindConstant('FIND_EXIT'))
+    .map(getExpansionTowerObjectPosition)
+    .filter((position): position is RoomPositionLike =>
+      isExpansionTowerSameRoomPosition(position, room.name)
+    );
+
+  if (exitPositions.length > 0) {
+    return selectRepresentativeExpansionTowerExits(exitPositions);
+  }
+
+  return getExpansionTowerFallbackEntranceAnchors(room.name);
+}
+
+function selectRepresentativeExpansionTowerExits(exitPositions: RoomPositionLike[]): RoomPositionLike[] {
+  const groups = groupExpansionTowerExits(exitPositions);
+  return groups.map((group) => {
+    const sortedPositions = [...group.positions].sort(compareExpansionTowerExitPositions);
+    const middle = sortedPositions[Math.floor(sortedPositions.length / 2)];
+    return {
+      x: middle.x,
+      y: middle.y,
+      roomName: middle.roomName
+    };
+  });
+}
+
+function groupExpansionTowerExits(exitPositions: RoomPositionLike[]): ExitGroup[] {
+  const groups: ExitGroup[] = [];
+  for (const position of [...exitPositions].sort(compareExpansionTowerExitPositions)) {
+    const side = getExpansionTowerExitSide(position);
+    if (!side) {
+      continue;
+    }
+
+    const previous = groups[groups.length - 1];
+    if (
+      previous &&
+      previous.side === side &&
+      areContiguousExpansionTowerExits(previous.positions[previous.positions.length - 1], position)
+    ) {
+      previous.positions.push(position);
+    } else {
+      groups.push({ side, positions: [position] });
+    }
+  }
+
+  return groups;
+}
+
+function getExpansionTowerFallbackEntranceAnchors(roomName: string): RoomPositionLike[] {
+  const exits = (globalThis as { Game?: Partial<Game> }).Game?.map?.describeExits?.(roomName) as
+    | Record<string, string>
+    | null
+    | undefined;
+  if (!isRecord(exits)) {
+    return [];
+  }
+
+  const anchors: RoomPositionLike[] = [];
+  if (isNonEmptyString(exits['1'])) {
+    anchors.push({ x: 25, y: 0, roomName });
+  }
+  if (isNonEmptyString(exits['3'])) {
+    anchors.push({ x: 49, y: 25, roomName });
+  }
+  if (isNonEmptyString(exits['5'])) {
+    anchors.push({ x: 25, y: 49, roomName });
+  }
+  if (isNonEmptyString(exits['7'])) {
+    anchors.push({ x: 0, y: 25, roomName });
+  }
+
+  return anchors;
+}
+
+function areContiguousExpansionTowerExits(
+  left: RoomPositionLike | undefined,
+  right: RoomPositionLike
+): boolean {
+  if (!left || getExpansionTowerExitSide(left) !== getExpansionTowerExitSide(right)) {
+    return false;
+  }
+
+  if (left.x === right.x) {
+    return Math.abs(left.y - right.y) <= 1;
+  }
+
+  if (left.y === right.y) {
+    return Math.abs(left.x - right.x) <= 1;
+  }
+
+  return false;
+}
+
+function compareExpansionTowerExitPositions(left: RoomPositionLike, right: RoomPositionLike): number {
+  const leftSide = getExpansionTowerExitSide(left) ?? '';
+  const rightSide = getExpansionTowerExitSide(right) ?? '';
+  return (
+    getExpansionTowerExitSideOrder(leftSide) - getExpansionTowerExitSideOrder(rightSide) ||
+    left.y - right.y ||
+    left.x - right.x
+  );
+}
+
+function getExpansionTowerExitSide(position: RoomPositionLike): ExitGroup['side'] | null {
+  if (position.y <= 0) {
+    return 'top';
+  }
+  if (position.x >= 49) {
+    return 'right';
+  }
+  if (position.y >= 49) {
+    return 'bottom';
+  }
+  if (position.x <= 0) {
+    return 'left';
+  }
+
+  return null;
+}
+
+function getExpansionTowerExitSideOrder(side: string): number {
+  switch (side) {
+    case 'top':
+      return 0;
+    case 'right':
+      return 1;
+    case 'bottom':
+      return 2;
+    case 'left':
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function canPlaceExpansionTower(
+  lookups: ExpansionTowerPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (
+    position.x >= EXPANSION_TOWER_ROOM_EDGE_MIN &&
+    position.x <= EXPANSION_TOWER_ROOM_EDGE_MAX &&
+    position.y >= EXPANSION_TOWER_ROOM_EDGE_MIN &&
+    position.y <= EXPANSION_TOWER_ROOM_EDGE_MAX &&
+    !lookups.blockedPositions.has(getExpansionTowerPositionKey(position)) &&
+    !isExpansionTowerTerrainWall(lookups.terrain, position)
+  );
+}
+
+function scoreExpansionTowerPlacement(
+  position: RoomPositionLike,
+  anchors: ExpansionTowerAnchor[],
+  roomName: string
+): ExpansionTowerPlacement {
+  const controllerRange = getNearestExpansionTowerAnchorRange(position, anchors, 'controller');
+  const nearestSourceRange = getNearestExpansionTowerAnchorRange(position, anchors, 'source');
+  const nearestEntranceRange = getNearestExpansionTowerAnchorRange(position, anchors, 'entrance');
+  return {
+    roomName,
+    x: position.x,
+    y: position.y,
+    score: anchors.reduce(
+      (score, anchor) => score + getExpansionTowerRange(position, anchor.position) * anchor.weight,
+      0
+    ),
+    ...(controllerRange !== null ? { controllerRange } : {}),
+    ...(nearestSourceRange !== null ? { nearestSourceRange } : {}),
+    ...(nearestEntranceRange !== null ? { nearestEntranceRange } : {})
+  };
+}
+
+function getNearestExpansionTowerAnchorRange(
+  position: RoomPositionLike,
+  anchors: ExpansionTowerAnchor[],
+  kind: ExpansionTowerPlacementAnchorKind
+): number | null {
+  let nearestRange: number | null = null;
+  for (const anchor of anchors) {
+    if (anchor.kind !== kind) {
+      continue;
+    }
+
+    const range = getExpansionTowerRange(position, anchor.position);
+    if (nearestRange === null || range < nearestRange) {
+      nearestRange = range;
+    }
+  }
+
+  return nearestRange;
+}
+
+function compareExpansionTowerPlacements(
+  left: ExpansionTowerPlacement,
+  right: ExpansionTowerPlacement
+): number {
+  return (
+    left.score - right.score ||
+    compareOptionalNumbers(left.controllerRange, right.controllerRange) ||
+    compareOptionalNumbers(left.nearestSourceRange, right.nearestSourceRange) ||
+    compareOptionalNumbers(left.nearestEntranceRange, right.nearestEntranceRange) ||
+    left.y - right.y ||
+    left.x - right.x
+  );
+}
+
+function addExpansionTowerBlockedPosition(
+  blockedPositions: Set<string>,
+  object: unknown,
+  roomName: string
+): void {
+  const position = getExpansionTowerObjectPosition(object);
+  if (isExpansionTowerSameRoomPosition(position, roomName)) {
+    blockedPositions.add(getExpansionTowerPositionKey(position));
+  }
+}
+
+function getExpansionTowerObjectPosition(object: unknown): RoomPositionLike | null {
+  if (!isRecord(object)) {
+    return null;
+  }
+
+  if (typeof object.x === 'number' && Number.isFinite(object.x) && typeof object.y === 'number' && Number.isFinite(object.y)) {
+    return {
+      x: object.x,
+      y: object.y,
+      ...(typeof object.roomName === 'string' ? { roomName: object.roomName } : {})
+    };
+  }
+
+  const position = object.pos;
+  if (
+    isRecord(position) &&
+    typeof position.x === 'number' &&
+    Number.isFinite(position.x) &&
+    typeof position.y === 'number' &&
+    Number.isFinite(position.y)
+  ) {
+    return {
+      x: position.x,
+      y: position.y,
+      ...(typeof position.roomName === 'string' ? { roomName: position.roomName } : {})
+    };
+  }
+
+  return null;
+}
+
+function isExpansionTowerSameRoomPosition(
+  position: RoomPositionLike | null,
+  roomName: string
+): position is RoomPositionLike {
+  return position !== null && (position.roomName === undefined || position.roomName === roomName);
+}
+
+function getExpansionTowerRange(left: RoomPositionLike, right: RoomPositionLike): number {
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
+}
+
+function getExpansionTowerPositionKey(position: RoomPositionLike): string {
+  return `${position.x},${position.y}`;
+}
+
+function getExpansionTowerRoomTerrain(roomName: string): RoomTerrain | null {
+  const gameMap = (globalThis as { Game?: Partial<Game> }).Game?.map;
+  return typeof gameMap?.getRoomTerrain === 'function' ? gameMap.getRoomTerrain(roomName) : null;
+}
+
+function isExpansionTowerTerrainWall(terrain: RoomTerrain | null, position: RoomPositionLike): boolean {
+  return terrain !== null && (terrain.get(position.x, position.y) & getExpansionTowerTerrainWallMask()) !== 0;
+}
+
+function getExpansionTowerTerrainWallMask(): number {
+  const terrainWallMask = (globalThis as { TERRAIN_MASK_WALL?: number }).TERRAIN_MASK_WALL;
+  return typeof terrainWallMask === 'number' ? terrainWallMask : DEFAULT_TERRAIN_WALL_MASK;
+}
+
+function getExpansionTowerMaxPlacements(maxPlacements: number | undefined): number {
+  if (typeof maxPlacements !== 'number' || !Number.isFinite(maxPlacements)) {
+    return EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS;
+  }
+
+  return Math.max(1, Math.floor(maxPlacements));
+}
+
+function compareExpansionTowerObjectIds(left: unknown, right: unknown): number {
+  return getExpansionTowerObjectId(left).localeCompare(getExpansionTowerObjectId(right));
+}
+
+function getExpansionTowerObjectId(object: unknown): string {
+  if (!isRecord(object)) {
+    return '';
+  }
+
+  return typeof object.id === 'string' ? object.id : '';
 }
 
 function evaluateExpansionSuitability({

--- a/prod/src/territory/towerConstructionExecutor.ts
+++ b/prod/src/territory/towerConstructionExecutor.ts
@@ -1,0 +1,228 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import { planExpansionTowerPlacements } from './expansionPlanner';
+
+export const EXPANSION_TOWER_CONSTRUCTION_MIN_RCL = 3;
+export const EXPANSION_TOWER_CONSTRUCTION_MIN_ENERGY = 1;
+
+const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_FULL_CODE = -8 as ScreepsReturnCode;
+const ERR_RCL_NOT_ENOUGH_CODE = -14 as ScreepsReturnCode;
+const FALLBACK_TOWER_LIMITS_BY_RCL = [0, 0, 0, 1, 1, 2, 2, 3, 6];
+
+type FindConstantGlobal = 'FIND_MY_STRUCTURES' | 'FIND_MY_CONSTRUCTION_SITES';
+type StructureConstantGlobal = 'STRUCTURE_TOWER';
+type ReturnCodeGlobal = 'ERR_FULL' | 'ERR_RCL_NOT_ENOUGH';
+
+export type TowerConstructionExecutorStatus = 'created' | 'skipped';
+export type TowerConstructionExecutorSkipReason =
+  | 'apiUnavailable'
+  | 'controllerLevelLow'
+  | 'energyUnavailable'
+  | 'notExpansionRoom'
+  | 'roomNotClaimed'
+  | 'towerCapacityCovered'
+  | 'noPlacement';
+
+export interface TowerConstructionExecutorOptions {
+  requireExpansionMemory?: boolean;
+  minEnergyAvailable?: number;
+  maxPlacementCandidates?: number;
+}
+
+export interface TowerConstructionExecutorResult {
+  roomName: string;
+  status: TowerConstructionExecutorStatus;
+  reason?: TowerConstructionExecutorSkipReason;
+  result?: ScreepsReturnCode;
+  x?: number;
+  y?: number;
+}
+
+export function runTowerConstructionExecutorForColony(
+  colony: ColonySnapshot,
+  options: TowerConstructionExecutorOptions = {}
+): TowerConstructionExecutorResult {
+  const room = colony.room;
+  if (options.requireExpansionMemory === true && !isExpansionControlledRoom(room.name)) {
+    return { roomName: room.name, status: 'skipped', reason: 'notExpansionRoom' };
+  }
+
+  if (room.controller?.my !== true) {
+    return { roomName: room.name, status: 'skipped', reason: 'roomNotClaimed' };
+  }
+
+  if (!hasTowerConstructionExecutorApis(room)) {
+    return { roomName: room.name, status: 'skipped', reason: 'apiUnavailable' };
+  }
+
+  const rcl = getOwnedRoomRcl(room);
+  if (rcl < EXPANSION_TOWER_CONSTRUCTION_MIN_RCL) {
+    return { roomName: room.name, status: 'skipped', reason: 'controllerLevelLow' };
+  }
+
+  const minEnergyAvailable = resolveNonNegativeInteger(
+    options.minEnergyAvailable,
+    EXPANSION_TOWER_CONSTRUCTION_MIN_ENERGY
+  );
+  if (getColonyEnergyAvailable(colony) < minEnergyAvailable) {
+    return { roomName: room.name, status: 'skipped', reason: 'energyUnavailable' };
+  }
+
+  const towerLimit = getTowerLimitForRcl(rcl);
+  const plannedTowerCount = countExistingAndPendingTowers(room);
+  if (towerLimit <= 0 || plannedTowerCount >= towerLimit) {
+    return { roomName: room.name, status: 'skipped', reason: 'towerCapacityCovered' };
+  }
+
+  const structureType = getStructureConstant('STRUCTURE_TOWER', 'tower');
+  const placements = planExpansionTowerPlacements(room, {
+    maxPlacements: options.maxPlacementCandidates
+  });
+  for (const placement of placements) {
+    const result = room.createConstructionSite(placement.x, placement.y, structureType);
+    if (result === OK_CODE) {
+      return {
+        roomName: room.name,
+        status: 'created',
+        result,
+        x: placement.x,
+        y: placement.y
+      };
+    }
+
+    if (isFatalConstructionSiteResult(result)) {
+      return { roomName: room.name, status: 'skipped', reason: 'noPlacement', result };
+    }
+  }
+
+  return { roomName: room.name, status: 'skipped', reason: 'noPlacement' };
+}
+
+function isExpansionControlledRoom(roomName: string): boolean {
+  const territoryMemory = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory;
+  if (!territoryMemory) {
+    return false;
+  }
+
+  if (isRecord(territoryMemory.postClaimBootstraps?.[roomName])) {
+    return true;
+  }
+
+  const claimedRoomRecord = territoryMemory.claimedRoomBootstrapper?.rooms?.[roomName];
+  if (claimedRoomRecord?.claimedAt !== undefined) {
+    return true;
+  }
+
+  return (
+    hasExpansionControlReference(territoryMemory.targets, roomName, 'roomName') ||
+    hasExpansionControlReference(territoryMemory.intents, roomName, 'targetRoom')
+  );
+}
+
+function hasExpansionControlReference(
+  records: unknown,
+  roomName: string,
+  roomKey: 'roomName' | 'targetRoom'
+): boolean {
+  return Array.isArray(records)
+    ? records.some(
+        (record) =>
+          isRecord(record) &&
+          record[roomKey] === roomName &&
+          (record.action === 'claim' || record.action === 'reserve')
+      )
+    : false;
+}
+
+function hasTowerConstructionExecutorApis(room: Room): boolean {
+  return typeof room.find === 'function' && typeof room.createConstructionSite === 'function';
+}
+
+function getOwnedRoomRcl(room: Room): number {
+  const level = room.controller?.level;
+  return typeof level === 'number' && Number.isFinite(level) ? Math.max(0, Math.floor(level)) : 0;
+}
+
+function getColonyEnergyAvailable(colony: ColonySnapshot): number {
+  return Math.max(
+    0,
+    Math.floor(
+      Number.isFinite(colony.energyAvailable)
+        ? colony.energyAvailable
+        : typeof colony.room.energyAvailable === 'number'
+          ? colony.room.energyAvailable
+          : 0
+    )
+  );
+}
+
+function getTowerLimitForRcl(rcl: number): number {
+  const normalizedRcl = Math.max(0, Math.floor(rcl));
+  const structureType = getStructureConstant('STRUCTURE_TOWER', 'tower');
+  const controllerStructures = (globalThis as { CONTROLLER_STRUCTURES?: Partial<Record<string, number[]>> })
+    .CONTROLLER_STRUCTURES;
+  const configuredLimit = controllerStructures?.[structureType]?.[normalizedRcl];
+  if (typeof configuredLimit === 'number' && Number.isFinite(configuredLimit)) {
+    return Math.max(0, Math.floor(configuredLimit));
+  }
+
+  return FALLBACK_TOWER_LIMITS_BY_RCL[normalizedRcl] ?? 0;
+}
+
+function countExistingAndPendingTowers(room: Room): number {
+  return (
+    findRoomObjects<AnyOwnedStructure>(room, 'FIND_MY_STRUCTURES').filter(isTowerLike).length +
+    findRoomObjects<ConstructionSite>(room, 'FIND_MY_CONSTRUCTION_SITES').filter(isTowerLike).length
+  );
+}
+
+function findRoomObjects<T>(room: Room, globalName: FindConstantGlobal): T[] {
+  const findConstant = getGlobalNumber(globalName);
+  if (findConstant === null || typeof room.find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = room.find(findConstant as FindConstant);
+    return Array.isArray(result) ? (result as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function isTowerLike(object: { structureType?: unknown }): boolean {
+  return object.structureType === getStructureConstant('STRUCTURE_TOWER', 'tower');
+}
+
+function getStructureConstant(
+  globalName: StructureConstantGlobal,
+  fallback: string
+): BuildableStructureConstant {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, BuildableStructureConstant>>;
+  return constants[globalName] ?? (fallback as BuildableStructureConstant);
+}
+
+function getGlobalNumber(name: FindConstantGlobal): number | null {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : null;
+}
+
+function getGlobalReturnCode(name: ReturnCodeGlobal, fallback: ScreepsReturnCode): ScreepsReturnCode {
+  const value = (globalThis as Partial<Record<ReturnCodeGlobal, ScreepsReturnCode>>)[name];
+  return typeof value === 'number' ? value : fallback;
+}
+
+function isFatalConstructionSiteResult(result: ScreepsReturnCode): boolean {
+  return (
+    result === getGlobalReturnCode('ERR_FULL', ERR_FULL_CODE) ||
+    result === getGlobalReturnCode('ERR_RCL_NOT_ENOUGH', ERR_RCL_NOT_ENOUGH_CODE)
+  );
+}
+
+function resolveNonNegativeInteger(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/prod/test/defense.test.ts
+++ b/prod/test/defense.test.ts
@@ -72,6 +72,18 @@ describe('automatic room defense response', () => {
     expect(rightTower.attack).toHaveBeenCalledWith(rightHostile);
   });
 
+  it('prioritizes hostiles near an owned controller before closer generic tower targets', () => {
+    const nearHostile = makeHostile('near-hostile', 21, 20);
+    const controllerHostile = makeHostile('controller-hostile', 26, 25);
+    const tower = makeTower('tower1', { energy: 500, x: 20, y: 20 });
+    const room = makeRoom({ hostiles: [nearHostile, controllerHostile], structures: [tower] });
+    attachRoom([tower], room);
+
+    runTowers(room);
+
+    expect(tower.attack).toHaveBeenCalledWith(controllerHostile);
+  });
+
   it('keeps low-energy towers from healing or repairing so attack reserve is preserved', () => {
     const wounded = makeFriendlyCreep('worker1', 25, 25, 70, 100);
     const spawn = makeSpawn('spawn1', 1_000, 5_000);

--- a/prod/test/defensePlanner.test.ts
+++ b/prod/test/defensePlanner.test.ts
@@ -132,6 +132,28 @@ describe('defensePlanner', () => {
     expect(selectTowerAttackTarget(tower, [crossRoomHostile], [closerStructure])).toBe(closerStructure);
   });
 
+  it('prioritizes hostile creeps near owned controllers before nearer room hostiles', () => {
+    const controller = makeController({ safeModeAvailable: 1 });
+    const tower = { pos: makePosition(20, 20, 'W1N1'), room: { controller } };
+    const nearestHostile = makeCreep('nearest-hostile', 21, 20, 'W1N1');
+    const controllerHostile = makeCreep('controller-hostile', 26, 25, 'W1N1');
+
+    expect(selectTowerAttackTarget(tower, [nearestHostile, controllerHostile], [])).toBe(controllerHostile);
+  });
+
+  it('prioritizes hostile creeps pressuring owned structures before generic nearest hostiles', () => {
+    const tower = { pos: makePosition(20, 20, 'W1N1') };
+    const nearestHostile = makeCreep('nearest-hostile', 21, 20, 'W1N1');
+    const structureHostile = makeCreep('structure-hostile', 30, 30, 'W1N1');
+    const protectedStructure = makeStructure('spawn1', 31, 30, 'W1N1');
+
+    expect(
+      selectTowerAttackTarget(tower, [nearestHostile, structureHostile], [], {
+        protectedStructures: [protectedStructure]
+      })
+    ).toBe(structureHostile);
+  });
+
   it('selects defender attack targets by hostile creep priority before hostile structures', () => {
     const defender = { pos: makePosition(25, 25, 'W1N1') };
     const farHostile = makeCreep('hostile1', 40, 25, 'W1N1');

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -5,6 +5,7 @@ import {
   createExpansionIntent,
   evaluateExpansionCandidate,
   evaluateExpansionRoomSuitability,
+  planExpansionTowerPlacements,
   prioritizeExpansionCandidates,
   refreshExpansionPlannerIntent
 } from '../src/territory/expansionPlanner';
@@ -15,6 +16,10 @@ describe('expansion planner', () => {
     (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
     (globalThis as unknown as { FIND_HOSTILE_CREEPS: number }).FIND_HOSTILE_CREEPS = 2;
     (globalThis as unknown as { FIND_HOSTILE_STRUCTURES: number }).FIND_HOSTILE_STRUCTURES = 3;
+    (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 4;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 5;
+    (globalThis as unknown as { FIND_EXIT: number }).FIND_EXIT = 6;
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     delete (globalThis as { Game?: Partial<Game> }).Game;
   });
@@ -100,6 +105,45 @@ describe('expansion planner', () => {
     ]);
 
     expect(orderedCandidates.map((candidate) => candidate.roomName)).toEqual(['W4N1', 'W1N2', 'W2N1']);
+  });
+
+  it('plans valid strategic tower placements from controller, source, and entrance anchors', () => {
+    const blockedStructure = makePositionedStructure('blocking-road', 25, 24, 'W2N1');
+    const wallPositions = new Set(['24,24']);
+    const room = makeTowerPlanningRoom('W2N1', {
+      controllerPosition: { x: 25, y: 25 },
+      sourcePositions: [
+        { x: 20, y: 25 },
+        { x: 30, y: 25 }
+      ],
+      exitPositions: [
+        { x: 24, y: 0 },
+        { x: 25, y: 0 },
+        { x: 26, y: 0 }
+      ],
+      structures: [blockedStructure],
+      wallPositions
+    });
+    installTerrain(room.name, wallPositions);
+
+    const placements = planExpansionTowerPlacements(room, { maxPlacements: 3 });
+
+    expect(placements).toHaveLength(3);
+    expect(placements[0]).toMatchObject({
+      roomName: 'W2N1',
+      controllerRange: expect.any(Number),
+      nearestSourceRange: expect.any(Number),
+      nearestEntranceRange: expect.any(Number)
+    });
+    expect(placements[0].score).toBeLessThanOrEqual(placements[1].score);
+    for (const placement of placements) {
+      expect(placement.x).toBeGreaterThanOrEqual(1);
+      expect(placement.x).toBeLessThanOrEqual(48);
+      expect(placement.y).toBeGreaterThanOrEqual(1);
+      expect(placement.y).toBeLessThanOrEqual(48);
+      expect(`${placement.x},${placement.y}`).not.toBe('25,24');
+      expect(wallPositions.has(`${placement.x},${placement.y}`)).toBe(false);
+    }
   });
 
   it('creates expansion targets and intents through territory planning', () => {
@@ -890,6 +934,77 @@ function makeExpansionRoom(
       }
     })
   } as unknown as Room;
+}
+
+function makeTowerPlanningRoom(
+  roomName: string,
+  {
+    controllerPosition,
+    sourcePositions,
+    exitPositions,
+    structures = [],
+    constructionSites = [],
+    wallPositions = new Set<string>()
+  }: {
+    controllerPosition: { x: number; y: number };
+    sourcePositions: Array<{ x: number; y: number }>;
+    exitPositions: Array<{ x: number; y: number }>;
+    structures?: Structure[];
+    constructionSites?: ConstructionSite[];
+    wallPositions?: Set<string>;
+  }
+): Room {
+  const sources = sourcePositions.map((position, index) => ({
+    id: `source-${roomName}-${index}`,
+    pos: makePosition(position.x, position.y, roomName)
+  }));
+  const room = {
+    name: roomName,
+    controller: {
+      id: `controller-${roomName}` as Id<StructureController>,
+      my: true,
+      pos: makePosition(controllerPosition.x, controllerPosition.y, roomName)
+    },
+    find: jest.fn((findType: number): unknown[] => {
+      switch (findType) {
+        case FIND_SOURCES:
+          return sources;
+        case FIND_STRUCTURES:
+          return structures;
+        case FIND_CONSTRUCTION_SITES:
+          return constructionSites;
+        case FIND_EXIT:
+          return exitPositions.map((position) => makePosition(position.x, position.y, roomName));
+        default:
+          return [];
+      }
+    }),
+    __wallPositions: wallPositions
+  } as unknown as Room;
+
+  return room;
+}
+
+function makePositionedStructure(id: string, x: number, y: number, roomName: string): Structure {
+  return {
+    id,
+    pos: makePosition(x, y, roomName)
+  } as unknown as Structure;
+}
+
+function makePosition(x: number, y: number, roomName: string): RoomPosition {
+  return { x, y, roomName } as RoomPosition;
+}
+
+function installTerrain(roomName: string, wallPositions: Set<string>): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    map: {
+      getRoomTerrain: jest.fn().mockReturnValue({
+        get: jest.fn((x: number, y: number) => (wallPositions.has(`${x},${y}`) ? 1 : 0))
+      })
+    } as unknown as GameMap,
+    rooms: {}
+  };
 }
 
 function installGame(

--- a/prod/test/towerConstructionExecutor.test.ts
+++ b/prod/test/towerConstructionExecutor.test.ts
@@ -1,0 +1,167 @@
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import { runTowerConstructionExecutorForColony } from '../src/territory/towerConstructionExecutor';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+const TEST_GLOBALS = {
+  FIND_SOURCES: 1,
+  FIND_STRUCTURES: 2,
+  FIND_CONSTRUCTION_SITES: 3,
+  FIND_MY_STRUCTURES: 4,
+  FIND_MY_CONSTRUCTION_SITES: 5,
+  FIND_EXIT: 6,
+  STRUCTURE_TOWER: 'tower',
+  TERRAIN_MASK_WALL: 1,
+  OK: OK_CODE
+} as const;
+
+describe('tower construction executor', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, TEST_GLOBALS);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim', createdBy: 'expansionPlanner' }]
+      }
+    };
+  });
+
+  afterEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const key of Object.keys(TEST_GLOBALS)) {
+      delete globals[key];
+    }
+    delete globals.Game;
+    delete globals.Memory;
+  });
+
+  it('creates a tower construction site in claimed expansion rooms with open tower capacity', () => {
+    const { colony, room } = makeTowerExecutorColony();
+    installGame(room);
+
+    const result = runTowerConstructionExecutorForColony(colony, { requireExpansionMemory: true });
+
+    expect(result).toMatchObject({
+      roomName: 'W2N1',
+      status: 'created',
+      result: OK_CODE,
+      x: expect.any(Number),
+      y: expect.any(Number)
+    });
+    expect(room.createConstructionSite).toHaveBeenCalledWith(
+      result.x,
+      result.y,
+      TEST_GLOBALS.STRUCTURE_TOWER
+    );
+  });
+
+  it('does not create duplicate tower sites when capacity is already covered', () => {
+    const towerSite = makeConstructionSite('tower-site', TEST_GLOBALS.STRUCTURE_TOWER, 24, 24);
+    const { colony, room } = makeTowerExecutorColony({ constructionSites: [towerSite] });
+    installGame(room);
+
+    const result = runTowerConstructionExecutorForColony(colony, { requireExpansionMemory: true });
+
+    expect(result).toEqual({
+      roomName: 'W2N1',
+      status: 'skipped',
+      reason: 'towerCapacityCovered'
+    });
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+});
+
+interface TowerExecutorRoom extends Room {
+  find: jest.Mock;
+  createConstructionSite: jest.Mock;
+}
+
+function makeTowerExecutorColony({
+  constructionSites = []
+}: {
+  constructionSites?: ConstructionSite[];
+} = {}): { colony: ColonySnapshot; room: TowerExecutorRoom } {
+  const roomName = 'W2N1';
+  const structures: Structure[] = [];
+  const sites = [...constructionSites];
+  const sources = [
+    makeSource('source-a', 20, 25, roomName),
+    makeSource('source-b', 30, 25, roomName)
+  ];
+  const room = {
+    name: roomName,
+    energyAvailable: 300,
+    energyCapacityAvailable: 300,
+    controller: {
+      id: 'controller-W2N1' as Id<StructureController>,
+      my: true,
+      level: 3,
+      pos: makePosition(25, 25, roomName)
+    },
+    find: jest.fn((findType: number): unknown[] => {
+      switch (findType) {
+        case TEST_GLOBALS.FIND_SOURCES:
+          return sources;
+        case TEST_GLOBALS.FIND_STRUCTURES:
+        case TEST_GLOBALS.FIND_MY_STRUCTURES:
+          return structures;
+        case TEST_GLOBALS.FIND_CONSTRUCTION_SITES:
+        case TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES:
+          return sites;
+        case TEST_GLOBALS.FIND_EXIT:
+          return [makePosition(25, 0, roomName)];
+        default:
+          return [];
+      }
+    }),
+    createConstructionSite: jest.fn((x: number, y: number, structureType: BuildableStructureConstant) => {
+      sites.push(makeConstructionSite(`site-${x}-${y}`, structureType, x, y));
+      return OK_CODE;
+    })
+  } as unknown as TowerExecutorRoom;
+
+  return {
+    room,
+    colony: {
+      room,
+      spawns: [],
+      energyAvailable: 300,
+      energyCapacityAvailable: 300
+    }
+  };
+}
+
+function makeSource(id: string, x: number, y: number, roomName: string): Source {
+  return {
+    id,
+    pos: makePosition(x, y, roomName)
+  } as unknown as Source;
+}
+
+function makeConstructionSite(
+  id: string,
+  structureType: BuildableStructureConstant,
+  x: number,
+  y: number
+): ConstructionSite {
+  return {
+    id,
+    structureType,
+    pos: makePosition(x, y, 'W2N1')
+  } as unknown as ConstructionSite;
+}
+
+function makePosition(x: number, y: number, roomName: string): RoomPosition {
+  return { x, y, roomName } as RoomPosition;
+}
+
+function installGame(room: Room): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time: 123,
+    rooms: { [room.name]: room },
+    map: {
+      getRoomTerrain: jest.fn().mockReturnValue({
+        get: jest.fn().mockReturnValue(0)
+      })
+    } as unknown as GameMap
+  };
+}


### PR DESCRIPTION
## Summary
Implement tower construction and active defense in claimed colonies (#745).

## Changes
- **Tower placement planning** in `expansionPlanner.ts` — determines optimal tower positions near controller, sources, and entrances
- **Tower construction executor** (`towerConstructionExecutor.ts`) — builds towers using available energy in claimed rooms
- **Tower targeting** in `towerManager.ts` — hostile creep prioritization (near controller > attacking structures > nearest)
- **Defense integration** in `defensePlanner.ts` — active defense targeting for claimed colonies
- **Economy loop** hook to trigger tower construction when energy is available
- **Comprehensive tests**: tower placement, construction, targeting priorities, defense integration

## Verification
- TypeScript typecheck: PASS
- Jest tests: 1390/1390 PASS (69 suites)
- Build: PASS
- git diff --check: clean

## Commit
d2e72ed by lanyusea's bot <lanyusea@gmail.com>
