### PR TITLE
feat(territory): implement rampart and wall construction in claimed colonies (#748)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8386,11 +8386,13 @@ var SOURCE_SCORE_WEIGHT = 1e3;
 var DISTANCE_SCORE_WEIGHT = 100;
 var EXPANSION_PLANNER_TARGET_CREATOR = "expansionPlanner";
 var EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS = 6;
+var EXPANSION_DEFENSE_BARRIER_DEFAULT_MAX_PLACEMENTS = 24;
 var EXPANSION_TOWER_ROOM_EDGE_MIN = 1;
 var EXPANSION_TOWER_ROOM_EDGE_MAX = 48;
 var EXPANSION_TOWER_CONTROLLER_WEIGHT = 6;
 var EXPANSION_TOWER_SOURCE_WEIGHT = 3;
 var EXPANSION_TOWER_ENTRANCE_WEIGHT = 1;
+var EXPANSION_DEFENSE_BARRIER_MAX_SECONDARY_RAMPARTS = 12;
 var DEFAULT_TERRAIN_WALL_MASK9 = 1;
 function evaluateExpansionRoomSuitability(room, colonyOwnerUsername) {
   var _a;
@@ -8688,6 +8690,25 @@ function planExpansionTowerPlacements(room, options = {}) {
   }
   return placements.sort(compareExpansionTowerPlacements).slice(0, getExpansionTowerMaxPlacements(options.maxPlacements));
 }
+function planExpansionDefenseBarrierPlacements(room, options = {}) {
+  if (!isNonEmptyString9(room.name)) {
+    return [];
+  }
+  const lookups = createExpansionDefenseBarrierPlacementLookups(room);
+  const entranceRampartTargets = getExpansionDefenseEntranceRampartTargets(room, lookups);
+  if (entranceRampartTargets.length === 0) {
+    return [];
+  }
+  const entranceRampartPlacements = entranceRampartTargets.filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position)).filter((position) => canPlaceExpansionDefenseRampart(lookups, position)).map((position) => createExpansionDefenseBarrierPlacement(room.name, position, "entranceRampart"));
+  if (entranceRampartPlacements.length > 0) {
+    return entranceRampartPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+  }
+  const entranceWallPlacements = getExpansionDefenseEntranceWallTargets(entranceRampartTargets, lookups).filter((position) => !hasExpansionDefenseWallCoverage(lookups, position)).filter((position) => canPlaceExpansionDefenseWall(lookups, position)).map((position) => createExpansionDefenseBarrierPlacement(room.name, position, "entranceWall"));
+  if (entranceWallPlacements.length > 0) {
+    return entranceWallPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+  }
+  return getExpansionDefenseSecondaryRampartTargets(room, lookups).filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position)).filter((position) => canPlaceExpansionDefenseRampart(lookups, position)).map((position) => createExpansionDefenseBarrierPlacement(room.name, position, "secondaryRampart")).slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+}
 function createExpansionTowerPlacementLookups(room) {
   const blockedPositions = /* @__PURE__ */ new Set();
   for (const object of [
@@ -8930,6 +8951,237 @@ function getExpansionTowerMaxPlacements(maxPlacements) {
     return EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS;
   }
   return Math.max(1, Math.floor(maxPlacements));
+}
+function createExpansionDefenseBarrierPlacementLookups(room) {
+  const structuresByPosition = /* @__PURE__ */ new Map();
+  const constructionSitesByPosition = /* @__PURE__ */ new Map();
+  const reservedPositions = /* @__PURE__ */ new Set();
+  addExpansionDefenseReservedPosition(reservedPositions, room.controller, room.name);
+  for (const source of findRoomObjects12(room, getFindConstant4("FIND_SOURCES"))) {
+    addExpansionDefenseReservedPosition(reservedPositions, source, room.name);
+  }
+  for (const mineral of findRoomObjects12(room, getFindConstant4("FIND_MINERALS"))) {
+    addExpansionDefenseReservedPosition(reservedPositions, mineral, room.name);
+  }
+  for (const structure of findRoomObjects12(room, getFindConstant4("FIND_STRUCTURES"))) {
+    addExpansionDefenseObjectAtPosition(structuresByPosition, structure, room.name);
+  }
+  for (const site of findRoomObjects12(room, getFindConstant4("FIND_CONSTRUCTION_SITES"))) {
+    addExpansionDefenseObjectAtPosition(constructionSitesByPosition, site, room.name);
+  }
+  return {
+    terrain: getExpansionTowerRoomTerrain(room.name),
+    reservedPositions,
+    structuresByPosition,
+    constructionSitesByPosition
+  };
+}
+function getExpansionDefenseEntranceRampartTargets(room, lookups) {
+  return dedupeExpansionDefensePositions(
+    getExpansionTowerEntranceAnchors(room).map((position) => projectExpansionDefenseEntranceInsideRoom(position, room.name)).filter((position) => position !== null).filter((position) => isExpansionDefenseRampartTargetAllowed(lookups, position))
+  );
+}
+function projectExpansionDefenseEntranceInsideRoom(position, roomName) {
+  const side = getExpansionTowerExitSide(position);
+  switch (side) {
+    case "top":
+      return { x: clampExpansionDefenseBuildCoordinate(position.x), y: 1, roomName };
+    case "right":
+      return { x: 48, y: clampExpansionDefenseBuildCoordinate(position.y), roomName };
+    case "bottom":
+      return { x: clampExpansionDefenseBuildCoordinate(position.x), y: 48, roomName };
+    case "left":
+      return { x: 1, y: clampExpansionDefenseBuildCoordinate(position.y), roomName };
+    default:
+      return null;
+  }
+}
+function isExpansionDefenseRampartTargetAllowed(lookups, position) {
+  return isExpansionDefenseBuildablePosition(lookups, position) && !lookups.reservedPositions.has(getExpansionTowerPositionKey(position)) && !hasExpansionDefenseStructureTypeAt(lookups, position, "STRUCTURE_WALL", "constructedWall");
+}
+function getExpansionDefenseEntranceWallTargets(entranceRampartTargets, lookups) {
+  const positions = [];
+  for (const rampartPosition of entranceRampartTargets) {
+    if (!hasExpansionDefenseRampartCoverage(lookups, rampartPosition)) {
+      continue;
+    }
+    positions.push(...getExpansionDefenseAdjacentWallTargets(rampartPosition));
+  }
+  return dedupeExpansionDefensePositions(positions);
+}
+function getExpansionDefenseAdjacentWallTargets(position) {
+  const side = getExpansionDefenseInteriorSide(position);
+  if (side === "top" || side === "bottom") {
+    return [
+      { x: position.x - 1, y: position.y, roomName: position.roomName },
+      { x: position.x + 1, y: position.y, roomName: position.roomName }
+    ];
+  }
+  if (side === "left" || side === "right") {
+    return [
+      { x: position.x, y: position.y - 1, roomName: position.roomName },
+      { x: position.x, y: position.y + 1, roomName: position.roomName }
+    ];
+  }
+  return [];
+}
+function getExpansionDefenseSecondaryRampartTargets(room, lookups) {
+  const targets = [];
+  const structures = findRoomObjects12(room, getFindConstant4("FIND_STRUCTURES"));
+  for (const spawn of structures.filter((structure) => isExpansionDefenseStructureType(structure.structureType, "STRUCTURE_SPAWN", "spawn")).sort(compareExpansionTowerObjectIds)) {
+    const spawnPosition = getExpansionTowerObjectPosition(spawn);
+    if (!isExpansionTowerSameRoomPosition(spawnPosition, room.name)) {
+      continue;
+    }
+    targets.push(spawnPosition, ...getExpansionDefenseAdjacentPositions(spawnPosition, true));
+  }
+  const controllerPosition = getExpansionTowerObjectPosition(room.controller);
+  if (isExpansionTowerSameRoomPosition(controllerPosition, room.name)) {
+    targets.push(...getExpansionDefenseAdjacentPositions(controllerPosition, false));
+  }
+  return dedupeExpansionDefensePositions(targets).filter((position) => isExpansionDefenseRampartTargetAllowed(lookups, position)).slice(0, EXPANSION_DEFENSE_BARRIER_MAX_SECONDARY_RAMPARTS);
+}
+function getExpansionDefenseAdjacentPositions(center, includeCenter) {
+  const positions = includeCenter ? [{ ...center }] : [];
+  const offsets = [
+    { dx: 0, dy: -1 },
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: 1 },
+    { dx: -1, dy: 0 },
+    { dx: -1, dy: -1 },
+    { dx: 1, dy: -1 },
+    { dx: 1, dy: 1 },
+    { dx: -1, dy: 1 }
+  ];
+  for (const offset of offsets) {
+    positions.push({
+      x: center.x + offset.dx,
+      y: center.y + offset.dy,
+      roomName: center.roomName
+    });
+  }
+  return positions;
+}
+function canPlaceExpansionDefenseRampart(lookups, position) {
+  return isExpansionDefenseRampartTargetAllowed(lookups, position) && !hasExpansionDefenseConstructionAt(lookups, position);
+}
+function canPlaceExpansionDefenseWall(lookups, position) {
+  return isExpansionDefenseBuildablePosition(lookups, position) && !lookups.reservedPositions.has(getExpansionTowerPositionKey(position)) && !hasExpansionDefenseStructureAt(lookups, position) && !hasExpansionDefenseConstructionAt(lookups, position);
+}
+function isExpansionDefenseBuildablePosition(lookups, position) {
+  return position.x >= EXPANSION_TOWER_ROOM_EDGE_MIN && position.x <= EXPANSION_TOWER_ROOM_EDGE_MAX && position.y >= EXPANSION_TOWER_ROOM_EDGE_MIN && position.y <= EXPANSION_TOWER_ROOM_EDGE_MAX && !isExpansionTowerTerrainWall(lookups.terrain, position);
+}
+function hasExpansionDefenseRampartCoverage(lookups, position) {
+  return hasExpansionDefenseStructureTypeAt(lookups, position, "STRUCTURE_RAMPART", "rampart") || hasExpansionDefenseConstructionTypeAt(lookups, position, "STRUCTURE_RAMPART", "rampart");
+}
+function hasExpansionDefenseWallCoverage(lookups, position) {
+  return hasExpansionDefenseStructureTypeAt(lookups, position, "STRUCTURE_WALL", "constructedWall") || hasExpansionDefenseConstructionTypeAt(lookups, position, "STRUCTURE_WALL", "constructedWall");
+}
+function hasExpansionDefenseStructureAt(lookups, position) {
+  var _a;
+  return ((_a = lookups.structuresByPosition.get(getExpansionTowerPositionKey(position))) != null ? _a : []).length > 0;
+}
+function hasExpansionDefenseConstructionAt(lookups, position) {
+  var _a;
+  return ((_a = lookups.constructionSitesByPosition.get(getExpansionTowerPositionKey(position))) != null ? _a : []).length > 0;
+}
+function hasExpansionDefenseStructureTypeAt(lookups, position, globalName, fallback) {
+  var _a;
+  return ((_a = lookups.structuresByPosition.get(getExpansionTowerPositionKey(position))) != null ? _a : []).some(
+    (structure) => isExpansionDefenseStructureType(structure.structureType, globalName, fallback)
+  );
+}
+function hasExpansionDefenseConstructionTypeAt(lookups, position, globalName, fallback) {
+  var _a;
+  return ((_a = lookups.constructionSitesByPosition.get(getExpansionTowerPositionKey(position))) != null ? _a : []).some(
+    (site) => isExpansionDefenseStructureType(String(site.structureType), globalName, fallback)
+  );
+}
+function createExpansionDefenseBarrierPlacement(roomName, position, stage) {
+  const isWall = stage === "entranceWall";
+  return {
+    roomName,
+    x: position.x,
+    y: position.y,
+    structureType: getExpansionDefenseStructureConstant(
+      isWall ? "STRUCTURE_WALL" : "STRUCTURE_RAMPART",
+      isWall ? "constructedWall" : "rampart"
+    ),
+    stage,
+    priority: getExpansionDefenseBarrierStagePriority(stage)
+  };
+}
+function getExpansionDefenseBarrierStagePriority(stage) {
+  switch (stage) {
+    case "entranceRampart":
+      return 0;
+    case "entranceWall":
+      return 1;
+    case "secondaryRampart":
+      return 2;
+  }
+}
+function getExpansionDefenseInteriorSide(position) {
+  if (position.y <= EXPANSION_TOWER_ROOM_EDGE_MIN) {
+    return "top";
+  }
+  if (position.x >= EXPANSION_TOWER_ROOM_EDGE_MAX) {
+    return "right";
+  }
+  if (position.y >= EXPANSION_TOWER_ROOM_EDGE_MAX) {
+    return "bottom";
+  }
+  if (position.x <= EXPANSION_TOWER_ROOM_EDGE_MIN) {
+    return "left";
+  }
+  return null;
+}
+function addExpansionDefenseReservedPosition(reservedPositions, object, roomName) {
+  const position = getExpansionTowerObjectPosition(object);
+  if (isExpansionTowerSameRoomPosition(position, roomName)) {
+    reservedPositions.add(getExpansionTowerPositionKey(position));
+  }
+}
+function addExpansionDefenseObjectAtPosition(objectsByPosition, object, roomName) {
+  var _a;
+  const position = getExpansionTowerObjectPosition(object);
+  if (!isExpansionTowerSameRoomPosition(position, roomName)) {
+    return;
+  }
+  const key = getExpansionTowerPositionKey(position);
+  const objects = (_a = objectsByPosition.get(key)) != null ? _a : [];
+  objects.push(object);
+  objectsByPosition.set(key, objects);
+}
+function dedupeExpansionDefensePositions(positions) {
+  const seen = /* @__PURE__ */ new Set();
+  const deduped = [];
+  for (const position of positions) {
+    const key = getExpansionTowerPositionKey(position);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(position);
+  }
+  return deduped;
+}
+function clampExpansionDefenseBuildCoordinate(value) {
+  return Math.max(EXPANSION_TOWER_ROOM_EDGE_MIN, Math.min(EXPANSION_TOWER_ROOM_EDGE_MAX, value));
+}
+function getExpansionDefenseBarrierMaxPlacements(maxPlacements) {
+  if (typeof maxPlacements !== "number" || !Number.isFinite(maxPlacements)) {
+    return EXPANSION_DEFENSE_BARRIER_DEFAULT_MAX_PLACEMENTS;
+  }
+  return Math.max(1, Math.floor(maxPlacements));
+}
+function isExpansionDefenseStructureType(actual, globalName, fallback) {
+  return actual === getExpansionDefenseStructureConstant(globalName, fallback);
+}
+function getExpansionDefenseStructureConstant(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
 }
 function compareExpansionTowerObjectIds(left, right) {
   return getExpansionTowerObjectId(left).localeCompare(getExpansionTowerObjectId(right));
@@ -30657,6 +30909,227 @@ function isRecord28(value) {
   return typeof value === "object" && value !== null;
 }
 
+// src/territory/rampartWallConstructionExecutor.ts
+var EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_RCL = 3;
+var EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_ENERGY = 1;
+var OK_CODE15 = 0;
+var ERR_FULL_CODE6 = -8;
+var ERR_RCL_NOT_ENOUGH_CODE3 = -14;
+var FALLBACK_EXTENSION_LIMITS_BY_RCL = [0, 0, 5, 10, 20, 30, 40, 50, 60];
+var FALLBACK_TOWER_LIMITS_BY_RCL2 = [0, 0, 0, 1, 1, 2, 2, 3, 6];
+function runRampartWallConstructionExecutorForColony(colony, options = {}) {
+  var _a, _b;
+  const room = colony.room;
+  if (options.requireExpansionMemory === true && !isExpansionControlledRoom2(room.name)) {
+    return { roomName: room.name, status: "skipped", reason: "notExpansionRoom" };
+  }
+  if (((_a = room.controller) == null ? void 0 : _a.my) !== true) {
+    return { roomName: room.name, status: "skipped", reason: "roomNotClaimed" };
+  }
+  if (!hasRampartWallConstructionExecutorApis(room)) {
+    return { roomName: room.name, status: "skipped", reason: "apiUnavailable" };
+  }
+  const rcl = getOwnedRoomRcl4(room);
+  if (rcl < EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_RCL) {
+    return { roomName: room.name, status: "skipped", reason: "controllerLevelLow" };
+  }
+  const minEnergyAvailable = resolveNonNegativeInteger4(
+    options.minEnergyAvailable,
+    EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_ENERGY
+  );
+  if (getColonyEnergyAvailable2(colony) < minEnergyAvailable) {
+    return { roomName: room.name, status: "skipped", reason: "energyUnavailable" };
+  }
+  if (!isDefenseBarrierStageReady(colony, rcl)) {
+    return { roomName: room.name, status: "skipped", reason: "essentialStructuresPending" };
+  }
+  const placements = planExpansionDefenseBarrierPlacements(room, {
+    maxPlacements: options.maxPlacementCandidates
+  });
+  const stage = (_b = placements[0]) == null ? void 0 : _b.stage;
+  if (!stage) {
+    return { roomName: room.name, status: "skipped", reason: "noPlacement" };
+  }
+  for (const placement of placements) {
+    if (placement.stage !== stage) {
+      continue;
+    }
+    const result = room.createConstructionSite(placement.x, placement.y, placement.structureType);
+    if (result === OK_CODE15) {
+      return {
+        roomName: room.name,
+        status: "created",
+        result,
+        stage: placement.stage,
+        structureType: placement.structureType,
+        x: placement.x,
+        y: placement.y
+      };
+    }
+    if (isFatalConstructionSiteResult3(result)) {
+      return {
+        roomName: room.name,
+        status: "skipped",
+        reason: "noPlacement",
+        result,
+        stage: placement.stage,
+        structureType: placement.structureType,
+        x: placement.x,
+        y: placement.y
+      };
+    }
+  }
+  return { roomName: room.name, status: "skipped", reason: "noPlacement", stage };
+}
+function isDefenseBarrierStageReady(colony, rcl) {
+  const room = colony.room;
+  return hasSpawnCoverage2(colony) && hasExtensionCapacityPlaced(room, rcl) && hasSourceContainerCoverage3(room) && hasTowerCoverage(room, rcl);
+}
+function hasSpawnCoverage2(colony) {
+  return colony.spawns.some((spawn) => {
+    var _a;
+    return ((_a = spawn.room) == null ? void 0 : _a.name) === colony.room.name;
+  }) || countExistingAndPendingStructures2(colony.room, "STRUCTURE_SPAWN", "spawn") > 0;
+}
+function hasExtensionCapacityPlaced(room, rcl) {
+  const extensionLimit = getStructureLimitForRcl("STRUCTURE_EXTENSION", "extension", rcl, FALLBACK_EXTENSION_LIMITS_BY_RCL);
+  return countExistingAndPendingStructures2(room, "STRUCTURE_EXTENSION", "extension") >= extensionLimit;
+}
+function hasTowerCoverage(room, rcl) {
+  const towerLimit = getStructureLimitForRcl("STRUCTURE_TOWER", "tower", rcl, FALLBACK_TOWER_LIMITS_BY_RCL2);
+  return towerLimit <= 0 || countExistingAndPendingStructures2(room, "STRUCTURE_TOWER", "tower") >= Math.min(1, towerLimit);
+}
+function hasSourceContainerCoverage3(room) {
+  const sources = findRoomObjects20(room, "FIND_SOURCES").filter(
+    (source) => isSameRoomPosition7(getRoomObjectPosition5(source), room.name)
+  );
+  if (sources.length === 0) {
+    return true;
+  }
+  const containers = [
+    ...findRoomObjects20(room, "FIND_STRUCTURES"),
+    ...findRoomObjects20(room, "FIND_CONSTRUCTION_SITES")
+  ].filter(
+    (object) => matchesStructureType23(object.structureType, "STRUCTURE_CONTAINER", "container")
+  );
+  return sources.every(
+    (source) => containers.some((container) => isNearRoomObject5(source, container))
+  );
+}
+function countExistingAndPendingStructures2(room, globalName, fallback) {
+  return findRoomObjects20(room, "FIND_MY_STRUCTURES").filter(
+    (structure) => matchesStructureType23(structure.structureType, globalName, fallback)
+  ).length + findRoomObjects20(room, "FIND_MY_CONSTRUCTION_SITES").filter(
+    (site) => matchesStructureType23(String(site.structureType), globalName, fallback)
+  ).length;
+}
+function isExpansionControlledRoom2(roomName) {
+  var _a, _b, _c, _d;
+  const territoryMemory = (_a = globalThis.Memory) == null ? void 0 : _a.territory;
+  if (!territoryMemory) {
+    return false;
+  }
+  if (isRecord29((_b = territoryMemory.postClaimBootstraps) == null ? void 0 : _b[roomName])) {
+    return true;
+  }
+  const claimedRoomRecord = (_d = (_c = territoryMemory.claimedRoomBootstrapper) == null ? void 0 : _c.rooms) == null ? void 0 : _d[roomName];
+  if ((claimedRoomRecord == null ? void 0 : claimedRoomRecord.claimedAt) !== void 0) {
+    return true;
+  }
+  return hasExpansionControlReference2(territoryMemory.targets, roomName, "roomName") || hasExpansionControlReference2(territoryMemory.intents, roomName, "targetRoom");
+}
+function hasExpansionControlReference2(records, roomName, roomKey) {
+  return Array.isArray(records) ? records.some(
+    (record) => isRecord29(record) && record[roomKey] === roomName && (record.action === "claim" || record.action === "reserve")
+  ) : false;
+}
+function hasRampartWallConstructionExecutorApis(room) {
+  return typeof room.find === "function" && typeof room.createConstructionSite === "function";
+}
+function getOwnedRoomRcl4(room) {
+  var _a;
+  const level = (_a = room.controller) == null ? void 0 : _a.level;
+  return typeof level === "number" && Number.isFinite(level) ? Math.max(0, Math.floor(level)) : 0;
+}
+function getColonyEnergyAvailable2(colony) {
+  return Math.max(
+    0,
+    Math.floor(
+      Number.isFinite(colony.energyAvailable) ? colony.energyAvailable : typeof colony.room.energyAvailable === "number" ? colony.room.energyAvailable : 0
+    )
+  );
+}
+function getStructureLimitForRcl(globalName, fallback, rcl, fallbackLimits) {
+  var _a, _b;
+  const normalizedRcl = Math.max(0, Math.floor(rcl));
+  const structureType = getStructureConstant4(globalName, fallback);
+  const controllerStructures = globalThis.CONTROLLER_STRUCTURES;
+  const configuredLimit = (_a = controllerStructures == null ? void 0 : controllerStructures[structureType]) == null ? void 0 : _a[normalizedRcl];
+  if (typeof configuredLimit === "number" && Number.isFinite(configuredLimit)) {
+    return Math.max(0, Math.floor(configuredLimit));
+  }
+  return (_b = fallbackLimits[normalizedRcl]) != null ? _b : 0;
+}
+function findRoomObjects20(room, globalName) {
+  const findConstant = getGlobalNumber14(globalName);
+  if (findConstant === null || typeof room.find !== "function") {
+    return [];
+  }
+  try {
+    const result = room.find(findConstant);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}
+function getRoomObjectPosition5(object) {
+  const position = object == null ? void 0 : object.pos;
+  if (typeof (position == null ? void 0 : position.x) !== "number" || typeof position.y !== "number" || !Number.isFinite(position.x) || !Number.isFinite(position.y)) {
+    return null;
+  }
+  return {
+    x: position.x,
+    y: position.y,
+    ...typeof position.roomName === "string" ? { roomName: position.roomName } : {}
+  };
+}
+function isNearRoomObject5(left, right) {
+  const leftPosition = getRoomObjectPosition5(left);
+  const rightPosition = getRoomObjectPosition5(right);
+  if (!leftPosition || !rightPosition || !isSameRoomPosition7(leftPosition, rightPosition.roomName)) {
+    return false;
+  }
+  return Math.max(Math.abs(leftPosition.x - rightPosition.x), Math.abs(leftPosition.y - rightPosition.y)) <= 1;
+}
+function isSameRoomPosition7(position, roomName) {
+  return position !== null && (position.roomName === void 0 || roomName === void 0 || position.roomName === roomName);
+}
+function matchesStructureType23(actual, globalName, fallback) {
+  return actual === getStructureConstant4(globalName, fallback);
+}
+function getStructureConstant4(globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function getGlobalNumber14(name) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : null;
+}
+function getGlobalReturnCode3(name, fallback) {
+  const value = globalThis[name];
+  return typeof value === "number" ? value : fallback;
+}
+function isFatalConstructionSiteResult3(result) {
+  return result === getGlobalReturnCode3("ERR_FULL", ERR_FULL_CODE6) || result === getGlobalReturnCode3("ERR_RCL_NOT_ENOUGH", ERR_RCL_NOT_ENOUGH_CODE3);
+}
+function resolveNonNegativeInteger4(value, fallback) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : fallback;
+}
+function isRecord29(value) {
+  return typeof value === "object" && value !== null;
+}
+
 // src/strategy/strategyRecommender.ts
 var DEFAULT_STRATEGY_RECOMMENDATION_CONFIDENCE_THRESHOLD = 0.7;
 var MAX_RECOMMENDATIONS = 5;
@@ -30785,11 +31258,11 @@ function buildStrategyRecommendationRoomState(colony, creeps) {
       return creep.memory.colony === room.name || ((_a2 = creep.room) == null ? void 0 : _a2.name) === room.name;
     }
   );
-  const hostileCreeps = findRoomObjects20(room, "FIND_HOSTILE_CREEPS");
-  const hostileStructures = findRoomObjects20(room, "FIND_HOSTILE_STRUCTURES");
-  const ownedStructures = findRoomObjects20(room, "FIND_MY_STRUCTURES");
-  const constructionSites = findRoomObjects20(room, "FIND_MY_CONSTRUCTION_SITES");
-  const sources = findRoomObjects20(room, "FIND_SOURCES");
+  const hostileCreeps = findRoomObjects21(room, "FIND_HOSTILE_CREEPS");
+  const hostileStructures = findRoomObjects21(room, "FIND_HOSTILE_STRUCTURES");
+  const ownedStructures = findRoomObjects21(room, "FIND_MY_STRUCTURES");
+  const constructionSites = findRoomObjects21(room, "FIND_MY_CONSTRUCTION_SITES");
+  const sources = findRoomObjects21(room, "FIND_SOURCES");
   return {
     roomName: room.name,
     controllerLevel: (_a = room.controller) == null ? void 0 : _a.level,
@@ -30880,7 +31353,7 @@ function buildMemoryTerritoryState(roomName) {
   const expansionCandidates = [];
   if (Array.isArray(targets)) {
     for (const target of targets) {
-      if (!isRecord29(target) || target.colony !== roomName || typeof target.roomName !== "string") {
+      if (!isRecord30(target) || target.colony !== roomName || typeof target.roomName !== "string") {
         continue;
       }
       const action = normalizeTerritoryAction(target.action);
@@ -30942,12 +31415,12 @@ function countVisibleOwnedRooms5() {
 }
 function countStructuresByType3(structures, globalName, fallback) {
   return structures.filter(
-    (structure) => isRecord29(structure) && matchesStructureType23(structure.structureType, globalName, fallback)
+    (structure) => isRecord30(structure) && matchesStructureType24(structure.structureType, globalName, fallback)
   ).length;
 }
 function estimateRepairBacklogHits(structures) {
   return structures.reduce((total, structure) => {
-    if (!isRecord29(structure)) {
+    if (!isRecord30(structure)) {
       return total;
     }
     const hits = finiteNumberOrNull(structure.hits);
@@ -30963,7 +31436,7 @@ function getStoredEnergy16(room) {
   return getEnergyInStore2(storage);
 }
 function getEnergyInStore2(object) {
-  if (!isRecord29(object) || !isRecord29(object.store)) {
+  if (!isRecord30(object) || !isRecord30(object.store)) {
     return 0;
   }
   const getUsedCapacity = object.store.getUsedCapacity;
@@ -30974,8 +31447,8 @@ function getEnergyInStore2(object) {
   }
   return finiteNumberOrZero(object.store[resourceEnergy]);
 }
-function findRoomObjects20(room, constantName) {
-  const findConstant = getGlobalNumber14(constantName);
+function findRoomObjects21(room, constantName) {
+  const findConstant = getGlobalNumber15(constantName);
   const find = room.find;
   if (typeof findConstant !== "number" || typeof find !== "function") {
     return [];
@@ -30987,7 +31460,7 @@ function findRoomObjects20(room, constantName) {
     return [];
   }
 }
-function matchesStructureType23(value, globalName, fallback) {
+function matchesStructureType24(value, globalName, fallback) {
   const globalValue = globalThis[globalName];
   return value === globalValue || value === fallback;
 }
@@ -30995,7 +31468,7 @@ function getResourceEnergy() {
   const value = globalThis.RESOURCE_ENERGY;
   return value != null ? value : "energy";
 }
-function getGlobalNumber14(name) {
+function getGlobalNumber15(name) {
   const value = globalThis[name];
   return typeof value === "number" ? value : void 0;
 }
@@ -31015,13 +31488,13 @@ function finiteNumberOrZero(value) {
 function finiteNumberOrNull(value) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
-function isRecord29(value) {
+function isRecord30(value) {
   return typeof value === "object" && value !== null;
 }
 
 // src/economy/economyLoop.ts
 var ERR_BUSY_CODE = -4;
-var OK_CODE15 = 0;
+var OK_CODE16 = 0;
 var BOOTSTRAP_WORKER_BUFFER_BYPASS_MIN_ENERGY = 300;
 var NEXT_EXPANSION_SCORING_REFRESH_INTERVAL = 50;
 var NEXT_EXPANSION_SCORING_DOWNGRADE_GUARD_TICKS = 5e3;
@@ -31059,6 +31532,7 @@ function runEconomy(preludeTelemetryEvents = []) {
     );
     refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
     runTowerConstructionExecutorForColony(colony, { requireExpansionMemory: true });
+    runRampartWallConstructionExecutorForColony(colony, { requireExpansionMemory: true });
     planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
     if (survivalAssessment.mode === "TERRITORY_READY") {
       refreshRemoteMiningSetup(colony, Game.time);
@@ -31100,7 +31574,7 @@ function runEconomy(preludeTelemetryEvents = []) {
         telemetryEvents,
         coordinatedPlan.spawns
       );
-      if (!outcome || outcome.result !== OK_CODE15) {
+      if (!outcome || outcome.result !== OK_CODE16) {
         break;
       }
       const spawnRoomName = (_b = (_a = outcome.spawn.room) == null ? void 0 : _a.name) != null ? _b : "unknown";
@@ -31212,7 +31686,7 @@ function attemptCrossRoomHaulerSpawn(colonies, telemetryEvents, usedSpawnsByRoom
     telemetryEvents,
     candidateSpawns
   );
-  if (!outcome || outcome.result !== OK_CODE15) {
+  if (!outcome || outcome.result !== OK_CODE16) {
     return;
   }
   recordUsedSpawn(usedSpawnsByRoom, sourceRoomName, outcome.spawn);
@@ -31244,7 +31718,7 @@ function attemptMineralHarvesterSpawns(colonies, creeps, telemetryEvents, usedSp
     }
     const bodyCost = getBodyCost(spawnRequest.body);
     const outcome = attemptSpawnRequest(spawnRequest, roomName, telemetryEvents, candidateSpawns);
-    if (!outcome || outcome.result !== OK_CODE15) {
+    if (!outcome || outcome.result !== OK_CODE16) {
       continue;
     }
     recordUsedSpawn(usedSpawnsByRoom, roomName, outcome.spawn);
@@ -31332,13 +31806,13 @@ function getCachedNextExpansionTargetSelection(colonyMemory, colonyName) {
   const refreshedAt = colonyMemory.lastExpansionScoreTime;
   const rawSelection = colonyMemory.cachedExpansionSelection;
   const selection = normalizeNextExpansionTargetSelection(rawSelection, colonyName);
-  if (!isFiniteNumber10(refreshedAt) || !isRecord30(rawSelection) || !isNonEmptyString28(rawSelection.stateKey) || !selection) {
+  if (!isFiniteNumber10(refreshedAt) || !isRecord31(rawSelection) || !isNonEmptyString28(rawSelection.stateKey) || !selection) {
     return null;
   }
   return { refreshedAt, stateKey: rawSelection.stateKey, selection };
 }
 function normalizeNextExpansionTargetSelection(rawSelection, colonyName) {
-  if (!isRecord30(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
+  if (!isRecord31(rawSelection) || rawSelection.colony !== colonyName || rawSelection.status !== "planned" && rawSelection.status !== "skipped") {
     return null;
   }
   if (rawSelection.status === "planned") {
@@ -31379,7 +31853,7 @@ function hasNextExpansionTarget(colony, targetRoom) {
   }
   const targets = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.targets;
   return Array.isArray(targets) ? targets.some(
-    (target) => isRecord30(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
+    (target) => isRecord31(target) && target.colony === colony && target.roomName === targetRoom && target.action === "claim" && target.createdBy === NEXT_EXPANSION_TARGET_CREATOR
   ) : false;
 }
 function getNextExpansionSelectionCacheStateKey(colony) {
@@ -31417,28 +31891,28 @@ function getGclLevel6() {
 function countActivePostClaimBootstraps3() {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
-  if (!isRecord30(records)) {
+  if (!isRecord31(records)) {
     return 0;
   }
   return Object.values(records).filter(
-    (record) => isRecord30(record) && record.status !== "ready"
+    (record) => isRecord31(record) && record.status !== "ready"
   ).length;
 }
 function getLatestTerritoryScoutIntelUpdatedAt(colony) {
   var _a, _b;
   const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.scoutIntel;
-  if (!isRecord30(records)) {
+  if (!isRecord31(records)) {
     return 0;
   }
   let latestUpdatedAt = 0;
   for (const record of Object.values(records)) {
-    if (isRecord30(record) && record.colony === colony && isFiniteNumber10(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
+    if (isRecord31(record) && record.colony === colony && isFiniteNumber10(record.updatedAt) && record.updatedAt > latestUpdatedAt) {
       latestUpdatedAt = record.updatedAt;
     }
   }
   return latestUpdatedAt;
 }
-function isRecord30(value) {
+function isRecord31(value) {
   return typeof value === "object" && value !== null;
 }
 function isNonEmptyString28(value) {
@@ -32722,10 +33196,10 @@ function getLatestFiniteScore(scores) {
   return void 0;
 }
 function normalizeHistoricalReplay(rawReplay) {
-  if (!isRecord31(rawReplay)) {
+  if (!isRecord32(rawReplay)) {
     return null;
   }
-  if (!isNonEmptyString29(rawReplay.replayId) || !isNonEmptyString29(rawReplay.room) || !isFiniteNumber11(rawReplay.startTick) || !isFiniteNumber11(rawReplay.endTick) || !isFiniteNumber11(rawReplay.finalScore) || !isRecord31(rawReplay.kpiHistory)) {
+  if (!isNonEmptyString29(rawReplay.replayId) || !isNonEmptyString29(rawReplay.room) || !isFiniteNumber11(rawReplay.startTick) || !isFiniteNumber11(rawReplay.endTick) || !isFiniteNumber11(rawReplay.finalScore) || !isRecord32(rawReplay.kpiHistory)) {
     return null;
   }
   const kpiHistory = Object.entries(rawReplay.kpiHistory).reduce(
@@ -32750,7 +33224,7 @@ function normalizeHistoricalReplay(rawReplay) {
 function formatCorrelation(correlation) {
   return correlation.toFixed(3);
 }
-function isRecord31(value) {
+function isRecord32(value) {
   return typeof value === "object" && value !== null;
 }
 function isNonEmptyString29(value) {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -93,6 +93,7 @@ import {
   runTerritoryControllerCreep
 } from '../territory/territoryRunner';
 import { runTowerConstructionExecutorForColony } from '../territory/towerConstructionExecutor';
+import { runRampartWallConstructionExecutorForColony } from '../territory/rampartWallConstructionExecutor';
 import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgrader';
 import { refreshControllerManagement } from '../territory/controllerManager';
 import {
@@ -177,6 +178,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
     );
     refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
     runTowerConstructionExecutorForColony(colony, { requireExpansionMemory: true });
+    runRampartWallConstructionExecutorForColony(colony, { requireExpansionMemory: true });
     planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
     if (survivalAssessment.mode === 'TERRITORY_READY') {
       refreshRemoteMiningSetup(colony, Game.time);

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -11,12 +11,14 @@ const SOURCE_SCORE_WEIGHT = 1_000;
 const DISTANCE_SCORE_WEIGHT = 100;
 export const EXPANSION_PLANNER_TARGET_CREATOR = 'expansionPlanner';
 export const EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS = 6;
+export const EXPANSION_DEFENSE_BARRIER_DEFAULT_MAX_PLACEMENTS = 24;
 
 const EXPANSION_TOWER_ROOM_EDGE_MIN = 1;
 const EXPANSION_TOWER_ROOM_EDGE_MAX = 48;
 const EXPANSION_TOWER_CONTROLLER_WEIGHT = 6;
 const EXPANSION_TOWER_SOURCE_WEIGHT = 3;
 const EXPANSION_TOWER_ENTRANCE_WEIGHT = 1;
+const EXPANSION_DEFENSE_BARRIER_MAX_SECONDARY_RAMPARTS = 12;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
 
 type TerminalExpansionIntentStatus = Extract<TerritoryIntentMemory['status'], 'inactive' | 'completed'>;
@@ -123,6 +125,24 @@ export interface ExpansionTowerPlacement {
   nearestEntranceRange?: number;
 }
 
+export type ExpansionDefenseBarrierPlacementStage =
+  | 'entranceRampart'
+  | 'entranceWall'
+  | 'secondaryRampart';
+
+export interface ExpansionDefenseBarrierPlacementOptions {
+  maxPlacements?: number;
+}
+
+export interface ExpansionDefenseBarrierPlacement {
+  roomName: string;
+  x: number;
+  y: number;
+  structureType: BuildableStructureConstant;
+  stage: ExpansionDefenseBarrierPlacementStage;
+  priority: number;
+}
+
 interface ExpansionTowerAnchor {
   kind: ExpansionTowerPlacementAnchorKind;
   position: RoomPositionLike;
@@ -139,6 +159,13 @@ interface ExpansionTowerPlacementLookups {
   terrain: RoomTerrain | null;
   blockedPositions: Set<string>;
   anchors: ExpansionTowerAnchor[];
+}
+
+interface ExpansionDefenseBarrierPlacementLookups {
+  terrain: RoomTerrain | null;
+  reservedPositions: Set<string>;
+  structuresByPosition: Map<string, AnyStructure[]>;
+  constructionSitesByPosition: Map<string, ConstructionSite[]>;
 }
 
 interface ExitGroup {
@@ -559,6 +586,43 @@ export function planExpansionTowerPlacements(
     .slice(0, getExpansionTowerMaxPlacements(options.maxPlacements));
 }
 
+export function planExpansionDefenseBarrierPlacements(
+  room: Room,
+  options: ExpansionDefenseBarrierPlacementOptions = {}
+): ExpansionDefenseBarrierPlacement[] {
+  if (!isNonEmptyString(room.name)) {
+    return [];
+  }
+
+  const lookups = createExpansionDefenseBarrierPlacementLookups(room);
+  const entranceRampartTargets = getExpansionDefenseEntranceRampartTargets(room, lookups);
+  if (entranceRampartTargets.length === 0) {
+    return [];
+  }
+
+  const entranceRampartPlacements = entranceRampartTargets
+    .filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position))
+    .filter((position) => canPlaceExpansionDefenseRampart(lookups, position))
+    .map((position) => createExpansionDefenseBarrierPlacement(room.name, position, 'entranceRampart'));
+  if (entranceRampartPlacements.length > 0) {
+    return entranceRampartPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+  }
+
+  const entranceWallPlacements = getExpansionDefenseEntranceWallTargets(entranceRampartTargets, lookups)
+    .filter((position) => !hasExpansionDefenseWallCoverage(lookups, position))
+    .filter((position) => canPlaceExpansionDefenseWall(lookups, position))
+    .map((position) => createExpansionDefenseBarrierPlacement(room.name, position, 'entranceWall'));
+  if (entranceWallPlacements.length > 0) {
+    return entranceWallPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+  }
+
+  return getExpansionDefenseSecondaryRampartTargets(room, lookups)
+    .filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position))
+    .filter((position) => canPlaceExpansionDefenseRampart(lookups, position))
+    .map((position) => createExpansionDefenseBarrierPlacement(room.name, position, 'secondaryRampart'))
+    .slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+}
+
 function createExpansionTowerPlacementLookups(room: Room): ExpansionTowerPlacementLookups {
   const blockedPositions = new Set<string>();
   for (const object of [
@@ -905,6 +969,378 @@ function getExpansionTowerMaxPlacements(maxPlacements: number | undefined): numb
   }
 
   return Math.max(1, Math.floor(maxPlacements));
+}
+
+function createExpansionDefenseBarrierPlacementLookups(room: Room): ExpansionDefenseBarrierPlacementLookups {
+  const structuresByPosition = new Map<string, AnyStructure[]>();
+  const constructionSitesByPosition = new Map<string, ConstructionSite[]>();
+  const reservedPositions = new Set<string>();
+
+  addExpansionDefenseReservedPosition(reservedPositions, room.controller, room.name);
+  for (const source of findRoomObjects<Source>(room, getFindConstant('FIND_SOURCES'))) {
+    addExpansionDefenseReservedPosition(reservedPositions, source, room.name);
+  }
+
+  for (const mineral of findRoomObjects<Mineral>(room, getFindConstant('FIND_MINERALS'))) {
+    addExpansionDefenseReservedPosition(reservedPositions, mineral, room.name);
+  }
+
+  for (const structure of findRoomObjects<AnyStructure>(room, getFindConstant('FIND_STRUCTURES'))) {
+    addExpansionDefenseObjectAtPosition(structuresByPosition, structure, room.name);
+  }
+
+  for (const site of findRoomObjects<ConstructionSite>(room, getFindConstant('FIND_CONSTRUCTION_SITES'))) {
+    addExpansionDefenseObjectAtPosition(constructionSitesByPosition, site, room.name);
+  }
+
+  return {
+    terrain: getExpansionTowerRoomTerrain(room.name),
+    reservedPositions,
+    structuresByPosition,
+    constructionSitesByPosition
+  };
+}
+
+function getExpansionDefenseEntranceRampartTargets(
+  room: Room,
+  lookups: ExpansionDefenseBarrierPlacementLookups
+): RoomPositionLike[] {
+  return dedupeExpansionDefensePositions(
+    getExpansionTowerEntranceAnchors(room)
+      .map((position) => projectExpansionDefenseEntranceInsideRoom(position, room.name))
+      .filter((position): position is RoomPositionLike => position !== null)
+      .filter((position) => isExpansionDefenseRampartTargetAllowed(lookups, position))
+  );
+}
+
+function projectExpansionDefenseEntranceInsideRoom(
+  position: RoomPositionLike,
+  roomName: string
+): RoomPositionLike | null {
+  const side = getExpansionTowerExitSide(position);
+  switch (side) {
+    case 'top':
+      return { x: clampExpansionDefenseBuildCoordinate(position.x), y: 1, roomName };
+    case 'right':
+      return { x: 48, y: clampExpansionDefenseBuildCoordinate(position.y), roomName };
+    case 'bottom':
+      return { x: clampExpansionDefenseBuildCoordinate(position.x), y: 48, roomName };
+    case 'left':
+      return { x: 1, y: clampExpansionDefenseBuildCoordinate(position.y), roomName };
+    default:
+      return null;
+  }
+}
+
+function isExpansionDefenseRampartTargetAllowed(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (
+    isExpansionDefenseBuildablePosition(lookups, position) &&
+    !lookups.reservedPositions.has(getExpansionTowerPositionKey(position)) &&
+    !hasExpansionDefenseStructureTypeAt(lookups, position, 'STRUCTURE_WALL', 'constructedWall')
+  );
+}
+
+function getExpansionDefenseEntranceWallTargets(
+  entranceRampartTargets: RoomPositionLike[],
+  lookups: ExpansionDefenseBarrierPlacementLookups
+): RoomPositionLike[] {
+  const positions: RoomPositionLike[] = [];
+  for (const rampartPosition of entranceRampartTargets) {
+    if (!hasExpansionDefenseRampartCoverage(lookups, rampartPosition)) {
+      continue;
+    }
+
+    positions.push(...getExpansionDefenseAdjacentWallTargets(rampartPosition));
+  }
+
+  return dedupeExpansionDefensePositions(positions);
+}
+
+function getExpansionDefenseAdjacentWallTargets(position: RoomPositionLike): RoomPositionLike[] {
+  const side = getExpansionDefenseInteriorSide(position);
+  if (side === 'top' || side === 'bottom') {
+    return [
+      { x: position.x - 1, y: position.y, roomName: position.roomName },
+      { x: position.x + 1, y: position.y, roomName: position.roomName }
+    ];
+  }
+
+  if (side === 'left' || side === 'right') {
+    return [
+      { x: position.x, y: position.y - 1, roomName: position.roomName },
+      { x: position.x, y: position.y + 1, roomName: position.roomName }
+    ];
+  }
+
+  return [];
+}
+
+function getExpansionDefenseSecondaryRampartTargets(
+  room: Room,
+  lookups: ExpansionDefenseBarrierPlacementLookups
+): RoomPositionLike[] {
+  const targets: RoomPositionLike[] = [];
+  const structures = findRoomObjects<AnyStructure>(room, getFindConstant('FIND_STRUCTURES'));
+  for (const spawn of structures
+    .filter((structure) => isExpansionDefenseStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn'))
+    .sort(compareExpansionTowerObjectIds)) {
+    const spawnPosition = getExpansionTowerObjectPosition(spawn);
+    if (!isExpansionTowerSameRoomPosition(spawnPosition, room.name)) {
+      continue;
+    }
+
+    targets.push(spawnPosition, ...getExpansionDefenseAdjacentPositions(spawnPosition, true));
+  }
+
+  const controllerPosition = getExpansionTowerObjectPosition(room.controller);
+  if (isExpansionTowerSameRoomPosition(controllerPosition, room.name)) {
+    targets.push(...getExpansionDefenseAdjacentPositions(controllerPosition, false));
+  }
+
+  return dedupeExpansionDefensePositions(targets)
+    .filter((position) => isExpansionDefenseRampartTargetAllowed(lookups, position))
+    .slice(0, EXPANSION_DEFENSE_BARRIER_MAX_SECONDARY_RAMPARTS);
+}
+
+function getExpansionDefenseAdjacentPositions(
+  center: RoomPositionLike,
+  includeCenter: boolean
+): RoomPositionLike[] {
+  const positions: RoomPositionLike[] = includeCenter ? [{ ...center }] : [];
+  const offsets = [
+    { dx: 0, dy: -1 },
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: 1 },
+    { dx: -1, dy: 0 },
+    { dx: -1, dy: -1 },
+    { dx: 1, dy: -1 },
+    { dx: 1, dy: 1 },
+    { dx: -1, dy: 1 }
+  ];
+
+  for (const offset of offsets) {
+    positions.push({
+      x: center.x + offset.dx,
+      y: center.y + offset.dy,
+      roomName: center.roomName
+    });
+  }
+
+  return positions;
+}
+
+function canPlaceExpansionDefenseRampart(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (
+    isExpansionDefenseRampartTargetAllowed(lookups, position) &&
+    !hasExpansionDefenseConstructionAt(lookups, position)
+  );
+}
+
+function canPlaceExpansionDefenseWall(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (
+    isExpansionDefenseBuildablePosition(lookups, position) &&
+    !lookups.reservedPositions.has(getExpansionTowerPositionKey(position)) &&
+    !hasExpansionDefenseStructureAt(lookups, position) &&
+    !hasExpansionDefenseConstructionAt(lookups, position)
+  );
+}
+
+function isExpansionDefenseBuildablePosition(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (
+    position.x >= EXPANSION_TOWER_ROOM_EDGE_MIN &&
+    position.x <= EXPANSION_TOWER_ROOM_EDGE_MAX &&
+    position.y >= EXPANSION_TOWER_ROOM_EDGE_MIN &&
+    position.y <= EXPANSION_TOWER_ROOM_EDGE_MAX &&
+    !isExpansionTowerTerrainWall(lookups.terrain, position)
+  );
+}
+
+function hasExpansionDefenseRampartCoverage(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (
+    hasExpansionDefenseStructureTypeAt(lookups, position, 'STRUCTURE_RAMPART', 'rampart') ||
+    hasExpansionDefenseConstructionTypeAt(lookups, position, 'STRUCTURE_RAMPART', 'rampart')
+  );
+}
+
+function hasExpansionDefenseWallCoverage(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (
+    hasExpansionDefenseStructureTypeAt(lookups, position, 'STRUCTURE_WALL', 'constructedWall') ||
+    hasExpansionDefenseConstructionTypeAt(lookups, position, 'STRUCTURE_WALL', 'constructedWall')
+  );
+}
+
+function hasExpansionDefenseStructureAt(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (lookups.structuresByPosition.get(getExpansionTowerPositionKey(position)) ?? []).length > 0;
+}
+
+function hasExpansionDefenseConstructionAt(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (lookups.constructionSitesByPosition.get(getExpansionTowerPositionKey(position)) ?? []).length > 0;
+}
+
+function hasExpansionDefenseStructureTypeAt(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike,
+  globalName: 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
+  fallback: string
+): boolean {
+  return (lookups.structuresByPosition.get(getExpansionTowerPositionKey(position)) ?? []).some((structure) =>
+    isExpansionDefenseStructureType(structure.structureType, globalName, fallback)
+  );
+}
+
+function hasExpansionDefenseConstructionTypeAt(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike,
+  globalName: 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
+  fallback: string
+): boolean {
+  return (lookups.constructionSitesByPosition.get(getExpansionTowerPositionKey(position)) ?? []).some((site) =>
+    isExpansionDefenseStructureType(String(site.structureType), globalName, fallback)
+  );
+}
+
+function createExpansionDefenseBarrierPlacement(
+  roomName: string,
+  position: RoomPositionLike,
+  stage: ExpansionDefenseBarrierPlacementStage
+): ExpansionDefenseBarrierPlacement {
+  const isWall = stage === 'entranceWall';
+  return {
+    roomName,
+    x: position.x,
+    y: position.y,
+    structureType: getExpansionDefenseStructureConstant(
+      isWall ? 'STRUCTURE_WALL' : 'STRUCTURE_RAMPART',
+      isWall ? 'constructedWall' : 'rampart'
+    ),
+    stage,
+    priority: getExpansionDefenseBarrierStagePriority(stage)
+  };
+}
+
+function getExpansionDefenseBarrierStagePriority(stage: ExpansionDefenseBarrierPlacementStage): number {
+  switch (stage) {
+    case 'entranceRampart':
+      return 0;
+    case 'entranceWall':
+      return 1;
+    case 'secondaryRampart':
+      return 2;
+  }
+}
+
+function getExpansionDefenseInteriorSide(position: RoomPositionLike): ExitGroup['side'] | null {
+  if (position.y <= EXPANSION_TOWER_ROOM_EDGE_MIN) {
+    return 'top';
+  }
+  if (position.x >= EXPANSION_TOWER_ROOM_EDGE_MAX) {
+    return 'right';
+  }
+  if (position.y >= EXPANSION_TOWER_ROOM_EDGE_MAX) {
+    return 'bottom';
+  }
+  if (position.x <= EXPANSION_TOWER_ROOM_EDGE_MIN) {
+    return 'left';
+  }
+
+  return null;
+}
+
+function addExpansionDefenseReservedPosition(
+  reservedPositions: Set<string>,
+  object: unknown,
+  roomName: string
+): void {
+  const position = getExpansionTowerObjectPosition(object);
+  if (isExpansionTowerSameRoomPosition(position, roomName)) {
+    reservedPositions.add(getExpansionTowerPositionKey(position));
+  }
+}
+
+function addExpansionDefenseObjectAtPosition<T extends { pos?: RoomPosition; structureType?: unknown }>(
+  objectsByPosition: Map<string, T[]>,
+  object: T,
+  roomName: string
+): void {
+  const position = getExpansionTowerObjectPosition(object);
+  if (!isExpansionTowerSameRoomPosition(position, roomName)) {
+    return;
+  }
+
+  const key = getExpansionTowerPositionKey(position);
+  const objects = objectsByPosition.get(key) ?? [];
+  objects.push(object);
+  objectsByPosition.set(key, objects);
+}
+
+function dedupeExpansionDefensePositions(positions: RoomPositionLike[]): RoomPositionLike[] {
+  const seen = new Set<string>();
+  const deduped: RoomPositionLike[] = [];
+  for (const position of positions) {
+    const key = getExpansionTowerPositionKey(position);
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(position);
+  }
+
+  return deduped;
+}
+
+function clampExpansionDefenseBuildCoordinate(value: number): number {
+  return Math.max(EXPANSION_TOWER_ROOM_EDGE_MIN, Math.min(EXPANSION_TOWER_ROOM_EDGE_MAX, value));
+}
+
+function getExpansionDefenseBarrierMaxPlacements(maxPlacements: number | undefined): number {
+  if (typeof maxPlacements !== 'number' || !Number.isFinite(maxPlacements)) {
+    return EXPANSION_DEFENSE_BARRIER_DEFAULT_MAX_PLACEMENTS;
+  }
+
+  return Math.max(1, Math.floor(maxPlacements));
+}
+
+function isExpansionDefenseStructureType(
+  actual: unknown,
+  globalName: 'STRUCTURE_SPAWN' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
+  fallback: string
+): boolean {
+  return actual === getExpansionDefenseStructureConstant(globalName, fallback);
+}
+
+function getExpansionDefenseStructureConstant(
+  globalName: 'STRUCTURE_SPAWN' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
+  fallback: string
+): BuildableStructureConstant {
+  const constants = globalThis as unknown as Partial<
+    Record<'STRUCTURE_SPAWN' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL', BuildableStructureConstant>
+  >;
+  return constants[globalName] ?? (fallback as BuildableStructureConstant);
 }
 
 function compareExpansionTowerObjectIds(left: unknown, right: unknown): number {

--- a/prod/src/territory/rampartWallConstructionExecutor.ts
+++ b/prod/src/territory/rampartWallConstructionExecutor.ts
@@ -1,0 +1,370 @@
+import type { ColonySnapshot } from '../colony/colonyRegistry';
+import {
+  planExpansionDefenseBarrierPlacements,
+  type ExpansionDefenseBarrierPlacementStage
+} from './expansionPlanner';
+
+export const EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_RCL = 3;
+export const EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_ENERGY = 1;
+
+const OK_CODE = 0 as ScreepsReturnCode;
+const ERR_FULL_CODE = -8 as ScreepsReturnCode;
+const ERR_RCL_NOT_ENOUGH_CODE = -14 as ScreepsReturnCode;
+const FALLBACK_EXTENSION_LIMITS_BY_RCL = [0, 0, 5, 10, 20, 30, 40, 50, 60];
+const FALLBACK_TOWER_LIMITS_BY_RCL = [0, 0, 0, 1, 1, 2, 2, 3, 6];
+
+type FindConstantGlobal =
+  | 'FIND_SOURCES'
+  | 'FIND_STRUCTURES'
+  | 'FIND_CONSTRUCTION_SITES'
+  | 'FIND_MY_STRUCTURES'
+  | 'FIND_MY_CONSTRUCTION_SITES';
+type StructureConstantGlobal =
+  | 'STRUCTURE_SPAWN'
+  | 'STRUCTURE_EXTENSION'
+  | 'STRUCTURE_CONTAINER'
+  | 'STRUCTURE_TOWER';
+type ReturnCodeGlobal = 'ERR_FULL' | 'ERR_RCL_NOT_ENOUGH';
+
+interface PositionedRoomObject {
+  pos?: {
+    x?: unknown;
+    y?: unknown;
+    roomName?: unknown;
+  };
+}
+
+interface RoomPositionLike {
+  x: number;
+  y: number;
+  roomName?: string;
+}
+
+export type RampartWallConstructionExecutorStatus = 'created' | 'skipped';
+export type RampartWallConstructionExecutorSkipReason =
+  | 'apiUnavailable'
+  | 'controllerLevelLow'
+  | 'energyUnavailable'
+  | 'essentialStructuresPending'
+  | 'notExpansionRoom'
+  | 'roomNotClaimed'
+  | 'noPlacement';
+
+export interface RampartWallConstructionExecutorOptions {
+  requireExpansionMemory?: boolean;
+  minEnergyAvailable?: number;
+  maxPlacementCandidates?: number;
+}
+
+export interface RampartWallConstructionExecutorResult {
+  roomName: string;
+  status: RampartWallConstructionExecutorStatus;
+  reason?: RampartWallConstructionExecutorSkipReason;
+  result?: ScreepsReturnCode;
+  stage?: ExpansionDefenseBarrierPlacementStage;
+  structureType?: BuildableStructureConstant;
+  x?: number;
+  y?: number;
+}
+
+export function runRampartWallConstructionExecutorForColony(
+  colony: ColonySnapshot,
+  options: RampartWallConstructionExecutorOptions = {}
+): RampartWallConstructionExecutorResult {
+  const room = colony.room;
+  if (options.requireExpansionMemory === true && !isExpansionControlledRoom(room.name)) {
+    return { roomName: room.name, status: 'skipped', reason: 'notExpansionRoom' };
+  }
+
+  if (room.controller?.my !== true) {
+    return { roomName: room.name, status: 'skipped', reason: 'roomNotClaimed' };
+  }
+
+  if (!hasRampartWallConstructionExecutorApis(room)) {
+    return { roomName: room.name, status: 'skipped', reason: 'apiUnavailable' };
+  }
+
+  const rcl = getOwnedRoomRcl(room);
+  if (rcl < EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_RCL) {
+    return { roomName: room.name, status: 'skipped', reason: 'controllerLevelLow' };
+  }
+
+  const minEnergyAvailable = resolveNonNegativeInteger(
+    options.minEnergyAvailable,
+    EXPANSION_DEFENSE_BARRIER_CONSTRUCTION_MIN_ENERGY
+  );
+  if (getColonyEnergyAvailable(colony) < minEnergyAvailable) {
+    return { roomName: room.name, status: 'skipped', reason: 'energyUnavailable' };
+  }
+
+  if (!isDefenseBarrierStageReady(colony, rcl)) {
+    return { roomName: room.name, status: 'skipped', reason: 'essentialStructuresPending' };
+  }
+
+  const placements = planExpansionDefenseBarrierPlacements(room, {
+    maxPlacements: options.maxPlacementCandidates
+  });
+  const stage = placements[0]?.stage;
+  if (!stage) {
+    return { roomName: room.name, status: 'skipped', reason: 'noPlacement' };
+  }
+
+  for (const placement of placements) {
+    if (placement.stage !== stage) {
+      continue;
+    }
+
+    const result = room.createConstructionSite(placement.x, placement.y, placement.structureType);
+    if (result === OK_CODE) {
+      return {
+        roomName: room.name,
+        status: 'created',
+        result,
+        stage: placement.stage,
+        structureType: placement.structureType,
+        x: placement.x,
+        y: placement.y
+      };
+    }
+
+    if (isFatalConstructionSiteResult(result)) {
+      return {
+        roomName: room.name,
+        status: 'skipped',
+        reason: 'noPlacement',
+        result,
+        stage: placement.stage,
+        structureType: placement.structureType,
+        x: placement.x,
+        y: placement.y
+      };
+    }
+  }
+
+  return { roomName: room.name, status: 'skipped', reason: 'noPlacement', stage };
+}
+
+function isDefenseBarrierStageReady(colony: ColonySnapshot, rcl: number): boolean {
+  const room = colony.room;
+  return (
+    hasSpawnCoverage(colony) &&
+    hasExtensionCapacityPlaced(room, rcl) &&
+    hasSourceContainerCoverage(room) &&
+    hasTowerCoverage(room, rcl)
+  );
+}
+
+function hasSpawnCoverage(colony: ColonySnapshot): boolean {
+  return (
+    colony.spawns.some((spawn) => spawn.room?.name === colony.room.name) ||
+    countExistingAndPendingStructures(colony.room, 'STRUCTURE_SPAWN', 'spawn') > 0
+  );
+}
+
+function hasExtensionCapacityPlaced(room: Room, rcl: number): boolean {
+  const extensionLimit = getStructureLimitForRcl('STRUCTURE_EXTENSION', 'extension', rcl, FALLBACK_EXTENSION_LIMITS_BY_RCL);
+  return countExistingAndPendingStructures(room, 'STRUCTURE_EXTENSION', 'extension') >= extensionLimit;
+}
+
+function hasTowerCoverage(room: Room, rcl: number): boolean {
+  const towerLimit = getStructureLimitForRcl('STRUCTURE_TOWER', 'tower', rcl, FALLBACK_TOWER_LIMITS_BY_RCL);
+  return towerLimit <= 0 || countExistingAndPendingStructures(room, 'STRUCTURE_TOWER', 'tower') >= Math.min(1, towerLimit);
+}
+
+function hasSourceContainerCoverage(room: Room): boolean {
+  const sources = findRoomObjects<Source>(room, 'FIND_SOURCES').filter((source) =>
+    isSameRoomPosition(getRoomObjectPosition(source), room.name)
+  );
+  if (sources.length === 0) {
+    return true;
+  }
+
+  const containers = [
+    ...findRoomObjects<Structure>(room, 'FIND_STRUCTURES'),
+    ...findRoomObjects<ConstructionSite>(room, 'FIND_CONSTRUCTION_SITES')
+  ].filter((object) =>
+    matchesStructureType((object as { structureType?: string }).structureType, 'STRUCTURE_CONTAINER', 'container')
+  );
+
+  return sources.every((source) =>
+    containers.some((container) => isNearRoomObject(source, container))
+  );
+}
+
+function countExistingAndPendingStructures(
+  room: Room,
+  globalName: StructureConstantGlobal,
+  fallback: string
+): number {
+  return (
+    findRoomObjects<AnyOwnedStructure>(room, 'FIND_MY_STRUCTURES').filter((structure) =>
+      matchesStructureType(structure.structureType, globalName, fallback)
+    ).length +
+    findRoomObjects<ConstructionSite>(room, 'FIND_MY_CONSTRUCTION_SITES').filter((site) =>
+      matchesStructureType(String(site.structureType), globalName, fallback)
+    ).length
+  );
+}
+
+function isExpansionControlledRoom(roomName: string): boolean {
+  const territoryMemory = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory;
+  if (!territoryMemory) {
+    return false;
+  }
+
+  if (isRecord(territoryMemory.postClaimBootstraps?.[roomName])) {
+    return true;
+  }
+
+  const claimedRoomRecord = territoryMemory.claimedRoomBootstrapper?.rooms?.[roomName];
+  if (claimedRoomRecord?.claimedAt !== undefined) {
+    return true;
+  }
+
+  return (
+    hasExpansionControlReference(territoryMemory.targets, roomName, 'roomName') ||
+    hasExpansionControlReference(territoryMemory.intents, roomName, 'targetRoom')
+  );
+}
+
+function hasExpansionControlReference(
+  records: unknown,
+  roomName: string,
+  roomKey: 'roomName' | 'targetRoom'
+): boolean {
+  return Array.isArray(records)
+    ? records.some(
+        (record) =>
+          isRecord(record) &&
+          record[roomKey] === roomName &&
+          (record.action === 'claim' || record.action === 'reserve')
+      )
+    : false;
+}
+
+function hasRampartWallConstructionExecutorApis(room: Room): boolean {
+  return typeof room.find === 'function' && typeof room.createConstructionSite === 'function';
+}
+
+function getOwnedRoomRcl(room: Room): number {
+  const level = room.controller?.level;
+  return typeof level === 'number' && Number.isFinite(level) ? Math.max(0, Math.floor(level)) : 0;
+}
+
+function getColonyEnergyAvailable(colony: ColonySnapshot): number {
+  return Math.max(
+    0,
+    Math.floor(
+      Number.isFinite(colony.energyAvailable)
+        ? colony.energyAvailable
+        : typeof colony.room.energyAvailable === 'number'
+          ? colony.room.energyAvailable
+          : 0
+    )
+  );
+}
+
+function getStructureLimitForRcl(
+  globalName: StructureConstantGlobal,
+  fallback: string,
+  rcl: number,
+  fallbackLimits: number[]
+): number {
+  const normalizedRcl = Math.max(0, Math.floor(rcl));
+  const structureType = getStructureConstant(globalName, fallback);
+  const controllerStructures = (globalThis as { CONTROLLER_STRUCTURES?: Partial<Record<string, number[]>> })
+    .CONTROLLER_STRUCTURES;
+  const configuredLimit = controllerStructures?.[structureType]?.[normalizedRcl];
+  if (typeof configuredLimit === 'number' && Number.isFinite(configuredLimit)) {
+    return Math.max(0, Math.floor(configuredLimit));
+  }
+
+  return fallbackLimits[normalizedRcl] ?? 0;
+}
+
+function findRoomObjects<T>(room: Room, globalName: FindConstantGlobal): T[] {
+  const findConstant = getGlobalNumber(globalName);
+  if (findConstant === null || typeof room.find !== 'function') {
+    return [];
+  }
+
+  try {
+    const result = room.find(findConstant as FindConstant);
+    return Array.isArray(result) ? (result as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function getRoomObjectPosition(object: PositionedRoomObject | undefined): RoomPositionLike | null {
+  const position = object?.pos;
+  if (
+    typeof position?.x !== 'number' ||
+    typeof position.y !== 'number' ||
+    !Number.isFinite(position.x) ||
+    !Number.isFinite(position.y)
+  ) {
+    return null;
+  }
+
+  return {
+    x: position.x,
+    y: position.y,
+    ...(typeof position.roomName === 'string' ? { roomName: position.roomName } : {})
+  };
+}
+
+function isNearRoomObject(left: PositionedRoomObject, right: PositionedRoomObject): boolean {
+  const leftPosition = getRoomObjectPosition(left);
+  const rightPosition = getRoomObjectPosition(right);
+  if (!leftPosition || !rightPosition || !isSameRoomPosition(leftPosition, rightPosition.roomName)) {
+    return false;
+  }
+
+  return Math.max(Math.abs(leftPosition.x - rightPosition.x), Math.abs(leftPosition.y - rightPosition.y)) <= 1;
+}
+
+function isSameRoomPosition(position: RoomPositionLike | null, roomName: string | undefined): boolean {
+  return position !== null && (position.roomName === undefined || roomName === undefined || position.roomName === roomName);
+}
+
+function matchesStructureType(
+  actual: string | undefined,
+  globalName: StructureConstantGlobal,
+  fallback: string
+): boolean {
+  return actual === getStructureConstant(globalName, fallback);
+}
+
+function getStructureConstant(
+  globalName: StructureConstantGlobal,
+  fallback: string
+): StructureConstant {
+  const constants = globalThis as unknown as Partial<Record<StructureConstantGlobal, StructureConstant>>;
+  return constants[globalName] ?? (fallback as StructureConstant);
+}
+
+function getGlobalNumber(name: FindConstantGlobal): number | null {
+  const value = (globalThis as Record<string, unknown>)[name];
+  return typeof value === 'number' ? value : null;
+}
+
+function getGlobalReturnCode(name: ReturnCodeGlobal, fallback: ScreepsReturnCode): ScreepsReturnCode {
+  const value = (globalThis as Partial<Record<ReturnCodeGlobal, ScreepsReturnCode>>)[name];
+  return typeof value === 'number' ? value : fallback;
+}
+
+function isFatalConstructionSiteResult(result: ScreepsReturnCode): boolean {
+  return (
+    result === getGlobalReturnCode('ERR_FULL', ERR_FULL_CODE) ||
+    result === getGlobalReturnCode('ERR_RCL_NOT_ENOUGH', ERR_RCL_NOT_ENOUGH_CODE)
+  );
+}
+
+function resolveNonNegativeInteger(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -5,6 +5,7 @@ import {
   createExpansionIntent,
   evaluateExpansionCandidate,
   evaluateExpansionRoomSuitability,
+  planExpansionDefenseBarrierPlacements,
   planExpansionTowerPlacements,
   prioritizeExpansionCandidates,
   refreshExpansionPlannerIntent
@@ -19,7 +20,11 @@ describe('expansion planner', () => {
     (globalThis as unknown as { FIND_STRUCTURES: number }).FIND_STRUCTURES = 4;
     (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 5;
     (globalThis as unknown as { FIND_EXIT: number }).FIND_EXIT = 6;
+    (globalThis as unknown as { FIND_MINERALS: number }).FIND_MINERALS = 7;
     (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
+    (globalThis as unknown as { STRUCTURE_WALL: StructureConstant }).STRUCTURE_WALL = 'constructedWall';
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
     delete (globalThis as { Game?: Partial<Game> }).Game;
   });
@@ -144,6 +149,136 @@ describe('expansion planner', () => {
       expect(`${placement.x},${placement.y}`).not.toBe('25,24');
       expect(wallPositions.has(`${placement.x},${placement.y}`)).toBe(false);
     }
+  });
+
+  it('plans entrance ramparts before other claimed-room defensive barriers', () => {
+    const spawn = makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN);
+    const room = makeTowerPlanningRoom('W2N1', {
+      controllerPosition: { x: 25, y: 25 },
+      sourcePositions: [],
+      exitPositions: [
+        { x: 24, y: 0 },
+        { x: 25, y: 0 },
+        { x: 26, y: 0 },
+        { x: 49, y: 25 }
+      ],
+      structures: [spawn]
+    });
+    installTerrain(room.name, new Set());
+
+    const placements = planExpansionDefenseBarrierPlacements(room, { maxPlacements: 4 });
+
+    expect(placements).toEqual([
+      {
+        roomName: 'W2N1',
+        x: 25,
+        y: 1,
+        structureType: STRUCTURE_RAMPART,
+        stage: 'entranceRampart',
+        priority: 0
+      },
+      {
+        roomName: 'W2N1',
+        x: 48,
+        y: 25,
+        structureType: STRUCTURE_RAMPART,
+        stage: 'entranceRampart',
+        priority: 0
+      }
+    ]);
+  });
+
+  it('plans walls adjacent to covered entrance ramparts before secondary ramparts', () => {
+    const structures = [
+      makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN),
+      makePositionedStructure('rampart-top', 25, 1, 'W2N1', STRUCTURE_RAMPART),
+      makePositionedStructure('rampart-right', 48, 25, 'W2N1', STRUCTURE_RAMPART)
+    ];
+    const room = makeTowerPlanningRoom('W2N1', {
+      controllerPosition: { x: 25, y: 25 },
+      sourcePositions: [],
+      exitPositions: [
+        { x: 24, y: 0 },
+        { x: 25, y: 0 },
+        { x: 26, y: 0 },
+        { x: 49, y: 25 }
+      ],
+      structures
+    });
+    installTerrain(room.name, new Set());
+
+    const placements = planExpansionDefenseBarrierPlacements(room, { maxPlacements: 4 });
+
+    expect(placements).toEqual([
+      {
+        roomName: 'W2N1',
+        x: 24,
+        y: 1,
+        structureType: STRUCTURE_WALL,
+        stage: 'entranceWall',
+        priority: 1
+      },
+      {
+        roomName: 'W2N1',
+        x: 26,
+        y: 1,
+        structureType: STRUCTURE_WALL,
+        stage: 'entranceWall',
+        priority: 1
+      },
+      {
+        roomName: 'W2N1',
+        x: 48,
+        y: 24,
+        structureType: STRUCTURE_WALL,
+        stage: 'entranceWall',
+        priority: 1
+      },
+      {
+        roomName: 'W2N1',
+        x: 48,
+        y: 26,
+        structureType: STRUCTURE_WALL,
+        stage: 'entranceWall',
+        priority: 1
+      }
+    ]);
+  });
+
+  it('plans spawn and controller ramparts after entrance ramparts and walls are covered', () => {
+    const structures = [
+      makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN),
+      makePositionedStructure('rampart-top', 25, 1, 'W2N1', STRUCTURE_RAMPART),
+      makePositionedStructure('rampart-right', 48, 25, 'W2N1', STRUCTURE_RAMPART),
+      makePositionedStructure('wall-top-left', 24, 1, 'W2N1', STRUCTURE_WALL),
+      makePositionedStructure('wall-top-right', 26, 1, 'W2N1', STRUCTURE_WALL),
+      makePositionedStructure('wall-right-top', 48, 24, 'W2N1', STRUCTURE_WALL),
+      makePositionedStructure('wall-right-bottom', 48, 26, 'W2N1', STRUCTURE_WALL)
+    ];
+    const room = makeTowerPlanningRoom('W2N1', {
+      controllerPosition: { x: 25, y: 25 },
+      sourcePositions: [],
+      exitPositions: [
+        { x: 24, y: 0 },
+        { x: 25, y: 0 },
+        { x: 26, y: 0 },
+        { x: 49, y: 25 }
+      ],
+      structures
+    });
+    installTerrain(room.name, new Set());
+
+    const placements = planExpansionDefenseBarrierPlacements(room, { maxPlacements: 3 });
+
+    expect(placements[0]).toEqual({
+      roomName: 'W2N1',
+      x: 20,
+      y: 20,
+      structureType: STRUCTURE_RAMPART,
+      stage: 'secondaryRampart',
+      priority: 2
+    });
+    expect(placements.every((placement) => placement.stage === 'secondaryRampart')).toBe(true);
   });
 
   it('creates expansion targets and intents through territory planning', () => {
@@ -985,10 +1120,17 @@ function makeTowerPlanningRoom(
   return room;
 }
 
-function makePositionedStructure(id: string, x: number, y: number, roomName: string): Structure {
+function makePositionedStructure(
+  id: string,
+  x: number,
+  y: number,
+  roomName: string,
+  structureType?: StructureConstant
+): Structure {
   return {
     id,
-    pos: makePosition(x, y, roomName)
+    pos: makePosition(x, y, roomName),
+    ...(structureType ? { structureType } : {})
   } as unknown as Structure;
 }
 

--- a/prod/test/rampartWallConstructionExecutor.test.ts
+++ b/prod/test/rampartWallConstructionExecutor.test.ts
@@ -1,0 +1,228 @@
+import type { ColonySnapshot } from '../src/colony/colonyRegistry';
+import { runRampartWallConstructionExecutorForColony } from '../src/territory/rampartWallConstructionExecutor';
+
+const OK_CODE = 0 as ScreepsReturnCode;
+
+const TEST_GLOBALS = {
+  FIND_SOURCES: 1,
+  FIND_STRUCTURES: 2,
+  FIND_CONSTRUCTION_SITES: 3,
+  FIND_MY_STRUCTURES: 4,
+  FIND_MY_CONSTRUCTION_SITES: 5,
+  FIND_EXIT: 6,
+  STRUCTURE_SPAWN: 'spawn',
+  STRUCTURE_EXTENSION: 'extension',
+  STRUCTURE_CONTAINER: 'container',
+  STRUCTURE_TOWER: 'tower',
+  STRUCTURE_RAMPART: 'rampart',
+  STRUCTURE_WALL: 'constructedWall',
+  TERRAIN_MASK_WALL: 1,
+  OK: OK_CODE
+} as const;
+
+describe('rampart and wall construction executor', () => {
+  beforeEach(() => {
+    Object.assign(globalThis, TEST_GLOBALS);
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        targets: [{ colony: 'W1N1', roomName: 'W2N1', action: 'claim', createdBy: 'expansionPlanner' }]
+      }
+    };
+  });
+
+  afterEach(() => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const key of Object.keys(TEST_GLOBALS)) {
+      delete globals[key];
+    }
+    delete globals.Game;
+    delete globals.Memory;
+  });
+
+  it('creates the first entrance rampart after essential claimed-room structures are covered', () => {
+    const { colony, room } = makeBarrierExecutorColony();
+    installGame(room);
+
+    const result = runRampartWallConstructionExecutorForColony(colony, { requireExpansionMemory: true });
+
+    expect(result).toEqual({
+      roomName: 'W2N1',
+      status: 'created',
+      result: OK_CODE,
+      stage: 'entranceRampart',
+      structureType: TEST_GLOBALS.STRUCTURE_RAMPART,
+      x: 25,
+      y: 1
+    });
+    expect(room.createConstructionSite).toHaveBeenCalledWith(25, 1, TEST_GLOBALS.STRUCTURE_RAMPART);
+  });
+
+  it('creates entrance walls only after the entrance rampart layer is covered', () => {
+    const entranceRampart = makeStructure('rampart-top', TEST_GLOBALS.STRUCTURE_RAMPART, 25, 1);
+    const { colony, room } = makeBarrierExecutorColony({ extraStructures: [entranceRampart] });
+    installGame(room);
+
+    const result = runRampartWallConstructionExecutorForColony(colony, { requireExpansionMemory: true });
+
+    expect(result).toMatchObject({
+      roomName: 'W2N1',
+      status: 'created',
+      stage: 'entranceWall',
+      structureType: TEST_GLOBALS.STRUCTURE_WALL,
+      x: 24,
+      y: 1
+    });
+    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 1, TEST_GLOBALS.STRUCTURE_WALL);
+  });
+
+  it('skips barrier placement until essential structures and tower coverage are placed', () => {
+    const { colony, room } = makeBarrierExecutorColony({ includeTower: false });
+    installGame(room);
+
+    const result = runRampartWallConstructionExecutorForColony(colony, { requireExpansionMemory: true });
+
+    expect(result).toEqual({
+      roomName: 'W2N1',
+      status: 'skipped',
+      reason: 'essentialStructuresPending'
+    });
+    expect(room.createConstructionSite).not.toHaveBeenCalled();
+  });
+});
+
+interface BarrierExecutorRoom extends Room {
+  find: jest.Mock;
+  createConstructionSite: jest.Mock;
+}
+
+interface BarrierExecutorOptions {
+  includeTower?: boolean;
+  extraStructures?: Structure[];
+  constructionSites?: ConstructionSite[];
+}
+
+function makeBarrierExecutorColony({
+  includeTower = true,
+  extraStructures = [],
+  constructionSites = []
+}: BarrierExecutorOptions = {}): { colony: ColonySnapshot; room: BarrierExecutorRoom } {
+  const roomName = 'W2N1';
+  const sources = [
+    makeSource('source-a', 10, 10),
+    makeSource('source-b', 40, 10)
+  ];
+  const spawn = makeStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 25, 25);
+  const containers = [
+    makeStructure('container-a', TEST_GLOBALS.STRUCTURE_CONTAINER, 11, 11),
+    makeStructure('container-b', TEST_GLOBALS.STRUCTURE_CONTAINER, 39, 11)
+  ];
+  const extensions = Array.from({ length: 10 }, (_value, index) =>
+    makeStructure(`extension-${index}`, TEST_GLOBALS.STRUCTURE_EXTENSION, 30 + index, 30)
+  );
+  const structures = [
+    spawn,
+    ...containers,
+    ...extensions,
+    ...(includeTower ? [makeStructure('tower1', TEST_GLOBALS.STRUCTURE_TOWER, 24, 24)] : []),
+    ...extraStructures
+  ];
+  const sites = [...constructionSites];
+  const room = {
+    name: roomName,
+    energyAvailable: 800,
+    energyCapacityAvailable: 800,
+    controller: {
+      id: 'controller-W2N1' as Id<StructureController>,
+      my: true,
+      level: 3,
+      pos: makePosition(25, 25, roomName)
+    },
+    find: jest.fn((findType: number): unknown[] => {
+      switch (findType) {
+        case TEST_GLOBALS.FIND_SOURCES:
+          return sources;
+        case TEST_GLOBALS.FIND_STRUCTURES:
+          return structures;
+        case TEST_GLOBALS.FIND_CONSTRUCTION_SITES:
+          return sites;
+        case TEST_GLOBALS.FIND_MY_STRUCTURES:
+          return structures.filter((structure) =>
+            structure.structureType !== TEST_GLOBALS.STRUCTURE_CONTAINER
+          );
+        case TEST_GLOBALS.FIND_MY_CONSTRUCTION_SITES:
+          return sites;
+        case TEST_GLOBALS.FIND_EXIT:
+          return [
+            makePosition(24, 0, roomName),
+            makePosition(25, 0, roomName),
+            makePosition(26, 0, roomName)
+          ];
+        default:
+          return [];
+      }
+    }),
+    createConstructionSite: jest.fn((x: number, y: number, structureType: BuildableStructureConstant) => {
+      sites.push(makeConstructionSite(`site-${x}-${y}`, structureType, x, y));
+      return OK_CODE;
+    })
+  } as unknown as BarrierExecutorRoom;
+
+  for (const structure of structures) {
+    (structure as Structure & { room?: Room }).room = room;
+  }
+
+  return {
+    room,
+    colony: {
+      room,
+      spawns: [spawn as StructureSpawn],
+      energyAvailable: 800,
+      energyCapacityAvailable: 800
+    }
+  };
+}
+
+function makeSource(id: string, x: number, y: number): Source {
+  return {
+    id,
+    pos: makePosition(x, y, 'W2N1')
+  } as unknown as Source;
+}
+
+function makeStructure(id: string, structureType: StructureConstant, x: number, y: number): Structure {
+  return {
+    id,
+    name: id,
+    structureType,
+    pos: makePosition(x, y, 'W2N1')
+  } as unknown as Structure;
+}
+
+function makeConstructionSite(
+  id: string,
+  structureType: BuildableStructureConstant,
+  x: number,
+  y: number
+): ConstructionSite {
+  return {
+    id,
+    structureType,
+    pos: makePosition(x, y, 'W2N1')
+  } as unknown as ConstructionSite;
+}
+
+function makePosition(x: number, y: number, roomName: string): RoomPosition {
+  return { x, y, roomName } as RoomPosition;
+}
+
+function installGame(room: Room): void {
+  (globalThis as unknown as { Game: Partial<Game> }).Game = {
+    time: 123,
+    rooms: { [room.name]: room },
+    map: {
+      getRoomTerrain: jest.fn().mockReturnValue({
+        get: jest.fn().mockReturnValue(0)
+      })
+    } as unknown as GameMap
+  };
+}


### PR DESCRIPTION
## Summary
- Implements rampart and wall construction in claimed colonies per issue #748
- Added `rampartWallConstructionExecutor.ts` with colony defense barrier construction logic
- Integrated with existing expansion planner for barrier placement stages
- Added regression tests
- Verification: typecheck passes, all 1397 tests pass, build succeeds

Closes #748
