### PR TITLE
feat(economy): reduce wasteful low-load worker returns for better energy throughput (#758)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -18773,9 +18773,7 @@ function selectLowLoadWorkerEnergyContinuationCandidate(creep, maximumRange = LO
   if (!shouldKeepLowLoadWorkerAcquiringEnergy(creep)) {
     return null;
   }
-  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep, maximumRange).filter(
-    (candidate) => isLowLoadWorkerEnergyContinuationCandidateInRange(candidate, maximumRange)
-  );
+  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep, maximumRange).filter((candidate) => isLowLoadWorkerEnergyContinuationCandidateInRange(candidate, maximumRange)).filter((candidate) => isLowLoadWorkerEnergyContinuationCandidateReachable(creep, candidate));
   if (candidates.length === 0) {
     return null;
   }
@@ -18800,6 +18798,9 @@ function findLowLoadWorkerEnergyContinuationCandidates(creep, maximumRange = LOW
 }
 function isLowLoadWorkerEnergyContinuationCandidateInRange(candidate, maximumRange = LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE) {
   return candidate.range !== null && candidate.range <= maximumRange;
+}
+function isLowLoadWorkerEnergyContinuationCandidateReachable(creep, candidate) {
+  return candidate.task.type !== "withdraw" || isReachable(creep, candidate.source);
 }
 function toLowLoadWorkerEnergyAcquisitionCandidate(candidate) {
   return candidate;

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -16425,7 +16425,8 @@ var CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 var URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
 var WORKER_PRE_HARVEST_REGEN_THRESHOLD = 50;
 var NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
-var MINIMUM_USEFUL_LOAD_RATIO = 0.4;
+var MINIMUM_USEFUL_LOAD_RATIO = 0.3;
+var LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS = 1e3;
 var LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 var LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 var LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
@@ -16597,7 +16598,7 @@ function selectHeuristicWorkerTask(creep) {
     return territoryControllerTask;
   }
   const controller = creep.room.controller;
-  if (controller && shouldGuardControllerDowngrade2(controller) && canUpgradeController(controller) && !remoteProductiveSpendingSuppressed) {
+  if (controller && shouldGuardControllerDowngradeForWorkerLoad(creep, controller) && canUpgradeController(controller) && !remoteProductiveSpendingSuppressed) {
     const downgradeGuardTask = {
       type: "upgrade",
       targetId: controller.id
@@ -16990,6 +16991,18 @@ function isTerritoryControlTask(task) {
 function hasEmergencySpawnExtensionRefillDemand(creep) {
   const energyAvailable = getRoomEnergyAvailable5(creep.room);
   return energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
+}
+function shouldGuardControllerDowngradeForWorkerLoad(creep, controller) {
+  if (!shouldGuardControllerDowngrade2(controller)) {
+    return false;
+  }
+  if (!getLowLoadWorkerEnergyContext(creep)) {
+    return true;
+  }
+  return isControllerDowngradeImminentForLowLoadReturn(controller);
+}
+function isControllerDowngradeImminentForLowLoadReturn(controller) {
+  return (controller == null ? void 0 : controller.my) === true && typeof controller.ticksToDowngrade === "number" && controller.ticksToDowngrade < LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS;
 }
 function getLowLoadWorkerEnergyContext(creep) {
   const carriedEnergy = getUsedEnergy2(creep);
@@ -18721,16 +18734,7 @@ function getWorkerEnergyAcquisitionSourceTypePriority(source) {
   return 0;
 }
 function selectLowLoadWorkerEnergyAcquisitionCandidate(creep) {
-  if (!shouldKeepLowLoadWorkerAcquiringEnergy(creep)) {
-    return null;
-  }
-  const nearbyCandidates = findLowLoadWorkerEnergyAcquisitionCandidates(creep).filter(
-    (candidate) => candidate.range !== null && candidate.range <= LOW_LOAD_NEARBY_ENERGY_RANGE
-  );
-  if (nearbyCandidates.length === 0) {
-    return null;
-  }
-  return nearbyCandidates.sort(compareLowLoadWorkerEnergyAcquisitionCandidates)[0];
+  return selectLowLoadWorkerEnergyContinuationCandidate(creep);
 }
 function selectLowLoadWorkerEnergyContinuationTask(creep) {
   const candidate = selectLowLoadWorkerEnergyContinuationCandidate(creep);
@@ -18793,78 +18797,6 @@ function findLowLoadWorkerEnergyContinuationCandidates(creep, maximumRange = LOW
       maximumRange
     }).map(toLowLoadWorkerEnergyAcquisitionCandidate)
   ];
-}
-function findLowLoadWorkerEnergyAcquisitionCandidates(creep) {
-  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
-  const nearbyLinkRefillCandidate = findNearestNearbyWorkerLinkRefillCandidate(creep, reservationContext);
-  return [
-    ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationContext),
-    ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationContext),
-    ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep, reservationContext),
-    ...nearbyLinkRefillCandidate ? [toNearbyWorkerLinkRefillCandidate(nearbyLinkRefillCandidate)] : [],
-    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep),
-    ...findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext, {
-      maximumRange: LOW_LOAD_NEARBY_ENERGY_RANGE
-    }).map(toLowLoadWorkerEnergyAcquisitionCandidate)
-  ];
-}
-function findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationContext) {
-  const context = {
-    creepOwnerUsername: getCreepOwnerUsername2(creep),
-    hasHostilePresence: hasVisibleHostilePresence(creep.room),
-    room: creep.room
-  };
-  return findVisibleRoomStructures(creep.room).filter(
-    (structure) => isSafeStoredEnergySource(structure, context) && !isLinkEnergySource(structure)
-  ).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).flatMap((source) => {
-    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
-      creep,
-      source,
-      getStoredEnergy10(source),
-      {
-        type: "withdraw",
-        targetId: source.id
-      },
-      reservationContext
-    );
-    return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
-  });
-}
-function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationContext) {
-  return [...findTombstones(creep.room), ...findRuins(creep.room)].filter(hasSalvageableEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).flatMap((source) => {
-    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
-      creep,
-      source,
-      getStoredEnergy10(source),
-      {
-        type: "withdraw",
-        targetId: source.id
-      },
-      reservationContext,
-      MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT
-    );
-    return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
-  });
-}
-function findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep, reservationContext) {
-  return findDroppedResources(creep.room).filter(isUsefulDroppedEnergy).filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source)).flatMap((source) => {
-    const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
-      creep,
-      source,
-      source.amount,
-      {
-        type: "pickup",
-        targetId: source.id
-      },
-      reservationContext,
-      MIN_DROPPED_ENERGY_PICKUP_AMOUNT
-    );
-    return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
-  }).filter((candidate) => isReachable(creep, candidate.source));
-}
-function isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source) {
-  const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
-  return range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE;
 }
 function isLowLoadWorkerEnergyContinuationCandidateInRange(candidate, maximumRange = LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE) {
   return candidate.range !== null && candidate.range <= maximumRange;
@@ -21760,7 +21692,34 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(creep, task, 
   if (creep.store.getUsedCapacity(RESOURCE_ENERGY) <= 0) {
     return false;
   }
+  if (hasLowWorkerEnergyLoad(creep)) {
+    return shouldPreemptLowLoadEnergyAcquisitionForReturn(creep, selectedTask);
+  }
   return isUrgentEnergySpendingTask(selectedTask) || isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+function shouldPreemptLowLoadEnergyAcquisitionForReturn(creep, selectedTask) {
+  var _a;
+  const sample = (_a = creep.memory) == null ? void 0 : _a.workerEfficiency;
+  return (sample == null ? void 0 : sample.type) === "lowLoadReturn" && sample.selectedTask === selectedTask.type && sample.targetId === String(selectedTask.targetId) && isCurrentWorkerEfficiencySample(sample);
+}
+function hasLowWorkerEnergyLoad(creep) {
+  const carriedEnergy = getUsedTransferEnergy(creep);
+  const freeCapacity = getFreeCreepEnergyCapacity(creep);
+  if (carriedEnergy <= 0 || freeCapacity <= 0) {
+    return false;
+  }
+  const capacity = getCreepEnergyCapacity(creep, carriedEnergy, freeCapacity);
+  return capacity > 0 && carriedEnergy < capacity * MINIMUM_USEFUL_LOAD_RATIO;
+}
+function getFreeCreepEnergyCapacity(creep) {
+  var _a, _b;
+  const freeCapacity = (_b = (_a = creep.store) == null ? void 0 : _a.getFreeCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY);
+  return typeof freeCapacity === "number" && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+function getCreepEnergyCapacity(creep, carriedEnergy, freeCapacity) {
+  var _a, _b;
+  const capacity = (_b = (_a = creep.store) == null ? void 0 : _a.getCapacity) == null ? void 0 : _b.call(_a, RESOURCE_ENERGY);
+  return typeof capacity === "number" && Number.isFinite(capacity) && capacity > 0 ? capacity : carriedEnergy + freeCapacity;
 }
 function shouldPreemptTaskForUpgraderBoost(creep, task, selectedTask) {
   var _a;

--- a/prod/src/creeps/workerRunner.ts
+++ b/prod/src/creeps/workerRunner.ts
@@ -1,6 +1,7 @@
 import {
   CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD,
   CONTROLLER_DOWNGRADE_GUARD_TICKS,
+  MINIMUM_USEFUL_LOAD_RATIO,
   selectWorkerPreHarvestTask,
   isUpgraderBoostActive,
   isWorkerRepairTargetComplete,
@@ -731,7 +732,47 @@ function shouldPreemptEnergyAcquisitionTaskForUrgentEnergySpending(
     return false;
   }
 
+  if (hasLowWorkerEnergyLoad(creep)) {
+    return shouldPreemptLowLoadEnergyAcquisitionForReturn(creep, selectedTask);
+  }
+
   return isUrgentEnergySpendingTask(selectedTask) || isDowngradeGuardUpgradeTask(creep, selectedTask);
+}
+
+function shouldPreemptLowLoadEnergyAcquisitionForReturn(
+  creep: Creep,
+  selectedTask: CreepTaskMemory
+): boolean {
+  const sample = creep.memory?.workerEfficiency;
+  return (
+    sample?.type === 'lowLoadReturn' &&
+    sample.selectedTask === selectedTask.type &&
+    sample.targetId === String(selectedTask.targetId) &&
+    isCurrentWorkerEfficiencySample(sample)
+  );
+}
+
+function hasLowWorkerEnergyLoad(creep: Creep): boolean {
+  const carriedEnergy = getUsedTransferEnergy(creep);
+  const freeCapacity = getFreeCreepEnergyCapacity(creep);
+  if (carriedEnergy <= 0 || freeCapacity <= 0) {
+    return false;
+  }
+
+  const capacity = getCreepEnergyCapacity(creep, carriedEnergy, freeCapacity);
+  return capacity > 0 && carriedEnergy < capacity * MINIMUM_USEFUL_LOAD_RATIO;
+}
+
+function getFreeCreepEnergyCapacity(creep: Creep): number {
+  const freeCapacity = creep.store?.getFreeCapacity?.(RESOURCE_ENERGY);
+  return typeof freeCapacity === 'number' && Number.isFinite(freeCapacity) ? Math.max(0, freeCapacity) : 0;
+}
+
+function getCreepEnergyCapacity(creep: Creep, carriedEnergy: number, freeCapacity: number): number {
+  const capacity = creep.store?.getCapacity?.(RESOURCE_ENERGY);
+  return typeof capacity === 'number' && Number.isFinite(capacity) && capacity > 0
+    ? capacity
+    : carriedEnergy + freeCapacity;
 }
 
 function shouldPreemptTaskForUpgraderBoost(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -64,7 +64,8 @@ export const CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD = 200;
 export const URGENT_SPAWN_REFILL_ENERGY_THRESHOLD = CRITICAL_SPAWN_REFILL_ENERGY_THRESHOLD;
 export const WORKER_PRE_HARVEST_REGEN_THRESHOLD = 50;
 export const NEAR_TERM_SPAWN_EXTENSION_REFILL_RESERVE_TICKS = 50;
-export const MINIMUM_USEFUL_LOAD_RATIO = 0.4;
+export const MINIMUM_USEFUL_LOAD_RATIO = 0.3;
+export const LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS = 1_000;
 export const LOW_LOAD_NEARBY_ENERGY_RANGE = 3;
 export const LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE = 6;
 export const LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE = 12;
@@ -403,7 +404,7 @@ function selectHeuristicWorkerTask(creep: Creep): CreepTaskMemory | null {
   const controller = creep.room.controller;
   if (
     controller &&
-    shouldGuardControllerDowngrade(controller) &&
+    shouldGuardControllerDowngradeForWorkerLoad(creep, controller) &&
     canUpgradeController(controller) &&
     !remoteProductiveSpendingSuppressed
   ) {
@@ -960,6 +961,31 @@ function isTerritoryControlTask(task: CreepTaskMemory | null): task is Extract<C
 function hasEmergencySpawnExtensionRefillDemand(creep: Creep): boolean {
   const energyAvailable = getRoomEnergyAvailable(creep.room);
   return energyAvailable === null || energyAvailable < URGENT_SPAWN_REFILL_ENERGY_THRESHOLD;
+}
+
+function shouldGuardControllerDowngradeForWorkerLoad(
+  creep: Creep,
+  controller: StructureController | undefined
+): boolean {
+  if (!shouldGuardControllerDowngrade(controller)) {
+    return false;
+  }
+
+  if (!getLowLoadWorkerEnergyContext(creep)) {
+    return true;
+  }
+
+  return isControllerDowngradeImminentForLowLoadReturn(controller);
+}
+
+function isControllerDowngradeImminentForLowLoadReturn(
+  controller: StructureController | undefined
+): boolean {
+  return (
+    controller?.my === true &&
+    typeof controller.ticksToDowngrade === 'number' &&
+    controller.ticksToDowngrade < LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS
+  );
 }
 
 interface LowLoadWorkerEnergyContext {
@@ -3717,18 +3743,7 @@ function getWorkerEnergyAcquisitionSourceTypePriority(source: WorkerEnergyAcquis
 function selectLowLoadWorkerEnergyAcquisitionCandidate(
   creep: Creep
 ): LowLoadWorkerEnergyAcquisitionCandidate | null {
-  if (!shouldKeepLowLoadWorkerAcquiringEnergy(creep)) {
-    return null;
-  }
-
-  const nearbyCandidates = findLowLoadWorkerEnergyAcquisitionCandidates(creep).filter(
-    (candidate) => candidate.range !== null && candidate.range <= LOW_LOAD_NEARBY_ENERGY_RANGE
-  );
-  if (nearbyCandidates.length === 0) {
-    return null;
-  }
-
-  return nearbyCandidates.sort(compareLowLoadWorkerEnergyAcquisitionCandidates)[0];
+  return selectLowLoadWorkerEnergyContinuationCandidate(creep);
 }
 
 function selectLowLoadWorkerEnergyContinuationTask(creep: Creep): LowLoadWorkerEnergyAcquisitionTask | null {
@@ -3813,111 +3828,6 @@ function findLowLoadWorkerEnergyContinuationCandidates(
       maximumRange
     }).map(toLowLoadWorkerEnergyAcquisitionCandidate)
   ];
-}
-
-function findLowLoadWorkerEnergyAcquisitionCandidates(creep: Creep): LowLoadWorkerEnergyAcquisitionCandidate[] {
-  const reservationContext = createWorkerEnergyAcquisitionReservationContext(creep);
-  const nearbyLinkRefillCandidate = findNearestNearbyWorkerLinkRefillCandidate(creep, reservationContext);
-
-  return [
-    ...findNearbyLowLoadStoredEnergyAcquisitionCandidates(creep, reservationContext),
-    ...findNearbyLowLoadSalvageEnergyAcquisitionCandidates(creep, reservationContext),
-    ...findNearbyLowLoadDroppedEnergyAcquisitionCandidates(creep, reservationContext),
-    ...(nearbyLinkRefillCandidate ? [toNearbyWorkerLinkRefillCandidate(nearbyLinkRefillCandidate)] : []),
-    ...findLowLoadHarvestEnergyAcquisitionCandidates(creep),
-    ...findWorkerLinkEnergyAcquisitionCandidates(creep, reservationContext, {
-      maximumRange: LOW_LOAD_NEARBY_ENERGY_RANGE
-    }).map(toLowLoadWorkerEnergyAcquisitionCandidate)
-  ];
-}
-
-function findNearbyLowLoadStoredEnergyAcquisitionCandidates(
-  creep: Creep,
-  reservationContext: WorkerEnergyAcquisitionReservationContext
-): LowLoadWorkerEnergyAcquisitionCandidate[] {
-  const context: StoredEnergySourceContext = {
-    creepOwnerUsername: getCreepOwnerUsername(creep),
-    hasHostilePresence: hasVisibleHostilePresence(creep.room),
-    room: creep.room
-  };
-
-  return findVisibleRoomStructures(creep.room)
-    .filter(
-      (structure): structure is StoredWorkerEnergySource =>
-        isSafeStoredEnergySource(structure, context) && !isLinkEnergySource(structure)
-    )
-    .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
-    .flatMap((source) => {
-      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
-        creep,
-        source,
-        getStoredEnergy(source),
-        {
-          type: 'withdraw',
-          targetId: source.id as Id<AnyStoreStructure>
-        },
-        reservationContext
-      );
-
-      return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
-    });
-}
-
-function findNearbyLowLoadSalvageEnergyAcquisitionCandidates(
-  creep: Creep,
-  reservationContext: WorkerEnergyAcquisitionReservationContext
-): LowLoadWorkerEnergyAcquisitionCandidate[] {
-  return [...findTombstones(creep.room), ...findRuins(creep.room)]
-    .filter(hasSalvageableEnergy)
-    .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
-    .flatMap((source) => {
-      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
-        creep,
-        source,
-        getStoredEnergy(source),
-        {
-          type: 'withdraw',
-          targetId: source.id as unknown as Id<AnyStoreStructure>
-        },
-        reservationContext,
-        MIN_SALVAGE_ENERGY_WITHDRAW_AMOUNT
-      );
-
-      return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
-    });
-}
-
-function findNearbyLowLoadDroppedEnergyAcquisitionCandidates(
-  creep: Creep,
-  reservationContext: WorkerEnergyAcquisitionReservationContext
-): LowLoadWorkerEnergyAcquisitionCandidate[] {
-  return findDroppedResources(creep.room)
-    .filter(isUsefulDroppedEnergy)
-    .filter((source) => isNearbyLowLoadWorkerEnergyAcquisitionSource(creep, source))
-    .flatMap((source) => {
-      const candidate = createUnreservedWorkerEnergyAcquisitionCandidate(
-        creep,
-        source,
-        source.amount,
-        {
-          type: 'pickup',
-          targetId: source.id
-        },
-        reservationContext,
-        MIN_DROPPED_ENERGY_PICKUP_AMOUNT
-      );
-
-      return candidate ? [toLowLoadWorkerEnergyAcquisitionCandidate(candidate)] : [];
-    })
-    .filter((candidate) => isReachable(creep, candidate.source));
-}
-
-function isNearbyLowLoadWorkerEnergyAcquisitionSource(
-  creep: Creep,
-  source: LowLoadWorkerEnergyAcquisitionSource
-): boolean {
-  const range = getRangeToLowLoadWorkerEnergyAcquisitionSource(creep, source);
-  return range !== null && range <= LOW_LOAD_NEARBY_ENERGY_RANGE;
 }
 
 function isLowLoadWorkerEnergyContinuationCandidateInRange(

--- a/prod/src/tasks/workerTasks.ts
+++ b/prod/src/tasks/workerTasks.ts
@@ -3797,9 +3797,9 @@ function selectLowLoadWorkerEnergyContinuationCandidate(
     return null;
   }
 
-  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep, maximumRange).filter((candidate) =>
-    isLowLoadWorkerEnergyContinuationCandidateInRange(candidate, maximumRange)
-  );
+  const candidates = findLowLoadWorkerEnergyContinuationCandidates(creep, maximumRange)
+    .filter((candidate) => isLowLoadWorkerEnergyContinuationCandidateInRange(candidate, maximumRange))
+    .filter((candidate) => isLowLoadWorkerEnergyContinuationCandidateReachable(creep, candidate));
   if (candidates.length === 0) {
     return null;
   }
@@ -3835,6 +3835,13 @@ function isLowLoadWorkerEnergyContinuationCandidateInRange(
   maximumRange = LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE
 ): boolean {
   return candidate.range !== null && candidate.range <= maximumRange;
+}
+
+function isLowLoadWorkerEnergyContinuationCandidateReachable(
+  creep: Creep,
+  candidate: LowLoadWorkerEnergyAcquisitionCandidate
+): boolean {
+  return candidate.task.type !== 'withdraw' || isReachable(creep, candidate.source);
 }
 
 function toLowLoadWorkerEnergyAcquisitionCandidate(

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -5423,7 +5423,7 @@ describe('selectWorkerTask', () => {
       };
       return ranges[String(target.id)] ?? 99;
     });
-    const findPathTo = jest.fn().mockReturnValue([]);
+    const findPathTo = jest.fn((target: { id: string }) => (target.id === 'container-near' ? [{ x: 1, y: 1 }] : []));
     const roomFind = jest.fn(
       (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
         if (type === FIND_MY_STRUCTURES) {
@@ -5476,7 +5476,69 @@ describe('selectWorkerTask', () => {
       energy: 80,
       range: 2
     });
-    expect(findPathTo).not.toHaveBeenCalled();
+    expect(findPathTo).toHaveBeenCalledWith(container, { ignoreCreeps: true });
+  });
+
+  it('returns to refill when nearby container energy is not reachable for low-load workers', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const container = makeStoredEnergyStructure('container-blocked', 'container' as StructureConstant, 80);
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'container-blocked': 2,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const findPathTo = jest.fn().mockReturnValue([]);
+    const roomFind = jest.fn(
+      (type: number, options?: { filter?: (structure: TestEnergySink) => boolean }) => {
+        if (type === FIND_MY_STRUCTURES) {
+          const structures = [spawn];
+          return options?.filter ? structures.filter(options.filter) : structures;
+        }
+
+        if (type === FIND_STRUCTURES) {
+          return [container];
+        }
+
+        if (
+          type === FIND_DROPPED_RESOURCES ||
+          type === FIND_HOSTILE_CREEPS ||
+          type === FIND_HOSTILE_STRUCTURES ||
+          type === FIND_TOMBSTONES ||
+          type === FIND_RUINS
+        ) {
+          return [];
+        }
+
+        return [];
+      }
+    );
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo, findPathTo },
+      room: {
+        energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+        find: roomFind
+      }
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 340 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 340,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'transfer',
+      targetId: 'spawn1',
+      reason: 'noReachableEnergy'
+    });
+    expect(findPathTo).toHaveBeenCalledWith(container, { ignoreCreeps: true });
   });
 
   it('refills a low-load worker from a nearby link before a distant harvest source', () => {
@@ -5495,6 +5557,7 @@ describe('selectWorkerTask', () => {
       };
       return ranges[String(target.id)] ?? 99;
     });
+    const findPathTo = jest.fn((target: { id: string }) => (target.id === 'link-near' ? [{ x: 1, y: 1 }] : []));
     const room = makeWorkerTaskRoom({
       controller,
       myStructures: [link as AnyOwnedStructure],
@@ -5507,7 +5570,7 @@ describe('selectWorkerTask', () => {
         getUsedCapacity: jest.fn().mockReturnValue(10),
         getFreeCapacity: jest.fn().mockReturnValue(40)
       },
-      pos: { getRangeTo },
+      pos: { getRangeTo, findPathTo },
       room
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 337 };
@@ -5523,6 +5586,47 @@ describe('selectWorkerTask', () => {
       energy: 20,
       range: 2
     });
+    expect(findPathTo).toHaveBeenCalledWith(link, { ignoreCreeps: true });
+  });
+
+  it('returns to refill when nearby link energy is not reachable for low-load workers', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const link = makeStoredEnergyLink('link-blocked', 11, 10, 20);
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'link-blocked': 2,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const findPathTo = jest.fn().mockReturnValue([]);
+    const room = makeWorkerTaskRoom({
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+      myStructures: [spawn as AnyOwnedStructure, link as AnyOwnedStructure]
+    });
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getCapacity: jest.fn().mockReturnValue(50),
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo, findPathTo },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 341 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'transfer', targetId: 'spawn1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'lowLoadReturn',
+      tick: 341,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'transfer',
+      targetId: 'spawn1',
+      reason: 'noReachableEnergy'
+    });
+    expect(findPathTo).toHaveBeenCalledWith(link, { ignoreCreeps: true });
   });
 
   it('ignores low-load link refill options beyond nearby range', () => {

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -6,6 +6,7 @@ import {
   IDLE_RAMPART_REPAIR_HITS_CEILING,
   BUILDER_DROPPED_PICKUP_RANGE,
   BUILDER_STORAGE_WITHDRAW_MIN,
+  LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS,
   LOW_LOAD_NEARBY_ENERGY_RANGE,
   LOW_LOAD_SPAWN_EXTENSION_REFILL_CONTINUATION_MAX_RANGE,
   LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
@@ -5063,6 +5064,48 @@ describe('selectWorkerTask', () => {
     expect(findPathTo).toHaveBeenCalledWith(droppedEnergy, { ignoreCreeps: true });
   });
 
+  it('continues with close stored energy outside the nearby-only range before farther harvest', () => {
+    const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
+    const container = makeStoredEnergyStructure('container-mid', 'container' as StructureConstant, 80);
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        'container-mid': LOW_LOAD_NEARBY_ENERGY_RANGE + 1,
+        source1: LOW_LOAD_WORKER_ENERGY_CONTINUATION_MAX_RANGE,
+        spawn1: 2
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const room = makeWorkerTaskRoom({
+      energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
+      myStructures: [spawn as AnyOwnedStructure],
+      sources: [source],
+      structures: [container]
+    });
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(2),
+        getFreeCapacity: jest.fn().mockReturnValue(48)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 339 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'withdraw', targetId: 'container-mid' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 339,
+      carriedEnergy: 2,
+      freeCapacity: 48,
+      selectedTask: 'withdraw',
+      targetId: 'container-mid',
+      energy: 80,
+      range: LOW_LOAD_NEARBY_ENERGY_RANGE + 1
+    });
+  });
+
   it('continues harvesting before durable stored energy outside the nearby-only range', () => {
     const spawn = makeEnergySink('spawn1', 'spawn' as StructureConstant, 300);
     const storedEnergy = makeStoredEnergyStructure('storage-mid', 'storage' as StructureConstant, 50, { my: true });
@@ -5582,12 +5625,12 @@ describe('selectWorkerTask', () => {
     });
   });
 
-  it('lets controller downgrade guard preempt the minimum useful load requirement', () => {
+  it('lets imminent controller downgrade guard preempt the minimum useful load requirement', () => {
     const controller = {
       id: 'controller1',
       my: true,
       level: 8,
-      ticksToDowngrade: CONTROLLER_DOWNGRADE_GUARD_TICKS
+      ticksToDowngrade: LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS - 1
     } as StructureController;
     const source = { id: 'source1', energy: 300 } as Source;
     const getRangeTo = jest.fn((target: { id: string }) => {
@@ -5621,6 +5664,49 @@ describe('selectWorkerTask', () => {
       selectedTask: 'upgrade',
       targetId: 'controller1',
       reason: 'controllerDowngradeGuard'
+    });
+  });
+
+  it('keeps low-load workers acquiring while controller downgrade is guarded but not imminent', () => {
+    const controller = {
+      id: 'controller1',
+      my: true,
+      level: 8,
+      ticksToDowngrade: LOW_LOAD_CONTROLLER_DOWNGRADE_IMMINENT_TICKS
+    } as StructureController;
+    const source = { id: 'source1', energy: 300 } as Source;
+    const getRangeTo = jest.fn((target: { id: string }) => {
+      const ranges: Record<string, number> = {
+        controller1: 2,
+        source1: 1
+      };
+      return ranges[String(target.id)] ?? 99;
+    });
+    const room = makeWorkerTaskRoom({
+      controller,
+      sources: [source]
+    });
+    const creep = {
+      memory: { role: 'worker' },
+      store: {
+        getUsedCapacity: jest.fn().mockReturnValue(10),
+        getFreeCapacity: jest.fn().mockReturnValue(40)
+      },
+      pos: { getRangeTo },
+      room
+    } as unknown as Creep;
+    (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 340 };
+
+    expect(selectWorkerTask(creep)).toEqual({ type: 'harvest', targetId: 'source1' });
+    expect(creep.memory.workerEfficiency).toEqual({
+      type: 'nearbyEnergyChoice',
+      tick: 340,
+      carriedEnergy: 10,
+      freeCapacity: 40,
+      selectedTask: 'harvest',
+      targetId: 'source1',
+      energy: 300,
+      range: 1
     });
   });
 

--- a/prod/test/workerTasks.test.ts
+++ b/prod/test/workerTasks.test.ts
@@ -5076,6 +5076,7 @@ describe('selectWorkerTask', () => {
       };
       return ranges[String(target.id)] ?? 99;
     });
+    const findPathTo = jest.fn().mockReturnValue([{ x: 1, y: 1 }]);
     const room = makeWorkerTaskRoom({
       energyAvailable: URGENT_SPAWN_REFILL_ENERGY_THRESHOLD,
       myStructures: [spawn as AnyOwnedStructure],
@@ -5088,7 +5089,7 @@ describe('selectWorkerTask', () => {
         getUsedCapacity: jest.fn().mockReturnValue(2),
         getFreeCapacity: jest.fn().mockReturnValue(48)
       },
-      pos: { getRangeTo },
+      pos: { getRangeTo, findPathTo },
       room
     } as unknown as Creep;
     (globalThis as unknown as { Game: Partial<Game> }).Game = { creeps: {}, time: 339 };
@@ -5104,6 +5105,7 @@ describe('selectWorkerTask', () => {
       energy: 80,
       range: LOW_LOAD_NEARBY_ENERGY_RANGE + 1
     });
+    expect(findPathTo).toHaveBeenCalledWith(container, { ignoreCreeps: true });
   });
 
   it('continues harvesting before durable stored energy outside the nearby-only range', () => {


### PR DESCRIPTION
Implement low-load worker return optimization to reduce wasteful haul cycles.

When a worker has collected energy but is carrying very little relative to its capacity, this change preempts the energy-acquisition task and triggers an early return/dropoff instead of continuing to a distant harvest source for a tiny top-up. This improves energy throughput and reduces wasted CPU on low-value haul trips.

- Typecheck: PASS
- Tests: 1422 PASS
- Build: PASS

Closes #758
