### PR TITLE
feat(territory): implement post-claim colony bootstrapping — spawn construction and controller progression (#761)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -10420,14 +10420,15 @@ function recordAutonomousExpansionClaimReserveFallbackIntent(colony, evaluation,
     gameTime
   );
 }
-function refreshRemoteMiningSetup(colony, gameTime = getGameTime12()) {
+function refreshRemoteMiningSetup(colony, gameTime = getGameTime12(), options = {}) {
   var _a, _b, _c, _d;
   const territoryMemory = getWritableTerritoryMemoryRecord5();
   if (!territoryMemory) {
     return;
   }
   const colonyName = colony.room.name;
-  const records = getRemoteMiningBootstrapRecords(territoryMemory, colonyName);
+  const allRecords = getRemoteMiningBootstrapRecords(territoryMemory, colonyName);
+  const records = allRecords.filter((record) => shouldRefreshRemoteMiningBootstrapRecord(record, options.focusRoomName));
   const storedRemoteMining = territoryMemory.remoteMining;
   if (storedRemoteMining === void 0 && records.length === 0) {
     return;
@@ -10439,10 +10440,9 @@ function refreshRemoteMiningSetup(colony, gameTime = getGameTime12()) {
     remoteMining = {};
     territoryMemory.remoteMining = remoteMining;
   }
-  const activeKeys = /* @__PURE__ */ new Set();
+  const activeKeys = new Set(allRecords.map((record) => getRemoteMiningMemoryKey(record.colony, record.roomName)));
   for (const record of records) {
     const key = getRemoteMiningMemoryKey(record.colony, record.roomName);
-    activeKeys.add(key);
     const room = getVisibleRoom3(record.roomName);
     if (!room) {
       const previous = remoteMining[key];
@@ -10525,6 +10525,9 @@ function refreshRemoteMiningSetup(colony, gameTime = getGameTime12()) {
       delete remoteMining[key];
     }
   }
+}
+function shouldRefreshRemoteMiningBootstrapRecord(record, focusRoomName) {
+  return record.status === "ready" || !isNonEmptyString10(focusRoomName) || record.roomName === focusRoomName;
 }
 function isTerritoryHomeSafe(colony, roleCounts, workerTarget) {
   if (getWorkerCapacity(roleCounts) < workerTarget) {
@@ -24819,12 +24822,15 @@ function recordClaimedRoomOccupation(roomName, claimedAt, gameTime) {
     ...((_a = memory.territory.claimedRoomBootstrapper.rooms[roomName]) == null ? void 0 : _a.completedAt) !== void 0 ? { completedAt: memory.territory.claimedRoomBootstrapper.rooms[roomName].completedAt } : {}
   };
 }
-function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents = []) {
+function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents = [], options = {}) {
   var _a, _b;
   const roomName = colony.room.name;
   const record = getPostClaimBootstrapRecord(roomName);
   if (!record || record.status === "ready" || ((_a = colony.room.controller) == null ? void 0 : _a.my) !== true) {
     return { active: false, spawnConstructionPending: false };
+  }
+  if (isPostClaimBootstrapDeferred(roomName, options.focusRoomName)) {
+    return { active: true, spawnConstructionPending: false, deferred: true };
   }
   const workerTarget = getPostClaimBootstrapWorkerTarget(record);
   const workerCount = (_b = roleCounts.worker) != null ? _b : 0;
@@ -24912,6 +24918,13 @@ function refreshPostClaimBootstrap(colony, roleCounts, gameTime, telemetryEvents
   }
   return { active: true, spawnConstructionPending: true };
 }
+function selectPostClaimBootstrapFocusRoomName(colonies) {
+  var _a, _b;
+  return (_b = (_a = getVisibleActivePostClaimBootstrapRecords(colonies)[0]) == null ? void 0 : _a.roomName) != null ? _b : null;
+}
+function isPostClaimBootstrapDeferred(roomName, focusRoomName) {
+  return isNonEmptyString19(focusRoomName) && roomName !== focusRoomName && getPostClaimBootstrapRecord(roomName) !== null;
+}
 function recordPostClaimBootstrapWorkerSpawn(roomName, spawnName, creepName, result, telemetryEvents = []) {
   if (!isNonEmptyString19(roomName)) {
     return;
@@ -24951,6 +24964,25 @@ function getPostClaimBootstrapSummary(roomName) {
     ...record.spawnSite ? { spawnSite: record.spawnSite } : {},
     ...record.lastResult !== void 0 ? { lastResult: record.lastResult } : {}
   };
+}
+function getVisibleActivePostClaimBootstrapRecords(colonies) {
+  var _a, _b;
+  const visibleOwnedRoomNames = new Set(
+    colonies.filter((colony) => {
+      var _a2;
+      return ((_a2 = colony.room.controller) == null ? void 0 : _a2.my) === true;
+    }).map((colony) => colony.room.name)
+  );
+  const records = (_b = (_a = globalThis.Memory) == null ? void 0 : _a.territory) == null ? void 0 : _b.postClaimBootstraps;
+  if (!isRecord18(records)) {
+    return [];
+  }
+  return Object.values(records).filter(
+    (record) => isAnyPostClaimBootstrapRecord(record) && record.status !== "ready" && visibleOwnedRoomNames.has(record.roomName)
+  ).sort(comparePostClaimBootstrapRecordsForFocus);
+}
+function comparePostClaimBootstrapRecordsForFocus(left, right) {
+  return left.claimedAt - right.claimedAt || left.updatedAt - right.updatedAt || left.roomName.localeCompare(right.roomName);
 }
 function placePostClaimSpawnConstructionSite(roomName, telemetryEvents) {
   const record = getPostClaimBootstrapRecord(roomName);
@@ -25280,6 +25312,9 @@ function getWritablePostClaimBootstrapRecords() {
 }
 function isPostClaimBootstrapRecord(value, expectedRoomName) {
   return isRecord18(value) && value.roomName === expectedRoomName && isNonEmptyString19(value.colony) && isPostClaimBootstrapStatus(value.status) && isFiniteNumber8(value.claimedAt) && isFiniteNumber8(value.updatedAt);
+}
+function isAnyPostClaimBootstrapRecord(value) {
+  return isRecord18(value) && isNonEmptyString19(value.roomName) && isPostClaimBootstrapRecord(value, value.roomName);
 }
 function isPostClaimBootstrapStatus(value) {
   return value === "detected" || value === "spawnSitePending" || value === "spawnSiteBlocked" || value === "spawningWorkers" || value === "ready";
@@ -29682,21 +29717,33 @@ var EXPANSION_EXECUTOR_DOWNGRADE_GUARD_TICKS = 5e3;
 function refreshExpansionExecutorIntent(colony, gameTime = getGameTime26(), telemetryEvents = []) {
   const colonyName = colony.room.name;
   const colonyMemory = getWritableColonyMemory2(colony);
-  const stateKey = getExpansionExecutorCacheStateKey(colony);
+  let stateKey = getExpansionExecutorCacheStateKey(colony);
   const cachedSelection = getCachedExpansionExecutorSelection(colonyMemory, colonyName);
   if (cachedSelection && isExpansionExecutorCacheReusable(cachedSelection, colonyName, gameTime, stateKey)) {
     return cachedSelection.selection;
   }
   const report = buildRuntimeExpansionCandidateReport(colony);
   const selection = refreshNextExpansionTargetSelection(colony, report, gameTime);
-  if (selection.status === "skipped" && selection.reason === "insufficientEvidence") {
-    refreshExpansionRoomScouting(colony, selectExpansionScoutTargets(report), gameTime, telemetryEvents);
+  const scoutTargetRooms = [];
+  if (selection.targetRoom) {
+    scoutTargetRooms.push(selection.targetRoom);
   }
+  if (selection.status === "skipped" && selection.reason === "insufficientEvidence") {
+    const scoutTargets = selectExpansionScoutTargets(report);
+    scoutTargetRooms.push(...scoutTargets.map((target) => target.roomName));
+    refreshExpansionRoomScouting(colony, scoutTargets, gameTime, telemetryEvents);
+  }
+  stateKey = refreshExpansionExecutorCacheStateKeyAfterCurrentTickScoutIntel(
+    stateKey,
+    colonyName,
+    scoutTargetRooms,
+    gameTime
+  );
   logBestClaimTarget(colony.room);
   colonyMemory.lastExpansionScoreTime = gameTime;
   colonyMemory.cachedExpansionSelection = {
     ...selection,
-    stateKey: getExpansionExecutorCacheStateKey(colony)
+    stateKey
   };
   return selection;
 }
@@ -29784,6 +29831,24 @@ function getExpansionExecutorCacheStateKey(colony) {
     countActivePostClaimBootstraps3(),
     getLatestTerritoryScoutIntelUpdatedAt(colony.room.name)
   ].join("|");
+}
+function refreshExpansionExecutorCacheStateKeyAfterCurrentTickScoutIntel(stateKey, colony, roomNames, gameTime) {
+  const recordedCurrentTickScoutIntel = roomNames.some(
+    (roomName) => {
+      var _a;
+      return ((_a = getTerritoryScoutIntel(colony, roomName)) == null ? void 0 : _a.updatedAt) === gameTime;
+    }
+  );
+  return recordedCurrentTickScoutIntel ? replaceExpansionExecutorCacheScoutIntelUpdatedAt(stateKey, gameTime) : stateKey;
+}
+function replaceExpansionExecutorCacheScoutIntelUpdatedAt(stateKey, updatedAt) {
+  const separatorIndex = stateKey.lastIndexOf("|");
+  if (separatorIndex < 0) {
+    return stateKey;
+  }
+  const currentUpdatedAt = Number(stateKey.slice(separatorIndex + 1));
+  const nextUpdatedAt = Math.max(Number.isFinite(currentUpdatedAt) ? currentUpdatedAt : 0, updatedAt);
+  return `${stateKey.slice(0, separatorIndex + 1)}${nextUpdatedAt}`;
 }
 function countVisibleOwnedRooms2() {
   var _a;
@@ -32402,6 +32467,7 @@ function runEconomy(preludeTelemetryEvents = []) {
   const plannedRoleCountsByRoom = new Map(initialRoleCountsByRoom);
   clearColonySurvivalAssessmentCache();
   refreshClaimedRoomBootstrapperOwnership();
+  const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
     let roleCounts = getPlannedOrCurrentRoleCounts(creeps, colony.room.name, plannedRoleCountsByRoom);
@@ -32419,12 +32485,20 @@ function runEconomy(preludeTelemetryEvents = []) {
         competingSpawnDemand: survivalAssessment.mode !== "TERRITORY_READY" || survivalAssessment.hostilePresence || survivalAssessment.controllerDowngradeGuard
       }
     );
-    refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
+    const postClaimBootstrapRefresh = refreshPostClaimBootstrap(
+      colony,
+      roleCounts,
+      Game.time,
+      telemetryEvents,
+      { focusRoomName: postClaimBootstrapFocusRoomName }
+    );
     runTowerConstructionExecutorForColony(colony, { requireExpansionMemory: true });
     runRampartWallConstructionExecutorForColony(colony, { requireExpansionMemory: true });
-    planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
+    if (postClaimBootstrapRefresh.deferred !== true) {
+      planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
+    }
     if (survivalAssessment.mode === "TERRITORY_READY") {
-      refreshRemoteMiningSetup(colony, Game.time);
+      refreshRemoteMiningSetup(colony, Game.time, { focusRoomName: postClaimBootstrapFocusRoomName });
     }
     refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
     if (survivalAssessment.territoryReady) {

--- a/prod/src/economy/economyLoop.ts
+++ b/prod/src/economy/economyLoop.ts
@@ -97,7 +97,8 @@ import { recordPlannedMultiRoomUpgraderSpawn } from '../territory/multiRoomUpgra
 import { refreshControllerManagement } from '../territory/controllerManager';
 import {
   recordPostClaimBootstrapWorkerSpawn,
-  refreshPostClaimBootstrap
+  refreshPostClaimBootstrap,
+  selectPostClaimBootstrapFocusRoomName
 } from '../territory/postClaimBootstrap';
 import {
   buildStrategyRecommendationRoomState,
@@ -148,6 +149,7 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
   const plannedRoleCountsByRoom = new Map<string, RoleCounts>(initialRoleCountsByRoom);
   clearColonySurvivalAssessmentCache();
   refreshClaimedRoomBootstrapperOwnership();
+  const postClaimBootstrapFocusRoomName = selectPostClaimBootstrapFocusRoomName(colonies);
 
   for (const colony of colonies) {
     recordSourceWorkloads(colony.room, creeps, Game.time);
@@ -169,12 +171,20 @@ export function runEconomy(preludeTelemetryEvents: RuntimeTelemetryEvent[] = [])
           survivalAssessment.controllerDowngradeGuard
       }
     );
-    refreshPostClaimBootstrap(colony, roleCounts, Game.time, telemetryEvents);
+    const postClaimBootstrapRefresh = refreshPostClaimBootstrap(
+      colony,
+      roleCounts,
+      Game.time,
+      telemetryEvents,
+      { focusRoomName: postClaimBootstrapFocusRoomName }
+    );
     runTowerConstructionExecutorForColony(colony, { requireExpansionMemory: true });
     runRampartWallConstructionExecutorForColony(colony, { requireExpansionMemory: true });
-    planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
+    if (postClaimBootstrapRefresh.deferred !== true) {
+      planConstructionForColony(colony, { respectRoomEnergyBuffer: true });
+    }
     if (survivalAssessment.mode === 'TERRITORY_READY') {
-      refreshRemoteMiningSetup(colony, Game.time);
+      refreshRemoteMiningSetup(colony, Game.time, { focusRoomName: postClaimBootstrapFocusRoomName });
     }
     refreshExecutableTerritoryRecommendation(colony, creeps, survivalAssessment.territoryReady, telemetryEvents);
     if (survivalAssessment.territoryReady) {

--- a/prod/src/territory/claimedRoomBootstrapper.ts
+++ b/prod/src/territory/claimedRoomBootstrapper.ts
@@ -130,8 +130,13 @@ export function runClaimedRoomBootstrapper(colonies: ColonySnapshot[]): ClaimedR
   const refreshResult = refreshClaimedRoomBootstrapperOwnership();
   const activeRoomNames: string[] = [];
   const planned: ClaimedRoomBootstrapPlanResult[] = [];
+  const focusRoomName = selectClaimedRoomBootstrapFocusRoomName(colonies);
 
   for (const colony of colonies) {
+    if (focusRoomName !== null && colony.room.name !== focusRoomName && isClaimedRoomBootstrapActive(colony.room.name)) {
+      continue;
+    }
+
     const result = runClaimedRoomBootstrapperForColony(colony);
     if (!result) {
       continue;
@@ -202,6 +207,30 @@ export function runClaimedRoomBootstrapperForColony(
   }
 
   return { roomName: room.name, phase: 'complete' };
+}
+
+function selectClaimedRoomBootstrapFocusRoomName(colonies: ColonySnapshot[]): string | null {
+  return colonies
+    .filter((colony) => colony.room.controller?.my === true && isClaimedRoomBootstrapActive(colony.room.name))
+    .sort(compareClaimedRoomBootstrapFocusColonies)[0]?.room.name ?? null;
+}
+
+function compareClaimedRoomBootstrapFocusColonies(left: ColonySnapshot, right: ColonySnapshot): number {
+  const leftRecord = getBootstrapperRoomRecord(left.room.name);
+  const rightRecord = getBootstrapperRoomRecord(right.room.name);
+  return (
+    getClaimedRoomBootstrapFocusClaimedAt(leftRecord) - getClaimedRoomBootstrapFocusClaimedAt(rightRecord) ||
+    (leftRecord?.updatedAt ?? 0) - (rightRecord?.updatedAt ?? 0) ||
+    left.room.name.localeCompare(right.room.name)
+  );
+}
+
+function getClaimedRoomBootstrapFocusClaimedAt(
+  record: TerritoryClaimedRoomBootstrapMemory | null
+): number {
+  return typeof record?.claimedAt === 'number' && Number.isFinite(record.claimedAt)
+    ? record.claimedAt
+    : Number.MAX_SAFE_INTEGER;
 }
 
 export function isClaimedRoomBootstrapActive(roomName: string): boolean {

--- a/prod/src/territory/postClaimBootstrap.ts
+++ b/prod/src/territory/postClaimBootstrap.ts
@@ -34,6 +34,11 @@ interface SpawnPlacementLookups {
 export interface PostClaimBootstrapRefreshResult {
   active: boolean;
   spawnConstructionPending: boolean;
+  deferred?: boolean;
+}
+
+export interface PostClaimBootstrapRefreshOptions {
+  focusRoomName?: string | null;
 }
 
 export interface PostClaimBootstrapSummary {
@@ -119,12 +124,17 @@ export function refreshPostClaimBootstrap(
   colony: ColonySnapshot,
   roleCounts: RoleCounts,
   gameTime: number,
-  telemetryEvents: RuntimeTelemetryEvent[] = []
+  telemetryEvents: RuntimeTelemetryEvent[] = [],
+  options: PostClaimBootstrapRefreshOptions = {}
 ): PostClaimBootstrapRefreshResult {
   const roomName = colony.room.name;
   const record = getPostClaimBootstrapRecord(roomName);
   if (!record || record.status === 'ready' || colony.room.controller?.my !== true) {
     return { active: false, spawnConstructionPending: false };
+  }
+
+  if (isPostClaimBootstrapDeferred(roomName, options.focusRoomName)) {
+    return { active: true, spawnConstructionPending: false, deferred: true };
   }
 
   const workerTarget = getPostClaimBootstrapWorkerTarget(record);
@@ -223,6 +233,17 @@ export function refreshPostClaimBootstrap(
   return { active: true, spawnConstructionPending: true };
 }
 
+export function selectPostClaimBootstrapFocusRoomName(colonies: ColonySnapshot[]): string | null {
+  return getVisibleActivePostClaimBootstrapRecords(colonies)[0]?.roomName ?? null;
+}
+
+function isPostClaimBootstrapDeferred(
+  roomName: string,
+  focusRoomName: string | null | undefined
+): boolean {
+  return isNonEmptyString(focusRoomName) && roomName !== focusRoomName && getPostClaimBootstrapRecord(roomName) !== null;
+}
+
 export function recordPostClaimBootstrapWorkerSpawn(
   roomName: string | undefined,
   spawnName: string,
@@ -272,6 +293,37 @@ export function getPostClaimBootstrapSummary(roomName: string): PostClaimBootstr
     ...(record.spawnSite ? { spawnSite: record.spawnSite } : {}),
     ...(record.lastResult !== undefined ? { lastResult: record.lastResult } : {})
   };
+}
+
+function getVisibleActivePostClaimBootstrapRecords(colonies: ColonySnapshot[]): TerritoryPostClaimBootstrapMemory[] {
+  const visibleOwnedRoomNames = new Set(
+    colonies
+      .filter((colony) => colony.room.controller?.my === true)
+      .map((colony) => colony.room.name)
+  );
+  const records = (globalThis as { Memory?: Partial<Memory> }).Memory?.territory?.postClaimBootstraps;
+  if (!isRecord(records)) {
+    return [];
+  }
+
+  return Object.values(records)
+    .filter((record): record is TerritoryPostClaimBootstrapMemory =>
+      isAnyPostClaimBootstrapRecord(record) &&
+      record.status !== 'ready' &&
+      visibleOwnedRoomNames.has(record.roomName)
+    )
+    .sort(comparePostClaimBootstrapRecordsForFocus);
+}
+
+function comparePostClaimBootstrapRecordsForFocus(
+  left: TerritoryPostClaimBootstrapMemory,
+  right: TerritoryPostClaimBootstrapMemory
+): number {
+  return (
+    left.claimedAt - right.claimedAt ||
+    left.updatedAt - right.updatedAt ||
+    left.roomName.localeCompare(right.roomName)
+  );
 }
 
 function placePostClaimSpawnConstructionSite(
@@ -705,6 +757,10 @@ function isPostClaimBootstrapRecord(
     isFiniteNumber(value.claimedAt) &&
     isFiniteNumber(value.updatedAt)
   );
+}
+
+function isAnyPostClaimBootstrapRecord(value: unknown): value is TerritoryPostClaimBootstrapMemory {
+  return isRecord(value) && isNonEmptyString(value.roomName) && isPostClaimBootstrapRecord(value, value.roomName);
 }
 
 function isPostClaimBootstrapStatus(value: unknown): value is TerritoryPostClaimBootstrapStatus {

--- a/prod/src/territory/territoryPlanner.ts
+++ b/prod/src/territory/territoryPlanner.ts
@@ -124,6 +124,10 @@ export interface TerritoryIntentPlanningOptions {
   followUpOnly?: boolean;
 }
 
+export interface RemoteMiningSetupOptions {
+  focusRoomName?: string | null;
+}
+
 interface TerritoryTargetSelectionOptions {
   controllerPressureOnly?: boolean;
   followUpOnly?: boolean;
@@ -931,14 +935,20 @@ export function recordAutonomousExpansionClaimReserveFallbackIntent(
   );
 }
 
-export function refreshRemoteMiningSetup(colony: ColonySnapshot, gameTime = getGameTime()): void {
+export function refreshRemoteMiningSetup(
+  colony: ColonySnapshot,
+  gameTime = getGameTime(),
+  options: RemoteMiningSetupOptions = {}
+): void {
   const territoryMemory = getWritableTerritoryMemoryRecord();
   if (!territoryMemory) {
     return;
   }
 
   const colonyName = colony.room.name;
-  const records = getRemoteMiningBootstrapRecords(territoryMemory, colonyName);
+  const allRecords = getRemoteMiningBootstrapRecords(territoryMemory, colonyName);
+  const records = allRecords
+    .filter((record) => shouldRefreshRemoteMiningBootstrapRecord(record, options.focusRoomName));
   const storedRemoteMining = territoryMemory.remoteMining;
   if (storedRemoteMining === undefined && records.length === 0) {
     return;
@@ -951,11 +961,10 @@ export function refreshRemoteMiningSetup(colony: ColonySnapshot, gameTime = getG
     remoteMining = {};
     territoryMemory.remoteMining = remoteMining;
   }
-  const activeKeys = new Set<string>();
+  const activeKeys = new Set(allRecords.map((record) => getRemoteMiningMemoryKey(record.colony, record.roomName)));
 
   for (const record of records) {
     const key = getRemoteMiningMemoryKey(record.colony, record.roomName);
-    activeKeys.add(key);
 
     const room = getVisibleRoom(record.roomName);
     if (!room) {
@@ -1044,6 +1053,13 @@ export function refreshRemoteMiningSetup(colony: ColonySnapshot, gameTime = getG
       delete remoteMining[key];
     }
   }
+}
+
+function shouldRefreshRemoteMiningBootstrapRecord(
+  record: TerritoryPostClaimBootstrapMemory,
+  focusRoomName: string | null | undefined
+): boolean {
+  return record.status === 'ready' || !isNonEmptyString(focusRoomName) || record.roomName === focusRoomName;
 }
 
 export function isTerritoryHomeSafe(colony: ColonySnapshot, roleCounts: RoleCounts, workerTarget: number): boolean {

--- a/prod/test/economyLoop.test.ts
+++ b/prod/test/economyLoop.test.ts
@@ -2369,6 +2369,106 @@ describe('runEconomy', () => {
     });
   });
 
+  it('keeps post-claim spawn construction focused on one active room per tick', () => {
+    (globalThis as unknown as {
+      FIND_MY_CONSTRUCTION_SITES: number;
+      FIND_SOURCES: number;
+      LOOK_STRUCTURES: LOOK_STRUCTURES;
+      LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES;
+      STRUCTURE_SPAWN: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      Memory: Partial<Memory>;
+    }).FIND_MY_CONSTRUCTION_SITES = 2;
+    (globalThis as unknown as { FIND_SOURCES: number }).FIND_SOURCES = 1;
+    (globalThis as unknown as { LOOK_STRUCTURES: LOOK_STRUCTURES }).LOOK_STRUCTURES = 'structure';
+    (globalThis as unknown as { LOOK_CONSTRUCTION_SITES: LOOK_CONSTRUCTION_SITES }).LOOK_CONSTRUCTION_SITES = 'constructionSite';
+    (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: {
+            colony: 'W1N1',
+            roomName: 'W2N1',
+            status: 'detected',
+            claimedAt: 400,
+            updatedAt: 400,
+            workerTarget: 2,
+            controllerId: 'controller2' as Id<StructureController>
+          },
+          W3N1: {
+            colony: 'W1N1',
+            roomName: 'W3N1',
+            status: 'detected',
+            claimedAt: 401,
+            updatedAt: 401,
+            workerTarget: 2,
+            controllerId: 'controller3' as Id<StructureController>
+          }
+        }
+      }
+    };
+
+    const makePostClaimRoom = (roomName: string, controllerId: Id<StructureController>): Room => {
+      const constructionSites: ConstructionSite[] = [];
+      return {
+        name: roomName,
+        energyAvailable: 0,
+        energyCapacityAvailable: 0,
+        controller: {
+          id: controllerId,
+          my: true,
+          level: 1,
+          pos: { x: 25, y: 25, roomName }
+        } as StructureController,
+        find: jest.fn((type: number) => {
+          if (type === FIND_SOURCES) {
+            return [{ id: `${roomName}-source1`, pos: { x: 21, y: 21, roomName } } as Source];
+          }
+
+          if (type === FIND_MY_CONSTRUCTION_SITES) {
+            return constructionSites;
+          }
+
+          return [];
+        }),
+        lookForAtArea: jest.fn().mockReturnValue([]),
+        createConstructionSite: jest.fn((x: number, y: number, structureType: StructureConstant) => {
+          constructionSites.push({
+            id: `${roomName}-site-${x}-${y}`,
+            structureType,
+            pos: { x, y, roomName }
+          } as ConstructionSite);
+          return OK_CODE;
+        })
+      } as unknown as Room;
+    };
+    const olderRoom = makePostClaimRoom('W2N1', 'controller2' as Id<StructureController>);
+    const newerRoom = makePostClaimRoom('W3N1', 'controller3' as Id<StructureController>);
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 402,
+      rooms: { W3N1: newerRoom, W2N1: olderRoom },
+      spawns: {},
+      creeps: {},
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    runEconomy();
+
+    expect(olderRoom.createConstructionSite).toHaveBeenCalledWith(23, 23, STRUCTURE_SPAWN);
+    expect(newerRoom.createConstructionSite).not.toHaveBeenCalled();
+    expect(Memory.territory?.postClaimBootstraps?.W2N1).toMatchObject({
+      status: 'spawnSitePending',
+      updatedAt: 402
+    });
+    expect(Memory.territory?.postClaimBootstraps?.W3N1).toMatchObject({
+      status: 'detected',
+      updatedAt: 401
+    });
+  });
+
   it('emits spawn-site telemetry when a claimed room already has an active spawn site', () => {
     (globalThis as unknown as {
       FIND_MY_CONSTRUCTION_SITES: number;

--- a/prod/test/territory/claimedRoomBootstrapper.test.ts
+++ b/prod/test/territory/claimedRoomBootstrapper.test.ts
@@ -260,8 +260,8 @@ describe('claimed room bootstrapper', () => {
     Memory.territory = {
       claimedRoomBootstrapper: {
         rooms: {
-          W2N1: { roomName: 'W2N1', owned: true, claimedAt: 80, updatedAt: 90 },
-          W3N1: { roomName: 'W3N1', owned: true, claimedAt: 90, updatedAt: 90 }
+          W3N1: { roomName: 'W3N1', owned: true, claimedAt: 90, updatedAt: 90 },
+          W2N1: { roomName: 'W2N1', owned: true, claimedAt: 80, updatedAt: 90 }
         }
       }
     };

--- a/prod/test/territory/claimedRoomBootstrapper.test.ts
+++ b/prod/test/territory/claimedRoomBootstrapper.test.ts
@@ -253,6 +253,27 @@ describe('claimed room bootstrapper', () => {
     expect(result.planned).toEqual([]);
     expect(room.createConstructionSite).not.toHaveBeenCalled();
   });
+
+  it('limits claimed-room bootstrap planning to the oldest active room', () => {
+    const older = makeBootstrapRoom({ controllerLevel: 1 });
+    const newer = makeBootstrapRoom({ controllerLevel: 1, roomName: 'W3N1' });
+    Memory.territory = {
+      claimedRoomBootstrapper: {
+        rooms: {
+          W2N1: { roomName: 'W2N1', owned: true, claimedAt: 80, updatedAt: 90 },
+          W3N1: { roomName: 'W3N1', owned: true, claimedAt: 90, updatedAt: 90 }
+        }
+      }
+    };
+    installGameRooms([newer.room, older.room], 101);
+
+    const result = runClaimedRoomBootstrapper([newer.colony, older.colony]);
+
+    expect(result.activeRoomNames).toEqual(['W2N1']);
+    expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'spawn', result: OK_CODE }]);
+    expect(older.room.createConstructionSite).toHaveBeenCalledTimes(1);
+    expect(newer.room.createConstructionSite).not.toHaveBeenCalled();
+  });
 });
 
 interface MockRoom extends Room {
@@ -268,6 +289,7 @@ interface TestPosition {
 
 interface BootstrapRoomOptions {
   controllerLevel: number;
+  roomName?: string;
   controllerPosition?: TestPosition;
   sources?: Source[];
   structures?: Structure[];
@@ -307,7 +329,7 @@ function makeBootstrapRoom(options: BootstrapRoomOptions): { room: MockRoom; col
   const constructionSites = [...(options.constructionSites ?? [])];
   const structures = [...(options.structures ?? [])];
   const sources = options.sources ?? [];
-  const roomName = 'W2N1';
+  const roomName = options.roomName ?? 'W2N1';
   const controller = {
     id: 'controller1',
     my: true,
@@ -402,16 +424,28 @@ function installActiveBootstrapMemory(updatedAt = 90, owned = true): void {
 }
 
 function installGame(room: Room, time = 100): void {
-  const wallPositions = (room as Room & { __wallPositions?: Set<string> }).__wallPositions ?? new Set<string>();
+  installGameRooms([room], time);
+}
+
+function installGameRooms(rooms: Room[], time = 100): void {
+  const roomsByName = Object.fromEntries(rooms.map((room) => [room.name, room]));
+  const wallPositionsByRoom = new Map(
+    rooms.map((room) => [
+      room.name,
+      (room as Room & { __wallPositions?: Set<string> }).__wallPositions ?? new Set<string>()
+    ])
+  );
   (globalThis as unknown as { Game: Partial<Game> }).Game = {
     time,
-    rooms: { [room.name]: room },
+    rooms: roomsByName,
     map: {
-      getRoomTerrain: jest.fn().mockReturnValue({
+      getRoomTerrain: jest.fn((roomName: string) => ({
         get: jest.fn((x: number, y: number) =>
-          wallPositions.has(`${x},${y}`) ? TEST_GLOBALS.TERRAIN_MASK_WALL : 0
+          (wallPositionsByRoom.get(roomName) ?? new Set<string>()).has(`${x},${y}`)
+            ? TEST_GLOBALS.TERRAIN_MASK_WALL
+            : 0
         )
-      })
+      }))
     } as unknown as GameMap
   };
 }

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -6584,6 +6584,7 @@ describe('planTerritoryIntent', () => {
       updatedAt: 699,
       sources: {}
     };
+    const deferredRemoteMiningSnapshot = JSON.parse(JSON.stringify(deferredRemoteMiningMemory)) as TerritoryRemoteMiningRoomMemory;
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
       territory: {
         postClaimBootstraps: {
@@ -6614,6 +6615,7 @@ describe('planTerritoryIntent', () => {
     expect(deferredRoom.createConstructionSite).not.toHaveBeenCalled();
     expect(Memory.territory?.remoteMining?.['W1N1:W2N1']).toBeDefined();
     expect(Memory.territory?.remoteMining?.['W1N1:W3N1']).toBe(deferredRemoteMiningMemory);
+    expect(Memory.territory?.remoteMining?.['W1N1:W3N1']).toEqual(deferredRemoteMiningSnapshot);
   });
 
   it('records active remote mining state from source containers and room-local assigned creeps', () => {

--- a/prod/test/territoryPlanner.test.ts
+++ b/prod/test/territoryPlanner.test.ts
@@ -6541,6 +6541,81 @@ describe('planTerritoryIntent', () => {
     });
   });
 
+  it('defers remote mining setup for non-focused active post-claim rooms', () => {
+    (globalThis as unknown as {
+      FIND_STRUCTURES: number;
+      FIND_CONSTRUCTION_SITES: number;
+      FIND_MY_CREEPS: number;
+      STRUCTURE_CONTAINER: StructureConstant;
+      TERRAIN_MASK_WALL: number;
+      OK: ScreepsReturnCode;
+    }).FIND_STRUCTURES = 10;
+    (globalThis as unknown as { FIND_CONSTRUCTION_SITES: number }).FIND_CONSTRUCTION_SITES = 11;
+    (globalThis as unknown as { FIND_MY_CREEPS: number }).FIND_MY_CREEPS = 12;
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
+    (globalThis as unknown as { OK: ScreepsReturnCode }).OK = 0 as ScreepsReturnCode;
+    const colony = makeSafeColony();
+    const makeFocusedRemoteRoom = (roomName: string): Room & { createConstructionSite: jest.Mock } => ({
+      name: roomName,
+      energyAvailable: 0,
+      energyCapacityAvailable: 0,
+      controller: {
+        id: `${roomName}-controller`,
+        my: true,
+        level: 1,
+        pos: { x: 25, y: 25, roomName } as RoomPosition
+      } as StructureController,
+      createConstructionSite: jest.fn().mockReturnValue(0 as ScreepsReturnCode),
+      find: jest.fn((type: number) => {
+        if (type === FIND_SOURCES) {
+          return [{ id: `${roomName}-source1`, pos: { x: 10, y: 10, roomName } as RoomPosition } as Source];
+        }
+
+        return [];
+      })
+    }) as unknown as Room & { createConstructionSite: jest.Mock };
+    const focusedRoom = makeFocusedRemoteRoom('W2N1');
+    const deferredRoom = makeFocusedRemoteRoom('W3N1');
+    const deferredRemoteMiningMemory: TerritoryRemoteMiningRoomMemory = {
+      colony: 'W1N1',
+      roomName: 'W3N1',
+      status: 'containerPending',
+      updatedAt: 699,
+      sources: {}
+    };
+    (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {
+      territory: {
+        postClaimBootstraps: {
+          W2N1: { ...makeRemoteMiningBootstrap(), status: 'detected', roomName: 'W2N1' },
+          W3N1: {
+            ...makeRemoteMiningBootstrap(),
+            status: 'detected',
+            roomName: 'W3N1',
+            controllerId: 'W3N1-controller' as Id<StructureController>
+          }
+        },
+        remoteMining: {
+          'W1N1:W3N1': deferredRemoteMiningMemory
+        }
+      }
+    };
+    (globalThis as unknown as { Game: Partial<Game> }).Game = {
+      time: 700,
+      rooms: { W1N1: colony.room, W2N1: focusedRoom, W3N1: deferredRoom },
+      map: {
+        getRoomTerrain: jest.fn().mockReturnValue({ get: jest.fn().mockReturnValue(0) })
+      } as unknown as GameMap
+    };
+
+    refreshRemoteMiningSetup(colony, 700, { focusRoomName: 'W2N1' });
+
+    expect(focusedRoom.createConstructionSite).toHaveBeenCalledWith(11, 11, STRUCTURE_CONTAINER);
+    expect(deferredRoom.createConstructionSite).not.toHaveBeenCalled();
+    expect(Memory.territory?.remoteMining?.['W1N1:W2N1']).toBeDefined();
+    expect(Memory.territory?.remoteMining?.['W1N1:W3N1']).toBe(deferredRemoteMiningMemory);
+  });
+
   it('records active remote mining state from source containers and room-local assigned creeps', () => {
     (globalThis as unknown as {
       FIND_STRUCTURES: number;


### PR DESCRIPTION
Implements post-claim colony bootstrapping: spawn construction and controller progression for newly claimed rooms.

Changes:
- `claimedRoomBootstrapper.ts`: orchestrates spawn construction + controller upgrade in claimed rooms
- `postClaimBootstrap.ts`: post-claim bootstrap state management
- `territoryPlanner.ts`: integrates bootstrapping into territory planning
- `economyLoop.ts`: economy coordination for bootstrap phase
- Tests for all new/modified modules

Verification:
- Typecheck PASS
- 1429 tests PASS
- Build PASS

Closes #761