### PR TITLE
feat(territory): optimize colony room defense — tower positioning and rampart priority after bootstrap (#765)

### DIFF
--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8561,10 +8561,14 @@ var EXPANSION_TOWER_DEFAULT_MAX_PLACEMENTS = 6;
 var EXPANSION_DEFENSE_BARRIER_DEFAULT_MAX_PLACEMENTS = 24;
 var EXPANSION_TOWER_ROOM_EDGE_MIN = 1;
 var EXPANSION_TOWER_ROOM_EDGE_MAX = 48;
-var EXPANSION_TOWER_CONTROLLER_WEIGHT = 6;
-var EXPANSION_TOWER_SOURCE_WEIGHT = 3;
+var EXPANSION_TOWER_SPAWN_WEIGHT = 10;
+var EXPANSION_TOWER_CONTROLLER_WEIGHT = 8;
+var EXPANSION_TOWER_CONTAINER_WEIGHT = 4;
+var EXPANSION_TOWER_SOURCE_WEIGHT = 2;
+var EXPANSION_TOWER_ROAD_WEIGHT = 1;
 var EXPANSION_TOWER_ENTRANCE_WEIGHT = 1;
-var EXPANSION_DEFENSE_BARRIER_MAX_SECONDARY_RAMPARTS = 12;
+var EXPANSION_TOWER_MAX_ROAD_ANCHORS = 12;
+var EXPANSION_DEFENSE_BARRIER_MAX_CORE_RAMPARTS = 16;
 var DEFAULT_TERRAIN_WALL_MASK9 = 1;
 function evaluateExpansionRoomSuitability(room, colonyOwnerUsername) {
   var _a;
@@ -8867,10 +8871,15 @@ function planExpansionDefenseBarrierPlacements(room, options = {}) {
     return [];
   }
   const lookups = createExpansionDefenseBarrierPlacementLookups(room);
-  const entranceRampartTargets = getExpansionDefenseEntranceRampartTargets(room, lookups);
-  if (entranceRampartTargets.length === 0) {
-    return [];
+  const towerRampartPlacements = getExpansionDefenseTowerRampartTargets(room, lookups).filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position)).filter((position) => canPlaceExpansionDefenseRampart(lookups, position)).map((position) => createExpansionDefenseBarrierPlacement(room.name, position, "towerRampart"));
+  if (towerRampartPlacements.length > 0) {
+    return towerRampartPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
   }
+  const coreRampartPlacements = getExpansionDefenseCoreRampartTargets(room, lookups).filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position)).filter((position) => canPlaceExpansionDefenseRampart(lookups, position)).map((position) => createExpansionDefenseBarrierPlacement(room.name, position, "coreRampart"));
+  if (coreRampartPlacements.length > 0) {
+    return coreRampartPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+  }
+  const entranceRampartTargets = getExpansionDefenseEntranceRampartTargets(room, lookups);
   const entranceRampartPlacements = entranceRampartTargets.filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position)).filter((position) => canPlaceExpansionDefenseRampart(lookups, position)).map((position) => createExpansionDefenseBarrierPlacement(room.name, position, "entranceRampart"));
   if (entranceRampartPlacements.length > 0) {
     return entranceRampartPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
@@ -8879,7 +8888,7 @@ function planExpansionDefenseBarrierPlacements(room, options = {}) {
   if (entranceWallPlacements.length > 0) {
     return entranceWallPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
   }
-  return getExpansionDefenseSecondaryRampartTargets(room, lookups).filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position)).filter((position) => canPlaceExpansionDefenseRampart(lookups, position)).map((position) => createExpansionDefenseBarrierPlacement(room.name, position, "secondaryRampart")).slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+  return [];
 }
 function createExpansionTowerPlacementLookups(room) {
   const blockedPositions = /* @__PURE__ */ new Set();
@@ -8906,8 +8915,28 @@ function buildExpansionTowerAnchors(room) {
     EXPANSION_TOWER_CONTROLLER_WEIGHT,
     room.name
   );
+  const structures = findRoomObjects12(room, getFindConstant4("FIND_STRUCTURES")).sort(
+    compareExpansionTowerObjects
+  );
+  const constructionSites = findRoomObjects12(room, getFindConstant4("FIND_CONSTRUCTION_SITES")).sort(
+    compareExpansionTowerObjects
+  );
+  const roadAnchorCandidates = [];
+  for (const object of [...structures, ...constructionSites]) {
+    const structureType = getExpansionTowerStructureType(object);
+    if (isExpansionTowerStructureType(structureType, "STRUCTURE_SPAWN", "spawn")) {
+      addExpansionTowerAnchor(anchors, object, "spawn", EXPANSION_TOWER_SPAWN_WEIGHT, room.name);
+    } else if (isExpansionTowerStructureType(structureType, "STRUCTURE_CONTAINER", "container")) {
+      addExpansionTowerAnchor(anchors, object, "container", EXPANSION_TOWER_CONTAINER_WEIGHT, room.name);
+    } else if (isExpansionTowerStructureType(structureType, "STRUCTURE_ROAD", "road")) {
+      roadAnchorCandidates.push(object);
+    }
+  }
   for (const source of findRoomObjects12(room, getFindConstant4("FIND_SOURCES")).sort(compareExpansionTowerObjectIds)) {
     addExpansionTowerAnchor(anchors, source, "source", EXPANSION_TOWER_SOURCE_WEIGHT, room.name);
+  }
+  for (const road of selectExpansionTowerRoadAnchors(roadAnchorCandidates, anchors, room.name)) {
+    addExpansionTowerAnchor(anchors, road, "road", EXPANSION_TOWER_ROAD_WEIGHT, room.name);
   }
   for (const entrancePosition of getExpansionTowerEntranceAnchors(room)) {
     anchors.push({
@@ -9038,7 +9067,10 @@ function canPlaceExpansionTower(lookups, position) {
   return position.x >= EXPANSION_TOWER_ROOM_EDGE_MIN && position.x <= EXPANSION_TOWER_ROOM_EDGE_MAX && position.y >= EXPANSION_TOWER_ROOM_EDGE_MIN && position.y <= EXPANSION_TOWER_ROOM_EDGE_MAX && !lookups.blockedPositions.has(getExpansionTowerPositionKey(position)) && !isExpansionTowerTerrainWall(lookups.terrain, position);
 }
 function scoreExpansionTowerPlacement(position, anchors, roomName) {
+  const spawnRange = getNearestExpansionTowerAnchorRange(position, anchors, "spawn");
   const controllerRange = getNearestExpansionTowerAnchorRange(position, anchors, "controller");
+  const nearestContainerRange = getNearestExpansionTowerAnchorRange(position, anchors, "container");
+  const nearestRoadRange = getNearestExpansionTowerAnchorRange(position, anchors, "road");
   const nearestSourceRange = getNearestExpansionTowerAnchorRange(position, anchors, "source");
   const nearestEntranceRange = getNearestExpansionTowerAnchorRange(position, anchors, "entrance");
   return {
@@ -9049,7 +9081,10 @@ function scoreExpansionTowerPlacement(position, anchors, roomName) {
       (score, anchor) => score + getExpansionTowerRange(position, anchor.position) * anchor.weight,
       0
     ),
+    ...spawnRange !== null ? { spawnRange } : {},
     ...controllerRange !== null ? { controllerRange } : {},
+    ...nearestContainerRange !== null ? { nearestContainerRange } : {},
+    ...nearestRoadRange !== null ? { nearestRoadRange } : {},
     ...nearestSourceRange !== null ? { nearestSourceRange } : {},
     ...nearestEntranceRange !== null ? { nearestEntranceRange } : {}
   };
@@ -9068,7 +9103,28 @@ function getNearestExpansionTowerAnchorRange(position, anchors, kind) {
   return nearestRange;
 }
 function compareExpansionTowerPlacements(left, right) {
-  return left.score - right.score || compareOptionalNumbers3(left.controllerRange, right.controllerRange) || compareOptionalNumbers3(left.nearestSourceRange, right.nearestSourceRange) || compareOptionalNumbers3(left.nearestEntranceRange, right.nearestEntranceRange) || left.y - right.y || left.x - right.x;
+  return left.score - right.score || compareOptionalNumbers3(left.spawnRange, right.spawnRange) || compareOptionalNumbers3(left.controllerRange, right.controllerRange) || compareOptionalNumbers3(left.nearestContainerRange, right.nearestContainerRange) || compareOptionalNumbers3(left.nearestRoadRange, right.nearestRoadRange) || compareOptionalNumbers3(left.nearestSourceRange, right.nearestSourceRange) || compareOptionalNumbers3(left.nearestEntranceRange, right.nearestEntranceRange) || left.y - right.y || left.x - right.x;
+}
+function selectExpansionTowerRoadAnchors(roadAnchorCandidates, anchors, roomName) {
+  return roadAnchorCandidates.map((object) => ({ object, position: getExpansionTowerObjectPosition(object) })).filter(
+    (candidate) => isExpansionTowerSameRoomPosition(candidate.position, roomName)
+  ).sort(
+    (left, right) => getNearestExpansionTowerAnyAnchorRange(left.position, anchors) - getNearestExpansionTowerAnyAnchorRange(right.position, anchors) || compareExpansionTowerPositions(left.position, right.position) || compareExpansionTowerObjectIds(left.object, right.object)
+  ).slice(0, EXPANSION_TOWER_MAX_ROAD_ANCHORS).map((candidate) => candidate.object);
+}
+function getNearestExpansionTowerAnyAnchorRange(position, anchors) {
+  if (anchors.length === 0) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  return Math.min(...anchors.map((anchor) => getExpansionTowerRange(position, anchor.position)));
+}
+function getExpansionTowerStructureType(object) {
+  return isRecord10(object) ? object.structureType : void 0;
+}
+function isExpansionTowerStructureType(actual, globalName, fallback) {
+  var _a;
+  const constants = globalThis;
+  return actual === ((_a = constants[globalName]) != null ? _a : fallback);
 }
 function addExpansionTowerBlockedPosition(blockedPositions, object, roomName) {
   const position = getExpansionTowerObjectPosition(object);
@@ -9197,7 +9253,15 @@ function getExpansionDefenseAdjacentWallTargets(position) {
   }
   return [];
 }
-function getExpansionDefenseSecondaryRampartTargets(room, lookups) {
+function getExpansionDefenseTowerRampartTargets(room, lookups) {
+  const targets = findRoomObjects12(room, getFindConstant4("FIND_STRUCTURES")).filter((structure) => isExpansionDefenseStructureType(structure.structureType, "STRUCTURE_TOWER", "tower")).sort(compareExpansionTowerObjects).map(getExpansionTowerObjectPosition).filter(
+    (position) => isExpansionTowerSameRoomPosition(position, room.name)
+  );
+  return dedupeExpansionDefensePositions(targets).filter(
+    (position) => isExpansionDefenseRampartTargetAllowed(lookups, position)
+  );
+}
+function getExpansionDefenseCoreRampartTargets(room, lookups) {
   const targets = [];
   const structures = findRoomObjects12(room, getFindConstant4("FIND_STRUCTURES"));
   for (const spawn of structures.filter((structure) => isExpansionDefenseStructureType(structure.structureType, "STRUCTURE_SPAWN", "spawn")).sort(compareExpansionTowerObjectIds)) {
@@ -9211,7 +9275,7 @@ function getExpansionDefenseSecondaryRampartTargets(room, lookups) {
   if (isExpansionTowerSameRoomPosition(controllerPosition, room.name)) {
     targets.push(...getExpansionDefenseAdjacentPositions(controllerPosition, false));
   }
-  return dedupeExpansionDefensePositions(targets).filter((position) => isExpansionDefenseRampartTargetAllowed(lookups, position)).slice(0, EXPANSION_DEFENSE_BARRIER_MAX_SECONDARY_RAMPARTS);
+  return dedupeExpansionDefensePositions(targets).filter((position) => isExpansionDefenseRampartTargetAllowed(lookups, position)).slice(0, EXPANSION_DEFENSE_BARRIER_MAX_CORE_RAMPARTS);
 }
 function getExpansionDefenseAdjacentPositions(center, includeCenter) {
   const positions = includeCenter ? [{ ...center }] : [];
@@ -9285,12 +9349,14 @@ function createExpansionDefenseBarrierPlacement(roomName, position, stage) {
 }
 function getExpansionDefenseBarrierStagePriority(stage) {
   switch (stage) {
-    case "entranceRampart":
+    case "towerRampart":
       return 0;
-    case "entranceWall":
+    case "coreRampart":
       return 1;
-    case "secondaryRampart":
+    case "entranceRampart":
       return 2;
+    case "entranceWall":
+      return 3;
   }
 }
 function getExpansionDefenseInteriorSide(position) {
@@ -9354,6 +9420,24 @@ function getExpansionDefenseStructureConstant(globalName, fallback) {
   var _a;
   const constants = globalThis;
   return (_a = constants[globalName]) != null ? _a : fallback;
+}
+function compareExpansionTowerObjects(left, right) {
+  const leftPosition = getExpansionTowerObjectPosition(left);
+  const rightPosition = getExpansionTowerObjectPosition(right);
+  if (leftPosition && rightPosition) {
+    return compareExpansionTowerPositions(leftPosition, rightPosition) || compareExpansionTowerObjectIds(left, right);
+  }
+  if (leftPosition) {
+    return -1;
+  }
+  if (rightPosition) {
+    return 1;
+  }
+  return compareExpansionTowerObjectIds(left, right);
+}
+function compareExpansionTowerPositions(left, right) {
+  var _a, _b;
+  return left.y - right.y || left.x - right.x || ((_a = left.roomName) != null ? _a : "").localeCompare((_b = right.roomName) != null ? _b : "");
 }
 function compareExpansionTowerObjectIds(left, right) {
   return getExpansionTowerObjectId(left).localeCompare(getExpansionTowerObjectId(right));

--- a/prod/dist/main.js
+++ b/prod/dist/main.js
@@ -8957,7 +8957,7 @@ function planExpansionDefenseBarrierPlacements(room, options = {}) {
     return [];
   }
   const lookups = createExpansionDefenseBarrierPlacementLookups(room);
-  const towerRampartPlacements = getExpansionDefenseTowerRampartTargets(room, lookups).filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position)).filter((position) => canPlaceExpansionDefenseRampart(lookups, position)).map((position) => createExpansionDefenseBarrierPlacement(room.name, position, "towerRampart"));
+  const towerRampartPlacements = getExpansionDefenseTowerRampartTargets(room, lookups).filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position)).filter((position) => canPlaceExpansionDefenseTowerRampart(lookups, position)).map((position) => createExpansionDefenseBarrierPlacement(room.name, position, "towerRampart"));
   if (towerRampartPlacements.length > 0) {
     return towerRampartPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
   }
@@ -9205,7 +9205,7 @@ function getNearestExpansionTowerAnyAnchorRange(position, anchors) {
   return Math.min(...anchors.map((anchor) => getExpansionTowerRange(position, anchor.position)));
 }
 function getExpansionTowerStructureType(object) {
-  return isRecord10(object) ? object.structureType : void 0;
+  return isRecord11(object) ? object.structureType : void 0;
 }
 function isExpansionTowerStructureType(actual, globalName, fallback) {
   var _a;
@@ -9340,7 +9340,14 @@ function getExpansionDefenseAdjacentWallTargets(position) {
   return [];
 }
 function getExpansionDefenseTowerRampartTargets(room, lookups) {
-  const targets = findRoomObjects12(room, getFindConstant4("FIND_STRUCTURES")).filter((structure) => isExpansionDefenseStructureType(structure.structureType, "STRUCTURE_TOWER", "tower")).sort(compareExpansionTowerObjects).map(getExpansionTowerObjectPosition).filter(
+  const targets = [
+    ...findRoomObjects12(room, getFindConstant4("FIND_STRUCTURES")).filter(
+      (structure) => isExpansionDefenseStructureType(structure.structureType, "STRUCTURE_TOWER", "tower")
+    ),
+    ...findRoomObjects12(room, getFindConstant4("FIND_CONSTRUCTION_SITES")).filter(
+      (site) => isExpansionDefenseStructureType(String(site.structureType), "STRUCTURE_TOWER", "tower")
+    )
+  ].sort(compareExpansionTowerObjects).map(getExpansionTowerObjectPosition).filter(
     (position) => isExpansionTowerSameRoomPosition(position, room.name)
   );
   return dedupeExpansionDefensePositions(targets).filter(
@@ -9386,6 +9393,9 @@ function getExpansionDefenseAdjacentPositions(center, includeCenter) {
 }
 function canPlaceExpansionDefenseRampart(lookups, position) {
   return isExpansionDefenseRampartTargetAllowed(lookups, position) && !hasExpansionDefenseConstructionAt(lookups, position);
+}
+function canPlaceExpansionDefenseTowerRampart(lookups, position) {
+  return isExpansionDefenseRampartTargetAllowed(lookups, position) && (!hasExpansionDefenseConstructionAt(lookups, position) || hasExpansionDefenseConstructionTypeAt(lookups, position, "STRUCTURE_TOWER", "tower"));
 }
 function canPlaceExpansionDefenseWall(lookups, position) {
   return isExpansionDefenseBuildablePosition(lookups, position) && !lookups.reservedPositions.has(getExpansionTowerPositionKey(position)) && !hasExpansionDefenseStructureAt(lookups, position) && !hasExpansionDefenseConstructionAt(lookups, position);
@@ -14109,8 +14119,8 @@ function getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy = getRoomEnerg
   const baseThresholdPerSpawn = getBaseSpawnEnergyBufferThreshold(room);
   const minerOutputEnergyPerTick = getRoomMinerThroughput(room).energyPerTick;
   const minerOutputBufferCredit = getMinerOutputBufferCredit(minerOutputEnergyPerTick);
-  const thresholdPerSpawn = getSpawnEnergyBufferThreshold(room);
   const spawnCount = getSpawnBufferCount(spawns);
+  const thresholdPerSpawn = getSpawnEnergyBufferThresholdForSpawnCount(room, spawnCount);
   const threshold = thresholdPerSpawn * spawnCount;
   const normalizedEnergy = normalizeEnergyAmount2(currentEnergy);
   const reservation = getRoomSpawnEnergyReservationState(room);
@@ -14128,18 +14138,19 @@ function getSpawnEnergyBufferSnapshot(room, spawns, currentEnergy = getRoomEnerg
     unmetReservedEnergy: reservation.unmetReservedEnergy
   };
 }
-function getSpawnEnergyBufferThreshold(room) {
+function getSpawnEnergyBufferThresholdForSpawnCount(room, spawnCount) {
   const configured = getConfiguredSpawnEnergyBufferThreshold(room);
   if (configured !== null) {
     return configured;
   }
-  return getMinerAdjustedSpawnEnergyBufferThreshold(room, getBaseSpawnEnergyBufferThreshold(room));
+  return getMinerAdjustedSpawnEnergyBufferThreshold(room, getBaseSpawnEnergyBufferThreshold(room), spawnCount);
 }
 function getBaseSpawnEnergyBufferThreshold(room) {
   return SPAWN_ENERGY_BUFFER_THRESHOLDS_BY_RCL[getRoomRcl2(room)];
 }
 function getSpawnEnergyBufferRequirement(room, spawns) {
-  return getSpawnEnergyBufferThreshold(room) * getSpawnBufferCount(spawns);
+  const spawnCount = getSpawnBufferCount(spawns);
+  return getSpawnEnergyBufferThresholdForSpawnCount(room, spawnCount) * spawnCount;
 }
 function getBufferedSpawnEnergyBudget(room, spawns, availableEnergy = getRoomEnergyAvailable4(room)) {
   return Math.max(0, normalizeEnergyAmount2(availableEnergy) - getSpawnEnergyBufferRequirement(room, spawns));
@@ -14157,7 +14168,7 @@ function getSpawnEnergyAvailableForWithdrawal(room, target, currentEnergy = getS
     (total, spawn) => total + (isSameSpawn(spawn, target) ? targetSpawnEnergy : getStoredEnergy4(spawn)),
     0
   );
-  const totalSpawnBuffer = getSpawnEnergyBufferThreshold(room) * spawns.length;
+  const totalSpawnBuffer = getSpawnEnergyBufferThresholdForSpawnCount(room, spawns.length) * spawns.length;
   const roomSurplus = Math.max(0, roomTotalSpawnEnergy - totalSpawnBuffer);
   return Math.min(targetSpawnEnergy, roomSurplus);
 }
@@ -14183,15 +14194,18 @@ function getConfiguredSpawnEnergyBufferThreshold(room) {
   );
   return memoryConfig;
 }
-function getMinerAdjustedSpawnEnergyBufferThreshold(room, baseThreshold) {
+function getMinerAdjustedSpawnEnergyBufferThreshold(room, baseThreshold, spawnCount) {
+  const normalizedSpawnCount = Math.max(1, normalizeEnergyAmount2(spawnCount));
   const minerOutputBufferCredit = getMinerOutputBufferCredit(getRoomMinerThroughput(room).energyPerTick);
   if (minerOutputBufferCredit <= 0) {
     return baseThreshold;
   }
-  return Math.max(
-    MINER_ADJUSTED_SPAWN_ENERGY_BUFFER_FLOOR,
-    baseThreshold - minerOutputBufferCredit
+  const roomBufferThreshold = baseThreshold * normalizedSpawnCount;
+  const adjustedRoomBufferThreshold = Math.max(
+    MINER_ADJUSTED_SPAWN_ENERGY_BUFFER_FLOOR * normalizedSpawnCount,
+    roomBufferThreshold - minerOutputBufferCredit
   );
+  return normalizeEnergyAmount2(Math.ceil(adjustedRoomBufferThreshold / normalizedSpawnCount));
 }
 function getMinerOutputBufferCredit(minerOutputEnergyPerTick) {
   return normalizeEnergyAmount2(minerOutputEnergyPerTick * MINER_OUTPUT_BUFFER_CREDIT_TICKS);

--- a/prod/src/construction/constructionPriority.ts
+++ b/prod/src/construction/constructionPriority.ts
@@ -1107,7 +1107,8 @@ function getProtectedRampartAnchorPositions(
 
   for (const structure of ownedStructures ?? []) {
     if (
-      matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') &&
+      (matchesStructureType(structure.structureType, 'STRUCTURE_SPAWN', 'spawn') ||
+        matchesStructureType(structure.structureType, 'STRUCTURE_TOWER', 'tower')) &&
       isSameRoomPosition(structure.pos ?? null, room.name)
     ) {
       anchors.push(structure.pos);

--- a/prod/src/territory/claimedRoomBootstrapper.ts
+++ b/prod/src/territory/claimedRoomBootstrapper.ts
@@ -594,6 +594,8 @@ function createTowerPlacementLookups(colony: ColonySnapshot): TowerPlacementLook
       addTowerAnchor(anchors, structure, 3, room.name);
     } else if (matchesStructureType(structureType, 'STRUCTURE_CONTAINER', 'container')) {
       addTowerAnchor(anchors, structure, 2, room.name);
+    } else if (matchesStructureType(structureType, 'STRUCTURE_ROAD', 'road')) {
+      addTowerAnchor(anchors, structure, 1, room.name);
     }
   }
 
@@ -606,6 +608,8 @@ function createTowerPlacementLookups(colony: ColonySnapshot): TowerPlacementLook
       addTowerAnchor(anchors, site, 3, room.name);
     } else if (matchesStructureType(structureType, 'STRUCTURE_CONTAINER', 'container')) {
       addTowerAnchor(anchors, site, 2, room.name);
+    } else if (matchesStructureType(structureType, 'STRUCTURE_ROAD', 'road')) {
+      addTowerAnchor(anchors, site, 1, room.name);
     }
   }
 

--- a/prod/src/territory/claimedRoomBootstrapper.ts
+++ b/prod/src/territory/claimedRoomBootstrapper.ts
@@ -594,8 +594,6 @@ function createTowerPlacementLookups(colony: ColonySnapshot): TowerPlacementLook
       addTowerAnchor(anchors, structure, 3, room.name);
     } else if (matchesStructureType(structureType, 'STRUCTURE_CONTAINER', 'container')) {
       addTowerAnchor(anchors, structure, 2, room.name);
-    } else if (matchesStructureType(structureType, 'STRUCTURE_ROAD', 'road')) {
-      addTowerAnchor(anchors, structure, 1, room.name);
     }
   }
 
@@ -608,8 +606,6 @@ function createTowerPlacementLookups(colony: ColonySnapshot): TowerPlacementLook
       addTowerAnchor(anchors, site, 3, room.name);
     } else if (matchesStructureType(structureType, 'STRUCTURE_CONTAINER', 'container')) {
       addTowerAnchor(anchors, site, 2, room.name);
-    } else if (matchesStructureType(structureType, 'STRUCTURE_ROAD', 'road')) {
-      addTowerAnchor(anchors, site, 1, room.name);
     }
   }
 

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -611,7 +611,7 @@ export function planExpansionDefenseBarrierPlacements(
   const lookups = createExpansionDefenseBarrierPlacementLookups(room);
   const towerRampartPlacements = getExpansionDefenseTowerRampartTargets(room, lookups)
     .filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position))
-    .filter((position) => canPlaceExpansionDefenseRampart(lookups, position))
+    .filter((position) => canPlaceExpansionDefenseTowerRampart(lookups, position))
     .map((position) => createExpansionDefenseBarrierPlacement(room.name, position, 'towerRampart'));
   if (towerRampartPlacements.length > 0) {
     return towerRampartPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
@@ -1182,8 +1182,14 @@ function getExpansionDefenseTowerRampartTargets(
   room: Room,
   lookups: ExpansionDefenseBarrierPlacementLookups
 ): RoomPositionLike[] {
-  const targets = findRoomObjects<AnyStructure>(room, getFindConstant('FIND_STRUCTURES'))
-    .filter((structure) => isExpansionDefenseStructureType(structure.structureType, 'STRUCTURE_TOWER', 'tower'))
+  const targets = [
+    ...findRoomObjects<AnyStructure>(room, getFindConstant('FIND_STRUCTURES')).filter((structure) =>
+      isExpansionDefenseStructureType(structure.structureType, 'STRUCTURE_TOWER', 'tower')
+    ),
+    ...findRoomObjects<ConstructionSite>(room, getFindConstant('FIND_CONSTRUCTION_SITES')).filter((site) =>
+      isExpansionDefenseStructureType(String(site.structureType), 'STRUCTURE_TOWER', 'tower')
+    )
+  ]
     .sort(compareExpansionTowerObjects)
     .map(getExpansionTowerObjectPosition)
     .filter((position): position is RoomPositionLike =>
@@ -1256,6 +1262,19 @@ function canPlaceExpansionDefenseRampart(
   return (
     isExpansionDefenseRampartTargetAllowed(lookups, position) &&
     !hasExpansionDefenseConstructionAt(lookups, position)
+  );
+}
+
+function canPlaceExpansionDefenseTowerRampart(
+  lookups: ExpansionDefenseBarrierPlacementLookups,
+  position: RoomPositionLike
+): boolean {
+  return (
+    isExpansionDefenseRampartTargetAllowed(lookups, position) &&
+    (
+      !hasExpansionDefenseConstructionAt(lookups, position) ||
+      hasExpansionDefenseConstructionTypeAt(lookups, position, 'STRUCTURE_TOWER', 'tower')
+    )
   );
 }
 
@@ -1332,7 +1351,7 @@ function hasExpansionDefenseStructureTypeAt(
 function hasExpansionDefenseConstructionTypeAt(
   lookups: ExpansionDefenseBarrierPlacementLookups,
   position: RoomPositionLike,
-  globalName: 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
+  globalName: 'STRUCTURE_TOWER' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
   fallback: string
 ): boolean {
   return (lookups.constructionSitesByPosition.get(getExpansionTowerPositionKey(position)) ?? []).some((site) =>

--- a/prod/src/territory/expansionPlanner.ts
+++ b/prod/src/territory/expansionPlanner.ts
@@ -15,10 +15,14 @@ export const EXPANSION_DEFENSE_BARRIER_DEFAULT_MAX_PLACEMENTS = 24;
 
 const EXPANSION_TOWER_ROOM_EDGE_MIN = 1;
 const EXPANSION_TOWER_ROOM_EDGE_MAX = 48;
-const EXPANSION_TOWER_CONTROLLER_WEIGHT = 6;
-const EXPANSION_TOWER_SOURCE_WEIGHT = 3;
+const EXPANSION_TOWER_SPAWN_WEIGHT = 10;
+const EXPANSION_TOWER_CONTROLLER_WEIGHT = 8;
+const EXPANSION_TOWER_CONTAINER_WEIGHT = 4;
+const EXPANSION_TOWER_SOURCE_WEIGHT = 2;
+const EXPANSION_TOWER_ROAD_WEIGHT = 1;
 const EXPANSION_TOWER_ENTRANCE_WEIGHT = 1;
-const EXPANSION_DEFENSE_BARRIER_MAX_SECONDARY_RAMPARTS = 12;
+const EXPANSION_TOWER_MAX_ROAD_ANCHORS = 12;
+const EXPANSION_DEFENSE_BARRIER_MAX_CORE_RAMPARTS = 16;
 const DEFAULT_TERRAIN_WALL_MASK = 1;
 
 type TerminalExpansionIntentStatus = Extract<TerritoryIntentMemory['status'], 'inactive' | 'completed'>;
@@ -109,7 +113,13 @@ interface ExpansionReservationUpgradeContext {
   action: TerritoryControlAction;
 }
 
-export type ExpansionTowerPlacementAnchorKind = 'controller' | 'source' | 'entrance';
+export type ExpansionTowerPlacementAnchorKind =
+  | 'spawn'
+  | 'controller'
+  | 'container'
+  | 'road'
+  | 'source'
+  | 'entrance';
 
 export interface ExpansionTowerPlacementOptions {
   maxPlacements?: number;
@@ -120,15 +130,19 @@ export interface ExpansionTowerPlacement {
   x: number;
   y: number;
   score: number;
+  spawnRange?: number;
   controllerRange?: number;
+  nearestContainerRange?: number;
+  nearestRoadRange?: number;
   nearestSourceRange?: number;
   nearestEntranceRange?: number;
 }
 
 export type ExpansionDefenseBarrierPlacementStage =
+  | 'towerRampart'
+  | 'coreRampart'
   | 'entranceRampart'
-  | 'entranceWall'
-  | 'secondaryRampart';
+  | 'entranceWall';
 
 export interface ExpansionDefenseBarrierPlacementOptions {
   maxPlacements?: number;
@@ -595,11 +609,23 @@ export function planExpansionDefenseBarrierPlacements(
   }
 
   const lookups = createExpansionDefenseBarrierPlacementLookups(room);
-  const entranceRampartTargets = getExpansionDefenseEntranceRampartTargets(room, lookups);
-  if (entranceRampartTargets.length === 0) {
-    return [];
+  const towerRampartPlacements = getExpansionDefenseTowerRampartTargets(room, lookups)
+    .filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position))
+    .filter((position) => canPlaceExpansionDefenseRampart(lookups, position))
+    .map((position) => createExpansionDefenseBarrierPlacement(room.name, position, 'towerRampart'));
+  if (towerRampartPlacements.length > 0) {
+    return towerRampartPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
   }
 
+  const coreRampartPlacements = getExpansionDefenseCoreRampartTargets(room, lookups)
+    .filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position))
+    .filter((position) => canPlaceExpansionDefenseRampart(lookups, position))
+    .map((position) => createExpansionDefenseBarrierPlacement(room.name, position, 'coreRampart'));
+  if (coreRampartPlacements.length > 0) {
+    return coreRampartPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+  }
+
+  const entranceRampartTargets = getExpansionDefenseEntranceRampartTargets(room, lookups);
   const entranceRampartPlacements = entranceRampartTargets
     .filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position))
     .filter((position) => canPlaceExpansionDefenseRampart(lookups, position))
@@ -616,11 +642,7 @@ export function planExpansionDefenseBarrierPlacements(
     return entranceWallPlacements.slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
   }
 
-  return getExpansionDefenseSecondaryRampartTargets(room, lookups)
-    .filter((position) => !hasExpansionDefenseRampartCoverage(lookups, position))
-    .filter((position) => canPlaceExpansionDefenseRampart(lookups, position))
-    .map((position) => createExpansionDefenseBarrierPlacement(room.name, position, 'secondaryRampart'))
-    .slice(0, getExpansionDefenseBarrierMaxPlacements(options.maxPlacements));
+  return [];
 }
 
 function createExpansionTowerPlacementLookups(room: Room): ExpansionTowerPlacementLookups {
@@ -651,8 +673,30 @@ function buildExpansionTowerAnchors(room: Room): ExpansionTowerAnchor[] {
     room.name
   );
 
+  const structures = findRoomObjects<AnyStructure>(room, getFindConstant('FIND_STRUCTURES')).sort(
+    compareExpansionTowerObjects
+  );
+  const constructionSites = findRoomObjects<ConstructionSite>(room, getFindConstant('FIND_CONSTRUCTION_SITES')).sort(
+    compareExpansionTowerObjects
+  );
+  const roadAnchorCandidates: unknown[] = [];
+  for (const object of [...structures, ...constructionSites]) {
+    const structureType = getExpansionTowerStructureType(object);
+    if (isExpansionTowerStructureType(structureType, 'STRUCTURE_SPAWN', 'spawn')) {
+      addExpansionTowerAnchor(anchors, object, 'spawn', EXPANSION_TOWER_SPAWN_WEIGHT, room.name);
+    } else if (isExpansionTowerStructureType(structureType, 'STRUCTURE_CONTAINER', 'container')) {
+      addExpansionTowerAnchor(anchors, object, 'container', EXPANSION_TOWER_CONTAINER_WEIGHT, room.name);
+    } else if (isExpansionTowerStructureType(structureType, 'STRUCTURE_ROAD', 'road')) {
+      roadAnchorCandidates.push(object);
+    }
+  }
+
   for (const source of findRoomObjects<Source>(room, getFindConstant('FIND_SOURCES')).sort(compareExpansionTowerObjectIds)) {
     addExpansionTowerAnchor(anchors, source, 'source', EXPANSION_TOWER_SOURCE_WEIGHT, room.name);
+  }
+
+  for (const road of selectExpansionTowerRoadAnchors(roadAnchorCandidates, anchors, room.name)) {
+    addExpansionTowerAnchor(anchors, road, 'road', EXPANSION_TOWER_ROAD_WEIGHT, room.name);
   }
 
   for (const entrancePosition of getExpansionTowerEntranceAnchors(room)) {
@@ -841,7 +885,10 @@ function scoreExpansionTowerPlacement(
   anchors: ExpansionTowerAnchor[],
   roomName: string
 ): ExpansionTowerPlacement {
+  const spawnRange = getNearestExpansionTowerAnchorRange(position, anchors, 'spawn');
   const controllerRange = getNearestExpansionTowerAnchorRange(position, anchors, 'controller');
+  const nearestContainerRange = getNearestExpansionTowerAnchorRange(position, anchors, 'container');
+  const nearestRoadRange = getNearestExpansionTowerAnchorRange(position, anchors, 'road');
   const nearestSourceRange = getNearestExpansionTowerAnchorRange(position, anchors, 'source');
   const nearestEntranceRange = getNearestExpansionTowerAnchorRange(position, anchors, 'entrance');
   return {
@@ -852,7 +899,10 @@ function scoreExpansionTowerPlacement(
       (score, anchor) => score + getExpansionTowerRange(position, anchor.position) * anchor.weight,
       0
     ),
+    ...(spawnRange !== null ? { spawnRange } : {}),
     ...(controllerRange !== null ? { controllerRange } : {}),
+    ...(nearestContainerRange !== null ? { nearestContainerRange } : {}),
+    ...(nearestRoadRange !== null ? { nearestRoadRange } : {}),
     ...(nearestSourceRange !== null ? { nearestSourceRange } : {}),
     ...(nearestEntranceRange !== null ? { nearestEntranceRange } : {})
   };
@@ -884,12 +934,62 @@ function compareExpansionTowerPlacements(
 ): number {
   return (
     left.score - right.score ||
+    compareOptionalNumbers(left.spawnRange, right.spawnRange) ||
     compareOptionalNumbers(left.controllerRange, right.controllerRange) ||
+    compareOptionalNumbers(left.nearestContainerRange, right.nearestContainerRange) ||
+    compareOptionalNumbers(left.nearestRoadRange, right.nearestRoadRange) ||
     compareOptionalNumbers(left.nearestSourceRange, right.nearestSourceRange) ||
     compareOptionalNumbers(left.nearestEntranceRange, right.nearestEntranceRange) ||
     left.y - right.y ||
     left.x - right.x
   );
+}
+
+function selectExpansionTowerRoadAnchors(
+  roadAnchorCandidates: unknown[],
+  anchors: ExpansionTowerAnchor[],
+  roomName: string
+): unknown[] {
+  return roadAnchorCandidates
+    .map((object) => ({ object, position: getExpansionTowerObjectPosition(object) }))
+    .filter((candidate): candidate is { object: unknown; position: RoomPositionLike } =>
+      isExpansionTowerSameRoomPosition(candidate.position, roomName)
+    )
+    .sort(
+      (left, right) =>
+        getNearestExpansionTowerAnyAnchorRange(left.position, anchors) -
+          getNearestExpansionTowerAnyAnchorRange(right.position, anchors) ||
+        compareExpansionTowerPositions(left.position, right.position) ||
+        compareExpansionTowerObjectIds(left.object, right.object)
+    )
+    .slice(0, EXPANSION_TOWER_MAX_ROAD_ANCHORS)
+    .map((candidate) => candidate.object);
+}
+
+function getNearestExpansionTowerAnyAnchorRange(
+  position: RoomPositionLike,
+  anchors: ExpansionTowerAnchor[]
+): number {
+  if (anchors.length === 0) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  return Math.min(...anchors.map((anchor) => getExpansionTowerRange(position, anchor.position)));
+}
+
+function getExpansionTowerStructureType(object: unknown): unknown {
+  return isRecord(object) ? object.structureType : undefined;
+}
+
+function isExpansionTowerStructureType(
+  actual: unknown,
+  globalName: 'STRUCTURE_SPAWN' | 'STRUCTURE_CONTAINER' | 'STRUCTURE_ROAD',
+  fallback: string
+): boolean {
+  const constants = globalThis as unknown as Partial<
+    Record<'STRUCTURE_SPAWN' | 'STRUCTURE_CONTAINER' | 'STRUCTURE_ROAD', StructureConstant>
+  >;
+  return actual === (constants[globalName] ?? fallback);
 }
 
 function addExpansionTowerBlockedPosition(
@@ -1078,7 +1178,24 @@ function getExpansionDefenseAdjacentWallTargets(position: RoomPositionLike): Roo
   return [];
 }
 
-function getExpansionDefenseSecondaryRampartTargets(
+function getExpansionDefenseTowerRampartTargets(
+  room: Room,
+  lookups: ExpansionDefenseBarrierPlacementLookups
+): RoomPositionLike[] {
+  const targets = findRoomObjects<AnyStructure>(room, getFindConstant('FIND_STRUCTURES'))
+    .filter((structure) => isExpansionDefenseStructureType(structure.structureType, 'STRUCTURE_TOWER', 'tower'))
+    .sort(compareExpansionTowerObjects)
+    .map(getExpansionTowerObjectPosition)
+    .filter((position): position is RoomPositionLike =>
+      isExpansionTowerSameRoomPosition(position, room.name)
+    );
+
+  return dedupeExpansionDefensePositions(targets).filter((position) =>
+    isExpansionDefenseRampartTargetAllowed(lookups, position)
+  );
+}
+
+function getExpansionDefenseCoreRampartTargets(
   room: Room,
   lookups: ExpansionDefenseBarrierPlacementLookups
 ): RoomPositionLike[] {
@@ -1102,7 +1219,7 @@ function getExpansionDefenseSecondaryRampartTargets(
 
   return dedupeExpansionDefensePositions(targets)
     .filter((position) => isExpansionDefenseRampartTargetAllowed(lookups, position))
-    .slice(0, EXPANSION_DEFENSE_BARRIER_MAX_SECONDARY_RAMPARTS);
+    .slice(0, EXPANSION_DEFENSE_BARRIER_MAX_CORE_RAMPARTS);
 }
 
 function getExpansionDefenseAdjacentPositions(
@@ -1244,12 +1361,14 @@ function createExpansionDefenseBarrierPlacement(
 
 function getExpansionDefenseBarrierStagePriority(stage: ExpansionDefenseBarrierPlacementStage): number {
   switch (stage) {
-    case 'entranceRampart':
+    case 'towerRampart':
       return 0;
-    case 'entranceWall':
+    case 'coreRampart':
       return 1;
-    case 'secondaryRampart':
+    case 'entranceRampart':
       return 2;
+    case 'entranceWall':
+      return 3;
   }
 }
 
@@ -1327,20 +1446,42 @@ function getExpansionDefenseBarrierMaxPlacements(maxPlacements: number | undefin
 
 function isExpansionDefenseStructureType(
   actual: unknown,
-  globalName: 'STRUCTURE_SPAWN' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
+  globalName: 'STRUCTURE_SPAWN' | 'STRUCTURE_TOWER' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
   fallback: string
 ): boolean {
   return actual === getExpansionDefenseStructureConstant(globalName, fallback);
 }
 
 function getExpansionDefenseStructureConstant(
-  globalName: 'STRUCTURE_SPAWN' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
+  globalName: 'STRUCTURE_SPAWN' | 'STRUCTURE_TOWER' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL',
   fallback: string
 ): BuildableStructureConstant {
   const constants = globalThis as unknown as Partial<
-    Record<'STRUCTURE_SPAWN' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL', BuildableStructureConstant>
+    Record<'STRUCTURE_SPAWN' | 'STRUCTURE_TOWER' | 'STRUCTURE_RAMPART' | 'STRUCTURE_WALL', BuildableStructureConstant>
   >;
   return constants[globalName] ?? (fallback as BuildableStructureConstant);
+}
+
+function compareExpansionTowerObjects(left: unknown, right: unknown): number {
+  const leftPosition = getExpansionTowerObjectPosition(left);
+  const rightPosition = getExpansionTowerObjectPosition(right);
+  if (leftPosition && rightPosition) {
+    return compareExpansionTowerPositions(leftPosition, rightPosition) || compareExpansionTowerObjectIds(left, right);
+  }
+
+  if (leftPosition) {
+    return -1;
+  }
+
+  if (rightPosition) {
+    return 1;
+  }
+
+  return compareExpansionTowerObjectIds(left, right);
+}
+
+function compareExpansionTowerPositions(left: RoomPositionLike, right: RoomPositionLike): number {
+  return left.y - right.y || left.x - right.x || (left.roomName ?? '').localeCompare(right.roomName ?? '');
 }
 
 function compareExpansionTowerObjectIds(left: unknown, right: unknown): number {

--- a/prod/test/constructionPriority.test.ts
+++ b/prod/test/constructionPriority.test.ts
@@ -328,6 +328,37 @@ describe('impact-weighted construction site selection', () => {
     );
   });
 
+  it('treats rampart sites around towers as protected defense construction', () => {
+    installTestGlobals();
+    try {
+      const tower = makeOwnedStructure('tower1', TEST_GLOBALS.STRUCTURE_TOWER, 20, 20);
+      const towerRampartSite = makeConstructionSite('tower-rampart-site', 'rampart', 20, 20);
+      const genericRampartSite = makeConstructionSite('generic-rampart-site', 'rampart', 35, 35);
+      const room = {
+        name: 'W1N1',
+        controller: { my: true, pos: makeRoomPosition(40, 40) } as StructureController,
+        find: jest.fn((findType: number) => {
+          if (findType === TEST_GLOBALS.FIND_MY_STRUCTURES) {
+            return [tower];
+          }
+
+          return [];
+        })
+      } as unknown as Room;
+      const context = buildConstructionSiteImpactPriorityContext(room);
+      const origin = makeSelectionOrigin({
+        'tower-rampart-site': 5,
+        'generic-rampart-site': 5
+      });
+
+      expect(
+        selectImpactWeightedConstructionSite(origin, [genericRampartSite, towerRampartSite], context)?.id
+      ).toBe('tower-rampart-site');
+    } finally {
+      clearTestGlobals();
+    }
+  });
+
   it('chooses the closest site when multiple sites have the same impact', () => {
     const farExtensionSite = makeConstructionSite('extension-far', 'extension', 20, 20);
     const nearExtensionSite = makeConstructionSite('extension-near', 'extension', 21, 20);

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -23,6 +23,9 @@ describe('expansion planner', () => {
     (globalThis as unknown as { FIND_MINERALS: number }).FIND_MINERALS = 7;
     (globalThis as unknown as { TERRAIN_MASK_WALL: number }).TERRAIN_MASK_WALL = 1;
     (globalThis as unknown as { STRUCTURE_SPAWN: StructureConstant }).STRUCTURE_SPAWN = 'spawn';
+    (globalThis as unknown as { STRUCTURE_TOWER: StructureConstant }).STRUCTURE_TOWER = 'tower';
+    (globalThis as unknown as { STRUCTURE_CONTAINER: StructureConstant }).STRUCTURE_CONTAINER = 'container';
+    (globalThis as unknown as { STRUCTURE_ROAD: StructureConstant }).STRUCTURE_ROAD = 'road';
     (globalThis as unknown as { STRUCTURE_RAMPART: StructureConstant }).STRUCTURE_RAMPART = 'rampart';
     (globalThis as unknown as { STRUCTURE_WALL: StructureConstant }).STRUCTURE_WALL = 'constructedWall';
     (globalThis as unknown as { Memory: Partial<Memory> }).Memory = {};
@@ -151,8 +154,41 @@ describe('expansion planner', () => {
     }
   });
 
-  it('plans entrance ramparts before other claimed-room defensive barriers', () => {
+  it('places claimed-room towers where they cover spawn, controller, roads, and containers', () => {
+    const spawn = makePositionedStructure('spawn1', 10, 12, 'W2N1', STRUCTURE_SPAWN);
+    const container = makePositionedStructure('container1', 12, 10, 'W2N1', STRUCTURE_CONTAINER);
+    const road = makePositionedStructure('road1', 11, 11, 'W2N1', STRUCTURE_ROAD);
+    const room = makeTowerPlanningRoom('W2N1', {
+      controllerPosition: { x: 10, y: 10 },
+      sourcePositions: [
+        { x: 40, y: 40 },
+        { x: 40, y: 42 }
+      ],
+      exitPositions: [],
+      structures: [spawn, container, road]
+    });
+    installTerrain(room.name, new Set());
+
+    const placements = planExpansionTowerPlacements(room, { maxPlacements: 1 });
+
+    expect(placements).toEqual([
+      {
+        roomName: 'W2N1',
+        x: 10,
+        y: 11,
+        score: expect.any(Number),
+        spawnRange: 1,
+        controllerRange: 1,
+        nearestContainerRange: 2,
+        nearestRoadRange: 1,
+        nearestSourceRange: 30
+      }
+    ]);
+  });
+
+  it('plans tower ramparts before other claimed-room defensive barriers', () => {
     const spawn = makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN);
+    const tower = makePositionedStructure('tower1', 21, 20, 'W2N1', STRUCTURE_TOWER);
     const room = makeTowerPlanningRoom('W2N1', {
       controllerPosition: { x: 25, y: 25 },
       sourcePositions: [],
@@ -162,7 +198,73 @@ describe('expansion planner', () => {
         { x: 26, y: 0 },
         { x: 49, y: 25 }
       ],
-      structures: [spawn]
+      structures: [spawn, tower]
+    });
+    installTerrain(room.name, new Set());
+
+    const placements = planExpansionDefenseBarrierPlacements(room, { maxPlacements: 4 });
+
+    expect(placements).toEqual([
+      {
+        roomName: 'W2N1',
+        x: 21,
+        y: 20,
+        structureType: STRUCTURE_RAMPART,
+        stage: 'towerRampart',
+        priority: 0
+      }
+    ]);
+  });
+
+  it('plans spawn and controller ramparts after tower ramparts are covered', () => {
+    const structures = [
+      makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN),
+      makePositionedStructure('tower1', 21, 20, 'W2N1', STRUCTURE_TOWER),
+      makePositionedStructure('tower-rampart', 21, 20, 'W2N1', STRUCTURE_RAMPART)
+    ];
+    const room = makeTowerPlanningRoom('W2N1', {
+      controllerPosition: { x: 25, y: 25 },
+      sourcePositions: [],
+      exitPositions: [
+        { x: 24, y: 0 },
+        { x: 25, y: 0 },
+        { x: 26, y: 0 },
+        { x: 49, y: 25 }
+      ],
+      structures
+    });
+    installTerrain(room.name, new Set());
+
+    const placements = planExpansionDefenseBarrierPlacements(room, { maxPlacements: 3 });
+
+    expect(placements[0]).toEqual({
+      roomName: 'W2N1',
+      x: 20,
+      y: 20,
+      structureType: STRUCTURE_RAMPART,
+      stage: 'coreRampart',
+      priority: 1
+    });
+    expect(placements.every((placement) => placement.stage === 'coreRampart')).toBe(true);
+  });
+
+  it('plans entrance ramparts after tower and core ramparts are covered', () => {
+    const structures = [
+      makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN),
+      makePositionedStructure('tower1', 21, 20, 'W2N1', STRUCTURE_TOWER),
+      makePositionedStructure('tower-rampart', 21, 20, 'W2N1', STRUCTURE_RAMPART),
+      ...makeCoreRampartCoverage('core', { x: 20, y: 20 }, { x: 25, y: 25 }, 'W2N1')
+    ];
+    const room = makeTowerPlanningRoom('W2N1', {
+      controllerPosition: { x: 25, y: 25 },
+      sourcePositions: [],
+      exitPositions: [
+        { x: 24, y: 0 },
+        { x: 25, y: 0 },
+        { x: 26, y: 0 },
+        { x: 49, y: 25 }
+      ],
+      structures
     });
     installTerrain(room.name, new Set());
 
@@ -175,7 +277,7 @@ describe('expansion planner', () => {
         y: 1,
         structureType: STRUCTURE_RAMPART,
         stage: 'entranceRampart',
-        priority: 0
+        priority: 2
       },
       {
         roomName: 'W2N1',
@@ -183,14 +285,17 @@ describe('expansion planner', () => {
         y: 25,
         structureType: STRUCTURE_RAMPART,
         stage: 'entranceRampart',
-        priority: 0
+        priority: 2
       }
     ]);
   });
 
-  it('plans walls adjacent to covered entrance ramparts before secondary ramparts', () => {
+  it('plans walls adjacent to covered entrance ramparts after core ramparts', () => {
     const structures = [
       makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN),
+      makePositionedStructure('tower1', 21, 20, 'W2N1', STRUCTURE_TOWER),
+      makePositionedStructure('tower-rampart', 21, 20, 'W2N1', STRUCTURE_RAMPART),
+      ...makeCoreRampartCoverage('core', { x: 20, y: 20 }, { x: 25, y: 25 }, 'W2N1'),
       makePositionedStructure('rampart-top', 25, 1, 'W2N1', STRUCTURE_RAMPART),
       makePositionedStructure('rampart-right', 48, 25, 'W2N1', STRUCTURE_RAMPART)
     ];
@@ -216,7 +321,7 @@ describe('expansion planner', () => {
         y: 1,
         structureType: STRUCTURE_WALL,
         stage: 'entranceWall',
-        priority: 1
+        priority: 3
       },
       {
         roomName: 'W2N1',
@@ -224,7 +329,7 @@ describe('expansion planner', () => {
         y: 1,
         structureType: STRUCTURE_WALL,
         stage: 'entranceWall',
-        priority: 1
+        priority: 3
       },
       {
         roomName: 'W2N1',
@@ -232,7 +337,7 @@ describe('expansion planner', () => {
         y: 24,
         structureType: STRUCTURE_WALL,
         stage: 'entranceWall',
-        priority: 1
+        priority: 3
       },
       {
         roomName: 'W2N1',
@@ -240,45 +345,9 @@ describe('expansion planner', () => {
         y: 26,
         structureType: STRUCTURE_WALL,
         stage: 'entranceWall',
-        priority: 1
+        priority: 3
       }
     ]);
-  });
-
-  it('plans spawn and controller ramparts after entrance ramparts and walls are covered', () => {
-    const structures = [
-      makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN),
-      makePositionedStructure('rampart-top', 25, 1, 'W2N1', STRUCTURE_RAMPART),
-      makePositionedStructure('rampart-right', 48, 25, 'W2N1', STRUCTURE_RAMPART),
-      makePositionedStructure('wall-top-left', 24, 1, 'W2N1', STRUCTURE_WALL),
-      makePositionedStructure('wall-top-right', 26, 1, 'W2N1', STRUCTURE_WALL),
-      makePositionedStructure('wall-right-top', 48, 24, 'W2N1', STRUCTURE_WALL),
-      makePositionedStructure('wall-right-bottom', 48, 26, 'W2N1', STRUCTURE_WALL)
-    ];
-    const room = makeTowerPlanningRoom('W2N1', {
-      controllerPosition: { x: 25, y: 25 },
-      sourcePositions: [],
-      exitPositions: [
-        { x: 24, y: 0 },
-        { x: 25, y: 0 },
-        { x: 26, y: 0 },
-        { x: 49, y: 25 }
-      ],
-      structures
-    });
-    installTerrain(room.name, new Set());
-
-    const placements = planExpansionDefenseBarrierPlacements(room, { maxPlacements: 3 });
-
-    expect(placements[0]).toEqual({
-      roomName: 'W2N1',
-      x: 20,
-      y: 20,
-      structureType: STRUCTURE_RAMPART,
-      stage: 'secondaryRampart',
-      priority: 2
-    });
-    expect(placements.every((placement) => placement.stage === 'secondaryRampart')).toBe(true);
   });
 
   it('creates expansion targets and intents through territory planning', () => {
@@ -1118,6 +1187,42 @@ function makeTowerPlanningRoom(
   } as unknown as Room;
 
   return room;
+}
+
+function makeCoreRampartCoverage(
+  idPrefix: string,
+  spawn: { x: number; y: number },
+  controller: { x: number; y: number },
+  roomName: string
+): Structure[] {
+  const positions = [
+    { x: spawn.x, y: spawn.y },
+    ...getAdjacentPositions(spawn),
+    ...getAdjacentPositions(controller)
+  ];
+  const seen = new Set<string>();
+  return positions.flatMap((position, index) => {
+    const key = `${position.x},${position.y}`;
+    if (seen.has(key)) {
+      return [];
+    }
+
+    seen.add(key);
+    return [makePositionedStructure(`${idPrefix}-${index}`, position.x, position.y, roomName, STRUCTURE_RAMPART)];
+  });
+}
+
+function getAdjacentPositions(center: { x: number; y: number }): Array<{ x: number; y: number }> {
+  return [
+    { x: center.x, y: center.y - 1 },
+    { x: center.x + 1, y: center.y },
+    { x: center.x, y: center.y + 1 },
+    { x: center.x - 1, y: center.y },
+    { x: center.x - 1, y: center.y - 1 },
+    { x: center.x + 1, y: center.y - 1 },
+    { x: center.x + 1, y: center.y + 1 },
+    { x: center.x - 1, y: center.y + 1 }
+  ];
 }
 
 function makePositionedStructure(

--- a/prod/test/expansionPlanner.test.ts
+++ b/prod/test/expansionPlanner.test.ts
@@ -216,6 +216,37 @@ describe('expansion planner', () => {
     ]);
   });
 
+  it('holds later defensive barrier stages while the tower is still a construction site', () => {
+    const spawn = makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN);
+    const towerSite = makePositionedConstructionSite('tower-site', 21, 20, 'W2N1', STRUCTURE_TOWER);
+    const room = makeTowerPlanningRoom('W2N1', {
+      controllerPosition: { x: 25, y: 25 },
+      sourcePositions: [],
+      exitPositions: [
+        { x: 24, y: 0 },
+        { x: 25, y: 0 },
+        { x: 26, y: 0 },
+        { x: 49, y: 25 }
+      ],
+      structures: [spawn],
+      constructionSites: [towerSite]
+    });
+    installTerrain(room.name, new Set());
+
+    const placements = planExpansionDefenseBarrierPlacements(room, { maxPlacements: 4 });
+
+    expect(placements).toEqual([
+      {
+        roomName: 'W2N1',
+        x: 21,
+        y: 20,
+        structureType: STRUCTURE_RAMPART,
+        stage: 'towerRampart',
+        priority: 0
+      }
+    ]);
+  });
+
   it('plans spawn and controller ramparts after tower ramparts are covered', () => {
     const structures = [
       makePositionedStructure('spawn1', 20, 20, 'W2N1', STRUCTURE_SPAWN),
@@ -1237,6 +1268,20 @@ function makePositionedStructure(
     pos: makePosition(x, y, roomName),
     ...(structureType ? { structureType } : {})
   } as unknown as Structure;
+}
+
+function makePositionedConstructionSite(
+  id: string,
+  x: number,
+  y: number,
+  roomName: string,
+  structureType: StructureConstant
+): ConstructionSite {
+  return {
+    id,
+    pos: makePosition(x, y, roomName),
+    structureType
+  } as unknown as ConstructionSite;
 }
 
 function makePosition(x: number, y: number, roomName: string): RoomPosition {

--- a/prod/test/rampartWallConstructionExecutor.test.ts
+++ b/prod/test/rampartWallConstructionExecutor.test.ts
@@ -39,7 +39,7 @@ describe('rampart and wall construction executor', () => {
     delete globals.Memory;
   });
 
-  it('creates the first entrance rampart after essential claimed-room structures are covered', () => {
+  it('creates the first tower rampart after essential claimed-room structures are covered', () => {
     const { colony, room } = makeBarrierExecutorColony();
     installGame(room);
 
@@ -49,17 +49,17 @@ describe('rampart and wall construction executor', () => {
       roomName: 'W2N1',
       status: 'created',
       result: OK_CODE,
-      stage: 'entranceRampart',
+      stage: 'towerRampart',
       structureType: TEST_GLOBALS.STRUCTURE_RAMPART,
-      x: 25,
-      y: 1
+      x: 24,
+      y: 24
     });
-    expect(room.createConstructionSite).toHaveBeenCalledWith(25, 1, TEST_GLOBALS.STRUCTURE_RAMPART);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 24, TEST_GLOBALS.STRUCTURE_RAMPART);
   });
 
-  it('creates entrance walls only after the entrance rampart layer is covered', () => {
-    const entranceRampart = makeStructure('rampart-top', TEST_GLOBALS.STRUCTURE_RAMPART, 25, 1);
-    const { colony, room } = makeBarrierExecutorColony({ extraStructures: [entranceRampart] });
+  it('creates spawn/controller core ramparts after tower ramparts are covered', () => {
+    const towerRampart = makeStructure('tower-rampart', TEST_GLOBALS.STRUCTURE_RAMPART, 24, 24);
+    const { colony, room } = makeBarrierExecutorColony({ extraStructures: [towerRampart] });
     installGame(room);
 
     const result = runRampartWallConstructionExecutorForColony(colony, { requireExpansionMemory: true });
@@ -67,12 +67,12 @@ describe('rampart and wall construction executor', () => {
     expect(result).toMatchObject({
       roomName: 'W2N1',
       status: 'created',
-      stage: 'entranceWall',
-      structureType: TEST_GLOBALS.STRUCTURE_WALL,
-      x: 24,
-      y: 1
+      stage: 'coreRampart',
+      structureType: TEST_GLOBALS.STRUCTURE_RAMPART,
+      x: 25,
+      y: 24
     });
-    expect(room.createConstructionSite).toHaveBeenCalledWith(24, 1, TEST_GLOBALS.STRUCTURE_WALL);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(25, 24, TEST_GLOBALS.STRUCTURE_RAMPART);
   });
 
   it('skips barrier placement until essential structures and tower coverage are placed', () => {

--- a/prod/test/territory/claimedRoomBootstrapper.test.ts
+++ b/prod/test/territory/claimedRoomBootstrapper.test.ts
@@ -201,6 +201,31 @@ describe('claimed room bootstrapper', () => {
     expect(rcl3.room.createConstructionSite).toHaveBeenCalledWith(23, 23, TEST_GLOBALS.STRUCTURE_TOWER);
   });
 
+  it('ignores roads when choosing claimed-room tower anchors', () => {
+    const spawn = makeStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 20, 20);
+    const distantRoads = Array.from({ length: 8 }, (_value, index) =>
+      makeStructure(`road-${index}`, TEST_GLOBALS.STRUCTURE_ROAD, 40 + (index % 4), 42 + Math.floor(index / 4))
+    );
+    const distantRoadSites = Array.from({ length: 8 }, (_value, index) =>
+      makeConstructionSite(`road-site-${index}`, TEST_GLOBALS.STRUCTURE_ROAD, 44 + (index % 4), 42 + Math.floor(index / 4))
+    );
+    const { room, colony } = makeBootstrapRoom({
+      controllerLevel: 3,
+      controllerPosition: { x: 20, y: 24 },
+      sources: [],
+      structures: [spawn, ...makeExtensions(10), ...distantRoads],
+      constructionSites: distantRoadSites,
+      spawns: [spawn as StructureSpawn]
+    });
+    installActiveBootstrapMemory();
+    installGame(room);
+
+    const result = runClaimedRoomBootstrapper([colony]);
+
+    expect(result.planned).toEqual([{ roomName: 'W2N1', phase: 'tower', result: OK_CODE }]);
+    expect(room.createConstructionSite).toHaveBeenCalledWith(20, 22, TEST_GLOBALS.STRUCTURE_TOWER);
+  });
+
   it('plans RCL3 claimed-room tower defense before adding more early roads', () => {
     const spawn = makeStructure('spawn1', TEST_GLOBALS.STRUCTURE_SPAWN, 10, 10);
     const source = makeSource('source-a', 20, 10);


### PR DESCRIPTION
Implements #765: tower positioning and rampart priority optimization for claimed colonies.

- constructionPriority.ts: rampart priority ordering (towers first, then spawn/controller)
- expansionPlanner.ts: tower positioning strategy for claimed colonies covering key structures
- claimedRoomBootstrapper.ts: integrates defense optimization into colony bootstrap
- 1443 tests PASS, typecheck PASS, build PASS

Closes #765